### PR TITLE
feat(py): add repo-aware vibe reference detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 - AI provenance — `--provenance` flag annotates findings with AI authorship (cursor, copilot, claude, etc.). Per-agent and per-severity breakdowns
 - TypeScript dead code detection — cross-file analysis with SKY-E003 (unused files with transitive propagation), SKY-E004 (unnecessary exports), wildcard re-export chain resolution, `.js`→`.ts` path resolution
 - TypeScript export graph — aliased imports, default re-exports, namespace re-exports all tracked correctly
+- Python vibe detection — phantom security calls/decorators now resolve imported local modules and package re-exports like `security.require_auth()` and `@guards.require_auth`
 - Next.js security — SKY-D280 (missing auth in API routes), SKY-S102 (server secrets in `"use client"` files), SKY-D281 (SQL injection in `"use server"` actions)
 - SKY-S102: Client-side secret exposure in `static/`, `public/`, `.next/`, `dist/`, `build/` paths
 - D230 enhanced: catches `redirect(request.args.get("next", "/"))` with `urlparse`/`startswith` guard suppression

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ The core product is dead code detection, security scanning, and PR gating. The A
 
 Skylos can also flag common AI-generated code mistakes. Every finding includes `vibe_category` and `ai_likelihood` (high/medium/low) metadata so you can filter them separately if you want.
 
-* **Phantom Call Detection:** Catches calls to security functions (`sanitize_input`, `validate_token`, `check_permission`, etc.) that are never defined or imported — AI hallucinates these constantly. `hallucinated_reference, high`
-* **Phantom Decorator Detection:** Catches security decorators (`@require_auth`, `@rate_limit`, `@authenticate`, etc.) that are never defined or imported. `hallucinated_reference, high`
+* **Phantom Call Detection:** Catches calls to security functions (`sanitize_input`, `validate_token`, `check_permission`, etc.) that are never defined or imported, including local-module references like `security.require_auth()`. `hallucinated_reference, high`
+* **Phantom Decorator Detection:** Catches security decorators (`@require_auth`, `@rate_limit`, `@authenticate`, etc.) that are never defined or imported, including local-module decorators like `@guards.require_auth`. `hallucinated_reference, high`
 * **Unfinished Generation:** Detects functions with only `pass`, `...`, or `raise NotImplementedError` — AI-generated stubs that silently do nothing in production. `incomplete_generation, medium`
 * **Undefined Config:** Flags `os.getenv("ENABLE_X")` referencing feature flags that are never defined anywhere in the project. `ghost_config, medium`
 * **Stale Mock Detection:** Catches `mock.patch("app.email.send_email")` where `send_email` no longer exists — AI renames functions but leaves tests pointing at the old name. `stale_reference, medium`

--- a/README_CN.md
+++ b/README_CN.md
@@ -202,8 +202,8 @@ skylos debt . --save-baseline
 
 Skylos 还可以标记常见的 AI 生成代码错误。每个发现包含 `vibe_category` 和 `ai_likelihood`（high/medium/low）元数据，你可以按需单独过滤。
 
-* **幻觉调用检测：** 捕获对安全函数（`sanitize_input`、`validate_token`、`check_permission` 等）的调用，这些函数从未定义或导入 — AI 经常虚构这些。`hallucinated_reference, high`
-* **幻觉装饰器检测：** 捕获安全装饰器（`@require_auth`、`@rate_limit`、`@authenticate` 等），这些装饰器从未定义或导入。`hallucinated_reference, high`
+* **幻觉调用检测：** 捕获对安全函数（`sanitize_input`、`validate_token`、`check_permission` 等）的调用，这些函数从未定义或导入，也包括像 `security.require_auth()` 这样的本地模块引用。`hallucinated_reference, high`
+* **幻觉装饰器检测：** 捕获安全装饰器（`@require_auth`、`@rate_limit`、`@authenticate` 等），这些装饰器从未定义或导入，也包括像 `@guards.require_auth` 这样的本地模块装饰器。`hallucinated_reference, high`
 * **未完成生成：** 检测仅包含 `pass`、`...` 或 `raise NotImplementedError` 的函数 — AI 生成的桩代码在生产环境中静默无操作。`incomplete_generation, medium`
 * **未定义配置：** 标记引用从未在项目中定义的特性标志的 `os.getenv("ENABLE_X")`。`ghost_config, medium`
 * **过时 Mock 检测：** 捕获 `mock.patch("app.email.send_email")`，其中 `send_email` 已不存在 — AI 重命名了函数但测试仍指向旧名称。`stale_reference, medium`

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -74,6 +74,7 @@ from skylos.rules.quality.logic import (
     BooleanTrapRule,
     BroadExceptionRule,
 )
