### PR TITLE
refactor(core): reduce sync debt

### DIFF
--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -236,6 +236,44 @@ def api_get(endpoint, token):
     return resp.json()
 
 
+def _extract_project_context(info):
+    project = info.get("project", {})
+    org = info.get("organization", {})
+    plan = info.get("plan", "free")
+    project_id = project.get("id") or project.get("project_id")
+    return {
+        "project": project,
+        "org": org,
+        "plan": plan,
+        "project_id": project_id,
+    }
+
+
+def _verify_project_context(token):
+    info = api_get("/api/sync/whoami", token)
+    return _extract_project_context(info)
+
+
+def _save_repo_link_and_token(repo_root, token, context):
+    link_path = _write_link(
+        repo_root,
+        context["project_id"],
+        project_name=context["project"].get("name"),
+        org_name=context["org"].get("name"),
+        plan=context["plan"],
+        base_url=get_api_url(),
+    )
+
+    creds_path = save_token(
+        token,
+        project_id=context["project_id"],
+        project_name=context["project"].get("name"),
+        org_name=context["org"].get("name"),
+        plan=context["plan"],
+    )
+    return link_path, creds_path
+
+
 def cmd_connect(token_arg=None):
     print("\n Connect to Skylos Cloud\n")
 
@@ -274,43 +312,28 @@ def cmd_connect(token_arg=None):
     print(f"Verifying token {mask_token(token)}...")
 
     try:
-        info = api_get("/api/sync/whoami", token)
+        context = _verify_project_context(token)
     except AuthError as e:
         print(f"\n✗ {e}")
         sys.exit(1)
 
-    project = info.get("project", {})
-    org = info.get("organization", {})
-    plan = info.get("plan", "free")
+    project = context["project"]
+    org = context["org"]
+    plan = context["plan"]
 
     print(f"\n✓ Connected!\n")
     print(f"  Project:      {project.get('name', 'Unknown')}")
     print(f"  Organization: {org.get('name', 'Unknown')}")
     print(f"  Plan:         {plan.capitalize()}")
 
-    project_id = project.get("id") or project.get("project_id")
+    project_id = context["project_id"]
     if not project_id:
         print("\n✗ Server did not return project id (expected project.id).")
         sys.exit(1)
 
     repo_root = _find_repo_root()
 
-    link_path = _write_link(
-        repo_root,
-        project_id,
-        project_name=project.get("name"),
-        org_name=org.get("name"),
-        plan=plan,
-        base_url=get_api_url(),
-    )
-
-    creds_path = save_token(
-        token,
-        project_id=project_id,
-        project_name=project.get("name"),
-        org_name=org.get("name"),
-        plan=plan,
-    )
+    link_path, creds_path = _save_repo_link_and_token(repo_root, token, context)
 
     print(f"\nLinked repo: {repo_root}")
     print(f"Link file:   {link_path}")
@@ -490,19 +513,11 @@ def cmd_pull():
     try:
         print("Pulling configuration...")
         config_data = api_get("/api/sync/config", token)
-
-        config_path = skylos_dir / CONFIG_FILE
-        with config_path.open("w") as f:
-            yaml.dump(config_data.get("config", {}), f, default_flow_style=False)
-        print(f"  ✓ {config_path}")
+        _write_sync_config(skylos_dir, config_data)
 
         print("Pulling suppressions...")
         supp_data = api_get("/api/sync/suppressions", token)
-
-        supp_path = skylos_dir / SUPPRESSIONS_FILE
-        with supp_path.open("w") as f:
-            json.dump(supp_data.get("suppressions", []), f, indent=2)
-        print(f"  ✓ {supp_path} ({supp_data.get('count', 0)} suppressions)")
+        _write_sync_suppressions(skylos_dir, supp_data)
 
         print("\n✓ Sync complete!")
 
@@ -536,6 +551,20 @@ repos:
     precommit_path.write_text(config_content)
     print("  ✓ Created .pre-commit-config.yaml")
     return True
+
+
+def _write_sync_config(skylos_dir: Path, config_data):
+    config_path = skylos_dir / CONFIG_FILE
+    with config_path.open("w") as f:
+        yaml.dump(config_data.get("config", {}), f, default_flow_style=False)
+    print(f"  ✓ {config_path}")
+
+
+def _write_sync_suppressions(skylos_dir: Path, supp_data):
+    supp_path = skylos_dir / SUPPRESSIONS_FILE
+    with supp_path.open("w") as f:
+        json.dump(supp_data.get("suppressions", []), f, indent=2)
+    print(f"  ✓ {supp_path} ({supp_data.get('count', 0)} suppressions)")
 
 
 def _build_pre_push_hook() -> str:
@@ -575,38 +604,23 @@ def cmd_setup(token_arg=None):
 
     print(f"\nConnecting...")
     try:
