### PR TITLE
upgrade: agents speed up changed scans and make fixes opt-in

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1623,13 +1623,16 @@ def run_whitelist(pattern=None, reason=None, show=False):
 
 
 def get_git_changed_files(root_path):
-    def _collect_py(output):
+    supported_exts = {".py", ".go", ".ts", ".tsx", ".java"}
+
+    def _collect_supported(output):
         files = []
         for line in output.splitlines():
-            if line.endswith(".py"):
-                full_path = pathlib.Path(root_path) / line
-                if full_path.exists():
-                    files.append(full_path)
+            full_path = pathlib.Path(root_path) / line
+            if full_path.suffix.lower() not in supported_exts:
+                continue
+            if full_path.exists():
+                files.append(full_path)
         return files
 
     try:
@@ -1644,7 +1647,7 @@ def get_git_changed_files(root_path):
             cwd=root_path,
             timeout=30,
         ).decode("utf-8")
-        files = _collect_py(output)
+        files = _collect_supported(output)
         if files:
             return files
 
@@ -1657,7 +1660,7 @@ def get_git_changed_files(root_path):
             output = subprocess.check_output(
                 cmd, cwd=root_path, stderr=subprocess.DEVNULL, timeout=30
             ).decode("utf-8")
-            return _collect_py(output)
+            return _collect_supported(output)
         except Exception:
             return []
     except Exception:
