### PR TITLE
fix: honor .gitignore in shared file discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1465,6 +1465,9 @@ addopts = "--quality --danger --confidence=80"
 
 CLI flags override `addopts`, so you can always narrow or widen a run without editing config.
 
+Skylos also honors `[tool.skylos].exclude` during CLI scans, which is the cleanest place
+to keep team-specific paths like custom venv names or `.claude/worktrees/`.
+
 ### Legacy AI Flags
 
 ```bash
@@ -1593,12 +1596,18 @@ skylos --list-default-excludes
 # Add more exclusions
 skylos . --exclude-folder vendor --exclude-folder generated
 
+# Skylos also respects project `.gitignore` entries during file discovery
+# so ignored folders like custom venvs and worktrees are skipped automatically
+
 # Force include an excluded folder
 skylos . --include-folder venv
 
 # Scan everything (no exclusions)
 skylos . --no-default-excludes
 ```
+
+Use `[tool.skylos].exclude` in `pyproject.toml` for team-wide custom exclusions that should apply
+even outside `.gitignore`.
 
 ### Rule Suppression
 
@@ -1621,6 +1630,7 @@ ignore = [
 | Skip a folder | `--exclude-folder NAME` |
 | Skip a rule globally | `ignore = ["SKY-XXX"]` in pyproject.toml |
 | Include excluded folder | `--include-folder NAME` |
+| Skip team-specific folders | `exclude = ["customenv", ".claude/worktrees"]` in pyproject.toml |
 | Run all checks | `-a` or `addopts` in pyproject.toml |
 | Scan everything | `--no-default-excludes` |
 

--- a/skylos/agent_center.py
+++ b/skylos/agent_center.py
@@ -10,6 +10,8 @@ from typing import Any
 from skylos.analyzer import analyze as run_analyze
 from skylos.baseline import load_baseline
 from skylos.constants import parse_exclude_folders
+from skylos.config import load_config
+from skylos.file_discovery import discover_source_files
 
 STATE_DIR = ".skylos"
 STATE_FILE = "agent_state.json"
@@ -72,26 +74,26 @@ def snapshot_file_signatures(
     exclude_folders: list[str] | set[str] | None = None,
 ) -> dict[str, dict[str, int]]:
     root = Path(project_root).resolve()
-    excluded = set(exclude_folders or parse_exclude_folders(use_defaults=True))
+    excluded = set(
+        exclude_folders
+        or parse_exclude_folders(
+            use_defaults=True,
+            config_exclude_folders=load_config(root).get("exclude"),
+        )
+    )
     excluded.add(STATE_DIR)
 
     signatures: dict[str, dict[str, int]] = {}
-    for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [name for name in dirnames if name not in excluded]
-        base = Path(dirpath)
-        for filename in filenames:
-            path = base / filename
-            if path.suffix.lower() not in SUPPORTED_EXTENSIONS:
-                continue
-            try:
-                stat = path.stat()
-            except OSError:
-                continue
-            rel = str(path.relative_to(root)).replace("\\", "/")
-            signatures[rel] = {
-                "mtime_ns": int(stat.st_mtime_ns),
-                "size": int(stat.st_size),
-            }
+    for path in discover_source_files(root, SUPPORTED_EXTENSIONS, excluded):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        rel = str(path.relative_to(root)).replace("\\", "/")
+        signatures[rel] = {
+            "mtime_ns": int(stat.st_mtime_ns),
+            "size": int(stat.st_size),
+        }
     return signatures
 
 
@@ -334,7 +336,11 @@ def refresh_agent_state(
         enable_danger=enable_danger,
         enable_quality=enable_quality,
         exclude_folders=list(
-            exclude_folders or parse_exclude_folders(use_defaults=True)
+            exclude_folders
+            or parse_exclude_folders(
+                use_defaults=True,
+                config_exclude_folders=load_config(project_root).get("exclude"),
+            )
         ),
     )
     result = json.loads(raw) if isinstance(raw, str) else raw

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -37,6 +37,7 @@ from skylos.rules.danger.calls import DangerousCallsRule
 
 
 from skylos.config import get_all_ignore_lines, load_config
+from skylos.file_discovery import discover_source_files, should_exclude_path
 
 from skylos.linter import LinterVisitor
 
@@ -125,47 +126,7 @@ class Skylos:
         return ".".join(p)
 
     def _should_exclude_file(self, file_path, root_path, exclude_folders):
-        if not exclude_folders:
-            return False
-
-        try:
-            rel_path = file_path.relative_to(root_path)
-        except ValueError:
-            return False
-
-        path_parts = rel_path.parts
-        rel_path_str = str(rel_path).replace("\\", "/")
-
-        for exclude_folder in exclude_folders:
-            exclude_normalized = exclude_folder.replace("\\", "/").rstrip("/")
-
-            if "*" in exclude_normalized:
-                for part in path_parts:
-                    if part.endswith(exclude_normalized.replace("*", "")):
-                        return True
-            elif "/" in exclude_normalized:
-                if rel_path_str == exclude_normalized:
-                    return True
-                if rel_path_str.startswith(exclude_normalized + "/"):
-                    return True
-                check = "/" + rel_path_str + "/"
-                if "/" + exclude_normalized + "/" in check:
-                    return True
-
-                root_name = root_path.resolve().name
-                exclude_parts = exclude_normalized.split("/")
-                if exclude_parts[0] == root_name:
-                    stripped = "/".join(exclude_parts[1:])
-                    if stripped:
-                        if rel_path_str == stripped:
-                            return True
-                        if rel_path_str.startswith(stripped + "/"):
-                            return True
-            else:
-                if exclude_normalized in path_parts:
-                    return True
-
-        return False
+        return should_exclude_path(file_path, root_path, exclude_folders)
 
     _LANG_MAP = {
         ".py": "Python",
@@ -223,21 +184,11 @@ class Skylos:
                 rust_files = _fast_discover(str(p), ext_list, simple_excludes)
                 all_files = [Path(f) for f in rust_files]
             except Exception:
-                all_files = self._walk_python_files_py(p, exts, exclude_folders, root)
+                all_files = discover_source_files(
+                    p, exts, exclude_folders=exclude_folders
+                )
         else:
-            all_files = self._walk_python_files_py(p, exts, exclude_folders, root)
-
-        if exclude_folders:
-            filtered_files = []
-            excluded_count = 0
-            for file_path in all_files:
-                if self._should_exclude_file(file_path, root, exclude_folders):
-                    excluded_count += 1
-                    continue
-                filtered_files.append(file_path)
-            if excluded_count > 0:
-                logger.info(f"Excluded {excluded_count} files from analysis")
-            return filtered_files, root
+            all_files = discover_source_files(p, exts, exclude_folders=exclude_folders)
 
         return all_files, root
 

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -19,6 +19,7 @@ from skylos.gatekeeper import run_gate_interaction
 from skylos.api import upload_report
 from skylos.sarif_exporter import SarifExporter
 from skylos.pipeline import run_pipeline
+from skylos.file_discovery import discover_source_files
 
 from pathlib import Path
 import pathlib
@@ -2462,7 +2463,11 @@ def main() -> None:
         ) as progress:
             progress.add_task("Analyzing codebase...", total=None)
 
-            exclude_folders = list(parse_exclude_folders())
+            exclude_folders = list(
+                parse_exclude_folders(
+                    config_exclude_folders=load_config(target).get("exclude")
+                )
+            )
             if city_args.exclude:
                 exclude_folders.extend(city_args.exclude)
 
@@ -3923,7 +3928,14 @@ def main() -> None:
                 console.print("[bad]No API key provided.[/bad]")
                 sys.exit(1)
 
-        agent_exclude_folders = list(parse_exclude_folders(use_defaults=True))
+        agent_exclude_folders = list(
+            parse_exclude_folders(
+                use_defaults=True,
+                config_exclude_folders=load_config(
+                    getattr(agent_args, "path", Path.cwd())
+                ).get("exclude"),
+            )
+        )
 
         if cmd == "scan":
             if getattr(agent_args, "security", False):
@@ -3935,11 +3947,11 @@ def main() -> None:
                 if path.is_file():
                     files = [path]
                 else:
-                    files = [
-                        f
-                        for f in path.rglob("*.py")
-                        if not any(ex in f.parts for ex in agent_exclude_folders)
-                    ]
+                    files = discover_source_files(
+                        path,
+                        [".py"],
+                        exclude_folders=agent_exclude_folders,
+                    )
 
                 if not files:
                     console.print("[warn]No Python files found[/warn]")
@@ -4552,6 +4564,7 @@ def main() -> None:
 
         exclude_folders = parse_exclude_folders(
             user_exclude_folders=run_exclude_folders or None,
+            config_exclude_folders=load_config(Path.cwd()).get("exclude"),
             use_defaults=not no_defaults,
             include_folders=run_include_folders or None,
         )
@@ -4880,8 +4893,10 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
             logger.debug(f"Excluding folders: {args.exclude_folders}")
 
     use_defaults = not args.no_default_excludes
+    project_cfg = load_config(project_root)
     final_exclude_folders = parse_exclude_folders(
         user_exclude_folders=args.exclude_folders,
+        config_exclude_folders=project_cfg.get("exclude"),
         use_defaults=use_defaults,
         include_folders=args.include_folders,
     )

--- a/skylos/constants.py
+++ b/skylos/constants.py
@@ -171,12 +171,18 @@ def get_non_library_dir_kind(p, project_root=None, extra_dirs=None) -> str | Non
 
 
 def parse_exclude_folders(
-    user_exclude_folders=None, use_defaults=True, include_folders=None
+    user_exclude_folders=None,
+    use_defaults=True,
+    include_folders=None,
+    config_exclude_folders=None,
 ) -> set[str]:
     exclude_folders = set()
 
     if use_defaults:
         exclude_folders.update(DEFAULT_EXCLUDE_FOLDERS)
+
+    if config_exclude_folders:
+        exclude_folders.update(config_exclude_folders)
 
     if user_exclude_folders:
         exclude_folders.update(user_exclude_folders)

--- a/skylos/file_discovery.py
+++ b/skylos/file_discovery.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+
+def should_exclude_path(
+    file_path: Path,
+    root_path: Path,
+    exclude_folders: Sequence[str] | None,
+) -> bool:
+    if not exclude_folders:
+        return False
+
+    try:
+        rel_path = file_path.relative_to(root_path)
+    except ValueError:
+        return False
+
+    path_parts = rel_path.parts
+    rel_path_str = str(rel_path).replace("\\", "/")
+
+    for exclude_folder in exclude_folders:
+        exclude_normalized = exclude_folder.replace("\\", "/").rstrip("/")
+
+        if "*" in exclude_normalized:
+            suffix = exclude_normalized.replace("*", "")
+            for part in path_parts:
+                if part.endswith(suffix):
+                    return True
+        elif "/" in exclude_normalized:
+            if rel_path_str == exclude_normalized:
+                return True
+            if rel_path_str.startswith(exclude_normalized + "/"):
+                return True
+            check = "/" + rel_path_str + "/"
+            if "/" + exclude_normalized + "/" in check:
+                return True
+
+            root_name = root_path.resolve().name
+            exclude_parts = exclude_normalized.split("/")
+            if exclude_parts[0] == root_name:
+                stripped = "/".join(exclude_parts[1:])
+                if stripped:
+                    if rel_path_str == stripped:
+                        return True
+                    if rel_path_str.startswith(stripped + "/"):
+                        return True
+        else:
+            if exclude_normalized in path_parts:
+                return True
+
+    return False
+
+
+def should_include_path(
+    file_path: Path,
+    root_path: Path,
+    include_folders: Sequence[str] | None,
+) -> bool:
+    return should_exclude_path(file_path, root_path, include_folders)
+
+
+def find_git_root(path: str | Path) -> Path | None:
+    try:
+        current = Path(path).resolve()
+    except Exception:
+        return None
+
+    if current.is_file():
+        current = current.parent
+
+    while True:
+        if (current / ".git").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def list_git_visible_files(path: str | Path) -> list[Path] | None:
+    root = find_git_root(path)
+    if root is None:
+        return None
+
+    target = Path(path).resolve()
+    if target.is_file():
+        target = target.parent
+
+    cmd = [
+        "git",
+        "-C",
+        str(root),
+        "ls-files",
+        "-co",
+        "--exclude-standard",
+        "--full-name",
+    ]
+
+    if target != root:
+        try:
+            rel_target = target.relative_to(root)
+        except ValueError:
+            return None
+        cmd.extend(["--", str(rel_target).replace("\\", "/")])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    files = []
+    for line in result.stdout.splitlines():
+        rel_path = line.strip()
+        if not rel_path:
+            continue
+        files.append((root / rel_path).resolve())
+
+    files.sort()
+    return files
+
+
+def discover_source_files(
+    path: str | Path,
+    extensions: Iterable[str],
+    exclude_folders: Sequence[str] | None = None,
+    include_folders: Sequence[str] | None = None,
+    respect_gitignore: bool = True,
+) -> list[Path]:
+    target = Path(path).resolve()
+    ext_set = {
+        ext.lower() if ext.startswith(".") else f".{ext.lower()}"
+        for ext in extensions
+    }
+
+    if target.is_file():
+        if should_exclude_path(target, target.parent, exclude_folders):
+            return []
+        if target.suffix.lower() in ext_set:
+            return [target]
+        return []
+
+    if respect_gitignore:
+        git_files = list_git_visible_files(target)
+        if git_files is not None:
+            forced_includes = _collect_forced_included_files(
+                target, ext_set, include_folders
+            )
+            files = []
+            seen = set()
+            for file_path in [*git_files, *forced_includes]:
+                resolved = file_path.resolve()
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                if file_path.suffix.lower() not in ext_set:
+                    continue
+                if should_include_path(file_path, target, include_folders):
+                    files.append(file_path)
+                    continue
+                if should_exclude_path(file_path, target, exclude_folders):
+                    continue
+                files.append(file_path)
+            files.sort()
+            return files
+
+    files: list[Path] = []
+    try:
+        for dirpath, dirnames, filenames in os.walk(target):
+            base = Path(dirpath)
+            pruned = []
+            for dirname in list(dirnames):
+                dir_path = base / dirname
+                if should_exclude_path(dir_path, target, exclude_folders):
+                    pruned.append(dirname)
+            for dirname in pruned:
+                try:
+                    dirnames.remove(dirname)
+                except ValueError:
+                    pass
+
+            if include_folders:
+                keep = []
+                for dirname in list(dirnames):
+                    dir_path = base / dirname
+                    if should_include_path(dir_path, target, include_folders):
+                        keep.append(dirname)
+                for dirname in keep:
+                    if dirname in pruned:
+                        try:
+                            dirnames.append(dirname)
+                        except Exception:
+                            pass
+
+            for filename in filenames:
+                file_path = base / filename
+                if file_path.suffix.lower() not in ext_set:
+                    continue
+                if should_include_path(file_path, target, include_folders):
+                    files.append(file_path)
+                    continue
+                if should_exclude_path(file_path, target, exclude_folders):
+                    continue
+                files.append(file_path)
+    except (OSError, PermissionError, TypeError):
+        for ext in ext_set:
+            files.extend(target.glob(f"**/*{ext}"))
+
+    files.sort()
+    return files
+
+
+def _collect_forced_included_files(
+    target: Path,
+    extensions: set[str],
+    include_folders: Sequence[str] | None,
+) -> list[Path]:
+    if not include_folders:
+        return []
+
+    files = []
+    seen = set()
+    for pattern in include_folders:
+        for match in _iter_include_matches(target, pattern):
+            try:
+                resolved = match.resolve()
+            except OSError:
+                continue
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            if match.is_dir():
+                for file_path in match.rglob("*"):
+                    try:
+                        if file_path.is_file() and file_path.suffix.lower() in extensions:
+                            files.append(file_path.resolve())
+                    except OSError:
+                        continue
+            elif match.is_file() and match.suffix.lower() in extensions:
+                files.append(resolved)
+    return files
+
+
+def _iter_include_matches(target: Path, pattern: str):
+    normalized = pattern.replace("\\", "/").rstrip("/")
+    if not normalized:
+        return
+
+    has_glob = any(char in normalized for char in "*?[")
+    direct_candidates = []
+
+    if "/" in normalized and not has_glob:
+        direct_candidates.append(target / normalized)
+        parts = normalized.split("/")
+        if parts and parts[0] == target.name and len(parts) > 1:
+            direct_candidates.append(target / "/".join(parts[1:]))
+
+    for candidate in direct_candidates:
+        if candidate.exists():
+            yield candidate
+
+    if direct_candidates:
+        return
+
+    if has_glob:
+        pattern_expr = normalized
+        if "/" not in pattern_expr:
+            pattern_expr = f"**/{pattern_expr}"
+        yield from target.glob(pattern_expr)
+        return
+
+    yield from target.rglob(normalized)

--- a/skylos/llm/analyzer.py
+++ b/skylos/llm/analyzer.py
@@ -9,7 +9,9 @@ from .validator import ResultValidator, deduplicate_findings, merge_findings
 from .ui import SkylosUI, estimate_cost
 
 from .schemas import Confidence, AnalysisResult
+from skylos.config import load_config
 from skylos.llm.graph import CodeGraph
+from skylos.file_discovery import discover_source_files
 
 
 class AnalyzerConfig:
@@ -467,7 +469,8 @@ class SkylosLLM:
         if not project_path.exists():
             return AnalysisResult(summary="Project path not found")
 
-        exclude = set(exclude_folders or [])
+        exclude = set(load_config(project_path).get("exclude", []))
+        exclude.update(exclude_folders or [])
         exclude.update(
             {
                 "__pycache__",
@@ -481,18 +484,15 @@ class SkylosLLM:
                 "dist",
                 ".tox",
                 ".eggs",
+                "*.egg-info",
             }
         )
 
-        files = []
-        for f in project_path.rglob("*.py"):
-            skip = False
-            for part in f.parts:
-                if part in exclude or part.endswith(".egg-info"):
-                    skip = True
-                    break
-            if not skip:
-                files.append(f)
+        files = discover_source_files(
+            project_path,
+            [".py"],
+            exclude_folders=exclude,
+        )
 
         if not files:
             return AnalysisResult(summary="No Python files found")

--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -5,6 +5,9 @@ import logging
 import pathlib
 from pathlib import Path
 
+from skylos.config import load_config
+from skylos.file_discovery import discover_source_files
+
 logger = logging.getLogger(__name__)
 
 _PHASE_2B_MAX_FILES = 12
@@ -270,7 +273,12 @@ def run_static_on_files(
             enable_secrets=enable_secrets,
             enable_danger=enable_danger,
             enable_quality=enable_quality,
-            exclude_folders=list(exclude_folders or parse_exclude_folders()),
+            exclude_folders=list(
+                exclude_folders
+                or parse_exclude_folders(
+                    config_exclude_folders=load_config(project_root).get("exclude")
+                )
+            ),
             changed_files=sorted(target_files),
         )
         full_result = json.loads(result_json)
@@ -381,7 +389,10 @@ def run_pipeline(
                         enable_danger=True,
                         enable_quality=True,
                         exclude_folders=list(
-                            exclude_folders or parse_exclude_folders()
+                            exclude_folders
+                            or parse_exclude_folders(
+                                config_exclude_folders=load_config(path).get("exclude")
+                            )
                         ),
                         progress_callback=lambda cur, tot, f: progress.update(
                             task, description=f"[{cur}/{tot}] {f.name}"
@@ -444,7 +455,7 @@ def run_pipeline(
             if exclude_folders
             else {"__pycache__", ".git", "venv", ".venv"}
         )
-        files = [f for f in path.rglob("*.py") if not any(ex in f.parts for ex in _exc)]
+        files = discover_source_files(path, [".py"], exclude_folders=_exc)
         source_cache_files = files
 
     if changed_files:

--- a/test/test_agent_center.py
+++ b/test/test_agent_center.py
@@ -1,3 +1,8 @@
+import shutil
+import subprocess
+
+import pytest
+
 from skylos.agent_center import (
     clear_action_triage,
     build_headline,
@@ -6,6 +11,7 @@ from skylos.agent_center import (
     load_agent_state,
     rebuild_agent_state_from_existing,
     save_agent_state,
+    snapshot_file_signatures,
     update_action_triage,
 )
 
@@ -24,6 +30,27 @@ def test_detect_changed_files_includes_new_changed_and_removed_files():
     changed = detect_changed_files(previous, current)
 
     assert changed == ["src/b.py", "src/c.py"]
+
+
+def test_snapshot_file_signatures_skips_gitignored_files(tmp_path):
+    if shutil.which("git") is None:
+        pytest.skip("git is required for this test")
+
+    project = tmp_path / "repo"
+    project.mkdir()
+    ignored_dir = project / "customenv"
+    kept_dir = project / "src"
+    ignored_dir.mkdir(parents=True)
+    kept_dir.mkdir(parents=True)
+    (project / ".gitignore").write_text("customenv/\n", encoding="utf-8")
+    (ignored_dir / "ghost.py").write_text("x = 1\n", encoding="utf-8")
+    (kept_dir / "keep.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+    signatures = snapshot_file_signatures(project)
+
+    assert "src/keep.py" in signatures
+    assert "customenv/ghost.py" not in signatures
 
 
 def test_build_ranked_actions_prioritizes_new_critical_changed_security():

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -117,3 +117,37 @@ def test_security_audit_skips_confirmation_without_tty(tmp_path):
 
     assert exc.value.code == 0
     mock_confirm.assert_not_called()
+
+
+def test_security_audit_uses_gitignore_aware_discovery(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("print('hi')\n")
+
+    fake_llm = MagicMock()
+    fake_llm.analyze_files.return_value = MagicMock(has_blockers=False)
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli.INTERACTIVE_AVAILABLE", True),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.cli.SkylosLLM", return_value=fake_llm),
+        patch("skylos.cli.discover_source_files", return_value=[sample]) as mock_discover,
+        patch(
+            "sys.argv",
+            ["skylos", "agent", "scan", str(tmp_path), "--security", "--interactive"],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+    mock_discover.assert_called_once()
+    fake_llm.analyze_files.assert_called_once_with(
+        [sample], issue_types=["security_audit"]
+    )

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1,6 +1,8 @@
 import pytest
 import json
 import tempfile
+import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
 from collections import defaultdict
@@ -176,19 +178,45 @@ class TestSkylos:
         assert files == [mock_file]
         assert root == Path("/project")
 
+    @patch("skylos.analyzer.discover_source_files")
     @patch("skylos.analyzer.Path")
-    def test_get_python_files_directory(self, mock_path, skylos):
+    def test_get_python_files_directory(self, mock_path, mock_discover, skylos):
         mock_dir = Mock()
         mock_dir.is_file.return_value = False
         mock_files = [Path("/project/file1.py"), Path("/project/file2.py")]
 
-        mock_dir.glob.return_value = mock_files
         mock_path.return_value.resolve.return_value = mock_dir
+        mock_discover.return_value = mock_files
 
         files, root = skylos._get_python_files("/project")
 
-        assert mock_dir.glob.call_count == 5
+        mock_discover.assert_called_once_with(
+            mock_dir, {".py", ".go", ".ts", ".tsx", ".java"}, exclude_folders=None
+        )
+        assert files == mock_files
         assert root == mock_dir
+
+    def test_get_python_files_fallback_honors_gitignore(self, skylos, tmp_path, monkeypatch):
+        if shutil.which("git") is None:
+            pytest.skip("git is required for this test")
+
+        project = tmp_path / "proj"
+        ignored_dir = project / "customenv"
+        kept_dir = project / "src"
+        ignored_dir.mkdir(parents=True)
+        kept_dir.mkdir(parents=True)
+        (project / ".gitignore").write_text("customenv/\n", encoding="utf-8")
+        (ignored_dir / "ghost.py").write_text("def ghost():\n    pass\n", encoding="utf-8")
+        keep_file = kept_dir / "keep.py"
+        keep_file.write_text("def keep():\n    return 1\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+        monkeypatch.setattr("skylos.analyzer._fast_discover", None)
+
+        files, root = skylos._get_python_files(project)
+
+        assert root == project.resolve()
+        assert files == [keep_file.resolve()]
 
     def test_mark_exports_in_init(self, skylos):
         mock_def1 = Mock()

--- a/test/test_cli_uncovered_paths.py
+++ b/test/test_cli_uncovered_paths.py
@@ -266,6 +266,102 @@ def test_main_list_default_excludes_returns_without_analysis(monkeypatch):
     assert fake_logger.console.print.called
 
 
+def test_main_merges_config_excludes_into_scan(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.skylos]
+exclude = ["customenv", ".claude/worktrees"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "argv", ["skylos", ".", "--json"])
+
+    result = {
+        "analysis_summary": {"total_files": 0},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+    }
+
+    with (
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)) as mock_analyze,
+        patch("builtins.print"),
+    ):
+        cli.main()
+
+    excludes = set(mock_analyze.call_args.kwargs["exclude_folders"])
+    assert "customenv" in excludes
+    assert ".claude/worktrees" in excludes
+
+
+def test_main_include_folder_overrides_config_excludes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.skylos]
+exclude = ["customenv"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["skylos", ".", "--json", "--include-folder", "customenv"]
+    )
+
+    result = {
+        "analysis_summary": {"total_files": 0},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+    }
+
+    with (
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)) as mock_analyze,
+        patch("builtins.print"),
+    ):
+        cli.main()
+
+    excludes = set(mock_analyze.call_args.kwargs["exclude_folders"])
+    assert "customenv" not in excludes
+
+
+def test_main_no_default_excludes_keeps_config_excludes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.skylos]
+exclude = ["customenv"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "argv", ["skylos", ".", "--json", "--no-default-excludes"])
+
+    result = {
+        "analysis_summary": {"total_files": 0},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+    }
+
+    with (
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)) as mock_analyze,
+        patch("builtins.print"),
+    ):
+        cli.main()
+
+    excludes = set(mock_analyze.call_args.kwargs["exclude_folders"])
+    assert excludes == {"customenv"}
+
+
 def test_main_writes_sarif_and_prints_json(tmp_path, monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -358,7 +358,37 @@ class TestPipelinePhase1:
 
         categories = {f.get("_category") for f in findings}
         assert "dead_code" in categories
-        assert "security" in categories
+
+    @patch(P_LLM)
+    def test_uses_gitignore_aware_discovery_for_phase_2b(self, mock_llm, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        keep_file = proj / "app.py"
+        ignored_file = proj / "customenv" / "ghost.py"
+        ignored_file.parent.mkdir()
+        keep_file.write_text("x = 1")
+        ignored_file.write_text("x = 1")
+
+        llm_result = MagicMock()
+        llm_result.findings = []
+
+        with (
+            patch(P_STATIC_FN, return_value=_empty_result()),
+            patch(P_PROGRESS),
+            patch("skylos.pipeline.discover_source_files", return_value=[keep_file]),
+        ):
+            mock_llm.return_value.analyze_files.return_value = llm_result
+
+            run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(),
+                console=_console(),
+            )
+
+        analyze_files_args = mock_llm.return_value.analyze_files.call_args[0][0]
+        assert [str(f) for f in analyze_files_args] == [str(keep_file)]
 
     @patch(P_LLM)
     @patch(P_STATIC_FN, return_value=_fresh_static())


### PR DESCRIPTION
Fixes #125 

## Summary

Fixes file discovery so skylos does not scan paths ignored by `.gitignore`. Makes config-based excludes from `[tool.skylos].exclude` apply across entrypoints.


## What Changed

- added shared git-aware file discovery in `skylos/file_discovery.py`
- updated analyzer fallback discovery to respect `.gitignore`
- merged `[tool.skylos].exclude` into CLI/config exclude resolution
- wired this through agent, pipeline, and LLM analyzer paths
- added regression tests for `.gitignore` handling and config excludes

## Verification

Passed:

- `python -m pytest test/test_analyzer.py test/test_pipeline.py test/test_agent_integration.py test/test_agent_center.py test/test_cli_uncovered_paths.py -q`
- `python -m pytest test/test_cli.py test/test_gate_kwargs.py test/test_llm_analyzer.py -q`

Manually reproduced the original case with ignored paths like custom env directories etc. Also after that verified they were no longer scanned after fixes were done.