-        info = api_get("/api/sync/whoami", token)
+        context = _verify_project_context(token)
     except AuthError as e:
         print(f"\n✗ {e}")
         return
 
-    project = info.get("project", {})
-    org = info.get("organization", {})
-    plan = info.get("plan", "free")
+    project = context["project"]
+    org = context["org"]
+    plan = context["plan"]
 
-    project_id = project.get("id") or project.get("project_id")
+    project_id = context["project_id"]
     if not project_id:
         print("\n✗ Server did not return project id (expected project.id).")
         return
 
     repo_root = _find_repo_root()
 
-    _write_link(
-        repo_root,
-        project_id,
-        project_name=project.get("name"),
-        org_name=org.get("name"),
-        plan=plan,
-        base_url=get_api_url(),
-    )
-
-    save_token(
-        token,
-        project_id=project_id,
-        project_name=project.get("name"),
-        org_name=org.get("name"),
-        plan=plan,
-    )
+    _save_repo_link_and_token(repo_root, token, context)
 
     print(f"✓ Connected!\n")
     print(f"  Project: {project.get('name', 'Unknown')}")
@@ -804,8 +818,7 @@ def cmd_upgrade():
 
     print("Checking plan...")
     try:
-        info = api_get("/api/sync/whoami", token)
-        plan = info.get("plan", "free")
+        plan = _verify_project_context(token)["plan"]
     except AuthError as e:
         print(f"✗ {e}")
         return
@@ -889,22 +902,19 @@ def main(args=None):
         return
 
     cmd = args[0].lower()
-
-    if cmd == "connect":
-        cmd_connect(args[1] if len(args) > 1 else None)
-    elif cmd == "status":
-        cmd_status()
-    elif cmd == "disconnect":
-        cmd_disconnect()
-    elif cmd == "pull":
-        cmd_pull()
-    elif cmd == "setup":
-        cmd_setup(args[1] if len(args) > 1 else None)
-    elif cmd == "upgrade":
-        cmd_upgrade()
-    else:
+    handlers = {
+        "connect": lambda: cmd_connect(args[1] if len(args) > 1 else None),
+        "status": cmd_status,
+        "disconnect": cmd_disconnect,
+        "pull": cmd_pull,
+        "setup": lambda: cmd_setup(args[1] if len(args) > 1 else None),
+        "upgrade": cmd_upgrade,
+    }
+    handler = handlers.get(cmd)
+    if handler is None:
         print(f"Unknown command: {cmd}")
         sys.exit(1)
+    handler()
 
 
 def project_main(args=None):
@@ -923,20 +933,18 @@ def project_main(args=None):
         return
 
     cmd = args[0].lower()
-
-    if cmd == "status":
-        cmd_project_status()
-    elif cmd == "list":
-        cmd_project_list()
-    elif cmd == "use":
-        cmd_project_use()
-    elif cmd == "create":
-        cmd_project_create()
-    elif cmd == "unlink":
-        cmd_project_unlink()
-    else:
+    handlers = {
+        "status": cmd_project_status,
+        "list": cmd_project_list,
+        "use": cmd_project_use,
+        "create": cmd_project_create,
+        "unlink": cmd_project_unlink,
+    }
+    handler = handlers.get(cmd)
+    if handler is None:
         print(f"Unknown command: {cmd}")
         sys.exit(1)
+    handler()
 
 
 def get_custom_rules():

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -304,6 +304,49 @@ def test_cmd_connect_cancel_input(monkeypatch):
     assert e.value.code == 1
 
 
+def test_cmd_connect_declines_env_token_then_cancels(monkeypatch, capsys):
+    monkeypatch.setenv("SKYLOS_TOKEN", "ENV_TOKEN")
+
+    answers = iter(["n"])
+
+    def fake_input(_prompt=""):
+        try:
+            return next(answers)
+        except StopIteration:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    with pytest.raises(SystemExit) as e:
+        syncmod.cmd_connect(None)
+
+    assert e.value.code == 1
+    out = capsys.readouterr().out
+    assert "SKYLOS_TOKEN environment variable is set" in out
+    assert "Cancelled." in out
+
+
+def test_cmd_connect_accepts_project_project_id(isolated_creds, monkeypatch, capsys):
+    def fake_api_get(endpoint, token):
+        assert endpoint == "/api/sync/whoami"
+        assert token == "TOK_ARG"
+        return {
+            "project": {"project_id": "proj_legacy", "name": "Proj"},
+            "organization": {"name": "Org"},
+            "plan": "pro",
+        }
+
+    monkeypatch.setattr(syncmod, "api_get", fake_api_get)
+
+    syncmod.cmd_connect("TOK_ARG")
+    out = capsys.readouterr().out
+
+    assert "✓ Connected!" in out
+    _, creds_file = isolated_creds
+    data = json.loads(creds_file.read_text())
+    assert data["tokens"]["proj_legacy"]["project_name"] == "Proj"
+
+
 def test_cmd_pull_not_connected_exits(isolated_creds, capsys):
     with pytest.raises(SystemExit) as e:
         syncmod.cmd_pull()
