### PR TITLE
fix: resolve TSX dead-code false positives

### DIFF
--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -235,6 +235,15 @@ _CONFIG_FILES = frozenset(
     }
 )
 
+_TS_ENTRY_FILES = frozenset(
+    {
+        "index.ts",
+        "index.tsx",
+        "main.ts",
+        "main.tsx",
+    }
+)
+
 
 def _is_ts_entry_or_infra(sf: str) -> bool:
     if sf.endswith(_TEST_SUFFIXES) or "/__tests__/" in sf:
@@ -280,7 +289,7 @@ def find_dead_ts_files(files, exclude_folders, importers_of, wildcard_edges):
 
     entry_points = set()
     for tf in ts_files:
-        if os.path.basename(tf) in ("index.ts", "index.tsx"):
+        if os.path.basename(tf) in _TS_ENTRY_FILES:
             entry_points.add(tf)
 
     dead_set = set()

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -79,6 +79,12 @@ _REFS_PATTERN = """
 (type_identifier) @type_ref
 """
 
+_REFS_JSX_PATTERN = """
+(jsx_expression (identifier) @ref)
+(jsx_opening_element name: (identifier) @ref (#match? @ref "^[A-Z]"))
+(jsx_self_closing_element name: (identifier) @ref (#match? @ref "^[A-Z]"))
+"""
+
 _IMPORTS_PATTERN = """
 (import_clause (named_imports (import_specifier name: (identifier) @import_name)))
 (import_clause (identifier) @import_name)
@@ -177,6 +183,10 @@ class TypeScriptCore:
         for k, v in ts_only.items():
             self._defs_captures.setdefault(k, []).extend(v)
         self._refs_captures = self._run_batch("refs", _REFS_PATTERN)
+        if str(self.file_path).endswith(".tsx"):
+            jsx_refs = self._run_batch("refs_jsx", _REFS_JSX_PATTERN)
+            for k, v in jsx_refs.items():
+                self._refs_captures.setdefault(k, []).extend(v)
         self._imports_captures = self._run_batch("imports", _IMPORTS_PATTERN)
 
         self._scan_defs()

--- a/test/test_ts_exports.py
+++ b/test/test_ts_exports.py
@@ -12,6 +12,7 @@ from skylos.visitors.languages.typescript.analysis import (
     build_ts_import_graph,
     demote_unconsumed_ts_exports,
     find_unused_ts_exports,
+    find_dead_ts_files,
     _is_nextjs_convention_file,
     _NEXTJS_CONVENTION_EXPORTS,
 )
@@ -242,3 +243,25 @@ class TestWildcardPassthrough:
 
         consumed, _, _ = build_ts_import_graph(ts_raw_imports, defs)
         assert "helper" in consumed[str(mod_file)]
+
+
+class TestTypeScriptDeadFiles:
+    def test_main_tsx_is_treated_as_entrypoint(self, tmp_path):
+        main_file = tmp_path / "src" / "main.tsx"
+        app_file = tmp_path / "src" / "App.tsx"
+        component_file = tmp_path / "src" / "components" / "UserMenu.tsx"
+
+        component_file.parent.mkdir(parents=True)
+        main_file.parent.mkdir(parents=True, exist_ok=True)
+
+        for path in (main_file, app_file, component_file):
+            path.write_text("", encoding="utf-8")
+
+        files = [main_file, app_file, component_file]
+        importers_of = {
+            str(app_file): {str(main_file)},
+            str(component_file): {str(app_file)},
+        }
+
+        dead_files = find_dead_ts_files(files, [], importers_of, {})
+        assert dead_files == []

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -8,12 +8,17 @@ from skylos.visitors.languages.typescript import scan_typescript_file
 _BENCHMARKS_DIR = Path(__file__).parent.parent / "manual" / "mixed_repo"
 
 
-def _scan_ts(tmp_path, code):
-    p = tmp_path / "test.ts"
+def _scan_ts_file(tmp_path, filename, code):
+    p = tmp_path / filename
+    p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(code, encoding="utf-8")
     results = scan_typescript_file(str(p))
     defs, refs, _, _, _, _, quality, danger, *_ = results
     return defs, refs, quality, danger
+
+
+def _scan_ts(tmp_path, code):
+    return _scan_ts_file(tmp_path, "test.ts", code)
 
 
 def _def_names(defs):
@@ -204,6 +209,37 @@ class TestTSImports:
 
 
 class TestTSDeadCodeFalsePositives:
+    def test_jsx_callback_reference(self, tmp_path):
+        code = (
+            "export function UserMenu() {\n"
+            "    const handleLogout = async () => {\n"
+            "        await Promise.resolve();\n"
+            "    };\n"
+            "    return <button onClick={handleLogout}>Logout</button>;\n"
+            "}\n"
+        )
+        defs, refs, _, _ = _scan_ts_file(tmp_path, "UserMenu.tsx", code)
+        ref_names = _ref_names(refs)
+        assert "handleLogout" in ref_names
+        assert "button" not in ref_names
+        assert "handleLogout" not in _unused(defs, refs)
+
+    def test_jsx_component_reference_self_closing(self, tmp_path):
+        code = (
+            "function UserMenu() { return <button />; }\n"
+            "export function Page() { return <UserMenu />; }\n"
+        )
+        defs, refs, _, _ = _scan_ts_file(tmp_path, "Page.tsx", code)
+        assert "UserMenu" not in _unused(defs, refs)
+
+    def test_jsx_component_reference_paired_tag(self, tmp_path):
+        code = (
+            "function UserMenu() { return <button />; }\n"
+            "export function Page() { return <UserMenu></UserMenu>; }\n"
+        )
+        defs, refs, _, _ = _scan_ts_file(tmp_path, "Page.tsx", code)
+        assert "UserMenu" not in _unused(defs, refs)
+
     def test_callback_passed_as_argument(self, tmp_path):
         code = (
             "function transformer(x: number): number { return x * 2; }\n"
@@ -367,6 +403,56 @@ class TestTSClassDefs:
 
 
 class TestMixedRepoIntegration:
+    def test_mixed_repo_tsx_jsx_refs_prevent_false_positives(self, tmp_path):
+        """TSX callbacks and component usage should count as live refs."""
+        from skylos.analyzer import analyze
+
+        frontend = tmp_path / "frontend"
+        (frontend / "src" / "components" / "Common").mkdir(parents=True)
+
+        (frontend / "src" / "components" / "Common" / "UserMenu.tsx").write_text(
+            "export function UserMenu() {\n"
+            "    const handleLogout = async () => {\n"
+            "        await Promise.resolve();\n"
+            "    };\n"
+            "    function deadHelper() {\n"
+            "        return 1;\n"
+            "    }\n"
+            "    return <button onClick={handleLogout}>Logout</button>;\n"
+            "}\n"
+        )
+        (frontend / "src" / "App.tsx").write_text(
+            'import { UserMenu } from "./components/Common/UserMenu";\n'
+            "\n"
+            "export function App() {\n"
+            "    return <UserMenu />;\n"
+            "}\n"
+        )
+        (frontend / "src" / "main.tsx").write_text(
+            'import { App } from "./App";\n'
+            "\n"
+            "function mount() {\n"
+            "    return <App />;\n"
+            "}\n"
+            "\n"
+            "mount();\n"
+        )
+
+        result_json = analyze(str(frontend), conf=10)
+        result = json.loads(result_json)
+
+        unused_functions = {item["name"] for item in result.get("unused_functions", [])}
+        unused_imports = {item["name"] for item in result.get("unused_imports", [])}
+        unused_files = {Path(item["file"]).name for item in result.get("unused_files", [])}
+
+        assert "deadHelper" in unused_functions
+        assert "handleLogout" not in unused_functions
+        assert "UserMenu" not in unused_functions
+        assert "App" not in unused_functions
+        assert "UserMenu" not in unused_imports
+        assert "App" not in unused_imports
+        assert unused_files == set()
+
     def test_mixed_repo_finds_dead_code_in_both(self, tmp_path):
         """Both Python and TS dead code should appear in results."""
         from skylos.analyzer import analyze


### PR DESCRIPTION
Closes #119

Summary:
- count JSX callback refs like `onClick={handleLogout}` in `.tsx`
- count uppercase JSX component refs like `<UserMenu />`
- avoid treating intrinsic tags like `<button>` as symbol refs
- treat `main.ts` and `main.tsx` as TS entrypoints for dead file analysis

Validation:
- pytest test/test_typescript_expanded.py test/test_ts_exports.py test/test_typescript_framework.py test/test_typescript.py -q
- manual check on temp Vite, Next.js app-router, and barrel-export TSX repos