### PR TITLE
feat(ts): report monorepo workspace inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Added
 - Added a Simplified Chinese README (`README_CN.md`)
 - Added configurable web UI port support for `skylos run` via `--port` or `SKYLOS_PORT`
+- Added monorepo workspace inventory reporting for TypeScript projects. Skylos now reports root packages, child workspaces from `package.json` / `pnpm-workspace.yaml`, `tsconfig.json` references, and undeclared workspace package diagnostics in analysis and MCP output
 
 ### Changed
 - SKY-L030: Lint rule for `except Exception`/`except BaseException` with trivial handler (CWE-396)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The core use case is straightforward: run it locally, add it to CI, and gate pul
 3. **One workflow instead of three tools:** Dead code, security scanning, and PR gating live in the same CLI and CI flow.
 4. **Local-first by default:** You can keep scans on your machine and add optional AI or cloud features later if you need them.
 5. **Self-explaining output:** Every table prints a legend explaining what each column and number means — no manual required.
+6. **Monorepo inventory for TS repos:** Skylos reports workspace packages discovered from `package.json` workspaces, `pnpm-workspace.yaml`, and `tsconfig.json` references, plus undeclared package diagnostics, in JSON and MCP output.
 
 ### Why Skylos over Vulture for Python dead code detection?
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,6 +60,7 @@ Skylos 是一款面向 Python、TypeScript 和 Go 的开源静态分析工具和
 3. **一个工作流替代三个工具：** 死代码、安全扫描和 PR 门控在同一 CLI 和 CI 流程中。
 4. **默认本地优先：** 你可以在本地运行扫描，需要时再添加可选的 AI 或云端功能。
 5. **自解释输出：** 每个表格都打印图例说明每列和数字的含义 — 无需额外文档。
+6. **面向 TS 仓库的 Monorepo 清单：** Skylos 会在 JSON 和 MCP 输出中报告从 `package.json` workspaces、`pnpm-workspace.yaml` 与 `tsconfig.json` references 发现的工作区包，以及未声明包的诊断信息。
 
 ### 为什么选择 Skylos 而非 Vulture 检测 Python 死代码？
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -992,6 +992,7 @@ class Skylos:
         all_raw_imports,
         path,
         unused_ts_exports=None,
+        workspace_inventory=None,
     ):
         """Assemble the final result dict from analysis outputs."""
         unused = []
@@ -1067,6 +1068,28 @@ class Skylos:
                 "languages": self._count_languages(files),
             },
         }
+
+        if workspace_inventory is not None:
+            project_root = (
+                self._project_root
+                if hasattr(self, "_project_root")
+                else Path(
+                    path[0] if isinstance(path, (list, tuple)) else path
+                ).resolve()
+            )
+            result["workspaces"] = workspace_inventory.to_dict(project_root)
+            result["analysis_summary"]["monorepo_detected"] = (
+                workspace_inventory.is_monorepo
+            )
+            result["analysis_summary"]["workspace_count"] = len(
+                workspace_inventory.packages
+            )
+            result["analysis_summary"]["workspace_total_packages"] = (
+                workspace_inventory.total_packages
+            )
+            result["analysis_summary"]["workspace_diagnostic_count"] = len(
+                workspace_inventory.diagnostics
+            )
 
         if enable_secrets and all_secrets:
             result["secrets"] = all_secrets
@@ -1218,24 +1241,44 @@ class Skylos:
 
         clear_go_cache()
 
+        if isinstance(path, (list, tuple)):
+            _first = Path(path[0]).resolve()
+            all_resolved = [Path(p).resolve() for p in path]
+            project_root = Path(os.path.commonpath(all_resolved))
+        else:
+            _first = Path(path).resolve()
+            project_root = _first
+        if not project_root.is_dir():
+            project_root = project_root.parent
+
         files, root = self._discover_files(path, exclude_folders)
+
+        from skylos.visitors.languages.typescript.workspace import (
+            discover_workspace_inventory,
+        )
+
+        workspace_inventory = discover_workspace_inventory(project_root)
 
         if not files:
             logger.warning(f"No Python files found in {path}")
