### PR TITLE
refactor(core): reduce agent service tech debt

### DIFF
--- a/skylos/agent_service.py
+++ b/skylos/agent_service.py
@@ -4,7 +4,7 @@ import json
 import threading
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import parse_qs, urlparse
 
 from skylos.agent_center import (
@@ -168,6 +168,199 @@ class AgentServiceController:
         }
 
 
+def _resolve_refresh_query(query: str) -> bool:
+    params = parse_qs(query or "", keep_blank_values=False)
+    return params.get("refresh", ["0"])[0] in {"1", "true", "yes"}
+
+
+def _resolve_limit_query(query: str, default: int) -> int:
+    params = parse_qs(query or "", keep_blank_values=False)
+    raw = params.get("limit", [str(default)])[0]
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(1, min(value, 100))
+
+
+def _dispatch_get_request(
+    *,
+    controller: AgentServiceController,
+    path: str,
+    query: str,
+    default_limit: int,
+) -> tuple[HTTPStatus, dict[str, Any]]:
+    if path == "/health":
+        return HTTPStatus.OK, controller.health()
+    if path == "/state":
+        return HTTPStatus.OK, controller.get_state(
+            refresh=_resolve_refresh_query(query)
+        )
+    if path == "/command-center":
+        payload = controller.get_command_center(
+            refresh=_resolve_refresh_query(query),
+            limit=_resolve_limit_query(query, default_limit),
+        )
+        return HTTPStatus.OK, payload
+    if path == "/suggestions":
+        return HTTPStatus.OK, controller.get_suggestions()
+    return HTTPStatus.NOT_FOUND, {"error": "Not found"}
+
+
+def _dispatch_post_request(
+    *,
+    controller: AgentServiceController,
+    path: str,
+    body: dict[str, Any],
+    require_action_id: Callable[[dict[str, Any]], str],
+) -> tuple[HTTPStatus, dict[str, Any]]:
+    if path == "/refresh":
+        return HTTPStatus.OK, controller.refresh(force=True)
+    if path == "/triage/dismiss":
+        return HTTPStatus.OK, controller.dismiss(require_action_id(body))
+    if path == "/triage/snooze":
+        action_id = require_action_id(body)
+        hours = float(body.get("hours", 24))
+        return HTTPStatus.OK, controller.snooze(action_id, hours=hours)
+    if path == "/triage/restore":
+        return HTTPStatus.OK, controller.restore(require_action_id(body))
+    if path == "/learn":
+        action_id = require_action_id(body)
+        action = str(body.get("action", "dismiss"))
+        return HTTPStatus.OK, controller.learn_triage(action_id, action)
+    return HTTPStatus.NOT_FOUND, {"error": "Not found"}
+
+
+class AgentServiceHandler(BaseHTTPRequestHandler):
+    server_version = "SkylosAgentService/0.1"
+    controller: AgentServiceController
+    token: str | None = None
+    default_limit: int = 10
+
+    def do_OPTIONS(self) -> None:
+        self.send_response(HTTPStatus.NO_CONTENT)
+        self._send_cors_headers()
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        if not self._is_authorized():
+            return
+
+        parsed = urlparse(self.path)
+        status, payload = _dispatch_get_request(
+            controller=self.controller,
+            path=parsed.path,
+            query=parsed.query,
+            default_limit=self.default_limit,
+        )
+        self._send_json(status, payload)
+
+    def do_POST(self) -> None:
+        if not self._is_authorized():
+            return
+
+        parsed = urlparse(self.path)
+        body = self._read_json_body()
+        status, payload = _dispatch_post_request(
+            controller=self.controller,
+            path=parsed.path,
+            body=body,
+            require_action_id=self._require_action_id,
+        )
+        self._send_json(status, payload)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+    def _is_authorized(self) -> bool:
+        if not self.token:
+            return True
+        header = self.headers.get("X-Skylos-Agent-Token", "")
+        if header == self.token:
+            return True
+        self._send_json(HTTPStatus.UNAUTHORIZED, {"error": "Unauthorized"})
+        return False
+
+    def _read_json_body(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return {}
+        raw = self.rfile.read(length)
+        if not raw:
+            return {}
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except Exception:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "Invalid JSON body"})
+            raise _HandledRequestError()
+        if not isinstance(payload, dict):
+            self._send_json(
+                HTTPStatus.BAD_REQUEST, {"error": "JSON body must be an object"}
+            )
+            raise _HandledRequestError()
+        return payload
+
+    def _require_action_id(self, body: dict[str, Any]) -> str:
+        action_id = str(body.get("action_id") or "").strip()
+        if action_id:
+            return action_id
+        self._send_json(HTTPStatus.BAD_REQUEST, {"error": "action_id is required"})
+        raise _HandledRequestError()
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload, indent=2, default=str).encode("utf-8")
+        self.send_response(status)
+        self._send_cors_headers()
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_cors_headers(self) -> None:
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header(
+            "Access-Control-Allow-Headers", "Content-Type, X-Skylos-Agent-Token"
+        )
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+
+
+class SafeAgentServiceHandler(AgentServiceHandler):
+    def do_GET(self) -> None:
+        try:
+            super().do_GET()
+        except _HandledRequestError:
+            return
+        except Exception as exc:
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
+
+    def do_POST(self) -> None:
+        try:
+            super().do_POST()
+        except _HandledRequestError:
+            return
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except Exception as exc:
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
+
+
+def _bind_agent_service_handler(
+    controller: AgentServiceController,
+    *,
+    token: str | None,
+    default_limit: int,
+) -> type[SafeAgentServiceHandler]:
+    return type(
+        "BoundAgentServiceHandler",
+        (SafeAgentServiceHandler,),
+        {
+            "controller": controller,
+            "token": token,
+            "default_limit": default_limit,
+        },
+    )
+
+
 def create_agent_service(
     path: str,
     *,
@@ -188,170 +381,12 @@ def create_agent_service(
         default_limit=default_limit,
         refresh_on_start=refresh_on_start,
     )
-
-    class AgentServiceHandler(BaseHTTPRequestHandler):
-        server_version = "SkylosAgentService/0.1"
-
-        def do_OPTIONS(self) -> None:
-            self.send_response(HTTPStatus.NO_CONTENT)
-            self._send_cors_headers()
-            self.end_headers()
-
-        def do_GET(self) -> None:
-            if not self._is_authorized():
-                return
-
-            parsed = urlparse(self.path)
-            if parsed.path == "/health":
-                self._send_json(HTTPStatus.OK, controller.health())
-                return
-
-            if parsed.path == "/state":
-                refresh = self._resolve_refresh(parsed.query)
-                self._send_json(HTTPStatus.OK, controller.get_state(refresh=refresh))
-                return
-
-            if parsed.path == "/command-center":
-                limit = self._resolve_limit(parsed.query, default_limit)
-                payload = controller.get_command_center(
-                    refresh=self._resolve_refresh(parsed.query),
-                    limit=limit,
-                )
-                self._send_json(HTTPStatus.OK, payload)
-                return
-
-            if parsed.path == "/suggestions":
-                self._send_json(HTTPStatus.OK, controller.get_suggestions())
-                return
-
-            self._send_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
-
-        def do_POST(self) -> None:
-            if not self._is_authorized():
-                return
-
-            parsed = urlparse(self.path)
-            body = self._read_json_body()
-
-            if parsed.path == "/refresh":
-                self._send_json(HTTPStatus.OK, controller.refresh(force=True))
-                return
-
-            if parsed.path == "/triage/dismiss":
-                action_id = self._require_action_id(body)
-                self._send_json(HTTPStatus.OK, controller.dismiss(action_id))
-                return
-
-            if parsed.path == "/triage/snooze":
-                action_id = self._require_action_id(body)
-                hours = float(body.get("hours", 24))
-                self._send_json(
-                    HTTPStatus.OK, controller.snooze(action_id, hours=hours)
-                )
-                return
-
-            if parsed.path == "/triage/restore":
-                action_id = self._require_action_id(body)
-                self._send_json(HTTPStatus.OK, controller.restore(action_id))
-                return
-
-            if parsed.path == "/learn":
-                action_id = self._require_action_id(body)
-                action = str(body.get("action", "dismiss"))
-                self._send_json(
-                    HTTPStatus.OK, controller.learn_triage(action_id, action)
-                )
-                return
-
-            self._send_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
-
-        def log_message(self, format: str, *args: Any) -> None:
-            return
-
-        def _resolve_refresh(self, query: str) -> bool:
-            params = parse_qs(query or "", keep_blank_values=False)
-            return params.get("refresh", ["0"])[0] in {"1", "true", "yes"}
-
-        def _is_authorized(self) -> bool:
-            if not token:
-                return True
-            header = self.headers.get("X-Skylos-Agent-Token", "")
-            if header == token:
-                return True
-            self._send_json(HTTPStatus.UNAUTHORIZED, {"error": "Unauthorized"})
-            return False
-
-        def _read_json_body(self) -> dict[str, Any]:
-            length = int(self.headers.get("Content-Length", "0") or "0")
-            if length <= 0:
-                return {}
-            raw = self.rfile.read(length)
-            if not raw:
-                return {}
-            try:
-                payload = json.loads(raw.decode("utf-8"))
-            except Exception:
-                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "Invalid JSON body"})
-                raise _HandledRequestError()
-            if not isinstance(payload, dict):
-                self._send_json(
-                    HTTPStatus.BAD_REQUEST, {"error": "JSON body must be an object"}
-                )
-                raise _HandledRequestError()
-            return payload
-
-        def _require_action_id(self, body: dict[str, Any]) -> str:
-            action_id = str(body.get("action_id") or "").strip()
-            if action_id:
-                return action_id
-            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "action_id is required"})
-            raise _HandledRequestError()
-
-        def _resolve_limit(self, query: str, default: int) -> int:
-            params = parse_qs(query or "", keep_blank_values=False)
-            raw = params.get("limit", [str(default)])[0]
-            try:
-                value = int(raw)
-            except ValueError:
-                return default
-            return max(1, min(value, 100))
-
-        def _send_json(self, status: int, payload: dict[str, Any]) -> None:
-            data = json.dumps(payload, indent=2, default=str).encode("utf-8")
-            self.send_response(status)
-            self._send_cors_headers()
-            self.send_header("Content-Type", "application/json; charset=utf-8")
-            self.send_header("Content-Length", str(len(data)))
-            self.end_headers()
-            self.wfile.write(data)
-
-        def _send_cors_headers(self) -> None:
-            self.send_header("Access-Control-Allow-Origin", "*")
-            self.send_header(
-                "Access-Control-Allow-Headers", "Content-Type, X-Skylos-Agent-Token"
-            )
-            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-
-    class SafeAgentServiceHandler(AgentServiceHandler):
-        def do_GET(self) -> None:
-            try:
-                super().do_GET()
-            except _HandledRequestError:
-                return
-            except Exception as exc:
-                self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
-
-        def do_POST(self) -> None:
-            try:
-                super().do_POST()
-            except _HandledRequestError:
-                return
-            except ValueError as exc:
-                self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
-            except Exception as exc:
-                self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
-
-    server = ThreadingHTTPServer((host, port), SafeAgentServiceHandler)
+    handler_class = _bind_agent_service_handler(
+        controller,
+        token=token,
+        default_limit=default_limit,
+    )
+    server = ThreadingHTTPServer((host, port), handler_class)
     server.controller = controller  # type: ignore[attr-defined]
     return server
 

