### PR TITLE
fix(ts): use declared workspaces for monorepo resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 ### Changed
 - SKY-L030: Lint rule for `except Exception`/`except BaseException` with trivial handler (CWE-396)
 - Continue CLI cleanup by extracting command boundaries, lazy-loading heavy analysis paths.Expanded regression guardrails around dispatch, output, and exit-code behavior
+- TypeScript monorepo resolution now uses declared workspaces as the package boundary, resolves root package self-imports, and honors JSONC-style `tsconfig` path inheritance
 
 ### Fixed
 - Browser login callback now validates `state` and verifies the returned token metadata via `whoami`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The core use case is straightforward: run it locally, add it to CI, and gate pul
 3. **One workflow instead of three tools:** Dead code, security scanning, and PR gating live in the same CLI and CI flow.
 4. **Local-first by default:** You can keep scans on your machine and add optional AI or cloud features later if you need them.
 5. **Self-explaining output:** Every table prints a legend explaining what each column and number means — no manual required.
-6. **Monorepo inventory for TS repos:** Skylos reports workspace packages discovered from `package.json` workspaces, `pnpm-workspace.yaml`, and `tsconfig.json` references, plus undeclared package diagnostics, in JSON and MCP output.
+6. **Monorepo-aware TS resolution:** Skylos reports declared workspaces for TypeScript repos and uses those workspace boundaries during package resolution, including root-package self imports and local `tsconfig` path inheritance.
 
 ### Why Skylos over Vulture for Python dead code detection?
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,7 +60,7 @@ Skylos 是一款面向 Python、TypeScript 和 Go 的开源静态分析工具和
 3. **一个工作流替代三个工具：** 死代码、安全扫描和 PR 门控在同一 CLI 和 CI 流程中。
 4. **默认本地优先：** 你可以在本地运行扫描，需要时再添加可选的 AI 或云端功能。
 5. **自解释输出：** 每个表格都打印图例说明每列和数字的含义 — 无需额外文档。
-6. **面向 TS 仓库的 Monorepo 清单：** Skylos 会在 JSON 和 MCP 输出中报告从 `package.json` workspaces、`pnpm-workspace.yaml` 与 `tsconfig.json` references 发现的工作区包，以及未声明包的诊断信息。
+6. **面向 TS 仓库的 Monorepo 感知解析：** Skylos 会报告 TypeScript 仓库中声明的工作区，并在包解析时使用这些边界，包括根包自导入和本地 `tsconfig` 路径继承。
 
 ### 为什么选择 Skylos 而非 Vulture 检测 Python 死代码？
 

--- a/skylos/visitors/languages/typescript/resolve.py
+++ b/skylos/visitors/languages/typescript/resolve.py
@@ -3,67 +3,171 @@ from __future__ import annotations
 import json
 import os
 from functools import lru_cache
+from pathlib import Path
+
+from skylos.visitors.languages.typescript.workspace import (
+    _load_jsonc,
+    discover_workspace_inventory,
+)
 
 
-def _find_tsconfig(project_root: str) -> str | None:
-    for name in ("tsconfig.json", "tsconfig.base.json"):
-        candidate = os.path.join(project_root, name)
-        if os.path.isfile(candidate):
-            return candidate
+def _find_nearest_tsconfig(start_path: str, stop_dir: str | None = None) -> str | None:
+    current = os.path.dirname(os.path.realpath(start_path))
+    stop_real = os.path.realpath(stop_dir) if stop_dir else None
+
+    while True:
+        for name in ("tsconfig.json", "tsconfig.base.json"):
+            candidate = os.path.join(current, name)
+            if os.path.isfile(candidate):
+                return candidate
+
+        if stop_real and current == stop_real:
+            break
+
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
     return None
 
 
