### PR TITLE
feat(cli): add suite command for the full local bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added configurable web UI port support for `skylos run` via `--port` or `SKYLOS_PORT`
 - Added monorepo workspace inventory reporting for TypeScript projects. Skylos now reports root packages, child workspaces from `package.json` / `pnpm-workspace.yaml`, `tsconfig.json` references, and undeclared workspace package diagnostics in analysis and MCP output
 - Added TypeScript AI defense beta support to `skylos discover` / `skylos defend` for direct Node / Next-style LLM integrations, reusing the existing guardrail engine and report format
+- Added `skylos suite <path>` as a single local command for static analysis, technical debt, AI defense, and provenance summary
 
 ### Changed
 - SKY-L030: Lint rule for `except Exception`/`except BaseException` with trivial handler (CWE-396)
@@ -45,6 +46,7 @@
 - TypeScript resolution now supports importer-local direct `tsconfig.json` project references for composite monorepos without leaking those references into global package resolution
 - TypeScript dead-file and unnecessary-export analysis now treats workspace package entrypoints as reachability roots, including packages kept alive through direct local `tsconfig.json` project references
 - AI defense file discovery for `discover` / `defend` now scans direct TypeScript and JavaScript source files in addition to Python
+- Docs, help, and tour now steer new users toward a smaller command set centered on `skylos suite .`, `skylos .`, `skylos cicd init`, and the agent commands
 
 ### Fixed
 - Browser login callback now validates `state` and verifies the returned token metadata via `whoami`

--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ The core use case is straightforward: run it locally, add it to CI, and gate pul
 
 | Goal | Command | What you get |
 |:---|:---|:---|
+| **Run everything local** | `skylos suite .` | Static findings, technical debt hotspots, Python AI defense, and provenance summary in one report |
 | **Scan a repo** | `skylos . -a` | Dead code, risky flows, secrets, and code quality findings |
 | **Gate pull requests** | `skylos cicd init` | A GitHub Actions workflow with a quality gate and inline annotations |
 | **Audit an LLM app** | `skylos defend .` | Optional AI defense checks for Python and direct TypeScript LLM integrations |
+
+### If you only remember 4 commands
+
+- `skylos suite .` for the full local overview
+- `skylos .` for the focused static scan
+- `skylos cicd init` for CI setup
+- `skylos agent scan .` for hybrid static + LLM review
 
 ### Why teams adopt it
 
@@ -136,6 +144,7 @@ If you are evaluating Skylos, start with the core workflow below. The LLM and AI
 
 | Objective | Command | Outcome |
 | :--- | :--- | :--- |
+| **Everything local** | `skylos suite .` | One report for static findings, technical debt, Python AI defense, and provenance |
 | **First scan** | `skylos .` | Dead code findings with confidence scoring |
 | **Audit risk and quality** | `skylos . -a` | Dead code, risky flows, secrets, quality, and SCA findings |
 | **Higher-confidence dead code** | `skylos . --trace` | Cross-reference static findings with runtime activity |
@@ -913,6 +922,7 @@ Release roles, prerequisites, branch protection guidance, semantic type policy, 
 
 | Command | Description |
 |---------|-------------|
+| `skylos suite <path>` | Full local bundle: static analysis, debt, Python AI defense, and provenance summary |
 | `skylos <path>` | Dead code, security, and quality analysis |
 | `skylos debt <path>` | Technical debt hotspot analysis with baseline-aware prioritization |
 | `skylos discover <path>` | Map LLM/AI integrations in your codebase |