@@ -356,6 +399,36 @@ def test_cmd_pull_writes_config_and_suppressions(
     assert supp[0]["rule_id"] == "SKY-D212"
 
 
+def test_cmd_pull_calls_endpoints_in_order(isolated_creds, monkeypatch, tmp_path):
+    _, creds_file = isolated_creds
+    creds_file.parent.mkdir(parents=True, exist_ok=True)
+    creds_file.write_text(json.dumps({"token": "TOK"}))
+
+    monkeypatch.setattr(syncmod, "SKYLOS_DIR", str(tmp_path / ".skylos"), raising=False)
+
+    calls = []
+
+    def fake_api_get(endpoint, token):
+        calls.append(endpoint)
+        if endpoint == "/api/sync/whoami":
+            return {"project": {"name": "Proj"}}
+        if endpoint == "/api/sync/config":
+            return {"config": {"complexity": 12}}
+        if endpoint == "/api/sync/suppressions":
+            return {"suppressions": [], "count": 0}
+        raise AssertionError(f"Unexpected endpoint {endpoint}")
+
+    monkeypatch.setattr(syncmod, "api_get", fake_api_get)
+
+    syncmod.cmd_pull()
+
+    assert calls == [
+        "/api/sync/whoami",
+        "/api/sync/config",
+        "/api/sync/suppressions",
+    ]
+
+
 def test_main_usage_no_args(capsys):
     syncmod.main([])
     out = capsys.readouterr().out
@@ -367,6 +440,14 @@ def test_main_usage_no_args(capsys):
 def test_main_unknown_command_exits(capsys):
     with pytest.raises(SystemExit) as e:
         syncmod.main(["wat"])
+    assert e.value.code == 1
+    out = capsys.readouterr().out
+    assert "Unknown command" in out
+
+
+def test_project_main_unknown_command_exits(capsys):
+    with pytest.raises(SystemExit) as e:
+        syncmod.project_main(["wat"])
     assert e.value.code == 1
     out = capsys.readouterr().out
     assert "Unknown command" in out
@@ -423,6 +504,37 @@ def test_cmd_setup_installs_parity_only_pre_push_hook(monkeypatch, tmp_path, cap
     assert "skylos ." not in hook
     assert "Rust/Python parity check" in hook
     assert "test/test_fast_parity.py" in hook
+
+
+def test_cmd_setup_accepts_project_project_id(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    monkeypatch.setattr(
+        syncmod,
+        "api_get",
+        lambda endpoint, token: {
+            "/api/sync/whoami": {
+                "project": {"project_id": "proj_legacy", "name": "Proj"},
+                "organization": {"name": "Org"},
+                "plan": "free",
+            }
+        }[endpoint],
+    )
+    monkeypatch.setattr(syncmod, "_write_link", lambda *args, **kwargs: None)
+    saved = {}
+
+    def fake_save_token(token, **kwargs):
+        saved.update(kwargs)
+        return str(tmp_path / "creds.json")
+
+    monkeypatch.setattr(syncmod, "save_token", fake_save_token)
+    answers = iter(["n", "n", "n"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+
+    syncmod.cmd_setup("TOK")
+
+    assert saved["project_id"] == "proj_legacy"
 
 
 def test_cmd_upgrade_installs_parity_only_pre_push_hook(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
  - reduce technical debt in `skylos/sync.py` with helper extractions
  - add tests to lock sync command behavior
  - preserve CLI output, exit behavior, pull sequencing, and setup/upgrade side effects

  ## What Changed
  - extract shared data-only helpers for:
    - project/org/plan/project_id extraction from `/api/sync/whoami`
    - repo link + token save sequence used by `cmd_connect()` and `cmd_setup()`
  - extract tiny literal write helpers for:
    - config sync output in `cmd_pull()`
    - suppressions sync output in `cmd_pull()`
  - convert `main()` and `project_main()` to dispatcher tables while preserving:
    - usage output on no args
    - `.lower()` normalization
    - argument passing for `connect` and `setup`
    - `sys.exit(1)` on unknown commands
  - leave `api_get()` request/error semantics unchanged
  - keep connect/setup/upgrade control-flow differences unchanged

  ### Tests
  - `uv run pytest test/test_sync.py`
  - `uv run pytest test/test_sync.py test/test_api.py test/test_cli_refactor_guardrails.py -q -k 'sync or get_custom_rules'`