### PR TITLE
ci(test): install llm extra in test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Create venv + install deps
         run: |
           uv venv
-          uv pip install -e .
+          uv pip install -e ".[llm]"
           uv pip install pytest pytest-cov
 
       - name: Run tests with coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        install_target:
+          - "."
+          - ".[llm]"
 
     steps:
       - uses: actions/checkout@v4
@@ -18,7 +24,7 @@ jobs:
       - name: Create venv + install deps
         run: |
           uv venv
-          uv pip install -e ".[llm]"
+          uv pip install -e "${{ matrix.install_target }}"
           uv pip install pytest pytest-cov
 
       - name: Run tests with coverage
@@ -31,3 +37,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: false
+          flags: ${{ matrix.install_target == '.[llm]' && 'llm-extra' || 'default-install' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  test_matrix:
+    name: test-matrix (${{ matrix.install_target }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,3 +39,17 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
           flags: ${{ matrix.install_target == '.[llm]' && 'llm-extra' || 'default-install' }}
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: [test_matrix]
+    if: ${{ always() }}
+
+    steps:
+      - name: Require matrix success
+        run: |
+          if [ "${{ needs.test_matrix.result }}" != "success" ]; then
+            echo "test_matrix result: ${{ needs.test_matrix.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
## What does this PR do?

Updates the main test workflow to install the `llm` extra before running the test suite.

## Why?

Follow-up to #198.

That PR validated Skylos against a newer LiteLLM release, but the existing `Tests + Coverage` workflow still installs `-e .` without `.[llm]`. That means CI can pass without exercising the optional LiteLLM dependency path.

This change makes the workflow cover the same optional dependency surface that the LiteLLM-related tests and adapter path depend on.

## How to test

- Review `.github/workflows/tests.yaml`
- Confirm the workflow now installs:
  - `uv pip install -e ".[llm]"`
- Let GitHub Actions run the updated workflow on this PR

## Precision Impact

None. This only updates CI dependency installation.

## Checklist

- [x] No analysis logic changed
- [x] No corpus update needed
- [x] No corpus guard needed
- [x] CHANGELOG not needed
