### PR TITLE
fix: support Metadata 2.4 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Build and publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build and publish (tag or branch)"
+        required: true
+        default: "main"
 
 jobs:
   build:
@@ -10,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -19,7 +27,7 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine
+          python -m pip install "build>=1.2.2" "packaging>=24.2" "twine>=6.1.0"
 
       - name: Build sdist + wheel
         run: |
@@ -53,5 +61,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install twine
+          python -m pip install "packaging>=24.2" "twine>=6.1.0"
           python -m twine upload --skip-existing dist/*


### PR DESCRIPTION
## Summary

Fix the release publish workflow so Skylos can publish packages that use Core Metadata 2.4 fields like `License-Expression` and `License-File`.

## What Changed

- upgraded publish tooling to use a Metadata 2.4-compatible parser stack
- added `workflow_dispatch` to `Build and publish`
- added a `ref` input so an existing release tag can be rebuilt and published manually
- made checkout use the requested ref for manual publish runs

## Why

The `v4.1.4` release build produced valid Metadata 2.4 artifacts, but the publish job failed during `twine upload` with:

  - Invalid distribution metadata
  - malformed field 'license-expression'

This patch updates the workflow