-            return json.dumps(
-                {
-                    "unused_functions": [],
-                    "unused_imports": [],
-                    "unused_classes": [],
-                    "unused_variables": [],
-                    "unused_parameters": [],
-                    "unused_files": [],
-                    "analysis_summary": {
-                        "total_files": 0,
-                        "excluded_folders": exclude_folders if exclude_folders else [],
-                    },
-                }
-            )
+            result = {
+                "unused_functions": [],
+                "unused_imports": [],
+                "unused_classes": [],
+                "unused_variables": [],
+                "unused_parameters": [],
+                "unused_files": [],
+                "analysis_summary": {
+                    "total_files": 0,
+                    "excluded_folders": exclude_folders if exclude_folders else [],
+                    "monorepo_detected": workspace_inventory.is_monorepo,
+                    "workspace_count": len(workspace_inventory.packages),
+                    "workspace_total_packages": workspace_inventory.total_packages,
+                    "workspace_diagnostic_count": len(workspace_inventory.diagnostics),
+                },
+                "workspaces": workspace_inventory.to_dict(project_root),
+            }
+            return json.dumps(result)
 
         logger.info(f"Analyzing {len(files)} files...")
 
@@ -1256,16 +1299,6 @@ class Skylos:
         global_pattern_tracker.traced_calls.clear()
         global_pattern_tracker.traced_by_file.clear()
         global_pattern_tracker._traced_by_basename.clear()
-
-        if isinstance(path, (list, tuple)):
-            _first = Path(path[0]).resolve()
-            all_resolved = [Path(p).resolve() for p in path]
-            project_root = Path(os.path.commonpath(all_resolved))
-        else:
-            _first = Path(path).resolve()
-            project_root = _first
-        if not project_root.is_dir():
-            project_root = project_root.parent
 
         project_cfg = load_config(project_root)
         project_ignore = set(project_cfg.get("ignore", []))
@@ -1911,6 +1944,7 @@ class Skylos:
             all_raw_imports,
             path,
             unused_ts_exports=unused_ts_exports,
+            workspace_inventory=workspace_inventory,
         )
 
         return json.dumps(result, indent=2)
@@ -2366,6 +2400,22 @@ if __name__ == "__main__":
     )
 
     print("Summary:")
+    workspace_data = data.get("workspaces") or {}
+    has_workspace_report = bool(
+        workspace_data.get("root_package")
+        or workspace_data.get("packages")
+        or workspace_data.get("diagnostics")
+    )
+    if has_workspace_report:
+        print(
+            " * Workspaces: "
+            f"{workspace_data.get('total_packages', 0)} packages "
+            f"({workspace_data.get('package_count', 0)} child workspaces)"
+        )
+        if workspace_data.get("diagnostic_count"):
+            print(
+                f" * Workspace diagnostics: {workspace_data.get('diagnostic_count', 0)}"
+            )
     if data["unused_functions"]:
         print(f" * Unreachable functions: {len(data['unused_functions'])}")
     if data["unused_imports"]:
@@ -2439,6 +2489,20 @@ if __name__ == "__main__":
             line = s.get("line", 1)
             sev = s.get("severity", "HIGH")
             print(f" {i}. {msg} [{rid}] ({file}:{line}) Severity: {sev}")
+
+    if has_workspace_report:
+        print("\n - Workspaces")
+        print("============")
+        root_pkg = workspace_data.get("root_package")
+        if root_pkg:
+            print(
+                f" Root: {root_pkg.get('name')} "
+                f"({root_pkg.get('relative_path', root_pkg.get('path'))})"
+            )
+        for pkg in workspace_data.get("packages", []):
+            print(f" * {pkg.get('name')} ({pkg.get('relative_path', pkg.get('path'))})")
+        for diag in workspace_data.get("diagnostics", [])[:5]:
+            print(f" ! {diag.get('message')}")
 
     print("\n" + "─" * 50)
     if enable_danger:

