### PR TITLE
fix(sync): support top-level cloud pull config

### DIFF
--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -554,9 +554,15 @@ repos:
 
 
 def _write_sync_config(skylos_dir: Path, config_data):
+    config_payload = config_data.get("config")
+    if not isinstance(config_payload, dict):
+        # Backward-compat: older/newer cloud deployments may return the
+        # sync config directly at the top level instead of wrapping it.
+        config_payload = config_data if isinstance(config_data, dict) else {}
+
     config_path = skylos_dir / CONFIG_FILE
     with config_path.open("w") as f:
-        yaml.dump(config_data.get("config", {}), f, default_flow_style=False)
+        yaml.dump(config_payload, f, default_flow_style=False)
     print(f"  ✓ {config_path}")
 
 

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -399,6 +399,45 @@ def test_cmd_pull_writes_config_and_suppressions(
     assert supp[0]["rule_id"] == "SKY-D212"
 
 
+def test_cmd_pull_writes_top_level_config_shape(
+    isolated_creds, monkeypatch, tmp_path, capsys
+):
+    _, creds_file = isolated_creds
+    creds_file.parent.mkdir(parents=True, exist_ok=True)
+    creds_file.write_text(json.dumps({"token": "TOK"}))
+
+    monkeypatch.setattr(syncmod, "SKYLOS_DIR", str(tmp_path / ".skylos"), raising=False)
+
+    def fake_api_get(endpoint, token):
+        assert token == "TOK"
+        if endpoint == "/api/sync/whoami":
+            return {"project": {"name": "Proj"}}
+        if endpoint == "/api/sync/config":
+            return {
+                "project_id": "p1",
+                "project_name": "Proj",
+                "gate_mode": "severity",
+                "gate": {"enabled": True, "mode": "severity"},
+            }
+        if endpoint == "/api/sync/suppressions":
+            return {"suppressions": [], "count": 0}
+        raise AssertionError(f"Unexpected endpoint {endpoint}")
+
+    monkeypatch.setattr(syncmod, "api_get", fake_api_get)
+
+    syncmod.cmd_pull()
+    out = capsys.readouterr().out
+
+    assert "Sync complete" in out
+
+    skylos_dir = Path(syncmod.SKYLOS_DIR)
+    config_path = skylos_dir / syncmod.CONFIG_FILE
+
+    config_text = config_path.read_text()
+    assert "project_id: p1" in config_text
+    assert "gate_mode: severity" in config_text
+
+
 def test_cmd_pull_calls_endpoints_in_order(isolated_creds, monkeypatch, tmp_path):
     _, creds_file = isolated_creds
     creds_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
  - fix `skylos sync pull` for Skylos Cloud responses that return config at the top level
  - keep existing wrapped `{"config": ...}` response shape working

  ## Why
  - update `_write_sync_config()` in `skylos/sync.py` to accept either:
    - wrapped config payloads like `{"config": {...}}`
    - top-level config payloads like `{"project_id": "...", "gate": {...}}`

## Tests
  - `uv run pytest test/test_sync.py -q`
  - `uv run pytest test/test_sync.py test/test_api.py test/test_cli_refactor_guardrails.py -k 'sync or get_custom_rules'`