### PR TITLE
chore(repo): ignore local scratch files and tighten PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,14 @@
 
 <!-- Steps to verify the change works -->
 
+## Precision Impact
+
+<!-- If this changes static analysis behavior, note the affected pattern or corpus case -->
+
 ## Checklist
 
 - [ ] Tests pass (`python3 -m pytest test/`)
 - [ ] No new false positives introduced (if modifying analysis logic)
+- [ ] Added or updated a corpus case for any confirmed precision regression or false positive fix
+- [ ] Ran the corpus guard (`python3 scripts/corpus_ci.py --manifest corpus/manifest.json`) if analysis logic changed
 - [ ] CHANGELOG updated (if user-facing change)

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ node_modules
 .skylos
 .mcpregistry_github_token
 .mcpregistry_registry_token
+/PR_LOG.md
+/manual/


### PR DESCRIPTION
## Summary

  - ignore local scratch files: `PR_LOG.md` and `manual/`
  - add a `Precision Impact` section to the PR template
  - expand the PR checklist to require corpus coverage and corpus guard runs when analysis logic changes

## Testing

  - template change only