@@ -1629,6 +1639,7 @@ skylos . --audit --model claude-haiku-4-5-20251001
 
 ### Combine Everything
 ```bash
+skylos suite .                        # Static + debt + AI defense + provenance
 skylos . -a                           # All static scans (danger + secrets + quality + sca)
 skylos agent remediate . --dry-run    # Preview AI-assisted fixes
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -49,9 +49,17 @@ Skylos 是一款面向 Python、TypeScript 和 Go 的开源静态分析工具和
 
 | 目标 | 命令 | 获得的结果 |
 |:---|:---|:---|
+| **运行完整本地套件** | `skylos suite .` | 在一份报告中查看静态发现、技术债务热点、Python AI 防御和来源摘要 |
 | **扫描代码仓库** | `skylos . -a` | 死代码、风险流程、密钥和代码质量发现 |
 | **门控拉取请求** | `skylos cicd init` | 带质量门控和内联注释的 GitHub Actions 工作流 |
 | **审计 LLM 应用** | `skylos defend .` | 针对 Python 和直接 TypeScript LLM 集成的可选 AI 防御检查 |
+
+### 如果你只记住 4 个命令
+
+- `skylos suite .` 用于完整本地概览
+- `skylos .` 用于聚焦的静态扫描
+- `skylos cicd init` 用于配置 CI
+- `skylos agent scan .` 用于静态 + LLM 混合审查
 
 ### 团队采用 Skylos 的原因
 
@@ -134,6 +142,7 @@ git add .github/workflows/skylos.yml && git push
 
 | 目标 | 命令 | 结果 |
 | :--- | :--- | :--- |
+| **完整本地概览** | `skylos suite .` | 一份报告中查看静态发现、技术债务、Python AI 防御和来源摘要 |
 | **首次扫描** | `skylos .` | 带置信度评分的死代码发现 |
 | **审计风险和质量** | `skylos . -a` | 死代码、风险流程、密钥、质量和 SCA 发现 |
 | **更高置信度的死代码** | `skylos . --trace` | 将静态发现与运行时活动交叉验证 |
@@ -833,6 +842,7 @@ skylos cicd init --llm --model claude-sonnet-4-20250514
 
 | 命令 | 描述 |
 |---------|-------------|
+| `skylos suite <path>` | 完整本地套件：静态分析、技术债务、Python AI 防御和来源摘要 |
 | `skylos <path>` | 死代码、安全和质量分析 |
 | `skylos debt <path>` | 基于基线感知优先级的技术债务热点分析 |
 | `skylos discover <path>` | 映射代码库中的 LLM/AI 集成 |
@@ -1540,6 +1550,7 @@ skylos . --audit --model claude-haiku-4-5-20251001
 
 ### 组合所有功能
 ```bash
