### PR TITLE
refactor(core): reduce api debt without changing behavior

### DIFF
--- a/skylos/api.py
+++ b/skylos/api.py
@@ -851,66 +851,34 @@ def _prepare_report_upload(
         git_root,
         extract_metadata=True,
     )
-
-    blame_map = _get_blame_map(all_findings, git_root)
-    for f in all_findings:
-        email = blame_map.get((f["file_path"], f.get("line_number", 0)))
-        if email:
-            meta = f.get("metadata") or {}
-            meta["blame_email"] = email
-            f["metadata"] = meta
+    _annotate_findings_with_blame(all_findings, git_root)
 
     exporter = SarifExporter(all_findings, tool_name="Skylos")
     core_payload = exporter.generate()
 
     ai_code = detect_ai_code(git_root)
-
-    provenance_data = None
-    try:
-        from skylos.provenance import analyze_provenance
-
-        prov_report = analyze_provenance(git_root)
-        if prov_report.agent_files:
-            provenance_data = prov_report.to_dict()
-    except (ImportError, subprocess.SubprocessError, OSError):
-        logger.debug("Provenance detection failed", exc_info=True)
+    provenance_data = _detect_report_provenance_data(git_root)
 
     definitions = result_json.get("definitions")
-    metadata = {
-        "commit_hash": commit,
-        "branch": branch,
-        "actor": actor,
-        "is_forced": bool(is_forced),
-        "ci": ci,
-        "analysis_mode": analysis_mode,
-        "ai_code": ai_code if ai_code.get("detected") else None,
-        "provenance": provenance_data,
-    }
-    core_payload.update(metadata)
-
     grade_data = result_json.get("grade") if isinstance(result_json, dict) else None
-    if grade_data:
-        core_payload["grade"] = grade_data
-        metadata["grade"] = grade_data
-
     link = _load_repo_link(git_root)
-    if link.get("project_id"):
-        core_payload["project_id"] = link["project_id"]
-        metadata["project_id"] = link["project_id"]
+    project_id = link.get("project_id")
 