--- a/test/test_agent_service.py
+++ b/test/test_agent_service.py
@@ -1,5 +1,75 @@
+from __future__ import annotations
+
+import contextlib
+import http.client
+import json
+import threading
+
 from skylos.agent_center import rebuild_agent_state_from_existing, save_agent_state
-from skylos.agent_service import AgentServiceController
+from skylos.agent_service import AgentServiceController, create_agent_service
+
+
+@contextlib.contextmanager
+def running_agent_service(
+    project_root, *, token: str | None = None, default_limit: int = 10
+):
+    server = create_agent_service(
+        str(project_root),
+        host="127.0.0.1",
+        port=0,
+        token=token,
+        default_limit=default_limit,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def request_json(
+    server,
+    method: str,
+    path: str,
+    *,
+    token: str | None = None,
+    body: dict | None = None,
+    raw_body: str | None = None,
+):
+    host, port = server.server_address
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    headers = {"Content-Type": "application/json"}
+    if token is not None:
+        headers["X-Skylos-Agent-Token"] = token
+    payload = (
+        raw_body
+        if raw_body is not None
+        else (None if body is None else json.dumps(body))
+    )
+    try:
+        conn.request(method, path, body=payload, headers=headers)
+        response = conn.getresponse()
+        raw = response.read().decode("utf-8")
+        return response.status, json.loads(raw)
+    finally:
+        conn.close()
+
+
+def build_service_state(project_root, findings):
+    state = rebuild_agent_state_from_existing(
+        {
+            "project_root": str(project_root),
+            "file_signatures": {"src/auth.py": {"mtime_ns": 1, "size": 10}},
+            "changed_files": ["src/auth.py"],
+            "baseline_present": False,
+            "findings": findings,
+        }
+    )
+    save_agent_state(project_root, state)
+    return state
 
 
 def test_agent_service_controller_serves_command_center_and_triage_updates(tmp_path):
@@ -90,3 +160,227 @@ def test_agent_service_controller_tracks_snoozed_actions(tmp_path):
     payload = controller.get_command_center()
     assert payload["triaged_count"] == 1
     assert payload["items"] == []
+
+
+def test_create_agent_service_http_routes_and_auth(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "security:1",
+                "rule_id": "SKY-D999",
+                "category": "security",
+                "severity": "HIGH",
+                "message": "Shell injection path",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 9,
+                "confidence": 91,
+                "is_new_vs_baseline": True,
+                "is_new_since_last_scan": True,
+                "is_in_changed_file": True,
+            },
+        ],
+    )
+
+    with running_agent_service(project_root, token="secret", default_limit=2) as server:
+        status, payload = request_json(server, "GET", "/health", token="wrong")
+        assert status == 401
+        assert payload == {"error": "Unauthorized"}
+
+        status, payload = request_json(server, "GET", "/health", token="secret")
+        assert status == 200
+        assert payload["ok"] is True
+        assert payload["has_state"] is True
+
+        status, payload = request_json(
+            server,
+            "GET",
+            "/command-center?limit=1",
+            token="secret",
+        )
+        assert status == 200
+        assert payload["triaged_count"] == 0
+        assert len(payload["items"]) == 1
+        assert payload["items"][0]["id"] == "security:1"
+
+        status, payload = request_json(server, "GET", "/nope", token="secret")
+        assert status == 404
+        assert payload == {"error": "Not found"}
+
+
+def test_create_agent_service_post_parsing_happens_before_route_dispatch(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "security:1",
+                "rule_id": "SKY-D999",
+                "category": "security",
+                "severity": "HIGH",
+                "message": "Shell injection path",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 9,
+                "confidence": 91,
+                "is_new_vs_baseline": True,
+                "is_new_since_last_scan": True,
+                "is_in_changed_file": True,
+            },
+        ],
+    )
+
+    with running_agent_service(project_root, token="secret") as server:
+        status, payload = request_json(
+            server,
+            "POST",
+            "/refresh",
+            token="secret",
+            raw_body='{"bad"',
+        )
+        assert status == 400
+        assert payload == {"error": "Invalid JSON body"}
+
+        status, payload = request_json(
+            server,
+            "POST",
+            "/nope",
+            token="secret",
+            raw_body='{"bad"',
+        )
+        assert status == 400
+        assert payload == {"error": "Invalid JSON body"}
+
+        status, payload = request_json(
+            server,
+            "POST",
+            "/nope",
+            token="secret",
+            body={},
+        )
+        assert status == 404
+        assert payload == {"error": "Not found"}
+
+
+def test_create_agent_service_auth_short_circuits_before_body_parsing(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "security:1",
+                "rule_id": "SKY-D999",
+                "category": "security",
+                "severity": "HIGH",
+                "message": "Shell injection path",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 9,
+                "confidence": 91,
+                "is_new_vs_baseline": True,
+                "is_new_since_last_scan": True,
+                "is_in_changed_file": True,
+            },
+        ],
+    )
+
+    with running_agent_service(project_root, token="secret") as server:
+        status, payload = request_json(
+            server,
+            "POST",
+            "/triage/dismiss",
+            token="wrong",
+            raw_body='{"bad"',
+        )
+        assert status == 401
+        assert payload == {"error": "Unauthorized"}
+
+
+def test_create_agent_service_validates_action_id_and_hours(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "security:1",
+                "rule_id": "SKY-D999",
+                "category": "security",
+                "severity": "HIGH",
+                "message": "Shell injection path",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 9,
+                "confidence": 91,
+                "is_new_vs_baseline": True,
+                "is_new_since_last_scan": True,
+                "is_in_changed_file": True,
+            },
+        ],
+    )
+
+    with running_agent_service(project_root, token="secret") as server:
+        status, payload = request_json(
+            server,
+            "POST",
+            "/triage/dismiss",
+            token="secret",
+            body={},
+        )
+        assert status == 400
+        assert payload == {"error": "action_id is required"}
+
+        status, payload = request_json(
+            server,
+            "POST",
+            "/triage/snooze",
+            token="secret",
+            body={"action_id": "security:1", "hours": "nope"},
+        )
+        assert status == 400
+        assert "could not convert string to float" in payload["error"]
+
+
+def test_create_agent_service_limit_fallback_and_clamp(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    findings = [
+        {
+            "fingerprint": f"security:{idx}",
+            "rule_id": "SKY-D999",
+            "category": "security",
+            "severity": "HIGH",
+            "message": f"Shell injection path {idx}",
+            "file": "src/auth.py",
+            "absolute_file": str(project_root / "src" / "auth.py"),
+            "line": idx,
+            "confidence": 91,
+            "is_new_vs_baseline": True,
+            "is_new_since_last_scan": True,
+            "is_in_changed_file": True,
+        }
+        for idx in range(1, 121)
+    ]
+    build_service_state(project_root, findings)
+
+    with running_agent_service(project_root, default_limit=2) as server:
+        status, payload = request_json(
+            server,
+            "GET",
+            "/command-center?limit=abc",
+        )
+        assert status == 200
+        assert len(payload["items"]) == 2
+
+        status, payload = request_json(
+            server,
+            "GET",
+            "/command-center?limit=999",
+        )
+        assert status == 200
+        assert len(payload["items"]) == 10


### PR DESCRIPTION
## Summary
  - reduce technical debt in `skylos/agent_service.py` by extracting the embedded HTTP handler logic
  - add tests to lock current service behavior
  - preserve auth, request parsing, routing, and response payload behavior

## What Changed
  - extract helper logic for:
    - refresh query parsing
    - limit query parsing
    - GET route dispatch
    - POST route dispatch
    - binding controller/token/default limit into the request handler
  - move the request handler classes out of the inline `create_agent_service` body
  - keep `AgentServiceController` behavior unchanged

## Tests
  - `uv run pytest test/test_agent_service.py -q`
  - `uv run pytest test/test_agent_service.py test/test_agent_center.py test/test_cli_refactor_guardrails.py -q`