+from skylos.rules.quality.phantom_refs import scan_repo_phantom_security_references
 from skylos.rules.quality.performance import PerformanceRule
 from skylos.rules.quality.unreachable import UnreachableCodeRule
 from skylos.rules.quality.async_blocking import AsyncBlockingRule
@@ -116,6 +117,33 @@ try:
     _heuristic_weights = get_tuned_weights()
 except (ImportError, OSError, ValueError):
     pass
+
+
+def _resolve_analysis_root(path_like: Path) -> Path:
+    current = path_like.resolve()
+    if not current.is_dir():
+        current = current.parent
+
+    probe = current
+    for _ in range(20):
+        if (probe / "pyproject.toml").exists():
+            return probe
+        if (probe / "setup.py").exists():
+            return probe
+        if (probe / ".git").exists():
+            return probe
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+
+    try:
+        git_root = find_git_root(current)
+        if git_root:
+            return Path(git_root).resolve()
+    except Exception:
+        pass
+
+    return current
 
 
 def _grep_verify_rescue_priority(candidate: dict) -> tuple:
@@ -1256,6 +1284,8 @@ class Skylos:
             project_root = _first
         if not project_root.is_dir():
             project_root = project_root.parent
+        if project_root.exists():
+            project_root = _resolve_analysis_root(project_root)
 
         files, root = self._discover_files(path, exclude_folders)
 
@@ -1854,6 +1884,44 @@ class Skylos:
                         ud_findings = scan_unused_dependencies(_ud_root, _ud_py_files)
                         if ud_findings:
                             all_quality.extend(ud_findings)
+
+                    if (
+                        "SKY-L012" not in project_ignore
+                        or "SKY-L023" not in project_ignore
+                    ) and project_root.exists():
+                        repo_py_files = discover_source_files(
+                            project_root,
+                            {".py"},
+                            exclude_folders=exclude_folders,
+                        )
+                        phantom_findings = scan_repo_phantom_security_references(
+                            project_root,
+                            repo_py_files,
+                            target_files=_ud_py_files,
+                        )
+                        if phantom_findings:
+                            phantom_findings = [
+                                f
+                                for f in phantom_findings
+                                if f.get("rule_id") not in project_ignore
+                            ]
+                            unsuppressed_findings = []
+                            for finding in phantom_findings:
+                                f_ignore = per_file_ignore_lines.get(
+                                    str(finding.get("file", "")), set()
+                                )
+                                if finding.get("line") in f_ignore:
+                                    all_suppressed.append(
+                                        {
+                                            **finding,
+                                            "category": "quality",
+                                            "reason": "inline ignore comment",
+                                        }
+                                    )
+                                    continue
+                                unsuppressed_findings.append(finding)
+                            phantom_findings = unsuppressed_findings
+                            all_quality.extend(phantom_findings)
             except Exception:
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error(traceback.format_exc())

--- a/skylos/rules/quality/logic.py
+++ b/skylos/rules/quality/logic.py
@@ -1244,6 +1244,8 @@ class PhantomCallRule(SkylosRule):
                 "basename": basename,
                 "line": node.lineno,
                 "col": node.col_offset,
+                "vibe_category": "hallucinated_reference",
+                "ai_likelihood": "high",
             }
         ]
 

