### PR TITLE
refactor(defend): deduplicate empty/json output paths

### DIFF
--- a/skylos/commands/defend_cmd.py
+++ b/skylos/commands/defend_cmd.py
@@ -5,6 +5,30 @@ from pathlib import Path
 from rich.progress import SpinnerColumn, TextColumn
 
 
+def _build_empty_defense_json() -> str:
+    return json.dumps(
+        {
+            "version": "1.0",
+            "summary": {
+                "integrations_found": 0,
+                "total_checks": 0,
+                "passed": 0,
+                "failed": 0,
+                "score_pct": 100,
+                "risk_rating": "SECURE",
+            },
+            "findings": [],
+            "ops_score": {
+                "passed": 0,
+                "total": 0,
+                "score_pct": 100,
+                "rating": "EXCELLENT",
+            },
+        },
+        indent=2,
+    )
+
+
 def run_defend_command(
     argv: list[str],
     *,
@@ -128,27 +152,7 @@ def run_defend_command(
 
     if not integrations:
         if def_args.output_json:
-            empty = json.dumps(
-                {
-                    "version": "1.0",
-                    "summary": {
-                        "integrations_found": 0,
-                        "total_checks": 0,
-                        "passed": 0,
-                        "failed": 0,
-                        "score_pct": 100,
-                        "risk_rating": "SECURE",
-                    },
-                    "findings": [],
-                    "ops_score": {
-                        "passed": 0,
-                        "total": 0,
-                        "score_pct": 100,
-                        "rating": "EXCELLENT",
-                    },
-                },
-                indent=2,
-            )
+            empty = _build_empty_defense_json()
             if def_args.output_file:
                 Path(def_args.output_file).write_text(empty, encoding="utf-8")
             else:
@@ -169,8 +173,9 @@ def run_defend_command(
 
     owasp_coverage = compute_owasp_coverage(results)
 
-    if def_args.output_json:
-        output = format_defense_json(
+    json_output = None
+    if def_args.output_json or def_args.upload:
+        json_output = format_defense_json(
             results,
             score,
             len(integrations),
@@ -180,6 +185,9 @@ def run_defend_command(
             ops_score,
             integrations=integrations,
         )
+
+    if def_args.output_json:
+        output = json_output
     else:
         output = format_defense_table(
             results,
@@ -205,17 +213,7 @@ def run_defend_command(
     if def_args.upload:
         from skylos.api import upload_defense_report
 
-        json_for_upload = format_defense_json(
-            results,
-            score,
-            len(integrations),
-            len(files),
-            str(target),
-            owasp_coverage,
-            ops_score,
-            integrations=integrations,
-        )
-        upload_result = upload_defense_report(json_for_upload)
+        upload_result = upload_defense_report(json_output)
         if not upload_result.get("success"):
             console.print(
                 f"[red]Upload failed: {upload_result.get('error', 'Unknown')}[/red]"

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -616,6 +616,83 @@ def test_defend_command_json_output_prints_empty_report(tmp_path):
     assert payload["ops_score"]["rating"] == "EXCELLENT"
 
 
+def test_defend_command_json_output_writes_empty_report_file(tmp_path):
+    target = tmp_path / "repo"
+    target.mkdir()
+    output_file = tmp_path / "defense.json"
+    console = Mock()
+
+    with (
+        patch("skylos.defend.policy.load_policy", return_value=None),
+        patch(
+            "skylos.discover.detector._collect_python_files",
+            return_value=[target / "app.py"],
+        ),
+        patch(
+            "skylos.discover.detector.detect_integrations",
+            return_value=([], {}),
+        ),
+    ):
+        from skylos.commands.defend_cmd import run_defend_command
+
+        exit_code = run_defend_command(
+            [str(target), "--json", "-o", str(output_file)],
+            console_factory=lambda: console,
+            progress_factory=lambda *args, **kwargs: _progress_ctx(),
+        )
+
+    assert exit_code == 0
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["summary"]["integrations_found"] == 0
+    assert payload["summary"]["score_pct"] == 100
+    assert payload["ops_score"]["rating"] == "EXCELLENT"
+
+
+def test_defend_command_json_upload_formats_once(tmp_path):
+    target = tmp_path / "repo"
+    target.mkdir()
+    console = Mock()
+    score = Mock(score_pct=100)
+    ops_score = Mock()
+    json_payload = '{"summary":{"score_pct":100}}'
+
+    with (
+        patch("skylos.defend.policy.load_policy", return_value=None),
+        patch(
+            "skylos.discover.detector._collect_python_files",
+            return_value=[target / "app.py"],
+        ),
+        patch(
+            "skylos.discover.detector.detect_integrations",
+            return_value=(["app.py"], {}),
+        ),
+        patch(
+            "skylos.defend.engine.run_defense_checks",
+            return_value=([], score, ops_score),
+        ),
+        patch("skylos.defend.policy.compute_owasp_coverage", return_value={}),
+        patch(
+            "skylos.defend.report.format_defense_json", return_value=json_payload
+        ) as mock_json,
+        patch(
+            "skylos.api.upload_defense_report", return_value={"success": True}
+        ) as mock_upload,
+        patch("builtins.print") as mock_print,
+    ):
+        from skylos.commands.defend_cmd import run_defend_command
+
+        exit_code = run_defend_command(
+            [str(target), "--json", "--upload"],
+            console_factory=lambda: console,
+            progress_factory=lambda *args, **kwargs: _progress_ctx(),
+        )
+
+    assert exit_code == 0
+    mock_json.assert_called_once()
+    mock_upload.assert_called_once_with(json_payload)
+    mock_print.assert_called_once_with(json_payload)
+
+
 def test_ingest_command_json_output_prints_normalized_result():
     console = Mock()
     result = {"success": True, "result": {"danger": []}, "findings_count": 0}


### PR DESCRIPTION
 ## Summary
- reuse the generated defense JSON when `skylos defend` is run with `--json --upload`
- extract the empty defense JSON payload into a small helper
- add guardrail coverage for the `--json --upload` path and empty-report file output

## Testing
  - `uv run pytest test/test_cli_refactor_guardrails.py test/test_defend.py test/test_api.py -q`
  - `uv run pytest -q`
  
## Manual smoke checks
- `.venv/bin/python -m skylos.cli defend /tmp/skylos-empty-smoke --json`
- `.venv/bin/python -m skylos.cli defend /tmp/skylos-empty-smoke --json -o /tmp/skylos-empty-smoke/defense.json`