### PR TITLE
refactor(core): reduce discover detector technical debt

### DIFF
--- a/skylos/discover/detector.py
+++ b/skylos/discover/detector.py
@@ -1049,55 +1049,73 @@ def detect_integrations(
 ) -> tuple[list[LLMIntegration], AIIntegrationGraph]:
     root = Path(path).resolve()
     if exclude_folders is None:
-        exclude_folders = {
-            "node_modules",
-            ".git",
-            "__pycache__",
-            ".venv",
-            "venv",
-            ".tox",
-            ".mypy_cache",
-            ".pytest_cache",
-            "dist",
-            "build",
-            "egg-info",
-        }
+        exclude_folders = _default_exclude_folders()
 
     integrations: list[LLMIntegration] = []
     graph = AIIntegrationGraph()
-    files_scanned = 0
 
-    py_files = _collect_python_files(root, exclude_folders)
-    for py_file in py_files:
-        files_scanned += 1
-        try:
-            source = py_file.read_text(encoding="utf-8", errors="ignore")
-            tree = ast.parse(source, filename=str(py_file))
-        except (SyntaxError, UnicodeDecodeError):
+    for py_file in _collect_python_files(root, exclude_folders):
+        scanned = _scan_python_file(root, py_file)
+        if scanned is None:
             continue
 
-        rel = str(py_file.relative_to(root))
-        visitor = _LLMDetectorVisitor(rel, source)
-        visitor.visit(tree)
-        visitor.finalize()
-
+        rel, visitor = scanned
         integrations.extend(visitor.integrations)
-
         _build_graph_from_visitor(visitor, graph, rel)
 
     return integrations, graph
 
 
+def _default_exclude_folders() -> set[str]:
+    return {
+        "node_modules",
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        "dist",
+        "build",
+        "egg-info",
+    }
+
+
+def _scan_python_file(
+    root: Path, py_file: Path
+) -> tuple[str, _LLMDetectorVisitor] | None:
+    try:
+        source = py_file.read_text(encoding="utf-8", errors="ignore")
+        tree = ast.parse(source, filename=str(py_file))
+    except (SyntaxError, UnicodeDecodeError):
+        return None
+
+    rel = str(py_file.relative_to(root))
+    visitor = _LLMDetectorVisitor(rel, source)
+    visitor.visit(tree)
+    visitor.finalize()
+    return rel, visitor
+
+
 def _collect_python_files(root: Path, exclude_folders: set[str]) -> list[Path]:
     files = []
     for py_file in root.rglob("*.py"):
-        parts = py_file.relative_to(root).parts
-        if any(part in exclude_folders for part in parts):
-            continue
-        if any(part.endswith(".egg-info") for part in parts):
+        if _should_skip_python_file(root, py_file, exclude_folders):
             continue
         files.append(py_file)
     return sorted(files)
