### PR TITLE
fix(core): honor root ignores and actionable clean edits

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1266,6 +1266,9 @@ class Skylos:
         if not project_root.is_dir():
             project_root = project_root.parent
 
+        project_cfg = load_config(project_root)
+        project_ignore = set(project_cfg.get("ignore", []))
+
         try:
             from skylos.pyproject_entrypoints import extract_entrypoints
 
@@ -1607,7 +1610,7 @@ class Skylos:
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error("Auto-detect git changes failed", exc_info=True)
 
-        if changed_files and enable_quality and "SKY-L021" not in cfg.get("ignore", []):
+        if changed_files and enable_quality and "SKY-L021" not in project_ignore:
             from skylos.rules.quality.regression import detect_security_regressions
 
             try:
@@ -1737,9 +1740,10 @@ class Skylos:
                         dep_root, py_files
                     )
                     if dep_findings:
-                        _ignore = cfg.get("ignore", [])
                         dep_findings = [
-                            f for f in dep_findings if f.get("rule_id") not in _ignore
+                            f
+                            for f in dep_findings
+                            if f.get("rule_id") not in project_ignore
                         ]
                         all_dangers.extend(dep_findings)
             except Exception:
@@ -1747,7 +1751,7 @@ class Skylos:
                     logger.error(traceback.format_exc())
 
             # --- SKY-D260: Prompt injection scanner (multi-file) ---
