### PR TITLE
refactor(core): reduce grep verify debt

### DIFF
--- a/skylos/grep_verify.py
+++ b/skylos/grep_verify.py
@@ -782,11 +782,11 @@ def parallel_multi_strategy_search(
     max_workers: int = _DEFAULT_GREP_WORKERS,
     cache: Any = None,
 ) -> dict[str, list[str]]:
-    simple_name = finding.get("simple_name", finding.get("name", ""))
+    simple_name = _finding_simple_name(finding)
     if not simple_name or len(simple_name) <= 1:
         return {}
 
-    lang = detect_language(finding.get("file", ""))
+    lang = _finding_language(finding)
     results: dict[str, list[str]] = {}
     results_lock = threading.Lock()
     early_exit_event = threading.Event()
@@ -816,73 +816,14 @@ def parallel_multi_strategy_search(
         if _check_early_exit():
             early_exit_event.set()
 
-    tasks: list[tuple[Callable, tuple]] = []
-
-    if lang == "python":
-        tasks.append(
-            (
-                lambda: multi_strategy_search(
-                    finding,
-                    project_root,
-                    max_per_strategy=max_per_strategy,
-                    early_exit_threshold=early_exit_threshold,
-                ),
-                "python_core",
-            )
-        )
-    else:
-
-        def _general_refs() -> dict[str, list[str]]:
-            r: dict[str, list[str]] = {}
-            boundary = rf"\b{re.escape(simple_name)}\b"
-            refs = _run_grep(
-                boundary,
-                project_root,
-                use_regex=True,
-                include_globs=_ALL_SOURCE_GLOBS,
-                max_results=max_per_strategy * 2,
-            )
-            if refs:
-                refs = [ref for ref in refs if not is_substring_match(ref, simple_name)]
-                _defs, usages = filter_grep_results(refs, finding)
-                if usages:
-                    r["references"] = usages[:max_per_strategy]
-                elif _defs:
-                    r["references_definition_only"] = [
-                        "(only the definition itself found, no usages)"
-                    ]
-            return r
-
-        tasks.append((_general_refs, "general_refs"))
-
-    if lang == "typescript":
-        tasks.append(
-            (
-                lambda: _run_ts_strategies(finding, project_root, max_per_strategy),
-                "typescript",
-            )
-        )
-    elif lang == "go":
-        tasks.append(
-            (
-                lambda: _run_go_strategies(finding, project_root, max_per_strategy),
-                "go",
-            )
-        )
-    elif lang == "java":
-        tasks.append(
-            (
-                lambda: _run_java_strategies(finding, project_root, max_per_strategy),
-                "java",
-            )
-        )
-    elif lang == "rust":
-        tasks.append(
-            (
-                lambda: _run_rust_strategies(finding, project_root, max_per_strategy),
-                "rust",
-            )
-        )
+    tasks = _build_parallel_strategy_tasks(
+        finding,
+        project_root,
+        simple_name=simple_name,
+        lang=lang,
+        max_per_strategy=max_per_strategy,
+        early_exit_threshold=early_exit_threshold,
+    )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
@@ -1297,6 +1238,114 @@ _DETERMINISTIC_RULES: list[tuple[str, str, str]] = [
 ]
 
 
+def _finding_simple_name(finding: dict) -> str:
+    return finding.get("simple_name", finding.get("name", ""))
+
+
+def _finding_full_name(finding: dict) -> str:
+    return finding.get("full_name", finding.get("name", ""))
+
+
+def _finding_language(finding: dict) -> str:
+    return detect_language(finding.get("file", ""))
+
+
+def _run_general_reference_strategies(
+    finding: dict,
+    project_root: str,
+    *,
+    simple_name: str,
+    max_per_strategy: int,
+) -> dict[str, list[str]]:
+    results: dict[str, list[str]] = {}
+    boundary = rf"\b{re.escape(simple_name)}\b"
+    refs = _run_grep(
+        boundary,
+        project_root,
+        use_regex=True,
+        include_globs=_ALL_SOURCE_GLOBS,
+        max_results=max_per_strategy * 2,
+    )
+    if refs:
+        refs = [ref for ref in refs if not is_substring_match(ref, simple_name)]
+        defs, usages = filter_grep_results(refs, finding)
+        if usages:
+            results["references"] = usages[:max_per_strategy]
+        elif defs:
+            results["references_definition_only"] = [
+                "(only the definition itself found, no usages)"
+            ]
+    return results
+
+
+def _build_parallel_strategy_tasks(
+    finding: dict,
+    project_root: str,
+    *,
+    simple_name: str,
+    lang: str,
+    max_per_strategy: int,
+    early_exit_threshold: int,
+) -> list[tuple[Callable[[], dict[str, list[str]]], str]]:
+    tasks: list[tuple[Callable[[], dict[str, list[str]]], str]] = []
+
+    if lang == "python":
+        tasks.append(
+            (
+                lambda: multi_strategy_search(
+                    finding,
+                    project_root,
+                    max_per_strategy=max_per_strategy,
+                    early_exit_threshold=early_exit_threshold,
+                ),
+                "python_core",
+            )
+        )
+    else:
+        tasks.append(
+            (
+                lambda: _run_general_reference_strategies(
+                    finding,
+                    project_root,
+                    simple_name=simple_name,
+                    max_per_strategy=max_per_strategy,
+                ),
+                "general_refs",
+            )
+        )
+
+    if lang == "typescript":
+        tasks.append(
+            (
+                lambda: _run_ts_strategies(finding, project_root, max_per_strategy),
+                "typescript",
+            )
+        )
+    elif lang == "go":
+        tasks.append(
+            (
+                lambda: _run_go_strategies(finding, project_root, max_per_strategy),
+                "go",
+            )
+        )
+    elif lang == "java":
+        tasks.append(
+            (
+                lambda: _run_java_strategies(finding, project_root, max_per_strategy),
+                "java",
+            )
+        )
+    elif lang == "rust":
+        tasks.append(
+            (
+                lambda: _run_rust_strategies(finding, project_root, max_per_strategy),
+                "rust",
+            )
+        )
+
+    return tasks
+
+
 def _apply_deterministic_rules(
     search_results: dict[str, list[str]],
     finding: dict,
@@ -1350,43 +1399,24 @@ def grep_verify_findings(
 ) -> dict[str, GrepVerdict]:
     verdicts: dict[str, GrepVerdict] = {}
     start_time = time.monotonic()
-
-    if parallel:
-
-        def search_fn(f: dict) -> dict[str, list[str]]:
-            return parallel_multi_strategy_search(
-                f, project_root, max_workers=max_workers, cache=cache
-            )
-    else:
-
-        def search_fn(f: dict) -> dict[str, list[str]]:
-            if cache is None:
-                return multi_strategy_search(f, project_root)
-
-            lang = detect_language(f.get("file", ""))
-            group_name = "python_core" if lang == "python" else f"serial_{lang}"
-            return _cached_group_results(
-                cache,
-                group_name,
-                f,
-                lambda: multi_strategy_search(f, project_root),
-            )
+    search_fn = _build_grep_search_fn(
+        project_root,
+        parallel=parallel,
+        max_workers=max_workers,
+        cache=cache,
+    )
 
     for finding in findings:
         if time.monotonic() - start_time > time_budget:
             break
 
-        full_name = finding.get("full_name", finding.get("name", ""))
+        full_name = _finding_full_name(finding)
         if not full_name:
             continue
 
-        if _deterministic_suppress_multilang(finding):
-            verdicts[full_name] = GrepVerdict(
-                alive=True,
-                suppression_code="lang_deterministic",
-                rationale=f"Language-specific deterministic suppression ({detect_language(finding.get('file', ''))})",
-                evidence=[finding.get("file", "")],
-            )
+        deterministic_verdict = _deterministic_suppression_verdict(finding)
+        if deterministic_verdict:
+            verdicts[full_name] = deterministic_verdict
             continue
 
         search_results = search_fn(finding)
@@ -1395,3 +1425,54 @@ def grep_verify_findings(
             verdicts[full_name] = verdict
 
     return verdicts
+
+
+def _build_grep_search_fn(
+    project_root: str,
+    *,
+    parallel: bool,
+    max_workers: int,
+    cache: Any,
+) -> Callable[[dict], dict[str, list[str]]]:
+    if parallel:
+
+        def search_fn(finding: dict) -> dict[str, list[str]]:
+            return parallel_multi_strategy_search(
+                finding, project_root, max_workers=max_workers, cache=cache
+            )
+
+        return search_fn
+
+    def search_fn(finding: dict) -> dict[str, list[str]]:
+        if cache is None:
+            return multi_strategy_search(finding, project_root)
+        return _cached_serial_search_results(finding, project_root, cache)
+
+    return search_fn
+
+
+def _cached_serial_search_results(
+    finding: dict, project_root: str, cache: Any
+) -> dict[str, list[str]]:
+    lang = _finding_language(finding)
+    group_name = "python_core" if lang == "python" else f"serial_{lang}"
+    return _cached_group_results(
+        cache,
+        group_name,
+        finding,
+        lambda: multi_strategy_search(finding, project_root),
+    )
+
+
+def _deterministic_suppression_verdict(finding: dict) -> GrepVerdict | None:
+    if not _deterministic_suppress_multilang(finding):
+        return None
+    return GrepVerdict(
+        alive=True,
+        suppression_code="lang_deterministic",
+        rationale=(
+            "Language-specific deterministic suppression "
+            f"({_finding_language(finding)})"
+        ),
+        evidence=[finding.get("file", "")],
+    )

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -296,6 +296,73 @@ class TestGrepVerifyFindings:
         assert "lib.helper" in first
         assert "lib.helper" in second
 
+    def test_explicit_empty_full_name_is_skipped(self, tmp_path):
+        (tmp_path / "lib.py").write_text("def helper():\n    return 42\n")
+
+        findings = [
+            {
+                "name": "helper",
+                "full_name": "",
+                "simple_name": "helper",
+                "type": "function",
+                "file": str(tmp_path / "lib.py"),
+                "line": 1,
+                "confidence": 80,
+            }
+        ]
+
+        with patch("skylos.grep_verify.multi_strategy_search") as mock_search:
+            verdicts = grep_verify_findings(findings, str(tmp_path))
+
+        assert verdicts == {}
+        mock_search.assert_not_called()
+
+    def test_deterministic_suppression_skips_search_and_cache(self, tmp_path):
+        findings = [
+            {
+                "name": "Button",
+                "full_name": "src.components.Button",
+                "simple_name": "Button",
+                "type": "import",
+                "file": str(tmp_path / "src" / "components" / "index.ts"),
+                "line": 1,
+                "confidence": 80,
+            }
+        ]
+        cache = GrepCache()
+
+        with (
+            patch("skylos.grep_verify.multi_strategy_search") as mock_search,
+            patch("skylos.grep_verify._cached_group_results") as mock_cached_group,
+        ):
+            verdicts = grep_verify_findings(findings, str(tmp_path), cache=cache)
+
+        verdict = verdicts["src.components.Button"]
+        assert verdict.alive is True
+        assert verdict.suppression_code == "lang_deterministic"
+        mock_search.assert_not_called()
+        mock_cached_group.assert_not_called()
+
+    def test_serial_cache_group_name_for_typescript(self, tmp_path):
+        finding = {
+            "name": "helper",
+            "full_name": "util.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(tmp_path / "util.ts"),
+            "line": 1,
+            "confidence": 80,
+        }
+        cache = GrepCache()
+
+        with patch(
+            "skylos.grep_verify._cached_group_results", return_value={}
+        ) as mock_cached_group:
+            grep_verify_findings([finding], str(tmp_path), cache=cache)
+
+        assert mock_cached_group.call_args.args[0] is cache
+        assert mock_cached_group.call_args.args[1] == "serial_typescript"
+
 
 class TestMethodCallWhitespace:
     def test_method_call_with_space_before_paren(self, tmp_path):
@@ -705,6 +772,51 @@ class TestParallelMultiStrategySearch:
         finding = {"simple_name": "", "type": "function", "file": "foo.py"}
         results = parallel_multi_strategy_search(finding, "/nonexistent")
         assert results == {}
+
+    def test_parallel_logs_and_ignores_strategy_group_failures(self, tmp_path):
+        finding = {
+            "name": "helper",
+            "full_name": "lib.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(tmp_path / "lib.py"),
+            "line": 1,
+        }
+
+        with (
+            patch(
+                "skylos.grep_verify._cached_group_results",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("skylos.grep_verify.logger.debug") as mock_debug,
+        ):
+            results = parallel_multi_strategy_search(
+                finding, str(tmp_path), max_workers=2
+            )
+
+        assert results == {}
+        mock_debug.assert_called()
+
+    def test_parallel_cache_group_names_for_typescript(self, tmp_path):
+        finding = {
+            "name": "helper",
+            "full_name": "util.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(tmp_path / "util.ts"),
+            "line": 1,
+        }
+        cache = GrepCache()
+
+        with patch(
+            "skylos.grep_verify._cached_group_results", return_value={}
+        ) as mock_cached_group:
+            parallel_multi_strategy_search(
+                finding, str(tmp_path), max_workers=2, cache=cache
+            )
+
+        group_names = {call.args[1] for call in mock_cached_group.call_args_list}
+        assert group_names == {"general_refs", "typescript"}
 
 
 class TestGrepVerifyParallel:


### PR DESCRIPTION
## Summary
  - reduce technical debt in `skylos/grep_verify.py` with wrapper/helper extractions
  - add tests to lock grep-verify wrapper behavior
  - preserve search dispatch, deterministic suppression, cache group naming, and parallel failure handling

  ## What Changed
  - extract shared helper logic for:
    - finding simple-name, full name and language lookup
    - non-Python general reference search in `parallel_multi_strategy_search()`
    - parallel strategy task assembly
    - serial vs parallel grep search dispatch in `grep_verify_findings()`
    - cached serial search execution
    - deterministic suppression verdict construction
  - leave `multi_strategy_search()` unchanged in this phase
  - keep `_apply_deterministic_rules()` order unchanged
 

## Tests
  - `uv run pytest test/test_grep_verify.py test/test_analyzer.py -k 'grep_verify or _grep_verify'`
  - `uv run pytest test/test_grep_verify.py test/test_analyzer.py`