### PR TITLE
fix: stop sync-installed hooks from running full scans on push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
         pass_filenames: false
         require_serial: true
         args: [".", "--json", "--confidence", "70", "--danger", "--no-grep-verify"]
+        stages: [pre-commit]
 
       - id: skylos-fail-on-findings
         name: skylos gate
@@ -15,6 +16,7 @@ repos:
         pass_filenames: false
         require_serial: true
         entry: python scripts/skylos_gate.py
+        stages: [pre-commit]
 
       - id: skylos-parity
         name: rust/python parity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Changed-file debt scans now resolve git diffs from the repository root and include `.js` / `.jsx`
 - Debt baseline and history writes require project-root scans
 - Debt baseline comparisons no longer count unseen hotspots as resolved
+- Sync-installed pre-push hooks now run only the fast Rust/Python parity guard instead of a full `skylos .` scan, and checked-in Skylos hooks are limited to the `pre-commit` stage
 
 ## [4.1.4] - 2026-03-25
 

--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -386,11 +386,31 @@ repos:
         pass_filenames: false
         require_serial: true
         args: [".", "--gate", "--danger"]
+        stages: [pre-commit]
 """
 
     precommit_path.write_text(config_content)
     print("  ✓ Created .pre-commit-config.yaml")
     return True
+
+
+def _build_pre_push_hook() -> str:
+    return """#!/bin/bash
+# Fast local parity guard only. Full Skylos scans should run manually or in CI.
+if python3 -c "import skylos_fast" 2>/dev/null; then
+    echo "Running Rust/Python parity check..."
+    python3 -m pytest test/test_fast_parity.py -k "synthetic or exact_match or same_cycles_found or python_files_match" -q --no-header --tb=line 2>&1
+    PARITY_EXIT=$?
+    if [ $PARITY_EXIT -ne 0 ]; then
+        echo ""
+        echo "BLOCKED: Rust/Python parity drift detected."
+        echo "Run 'pytest test/test_fast_parity.py -v' for details."
+        exit 1
+    fi
+fi
+
+exit 0
+"""
 
 
 def cmd_setup(token_arg=None):
@@ -534,11 +554,7 @@ def cmd_setup(token_arg=None):
         hooks_dir = git_dir / "hooks"
         hooks_dir.mkdir(exist_ok=True)
         hook_path = hooks_dir / "pre-push"
-        hook_content = r"""#!/bin/bash
-echo "Running Skylos quality gate..."
-skylos .
-exit $?
-"""
+        hook_content = _build_pre_push_hook()
         hook_path.write_text(hook_content)
         hook_path.chmod(0o755)
         print("  ✓ Installed git hooks (.git/hooks/pre-push)")
@@ -663,11 +679,7 @@ def cmd_upgrade():
         hooks_dir = git_dir / "hooks"
         hooks_dir.mkdir(exist_ok=True)
         hook_path = hooks_dir / "pre-push"
-        hook_content = """#!/bin/bash
-echo "Running Skylos quality gate..."
-skylos . --gate
-exit $?
-"""
+        hook_content = _build_pre_push_hook()
         hook_path.write_text(hook_content)
         hook_path.chmod(0o755)
         print(" ✓ Installed git hooks")

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -313,3 +313,55 @@ def test_main_dispatch_connect(monkeypatch):
     monkeypatch.setattr(syncmod, "cmd_connect", fake_connect)
     syncmod.main(["connect", "T"])
     assert called["ok"] is True
+
+
+def test_create_precommit_config_limits_gate_to_pre_commit(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    created = syncmod.create_precommit_config()
+
+    assert created is True
+    content = (tmp_path / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    assert "stages: [pre-commit]" in content
+
+
+def test_cmd_setup_installs_parity_only_pre_push_hook(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    monkeypatch.setattr(syncmod, "api_get", lambda endpoint, token: {
+        "/api/sync/whoami": {
+            "project": {"id": "proj_123", "name": "Proj"},
+            "organization": {"name": "Org"},
+            "plan": "pro",
+        }
+    }[endpoint])
+    monkeypatch.setattr(syncmod, "_write_link", lambda *args, **kwargs: None)
+    monkeypatch.setattr(syncmod, "save_token", lambda *args, **kwargs: str(tmp_path / "creds.json"))
+
+    answers = iter(["y", "n", "n"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+
+    syncmod.cmd_setup("TOK")
+
+    hook = (tmp_path / ".git" / "hooks" / "pre-push").read_text(encoding="utf-8")
+    assert "skylos ." not in hook
+    assert "Rust/Python parity check" in hook
+    assert "test/test_fast_parity.py" in hook
+
+
+def test_cmd_upgrade_installs_parity_only_pre_push_hook(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    monkeypatch.setattr(syncmod, "get_token", lambda: "TOK")
+    monkeypatch.setattr(syncmod, "api_get", lambda endpoint, token: {
+        "/api/sync/whoami": {"plan": "pro"}
+    }[endpoint])
+
+    syncmod.cmd_upgrade()
+
+    hook = (tmp_path / ".git" / "hooks" / "pre-push").read_text(encoding="utf-8")
+    assert "skylos ." not in hook
+    assert "Rust/Python parity check" in hook
+    assert "test/test_fast_parity.py" in hook


### PR DESCRIPTION
## Summary

Stop Skylos upgrade from installing a pre-push hook that runs a full `skylos .` scan, and limit the Skylos hooks to the correct stage. 

## What Changed

- `sync setup` and `sync upgrade` now install a parity-only `pre-push` hook
- `skylos-scan` and `skylos-fail-on-findings` hooks are now restricted to `pre-commit`

## Verification

Passed:

- `python -m pytest test/test_sync.py`
- `python -m pytest test/test_cli_refactor_guardrails.py test/test_cli.py test/test_cli_uncovered_paths.py test/test_debt.py`