### PR TITLE
feat: detect pytest and pluggy hook entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `uvx skylos` crash on Windows due to litellm's `.pth` file exceeding MAX_PATH (260 chars) in uvx cache paths (fixes [#120](https://github.com/duriantaco/skylos/issues/120))
 - Skylos now honors project `.gitignore` entries during file discovery, so ignored worktrees, custom virtualenvs, and other excluded paths are no longer scanned
 - Flask, FastAPI, Starlette, and Sanic imperative route or lifecycle registration (`add_url_rule`, `add_api_route`, `add_route`, `register_listener`, `register_middleware`) is now treated as a live framework entrypoint instead of dead code
+- Pytest and Pluggy hook implementations (`@pytest.hookimpl`, `@hookimpl`) are now treated as live plugin entrypoints instead of dead code
 - Grep cache saves now fail open on non-writable roots instead of aborting analysis
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ When Skylos sees Flask, Django, FastAPI, Next.js, or React imports, it adjusts s
 | `@app.route`, `@router.get` | Entry point → marked as used |
 | `app.add_url_rule(...)`, `app.add_api_route(...)`, `app.add_route(...)`, `app.register_listener(...)`, `app.register_middleware(...)` | Imperative route or lifecycle registration → marked as used |
 | `@pytest.fixture` | Treated as a pytest entrypoint, but can be reported as unused if never referenced |
+| `@pytest.hookimpl`, `@hookimpl` | Plugin hook implementation → marked as used |
 | `@celery.task` | Entry point → marked as used |
 | `getattr(mod, "func")` | Tracks dynamic reference |
 | `getattr(mod, f"handle_{x}")` | Tracks pattern `handle_*` |

--- a/skylos/visitors/framework_aware.py
+++ b/skylos/visitors/framework_aware.py
@@ -64,6 +64,8 @@ FRAMEWORK_DECORATORS = [
     "@*.validates_schema",
     "@*.listens_for",
     "@listens_for",
+    "@*.hookimpl",
+    "@hookimpl",
 ]
 
 FRAMEWORK_FUNCTIONS = [

--- a/test/test_framework_aware.py
+++ b/test/test_framework_aware.py
@@ -299,6 +299,38 @@ app.register_middleware(auth_middleware, "request")
         assert v.is_framework_file is True
         assert 5 in v.framework_decorated_lines
 
+    def test_pytest_hookimpl_marks_plugin_hook(self):
+        code = """
+import pytest
+
+class Plugin:
+    @pytest.hookimpl(optionalhook=True)
+    def pytest_testnodedown(self, node, error):
+        return None
+"""
+        tree = ast.parse(code)
+        v = FrameworkAwareVisitor()
+        v.visit(tree)
+        v.finalize()
+        assert v.is_framework_file is True
+        assert 6 in v.framework_decorated_lines
+
+    def test_direct_hookimpl_marks_plugin_hook(self):
+        code = """
+from pluggy import hookimpl
+
+class Plugin:
+    @hookimpl
+    def pytest_addoption(self, parser):
+        return None
+"""
+        tree = ast.parse(code)
+        v = FrameworkAwareVisitor()
+        v.visit(tree)
+        v.finalize()
+        assert v.is_framework_file is True
+        assert 6 in v.framework_decorated_lines
+
     @patch("skylos.visitors.framework_aware.Path")
     def test_file_content_framework_detection(self, mock_path):
         mock_file = Mock()


### PR DESCRIPTION
## Summary

This PR improves static dead-code precision for plugin-style entrypoints by treating pytest and Pluggy hook implementations as live code.

## What Changed

- added framework-aware detection for `@pytest.hookimpl`
- added framework-aware detection for direct `@hookimpl`
- added regression tests covering both decorator forms
- updated README and CHANGELOG under `4.1.4`

## Why

Plugin hooks are invoked externally by pytest/Pluggy and can look unused to normal static analysis. We have marked them as live. No wider analysis pipeline changes done.

## Verification

Passed:

- `python -m pytest test/test_framework_aware.py -q`
- `python -m pytest test/test_analyzer.py -q`
- `python -m skylos.cli --help`

## Notes

- scope is intentionally narrow: hook decorator entrypoints only
- no pipeline or caching behavior changed in this PR