+
+
+def _should_skip_python_file(
+    root: Path, py_file: Path, exclude_folders: set[str]
+) -> bool:
+    parts = py_file.relative_to(root).parts
+    if any(part in exclude_folders for part in parts):
+        return True
+    if any(part.endswith(".egg-info") for part in parts):
+        return True
+    return False
 
 
 def _build_graph_from_visitor(
@@ -1106,115 +1124,153 @@ def _build_graph_from_visitor(
     filepath: str,
 ) -> None:
     for integration in visitor.integrations:
-        call_id = f"call:{integration.location}"
+        call_id = _add_call_node(graph, integration)
+        _add_input_source_nodes(graph, filepath, integration, call_id)
+        _add_prompt_site_nodes(graph, integration, call_id)
+        _add_output_sink_nodes(graph, filepath, integration, call_id)
+        _add_tool_nodes(graph, integration, call_id)
+        _add_validation_node(graph, integration, call_id)
+
+
+def _add_call_node(graph: AIIntegrationGraph, integration: LLMIntegration) -> str:
+    call_id = f"call:{integration.location}"
+    graph.add_node(
+        GraphNode(
+            id=call_id,
+            node_type=NodeType.LLM_CALL,
+            location=integration.location,
+            label=f"{integration.provider} {integration.integration_type}",
+            metadata={
+                "provider": integration.provider,
+                "type": integration.integration_type,
+            },
+        )
+    )
+    return call_id
+
+
+def _add_input_source_nodes(
+    graph: AIIntegrationGraph,
+    filepath: str,
+    integration: LLMIntegration,
+    call_id: str,
+) -> None:
+    for src in integration.input_sources:
+        src_id = f"input:{filepath}:{src}"
         graph.add_node(
             GraphNode(
-                id=call_id,
-                node_type=NodeType.LLM_CALL,
-                location=integration.location,
-                label=f"{integration.provider} {integration.integration_type}",
-                metadata={
-                    "provider": integration.provider,
-                    "type": integration.integration_type,
-                },
+                id=src_id,
+                node_type=NodeType.INPUT_SOURCE,
+                location=f"{filepath}:{src}",
+                label=src,
+            )
+        )
+        graph.add_edge(
+            GraphEdge(
+                source_id=src_id,
+                target_id=call_id,
+                edge_type="data_flow",
+                label="user input → LLM call",
             )
         )
 
-        for src in integration.input_sources:
-            src_id = f"input:{filepath}:{src}"
-            graph.add_node(
-                GraphNode(
-                    id=src_id,
-                    node_type=NodeType.INPUT_SOURCE,
-                    location=f"{filepath}:{src}",
-                    label=src,
-                )
-            )
-            graph.add_edge(
-                GraphEdge(
-                    source_id=src_id,
-                    target_id=call_id,
-                    edge_type="data_flow",
-                    label="user input → LLM call",
-                )
-            )
 
-        for prompt in integration.prompt_sites:
-            prompt_id = f"prompt:{prompt}"
-            graph.add_node(
-                GraphNode(
-                    id=prompt_id,
-                    node_type=NodeType.PROMPT_SITE,
-                    location=prompt,
-                    label="prompt construction",
-                )
+def _add_prompt_site_nodes(
+    graph: AIIntegrationGraph, integration: LLMIntegration, call_id: str
+) -> None:
+    for prompt in integration.prompt_sites:
+        prompt_id = f"prompt:{prompt}"
+        graph.add_node(
+            GraphNode(
+                id=prompt_id,
+                node_type=NodeType.PROMPT_SITE,
+                location=prompt,
+                label="prompt construction",
             )
-            graph.add_edge(
-                GraphEdge(
-                    source_id=prompt_id,
-                    target_id=call_id,
-                    edge_type="data_flow",
-                    label="prompt → LLM call",
-                )
+        )
+        graph.add_edge(
+            GraphEdge(
+                source_id=prompt_id,
+                target_id=call_id,
+                edge_type="data_flow",
+                label="prompt → LLM call",
             )
+        )
 
-        for sink in integration.output_sinks:
-            sink_id = f"sink:{filepath}:{sink}"
-            graph.add_node(
-                GraphNode(
-                    id=sink_id,
-                    node_type=NodeType.OUTPUT_SINK,
-                    location=f"{filepath}:{sink}",
-                    label=sink,
-                )
-            )
-            graph.add_edge(
-                GraphEdge(
-                    source_id=call_id,
-                    target_id=sink_id,
-                    edge_type="data_flow",
-                    label="LLM output → dangerous sink",
-                )
-            )
 
-        for tool in integration.tools:
-            tool_id = f"tool:{tool.location}"
-            graph.add_node(
-                GraphNode(
-                    id=tool_id,
-                    node_type=NodeType.TOOL_DEF,
-                    location=tool.location,
-                    label=f"tool: {tool.name}",
-                    metadata={
-                        "has_typed_schema": tool.has_typed_schema,
-                        "dangerous_calls": tool.dangerous_calls,
-                    },
-                )
+def _add_output_sink_nodes(
+    graph: AIIntegrationGraph,
+    filepath: str,
+    integration: LLMIntegration,
+    call_id: str,
+) -> None:
+    for sink in integration.output_sinks:
+        sink_id = f"sink:{filepath}:{sink}"
+        graph.add_node(
+            GraphNode(
+                id=sink_id,
+                node_type=NodeType.OUTPUT_SINK,
+                location=f"{filepath}:{sink}",
+                label=sink,
             )
-            graph.add_edge(
-                GraphEdge(
-                    source_id=call_id,
-                    target_id=tool_id,
-                    edge_type="tool_call",
-                    label=f"LLM → tool {tool.name}",
-                )
+        )
+        graph.add_edge(
+            GraphEdge(
+                source_id=call_id,
+                target_id=sink_id,
+                edge_type="data_flow",
+                label="LLM output → dangerous sink",
             )
+        )
 
-        if integration.has_output_validation:
-            val_id = f"validation:{integration.output_validation_location}"
-            graph.add_node(
-                GraphNode(
-                    id=val_id,
-                    node_type=NodeType.VALIDATION,
-                    location=integration.output_validation_location,
-                    label="output validation",
-                )
+
+def _add_tool_nodes(
+    graph: AIIntegrationGraph, integration: LLMIntegration, call_id: str
+) -> None:
+    for tool in integration.tools:
+        tool_id = f"tool:{tool.location}"
+        graph.add_node(
+            GraphNode(
+                id=tool_id,
+                node_type=NodeType.TOOL_DEF,
+                location=tool.location,
+                label=f"tool: {tool.name}",
+                metadata={
+                    "has_typed_schema": tool.has_typed_schema,
+                    "dangerous_calls": tool.dangerous_calls,
+                },
             )
-            graph.add_edge(
-                GraphEdge(
-                    source_id=call_id,
-                    target_id=val_id,
-                    edge_type="data_flow",
-                    label="LLM output → validation",
-                )
+        )
+        graph.add_edge(
+            GraphEdge(
+                source_id=call_id,
+                target_id=tool_id,
+                edge_type="tool_call",
+                label=f"LLM → tool {tool.name}",
             )
+        )
+
+
+def _add_validation_node(
+    graph: AIIntegrationGraph, integration: LLMIntegration, call_id: str
+) -> None:
+    if not integration.has_output_validation:
+        return
+
+    val_id = f"validation:{integration.output_validation_location}"
+    graph.add_node(
+        GraphNode(
+            id=val_id,
+            node_type=NodeType.VALIDATION,
+            location=integration.output_validation_location,
+            label="output validation",
+        )
+    )
+    graph.add_edge(
+        GraphEdge(
+            source_id=call_id,
+            target_id=val_id,
+            edge_type="data_flow",
+            label="LLM output → validation",
+        )
+    )

--- a/test/test_discover.py
+++ b/test/test_discover.py
@@ -3,10 +3,16 @@
 import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from skylos.discover.detector import detect_integrations, _LLMDetectorVisitor
+from skylos.discover.detector import (
+    _LLMDetectorVisitor,
+    _build_graph_from_visitor,
+    _collect_python_files,
+    detect_integrations,
+)
 from skylos.discover.integration import LLMIntegration, ToolDef
 from skylos.discover.graph import AIIntegrationGraph, GraphNode, GraphEdge, NodeType
 from skylos.discover.report import format_table, format_json
@@ -318,6 +324,194 @@ class TestIntegrationGraph:
         graph.add_edge(GraphEdge("b", "c", "data_flow"))
         assert graph.has_path("a", "c")
         assert not graph.has_path("c", "a")
+
+
+class TestDetectorOuterFlow:
+    def test_collect_python_files_sorts_and_skips_excluded_and_egg_info(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "pkg").mkdir()
+            (root / "venv").mkdir()
+            (root / "dist").mkdir()
+            (root / "demo.egg-info").mkdir()
+            (root / "b.py").write_text("pass\n", encoding="utf-8")
+            (root / "a.py").write_text("pass\n", encoding="utf-8")
+            (root / "pkg" / "c.py").write_text("pass\n", encoding="utf-8")
+            (root / "venv" / "skip.py").write_text("pass\n", encoding="utf-8")
+            (root / "dist" / "skip.py").write_text("pass\n", encoding="utf-8")
+            (root / "demo.egg-info" / "skip.py").write_text("pass\n", encoding="utf-8")
+
+            files = [
+                str(path.relative_to(root))
+                for path in _collect_python_files(root, {"venv", "dist"})
+            ]
+
+        assert files == ["a.py", "b.py", "pkg/c.py"]
+
+    def test_detect_integrations_skips_broken_files_and_keeps_relative_paths(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "pkg").mkdir()
+            (root / "a_broken.py").write_text("def broken(:\n", encoding="utf-8")
+            (root / "pkg" / "app.py").write_text(
+                """
+import openai
+
+client = openai.OpenAI()
+
+def chat(user_msg):
+    return client.chat.completions.create(
+        model="gpt-4o-2024-08-06",
+        messages=[{"role": "user", "content": user_msg}],
+    )
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            integrations, graph = detect_integrations(root, exclude_folders=set())
+
+        assert [integration.location for integration in integrations] == [
+            "pkg/app.py:6"
+        ]
+        assert [node["id"] for node in graph.to_dict()["nodes"]] == [
+            "call:pkg/app.py:6"
+        ]
+
+    def test_detect_integrations_skips_unicode_decode_errors(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            bad_file = root / "bad.py"
+            good_file = root / "good.py"
+            bad_file.write_text("import openai\n", encoding="utf-8")
+            good_file.write_text(
+                """
+import openai
+
+client = openai.OpenAI()
+
+def chat(msg):
+    return client.chat.completions.create(
+        model="gpt-4o-2024-08-06",
+        messages=[{"role": "user", "content": msg}],
+    )
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            original_read_text = Path.read_text
+
+            def flaky_read_text(self, *args, **kwargs):
+                if self == bad_file:
+                    raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "boom")
+                return original_read_text(self, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "read_text", flaky_read_text)
+            integrations, _ = detect_integrations(root, exclude_folders=set())
+
+        assert [integration.location for integration in integrations] == ["good.py:6"]
+
+
+class TestGraphBuilderContract:
+    def test_build_graph_from_visitor_emits_stable_ids_labels_and_order(self):
+        integration = LLMIntegration(
+            provider="OpenAI",
+            location="pkg/app.py:42",
+            integration_type="agent",
+            prompt_sites=["pkg/app.py:10", "pkg/app.py:11"],
+            tools=[
+                ToolDef(
+                    name="search",
+                    location="pkg/tools.py:5",
+                    has_typed_schema=True,
+                    dangerous_calls=["subprocess.run"],
+                )
+            ],
+            input_sources=["request.json (L8)"],
+            output_sinks=["eval (L50)"],
+            has_system_prompt=True,
+            model_pinned=True,
+            model_value="gpt-4o-2024-08-06",
+            has_output_validation=True,
+            output_validation_location="pkg/app.py:70",
+        )
+        graph = AIIntegrationGraph()
+
+        _build_graph_from_visitor(
+            SimpleNamespace(integrations=[integration]), graph, "pkg/app.py"
+        )
+
+        assert list(graph.nodes) == [
+            "call:pkg/app.py:42",
+            "input:pkg/app.py:request.json (L8)",
+            "prompt:pkg/app.py:10",
+            "prompt:pkg/app.py:11",
+            "sink:pkg/app.py:eval (L50)",
+            "tool:pkg/tools.py:5",
+            "validation:pkg/app.py:70",
+        ]
+        assert [edge.to_dict() for edge in graph.edges] == [
+            {
+                "source": "input:pkg/app.py:request.json (L8)",
+                "target": "call:pkg/app.py:42",
+                "type": "data_flow",
+                "label": "user input → LLM call",
+            },
+            {
+                "source": "prompt:pkg/app.py:10",
+                "target": "call:pkg/app.py:42",
+                "type": "data_flow",
+                "label": "prompt → LLM call",
+            },
+            {
+                "source": "prompt:pkg/app.py:11",
+                "target": "call:pkg/app.py:42",
+                "type": "data_flow",
+                "label": "prompt → LLM call",
+            },
+            {
+                "source": "call:pkg/app.py:42",
+                "target": "sink:pkg/app.py:eval (L50)",
+                "type": "data_flow",
+                "label": "LLM output → dangerous sink",
+            },
+            {
+                "source": "call:pkg/app.py:42",
+                "target": "tool:pkg/tools.py:5",
+                "type": "tool_call",
+                "label": "LLM → tool search",
+            },
+            {
+                "source": "call:pkg/app.py:42",
+                "target": "validation:pkg/app.py:70",
+                "type": "data_flow",
+                "label": "LLM output → validation",
+            },
+        ]
+
+    def test_build_graph_from_visitor_deduplicates_duplicate_prompt_edges(self):
+        integration = LLMIntegration(
+            provider="OpenAI",
+            location="pkg/app.py:42",
+            integration_type="chat",
+            prompt_sites=["pkg/app.py:10", "pkg/app.py:10"],
+        )
+        graph = AIIntegrationGraph()
+
+        _build_graph_from_visitor(
+            SimpleNamespace(integrations=[integration]), graph, "pkg/app.py"
+        )
+
+        assert list(graph.nodes) == ["call:pkg/app.py:42", "prompt:pkg/app.py:10"]
+        assert [edge.to_dict() for edge in graph.edges] == [
+            {
+                "source": "prompt:pkg/app.py:10",
+                "target": "call:pkg/app.py:42",
+                "type": "data_flow",
+                "label": "prompt → LLM call",
+            }
+        ]
 
 
 class TestModelPinning:


### PR DESCRIPTION
## Summary
  - reduce technical debt in `skylos/discover/detector.py` with outer-flow helper extractions
  - add tests to lock file collection, skip behavior, and graph emission contracts
  - preserve integration detection and graph output behavior

  ## What Changed
  - extract default exclude-folder construction and per-file scan/parse/visit/finalize flow from `detect_integrations()`
  - extract file-skip logic from `_collect_python_files()`
  - split `_build_graph_from_visitor()` into literal type-specific helpers for:
    - LLM call node emission
    - input source node emission
    - prompt site node emission
    - output sink node emission
    - tool node emission
    - validation node emission
  - left AST-heavy detector logic unchanged:
    - `_detect_llm_call()`
    - `finalize()`
    - `_detect_framework_call()`
    - related call-analysis helpers

  ## Tests
  - `uv run pytest test/test_discover.py`
  - `uv run pytest test/test_discover.py test/test_defend.py test/test_provenance.py test/test_provenance_risk.py test/test_cli_refactor_guardrails.py`