### PR TITLE
fix: populate empty Problem field in --llm output for dead code findings

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -607,16 +607,29 @@ def _generate_llm_report(result: dict, project_root: pathlib.Path) -> str:
         for f in result.get(category, []):
             all_findings.append((f, label))
 
-    for category, label in [
-        ("unused_functions", "Dead Code"),
-        ("unused_imports", "Dead Code"),
-        ("unused_classes", "Dead Code"),
-        ("unused_variables", "Dead Code"),
-        ("unused_parameters", "Dead Code"),
-        ("unused_files", "Dead Code"),
-    ]:
+    _dead_code_meta = {
+        "unused_functions": ("SKY-DC001", "MEDIUM", "Unused function"),
+        "unused_imports": ("SKY-DC002", "LOW", "Unused import"),
+        "unused_classes": ("SKY-DC003", "MEDIUM", "Unused class"),
+        "unused_variables": ("SKY-DC004", "LOW", "Unused variable"),
+        "unused_parameters": ("SKY-DC005", "LOW", "Unused parameter"),
+        "unused_files": ("SKY-DC006", "LOW", "Empty file"),
+    }
+    for category in _dead_code_meta:
+        rule_id, sev, human_label = _dead_code_meta[category]
         for f in result.get(category, []):
-            all_findings.append((f, label))
+            if not f.get("message"):
+                name = f.get("name") or f.get("simple_name") or ""
+                why = f.get("why_unused")
+                if why:
+                    f["message"] = f"{human_label} '{name}' is never used ({', '.join(why)})"
+                else:
+                    f["message"] = f"{human_label} '{name}' is never used"
+            if not f.get("rule_id"):
+                f["rule_id"] = rule_id
+            if not f.get("severity"):
+                f["severity"] = sev
+            all_findings.append((f, "Dead Code"))
 
     if not all_findings:
         return "# Skylos Report\n\nNo findings.\n"


### PR DESCRIPTION
Closes #118     
                                                                                       
## What does this PR do?     
                                                                                                        
Populates the empty `Problem:` field in `--llm` output for dead code findings.                                                                     
                                                                                                      
## Why?

Dead code findings from `Definition.to_dict()` never included a `message`, `rule_id`, or `severity` field. The LLM report template expected these, resulting in the bug which is `Problem:` lines, empty rule IDs, and default INFO severity for all dead code output.                                                   
                                                            
## How to test

1. Run `skylos --llm` on any repo with dead code                                                      
2. Verify `Problem:` lines are populated
3. Verify rule IDs show (e.g. `SKY-DC001`) and severity is MEDIUM or LOW, not INFO                    
4. Run `python3 -m pytest test/ -x`. All 2731 tests pass                                             
                                                                                                        
## Checklist                                                                                          
                                                                                                        
- [x] Tests pass (`python3 -m pytest test/`)              
- [x] No new false positives introduced (if modifying analysis logic)
- [ ] CHANGELOG updated (if user-facing change)  