-def _parse_tsconfig_paths(tsconfig_path: str) -> tuple[str, dict[str, list[str]]]:
-    try:
-        with open(tsconfig_path) as f:
-            data = json.load(f)
-    except (json.JSONDecodeError, OSError):
+def _resolve_extends_path(tsconfig_dir: str, extends: str) -> str | None:
+    if not extends:
+        return None
+
+    candidates: list[str] = []
+    if os.path.isabs(extends):
+        candidates.append(extends)
+    else:
+        candidates.append(os.path.normpath(os.path.join(tsconfig_dir, extends)))
+
+    if not extends.endswith(".json"):
+        if os.path.isabs(extends):
+            candidates.append(extends + ".json")
+        else:
+            candidates.append(
+                os.path.normpath(os.path.join(tsconfig_dir, extends + ".json"))
+            )
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if os.path.isfile(candidate):
+            return candidate
+
+    if not os.path.isabs(extends) and not extends.startswith("."):
+        current = os.path.realpath(tsconfig_dir)
+        while True:
+            package_root = os.path.join(current, "node_modules", extends)
+            package_candidates = [package_root, package_root + ".json"]
+
+            if os.path.isdir(package_root):
+                package_candidates.append(os.path.join(package_root, "tsconfig.json"))
+                package_json = _read_json_file(
+                    os.path.join(package_root, "package.json")
+                )
+                package_tsconfig = package_json.get("tsconfig")
+                if isinstance(package_tsconfig, str):
+                    package_candidates.append(
+                        os.path.normpath(os.path.join(package_root, package_tsconfig))
+                    )
+
+            for candidate in package_candidates:
+                if candidate in seen:
+                    continue
+                seen.add(candidate)
+                if os.path.isfile(candidate):
+                    return candidate
+
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
+    return None
+
+
+def _parse_tsconfig_paths(
+    tsconfig_path: str, _seen: set[str] | None = None
+) -> tuple[str, dict[str, list[str]]]:
+    if _seen is None:
+        _seen = set()
+
+    real_tsconfig_path = os.path.realpath(tsconfig_path)
+    if real_tsconfig_path in _seen:
+        return os.path.dirname(tsconfig_path), {}
+    _seen.add(real_tsconfig_path)
+
+    data = _load_jsonc(Path(tsconfig_path))
+    if not data:
         return os.path.dirname(tsconfig_path), {}
 
     tsconfig_dir = os.path.dirname(tsconfig_path)
     compiler_opts = data.get("compilerOptions", {})
-    base_url = compiler_opts.get("baseUrl", ".")
-    base_url_abs = os.path.normpath(os.path.join(tsconfig_dir, base_url))
-    paths = compiler_opts.get("paths", {})
+
+    parent_base = tsconfig_dir
+    parent_paths: dict[str, list[str]] = {}
 
     extends = data.get("extends")
-    if extends and not paths:
-        ext_path = os.path.normpath(os.path.join(tsconfig_dir, extends))
-        if os.path.isfile(ext_path):
-            parent_base, parent_paths = _parse_tsconfig_paths(ext_path)
-            if not paths:
-                paths = parent_paths
-            if base_url == ".":
-                base_url_abs = parent_base
+    if isinstance(extends, str):
+        ext_path = _resolve_extends_path(tsconfig_dir, extends)
+        if ext_path:
+            parent_base, parent_paths = _parse_tsconfig_paths(ext_path, _seen)
+
+    base_url = compiler_opts.get("baseUrl")
+    if isinstance(base_url, str):
+        base_url_abs = os.path.normpath(os.path.join(tsconfig_dir, base_url))
+    else:
+        base_url_abs = parent_base
+
+    raw_paths = compiler_opts.get("paths", {})
+    paths: dict[str, list[str]] = dict(parent_paths)
+    if isinstance(raw_paths, dict):
+        for key, value in raw_paths.items():
+            if isinstance(value, list):
+                resolved_targets: list[str] = []
+                for item in value:
+                    if not isinstance(item, str):
+                        continue
+                    if os.path.isabs(item):
+                        resolved_targets.append(item)
+                    else:
+                        resolved_targets.append(
+                            os.path.normpath(os.path.join(base_url_abs, item))
+                        )
+                paths[key] = resolved_targets
 
     return base_url_abs, paths
 
 
 def _build_package_map(project_root: str) -> dict[str, str]:
     pkg_map: dict[str, str] = {}
