### PR TITLE
fix(ts): resolve direct project references in monorepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - SKY-L030: Lint rule for `except Exception`/`except BaseException` with trivial handler (CWE-396)
 - Continue CLI cleanup by extracting command boundaries, lazy-loading heavy analysis paths.Expanded regression guardrails around dispatch, output, and exit-code behavior
 - TypeScript monorepo resolution now uses declared workspaces as the package boundary, resolves root package self-imports, and honors JSONC-style `tsconfig` path inheritance
+- TypeScript resolution now supports importer-local direct `tsconfig.json` project references for composite monorepos without leaking those references into global package resolution
 
 ### Fixed
 - Browser login callback now validates `state` and verifies the returned token metadata via `whoami`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The core use case is straightforward: run it locally, add it to CI, and gate pul
 3. **One workflow instead of three tools:** Dead code, security scanning, and PR gating live in the same CLI and CI flow.
 4. **Local-first by default:** You can keep scans on your machine and add optional AI or cloud features later if you need them.
 5. **Self-explaining output:** Every table prints a legend explaining what each column and number means — no manual required.
-6. **Monorepo-aware TS resolution:** Skylos reports declared workspaces for TypeScript repos and uses those workspace boundaries during package resolution, including root-package self imports and local `tsconfig` path inheritance.
+6. **Monorepo-aware TS resolution:** Skylos uses declared workspaces and importer-local direct `tsconfig` project references during TypeScript package resolution, including root-package self imports and local `tsconfig` path inheritance.
 
 ### Why Skylos over Vulture for Python dead code detection?
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,7 +60,7 @@ Skylos 是一款面向 Python、TypeScript 和 Go 的开源静态分析工具和
 3. **一个工作流替代三个工具：** 死代码、安全扫描和 PR 门控在同一 CLI 和 CI 流程中。
 4. **默认本地优先：** 你可以在本地运行扫描，需要时再添加可选的 AI 或云端功能。
 5. **自解释输出：** 每个表格都打印图例说明每列和数字的含义 — 无需额外文档。
-6. **面向 TS 仓库的 Monorepo 感知解析：** Skylos 会报告 TypeScript 仓库中声明的工作区，并在包解析时使用这些边界，包括根包自导入和本地 `tsconfig` 路径继承。
+6. **面向 TS 仓库的 Monorepo 感知解析：** Skylos 会在 TypeScript 包解析时使用声明的工作区和导入方本地的直接 `tsconfig` 项目引用，包括根包自导入和本地 `tsconfig` 路径继承。
 
 ### 为什么选择 Skylos 而非 Vulture 检测 Python 死代码？
 

--- a/skylos/visitors/languages/typescript/resolve.py
+++ b/skylos/visitors/languages/typescript/resolve.py
@@ -141,6 +141,45 @@ def _parse_tsconfig_paths(
     return base_url_abs, paths
 
 
+def _parse_tsconfig_references(tsconfig_path: str) -> list[str]:
+    data = _load_jsonc(Path(tsconfig_path))
+    refs = data.get("references")
+    if not isinstance(refs, list):
+        return []
+
+    tsconfig_dir = os.path.dirname(tsconfig_path)
+    results: list[str] = []
+    seen: set[str] = set()
+
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        ref_path = ref.get("path")
+        if not isinstance(ref_path, str) or not ref_path:
+            continue
+
+        candidates = [os.path.normpath(os.path.join(tsconfig_dir, ref_path))]
+        if not ref_path.endswith(".json"):
+            candidates.append(
+                os.path.normpath(os.path.join(tsconfig_dir, ref_path + ".json"))
+            )
+
+        resolved_root: str | None = None
+        for candidate in candidates:
+            if os.path.isdir(candidate):
+                resolved_root = os.path.realpath(candidate)
+                break
+            if os.path.isfile(candidate):
+                resolved_root = os.path.realpath(os.path.dirname(candidate))
+                break
+
+        if resolved_root and resolved_root not in seen:
+            seen.add(resolved_root)
+            results.append(resolved_root)
+
+    return results
+
+
 def _build_package_map(project_root: str) -> dict[str, str]:
     pkg_map: dict[str, str] = {}
     inventory = discover_workspace_inventory(Path(project_root))
@@ -366,17 +405,21 @@ class MonorepoResolver:
     def __init__(self, project_root: str) -> None:
         self.project_root = project_root
         self._package_map: dict[str, str] | None = None
-        self._tsconfig_cache: dict[str, tuple[str, dict[str, list[str]]]] = {}
+        self._tsconfig_cache: dict[
+            str, tuple[str, dict[str, list[str]], list[str]]
+        ] = {}
 
     def _get_tsconfig_context(
         self, importer: str
-    ) -> tuple[str, dict[str, list[str]]] | None:
+    ) -> tuple[str, dict[str, list[str]], list[str]] | None:
         tsconfig = _find_nearest_tsconfig(importer, self.project_root)
         if not tsconfig:
             return None
 
         if tsconfig not in self._tsconfig_cache:
-            self._tsconfig_cache[tsconfig] = _parse_tsconfig_paths(tsconfig)
+            base_url, paths = _parse_tsconfig_paths(tsconfig)
+            references = _parse_tsconfig_references(tsconfig)
+            self._tsconfig_cache[tsconfig] = (base_url, paths, references)
         return self._tsconfig_cache[tsconfig]
 
     def _ensure_package_map(self) -> dict[str, str]:
@@ -395,8 +438,11 @@ class MonorepoResolver:
 
         tsconfig_context = self._get_tsconfig_context(importer)
         if tsconfig_context is not None:
-            base_url, tsconfig_paths = tsconfig_context
+            base_url, tsconfig_paths, project_references = tsconfig_context
             result = self._resolve_via_tsconfig(source, base_url, tsconfig_paths)
+            if result:
+                return result
+            result = self._resolve_via_project_references(source, project_references)
             if result:
                 return result
 
@@ -435,6 +481,38 @@ class MonorepoResolver:
             candidate = resolved_base + suffix
             if os.path.isfile(candidate):
                 return candidate
+        return None
+
+    def _resolve_via_project_references(
+        self, source: str, project_references: list[str]
+    ) -> str | None:
+        if not project_references:
+            return None
+
+        parts = source.split("/")
+        package_name: str | None = None
+        subpath: str | None = None
+
+        if parts[0].startswith("@") and len(parts) >= 2:
+            package_name = parts[0] + "/" + parts[1]
+            if len(parts) > 2:
+                subpath = "/".join(parts[2:])
+        elif parts:
+            package_name = parts[0]
+            if len(parts) > 1:
+                subpath = "/".join(parts[1:])
+
+        if not package_name:
+            return None
+
+        for reference_root in project_references:
+            pkg_json = os.path.join(reference_root, "package.json")
+            pkg_data = _read_json_file(pkg_json)
+            ref_name = pkg_data.get("name")
+            if ref_name != package_name:
+                continue
+            return _resolve_from_pkg_dir(reference_root, subpath)
+
         return None
 
     def _resolve_via_packages(self, source: str) -> str | None:

--- a/skylos/visitors/languages/typescript/workspace.py
+++ b/skylos/visitors/languages/typescript/workspace.py
@@ -264,14 +264,16 @@ def _load_jsonc(path: Path) -> dict:
     return {}
 
 
-def _parse_tsconfig_references(root: Path) -> list[Path]:
+def _parse_tsconfig_references(root: Path) -> tuple[list[Path], list[str]]:
     data = _load_jsonc(root / "tsconfig.json")
     refs = data.get("references")
     if not isinstance(refs, list):
-        return []
+        return [], []
 
     results: list[Path] = []
-    seen: set[Path] = set()
+    reported_refs: list[str] = []
+    seen_roots: set[Path] = set()
+    seen_reported: set[str] = set()
     for ref in refs:
         if not isinstance(ref, dict):
             continue
@@ -279,10 +281,24 @@ def _parse_tsconfig_references(root: Path) -> list[Path]:
         if not isinstance(ref_path, str):
             continue
         candidate = (root / ref_path).resolve()
-        if candidate.is_dir() and candidate not in seen:
-            results.append(candidate)
-            seen.add(candidate)
-    return results
+
+        resolved_root: Path | None = None
+        if candidate.is_dir():
+            resolved_root = candidate
+        elif candidate.is_file():
+            resolved_root = candidate.parent
+
+        if resolved_root is not None and resolved_root not in seen_roots:
+            results.append(resolved_root)
+            seen_roots.add(resolved_root)
+
+        if candidate.exists():
+            reported_ref = _normalize_relpath(candidate, root)
+            if reported_ref not in seen_reported:
+                reported_refs.append(reported_ref)
+                seen_reported.add(reported_ref)
+
+    return results, reported_refs
 
 
 def _collect_dependency_names(package_data: dict) -> set[str]:
@@ -426,8 +442,10 @@ def discover_workspace_inventory(project_root: Path) -> WorkspaceInventory:
             root, source_patterns, source_label
         ).items():
             workspace_sources.setdefault(pkg_root, set()).update(sources)
-    tsconfig_reference_paths = _parse_tsconfig_references(root)
-    for ref_path in tsconfig_reference_paths:
+    tsconfig_reference_roots, tsconfig_reference_paths = _parse_tsconfig_references(
+        root
+    )
+    for ref_path in tsconfig_reference_roots:
         workspace_sources.setdefault(ref_path, set()).add("tsconfig.json:references")
 
     packages: list[WorkspaceInfo] = []