-    legacy_payload = dict(core_payload)
-    legacy_payload["definitions"] = definitions
-
-    runs = core_payload.get("runs") or []
-    scan_summary = {
-        "finding_count": len(all_findings),
-        "sarif_result_count": sum(len(run.get("results") or []) for run in runs),
-        "sarif_rule_count": sum(
-            len((run.get("tool") or {}).get("driver", {}).get("rules") or [])
-            for run in runs
-        ),
-        "definitions_count": len(definitions or {}),
-    }
+    metadata = _build_report_metadata(
+        commit_hash=commit,
+        branch=branch,
+        actor=actor,
+        is_forced=is_forced,
+        ci=ci,
+        analysis_mode=analysis_mode,
+        ai_code=ai_code,
+        provenance_data=provenance_data,
+        grade_data=grade_data,
+        project_id=project_id,
+    )
+    core_payload.update(metadata)
+    legacy_payload = _build_legacy_payload(core_payload, definitions)
+    scan_summary = _build_report_scan_summary(all_findings, core_payload, definitions)
 
     return PreparedReportUpload(
         legacy_payload=legacy_payload,
@@ -921,6 +889,80 @@ def _prepare_report_upload(
         grade_data=grade_data,
         legacy_payload_size_bytes=_json_size_bytes(legacy_payload),
     )
+
+
+def _annotate_findings_with_blame(all_findings: list[dict], git_root) -> None:
+    blame_map = _get_blame_map(all_findings, git_root)
+    for finding in all_findings:
+        email = blame_map.get((finding["file_path"], finding.get("line_number", 0)))
+        if email:
+            metadata = finding.get("metadata") or {}
+            metadata["blame_email"] = email
+            finding["metadata"] = metadata
+
+
+def _detect_report_provenance_data(git_root):
+    provenance_data = None
+    try:
+        from skylos.provenance import analyze_provenance
+
+        prov_report = analyze_provenance(git_root)
+        if prov_report.agent_files:
+            provenance_data = prov_report.to_dict()
+    except (ImportError, subprocess.SubprocessError, OSError):
+        logger.debug("Provenance detection failed", exc_info=True)
+    return provenance_data
+
+
+def _build_report_metadata(
+    *,
+    commit_hash,
+    branch,
+    actor,
+    is_forced=False,
+    ci=None,
+    analysis_mode="static",
+    ai_code=None,
+    provenance_data=None,
+    grade_data=None,
+    project_id=None,
+) -> dict[str, Any]:
+    metadata = {
+        "commit_hash": commit_hash,
+        "branch": branch,
+        "actor": actor,
+        "is_forced": bool(is_forced),
+        "ci": ci,
+        "analysis_mode": analysis_mode,
+        "ai_code": ai_code if ai_code and ai_code.get("detected") else None,
+        "provenance": provenance_data,
+    }
+    if grade_data:
+        metadata["grade"] = grade_data
+    if project_id:
+        metadata["project_id"] = project_id
+    return metadata
+
+
+def _build_legacy_payload(core_payload, definitions) -> dict[str, Any]:
+    legacy_payload = dict(core_payload)
+    legacy_payload["definitions"] = definitions
+    return legacy_payload
+
+
+def _build_report_scan_summary(
+    all_findings: list[dict], core_payload: dict[str, Any], definitions
+) -> dict[str, int]:
+    runs = core_payload.get("runs") or []
+    return {
+        "finding_count": len(all_findings),
+        "sarif_result_count": sum(len(run.get("results") or []) for run in runs),
+        "sarif_rule_count": sum(
+            len((run.get("tool") or {}).get("driver", {}).get("rules") or [])
+            for run in runs
+        ),
+        "definitions_count": len(definitions or {}),
+    }
 
 
 def _build_report_artifacts(
@@ -1199,6 +1241,64 @@ def upload_report_legacy(
     )
 
 
+def _missing_artifact_instruction_result(
+    artifact_name: str, artifact: UploadArtifact
+) -> dict[str, Any]:
+    if artifact.required:
+        return {
+            "success": False,
+            "error": f"Large-upload response omitted required artifact instructions for {artifact_name}.",
+        }
+    return {"name": artifact_name, "reason": "not_requested"}
+
+
+def _append_skipped_artifact(
+    skipped_artifacts: list[dict[str, Any]],
+    artifact_name: str,
+    reason: str,
+    error: str | None = None,
+) -> None:
+    record = {"name": artifact_name, "reason": reason}
+    if error is not None:
+        record["error"] = error
+    skipped_artifacts.append(record)
+
+
+def _build_uploaded_artifact_record(
+    artifact: UploadArtifact,
+    artifact_info: dict[str, Any],
+    upload_result: dict[str, Any],
+) -> dict[str, Any]:
+    record = {
+        "artifact_id": artifact_info.get("artifact_id") or artifact_info.get("id"),
+        "key": artifact_info.get("key") or artifact_info.get("artifact_key"),
+        "filename": artifact.filename,
+        "size_bytes": artifact.size_bytes,
+        "sha256": artifact.sha256,
+        "content_type": artifact.content_type,
+        "content_encoding": artifact.content_encoding,
+    }
+    if upload_result.get("etag"):
+        record["etag"] = upload_result["etag"]
+    return record
+
+
+def _build_report_complete_payload(
+    init_data: dict[str, Any],
+    uploaded_artifacts: dict[str, dict[str, Any]],
+    skipped_artifacts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    payload = {
+        "upload_protocol_version": UPLOAD_PROTOCOL_VERSION,
+        "scan_id": init_data.get("scan_id") or init_data.get("scanId"),
+        "upload_id": init_data.get("upload_id") or init_data.get("uploadId"),
+        "artifacts": uploaded_artifacts,
+    }
+    if skipped_artifacts:
+        payload["skipped_artifacts"] = skipped_artifacts
+    return payload
+
+
 def upload_report_v2(
     token,
     prepared: PreparedReportUpload,
@@ -1253,13 +1353,15 @@ def upload_report_v2(
         for artifact_name, artifact in artifacts.items():
             artifact_info = artifact_instructions.get(artifact_name)
             if not artifact_info:
-                if artifact.required:
-                    return {
-                        "success": False,
-                        "error": f"Large-upload response omitted required artifact instructions for {artifact_name}.",
-                    }
-                skipped_artifacts.append(
-                    {"name": artifact_name, "reason": "not_requested"}
+                missing_result = _missing_artifact_instruction_result(
+                    artifact_name, artifact
+                )
+                if not missing_result.get("success", True):
+                    return missing_result
+                _append_skipped_artifact(
+                    skipped_artifacts,
+                    artifact_name,
+                    missing_result["reason"],
                 )
                 continue
 
@@ -1271,37 +1373,25 @@ def upload_report_v2(
                         "success": False,
                         "error": upload_result["error"],
                     }
-                skipped_artifacts.append(
-                    {
-                        "name": artifact_name,
-                        "reason": "upload_failed",
-                        "error": upload_result["error"],
-                    }
+                _append_skipped_artifact(
+                    skipped_artifacts,
+                    artifact_name,
+                    "upload_failed",
+                    upload_result["error"],
                 )
                 continue
 
-            record = {
-                "artifact_id": artifact_info.get("artifact_id")
-                or artifact_info.get("id"),
-                "key": artifact_info.get("key") or artifact_info.get("artifact_key"),
-                "filename": artifact.filename,
-                "size_bytes": artifact.size_bytes,
-                "sha256": artifact.sha256,
-                "content_type": artifact.content_type,
-                "content_encoding": artifact.content_encoding,
-            }
-            if upload_result.get("etag"):
-                record["etag"] = upload_result["etag"]
-            uploaded_artifacts[artifact_name] = record
+            uploaded_artifacts[artifact_name] = _build_uploaded_artifact_record(
+                artifact,
+                artifact_info,
+                upload_result,
+            )
 
-        complete_payload = {
-            "upload_protocol_version": UPLOAD_PROTOCOL_VERSION,
-            "scan_id": init_data.get("scan_id") or init_data.get("scanId"),
-            "upload_id": init_data.get("upload_id") or init_data.get("uploadId"),
-            "artifacts": uploaded_artifacts,
-        }
-        if skipped_artifacts:
-            complete_payload["skipped_artifacts"] = skipped_artifacts
+        complete_payload = _build_report_complete_payload(
+            init_data,
+            uploaded_artifacts,
+            skipped_artifacts,
+        )
 
         complete_response, last_err = _post_json_with_retries(
             REPORT_COMPLETE_URL,
@@ -1352,7 +1442,7 @@ def upload_report(
         analysis_mode=analysis_mode,
     )
 
-    if prepared.legacy_payload_size_bytes <= _legacy_inline_upload_limit_bytes():
+    if _should_use_legacy_inline_report_upload(prepared):
         return upload_report_legacy(
             token,
             prepared.legacy_payload,
@@ -1369,11 +1459,7 @@ def upload_report(
         strict=strict,
         is_forced=is_forced,
     )
-    if (
-        (not upload_result.get("success"))
-        and upload_result.get("code") == "UPLOAD_PROTOCOL_UNSUPPORTED"
-        and _truthy_env("SKYLOS_ALLOW_DEGRADED_LARGE_UPLOAD")
-    ):
+    if _should_retry_with_degraded_large_upload(upload_result):
         if not quiet:
             print(
                 " Skylos Cloud artifact upload unavailable; retrying condensed compatibility upload...",
@@ -1390,6 +1476,20 @@ def upload_report(
             initial_message=None,
         )
     return upload_result
+
+
+def _should_use_legacy_inline_report_upload(
+    prepared: PreparedReportUpload,
+) -> bool:
+    return prepared.legacy_payload_size_bytes <= _legacy_inline_upload_limit_bytes()
+
+
+def _should_retry_with_degraded_large_upload(upload_result: dict[str, Any]) -> bool:
+    return (
+        (not upload_result.get("success"))
+        and upload_result.get("code") == "UPLOAD_PROTOCOL_UNSUPPORTED"
+        and _truthy_env("SKYLOS_ALLOW_DEGRADED_LARGE_UPLOAD")
+    )
 
 
 def upload_defense_report(defense_json_str, quiet=False) -> dict:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -303,6 +303,84 @@ class TestSkylosApi(unittest.TestCase):
         self.assertEqual(payload["ci"]["provider"], "jenkins")
         self.assertEqual(payload["ci"]["pr_number"], 99)
 
+    @patch("skylos.provenance.analyze_provenance")
+    @patch("skylos.api._load_repo_link", return_value={"project_id": "proj-1"})
+    @patch("skylos.api.detect_ai_code", return_value={"detected": False})
+    @patch("skylos.api.SarifExporter")
+    @patch("skylos.api._get_blame_map", return_value={("app.py", 5): "dev@example.com"})
+    @patch(
+        "skylos.api._normalize_result_sections",
+        return_value=[{"file_path": "app.py", "line_number": 5, "message": "oops"}],
+    )
+    @patch("skylos.api.get_git_root", return_value="/repo")
+    @patch("skylos.api.get_git_info", return_value=("abc123", "main", "actor", {}))
+    def test_prepare_report_upload_enriches_blame_and_provenance(
+        self,
+        _mock_git_info,
+        _mock_root,
+        _mock_normalize,
+        _mock_blame,
+        mock_exporter,
+        _mock_ai,
+        _mock_link,
+        mock_analyze_provenance,
+    ):
+        prov_report = MagicMock()
+        prov_report.agent_files = ["app.py"]
+        prov_report.to_dict.return_value = {"agent_files": ["app.py"]}
+        mock_analyze_provenance.return_value = prov_report
+        mock_exporter.return_value.generate.return_value = {
+            "version": "2.1.0",
+            "runs": [],
+        }
+
+        prepared = api._prepare_report_upload(
+            {"danger": [{"file": "app.py", "line": 5, "message": "oops"}]},
+            analysis_mode="hybrid",
+        )
+
+        finding = mock_exporter.call_args[0][0][0]
+        self.assertEqual(finding["metadata"]["blame_email"], "dev@example.com")
+        self.assertEqual(prepared.metadata["provenance"], {"agent_files": ["app.py"]})
+        self.assertEqual(prepared.metadata["project_id"], "proj-1")
+
+    @patch("skylos.provenance.analyze_provenance")
+    @patch("skylos.api._load_repo_link", return_value={})
+    @patch("skylos.api.detect_ai_code", return_value={"detected": False})
+    @patch("skylos.api.SarifExporter")
+    @patch("skylos.api._get_blame_map", return_value={})
+    @patch(
+        "skylos.api._normalize_result_sections",
+        return_value=[{"file_path": "app.py", "line_number": 5, "message": "oops"}],
+    )
+    @patch("skylos.api.get_git_root", return_value="/repo")
+    @patch("skylos.api.get_git_info", return_value=("abc123", "main", "actor", {}))
+    def test_prepare_report_upload_swallows_provenance_failure_without_empty_metadata(
+        self,
+        _mock_git_info,
+        _mock_root,
+        _mock_normalize,
+        _mock_blame,
+        mock_exporter,
+        _mock_ai,
+        _mock_link,
+        mock_analyze_provenance,
+    ):
+        mock_analyze_provenance.side_effect = subprocess.SubprocessError("boom")
+        mock_exporter.return_value.generate.return_value = {
+            "version": "2.1.0",
+            "runs": [],
+        }
+
+        prepared = api._prepare_report_upload(
+            {"danger": [{"file": "app.py", "line": 5, "message": "oops"}]},
+            analysis_mode="static",
+        )
+
+        finding = mock_exporter.call_args[0][0][0]
+        self.assertNotIn("metadata", finding)
+        self.assertIsNone(prepared.metadata["provenance"])
+
     @patch("skylos.api.get_project_token")
     @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
     @patch("skylos.api.get_git_root", return_value=None)
@@ -399,6 +477,72 @@ class TestSkylosApi(unittest.TestCase):
         self.assertEqual(complete_payload["scan_id"], "scan_artifact")
         self.assertIn("scan_report", complete_payload["artifacts"])
         self.assertIn("definitions", complete_payload["artifacts"])
+        self.assertEqual(
+            complete_payload["artifacts"]["scan_report"]["artifact_id"],
+            "artifact-scan",
+        )
+        self.assertEqual(
+            complete_payload["artifacts"]["scan_report"]["key"],
+            "scan-key",
+        )
+        self.assertEqual(
+            complete_payload["artifacts"]["definitions"]["artifact_id"],
+            "artifact-defs",
+        )
+        self.assertEqual(
+            complete_payload["artifacts"]["definitions"]["key"],
+            "definitions-key",
+        )
+
+    @patch("skylos.api.get_project_token")
+    @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
+    @patch("skylos.api.get_git_root", return_value=None)
+    @patch("skylos.api.get_project_info", return_value={})
+    @patch("skylos.api.detect_ai_code", return_value={"detected": False})
+    @patch("requests.post")
+    def test_upload_report_large_payload_missing_required_artifact_instructions_fails(
+        self,
+        mock_post,
+        _mock_ai,
+        _mock_info,
+        _mock_root,
+        _mock_git_info,
+        mock_token,
+    ):
+        mock_token.return_value = "token"
+
+        init_resp = MagicMock()
+        init_resp.status_code = 201
+        init_resp.json.return_value = {
+            "scanId": "scan_artifact",
+            "upload_id": "upload-1",
+            "artifacts": {
+                "definitions": {
+                    "artifact_id": "artifact-defs",
+                    "upload": {
+                        "method": "PUT",
+                        "url": "https://upload.example.com/definitions",
+                    },
+                }
+            },
+        }
+        mock_post.return_value = init_resp
+
+        with patch("skylos.api._legacy_inline_upload_limit_bytes", return_value=10):
+            result = upload_report(
+                {
+                    "danger": [{"file": "app.py", "line": 5, "message": "oops"}],
+                    "definitions": {"app.func": {"file": "app.py", "line": 5}},
+                },
+                quiet=True,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(
+            result["error"],
+            "Large-upload response omitted required artifact instructions for scan_report.",
+        )
+        self.assertEqual(mock_post.call_count, 1)
 
     @patch("skylos.api.get_project_token")
     @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
@@ -471,6 +615,72 @@ class TestSkylosApi(unittest.TestCase):
         self.assertNotIn("definitions", complete_payload["artifacts"])
         self.assertEqual(
             complete_payload["skipped_artifacts"][0]["name"], "definitions"
+        )
+
+    @patch("skylos.api.get_project_token")
+    @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
+    @patch("skylos.api.get_git_root", return_value=None)
+    @patch("skylos.api.get_project_info", return_value={})
+    @patch("skylos.api.detect_ai_code", return_value={"detected": False})
+    @patch("requests.put")
+    @patch("requests.post")
+    def test_upload_report_large_payload_optional_definitions_not_requested(
+        self,
+        mock_post,
+        mock_put,
+        _mock_ai,
+        _mock_info,
+        _mock_root,
+        _mock_git_info,
+        mock_token,
+    ):
+        mock_token.return_value = "token"
+
+        init_resp = MagicMock()
+        init_resp.status_code = 201
+        init_resp.json.return_value = {
+            "scanId": "scan_artifact",
+            "upload_id": "upload-1",
+            "artifacts": {
+                "scan_report": {
+                    "artifact_id": "artifact-scan",
+                    "upload": {
+                        "method": "PUT",
+                        "url": "https://upload.example.com/report",
+                    },
+                }
+            },
+        }
+        complete_resp = MagicMock()
+        complete_resp.status_code = 200
+        complete_resp.json.return_value = {"scanId": "scan_artifact"}
+        mock_post.side_effect = [init_resp, complete_resp]
+
+        ok_upload = MagicMock()
+        ok_upload.status_code = 200
+        ok_upload.headers = {}
+        ok_upload.text = "OK"
+        mock_put.return_value = ok_upload
+
+        with patch("skylos.api._legacy_inline_upload_limit_bytes", return_value=10):
+            result = upload_report(
+                {
+                    "danger": [{"file": "app.py", "line": 5, "message": "oops"}],
+                    "definitions": {"app.func": {"file": "app.py", "line": 5}},
+                },
+                quiet=True,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(mock_put.call_count, 1)
+        complete_payload = mock_post.call_args_list[1].kwargs["json"]
+        self.assertEqual(
+            complete_payload["skipped_artifacts"],
+            [{"name": "definitions", "reason": "not_requested"}],
+        )
+        self.assertEqual(
+            list(complete_payload["artifacts"].keys()),
+            ["scan_report"],
         )
 
     @patch("skylos.api.get_project_token")


### PR DESCRIPTION
## Summary
  - reduce debt in `skylos/api.py` with conservative helper extractions in the report upload path
  - add tests to lock current upload, artifact, blame, and provenance behavior
  - preserve auth, retry, finalize, and degraded fallback behavior

## What Changed
  - extract helper logic for:
    - report metadata assembly
    - legacy payload assembly
    - report scan summary assembly
    - missing artifact-instruction handling
    - skipped artifact recording
    - uploaded artifact record assembly
    - large-upload complete payload assembly
    - upload strategy selection helpers in `upload_report()`
    - blame enrichment during `_prepare_report_upload()`
    - provenance detection during `_prepare_report_upload()`

## Tests
  - `uv run pytest test/test_api.py test/test_credits.py test/test_sync.py`
  - `uv run pytest test/test_api.py test/test_credits.py test/test_sync.py test/test_cli_refactor_guardrails.py`