-    skip = {"node_modules", ".git", "dist", "build", ".next", "__pycache__"}
+    inventory = discover_workspace_inventory(Path(project_root))
 
-    for dirpath, dirnames, filenames in os.walk(project_root):
-        dirnames[:] = [d for d in dirnames if d not in skip]
-        if "package.json" in filenames:
-            pkg_json = os.path.join(dirpath, "package.json")
-            if dirpath == project_root:
-                continue
-            try:
-                with open(pkg_json) as f:
-                    data = json.load(f)
-                name = data.get("name")
-                if name:
-                    pkg_map[name] = dirpath
-            except (json.JSONDecodeError, OSError):
-                pass
+    package_roots: list[Path] = []
+    if inventory.root_package and inventory.root_package.has_package_json:
+        package_roots.append(inventory.root_package.root)
+    for workspace in inventory.packages:
+        if workspace.has_package_json and (
+            "package.json:workspaces" in workspace.discovered_from
+            or "pnpm-workspace.yaml" in workspace.discovered_from
+        ):
+            package_roots.append(workspace.root)
+
+    for package_root in package_roots:
+        pkg_json = os.path.join(str(package_root), "package.json")
+        data = _read_json_file(pkg_json)
+        name = data.get("name")
+        if isinstance(name, str) and name.strip():
+            pkg_map[name] = str(package_root)
     return pkg_map
 
 
 @lru_cache(maxsize=None)
 def _read_json_file(path: str) -> dict:
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         if isinstance(data, dict):
             return data
@@ -127,12 +231,21 @@ def _resolve_path_target(base_dir: str, target: str) -> str | None:
 def _extract_package_target(entry) -> str | None:
     if isinstance(entry, str):
         return entry
+    if isinstance(entry, list):
+        for item in entry:
+            target = _extract_package_target(item)
+            if target:
+                return target
     if isinstance(entry, dict):
         for key in ("types", "import", "default", "require", "node"):
             if key in entry:
                 target = _extract_package_target(entry[key])
                 if target:
                     return target
+        for value in entry.values():
+            target = _extract_package_target(value)
+            if target:
+                return target
     return None
 
 
@@ -159,6 +272,24 @@ def _resolve_package_exports(pkg_dir: str, subpath: str | None = None) -> str | 
     pkg_json = os.path.join(pkg_dir, "package.json")
     data = _read_json_file(pkg_json)
     exports = data.get("exports")
+    if exports is None:
+        return None
+
+    if subpath is None and not isinstance(exports, dict):
+        target = _extract_package_target(exports)
+        if not target:
+            return None
+        return _resolve_path_target(pkg_dir, target)
+
+    if subpath is None and isinstance(exports, dict):
+        if "." not in exports and not any(
+            isinstance(key, str) and key.startswith(".") for key in exports
+        ):
+            target = _extract_package_target(exports)
+            if not target:
+                return None
+            return _resolve_path_target(pkg_dir, target)
+
     if not isinstance(exports, dict):
         return None
 
@@ -234,21 +365,19 @@ def _resolve_from_pkg_dir(pkg_dir: str, subpath: str | None = None) -> str | Non
 class MonorepoResolver:
     def __init__(self, project_root: str) -> None:
         self.project_root = project_root
-        self._tsconfig_paths: dict[str, list[str]] | None = None
-        self._base_url: str = project_root
         self._package_map: dict[str, str] | None = None
-        self._initialized = False
+        self._tsconfig_cache: dict[str, tuple[str, dict[str, list[str]]]] = {}
 
-    def _ensure_init(self) -> None:
-        if self._initialized:
-            return
-        self._initialized = True
+    def _get_tsconfig_context(
+        self, importer: str
+    ) -> tuple[str, dict[str, list[str]]] | None:
+        tsconfig = _find_nearest_tsconfig(importer, self.project_root)
+        if not tsconfig:
+            return None
 
-        tsconfig = _find_tsconfig(self.project_root)
-        if tsconfig:
-            self._base_url, paths = _parse_tsconfig_paths(tsconfig)
-            if paths:
-                self._tsconfig_paths = paths
+        if tsconfig not in self._tsconfig_cache:
+            self._tsconfig_cache[tsconfig] = _parse_tsconfig_paths(tsconfig)
+        return self._tsconfig_cache[tsconfig]
 
     def _ensure_package_map(self) -> dict[str, str]:
         if self._package_map is None:
@@ -259,36 +388,32 @@ class MonorepoResolver:
         if source.startswith("."):
             return None
 
-        self._ensure_init()
-
         if source.startswith("#"):
             result = _resolve_package_imports(self.project_root, importer, source)
             if result:
                 return result
 
-        if self._tsconfig_paths:
-            result = self._resolve_via_tsconfig(source)
+        tsconfig_context = self._get_tsconfig_context(importer)
+        if tsconfig_context is not None:
+            base_url, tsconfig_paths = tsconfig_context
+            result = self._resolve_via_tsconfig(source, base_url, tsconfig_paths)
             if result:
                 return result
 
         return self._resolve_via_packages(source)
 
-    def _resolve_via_tsconfig(self, source: str) -> str | None:
-        if not self._tsconfig_paths:
-            return None
-
-        if source in self._tsconfig_paths:
-            for target_pattern in self._tsconfig_paths[source]:
-                resolved = os.path.normpath(
-                    os.path.join(self._base_url, target_pattern)
-                )
+    def _resolve_via_tsconfig(
+        self, source: str, base_url: str, tsconfig_paths: dict[str, list[str]]
+    ) -> str | None:
+        if source in tsconfig_paths:
+            for resolved in tsconfig_paths[source]:
                 if os.path.isfile(resolved):
                     return resolved
                 for suffix in (".ts", ".tsx", "/index.ts", "/index.tsx"):
                     if os.path.isfile(resolved + suffix):
                         return resolved + suffix
 
-        for pattern, targets in self._tsconfig_paths.items():
+        for pattern, targets in tsconfig_paths.items():
             if not pattern.endswith("/*"):
                 continue
             prefix = pattern[:-2]
@@ -299,13 +424,17 @@ class MonorepoResolver:
                 if not target_pattern.endswith("/*"):
                     continue
                 target_base = target_pattern[:-2]
-                resolved_base = os.path.normpath(
-                    os.path.join(self._base_url, target_base, rest)
-                )
+                resolved_base = os.path.normpath(os.path.join(target_base, rest))
                 for suffix in ("", ".ts", ".tsx", "/index.ts", "/index.tsx"):
                     candidate = resolved_base + suffix
                     if os.path.isfile(candidate):
                         return candidate
+
+        resolved_base = os.path.normpath(os.path.join(base_url, source))
+        for suffix in ("", ".ts", ".tsx", "/index.ts", "/index.tsx"):
+            candidate = resolved_base + suffix
+            if os.path.isfile(candidate):
+                return candidate
         return None
 
     def _resolve_via_packages(self, source: str) -> str | None:

--- a/test/test_typescript_resolve.py
+++ b/test/test_typescript_resolve.py
@@ -24,6 +24,10 @@ def test_workspace_package_exports_root_and_subpath_resolution(tmp_path):
     app_file = tmp_path / "packages" / "app" / "src" / "index.ts"
 
     _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "@workspace/root", "workspaces": ["packages/*"]}),
