### PR TITLE
Use correct .pre-commit-hooks.yaml format

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,12 +1,8 @@
-repos:
-  - repo: https://github.com/duriantaco/skylos
-    rev: v2.5.1
-    hooks:
-      - id: skylos-scan
-        name: skylos (report only)
-        entry: python -m skylos.cli
-        language: python
-        types_or: [python]
-        pass_filenames: false
-        require_serial: true
-        args: [".", "--output", "report.json", "--confidence", "70", "--danger"]
+- id: skylos-scan
+  name: skylos (report only)
+  entry: python -m skylos.cli
+  language: python
+  types_or: [python]
+  pass_filenames: false
+  require_serial: true
+  args: [".", "--output", "report.json", "--confidence", "70", "--danger"]


### PR DESCRIPTION
Hi, it seems the current `.pre-commit-hooks.yaml` is not set up correctly.

My `.pre-commit-config.yaml`:

```yaml
repos:
  - repo: https://github.com/duriantaco/skylos
    rev: v2.5.1
    hooks:
      - id: skylos-scan
```

When running `pre-commit run --all-files` with this config, I get:

```console
An error has occurred: InvalidManifestError: 
==> File /home/jannik/.cache/pre-commit/repo182eswu4/.pre-commit-hooks.yaml
=====> Expected array but got 'dict'
Check the log at /home/jannik/.cache/pre-commit/pre-commit.log
```

This is due to the `.pre-commit-config.yaml` defining **repos** while it should only provide the hook IDs.

See the [pre-commit/pre-commit-hooks.yaml](https://github.com/pre-commit/pre-commit-hooks/blob/main/.pre-commit-hooks.yaml) for how it is usually defined.