@@ -3296,13 +3299,18 @@ def main() -> None:
         p_scan.add_argument(
             "--verification-mode",
             choices=["judge_all", "production"],
-            default="judge_all",
+            default="production",
             help="Dead-code verifier mode: judge_all sends nearly every refs==0 candidate to the LLM",
+        )
+        p_scan.add_argument(
+            "--with-fixes",
+            action="store_true",
+            help="Generate fix suggestions for findings (slower)",
         )
         p_scan.add_argument(
             "--no-fixes",
             action="store_true",
-            help="Skip fix suggestions (faster)",
+            help="Disable fix suggestions (compatibility alias; fixes are off by default)",
         )
         p_scan.add_argument(
             "--changed",
@@ -3981,8 +3989,9 @@ def main() -> None:
 
                 console.print(f"Found {len(changed_files)} changed files")
 
-            if not getattr(agent_args, "no_fixes", False):
-                agent_args.with_fixes = True
+            agent_args.with_fixes = bool(getattr(agent_args, "with_fixes", False))
+            if getattr(agent_args, "no_fixes", False):
+                agent_args.with_fixes = False
 
             path = pathlib.Path(agent_args.path)
             if not path.exists():
@@ -3994,6 +4003,7 @@ def main() -> None:
             import time as _time
 
             _scan_start = _time.time()
+            pipeline_stats = {}
             merged_findings = run_pipeline(
                 path=str(path),
                 model=model,
@@ -4002,6 +4012,7 @@ def main() -> None:
                 console=console,
                 changed_files=changed_files,
                 exclude_folders=agent_exclude_folders,
+                stats_out=pipeline_stats,
             )
 
             merged_findings = _normalize_agent_findings(merged_findings, project_root)
@@ -4026,6 +4037,15 @@ def main() -> None:
             console.print(
                 f"  [yellow]MEDIUM (LLM only, needs review):[/yellow] {llm_only}"
             )
+            if pipeline_stats:
+                console.print("[dim]Timings:[/dim]")
+                console.print(
+                    f"  static={pipeline_stats.get('phase_1_seconds', 0):.1f}s "
+                    f"verify={pipeline_stats.get('phase_2a_seconds', 0):.1f}s "
+                    f"audit={pipeline_stats.get('phase_2b_seconds', 0):.1f}s "
+                    f"fixes={pipeline_stats.get('phase_3_seconds', 0):.1f}s "
+                    f"total={pipeline_stats.get('elapsed_seconds', 0):.1f}s"
+                )
 
             if agent_args.format == "json":
                 output = json.dumps(merged_findings, indent=2, default=str)

--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -193,6 +193,7 @@ def run_static_on_files(
             enable_danger=enable_danger,
             enable_quality=enable_quality,
             exclude_folders=list(exclude_folders or parse_exclude_folders()),
+            changed_files=sorted(target_files),
         )
         full_result = json.loads(result_json)
     except Exception:
@@ -234,8 +235,10 @@ def run_pipeline(
     *,
     changed_files=None,
     exclude_folders=None,
+    stats_out=None,
 ):
     import sys
+    import time
     from concurrent.futures import ThreadPoolExecutor
     from rich.progress import Progress, SpinnerColumn, TextColumn
     from skylos.analyzer import analyze as run_analyze
@@ -257,6 +260,13 @@ def run_pipeline(
         "quality": [],
         "secrets": [],
     }
+    phase_stats = {
+        "phase_1_seconds": 0.0,
+        "phase_2a_seconds": 0.0,
+        "phase_2b_seconds": 0.0,
+        "phase_3_seconds": 0.0,
+    }
+    pipeline_start = time.time()
 
     if not getattr(agent_args, "llm_only", False):
         console.print(
@@ -264,6 +274,7 @@ def run_pipeline(
         )
 
         try:
+            phase_1_start = time.time()
             with Progress(
                 SpinnerColumn(style="brand"),
                 TextColumn("[brand]Skylos[/brand] {task.description}"),
@@ -299,6 +310,7 @@ def run_pipeline(
                         ),
                     )
                     static_result = json.loads(result_json)
+            phase_stats["phase_1_seconds"] = round(time.time() - phase_1_start, 1)
 
             defs_map = static_result.get("definitions", {}) or {}
 
@@ -346,7 +358,8 @@ def run_pipeline(
             console.print(f"[warn]Static analysis failed: {e}[/warn]")
 
     if path.is_file():
-        files = [path]
+        files = [path] if path.suffix.lower() == ".py" else []
+        source_cache_files = [path]
     else:
         _exc = (
             set(exclude_folders)
@@ -354,11 +367,13 @@ def run_pipeline(
             else {"__pycache__", ".git", "venv", ".venv"}
         )
         files = [f for f in path.rglob("*.py") if not any(ex in f.parts for ex in _exc)]
+        source_cache_files = files
 
     if changed_files:
-        files = changed_files
+        source_cache_files = changed_files
+        files = [f for f in changed_files if pathlib.Path(f).suffix.lower() == ".py"]
 
-    for f in files:
+    for f in source_cache_files:
         try:
             source_cache[_norm(f)] = pathlib.Path(f).read_text(
                 encoding="utf-8", errors="ignore"
@@ -416,6 +431,7 @@ def run_pipeline(
             _2a_state["failed"] = True
 
     def _do_phase_2a():
+        phase_2a_start = time.time()
         results = []
         try:
             result = dead_code_agent.verify_candidates(
@@ -477,9 +493,11 @@ def run_pipeline(
                 f"because verification was unavailable.[/dim]"
             )
             _2a_state["failed"] = True
+        phase_stats["phase_2a_seconds"] = round(time.time() - phase_2a_start, 1)
         return results
 
     def _do_phase_2b():
+        phase_2b_start = time.time()
         results = []
         console.print("[brand]Phase 2b:[/brand] LLM security & quality analysis...")
 
@@ -549,6 +567,7 @@ def run_pipeline(
 
         except Exception as e:
             console.print(f"[warn]LLM analysis failed: {e}[/warn]")
+        phase_stats["phase_2b_seconds"] = round(time.time() - phase_2b_start, 1)
         return results
 
     for category in ["security", "quality", "secrets"]:
@@ -595,15 +614,17 @@ def run_pipeline(
     if (
         enrich_findings
         and not getattr(agent_args, "static_only", False)
-        and getattr(agent_args, "with_fixes", True)
+        and getattr(agent_args, "with_fixes", False)
     ):
         console.print(
             f"[brand]Phase 3:[/brand] LLM generating fix suggestions for "
             f"{len(enrich_findings)} findings..."
         )
         try:
+            phase_3_start = time.time()
             _enrich_with_llm_suggestions(enrich_findings, source_cache, model, api_key)
             enriched = sum(1 for f in enrich_findings if f.get("fixed_code"))
+            phase_stats["phase_3_seconds"] = round(time.time() - phase_3_start, 1)
             console.print(
                 f"[good]✓ Suggestions:[/good] {enriched}/{len(enrich_findings)} "
                 f"findings enriched with fix advice"
@@ -616,6 +637,21 @@ def run_pipeline(
         return (conf_order, f.get("file", ""), f.get("line", 0))
 
     all_findings.sort(key=sort_key)
+
+    if stats_out is not None:
+        stats_out.update(phase_stats)
+        stats_out.update(
+            {
+                "elapsed_seconds": round(time.time() - pipeline_start, 1),
+                "dead_code_candidates": len(dead_code_findings),
+                "llm_audit_files": len(files),
+                "changed_files_count": len(changed_files or []),
+                "with_fixes": bool(getattr(agent_args, "with_fixes", False)),
+                "verification_mode": getattr(
+                    agent_args, "verification_mode", "production"
+                ),
+            }
+        )
 
     return all_findings
 

--- a/test/test_cli_uncovered_paths.py
+++ b/test/test_cli_uncovered_paths.py
@@ -200,16 +200,18 @@ def test_run_whitelist_creates_names_section_if_missing(tmp_path, monkeypatch):
     assert '"dark_logic"' in content
 
 
-def test_get_git_changed_files_returns_only_existing_py(tmp_path):
+def test_get_git_changed_files_returns_existing_supported_files_only(tmp_path):
     root = tmp_path
     (root / "a.py").write_text("x=1", encoding="utf-8")
+    (root / "b.tsx").write_text("export const x = 1", encoding="utf-8")
+    (root / "c.go").write_text("package main", encoding="utf-8")
     (root / "b.txt").write_text("no", encoding="utf-8")
 
     def fake_check_output(cmd, cwd=None, stderr=None, **kwargs):
         if cmd[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
             return b"true"
         if cmd[:3] == ["git", "diff", "--name-only"]:
-            return b"a.py\nb.txt\nmissing.py\n"
+            return b"a.py\nb.tsx\nc.go\nb.txt\nmissing.py\nmissing.ts\n"
         raise AssertionError("unexpected cmd")
 
     with patch("skylos.cli.subprocess.check_output", side_effect=fake_check_output):
@@ -220,7 +222,7 @@ def test_get_git_changed_files_returns_only_existing_py(tmp_path):
         names.append(p.name)
     names.sort()
 
-    assert names == ["a.py"]
+    assert names == ["a.py", "b.tsx", "c.go"]
 
 
 def test_get_git_changed_files_on_error_returns_empty(tmp_path):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -88,7 +88,8 @@ def _agent_args(**overrides):
         static_only=False,
         skip_verification=False,
         min_confidence="low",
-        verification_mode="judge_all",
+        verification_mode="production",
+        with_fixes=False,
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -320,6 +321,20 @@ class TestRunStaticOnFiles:
         result = run_static_on_files(["/proj/a.py"], project_root=pathlib.Path("/proj"))
         assert result["analysis_summary"]["total_files"] == 42
 
+    @patch(P_CUSTOM, return_value=None)
+    @patch(P_EXCLUDE, return_value=set())
+    @patch(P_ANALYZE)
+    def test_passes_changed_files_to_incremental_analyzer(self, mock_analyze, _e, _c):
+        mock_analyze.return_value = json.dumps(_fresh_static())
+
+        run_static_on_files(
+            ["/proj/a.py", "/proj/b.py"],
+            project_root=pathlib.Path("/proj"),
+        )
+
+        kwargs = mock_analyze.call_args.kwargs
+        assert sorted(kwargs["changed_files"]) == ["/proj/a.py", "/proj/b.py"]
+
 
 class TestPipelinePhase1:
     @patch(P_LLM)
@@ -502,7 +517,7 @@ class TestPipelinePhase2a:
         kwargs = mock_agent.verify_candidates.call_args[1]
         assert "defs_map" in kwargs
         assert "project_root" in kwargs
-        assert kwargs["verification_mode"] == "judge_all"
+        assert kwargs["verification_mode"] == "production"
 
     def test_skip_verification_passes_through(self, tmp_path):
         proj = tmp_path / "proj"
@@ -791,6 +806,36 @@ class TestPipelinePhase2b:
         llm = [f for f in findings if f["_source"] == "llm"]
         assert llm[0]["_confidence"] == "medium"
 
+    def test_changed_scan_only_sends_python_files_to_llm_audit(self, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        py_file = proj / "a.py"
+        ts_file = proj / "b.tsx"
+        py_file.write_text("x = 1")
+        ts_file.write_text("export const x = 1;")
+
+        llm_result = MagicMock()
+        llm_result.findings = []
+
+        with (
+            patch(P_STATIC_FN, return_value=_empty_result()),
+            patch(P_PROGRESS),
+            patch(P_LLM) as mock_llm,
+        ):
+            mock_llm.return_value.analyze_files.return_value = llm_result
+
+            run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(),
+                console=_console(),
+                changed_files=[str(py_file), str(ts_file)],
+            )
+
+        analyze_files_args = mock_llm.return_value.analyze_files.call_args[0][0]
+        assert [str(f) for f in analyze_files_args] == [str(py_file)]
+
 
 class TestPipelineOutput:
     def test_high_confidence_sorted_before_medium(self, tmp_path):
@@ -906,6 +951,84 @@ class TestPipelineOutput:
         for f in findings:
             assert "_source" in f
             assert "_category" in f
+
+
+class TestPipelinePhase3:
+    @patch("skylos.pipeline._enrich_with_llm_suggestions")
+    @patch(P_LLM)
+    @patch(P_STATIC_FN, return_value=_fresh_static())
+    @patch(P_PROGRESS)
+    def test_fix_suggestions_are_opt_in(
+        self, _prog, _static, mock_llm, mock_enrich, tmp_path
+    ):
+        mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+
+        run_pipeline(
+            path=str(proj),
+            model="t",
+            api_key="k",
+            agent_args=_agent_args(skip_verification=True),
+            console=_console(),
+            changed_files=[str(proj / "a.py")],
+        )
+
+        mock_enrich.assert_not_called()
+
+    @patch("skylos.pipeline._enrich_with_llm_suggestions")
+    @patch(P_LLM)
+    @patch(P_STATIC_FN, return_value=_fresh_static())
+    @patch(P_PROGRESS)
+    def test_fix_suggestions_run_when_enabled(
+        self, _prog, _static, mock_llm, mock_enrich, tmp_path
+    ):
+        mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+
+        run_pipeline(
+            path=str(proj),
+            model="t",
+            api_key="k",
+            agent_args=_agent_args(skip_verification=True, with_fixes=True),
+            console=_console(),
+            changed_files=[str(proj / "a.py")],
+        )
+
+        mock_enrich.assert_called_once()
+
+    @patch(P_LLM)
+    @patch(P_STATIC_FN, return_value=_fresh_static())
+    @patch(P_PROGRESS)
+    def test_collects_pipeline_stats(self, _prog, _static, mock_llm, tmp_path):
+        mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+
+        stats = {}
+        run_pipeline(
+            path=str(proj),
+            model="t",
+            api_key="k",
+            agent_args=_agent_args(static_only=True, skip_verification=True),
+            console=_console(),
+            changed_files=[str(proj / "a.py")],
+            stats_out=stats,
+        )
+
+        assert "phase_1_seconds" in stats
+        assert "phase_2a_seconds" in stats
+        assert "phase_2b_seconds" in stats
+        assert "phase_3_seconds" in stats
+        assert "elapsed_seconds" in stats
+        assert stats["verification_mode"] == "production"
 
 
 class TestPipelineIntegration:


### PR DESCRIPTION
Summary:
- default `agent scan` dead-code verification to `production` instead of `judge_all`
- make fix suggestions opt-in via `--with-fixes`
- pass `changed_files` into the analyzer incremental path
- add "phases" timing stats to `agent scan`
- fix `--changed` so supported non-Python files like `.ts` and `.tsx` are included in git change detection

Why:
- reduce default local scan latency without removing the deeper analysis path
- avoid paying for fix generation unless explicitly requested
- expose timing data so future performance is measurable

Validation:
- `pytest test/test_pipeline.py test/test_cli_uncovered_paths.py -q`
- `pytest test/test_cli.py test/test_cli_llm_provider.py test/test_cli_coverage.py test/test_cli_decorators.py test/test_verify_orchestrator.py -q`

Manual validation:
- Python and TS changed-scan smoke on a manual repo separately
- Mixed Python + TS changed-scan smoke on a manual repo together