### PR TITLE
fix(ci): publish releases from tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Build and publish
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       ref:
@@ -10,11 +13,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
     steps:
       - name: Validate release tag input
         run: |
-          ref="${{ github.event.inputs.ref }}"
+          ref="${RELEASE_REF}"
           case "$ref" in
             refs/tags/*|v[0-9]*)
               ;;
@@ -26,7 +31,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,50 +13,11 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0 (pin SHA to avoid supply chain attacks))
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a dedicated token/App so release PRs can satisfy required PR checks.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: tools/release/release-please-config.json
           manifest-file: tools/release/.release-please-manifest.json
-
-  build-and-publish:
-    name: Build and publish
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out release tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-        with:
-          python-version: "3.12"
-
-      - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "build>=1.2.2" "packaging>=24.2" "twine>=6.1.0"
-
-      - name: Build sdist + wheel
-        run: |
-          python -m build --sdist --wheel --outdir dist
-
-      - name: Check dist contents
-        run: |
-          ls -lah dist
-          python -m twine check dist/*
-
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          python -m twine upload --skip-existing dist/*

--- a/README.md
+++ b/README.md
@@ -844,10 +844,11 @@ For the default `skylos cicd init` workflow, you do not need any Skylos-specific
 
 ## Release Automation
 
-Skylos uses a single release workflow for automation:
+Skylos uses a split release workflow:
 
-- `.github/workflows/release-please.yml` updates `CHANGELOG.md`, bumps `pyproject.toml`, opens a release PR, creates the GitHub Release when merged, then builds wheel+sdist and publishes to PyPI in the same workflow.
-- `.github/workflows/publish.yml` is kept as a manual fallback (`workflow_dispatch`) if you ever need to republish an existing release tag.
+- `.github/workflows/release-please.yml` updates `CHANGELOG.md`, bumps `pyproject.toml`, and opens or updates the release PR.
+- `.github/workflows/publish.yml` publishes from an immutable release tag, either automatically on `v*` tag pushes or manually via `workflow_dispatch`.
+- For protected repos, prefer a dedicated `RELEASE_PLEASE_TOKEN` secret so bot-authored release PRs can satisfy required PR checks.
 
 ### First-time bootstrap (already configured in this repo)
 
@@ -864,7 +865,8 @@ This prevents backfilling old history and starts automated releases from the cur
 2. Release Please opens/updates the release PR.
 3. Merge the release PR to `main`.
 4. Release Please creates the GitHub release tag (`vX.Y.Z`).
-5. In the same workflow run, Skylos builds and publishes to PyPI using `PYPI_TOKEN`.
+5. The tag push triggers `.github/workflows/publish.yml`.
+6. Skylos builds and publishes to PyPI from that tag using `PYPI_TOKEN`.
 
 ### Manual build/publish checks
 

--- a/RELEASE_WORKFLOW.md
+++ b/RELEASE_WORKFLOW.md
@@ -21,7 +21,7 @@ This document defines how Skylos releases are prepared, created, and published.
 - **GitHub Actions (automation)**
   - Generates release PRs.
   - Creates tags/releases.
-  - Builds and publishes packages to PyPI.
+  - Publishes packages to PyPI from release tags.
 
 ## Required Guardrails and Prerequisites
 
@@ -63,6 +63,11 @@ These must be enabled for predictable releases:
    - `issues: write`
    - `pull-requests: write`
 
+6. **Preferred release token**
+   - Repo secret preferred: `RELEASE_PLEASE_TOKEN`
+   - Fallback: `GITHUB_TOKEN`
+   - For repos with required PR checks, a dedicated token/App is preferred so release PR checks can report normally.
+
 ## Release Baseline (Bootstrap)
 
 Skylos bootstraps Release Please from the existing version history using:
@@ -82,7 +87,8 @@ This prevents retroactive release generation for older history and starts automa
 2. On push to `main`, Release Please updates or opens a release PR.
 3. Maintainer reviews and merges the Release Please PR.
 4. Release Please creates the GitHub tag/release (`vX.Y.Z`).
-5. In the same workflow run, `build-and-publish`:
+5. The tag push triggers `.github/workflows/publish.yml`.
+6. `publish.yml`:
    - checks out the generated tag,
    - builds wheel + sdist,
    - validates artifacts (`twine check`),
@@ -97,9 +103,11 @@ This prevents retroactive release generation for older history and starts automa
 
 ## Operational Notes
 
-- The release and publish logic intentionally lives in one workflow (`release-please.yml`) to avoid cross-workflow timing issues.
-- `.github/workflows/publish.yml` is retained as a **manual fallback** (`workflow_dispatch`) for emergency republish of an existing release tag.
-- Publish step uses `--skip-existing` to reduce failure risk on re-runs.
+- Release orchestration and publishing are intentionally split:
+  - `release-please.yml` manages release PRs and tags.
+  - `publish.yml` publishes from immutable tags.
+- `publish.yml` runs on both `push.tags: ["v*"]` and `workflow_dispatch`.
+- Publish uses `--skip-existing` to reduce failure risk on re-runs.
 
 ## Manual Validation (Optional)
 
@@ -117,6 +125,6 @@ python -m twine check dist/*
 If automated publish fails:
 
 1. Fix the cause (token, package metadata, transient registry error).
-2. Re-run failed workflow job if safe.
-3. If needed, run `.github/workflows/publish.yml` manually with `ref=vX.Y.Z` only. Do not publish from a branch ref.
+2. Re-run failed `publish.yml` job if safe.
+3. If the release tag was created but publish did not run, trigger `.github/workflows/publish.yml` manually with `ref=vX.Y.Z` only. Do not publish from a branch ref.
 4. Confirm version appears on PyPI and matches the GitHub release tag.


### PR DESCRIPTION
## Summary
- publish releases from immutable `v*` tags instead of coupling PyPI publish to the `release-please` job output
- document the split release flow and the preferred `RELEASE_PLEASE_TOKEN` setup for protected repos
- keep manual `workflow_dispatch` publish as a fallback for existing tags

## Why
The `4.3.2` release exposed two workflow gaps:
- the bot-authored release PR could not satisfy required PR checks on this repo
- after mirroring the release bump onto a normal branch, the version bump landed on `main` but publish was skipped because `release-please.yml` only published when `release_created == true`

Publishing from the release tag is the safer and more standard model. It also makes recovery straightforward: if a tag exists, `publish.yml` can always build and publish from that immutable ref.

## What Changed
- update `.github/workflows/publish.yml` to run on:
  - `push.tags: ["v*"]`
  - `workflow_dispatch`
- make `publish.yml` build from a shared `RELEASE_REF` so both tag-push and manual dispatch use the same path
- remove the embedded `build-and-publish` job from `.github/workflows/release-please.yml`
- prefer `RELEASE_PLEASE_TOKEN` over `GITHUB_TOKEN` when available so release PRs can work better with protected repos
- update `README.md` and `RELEASE_WORKFLOW.md` to document the split release model and the recovery path

## Verification
- workflow YAML validation: `WORKFLOW_VALIDATION_OK`
- `uv run pytest test/test_sync.py test/test_api.py -q`
  - result: `98 passed`
- manual review of the workflow diff confirms:
  - `release-please.yml` no longer publishes directly
  - `publish.yml` now triggers on `v*` tags and still supports manual dispatch

## Follow-up
This PR prepares the repo for the correct release model, but the preferred long-term setup is to add a `RELEASE_PLEASE_TOKEN` secret (PAT or GitHub App token) so release PR checks can report normally under branch protection.
