### PR TITLE
chore(quality): add Ruff guardrails for core modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,22 @@
 repos:
   - repo: local
     hooks:
+      - id: ruff-format
+        name: ruff format
+        entry: uvx ruff format . --check
+        language: system
+        pass_filenames: false
+        require_serial: true
+        stages: [pre-commit]
+
+      - id: ruff-core-lint
+        name: ruff core lint
+        entry: uvx ruff check skylos/llm skylos/adapters skylos/pipeline.py skylos/api.py
+        language: system
+        pass_filenames: false
+        require_serial: true
+        stages: [pre-commit]
+
       - id: skylos-scan
         name: skylos report
         entry: python -m skylos.cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,10 @@ strict = false
 [tool.uv.workspace]
 exclude = ["rust"]
 
+[tool.ruff]
+target-version = "py310"
+extend-exclude = ["manual"]
+
 [tool.pytest.ini_options]
 testpaths = ["test"]
 norecursedirs = [

--- a/skylos/api.py
+++ b/skylos/api.py
@@ -256,7 +256,7 @@ def print_credit_status(token=None, quiet=False):
     plan = data.get("plan", "free")
 
     if plan == "enterprise":
-        print(f"Credits: unlimited (Enterprise)")
+        print("Credits: unlimited (Enterprise)")
     else:
         print(f"Credits: {balance:,}")
         if balance < 10:
@@ -840,12 +840,12 @@ def upload_report(
                 plan = data.get("plan", "free")
 
                 if not quiet:
-                    print(f" done!\n✓ Scan uploaded")
+                    print(" done!\n✓ Scan uploaded")
                     if grade_data:
                         g = grade_data["overall"]
                         print(f"Grade: {g['letter']} ({g['score']}/100)")
                     if passed:
-                        print(f"✅ PASS Quality gate: PASSED")
+                        print("✅ PASS Quality gate: PASSED")
                     else:
                         print(
                             f"❌ FAIL Quality gate: FAILED ({new_violations} new violation{'' if new_violations == 1 else 's'})"
@@ -855,9 +855,9 @@ def upload_report(
                         print(f"\nView: {BASE_URL}/dashboard/scans/{scan_id}")
 
                     if not passed and plan == "free":
-                        print(f"\n⚠️  Quality gate failed but continuing (Free plan)")
+                        print("\n⚠️  Quality gate failed but continuing (Free plan)")
                         print(
-                            f"💡 Upgrade to Pro to automatically block commits/CI on failures"
+                            "💡 Upgrade to Pro to automatically block commits/CI on failures"
                         )
                         print(
                             f"   Learn more: {BASE_URL}/dashboard/settings?upgrade=true"
@@ -880,7 +880,7 @@ def upload_report(
                 if not passed:
                     if strict and (not is_forced):
                         if not quiet:
-                            print(f"\n Commit blocked by quality gate")
+                            print("\n Commit blocked by quality gate")
                         sys.exit(1)
 
                     if not quiet:
@@ -985,8 +985,8 @@ def upload_defense_report(defense_json_str, quiet=False) -> dict:
 
                 if not quiet:
                     score = defense_data.get("summary", {})
-                    print(f" done!")
-                    print(f"✓ Defense scan uploaded")
+                    print(" done!")
+                    print("✓ Defense scan uploaded")
                     print(
                         f"  Defense Score: {score.get('score_pct', 0)}% ({score.get('risk_rating', 'UNKNOWN')})"
                     )

--- a/skylos/demo_deadcode_benchmark.py
+++ b/skylos/demo_deadcode_benchmark.py
@@ -98,7 +98,9 @@ def load_corrected_ground_truth(
 ) -> dict[str, set[tuple[str, str]]]:
     demo_root = Path(demo_root)
     bench_path = demo_root / "benchmark_hybrid.py"
-    spec = importlib.util.spec_from_file_location("skylos_demo_benchmark_hybrid", bench_path)
+    spec = importlib.util.spec_from_file_location(
+        "skylos_demo_benchmark_hybrid", bench_path
+    )
     if spec is None or spec.loader is None:
         raise ValueError(f"unable to load benchmark file: {bench_path}")
     module = importlib.util.module_from_spec(spec)
@@ -126,10 +128,7 @@ def normalize_skylos_symbol(finding: dict[str, Any], demo_root: str | Path) -> s
     if file.startswith("./"):
         file = file[2:]
     symbol = str(
-        finding.get("simple_name")
-        or finding.get("name")
-        or finding.get("symbol")
-        or ""
+        finding.get("simple_name") or finding.get("name") or finding.get("symbol") or ""
     )
     if file == "app/api/routers/reports.py" and symbol == "format_money":
         symbol = "fmt_money"

--- a/skylos/llm/cleanup_orchestrator.py
+++ b/skylos/llm/cleanup_orchestrator.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
 from .agents import AgentConfig, create_llm_adapter
 from .executor import RemediationExecutor
@@ -517,4 +515,4 @@ class CleanupOrchestrator:
             executor.revert_fix(str(fp))
             item.status = "reverted"
             item.skip_reason = f"tests failed: {test_result.output[:200]}"
-            log(f"    [red]Reverted[/red] — tests failed")
+            log("    [red]Reverted[/red] — tests failed")

--- a/skylos/llm/orchestrator.py
+++ b/skylos/llm/orchestrator.py
@@ -96,7 +96,7 @@ class RemediationAgent:
 
             if batch.status == "fixed":
                 fixed_files.append(batch.file)
-                log(f"    ✓ Fixed successfully")
+                log("    ✓ Fixed successfully")
             else:
                 log(f"    ✗ Status: {batch.status} — {batch.fix_description}")
 

--- a/skylos/llm/repo_activation.py
+++ b/skylos/llm/repo_activation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 

--- a/skylos/llm/verify_orchestrator.py
+++ b/skylos/llm/verify_orchestrator.py
@@ -10,9 +10,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-MAX_LLM_RETRIES = 3
-RETRY_BACKOFF_BASE = 5
-
 from .dead_code_verifier import (
     DeadCodeVerifierAgent,
     Verdict,
@@ -26,14 +23,14 @@ from skylos.grep_verify import (
     _run_grep,
     multi_strategy_search as _multi_strategy_search,
     parallel_multi_strategy_search as _parallel_multi_strategy_search,
-    filter_grep_results as _filter_grep_results,
-    is_definition_line as _is_definition_line,
-    is_substring_match as _is_substring_match,
     repo_relative_path as _repo_relative_path,
     module_candidates as _module_candidates,
     parameter_owner_name as _parameter_owner_name,
     detect_language as _detect_language,
 )
+
+MAX_LLM_RETRIES = 3
+RETRY_BACKOFF_BASE = 5
 
 logger = logging.getLogger(__name__)
 
@@ -975,7 +972,7 @@ def _find_parent_class_info_ts(
     else:
         info += f"\n  Method `{simple_name}` has parent classes but could not confirm it overrides a parent method."
         info += (
-            f"\n  Check if the parent framework/library defines this method externally."
+            "\n  Check if the parent framework/library defines this method externally."
         )
 
     return info
@@ -1253,14 +1250,14 @@ def _find_parent_class_info(
                         "protocol",
                     ]
                 ):
-                    info += f"\n  HINT: Code comments/pragmas suggest this is an ABC/interface override."
+                    info += "\n  HINT: Code comments/pragmas suggest this is an ABC/interface override."
                     info += f"\n  Method `{simple_name}` is likely a required override — treat as NOT dead code."
                 else:
                     info += f"\n  Method `{simple_name}` has parent classes but could not confirm it overrides a parent method."
-                    info += f"\n  Check if the parent framework/library defines this method externally."
+                    info += "\n  Check if the parent framework/library defines this method externally."
             else:
                 info += f"\n  Method `{simple_name}` has parent classes but could not confirm it overrides a parent method."
-                info += f"\n  Check if the parent framework/library defines this method externally."
+                info += "\n  Check if the parent framework/library defines this method externally."
 
     return info
 
@@ -1455,9 +1452,7 @@ def _module_local_dynamic_dispatch_evidence(
             if not family:
                 continue
             prefix, dynamic_name, suffix = family
-            dynamic_fragment = _match_dynamic_dispatch_name(
-                simple_name, prefix, suffix
-            )
+            dynamic_fragment = _match_dynamic_dispatch_name(simple_name, prefix, suffix)
             if not dynamic_fragment:
                 continue
 
@@ -1468,9 +1463,8 @@ def _module_local_dynamic_dispatch_evidence(
                 ):
                     continue
                 literal_values = _literal_string_values(generator.iter)
-                if (
-                    dynamic_fragment in literal_values
-                    and _map_used_later(map_name, getattr(assign, "lineno", 0))
+                if dynamic_fragment in literal_values and _map_used_later(
+                    map_name, getattr(assign, "lineno", 0)
                 ):
                     line_no = getattr(child, "lineno", getattr(assign, "lineno", 0))
                     return [
@@ -1493,16 +1487,14 @@ def _module_local_dynamic_dispatch_evidence(
             if not family:
                 continue
             prefix, _dynamic_name, suffix = family
-            dynamic_fragment = _match_dynamic_dispatch_name(
-                simple_name, prefix, suffix
-            )
+            dynamic_fragment = _match_dynamic_dispatch_name(simple_name, prefix, suffix)
             if not dynamic_fragment:
                 continue
             if not _dispatcher_alive(func.name):
                 continue
             line_no = getattr(child, "lineno", getattr(func, "lineno", 0))
             return [
-                f"{file_path}:{line_no}: `{func.name}` resolves `{simple_name}` via getattr(..., f\"{prefix}{{...}}{suffix}\")"
+                f'{file_path}:{line_no}: `{func.name}` resolves `{simple_name}` via getattr(..., f"{prefix}{{...}}{suffix}")'
             ]
 
     return []
@@ -1618,10 +1610,7 @@ def _build_graph_context(
         and not discovered_entry_point
         and not prefilter_reason
         and not guarded_import
-        and (
-            not search_results
-            or set(search_results).issubset(compact_search_keys)
-        )
+        and (not search_results or set(search_results).issubset(compact_search_keys))
     )
 
     if compact_context_ok:
@@ -1790,7 +1779,7 @@ def _build_graph_context(
                         for ci in range(cs, ce):
                             parts.append(f"  {ci + 1:4d} | {clines[ci]}")
             else:
-                parts.append(f"  (not found in defs_map)")
+                parts.append("  (not found in defs_map)")
     else:
         parts.append("  NOBODY calls this function. Zero callers in entire project.")
     parts.append("")
@@ -2664,7 +2653,10 @@ def _batch_verify_findings(
         )
         return all(
             verdict.get("verdict", Verdict.UNCERTAIN) == Verdict.UNCERTAIN
-            and any(marker in str(verdict.get("rationale", "")) for marker in failure_markers)
+            and any(
+                marker in str(verdict.get("rationale", ""))
+                for marker in failure_markers
+            )
             for verdict in verdicts
         )
 
@@ -3622,7 +3614,6 @@ def run_verification(
                 )
                 stats.llm_calls += 1
                 if result.verdict != Verdict.TRUE_POSITIVE:
-                    old_verdict = finding["_llm_verdict"]
                     finding["_llm_verdict"] = result.verdict.value
                     finding["_llm_rationale"] = f"[re-verified] {result.rationale}"
                     finding["_verified_by_llm"] = result.verdict != Verdict.UNCERTAIN
@@ -3963,7 +3954,7 @@ def run_verification(
     try:
         from .feedback import record_verification_results, get_feedback_summary
 
-        feedback = record_verification_results(output)
+        record_verification_results(output)
         summary = get_feedback_summary()
 
         tuned_types = []
@@ -4087,10 +4078,7 @@ def _search_local_emit_sites(
     owner: str, event_name: str, project_root: str | Path
 ) -> list[str]:
     pattern = (
-        re.escape(owner)
-        + r"""\.emit\(\s*['"]"""
-        + re.escape(event_name)
-        + r"""['"]"""
+        re.escape(owner) + r"""\.emit\(\s*['"]""" + re.escape(event_name) + r"""['"]"""
     )
     matches: list[str] = []
     for subdir in ("app", "tests"):

--- a/test/test_verify_orchestrator.py
+++ b/test/test_verify_orchestrator.py
@@ -861,8 +861,8 @@ def test_deterministic_suppress_dynamic_globals_family(tmp_path):
         "def handle_update(payload):\n"
         "    return payload\n\n"
         "HANDLER_MAP = {\n"
-        "    action: globals()[f\"handle_{action}\"]\n"
-        "    for action in (\"create\", \"update\")\n"
+        '    action: globals()[f"handle_{action}"]\n'
+        '    for action in ("create", "update")\n'
         "}\n\n"
         "def dispatch(action, payload):\n"
         "    return HANDLER_MAP[action](payload)\n"
@@ -901,7 +901,7 @@ def test_deterministic_suppress_dynamic_getattr_family(tmp_path):
         "    return data\n\n"
         "def run_export(data, fmt):\n"
         "    import sys\n"
-        "    handler = getattr(sys.modules[__name__], f\"export_{fmt}\", None)\n"
+        '    handler = getattr(sys.modules[__name__], f"export_{fmt}", None)\n'
         "    return handler(data)\n"
     )
     source_file.write_text(source)
@@ -1324,8 +1324,8 @@ def test_run_verification_judge_all_hard_dynamic_suppression_skips_llm(
         "def handle_update(payload):\n"
         "    return payload\n\n"
         "HANDLER_MAP = {\n"
-        "    action: globals()[f\"handle_{action}\"]\n"
-        "    for action in (\"create\", \"update\")\n"
+        '    action: globals()[f"handle_{action}"]\n'
+        '    for action in ("create", "update")\n'
         "}\n\n"
         "def dispatch(action, payload):\n"
         "    return HANDLER_MAP[action](payload)\n"
@@ -1872,34 +1872,38 @@ def test_batch_verify_falls_back_to_individual_on_batch_failure(
 
     agent = MagicMock(spec=DeadCodeVerifierAgent)
 
-    with patch(
-        "skylos.llm.verify_orchestrator._build_graph_context",
-        return_value="context",
-    ), patch(
-        "skylos.llm.verify_orchestrator._parse_batch_response",
-        return_value=[
-            {"verdict": Verdict.UNCERTAIN, "rationale": "LLM call failed"},
-            {"verdict": Verdict.UNCERTAIN, "rationale": "LLM call failed"},
-        ],
-    ) as parse_batch, patch(
-        "skylos.llm.verify_orchestrator.verify_with_graph_context",
-        side_effect=[
-            VerificationResult(
-                finding=sample_finding,
-                verdict=Verdict.TRUE_POSITIVE,
-                rationale="dead",
-                original_confidence=75,
-                adjusted_confidence=95,
-            ),
-            VerificationResult(
-                finding=finding_two,
-                verdict=Verdict.FALSE_POSITIVE,
-                rationale="alive",
-                original_confidence=75,
-                adjusted_confidence=20,
-            ),
-        ],
-    ) as verify_single:
+    with (
+        patch(
+            "skylos.llm.verify_orchestrator._build_graph_context",
+            return_value="context",
+        ),
+        patch(
+            "skylos.llm.verify_orchestrator._parse_batch_response",
+            return_value=[
+                {"verdict": Verdict.UNCERTAIN, "rationale": "LLM call failed"},
+                {"verdict": Verdict.UNCERTAIN, "rationale": "LLM call failed"},
+            ],
+        ) as parse_batch,
+        patch(
+            "skylos.llm.verify_orchestrator.verify_with_graph_context",
+            side_effect=[
+                VerificationResult(
+                    finding=sample_finding,
+                    verdict=Verdict.TRUE_POSITIVE,
+                    rationale="dead",
+                    original_confidence=75,
+                    adjusted_confidence=95,
+                ),
+                VerificationResult(
+                    finding=finding_two,
+                    verdict=Verdict.FALSE_POSITIVE,
+                    rationale="alive",
+                    original_confidence=75,
+                    adjusted_confidence=20,
+                ),
+            ],
+        ) as verify_single,
+    ):
         results = _batch_verify_findings(
             agent,
             [sample_finding, finding_two],


### PR DESCRIPTION
This adds a low-friction Ruff guardrail 

## Changes:
- add a minimal `[tool.ruff]` config
- add Ruff format and Ruff lint hooks to pre-commit
- clean up core Ruff violations in `skylos/llm`, `skylos/adapters`, `skylos/pipeline.py`, and `skylos/api.py`
- apply the small formatting and cleanup fixes needed for the new guardrail to pass

## Validation:
- `uvx ruff format . --check`
- `uvx ruff check skylos/llm skylos/adapters skylos/pipeline.py skylos/api.py`
- `uv run pytest -q test/test_api.py test/test_cleanup_orchestrator.py test/test_repo_activation.py test/test_verify_orchestrator.py`
- `pre-commit run --all-files`