### PR TITLE
chore: bump version to 4.1.4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use Skylos in research, benchmarks, or tooling comparisons, please cite it using this metadata."
 title: "Skylos"
 type: software
-version: "4.1.3"
+version: "4.1.4"
 abstract: "Open-source AI code security and static analysis for Python, TypeScript, and Go. Skylos finds dead code, secrets, vulnerabilities, and diff-aware regressions."
 license: "Apache-2.0"
 authors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skylos"
-version = "4.1.3"
+version = "4.1.4"
 requires-python = ">=3.10"
 description = "Open-source AI code security and static analysis for Python, TypeScript, and Go. Finds dead code, secrets, vulnerabilities, and diff-aware regressions."
 authors = [{name = "Aaron Oh", email = "aaronoh2015@gmail.com"}]

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/duriantaco/skylos",
     "source": "github"
   },
-  "version": "4.1.3",
+  "version": "4.1.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "skylos",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "transport": {
         "type": "stdio"
       },

--- a/skylos/__init__.py
+++ b/skylos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.1.3"
+__version__ = "4.1.4"
 
 
 def analyze(*args, **kwargs):

--- a/uv.lock
+++ b/uv.lock
@@ -2399,7 +2399,7 @@ wheels = [
 
 [[package]]
 name = "skylos"
-version = "4.1.3"
+version = "4.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "ca9" },


### PR DESCRIPTION
## Summary

Prepare the `4.1.4` release.

This release includes:
- `.gitignore`-aware file discovery. Ignored worktrees, custom virtualenvs, and other excluded paths are no longer scanned
- improved static dead-code precision for imperative framework entrypoints:
    - Flask `add_url_rule(...)`
    - FastAPI `add_api_route(...)`
    - Starlette `add_route(...)` / `add_websocket_route(...)`
    - Sanic `register_listener(...)` / `register_middleware(...)`
    - pytest / Pluggy hook entrypoints via `@pytest.hookimpl` and `@hookimpl`
- repeated static `grep_verify` runs now reuse grep cache data
- Phase 2b LLM audits now focus on high-signal files instead of the full Python set
- changed-file agent scans are faster, and fix generation is now opt-in

## Release Prep

- bumped version metadata to `4.1.4`
- synced runtime version, package metadata, citation metadata, MCP metadata, and lockfile version

## Verification

Passed:

- `python -m skylos.cli --version`
- `python -m pytest test/test_analyzer.py -q`