--- a/skylos/rules/quality/phantom_refs.py
+++ b/skylos/rules/quality/phantom_refs.py
@@ -1,0 +1,564 @@
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from skylos.rules.quality.logic import (
+    _PHANTOM_SECURITY_DECORATORS,
+    _PHANTOM_SECURITY_NAMES,
+)
+
+
+@dataclass
+class _ScopeInfo:
+    shadowed_names: set[str]
+    local_imports: dict[str, list[tuple[int, str]]]
+
+
+def scan_repo_phantom_security_references(project_root, py_files, target_files=None):
+    root = Path(project_root).resolve()
+    files = [Path(f).resolve() for f in py_files if Path(f).suffix == ".py"]
+    target_paths = {
+        Path(f).resolve() for f in (target_files or files) if Path(f).suffix == ".py"
+    }
+
+    module_to_file = {}
+    file_to_module = {}
+    module_members = {}
+    module_alias_exports = {}
+    dynamic_modules = set()
+    parse_failures = set()
+
+    for file_path in files:
+        try:
+            file_path.relative_to(root)
+        except ValueError:
+            continue
+        module_name = _module_name(root, file_path)
+        if not module_name:
+            continue
+        module_to_file[module_name] = file_path
+        file_to_module[file_path] = module_name
+
+    local_modules = set(module_to_file)
+    if not local_modules:
+        return []
+
+    def _store_module_facts(module_name, tree):
+        members, has_dynamic_getattr, exported_modules = _collect_module_facts(
+            tree, module_name, local_modules
+        )
+        module_members[module_name] = members
+        module_alias_exports[module_name] = {
+            alias: target
+            for alias, target in exported_modules.items()
+            if target in local_modules
+        }
+        if has_dynamic_getattr:
+            dynamic_modules.add(module_name)
+
+    def _ensure_module_loaded(module_name):
+        if module_name in module_members:
+            return True
+        if module_name in parse_failures:
+            return False
+
+        file_path = module_to_file.get(module_name)
+        if not file_path:
+            parse_failures.add(module_name)
+            return False
+
+        try:
+            tree = ast.parse(file_path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, SyntaxError):
+            parse_failures.add(module_name)
+            return False
+
+        _store_module_facts(module_name, tree)
+        return True
+
+    findings = []
+
+    for file_path, current_module in file_to_module.items():
+        if target_paths and file_path not in target_paths:
+            continue
+        try:
+            tree = ast.parse(file_path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, SyntaxError):
+            continue
+
+        _store_module_facts(current_module, tree)
+        parent_map = _build_parent_map(tree)
+        scope_infos = _build_scope_infos(tree, current_module, local_modules)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                resolved = _resolve_local_module_member(
+                    expr=node.func,
+                    node=node,
+                    tree=tree,
+                    parent_map=parent_map,
+                    scope_infos=scope_infos,
+                    module_alias_exports=module_alias_exports,
+                    local_modules=local_modules,
+                    ensure_module_loaded=_ensure_module_loaded,
+                )
+                if not resolved:
+                    continue
+
+                target_module, member_name, expr_text = resolved
+                if member_name not in _PHANTOM_SECURITY_NAMES:
+                    continue
+                if not _ensure_module_loaded(target_module):
+                    continue
+                if target_module in dynamic_modules:
+                    continue
+                if member_name in module_members.get(target_module, set()):
+                    continue
+
+                findings.append(
+                    _build_call_finding(
+                        file_path=file_path,
+                        node=node.func,
+                        expr_text=expr_text,
+                        target_module=target_module,
+                        member_name=member_name,
+                    )
+                )
+                continue
+
+            if not isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                continue
+
+            for deco in node.decorator_list:
+                deco_target = deco.func if isinstance(deco, ast.Call) else deco
+                resolved = _resolve_local_module_member(
+                    expr=deco_target,
+                    node=deco_target,
+                    tree=tree,
+                    parent_map=parent_map,
+                    scope_infos=scope_infos,
+                    module_alias_exports=module_alias_exports,
+                    local_modules=local_modules,
+                    ensure_module_loaded=_ensure_module_loaded,
+                )
+                if not resolved:
+                    continue
+
+                target_module, member_name, expr_text = resolved
+                if member_name not in _PHANTOM_SECURITY_DECORATORS:
+                    continue
+                if not _ensure_module_loaded(target_module):
+                    continue
+                if target_module in dynamic_modules:
+                    continue
+                if member_name in module_members.get(target_module, set()):
+                    continue
+
+                findings.append(
+                    _build_decorator_finding(
+                        file_path=file_path,
+                        node=deco_target,
+                        expr_text=expr_text,
+                        target_module=target_module,
+                        member_name=member_name,
+                    )
+                )
+
+    return findings
+
+
+def _module_name(root: Path, file_path: Path) -> str:
+    parts = list(file_path.relative_to(root).parts)
+
+    if "src" in parts:
+        src_idx = parts.index("src")
+        src_path = root / "/".join(parts[: src_idx + 1])
+        if not (src_path / "__init__.py").exists():
+            parts = parts[src_idx + 1 :]
+
+    if not parts:
+        return ""
+
+    if parts[-1].endswith(".py"):
+        parts[-1] = parts[-1][:-3]
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _collect_module_facts(tree, current_module, local_modules):
+    members = set()
+    exported_modules = {}
+    has_dynamic_getattr = False
+
+    if not isinstance(tree, ast.Module):
+        return members, has_dynamic_getattr, exported_modules
+
+    for stmt in tree.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            members.add(stmt.name)
+            if stmt.name == "__getattr__":
+                has_dynamic_getattr = True
+        elif isinstance(stmt, ast.ClassDef):
+            members.add(stmt.name)
+        elif isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                members.update(_extract_target_names(target))
+        elif isinstance(stmt, ast.AnnAssign):
+            members.update(_extract_target_names(stmt.target))
+        elif isinstance(stmt, ast.Import):
+            for alias in stmt.names:
+                bound_name = alias.asname or alias.name.split(".", 1)[0]
+                members.add(bound_name)
+                if alias.asname and alias.name in local_modules:
+                    exported_modules[bound_name] = alias.name
+                elif not alias.asname:
+                    head = alias.name.split(".", 1)[0]
+                    if head in local_modules:
+                        exported_modules[head] = head
+        elif isinstance(stmt, ast.ImportFrom):
+            base = _resolve_import_from_base(current_module, stmt)
+            for alias in stmt.names:
+                if alias.name == "*":
+                    if base in local_modules:
+                        has_dynamic_getattr = True
+                    continue
+                bound_name = alias.asname or alias.name
+                members.add(bound_name)
+                full_name = f"{base}.{alias.name}" if base else alias.name
+                if full_name in local_modules:
+                    exported_modules[bound_name] = full_name
+
+    return members, has_dynamic_getattr, exported_modules
+
+
+def _build_parent_map(tree):
+    parent_map = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parent_map[child] = parent
+    return parent_map
+
+
+def _build_scope_infos(tree, current_module, local_modules):
+    scope_infos = {tree: _collect_scope_info(tree, current_module, local_modules)}
+    for node in ast.walk(tree):
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+        ):
+            scope_infos[node] = _collect_scope_info(node, current_module, local_modules)
+    return scope_infos
+
+
+def _collect_scope_info(scope_node, current_module, local_modules):
+    shadowed = set()
+    local_imports = defaultdict(list)
+
+    if isinstance(scope_node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        shadowed.update(_extract_args_names(scope_node.args))
+
+    class ScopeCollector(ast.NodeVisitor):
+        def generic_visit(self, node):
+            for child in ast.iter_child_nodes(node):
+                self.visit(child)
+
+        def visit_Import(self, node):
+            for alias in node.names:
+                bound_name = alias.asname or alias.name.split(".", 1)[0]
+                full_name = alias.name if alias.asname else alias.name.split(".", 1)[0]
+                if full_name in local_modules:
+                    local_imports[bound_name].append((node.lineno, full_name))
+
+        def visit_ImportFrom(self, node):
+            base = _resolve_import_from_base(current_module, node)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                full_name = f"{base}.{alias.name}" if base else alias.name
+                if full_name in local_modules:
+                    local_imports[alias.asname or alias.name].append(
+                        (node.lineno, full_name)
+                    )
+
+        def visit_Assign(self, node):
+            for target in node.targets:
+                shadowed.update(_extract_target_names(target))
+            self.generic_visit(node.value)
+
+        def visit_AnnAssign(self, node):
+            shadowed.update(_extract_target_names(node.target))
+            if node.value:
+                self.generic_visit(node.value)
+
+        def visit_AugAssign(self, node):
+            shadowed.update(_extract_target_names(node.target))
+            self.generic_visit(node.value)
+
+        def visit_NamedExpr(self, node):
+            shadowed.update(_extract_target_names(node.target))
+            self.generic_visit(node.value)
+
+        def visit_For(self, node):
+            shadowed.update(_extract_target_names(node.target))
+            self.generic_visit(node.iter)
+            for stmt in node.body:
+                self.visit(stmt)
+            for stmt in node.orelse:
+                self.visit(stmt)
+
+        visit_AsyncFor = visit_For
+
+        def visit_With(self, node):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    shadowed.update(_extract_target_names(item.optional_vars))
+                self.visit(item.context_expr)
+            for stmt in node.body:
+                self.visit(stmt)
+
+        visit_AsyncWith = visit_With
+
+        def visit_ExceptHandler(self, node):
+            if node.name:
+                shadowed.add(node.name)
+            if node.type:
+                self.visit(node.type)
+            for stmt in node.body:
+                self.visit(stmt)
+
+        def visit_FunctionDef(self, node):
+            shadowed.add(node.name)
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_ClassDef(self, node):
+            shadowed.add(node.name)
+
+        def visit_Lambda(self, node):
+            return
+
+    collector = ScopeCollector()
+    if isinstance(scope_node, ast.Module):
+        for stmt in scope_node.body:
+            collector.visit(stmt)
+    elif isinstance(scope_node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        for stmt in scope_node.body:
+            collector.visit(stmt)
+    elif isinstance(scope_node, ast.Lambda):
+        collector.visit(scope_node.body)
+
+    return _ScopeInfo(
+        shadowed_names=shadowed,
+        local_imports={k: sorted(v) for k, v in local_imports.items()},
+    )
+
+
+def _resolve_local_module_member(
+    expr,
+    node,
+    tree,
+    parent_map,
+    scope_infos,
+    module_alias_exports,
+    local_modules,
+    ensure_module_loaded,
+):
+    chain = _flatten_attribute_chain(expr)
+    if not chain or len(chain) < 2:
+        return None
+
+    base_module = _resolve_visible_alias(
+        base_name=chain[0],
+        node=node,
+        tree=tree,
+        parent_map=parent_map,
+        scope_infos=scope_infos,
+    )
+    if not base_module:
+        return None
+
+    current_module = base_module
+    for segment in chain[1:-1]:
+        direct_module = f"{current_module}.{segment}"
+        if direct_module in local_modules:
+            current_module = direct_module
+            continue
+
+        if not ensure_module_loaded(current_module):
+            return None
+        exported_module = module_alias_exports.get(current_module, {}).get(segment)
+        if exported_module:
+            current_module = exported_module
+            continue
+
+        return None
+
+    return current_module, chain[-1], ".".join(chain)
+
+
+def _resolve_visible_alias(base_name, node, tree, parent_map, scope_infos):
+    visible_module = None
+    for scope in _enclosing_scopes(node, tree, parent_map):
+        info = scope_infos.get(scope)
+        if not info:
+            continue
+
+        if base_name in info.shadowed_names:
+            return None
+
+        imports = info.local_imports.get(base_name, [])
+        if not imports:
+            continue
+
+        matching = [module_name for line, module_name in imports if line <= node.lineno]
+        if not matching:
+            return None
+        visible_module = matching[-1]
+
+    return visible_module
+
+
+def _enclosing_scopes(node, tree, parent_map):
+    scopes = [tree]
+    cur = parent_map.get(node)
+    child = node
+    nested_scopes = []
+    function_barrier = False
+
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            if _is_decorator_expression(child, cur):
+                child = cur
+                cur = parent_map.get(cur)
+                continue
+            nested_scopes.append(cur)
+            function_barrier = True
+        elif isinstance(cur, ast.ClassDef) and not function_barrier:
+            nested_scopes.append(cur)
+
+        child = cur
+        cur = parent_map.get(cur)
+
+    scopes.extend(reversed(nested_scopes))
+    return scopes
+
+
+def _is_decorator_expression(child, parent):
+    decorator_list = getattr(parent, "decorator_list", None)
+    return bool(decorator_list) and child in decorator_list
+
+
+def _resolve_import_from_base(current_module, node):
+    module = node.module or ""
+    cur_pkg = (
+        current_module.rsplit(".", 1)[0] if "." in current_module else current_module
+    )
+
+    if node.level and node.level > 0:
+        parts = cur_pkg.split(".") if cur_pkg else []
+        up = node.level - 1
+
+        if up > len(parts):
+            base = ""
+        else:
+            base = ".".join(parts[: len(parts) - up])
+
+        if module:
+            base = f"{base}.{module}" if base else module
+        return base
+
+    return module
+
+
+def _flatten_attribute_chain(expr):
+    parts = []
+    current = expr
+
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+
+    if not isinstance(current, ast.Name):
+        return None
+
+    parts.append(current.id)
+    parts.reverse()
+    return parts
+
+
+def _extract_target_names(target):
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names = set()
+        for elt in target.elts:
+            names.update(_extract_target_names(elt))
+        return names
+    if isinstance(target, ast.Starred):
+        return _extract_target_names(target.value)
+    return set()
+
+
+def _extract_args_names(args):
+    names = {
+        arg.arg
+        for arg in (list(args.posonlyargs) + list(args.args) + list(args.kwonlyargs))
+    }
+    if args.vararg:
+        names.add(args.vararg.arg)
+    if args.kwarg:
+        names.add(args.kwarg.arg)
+    return names
+
+
+def _build_call_finding(file_path, node, expr_text, target_module, member_name):
+    return {
+        "rule_id": "SKY-L012",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": "call",
+        "name": expr_text,
+        "simple_name": member_name,
+        "value": "phantom",
+        "threshold": 0,
+        "message": (
+            f"Call to '{expr_text}()' resolves to local module '{target_module}', "
+            f"but '{member_name}' is not defined or re-exported there. "
+            f"AI-generated code often hallucinates security helpers on local modules."
+        ),
+        "file": str(file_path),
+        "basename": file_path.name,
+        "line": node.lineno,
+        "col": node.col_offset,
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+    }
+
+
+def _build_decorator_finding(file_path, node, expr_text, target_module, member_name):
+    return {
+        "rule_id": "SKY-L023",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": "decorator",
+        "name": expr_text,
+        "simple_name": member_name,
+        "value": "phantom",
+        "threshold": 0,
+        "message": (
+            f"Decorator '@{expr_text}' resolves to local module '{target_module}', "
+            f"but '{member_name}' is not defined or re-exported there. "
+            f"AI-generated code often hallucinates security decorators on local modules."
+        ),
+        "file": str(file_path),
+        "basename": file_path.name,
+        "line": node.lineno,
+        "col": node.col_offset,
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+    }

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1151,5 +1151,242 @@ ignore = []
         assert "SKY-D260" not in danger_rule_ids
 
 
+class TestRepoPhantomReferences:
+    def test_analyze_flags_imported_local_module_member_call(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        pkg = tmp_path / "app"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "security.py").write_text(
+            """
+def authenticate(request):
+    return request
+""".strip(),
+            encoding="utf-8",
+        )
+        (pkg / "views.py").write_text(
+            """
+from app import security
+
+def handler(request):
+    return security.require_auth(request)
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert len(quality) == 1
+        assert quality[0]["name"] == "security.require_auth"
+        assert quality[0]["vibe_category"] == "hallucinated_reference"
+
+    def test_analyze_single_file_skips_repo_phantom_reference_scan(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        pkg = tmp_path / "app"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "security.py").write_text(
+            """
+def authenticate(request):
+    return request
+""".strip(),
+            encoding="utf-8",
+        )
+        views = pkg / "views.py"
+        views.write_text(
+            """
+from app import security
+
+def handler(request):
+    return security.require_auth(request)
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(views), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert quality == []
+
+    def test_analyze_subdirectory_uses_repo_root_for_phantom_scan(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        pkg = tmp_path / "app"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "security.py").write_text(
+            """
+def authenticate(request):
+    return request
+""".strip(),
+            encoding="utf-8",
+        )
+        (pkg / "views.py").write_text(
+            """
+from app import security
+
+def handler(request):
+    return security.require_auth(request)
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(pkg), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert len(quality) == 1
+        assert quality[0]["name"] == "security.require_auth"
+
+    def test_analyze_nested_subproject_uses_nearest_project_root(self, tmp_path):
+        backend = tmp_path / "backend"
+        backend.mkdir()
+        (backend / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+
+        pkg = backend / "app"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "security.py").write_text(
+            """
+def authenticate(request):
+    return request
+""".strip(),
+            encoding="utf-8",
+        )
+        (pkg / "views.py").write_text(
+            """
+from app import security
+
+def handler(request):
+    return security.require_auth(request)
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(pkg), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert len(quality) == 1
+        assert quality[0]["name"] == "security.require_auth"
+
+    def test_analyze_nested_subproject_ignore_applies_to_repo_phantom_scan(
+        self, tmp_path
+    ):
+        backend = tmp_path / "backend"
+        backend.mkdir()
+        (backend / "pyproject.toml").write_text(
+            """
+[tool.skylos]
+ignore = ["SKY-L012"]
+""".strip(),
+            encoding="utf-8",
+        )
+
+        pkg = backend / "app"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "security.py").write_text(
+            """
+def authenticate(request):
+    return request
+""".strip(),
+            encoding="utf-8",
+        )
+        (pkg / "views.py").write_text(
+            """
+from app import security
+
+def handler(request):
+    return security.require_auth(request)
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(backend), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert quality == []
+
+    def test_analyze_repo_phantom_respects_inline_ignore_pragmas(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        pkg = tmp_path / "app"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "security.py").write_text(
+            """
+def authenticate(request):
+    return request
+""".strip(),
+            encoding="utf-8",
+        )
+        (pkg / "views.py").write_text(
+            """
+from app import security
+
+def handler(request):
+    return security.require_auth(request)  # skylos: ignore
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+        suppressed = [
+            f for f in result.get("suppressed", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert quality == []
+        assert len(suppressed) == 1
+        assert suppressed[0]["reason"] == "inline ignore comment"
+
+    def test_analyze_subtree_resolves_repo_local_modules_outside_selection(
+        self, tmp_path
+    ):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+
+        common = tmp_path / "common"
+        common.mkdir()
+        (common / "__init__.py").write_text("", encoding="utf-8")
+        (common / "security.py").write_text(
+            """
+def authenticate(request):
+    return request
+""".strip(),
+            encoding="utf-8",
+        )
+
+        app = tmp_path / "app"
+        app.mkdir()
+        (app / "__init__.py").write_text("", encoding="utf-8")
+        (app / "views.py").write_text(
+            """
+from common import security
+
+def handler(request):
+    return security.require_auth(request)
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(app), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert len(quality) == 1
+        assert quality[0]["name"] == "security.require_auth"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/test_vibe_rules.py
+++ b/test/test_vibe_rules.py
@@ -1,4 +1,6 @@
 import ast
+import os
+import shutil
 import textwrap
 import tempfile
 import warnings
@@ -20,6 +22,7 @@ from skylos.rules.quality.logic import (
     ErrorDisclosureRule,
     BroadFilePermissionsRule,
 )
+from skylos.rules.quality.phantom_refs import scan_repo_phantom_security_references
 from skylos.rules.quality.unused_deps import scan_unused_dependencies
 
 
@@ -32,6 +35,21 @@ def check_code(rule, code, filename="test.py"):
         if res:
             findings.extend(res)
     return findings
+
+
+def scan_repo_code(files):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        root = Path(tmpdir)
+        (root / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        for rel_path, content in files.items():
+            target = root / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(textwrap.dedent(content), encoding="utf-8")
+        py_files = sorted(root.rglob("*.py"))
+        return scan_repo_phantom_security_references(root, py_files)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 class TestEmptyErrorHandler:
@@ -828,6 +846,9 @@ class TestPhantomCall:
         """
         findings = check_code(PhantomCallRule(), code)
         assert any(f["rule_id"] == "SKY-L012" for f in findings)
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert l012[0]["vibe_category"] == "hallucinated_reference"
+        assert l012[0]["ai_likelihood"] == "high"
 
     def test_defined_locally_not_flagged(self):
         code = """
@@ -882,6 +903,258 @@ class TestPhantomCall:
         findings = check_code(PhantomCallRule(), code)
         l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
         assert len(l012) == 3
+
+    def test_repo_local_module_attribute_call_phantom(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(request):
+                        return request
+                """,
+                "app/views.py": """
+                    from app import security
+
+                    def handler(request):
+                        return security.require_auth(request)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 1
+        assert l012[0]["name"] == "security.require_auth"
+        assert l012[0]["simple_name"] == "require_auth"
+
+    def test_repo_dynamic_module_not_flagged(self):
+        findings = scan_repo_code(
+            {
+                "guards/__init__.py": """
+                    def __getattr__(name):
+                        return lambda *args, **kwargs: None
+                """,
+                "app.py": """
+                    import guards
+
+                    def handler(request):
+                        return guards.require_auth(request)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 0
+
+    def test_repo_function_local_import_is_detected(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(request):
+                        return request
+                """,
+                "app/views.py": """
+                    def handler(request):
+                        from app import security
+                        return security.require_auth(request)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 1
+        assert l012[0]["name"] == "security.require_auth"
+
+    def test_repo_root_package_import_chain_is_detected(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(request):
+                        return request
+                """,
+                "app/views.py": """
+                    import app.security
+
+                    def handler(request):
+                        return app.security.require_auth(request)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 1
+        assert l012[0]["name"] == "app.security.require_auth"
+
+    def test_repo_shadowed_import_name_not_flagged(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(request):
+                        return request
+                """,
+                "app/views.py": """
+                    from app import security
+
+                    def handler(security):
+                        return security.require_auth(request=None)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 0
+
+    def test_repo_imported_module_with_parse_error_not_flagged(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def broken(
+                """,
+                "app/views.py": """
+                    from app import security
+
+                    def handler(request):
+                        return security.require_auth(request)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 0
+
+    def test_repo_symlinked_external_python_file_not_scanned(self):
+        tmpdir = tempfile.mkdtemp()
+        external_dir = tempfile.mkdtemp()
+        try:
+            root = Path(tmpdir)
+            external = Path(external_dir) / "security.py"
+            external.write_text(
+                textwrap.dedent(
+                    """
+                    def broken(
+                    """
+                ),
+                encoding="utf-8",
+            )
+            (root / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+            app = root / "app"
+            app.mkdir()
+            (app / "__init__.py").write_text("", encoding="utf-8")
+            os.symlink(external, app / "security.py")
+            (app / "views.py").write_text(
+                textwrap.dedent(
+                    """
+                    from app import security
+
+                    def handler(request):
+                        return security.require_auth(request)
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            py_files = sorted(root.rglob("*.py"))
+            findings = scan_repo_phantom_security_references(root, py_files)
+            l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+            assert len(l012) == 0
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            shutil.rmtree(external_dir, ignore_errors=True)
+
+    def test_repo_class_body_shadowed_alias_not_flagged(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(request):
+                        return request
+                """,
+                "app/views.py": """
+                    from app import security
+
+                    class WrappedView:
+                        security = object()
+
+                        @security.require_auth
+                        def get(self):
+                            return "ok"
+                """,
+            }
+        )
+
+        l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
+        assert len(l023) == 0
+
+    def test_repo_class_body_import_is_detected(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(fn):
+                        return fn
+                """,
+                "app/views.py": """
+                    class WrappedView:
+                        from app import security
+
+                        @security.require_auth
+                        def get(self):
+                            return "ok"
+                """,
+            }
+        )
+
+        l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
+        assert len(l023) == 1
+        assert l023[0]["name"] == "security.require_auth"
+
+    def test_repo_class_body_import_does_not_leak_into_method_body(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(request):
+                        return request
+                """,
+                "app/views.py": """
+                    class WrappedView:
+                        from app import security
+
+                        def get(self, request):
+                            return security.require_auth(request)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 0
+
+    def test_repo_class_body_shadow_does_not_hide_module_call_in_method_body(self):
+        findings = scan_repo_code(
+            {
+                "app/__init__.py": "",
+                "app/security.py": """
+                    def authenticate(request):
+                        return request
+                """,
+                "app/views.py": """
+                    from app import security
+
+                    class WrappedView:
+                        security = object()
+
+                        def get(self, request):
+                            return security.require_auth(request)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 1
+        assert l012[0]["name"] == "security.require_auth"
 
 
 class TestInsecureRandom:
@@ -1291,6 +1564,115 @@ class TestPhantomDecorator:
         findings = check_code(PhantomDecoratorRule(), code)
         l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
         assert len(l023) == 2
+
+    def test_repo_local_module_decorator_phantom(self):
+        findings = scan_repo_code(
+            {
+                "pkg/__init__.py": "",
+                "pkg/guards.py": """
+                    def authenticate(fn):
+                        return fn
+                """,
+                "pkg/views.py": """
+                    from . import guards as auth
+
+                    @auth.require_auth
+                    def secret():
+                        return "secret"
+                """,
+            }
+        )
+
+        l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
+        assert len(l023) == 1
+        assert l023[0]["name"] == "auth.require_auth"
+        assert l023[0]["simple_name"] == "require_auth"
+
+    def test_repo_reexported_package_member_not_flagged(self):
+        findings = scan_repo_code(
+            {
+                "pkg/__init__.py": """
+                    from .guards import require_auth
+                """,
+                "pkg/guards.py": """
+                    def require_auth(fn):
+                        return fn
+                """,
+                "pkg/views.py": """
+                    import pkg
+
+                    @pkg.require_auth
+                    def secret():
+                        return "secret"
+                """,
+            }
+        )
+
+        l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
+        assert len(l023) == 0
+
+    def test_repo_module_alias_reexport_resolves(self):
+        findings = scan_repo_code(
+            {
+                "pkg/__init__.py": """
+                    from . import guards as security
+                """,
+                "pkg/guards.py": """
+                    def authenticate(fn):
+                        return fn
+                """,
+                "pkg/views.py": """
+                    import pkg
+
+                    @pkg.security.require_auth
+                    def secret():
+                        return "secret"
+                """,
+            }
+        )
+
+        l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
+        assert len(l023) == 1
+        assert l023[0]["name"] == "pkg.security.require_auth"
+
+    def test_repo_star_reexport_not_flagged(self):
+        findings = scan_repo_code(
+            {
+                "pkg/__init__.py": """
+                    from .guards import *
+                """,
+                "pkg/guards.py": """
+                    def require_auth(fn):
+                        return fn
+                """,
+                "pkg/views.py": """
+                    import pkg
+
+                    @pkg.require_auth
+                    def secret():
+                        return "secret"
+                """,
+            }
+        )
+
+        l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
+        assert len(l023) == 0
+
+    def test_third_party_module_attribute_not_flagged(self):
+        findings = scan_repo_code(
+            {
+                "app.py": """
+                    import flask_login
+
+                    @flask_login.require_auth
+                    def secret():
+                        return "secret"
+                """
+            }
+        )
+
+        l023 = [f for f in findings if f["rule_id"] == "SKY-L023"]
+        assert len(l023) == 0
 
 
 class TestUnfinishedGeneration:


### PR DESCRIPTION
## Summary

This PR extends that to imported local-module references and package re-exports, for example:
  - `security.require_auth(...)`
  - `app.security.validate_token(...)`
  - `@guards.require_auth`
  - `@pkg.security.require_auth`

Code that looks plausible, imports real local modules, but calls or decorates with security helpers that do not actually exist there.

## Why

The existing vibe rules were useful but still too file-local. It strengthens the main static-analysis engine using deterministic repo-aware resolution.

## User-visible behavior

  This reuses the existing rule IDs:
  - `SKY-L012` for phantom calls
  - `SKY-L023` for phantom decorators

  The findings also now consistently carry:
  - `vibe_category: hallucinated_reference`
  - `ai_likelihood: high`

## Files

  Main implementation:
  - `skylos/rules/quality/phantom_refs.py`
  - `skylos/analyzer.py`
  - `skylos/rules/quality/logic.py`

  Tests:
  - `test/test_vibe_rules.py`
  - `test/test_analyzer.py`

  Docs:
  - `README.md`
  - `README_CN.md`
  - `CHANGELOG.md`

## Validation

  - `pytest test/test_vibe_rules.py test/test_analyzer.py`
  - `pytest test/test_quality_rules.py test/test_vibe_rules.py test/test_analyzer.py`