@@ -473,7 +491,5 @@ def discover_workspace_inventory(project_root: Path) -> WorkspaceInventory:
         packages=packages,
         diagnostics=diagnostics,
         declared_patterns=patterns,
-        tsconfig_references=[
-            _normalize_relpath(ref_path, root) for ref_path in tsconfig_reference_paths
-        ],
+        tsconfig_references=tsconfig_reference_paths,
     )

--- a/test/test_typescript_resolve.py
+++ b/test/test_typescript_resolve.py
@@ -314,13 +314,89 @@ def test_tsconfig_reference_without_package_json_is_not_name_resolved(tmp_path):
     assert resolver.resolve("tools/build", str(importer)) is None
 
 
-def test_tsconfig_reference_with_package_json_is_not_treated_as_workspace(tmp_path):
-    importer = tmp_path / "src" / "main.ts"
+def test_tsconfig_reference_without_package_name_does_not_bare_resolve(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "main.ts"
 
     _write(
-        tmp_path / "tsconfig.json",
-        json.dumps({"references": [{"path": "./packages/ui"}]}),
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../ui"}]}),
     )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"exports": "./src/index.ts"}),
+    )
+    _write(tmp_path / "packages" / "ui" / "src" / "index.ts", "export const ui = 1;\n")
+    _write(importer, "import { ui } from '@repo/ui';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) is None
+
+
+def test_direct_tsconfig_reference_with_package_json_resolves_importer_locally(
+    tmp_path,
+):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "main.ts"
+    target = tmp_path / "packages" / "ui" / "src" / "index.ts"
+
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../ui"}]}),
+    )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(target, "export const ui = 1;\n")
+    _write(importer, "import { ui } from '@repo/ui';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) == str(target)
+
+
+def test_tsconfig_reference_subpath_uses_referenced_package_exports(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "main.ts"
+    target = tmp_path / "packages" / "ui" / "src" / "helpers.ts"
+
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../ui"}]}),
+    )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps(
+            {
+                "name": "@repo/ui",
+                "exports": {
+                    ".": "./src/index.ts",
+                    "./helpers": "./dist/helpers.js",
+                },
+            }
+        ),
+    )
+    _write(tmp_path / "packages" / "ui" / "src" / "index.ts", "export const ui = 1;\n")
+    _write(target, "export const helper = 1;\n")
+    _write(importer, "import { helper } from '@repo/ui/helpers';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui/helpers", str(importer)) == str(target)
+
+
+def test_project_reference_does_not_leak_to_sibling_package(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    web_dir = tmp_path / "packages" / "web"
+    importer = web_dir / "src" / "main.ts"
+
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../ui"}]}),
+    )
+    _write(web_dir / "tsconfig.json", json.dumps({"compilerOptions": {"baseUrl": "."}}))
     _write(
         tmp_path / "packages" / "ui" / "package.json",
         json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
@@ -331,6 +407,152 @@ def test_tsconfig_reference_with_package_json_is_not_treated_as_workspace(tmp_pa
     resolver = MonorepoResolver(str(tmp_path))
 
     assert resolver.resolve("@repo/ui", str(importer)) is None
+
+
+def test_tsconfig_paths_still_beat_project_references(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "main.ts"
+    local_target = app_dir / "src" / "ui.ts"
+    referenced_target = tmp_path / "packages" / "ui" / "src" / "index.ts"
+
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps(
+            {
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {"@repo/ui": ["src/ui.ts"]},
+                },
+                "references": [{"path": "../ui"}],
+            }
+        ),
+    )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(local_target, "export const local = true;\n")
+    _write(referenced_target, "export const referenced = true;\n")
+    _write(importer, "import { local } from '@repo/ui';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) == str(local_target)
+
+
+def test_tsconfig_reference_via_explicit_config_file_path_resolves_package(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "main.ts"
+    target = tmp_path / "packages" / "ui" / "src" / "index.ts"
+
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../ui/tsconfig.lib.json"}]}),
+    )
+    _write(tmp_path / "packages" / "ui" / "tsconfig.lib.json", json.dumps({}))
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(target, "export const ui = 1;\n")
+    _write(importer, "import { ui } from '@repo/ui';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) == str(target)
+
+
+def test_direct_project_reference_precedes_declared_workspace_fallback(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    importer = app_dir / "src" / "main.ts"
+    referenced_target = tmp_path / "libs" / "ui" / "src" / "index.ts"
+    workspace_target = tmp_path / "packages" / "ui" / "src" / "index.ts"
+
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "@repo/root", "workspaces": ["packages/*"]}),
+    )
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../../libs/ui"}]}),
+    )
+    _write(
+        tmp_path / "libs" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(referenced_target, "export const referenced = true;\n")
+    _write(workspace_target, "export const workspace = true;\n")
+    _write(importer, "import { ui } from '@repo/ui';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/ui", str(importer)) == str(referenced_target)
+
+
+def test_transitive_project_reference_does_not_resolve_without_direct_reference(
+    tmp_path,
+):
+    app_dir = tmp_path / "packages" / "app"
+    ui_dir = tmp_path / "packages" / "ui"
+    importer = app_dir / "src" / "main.ts"
+
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../ui"}]}),
+    )
+    _write(
+        ui_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../core"}]}),
+    )
+    _write(
+        tmp_path / "packages" / "core" / "package.json",
+        json.dumps({"name": "@repo/core", "exports": "./src/index.ts"}),
+    )
+    _write(
+        tmp_path / "packages" / "core" / "src" / "index.ts",
+        "export const core = 1;\n",
+    )
+    _write(importer, "import { core } from '@repo/core';\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@repo/core", str(importer)) is None
+
+
+def test_build_ts_import_graph_uses_project_reference_resolution(tmp_path):
+    app_dir = tmp_path / "packages" / "app"
+    app_file = app_dir / "src" / "index.ts"
+    index_file = tmp_path / "packages" / "ui" / "src" / "index.ts"
+
+    _write(
+        app_dir / "tsconfig.json",
+        json.dumps({"references": [{"path": "../ui"}]}),
+    )
+    _write(
+        tmp_path / "packages" / "ui" / "package.json",
+        json.dumps({"name": "@repo/ui", "exports": "./src/index.ts"}),
+    )
+    _write(index_file, 'export const Button = () => "button";')
+    _write(app_file, "import { Button } from '@repo/ui';\n")
+
+    defs = {
+        f"{index_file}:Button": _make_def("Button", str(index_file)),
+    }
+    ts_raw_imports = {
+        str(app_file): [
+            {"source": "@repo/ui", "names": ["Button"], "line": 1},
+        ]
+    }
+
+    consumed, _, _ = build_ts_import_graph(
+        ts_raw_imports, defs, MonorepoResolver(str(tmp_path))
+    )
+
+    assert "Button" in consumed[str(index_file)]
 
 
 def test_tsconfig_paths_support_jsonc_comments_and_trailing_commas(tmp_path):