+    )
+    _write(
         ui_dir / "package.json",
         json.dumps(
             {
@@ -92,6 +96,10 @@ def test_build_ts_import_graph_uses_exports_map_resolution(tmp_path):
     helpers_file = ui_dir / "src" / "helpers.ts"
 
     _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "@workspace/root", "workspaces": ["packages/*"]}),
+    )
+    _write(
         ui_dir / "package.json",
         json.dumps(
             {
@@ -128,3 +136,265 @@ def test_build_ts_import_graph_uses_exports_map_resolution(tmp_path):
 
     assert "Button" in consumed[str(index_file)]
     assert "clamp" in consumed[str(helpers_file)]
+
+
+def test_package_local_tsconfig_paths_override_root_in_monorepo(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "index.ts"
+    local_target = app_dir / "src" / "components" / "Button.ts"
+    root_target = tmp_path / "shared" / "components" / "Button.ts"
+
+    _write(
+        tmp_path / "tsconfig.json",
+        json.dumps(
+            {
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {"@app/*": ["shared/*"]},
+                }
+            }
+        ),
+    )
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps(
+            {
+                "extends": "../../tsconfig.json",
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {"@app/*": ["src/*"]},
+                },
+            }
+        ),
+    )
+    _write(importer, "export const main = 1;")
+    _write(local_target, 'export const Button = () => "local";')
+    _write(root_target, 'export const Button = () => "root";')
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@app/components/Button", str(importer)) == str(
+        local_target
+    )
+
+
+def test_package_local_tsconfig_inherits_root_paths_via_extends(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "index.ts"
+    shared_target = tmp_path / "shared" / "utils" / "format.ts"
+
+    _write(
+        tmp_path / "tsconfig.json",
+        json.dumps(
+            {
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {"@shared/*": ["shared/*"]},
+                }
+            }
+        ),
+    )
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps(
+            {
+                "extends": "../../tsconfig.json",
+                "compilerOptions": {"baseUrl": "."},
+            }
+        ),
+    )
+    _write(importer, "export const main = 1;")
+    _write(shared_target, 'export const format = () => "ok";')
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@shared/utils/format", str(importer)) == str(shared_target)
+
+
+def test_root_package_self_import_uses_declared_root_package(tmp_path):
+    importer = tmp_path / "src" / "consumer.ts"
+    target = tmp_path / "src" / "index.ts"
+
+    _write(
+        tmp_path / "package.json",
+        json.dumps(
+            {
+                "name": "@repo/root",
+                "exports": "./src/index.ts",
+                "workspaces": ["packages/*"],
+            }
+        ),
+    )
+    _write(importer, "import { core } from '@repo/root';\n")
+    _write(target, "export const core = 1;\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/root", str(importer)) == str(target)
+
+
+def test_pnpm_workspace_package_resolution_uses_declared_packages_only(tmp_path):
+    importer = tmp_path / "src" / "main.ts"
+    target = tmp_path / "packages" / "ui" / "src" / "index.ts"
+
+    _write(tmp_path / "pnpm-workspace.yaml", "packages:\n  - 'packages/*'\n")
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(importer, "import { Button } from '@repo/ui';\n")
+    _write(target, "export const Button = 1;\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) == str(target)
+
+
+def test_undeclared_nested_package_does_not_participate_in_resolution(tmp_path):
+    importer = tmp_path / "src" / "main.ts"
+
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "@repo/root", "workspaces": ["packages/*"]}),
+    )
+    _write(
+        tmp_path / "examples" / "demo" / "package.json",
+        json.dumps({"name": "@repo/demo", "exports": "./src/index.ts"}),
+    )
+    _write(
+        tmp_path / "examples" / "demo" / "src" / "index.ts", "export const demo = 1;\n"
+    )
+    _write(importer, "import { demo } from '@repo/demo';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/demo", str(importer)) is None
+
+
+def test_declared_workspace_wins_when_undeclared_package_has_same_name(tmp_path):
+    importer = tmp_path / "src" / "main.ts"
+    declared_target = tmp_path / "packages" / "ui" / "src" / "index.ts"
+    undeclared_target = tmp_path / "examples" / "ui" / "src" / "index.ts"
+
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "@repo/root", "workspaces": ["packages/*"]}),
+    )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(
+        tmp_path / "examples" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(declared_target, "export const declared = true;\n")
+    _write(undeclared_target, "export const undeclared = true;\n")
+    _write(importer, "import { declared } from '@repo/ui';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) == str(declared_target)
+
+
+def test_tsconfig_reference_without_package_json_is_not_name_resolved(tmp_path):
+    importer = tmp_path / "src" / "main.ts"
+
+    _write(
+        tmp_path / "tsconfig.json",
+        json.dumps({"references": [{"path": "./tools/build"}]}),
+    )
+    _write(
+        tmp_path / "tools" / "build" / "src" / "index.ts", "export const tool = 1;\n"
+    )
+    _write(importer, "import { tool } from 'tools/build';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("tools/build", str(importer)) is None
+
+
+def test_tsconfig_reference_with_package_json_is_not_treated_as_workspace(tmp_path):
+    importer = tmp_path / "src" / "main.ts"
+
+    _write(
+        tmp_path / "tsconfig.json",
+        json.dumps({"references": [{"path": "./packages/ui"}]}),
+    )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(tmp_path / "packages" / "ui" / "src" / "index.ts", "export const ui = 1;\n")
+    _write(importer, "import { ui } from '@repo/ui';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) is None
+
+
+def test_tsconfig_paths_support_jsonc_comments_and_trailing_commas(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "index.ts"
+    target = tmp_path / "shared" / "utils" / "format.ts"
+
+    _write(
+        tmp_path / "tsconfig.json",
+        "{\n"
+        "  // root config\n"
+        '  "compilerOptions": {\n'
+        '    "baseUrl": ".",\n'
+        '    "paths": {\n'
+        '      "@shared/*": ["shared/*"],\n'
+        "    },\n"
+        "  },\n"
+        "}\n",
+    )
+    _write(
+        app_dir / "tsconfig.json",
+        "{\n"
+        '  "extends": "../../tsconfig.json",\n'
+        '  "compilerOptions": {\n'
+        '    "baseUrl": ".",\n'
+        "  },\n"
+        "}\n",
+    )
+    _write(importer, "export const main = 1;\n")
+    _write(target, 'export const format = () => "ok";\n')
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@shared/utils/format", str(importer)) == str(target)
+
+
+def test_tsconfig_extends_supports_node_modules_package_paths(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "index.ts"
+    target = tmp_path / "shared" / "utils" / "format.ts"
+
+    _write(
+        tmp_path / "node_modules" / "@repo" / "tsconfig-base" / "tsconfig.json",
+        json.dumps(
+            {
+                "compilerOptions": {
+                    "baseUrl": "../../..",
+                    "paths": {"@shared/*": ["shared/*"]},
+                }
+            }
+        ),
+    )
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps(
+            {
+                "extends": "@repo/tsconfig-base/tsconfig.json",
+                "compilerOptions": {"baseUrl": "."},
+            }
+        ),
+    )
+    _write(importer, "export const main = 1;\n")
+    _write(target, 'export const format = () => "ok";\n')
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@shared/utils/format", str(importer)) == str(target)


### PR DESCRIPTION
## Summary
 
TypeScript monorepo support: workspace-aware package resolution.

## Why

Before this PR, the resolver still walked the tree and indexed any nested `package.json`, which meant:
  - fixture/example packages could pollute resolution
  - root package self-imports were broken
  - resolver behavior could contradict the workspace inventory Skylos reported

## User-visible changes

  TypeScript resolution now:
  - resolves bare package imports only from the root package plus declared workspaces
  - excludes undeclared nested packages from package-name resolution
  - resolves root-package self imports
  - supports importer-local `tsconfig` path inheritance more reliably in monorepos

## Scope

  - workspace-aware package map construction
  - root package self-import resolution
  - continued nearest-importer `tsconfig` support
  - JSONC `tsconfig` parsing for resolver path inheritance
  - package-based `tsconfig` `extends` support from `node_modules`
  - regression tests
  - changelog/readme updates

## Files

Tests:
  - `test/test_typescript_resolve.py`

## Key behaviors covered

  This PR adds/keeps coverage for:
  - workspace package exports and subpath resolution
  - package `imports` exact and wildcard resolution
  - nearest `tsconfig` override behavior in package-local monorepos
  - inherited root aliases via `extends`
  - root package self-imports
  - pnpm workspace-only discovery
  - undeclared nested package exclusion
  - declared vs undeclared package name collision handling
  - `tsconfig` references without package resolution leakage
  - JSONC `tsconfig` comments/trailing commas
  - package-based `tsconfig` `extends` from `node_modules`

## Verification

  - `pytest test/test_ts_exports.py test/test_typescript_resolve.py test/test_typescript.py test/
  test_typescript_framework.py`

  Result:
  - `71 passed`

  Additional manual verification:
  - created synthetic monorepos under `/tmp`