+skylos suite .                        # 静态分析 + 技术债务 + AI 防御 + 来源摘要
 skylos . -a                           # 所有静态扫描（danger + secrets + quality + sca）
 skylos agent remediate . --dry-run    # 预览 AI 辅助修复
 ```

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -576,6 +576,7 @@ def _print_feature_hints(console: Console, args):
         idx = 0
 
     rotating_hints = [
+        "[dim]Run the full local bundle:[/dim] [bold]skylos suite .[/bold]",
         "[dim]Scan for AI/LLM guardrails:[/dim] [bold]skylos defend .[/bold]",
         "[dim]Map LLM integrations:[/dim] [bold]skylos discover .[/bold]",
         "[dim]LLM-verified dead code (100% accuracy):[/dim] [bold]skylos agent verify .[/bold]",
@@ -1655,6 +1656,21 @@ def run_defend_command(argv):
     )
 
 
+def run_suite_command(argv):
+    from skylos.api import get_git_root
+    from skylos.commands.suite_cmd import run_suite_command as run_suite_command_impl
+
+    return run_suite_command_impl(
+        argv,
+        console_factory=Console,
+        progress_factory=Progress,
+        parse_exclude_folders_func=parse_exclude_folders,
+        load_config_func=load_config,
+        run_analyze_func=run_analyze,
+        get_git_root_func=get_git_root,
+    )
+
+
 def run_ingest_command(argv):
     from skylos.commands.ingest_cmd import run_ingest_command as run_ingest_command_impl
 
@@ -1812,7 +1828,8 @@ def _run_removed_city_command(_argv):
     console = Console()
     console.print("[bold red]Error:[/bold red] `skylos city` has been removed.")
     console.print(
-        "[dim]Use[/dim] [bold]skylos debt .[/bold] [dim]for technical debt hotspots or[/dim] "
+        "[dim]Use[/dim] [bold]skylos suite .[/bold] [dim]for the full local bundle,[/dim] "
+        "[bold]skylos debt .[/bold] [dim]for technical debt hotspots, or[/dim] "
         "[bold]skylos discover .[/bold] [dim]for codebase mapping.[/dim]"
     )
     raise SystemExit(2)
@@ -1840,6 +1857,7 @@ EARLY_COMMAND_HANDLERS = {
     "sync": "_run_sync_command",
     "project": "_run_project_command",
     "city": "_run_removed_city_command",
+    "suite": "run_suite_command",
     "discover": "_run_discover_command",
     "defend": "run_defend_command",
     "debt": "run_debt_command",

--- a/skylos/commands/suite_cmd.py
+++ b/skylos/commands/suite_cmd.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from skylos.suite import format_suite_json, format_suite_table, run_suite
+
+
+def run_suite_command(
+    argv: list[str],
+    *,
+    console_factory,
+    progress_factory,
+    parse_exclude_folders_func,
+    load_config_func,
+    run_analyze_func,
+    get_git_root_func,
+) -> int:
+    suite_parser = argparse.ArgumentParser(
+        prog="skylos suite",
+        description=(
+            "Run the full local Skylos suite: static analysis, technical debt, "
+            "AI defense, and provenance summary"
+        ),
+    )
+    suite_parser.add_argument("path", nargs="?", default=".", help="Path to scan")
+    suite_parser.add_argument(
+        "--json", action="store_true", dest="output_json", help="Output as JSON"
+    )
+    suite_parser.add_argument(
+        "-o", "--output", dest="output_file", help="Write output to file"
+    )
+    suite_parser.add_argument(
+        "--exclude",
+        nargs="+",
+        default=None,
+        help="Additional folders to exclude",
+    )
+    suite_parser.add_argument(
+        "--confidence",
+        "-c",
+        type=int,
+        default=60,
+        help="Confidence threshold for static dead-code findings (0-100)",
+    )
+    suite_parser.add_argument(
+        "--diff-base",
+        default=None,
+        help="Base ref for provenance detection (default: auto-detect)",
+    )
+    suite_parser.add_argument(
+        "--no-provenance",
+        action="store_true",
+        help="Disable automatic AI provenance summary",
+    )
+
+    suite_args = suite_parser.parse_args(argv)
+    console = console_factory()
+
+    target = Path(suite_args.path).resolve()
+    if not target.exists():
+        console.print(f"[red]Error: path does not exist: {target}[/red]")
+        return 1
+    if not target.is_dir():
+        console.print(
+            f"[red]Error: suite expects a directory, got file: {target}. "
+            "Use `skylos <file>` for single-file static analysis.[/red]"
+        )
+        return 1
+
+    exclude = set(
+        parse_exclude_folders_func(
+            use_defaults=True,
+            config_exclude_folders=load_config_func(target).get("exclude"),
+        )
+    )
+    if suite_args.exclude:
+        exclude.update(suite_args.exclude)
+
+    try:
+        report = run_suite(
+            target,
+            conf=suite_args.confidence,
+            exclude_folders=sorted(exclude),
+            run_analyze_func=run_analyze_func,
+            progress_factory=progress_factory,
+            console=console,
+            output_json=suite_args.output_json,
+            no_provenance=suite_args.no_provenance,
+            diff_base=suite_args.diff_base,
+            get_git_root_func=get_git_root_func,
+        )
+    except (FileNotFoundError, ValueError, ImportError) as exc:
+        console.print(f"[bold red]Suite error: {exc}[/bold red]")
+        return 1
+
+    output = (
+        format_suite_json(report)
+        if suite_args.output_json
+        else format_suite_table(report)
+    )
+
+    if suite_args.output_file:
+        try:
+            Path(suite_args.output_file).write_text(output, encoding="utf-8")
+        except OSError as exc:
+            console.print(f"[red]Error writing output file: {exc}[/red]")
+            return 1
+        console.print(f"[green]Output written to {suite_args.output_file}[/green]")
+    elif suite_args.output_json:
+        print(output)
+    else:
+        console.print(output)
+
+    return 0

--- a/skylos/debt/__init__.py
+++ b/skylos/debt/__init__.py
@@ -30,6 +30,12 @@ def collect_debt_signals(*args, **kwargs):
     return collect_debt_signals_impl(*args, **kwargs)
 
 
+def build_debt_snapshot(*args, **kwargs):
+    from skylos.debt.engine import build_debt_snapshot as build_debt_snapshot_impl
+
+    return build_debt_snapshot_impl(*args, **kwargs)
+
+
 def run_debt_analysis(*args, **kwargs):
     from skylos.debt.engine import run_debt_analysis as run_debt_analysis_impl
 
@@ -40,6 +46,7 @@ __all__ = [
     "append_history",
     "annotate_hotspots",
     "augment_hotspots_with_advisories",
+    "build_debt_snapshot",
     "collect_debt_signals",
     "compare_to_baseline",
     "DebtAdvisory",

--- a/skylos/debt/engine.py
+++ b/skylos/debt/engine.py
@@ -205,31 +205,19 @@ def collect_debt_signals(
     return signals
 
 
-def run_debt_analysis(
-    path: str | Path,
+def build_debt_snapshot(
+    result: dict[str, Any],
     *,
-    exclude_folders: list[str] | set[str] | None = None,
+    project_root: str | Path,
     changed_files: list[str] | list[Path] | None = None,
-    conf: int = 80,
 ) -> DebtSnapshot:
-    target = Path(path).resolve()
-    project_root = _project_root(target)
-
-    raw = run_analyze(
-        str(target),
-        conf=conf,
-        enable_quality=True,
-        enable_danger=False,
-        enable_secrets=False,
-        exclude_folders=list(exclude_folders or []),
-    )
-    result = json.loads(raw) if isinstance(raw, str) else raw
+    project_root_path = Path(project_root).resolve()
 
     all_signals = collect_debt_signals(
         result,
-        project_root=project_root,
+        project_root=project_root_path,
     )
-    changed = _normalize_changed_files(changed_files, project_root)
+    changed = _normalize_changed_files(changed_files, project_root_path)
     all_hotspots = build_hotspots(all_signals, changed_files=changed)
     hotspots = (
         [hotspot for hotspot in all_hotspots if hotspot.file in changed]
@@ -262,11 +250,38 @@ def run_debt_analysis(
     return DebtSnapshot(
         version=DEBT_VERSION,
         timestamp=datetime.now(timezone.utc).isoformat(),
-        project=str(project_root),
+        project=str(project_root_path),
         files_scanned=int(analysis_summary.get("total_files") or 0),
         total_loc=total_loc,
         score=score,
         hotspots=hotspots,
         all_hotspots=all_hotspots,
         summary=summary,
+    )
+
+
+def run_debt_analysis(
+    path: str | Path,
+    *,
+    exclude_folders: list[str] | set[str] | None = None,
+    changed_files: list[str] | list[Path] | None = None,
+    conf: int = 80,
+) -> DebtSnapshot:
+    target = Path(path).resolve()
+    project_root = _project_root(target)
+
+    raw = run_analyze(
+        str(target),
+        conf=conf,
+        enable_quality=True,
+        enable_danger=False,
+        enable_secrets=False,
+        exclude_folders=list(exclude_folders or []),
+    )
+    result = json.loads(raw) if isinstance(raw, str) else raw
+
+    return build_debt_snapshot(
+        result,
+        project_root=project_root,
+        changed_files=changed_files,
     )

--- a/skylos/help.py
+++ b/skylos/help.py
@@ -2,6 +2,11 @@ import skylos
 
 COMMANDS = [
     {
+        "name": "skylos suite <path>",
+        "desc": "Run the full local analysis bundle",
+        "group": "Core Analysis",
+    },
+    {
         "name": "skylos <path>",
         "desc": "Dead code, security, and quality analysis",
         "group": "Core Analysis",

--- a/skylos/suite.py
+++ b/skylos/suite.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from rich.progress import SpinnerColumn, TextColumn
+
+
+_DEAD_CODE_CATEGORIES = (
+    "unused_functions",
+    "unused_imports",
+    "unused_classes",
+    "unused_variables",
+    "unused_parameters",
+)
+
+_DEFENSE_NOTE = "AI defense currently scans Python direct SDK integrations only."
+
+
+def _empty_defense_payload(project_path: str) -> dict[str, Any]:
+    return {
+        "version": "1.0",
+        "project": project_path,
+        "summary": {
+            "integrations_found": 0,
+            "files_scanned": 0,
+            "total_checks": 0,
+            "passed": 0,
+            "failed": 0,
+            "weighted_score": 0,
+            "weighted_max": 0,
+            "score_pct": 100,
+            "risk_rating": "SECURE",
+            "by_severity": {
+                sev: {"passed": 0, "failed": 0, "weight": weight}
+                for sev, weight in {
+                    "critical": 10,
+                    "high": 7,
+                    "medium": 4,
+                    "low": 1,
+                }.items()
+            },
+        },
+        "integrations": [],
+        "findings": [],
+        "ops_score": {
+            "passed": 0,
+            "total": 0,
+            "score_pct": 100,
+            "rating": "EXCELLENT",
+        },
+        "note": _DEFENSE_NOTE,
+    }
+
+
+def _static_summary(static_result: dict[str, Any]) -> dict[str, int]:
+    return {
+        "dead_code": sum(
+            len(static_result.get(category, []) or [])
+            for category in _DEAD_CODE_CATEGORIES
+        ),
+        "security": len(static_result.get("danger", []) or []),
+        "secrets": len(static_result.get("secrets", []) or []),
+        "quality": len(static_result.get("quality", []) or []),
+        "dependencies": len(static_result.get("dependency_vulnerabilities", []) or []),
+    }
+
+
+def _annotatable_findings(result: dict[str, Any]) -> list[dict[str, Any]]:
+    categories = [
+        "danger",
+        "quality",
+        "secrets",
+        "custom_rules",
+        "unused_functions",
+        "unused_imports",
+        "unused_classes",
+        "unused_variables",
+        "unused_parameters",
+        "dependency_vulnerabilities",
+    ]
+    items: list[dict[str, Any]] = []
+    for category in categories:
+        findings = result.get(category) or []
+        for finding in findings:
+            finding.setdefault("category", category)
+            items.append(finding)
+    return items
+
+
+def _format_provenance_lines(provenance: dict[str, Any]) -> list[str]:
+    if not provenance.get("enabled", True):
+        return ["AI Provenance", "  Disabled"]
+    if not provenance.get("available", False):
+        message = provenance.get("error") or "Unavailable"
+        return ["AI Provenance", f"  {message}"]
+
+    summary = provenance.get("summary") or {}
+    ai_stats = provenance.get("ai_security_stats") or {}
+    return [
+        "AI Provenance",
+        (
+            "  "
+            f"AI-authored files: {summary.get('agent_count', 0)}/"
+            f"{summary.get('total_files', 0)}"
+        ),
+        (
+            "  "
+            f"AI-authored findings: {ai_stats.get('ai_authored_findings', 0)} "
+            f"({ai_stats.get('ai_authored_pct', 0)}%)"
+        ),
+    ]
+
+
+def format_suite_table(report: dict[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    static_summary = summary.get("static") or {}
+    debt = report.get("debt") or {}
+    debt_score = debt.get("score") or {}
+    defense = report.get("defense") or {}
+    defense_summary = defense.get("summary") or {}
+
+    lines = [
+        "",
+        "Skylos Suite",
+        f"Project: {report.get('project', '.')}",
+        (
+            "Scanned: "
+            f"{summary.get('files_scanned', 0)} files | "
+            f"LOC: {summary.get('total_loc', 0)}"
+        ),
+        "",
+        "Static Analysis",
+        f"  Dead code: {static_summary.get('dead_code', 0)}",
+        f"  Security: {static_summary.get('security', 0)}",
+        f"  Secrets: {static_summary.get('secrets', 0)}",
+        f"  Quality: {static_summary.get('quality', 0)}",
+        f"  Dependencies: {static_summary.get('dependencies', 0)}",
+        "",
+        "Technical Debt",
+        (
+            "  "
+            f"Score: {debt_score.get('score_pct', 100)}% "
+            f"({debt_score.get('risk_rating', 'LOW')})"
+        ),
+        f"  Hotspots: {len(debt.get('hotspots', []) or [])}",
+        "",
+        "AI Defense",
+        f"  Integrations: {defense_summary.get('integrations_found', 0)}",
+        (
+            "  "
+            f"Score: {defense_summary.get('score_pct', 100)}% "
+            f"({defense_summary.get('risk_rating', 'SECURE')})"
+        ),
+        f"  Failed checks: {defense_summary.get('failed', 0)}",
+        f"  Coverage: {defense.get('note', _DEFENSE_NOTE)}",
+        "",
+    ]
+
+    lines.extend(_format_provenance_lines(report.get("provenance") or {}))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_suite_json(report: dict[str, Any]) -> str:
+    return json.dumps(report, indent=2)
+
+
+def run_suite(
+    target: str | Path,
+    *,
+    conf: int,
+    exclude_folders: list[str] | set[str] | None,
+    run_analyze_func,
+    progress_factory,
+    console,
+    output_json: bool,
+    no_provenance: bool = False,
+    diff_base: str | None = None,
+    get_git_root_func=None,
+) -> dict[str, Any]:
+    target_path = Path(target).resolve()
+    exclude = set(exclude_folders or [])
+
+    from skylos.debt import build_debt_snapshot
+    from skylos.defend.engine import run_defense_checks
+    from skylos.defend.policy import compute_owasp_coverage, load_policy
+    from skylos.defend.report import format_defense_json
+    from skylos.discover.detector import _collect_python_files, detect_integrations
+
+    analyzer_logger = logging.getLogger("Skylos")
+    original_level = analyzer_logger.level
+    analyzer_logger.setLevel(logging.ERROR)
+    try:
+        with progress_factory(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+            transient=True,
+            disable=output_json,
+        ) as progress:
+            progress.add_task("Running static analysis...", total=None)
+            static_raw = run_analyze_func(
+                str(target_path),
+                conf=conf,
+                enable_secrets=True,
+                enable_danger=True,
+                enable_quality=True,
+                exclude_folders=sorted(exclude),
+            )
+    finally:
+        analyzer_logger.setLevel(original_level)
+
+    static_result = (
+        json.loads(static_raw) if isinstance(static_raw, str) else static_raw
+    )
+
+    try:
+        from skylos.rules.sca.vulnerability_scanner import scan_dependencies
+
+        sca_findings = scan_dependencies(target_path)
+        if sca_findings:
+            try:
+                from skylos.rules.sca.reachability import enrich_with_reachability
+
+                sca_findings = enrich_with_reachability(sca_findings, target_path)
+            except Exception:
+                pass
+            static_result["dependency_vulnerabilities"] = sca_findings
+            static_result.setdefault("analysis_summary", {})["sca_count"] = len(
+                sca_findings
+            )
+    except Exception:
+        pass
+
+    debt_snapshot = build_debt_snapshot(static_result, project_root=target_path)
+
+    provenance_section: dict[str, Any] = {
+        "enabled": not no_provenance,
+        "available": False,
+        "summary": None,
+        "ai_security_stats": None,
+    }
+    if not no_provenance:
+        try:
+            from skylos.file_discovery import find_git_root
+            from skylos.provenance import (
+                analyze_provenance,
+                annotate_findings_with_provenance,
+                compute_ai_security_stats,
+            )
+
+            git_root = str(find_git_root(target_path) or "")
+            if not git_root and get_git_root_func is not None:
+                git_root = get_git_root_func() or ""
+            if not git_root:
+                raise RuntimeError("not a git repository")
+            with progress_factory(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                console=console,
+                transient=True,
+                disable=output_json,
+            ) as progress:
+                progress.add_task("Analyzing AI provenance...", total=None)
+                provenance_report = analyze_provenance(git_root, base_ref=diff_base)
+
+            annotatable = _annotatable_findings(static_result)
+            annotate_findings_with_provenance(annotatable, provenance_report)
+            ai_stats = compute_ai_security_stats(annotatable)
+            static_result["ai_security_stats"] = ai_stats
+            static_result["provenance_summary"] = provenance_report.summary
+            provenance_section.update(
+                {
+                    "available": True,
+                    "summary": provenance_report.summary,
+                    "ai_security_stats": ai_stats,
+                }
+            )
+        except Exception as exc:
+            provenance_section["error"] = str(exc)
+
+    policy = load_policy(None)
+
+    with progress_factory(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=console,
+        transient=True,
+        disable=output_json,
+    ) as progress:
+        progress.add_task("Scanning AI defenses...", total=None)
+        files = _collect_python_files(target_path, exclude)
+        integrations, graph = detect_integrations(target_path, exclude_folders=exclude)
+
+    if integrations:
+        results, score, ops_score = run_defense_checks(
+            integrations,
+            graph,
+            policy=policy,
+            min_severity=None,
+            owasp_filter=None,
+        )
+        owasp_coverage = compute_owasp_coverage(results)
+        defense_report = json.loads(
+            format_defense_json(
+                results,
+                score,
+                len(integrations),
+                len(files),
+                str(target_path),
+                owasp_coverage,
+                ops_score,
+                integrations=integrations,
+            )
+        )
+        defense_report["note"] = _DEFENSE_NOTE
+    else:
+        defense_report = _empty_defense_payload(str(target_path))
+
+    static_summary = _static_summary(static_result)
+    return {
+        "version": "1.0",
+        "project": str(target_path),
+        "summary": {
+            "files_scanned": int(
+                (static_result.get("analysis_summary") or {}).get("total_files") or 0
+            ),
+            "total_loc": int(
+                (static_result.get("analysis_summary") or {}).get("total_loc") or 0
+            ),
+            "static": static_summary,
+            "debt_score_pct": debt_snapshot.score.score_pct,
+            "debt_hotspots": len(debt_snapshot.hotspots),
+            "defense_score_pct": int(
+                (defense_report.get("summary") or {}).get("score_pct") or 0
+            ),
+            "integrations_found": int(
+                (defense_report.get("summary") or {}).get("integrations_found") or 0
+            ),
+            "provenance_available": provenance_section.get("available", False),
+        },
+        "static": static_result,
+        "debt": debt_snapshot.to_dict(),
+        "defense": defense_report,
+        "provenance": provenance_section,
+    }

--- a/skylos/tour.py
+++ b/skylos/tour.py
@@ -17,6 +17,9 @@ STEPS = [
         "title": "Quick Scan",
         "step": 2,
         "body": (
+            "[bold]Everything local[/bold] (static + debt + defense + provenance):\n"
+            "  [bold cyan]skylos suite .[/bold cyan]\n"
+            "\n"
             "[bold]Basic scan[/bold] (dead code only):\n"
             "  [bold cyan]skylos .[/bold cyan]\n"
             "\n"

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -7,7 +7,11 @@ import pytest
 import skylos.cli as cli
 from skylos.debt.advisor import augment_hotspots_with_advisories
 from skylos.debt.baseline import compare_to_baseline, save_baseline
-from skylos.debt.engine import collect_debt_signals, run_debt_analysis
+from skylos.debt.engine import (
+    build_debt_snapshot,
+    collect_debt_signals,
+    run_debt_analysis,
+)
 from skylos.debt.policy import _parse_policy, load_policy
 from skylos.debt.result import (
     DebtAdvisory,
@@ -150,6 +154,15 @@ def test_run_debt_analysis_changed_mode_keeps_project_score_and_filters_hotspots
     assert changed_snapshot.hotspots[0].file == "app/services.py"
     assert changed_snapshot.summary["scope"]["score"] == "project"
     assert changed_snapshot.summary["scope"]["hotspots"] == "changed"
+
+
+def test_build_debt_snapshot_reuses_static_result():
+    snapshot = build_debt_snapshot(SAMPLE_RESULT, project_root="/repo")
+
+    assert snapshot.files_scanned == 3
+    assert snapshot.total_loc == 500
+    assert snapshot.score.hotspot_count == len(snapshot.hotspots)
+    assert snapshot.summary["dimensions"]["complexity"] == 1
 
 
 def test_build_hotspots_changed_files_raise_priority_not_structural_score():

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1,0 +1,140 @@
+import io
+import json
+from unittest.mock import patch
+
+from rich.console import Console
+from rich.progress import Progress
+
+from skylos.commands.suite_cmd import run_suite_command
+
+
+def _console_factory():
+    return Console(file=io.StringIO(), force_terminal=False, color_system=None)
+
+
+def _static_result(project_root: str) -> dict:
+    return {
+        "analysis_summary": {"total_files": 3, "total_loc": 120},
+        "danger": [
+            {
+                "rule_id": "SKY-D201",
+                "severity": "HIGH",
+                "file": f"{project_root}/app.py",
+                "line": 8,
+                "message": "SQL injection",
+            }
+        ],
+        "quality": [
+            {
+                "rule_id": "SKY-Q301",
+                "severity": "HIGH",
+                "file": f"{project_root}/app.py",
+                "line": 12,
+                "name": "handler",
+                "message": "Cyclomatic complexity is 12 (threshold: 10)",
+                "value": 12,
+                "threshold": 10,
+            }
+        ],
+        "secrets": [
+            {
+                "file": f"{project_root}/settings.py",
+                "line": 2,
+                "provider": "generic",
+                "message": "Hardcoded secret",
+            }
+        ],
+        "unused_functions": [
+            {
+                "name": "legacy",
+                "file": f"{project_root}/legacy.py",
+                "line": 3,
+                "confidence": 92,
+            }
+        ],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "unused_parameters": [],
+    }
+
+
+def test_suite_json_outputs_combined_sections(tmp_path, capsys):
+    static_result = _static_result(str(tmp_path))
+
+    with (
+        patch(
+            "skylos.defend.policy.load_policy",
+            return_value=None,
+        ),
+        patch(
+            "skylos.rules.sca.vulnerability_scanner.scan_dependencies",
+            return_value=[],
+        ),
+    ):
+        exit_code = run_suite_command(
+            [str(tmp_path), "--json", "--no-provenance"],
+            console_factory=_console_factory,
+            progress_factory=Progress,
+            parse_exclude_folders_func=lambda **kwargs: [],
+            load_config_func=lambda _path: {},
+            run_analyze_func=lambda *_args, **_kwargs: json.dumps(static_result),
+            get_git_root_func=lambda: None,
+        )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["static"]["dead_code"] == 1
+    assert payload["summary"]["static"]["security"] == 1
+    assert payload["summary"]["static"]["quality"] == 1
+    assert payload["summary"]["static"]["secrets"] == 1
+    assert payload["debt"]["score"]["hotspot_count"] == len(payload["debt"]["hotspots"])
+    assert payload["defense"]["summary"]["integrations_found"] == 0
+    assert payload["provenance"]["enabled"] is False
+    assert (
+        payload["defense"]["note"]
+        == "AI defense currently scans Python direct SDK integrations only."
+    )
+
+
+def test_suite_rejects_file_paths(tmp_path):
+    target = tmp_path / "app.py"
+    target.write_text("print('hi')\n", encoding="utf-8")
+
+    exit_code = run_suite_command(
+        [str(target)],
+        console_factory=_console_factory,
+        progress_factory=Progress,
+        parse_exclude_folders_func=lambda **kwargs: [],
+        load_config_func=lambda _path: {},
+        run_analyze_func=lambda *_args, **_kwargs: "{}",
+        get_git_root_func=lambda: None,
+    )
+
+    assert exit_code == 1
+
+
+def test_main_suite_subcommand_calls_run_suite_and_exits(monkeypatch):
+    import skylos.cli as cli
+
+    monkeypatch.setattr(cli.sys, "argv", ["skylos", "suite", "."])
+    with patch("skylos.commands.suite_cmd.run_suite_command", return_value=0) as runner:
+        try:
+            cli.main()
+        except SystemExit as exc:
+            assert exc.code == 0
+        else:
+            raise AssertionError("Expected SystemExit")
+
+    runner.assert_called_once()
+    assert runner.call_args.args == (["."],)
+    assert runner.call_args.kwargs["console_factory"] is cli.Console
+    assert runner.call_args.kwargs["progress_factory"] is cli.Progress
+    assert (
+        runner.call_args.kwargs["parse_exclude_folders_func"]
+        is cli.parse_exclude_folders
+    )
+    assert runner.call_args.kwargs["load_config_func"] is cli.load_config
+    assert runner.call_args.kwargs["run_analyze_func"] is cli.run_analyze
+    assert callable(runner.call_args.kwargs["get_git_root_func"])


### PR DESCRIPTION
## Summary

Single local command for the most common "run everything useful" workflow.

  `skylos suite` gives users one report that combines static analysis, technical debt hotspots, AI defense, AI provenance summary. The goal is to reduce command-surface sprawl for normal users.

## Why

This PR adds a cleaner "easy mode":
  - `skylos suite .` for the full local bundle
  - keep leaf commands like `debt`, `defend`, and `provenance` for deeper specialist workflows

## User-visible changes

  New command:
  - `skylos suite <path>`


## Note:
  - the AI defense portion is currently limited to Python direct SDK integrations
  - the suite output explicitly says this, so “0 integrations found” is not presented as a global
  clean bill of health for TS/Go AI apps

## Implementation

  Main command wiring:
  - `skylos/commands/suite_cmd.py`
  - `skylos/suite.py`
  - `skylos/cli.py`
  - `skylos/help.py`
  - `skylos/tour.py`

  Debt reuse refactor:
  - `skylos/debt/engine.py`
  - `skylos/debt/__init__.py`

  Tests:
  - `test/test_suite.py`
  - `test/test_debt.py`

## Validation

- `pytest test/test_suite.py test/test_debt.py test/test_cli.py`