### PR TITLE
fix: wire agent watch learn mode

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2185,6 +2185,7 @@ def main() -> None:
                     conf=agent_args.conf,
                     use_baseline=not agent_args.no_baseline,
                     state_file=agent_args.state_file,
+                    enable_learning=agent_args.learn,
                 )
                 if agent_args.format == "json":
                     print(json.dumps(state, indent=2, default=str))

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -724,3 +724,22 @@ def test_cli_guardrail_debt_top_flag_overrides_policy(tmp_path, monkeypatch):
 
     assert exc.value.code == 0
     assert mock_table.call_args.kwargs["top"] == 2
+
+
+def test_cli_guardrail_agent_watch_forwards_learn_flag(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "agent", "watch", "repo", "--once", "--learn", "--format", "json"],
+    )
+
+    with (
+        patch("skylos.agent_center.watch_project", return_value={"summary": {}}) as mock_watch,
+        patch("builtins.print") as mock_print,
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    assert mock_watch.call_args.kwargs["enable_learning"] is True
+    mock_print.assert_called_once()


### PR DESCRIPTION
## Summary

Wire `skylos agent watch --learn` through to the agent watch loop so the flag actually takes effect.

## What Changed

- passed `--learn` from the CLI agent watch command into `watch_project(...)`
- added a CLI guardrail test covering the `agent watch --learn` path

## Why

The CLI exposed `--learn`, but the watch command was not forwarding it into the underlying watch loop, so the flag was effectively a no-op.

## Verification

Passed:

- `python -m pytest test/test_cli_refactor_guardrails.py test/test_cli.py -q`

No manual checks done here