--- a/test/test_typescript_workspace.py
+++ b/test/test_typescript_workspace.py
@@ -98,3 +98,28 @@ def test_analyze_reports_workspace_inventory_without_source_files(tmp_path):
     assert result["analysis_summary"]["workspace_diagnostic_count"] == 0
     assert result["workspaces"]["root_package"]["name"] == "@repo/root"
     assert result["workspaces"]["packages"][0]["name"] == "@repo/app"
+
+
+def test_discover_workspace_inventory_includes_explicit_tsconfig_file_references(
+    tmp_path,
+):
+    (tmp_path / "packages" / "ui").mkdir(parents=True)
+
+    (tmp_path / "tsconfig.json").write_text(
+        json.dumps({"references": [{"path": "./packages/ui/tsconfig.lib.json"}]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "packages" / "ui" / "tsconfig.lib.json").write_text(
+        json.dumps({"compilerOptions": {}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "packages" / "ui" / "package.json").write_text(
+        json.dumps({"name": "@repo/ui"}),
+        encoding="utf-8",
+    )
+
+    inventory = discover_workspace_inventory(tmp_path)
+
+    packages = {pkg.name: pkg for pkg in inventory.packages}
+    assert packages["@repo/ui"].discovered_from == {"tsconfig.json:references"}
+    assert inventory.tsconfig_references == ["packages/ui/tsconfig.lib.json"]


### PR DESCRIPTION
## Summary

  This PR adds TypeScript monorepo support: importer-local direct project-reference
  resolution.

  Skylos now resolves bare package imports through the nearest importer `tsconfig.json`’s direct
  `references`, while keeping that behavior strictly local to the importer’s project. This is
  intended for composite TypeScript monorepos that rely on project references rather than only
  declared workspaces or path aliases.

  This PR also patches reporting mismatch: explicit `tsconfig` file references

## Why

 This covers another real monorepo shape: composite TS repos where a package resolves another package through direct `tsconfig` project references.

## Scope

  - importer-local direct project-reference resolution
  - explicit tsconfig-file reference support
  - no-name / no-package guards for referenced projects
  - Phase 1 reporting fix for explicit tsconfig-file references
  - regression tests
  - docs/changelog updates

## Files

  Main implementation:
  - `skylos/visitors/languages/typescript/resolve.py`
  - `skylos/visitors/languages/typescript/workspace.py`

  Tests:
  - `test/test_typescript_resolve.py`
  - `test/test_typescript_workspace.py`

 
## Verification

  - `pytest test/test_ts_exports.py test/test_typescript_resolve.py test/test_typescript.py test/
  test_typescript_framework.py`
  - `pytest test/test_typescript_workspace.py test/test_mcp_summary.py test/test_analyzer.py`

 