-            if "SKY-D260" not in cfg.get("ignore", []):
+            if "SKY-D260" not in project_ignore:
                 try:
                     from skylos.injection_scanner import (
                         scan_file as _injection_scan_file,
@@ -1806,10 +1810,7 @@ class Skylos:
                     if _ud_root.is_file():
                         _ud_root = _ud_root.parent
 
-                    _ud_cfg = load_config(
-                        path[0] if isinstance(path, (list, tuple)) else path
-                    )
-                    if "SKY-U005" not in _ud_cfg.get("ignore", []):
+                    if "SKY-U005" not in project_ignore:
                         ud_findings = scan_unused_dependencies(_ud_root, _ud_py_files)
                         if ud_findings:
                             all_quality.extend(ud_findings)

--- a/skylos/api.py
+++ b/skylos/api.py
@@ -816,12 +816,101 @@ def upload_report(
     if link.get("project_id"):
         payload["project_id"] = link["project_id"]
 
+    response, last_err = _post_report_payload(
+        token,
+        payload,
+        quiet=quiet,
+        initial_message="Uploading scan results...",
+    )
+    if response is None:
+        return {"success": False, "error": last_err or "Unknown error"}
+
+    if response.status_code == 401:
+        return {
+            "success": False,
+            "error": "Invalid API token. Run 'skylos sync connect' to reconnect.",
+        }
+
+    if response.status_code == 402:
+        data = {}
+        try:
+            data = response.json()
+        except (ValueError, KeyError):
+            pass
+        return {
+            "success": False,
+            "error": data.get(
+                "error",
+                "No credits remaining. Buy more at skylos.dev/dashboard/credits",
+            ),
+            "code": "NO_CREDITS",
+        }
+
+    data = response.json()
+    scan_id = data.get("scanId") or data.get("scan_id")
+    quality_gate = data.get("quality_gate", {})
+    passed = quality_gate.get("passed", True)
+    new_violations = quality_gate.get("new_violations", 0)
+
+    plan = data.get("plan", "free")
+
+    if not quiet:
+        print(" done!\n✓ Scan uploaded")
+        if grade_data:
+            g = grade_data["overall"]
+            print(f"Grade: {g['letter']} ({g['score']}/100)")
+        if passed:
+            print("✅ PASS Quality gate: PASSED")
+        else:
+            print(
+                f"❌ FAIL Quality gate: FAILED ({new_violations} new violation{'' if new_violations == 1 else 's'})"
+            )
+
+        if scan_id:
+            print(f"\nView: {BASE_URL}/dashboard/scans/{scan_id}")
+
+        if not passed and plan == "free":
+            print("\n⚠️  Quality gate failed but continuing (Free plan)")
+            print("💡 Upgrade to Pro to automatically block commits/CI on failures")
+            print(f"   Learn more: {BASE_URL}/dashboard/settings?upgrade=true")
+
+        if scan_id:
+            print(f"\n🔗 View details: {BASE_URL}/dashboard/scans/{scan_id}")
+
+    credits_left = data.get("credits_remaining")
+    if not quiet and credits_left is not None:
+        if credits_left < 50:
+            print(
+                f"\n⚠️  Credits remaining: {credits_left}. Top up at skylos.dev/dashboard/billing"
+            )
+        else:
+            print(f"\n💰 Credits remaining: {credits_left}")
+
+    if not passed:
+        if strict and (not is_forced):
+            if not quiet:
+                print("\n Commit blocked by quality gate")
+            sys.exit(1)
+
+        if not quiet:
+            print("\n⚠️ Quality gate failed, but not enforcing in local mode.")
+
+    return {
+        "success": True,
+        "scan_id": scan_id,
+        "quality_gate_passed": passed,
+        "plan": plan,
+        "credits_warning": data.get("credits_warning", False),
+    }
+
+
+def _post_report_payload(token, payload, *, quiet=False, initial_message=None):
     last_err = None
     for attempt in range(3):
         try:
             if not quiet:
-                if attempt == 0:
-                    print("Uploading scan results...", end="", flush=True)
+                if attempt == 0 and initial_message:
+                    print(initial_message, end="", flush=True)
                 else:
                     print(f" retrying ({attempt + 1}/3)...", end="", flush=True)
             response = requests.post(
@@ -830,101 +919,15 @@ def upload_report(
                 headers=_build_auth_headers(token),
                 timeout=NETWORK_TIMEOUT_LONG,
             )
-            if response.status_code in (200, 201):
-                data = response.json()
-                scan_id = data.get("scanId") or data.get("scan_id")
-                quality_gate = data.get("quality_gate", {})
-                passed = quality_gate.get("passed", True)
-                new_violations = quality_gate.get("new_violations", 0)
-
-                plan = data.get("plan", "free")
-
-                if not quiet:
-                    print(" done!\n✓ Scan uploaded")
-                    if grade_data:
-                        g = grade_data["overall"]
-                        print(f"Grade: {g['letter']} ({g['score']}/100)")
-                    if passed:
-                        print("✅ PASS Quality gate: PASSED")
-                    else:
-                        print(
-                            f"❌ FAIL Quality gate: FAILED ({new_violations} new violation{'' if new_violations == 1 else 's'})"
-                        )
-
-                    if scan_id:
-                        print(f"\nView: {BASE_URL}/dashboard/scans/{scan_id}")
-
-                    if not passed and plan == "free":
-                        print("\n⚠️  Quality gate failed but continuing (Free plan)")
-                        print(
-                            "💡 Upgrade to Pro to automatically block commits/CI on failures"
-                        )
-                        print(
-                            f"   Learn more: {BASE_URL}/dashboard/settings?upgrade=true"
-                        )
-
-                    if scan_id:
-                        print(
-                            f"\n🔗 View details: {BASE_URL}/dashboard/scans/{scan_id}"
-                        )
-
-                credits_left = data.get("credits_remaining")
-                if not quiet and credits_left is not None:
-                    if credits_left < 50:
-                        print(
-                            f"\n⚠️  Credits remaining: {credits_left}. Top up at skylos.dev/dashboard/billing"
-                        )
-                    else:
-                        print(f"\n💰 Credits remaining: {credits_left}")
-
-                if not passed:
-                    if strict and (not is_forced):
-                        if not quiet:
-                            print("\n Commit blocked by quality gate")
-                        sys.exit(1)
-
-                    if not quiet:
-                        print(
-                            "\n⚠️ Quality gate failed, but not enforcing in local mode."
-                        )
-
-                return {
-                    "success": True,
-                    "scan_id": scan_id,
-                    "quality_gate_passed": passed,
-                    "plan": plan,
-                    "credits_warning": data.get("credits_warning", False),
-                }
-
-            if not quiet:
-                print(" failed." if response.status_code >= 400 else "")
-
-            if response.status_code == 401:
-                return {
-                    "success": False,
-                    "error": "Invalid API token. Run 'skylos sync connect' to reconnect.",
-                }
-
-            if response.status_code == 402:
-                data = {}
-                try:
-                    data = response.json()
-                except (ValueError, KeyError):
-                    pass
-                return {
-                    "success": False,
-                    "error": data.get(
-                        "error",
-                        "No credits remaining. Buy more at skylos.dev/dashboard/credits",
-                    ),
-                    "code": "NO_CREDITS",
-                }
-
+            if response.status_code in (200, 201, 401, 402):
+                return response, None
+            if not quiet and response.status_code >= 400:
+                print(" failed.")
             last_err = f"Server Error {response.status_code}: {response.text}"
         except Exception as e:
             last_err = f"Connection Error: {str(e)}"
 
-    return {"success": False, "error": last_err or "Unknown error"}
+    return None, last_err or "Unknown error"
 
 
 def upload_defense_report(defense_json_str, quiet=False) -> dict:
@@ -965,69 +968,57 @@ def upload_defense_report(defense_json_str, quiet=False) -> dict:
     if link.get("project_id"):
         payload["project_id"] = link["project_id"]
 
-    if not quiet:
-        print("Uploading defense results...", end="", flush=True)
+    response, last_err = _post_report_payload(
+        token,
+        payload,
+        quiet=quiet,
+        initial_message="Uploading defense results...",
+    )
+    if response is None:
+        if not quiet:
+            print(" failed.")
+        return {"success": False, "error": last_err or "Unknown error"}
 
-    last_err = None
-    for attempt in range(3):
-        try:
-            if attempt > 0 and not quiet:
-                print(f" retrying ({attempt + 1}/3)...", end="", flush=True)
-            response = requests.post(
-                REPORT_URL,
-                json=payload,
-                headers=_build_auth_headers(token),
-                timeout=NETWORK_TIMEOUT_LONG,
+    if response.status_code == 401:
+        if not quiet:
+            print(" failed.")
+        return {
+            "success": False,
+            "error": "Invalid API token. Run 'skylos sync connect' to reconnect.",
+        }
+
+    if response.status_code == 402:
+        if not quiet:
+            print(" failed.")
+        return {
+            "success": False,
+            "error": "No credits remaining. Buy more at skylos.dev/dashboard/credits",
+            "code": "NO_CREDITS",
+        }
+
+    data = response.json()
+    scan_id = data.get("scanId") or data.get("scan_id")
+
+    if not quiet:
+        score = defense_data.get("summary", {})
+        print(" done!")
+        print("✓ Defense scan uploaded")
+        print(
+            f"  Defense Score: {score.get('score_pct', 0)}% ({score.get('risk_rating', 'UNKNOWN')})"
+        )
+        if scan_id:
+            print(f"\n🔗 View: {BASE_URL}/dashboard/scans/{scan_id}")
+
+        credits_left = data.get("credits_remaining")
+        if credits_left is not None and credits_left < 50:
+            print(
+                f"\n⚠️  Credits remaining: {credits_left}. Top up at skylos.dev/dashboard/billing"
             )
-            if response.status_code in (200, 201):
-                data = response.json()
-                scan_id = data.get("scanId") or data.get("scan_id")
 
-                if not quiet:
-                    score = defense_data.get("summary", {})
-                    print(" done!")
-                    print("✓ Defense scan uploaded")
-                    print(
-                        f"  Defense Score: {score.get('score_pct', 0)}% ({score.get('risk_rating', 'UNKNOWN')})"
-                    )
-                    if scan_id:
-                        print(f"\n🔗 View: {BASE_URL}/dashboard/scans/{scan_id}")
-
-                    credits_left = data.get("credits_remaining")
-                    if credits_left is not None and credits_left < 50:
-                        print(
-                            f"\n⚠️  Credits remaining: {credits_left}. Top up at skylos.dev/dashboard/billing"
-                        )
-
-                return {
-                    "success": True,
-                    "scan_id": scan_id,
-                }
-
-            if response.status_code == 401:
-                if not quiet:
-                    print(" failed.")
-                return {
-                    "success": False,
-                    "error": "Invalid API token. Run 'skylos sync connect' to reconnect.",
-                }
-
-            if response.status_code == 402:
-                if not quiet:
-                    print(" failed.")
-                return {
-                    "success": False,
-                    "error": "No credits remaining. Buy more at skylos.dev/dashboard/credits",
-                    "code": "NO_CREDITS",
-                }
-
-            last_err = f"Server Error {response.status_code}: {response.text}"
-        except Exception as e:
-            last_err = f"Connection Error: {str(e)}"
-
-    if not quiet:
-        print(" failed.")
-    return {"success": False, "error": last_err or "Unknown error"}
+    return {
+        "success": True,
+        "scan_id": scan_id,
+    }
 
 
 def upload_agent_run(

--- a/skylos/commands/clean_cmd.py
+++ b/skylos/commands/clean_cmd.py
@@ -12,6 +12,8 @@ from skylos.codemods import (
     remove_unused_import_cst,
 )
 
+SUPPORTED_FINDING_TYPES = {"function", "import"}
+
 
 def run_analyze(*args, **kwargs):
     from skylos.analyzer import analyze as run_analyze_impl
@@ -28,6 +30,19 @@ def _apply_codemod(file_path, transform, *transform_args, **transform_kwargs):
     return changed
 
 
+def _collect_findings(items, finding_type):
+    return [
+        {
+            "type": finding_type,
+            "name": item.get("name", ""),
+            "file": item.get("file", ""),
+            "line": item.get("line", 0),
+            "confidence": item.get("confidence", 100),
+        }
+        for item in items
+    ]
+
+
 def run_clean_command(argv: list[str]) -> int:
     console = Console()
     path = argv[0] if argv else "."
@@ -42,55 +57,47 @@ def run_clean_command(argv: list[str]) -> int:
 
     result = json.loads(run_analyze(path))
 
-    findings = []
-    for fn in result.get("unused_functions", []):
-        findings.append(
-            {
-                "type": "function",
-                "name": fn.get("name", ""),
-                "file": fn.get("file", ""),
-                "line": fn.get("line", 0),
-                "confidence": fn.get("confidence", 100),
-            }
-        )
-    for imp in result.get("unused_imports", []):
-        findings.append(
-            {
-                "type": "import",
-                "name": imp.get("name", ""),
-                "file": imp.get("file", ""),
-                "line": imp.get("line", 0),
-                "confidence": imp.get("confidence", 100),
-            }
-        )
-    for var in result.get("unused_variables", []):
-        findings.append(
-            {
-                "type": "variable",
-                "name": var.get("name", ""),
-                "file": var.get("file", ""),
-                "line": var.get("line", 0),
-                "confidence": var.get("confidence", 100),
-            }
-        )
-    for cls in result.get("unused_classes", []):
-        findings.append(
-            {
-                "type": "class",
-                "name": cls.get("name", ""),
-                "file": cls.get("file", ""),
-                "line": cls.get("line", 0),
-                "confidence": cls.get("confidence", 100),
-            }
-        )
+    all_findings = []
+    all_findings.extend(
+        _collect_findings(result.get("unused_functions", []), "function")
+    )
+    all_findings.extend(_collect_findings(result.get("unused_imports", []), "import"))
+    all_findings.extend(
+        _collect_findings(result.get("unused_variables", []), "variable")
+    )
+    all_findings.extend(_collect_findings(result.get("unused_classes", []), "class"))
+    all_findings.sort(key=lambda f: -f["confidence"])
 
-    findings.sort(key=lambda f: -f["confidence"])
-
-    if not findings:
+    if not all_findings:
         console.print("[green]No dead code found. Your codebase is clean![/green]")
         return 0
 
-    console.print(f"Found [bold]{len(findings)}[/bold] potential dead code items.\n")
+    unsupported_findings = [
+        finding
+        for finding in all_findings
+        if finding["type"] not in SUPPORTED_FINDING_TYPES
+    ]
+    findings = [
+        finding
+        for finding in all_findings
+        if finding["type"] in SUPPORTED_FINDING_TYPES
+    ]
+
+    if unsupported_findings:
+        unsupported_types = ", ".join(
+            sorted({finding["type"] for finding in unsupported_findings})
+        )
+        count = len(unsupported_findings)
+        console.print(
+            f"[yellow]Skipping {count} unsupported dead code item{'s' if count != 1 else ''} "
+            f"({unsupported_types}). Automatic edits currently support imports and functions only.[/yellow]\n"
+        )
+
+    if not findings:
+        console.print("[dim]No actionable dead code edits found.[/dim]")
+        return 0
+
+    console.print(f"Found [bold]{len(findings)}[/bold] actionable dead code items.\n")
 
     to_remove = []
     to_comment = []

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1022,6 +1022,100 @@ def fake_call():
 
         assert dependency_findings == []
 
+    def test_analyze_repo_rules_use_root_project_ignore_config(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            """
+[tool.skylos]
+ignore = ["SKY-L021", "SKY-D222", "SKY-D260"]
+""".strip(),
+            encoding="utf-8",
+        )
+        root_file = tmp_path / "app.py"
+        root_file.write_text("def root_fn():\n    return 1\n", encoding="utf-8")
+
+        nested = tmp_path / "packages" / "nested"
+        nested.mkdir(parents=True)
+        (nested / "pyproject.toml").write_text(
+            """
+[tool.skylos]
+ignore = []
+""".strip(),
+            encoding="utf-8",
+        )
+        nested_file = nested / "module.py"
+        nested_file.write_text("def nested_fn():\n    return 2\n", encoding="utf-8")
+
+        diff_result = Mock(returncode=0, stdout="diff")
+        real_subprocess_run = subprocess.run
+
+        def selective_subprocess_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args")
+            if cmd[:4] == ["git", "diff", "HEAD", "--"]:
+                return diff_result
+            return real_subprocess_run(*args, **kwargs)
+
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=selective_subprocess_run,
+            ),
+            patch(
+                "skylos.rules.quality.regression.detect_security_regressions",
+                return_value=[
+                    {
+                        "rule_id": "SKY-L021",
+                        "file": str(root_file),
+                        "line": 1,
+                        "message": "regression",
+                    }
+                ],
+            ),
+            patch(
+                "skylos.rules.danger.danger_hallucination.dependency_hallucination.scan_python_dependency_hallucinations",
+                return_value=[
+                    {
+                        "rule_id": "SKY-D222",
+                        "file": str(root_file),
+                        "line": 1,
+                        "message": "dependency hallucination",
+                    }
+                ],
+            ),
+            patch(
+                "skylos.injection_scanner.scan_file",
+                return_value=[
+                    {
+                        "rule_id": "SKY-D260",
+                        "file": str(root_file),
+                        "line": 1,
+                        "message": "prompt injection",
+                    }
+                ],
+            ),
+        ):
+            result = json.loads(
+                analyze(
+                    [str(root_file), str(nested_file)],
+                    conf=0,
+                    enable_danger=True,
+                    enable_quality=True,
+                    changed_files={str(root_file.resolve())},
+                    grep_verify=False,
+                )
+            )
+
+        assert "error" not in result
+        quality_rule_ids = {
+            finding.get("rule_id") for finding in result.get("quality", [])
+        }
+        danger_rule_ids = {
+            finding.get("rule_id") for finding in result.get("danger", [])
+        }
+
+        assert "SKY-L021" not in quality_rule_ids
+        assert "SKY-D222" not in danger_rule_ids
+        assert "SKY-D260" not in danger_rule_ids
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,4 +1,5 @@
 import os
+import json
 import importlib
 import subprocess
 import unittest
@@ -7,6 +8,7 @@ from unittest.mock import patch, MagicMock, mock_open
 import skylos.api as api
 from skylos.api import (
     upload_report,
+    upload_defense_report,
     extract_snippet,
     get_git_info,
     _detect_ci,
@@ -83,6 +85,32 @@ class TestSkylosApi(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertEqual(mock_post.call_count, 3)
         self.assertIn("Server Error 500", result["error"])
+
+    @patch("skylos.api.get_project_token")
+    @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
+    @patch("skylos.api.get_git_root", return_value=None)
+    @patch("requests.post")
+    def test_upload_defense_report_retry_logic(
+        self, mock_post, _mock_root, _mock_git_info, mock_token
+    ):
+        mock_token.return_value = "token"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_post.return_value = mock_response
+
+        result = upload_defense_report(
+            json.dumps({"summary": {"score_pct": 92, "risk_rating": "LOW"}}),
+            quiet=True,
+        )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(mock_post.call_count, 3)
+        self.assertIn("Server Error 500", result["error"])
+        args, kwargs = mock_post.call_args
+        payload = kwargs["json"]
+        self.assertEqual(payload["tool"], "skylos-defend")
 
     def test_extract_snippet_valid(self):
         content = "line1\nline2\nline3\nline4\nline5\n"

--- a/test/test_clean_cmd.py
+++ b/test/test_clean_cmd.py
@@ -71,3 +71,53 @@ def test_clean_command_comment_out_function_uses_source_and_line(tmp_path):
         1,
     )
     assert target.read_text(encoding="utf-8") == "# SKYLOS DEADCODE\npass\n"
+
+
+def test_clean_command_skips_unsupported_findings_from_prompt(tmp_path):
+    target = tmp_path / "sample.py"
+    target.write_text(
+        "def unused():\n    return 1\n\nvalue = 1\n",
+        encoding="utf-8",
+    )
+    result = {
+        "unused_functions": [
+            {
+                "name": "unused",
+                "file": str(target),
+                "line": 1,
+                "confidence": 100,
+            }
+        ],
+        "unused_variables": [
+            {
+                "name": "value",
+                "file": str(target),
+                "line": 4,
+                "confidence": 90,
+            }
+        ],
+    }
+    console = Mock()
+
+    with (
+        patch("skylos.commands.clean_cmd.Console", return_value=console),
+        patch("skylos.commands.clean_cmd.run_analyze", return_value=json.dumps(result)),
+        patch("builtins.input", side_effect=["r", "y"]),
+        patch(
+            "skylos.commands.clean_cmd.remove_unused_function_cst",
+            return_value=("value = 1\n", True),
+        ) as remove_function,
+    ):
+        exit_code = clean_cmd.run_clean_command([str(tmp_path)])
+
+    assert exit_code == 0
+    remove_function.assert_called_once_with(
+        "def unused():\n    return 1\n\nvalue = 1\n",
+        "unused",
+        1,
+    )
+    printed = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "Skipping 1 unsupported dead code item" in printed
+    assert target.read_text(encoding="utf-8") == "value = 1\n"


### PR DESCRIPTION
## Summary

- fix repo-wide analyzer ignore handling to use the root project config instead of the last processed file config
- make `skylos clean` only prompt for actionable edits and explicitly skip unsupported variable/class findings
- dedup report upload retry logic
- add regressions for analyzer, clean, and defense upload behavior

## Testing
- uv run pytest test/test_clean_cmd.py test/test_api.py test/test_analyzer.py -q
- uv run pytest -q