--- a/skylos/visitors/languages/typescript/workspace.py
+++ b/skylos/visitors/languages/typescript/workspace.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import fnmatch
+import glob
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class WorkspaceInfo:
+    root: Path
+    name: str
+    discovered_from: set[str] = field(default_factory=set)
+    is_root: bool = False
+    is_internal_dependency: bool = False
+    has_package_json: bool = True
+
+    def to_dict(self, project_root: Path) -> dict:
+        try:
+            relative = self.root.relative_to(project_root)
+            relative_path = "." if str(relative) == "." else str(relative)
+        except ValueError:
+            relative_path = str(self.root)
+
+        return {
+            "name": self.name,
+            "path": str(self.root),
+            "relative_path": relative_path,
+            "discovered_from": sorted(self.discovered_from),
+            "is_root": self.is_root,
+            "is_internal_dependency": self.is_internal_dependency,
+            "has_package_json": self.has_package_json,
+        }
+
+
+@dataclass
+class WorkspaceDiagnostic:
+    kind: str
+    path: Path
+    message: str
+
+    def to_dict(self, project_root: Path) -> dict:
+        try:
+            relative = self.path.relative_to(project_root)
+            relative_path = "." if str(relative) == "." else str(relative)
+        except ValueError:
+            relative_path = str(self.path)
+
+        return {
+            "kind": self.kind,
+            "path": str(self.path),
+            "relative_path": relative_path,
+            "message": self.message,
+        }
+
+
+@dataclass
+class WorkspaceInventory:
+    root_package: WorkspaceInfo | None
+    packages: list[WorkspaceInfo]
+    diagnostics: list[WorkspaceDiagnostic]
+    declared_patterns: list[str]
+    tsconfig_references: list[str]
+
+    @property
+    def total_packages(self) -> int:
+        return len(self.packages) + (1 if self.root_package else 0)
+
+    @property
+    def is_monorepo(self) -> bool:
+        return bool(self.packages or self.declared_patterns or self.tsconfig_references)
+
+    def to_dict(self, project_root: Path) -> dict:
+        return {
+            "is_monorepo": self.is_monorepo,
+            "root_package": (
+                self.root_package.to_dict(project_root) if self.root_package else None
+            ),
+            "packages": [pkg.to_dict(project_root) for pkg in self.packages],
+            "diagnostics": [diag.to_dict(project_root) for diag in self.diagnostics],
+            "declared_patterns": list(self.declared_patterns),
+            "tsconfig_references": list(self.tsconfig_references),
+            "package_count": len(self.packages),
+            "total_packages": self.total_packages,
+            "diagnostic_count": len(self.diagnostics),
+        }
+
+
+def _read_json_file(path: Path) -> dict:
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except (json.JSONDecodeError, OSError):
+        pass
+    return {}
+
+
+def _normalize_relpath(path: Path, root: Path) -> str:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return str(path).replace(os.sep, "/")
+    rel_str = str(relative).replace(os.sep, "/")
+    return "." if rel_str == "." else rel_str
+
+
+def _workspace_name(path: Path, root: Path, package_data: dict) -> str:
+    name = package_data.get("name")
+    if isinstance(name, str) and name.strip():
+        return name
+    return _normalize_relpath(path, root)
+
+
+def _extract_workspace_patterns(package_data: dict) -> list[str]:
+    workspaces = package_data.get("workspaces")
+    if isinstance(workspaces, list):
+        return [item for item in workspaces if isinstance(item, str)]
+    if isinstance(workspaces, dict):
+        packages = workspaces.get("packages")
+        if isinstance(packages, list):
+            return [item for item in packages if isinstance(item, str)]
+    return []
+
+
+def _parse_pnpm_workspace_yaml(content: str) -> list[str]:
+    patterns: list[str] = []
+    in_packages = False
+
+    for line in content.splitlines():
+        trimmed = line.strip()
+        if trimmed == "packages:":
+            in_packages = True
+            continue
+        if not in_packages:
+            continue
+        if trimmed.startswith("- "):
+            value = trimmed[2:].strip().strip("'").strip('"')
+            if value:
+                patterns.append(value)
+            continue
+        if trimmed and not trimmed.startswith("#"):
+            break
+
+    return patterns
+
+
+def _strip_json_comments(text: str) -> str:
+    out: list[str] = []
+    in_string = False
+    in_line_comment = False
+    in_block_comment = False
+    escaped = False
+    i = 0
+
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+                out.append(ch)
+            i += 1
+            continue
+
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def _strip_trailing_commas(text: str) -> str:
+    out: list[str] = []
+    in_string = False
+    escaped = False
+    i = 0
+
+    while i < len(text):
+        ch = text[i]
+
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch == ",":
+            j = i + 1
+            while j < len(text) and text[j].isspace():
+                j += 1
+            if j < len(text) and text[j] in "]}":
+                i += 1
+                continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def _load_jsonc(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    cleaned = _strip_trailing_commas(_strip_json_comments(raw.lstrip("\ufeff")))
+    try:
+        data = json.loads(cleaned)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+    return {}
+
+
+def _parse_tsconfig_references(root: Path) -> list[Path]:
+    data = _load_jsonc(root / "tsconfig.json")
+    refs = data.get("references")
+    if not isinstance(refs, list):
+        return []
+
+    results: list[Path] = []
+    seen: set[Path] = set()
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        ref_path = ref.get("path")
+        if not isinstance(ref_path, str):
+            continue
+        candidate = (root / ref_path).resolve()
+        if candidate.is_dir() and candidate not in seen:
+            results.append(candidate)
+            seen.add(candidate)
+    return results
+
+
+def _collect_dependency_names(package_data: dict) -> set[str]:
+    names: set[str] = set()
+    for key in (
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ):
+        deps = package_data.get(key)
+        if isinstance(deps, dict):
+            names.update(name for name in deps if isinstance(name, str))
+    return names
+
+
+def _should_skip_dir(path: Path, root: Path) -> bool:
+    if path == root:
+        return False
+    for part in path.parts:
+        if part.startswith("."):
+            return True
+        if part in {"node_modules", "build", "dist"}:
+            return True
+    return False
+
+
+def _expand_workspace_patterns(
+    root: Path, patterns: list[str], source_label: str
+) -> dict[Path, set[str]]:
+    matches: dict[Path, set[str]] = {}
+    positives = [pattern for pattern in patterns if not pattern.startswith("!")]
+    negatives = [pattern[1:] for pattern in patterns if pattern.startswith("!")]
+
+    for pattern in positives:
+        if pattern.endswith("/"):
+            pattern = pattern + "*"
+
+        full_pattern = str(root / pattern)
+        for matched in glob.glob(full_pattern, recursive=True):
+            candidate = Path(matched).resolve()
+            if not candidate.is_dir():
+                continue
+            if _should_skip_dir(candidate, root):
+                continue
+
+            rel = _normalize_relpath(candidate, root)
+            if any(fnmatch.fnmatch(rel, neg) for neg in negatives):
+                continue
+
+            pkg_json = candidate / "package.json"
+            if not pkg_json.is_file():
+                continue
+
+            matches.setdefault(candidate, set()).add(source_label)
+
+    return matches
+
+
+def _discover_undeclared_packages(
+    root: Path, declared_roots: set[Path]
+) -> list[WorkspaceDiagnostic]:
+    diagnostics: list[WorkspaceDiagnostic] = []
+
+    top_level: list[Path] = []
+    try:
+        top_level = [entry for entry in root.iterdir() if entry.is_dir()]
+    except OSError:
+        return diagnostics
+
+    for entry in top_level:
+        if _should_skip_dir(entry, root):
+            continue
+
+        candidates = [entry]
+        try:
+            candidates.extend(child for child in entry.iterdir() if child.is_dir())
+        except OSError:
+            pass
+
+        for candidate in candidates:
+            if _should_skip_dir(candidate, root):
+                continue
+            pkg_json = candidate / "package.json"
+            if not pkg_json.is_file():
+                continue
+            resolved = candidate.resolve()
+            if resolved == root or resolved in declared_roots:
+                continue
+            diagnostics.append(
+                WorkspaceDiagnostic(
+                    kind="undeclared_workspace_package",
+                    path=resolved,
+                    message=(
+                        f"Directory '{_normalize_relpath(resolved, root)}' contains "
+                        "package.json but is not declared as a workspace"
+                    ),
+                )
+            )
+
+    diagnostics.sort(key=lambda item: str(item.path))
+    return diagnostics
+
+
+def discover_workspace_inventory(project_root: Path) -> WorkspaceInventory:
+    root = project_root.resolve()
+
+    root_package_json = root / "package.json"
+    root_package_data = _read_json_file(root_package_json)
+    root_package = None
+    if root_package_json.is_file():
+        root_package = WorkspaceInfo(
+            root=root,
+            name=_workspace_name(root, root, root_package_data),
+            discovered_from={"root-package"},
+            is_root=True,
+            has_package_json=True,
+        )
+
+    package_json_patterns = _extract_workspace_patterns(root_package_data)
+    patterns = list(package_json_patterns)
+    pattern_sources: list[tuple[list[str], str]] = []
+    if package_json_patterns:
+        pattern_sources.append((package_json_patterns, "package.json:workspaces"))
+
+    pnpm_workspace = root / "pnpm-workspace.yaml"
+    if pnpm_workspace.is_file():
+        try:
+            pnpm_patterns = _parse_pnpm_workspace_yaml(
+                pnpm_workspace.read_text(encoding="utf-8")
+            )
+            patterns.extend(pnpm_patterns)
+            if pnpm_patterns:
+                pattern_sources.append((pnpm_patterns, "pnpm-workspace.yaml"))
+        except OSError:
+            pass
+
+    workspace_sources: dict[Path, set[str]] = {}
+    for source_patterns, source_label in pattern_sources:
+        for pkg_root, sources in _expand_workspace_patterns(
+            root, source_patterns, source_label
+        ).items():
+            workspace_sources.setdefault(pkg_root, set()).update(sources)
+    tsconfig_reference_paths = _parse_tsconfig_references(root)
+    for ref_path in tsconfig_reference_paths:
+        workspace_sources.setdefault(ref_path, set()).add("tsconfig.json:references")
+
+    packages: list[WorkspaceInfo] = []
+    package_data_by_root: dict[Path, dict] = {}
+    for pkg_root in sorted(workspace_sources, key=lambda item: str(item)):
+        pkg_json = pkg_root / "package.json"
+        pkg_data = _read_json_file(pkg_json)
+        has_package_json = pkg_json.is_file()
+        package_data_by_root[pkg_root] = pkg_data
+        packages.append(
+            WorkspaceInfo(
+                root=pkg_root,
+                name=_workspace_name(pkg_root, root, pkg_data),
+                discovered_from=set(workspace_sources[pkg_root]),
+                has_package_json=has_package_json,
+            )
+        )
+
+    name_to_workspace: dict[str, WorkspaceInfo] = {}
+    all_packages_for_deps = list(packages)
+    if root_package is not None:
+        all_packages_for_deps = [root_package, *all_packages_for_deps]
+        package_data_by_root[root] = root_package_data
+
+    for workspace in all_packages_for_deps:
+        name_to_workspace[workspace.name] = workspace
+
+    for workspace in all_packages_for_deps:
+        pkg_data = package_data_by_root.get(workspace.root, {})
+        for dep_name in _collect_dependency_names(pkg_data):
+            target = name_to_workspace.get(dep_name)
+            if target and target.root != workspace.root:
+                target.is_internal_dependency = True
+
+    diagnostics: list[WorkspaceDiagnostic] = []
+    if workspace_sources:
+        diagnostics = _discover_undeclared_packages(
+            root, {pkg.root.resolve() for pkg in packages}
+        )
+
+    return WorkspaceInventory(
+        root_package=root_package,
+        packages=packages,
+        diagnostics=diagnostics,
+        declared_patterns=patterns,
+        tsconfig_references=[
+            _normalize_relpath(ref_path, root) for ref_path in tsconfig_reference_paths
+        ],
+    )

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -470,6 +470,14 @@ def _make_summary(result: dict, focus: str | None = None) -> dict:
     summary = result.get("analysis_summary", {})
     out: dict[str, Any] = {"analysis_summary": summary}
 
+    workspace_info = result.get("workspaces") or {}
+    if (
+        workspace_info.get("root_package")
+        or workspace_info.get("packages")
+        or workspace_info.get("diagnostics")
+    ):
+        out["workspaces"] = result["workspaces"]
+
     if focus is None or focus == "dead_code":
         for key in [
             "unused_functions",

--- a/test/test_mcp_summary.py
+++ b/test/test_mcp_summary.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from skylos_mcp.server import _make_summary
+
+
+def test_make_summary_includes_workspace_report_when_present():
+    result = {
+        "analysis_summary": {"total_files": 1, "monorepo_detected": True},
+        "workspaces": {
+            "root_package": {"name": "@repo/root"},
+            "packages": [{"name": "@repo/app"}],
+            "diagnostics": [],
+        },
+    }
+
+    summary = _make_summary(result)
+
+    assert summary["analysis_summary"]["monorepo_detected"] is True
+    assert summary["workspaces"]["root_package"]["name"] == "@repo/root"
+
+
+def test_make_summary_omits_empty_workspace_report():
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "workspaces": {
+            "root_package": None,
+            "packages": [],
+            "diagnostics": [],
+        },
+    }
+
+    summary = _make_summary(result)
+
+    assert "workspaces" not in summary

--- a/test/test_typescript_workspace.py
+++ b/test/test_typescript_workspace.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+
+from skylos.analyzer import analyze
+from skylos.visitors.languages.typescript.workspace import discover_workspace_inventory
+
+
+def test_discover_workspace_inventory_reports_sources_and_diagnostics(tmp_path):
+    (tmp_path / "packages" / "app").mkdir(parents=True)
+    (tmp_path / "packages" / "lib").mkdir(parents=True)
+    (tmp_path / "apps" / "web").mkdir(parents=True)
+    (tmp_path / "tools" / "cli").mkdir(parents=True)
+    (tmp_path / "examples" / "demo").mkdir(parents=True)
+
+    (tmp_path / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@repo/root",
+                "workspaces": ["packages/*"],
+                "dependencies": {"@repo/app": "workspace:*"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "pnpm-workspace.yaml").write_text(
+        "packages:\n  - 'apps/*'\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "tsconfig.json").write_text(
+        "{\n"
+        "  // workspace refs\n"
+        '  "references": [\n'
+        '    { "path": "./tools/cli" },\n'
+        "  ],\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    (tmp_path / "packages" / "app" / "package.json").write_text(
+        json.dumps({"name": "@repo/app", "dependencies": {"@repo/lib": "workspace:*"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "packages" / "lib" / "package.json").write_text(
+        json.dumps({"name": "@repo/lib"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "apps" / "web" / "package.json").write_text(
+        json.dumps({"name": "@repo/web"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "examples" / "demo" / "package.json").write_text(
+        json.dumps({"name": "@repo/demo"}),
+        encoding="utf-8",
+    )
+
+    inventory = discover_workspace_inventory(tmp_path)
+
+    assert inventory.root_package is not None
+    assert inventory.root_package.name == "@repo/root"
+    assert inventory.root_package.is_root is True
+
+    packages = {pkg.name: pkg for pkg in inventory.packages}
+    assert packages["@repo/app"].discovered_from == {"package.json:workspaces"}
+    assert packages["@repo/web"].discovered_from == {"pnpm-workspace.yaml"}
+    assert packages["@repo/lib"].is_internal_dependency is True
+
+    ref_workspace = packages["tools/cli"]
+    assert ref_workspace.has_package_json is False
+    assert ref_workspace.discovered_from == {"tsconfig.json:references"}
+
+    assert inventory.tsconfig_references == ["tools/cli"]
+    assert any(
+        diag.kind == "undeclared_workspace_package"
+        and diag.path == (tmp_path / "examples" / "demo").resolve()
+        for diag in inventory.diagnostics
+    )
+
+
+def test_analyze_reports_workspace_inventory_without_source_files(tmp_path):
+    (tmp_path / "packages" / "app").mkdir(parents=True)
+
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "@repo/root", "workspaces": ["packages/*"]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "packages" / "app" / "package.json").write_text(
+        json.dumps({"name": "@repo/app"}),
+        encoding="utf-8",
+    )
+
+    result = json.loads(analyze(str(tmp_path)))
+
+    assert result["analysis_summary"]["total_files"] == 0
+    assert result["analysis_summary"]["monorepo_detected"] is True
+    assert result["analysis_summary"]["workspace_count"] == 1
+    assert result["analysis_summary"]["workspace_total_packages"] == 2
+    assert result["analysis_summary"]["workspace_diagnostic_count"] == 0
+    assert result["workspaces"]["root_package"]["name"] == "@repo/root"
+    assert result["workspaces"]["packages"][0]["name"] == "@repo/app"


### PR DESCRIPTION
## Summary

Adding monorepo support for the TypeScript engine: workspace inventory discovery and reporting.

## User-visible changes

Skylos now includes a `workspaces` section in analysis output, plus workspace summary counters:
  - `monorepo_detected`
  - `workspace_count`
  - `workspace_total_packages`
  - `workspace_diagnostic_count`

This will show up in:
  - analyzer JSON output
  - CLI summary output
  - MCP summary output

## Why

Monorepo support needs a clean, usable first slice before changing resolver behaviour.

This PR establishes a workspace model that users can inspect directly. That gives us:
  - visibility into what Skylos believes the monorepo structure is
  - diagnostics for undeclared nested packages
  - a stable foundation for later phases like workspace-aware resolution and project-reference
  reachability

## Scope

  Included:
  - workspace inventory discovery
  - reporting in analyzer results
  - reporting in CLI output
  - reporting in MCP summaries
  - tests
  - docs/changelog updates

## Files

  Main implementation:
  - `skylos/visitors/languages/typescript/workspace.py`
  - `skylos/analyzer.py`
  - `skylos_mcp/server.py`

  Tests:
  - `test/test_typescript_workspace.py`
  - `test/test_mcp_summary.py`

  Docs:
  - `README.md`
  - `README_CN.md`
  - `CHANGELOG.md`

## Verification

- `pytest test/test_typescript_workspace.py test/test_mcp_summary.py test/test_analyzer.py`

## Follow-up

Next phase should make TypeScript resolution consume declared workspaces instead of generic package scanning.