### PR TITLE
fix(cli): scan staged test files for secrets only

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -115,6 +115,32 @@ def _read_staged_text(project_root: Path, relpath: str) -> str | None:
     return None
 
 
+def _scan_staged_secret_files(
+    project_root: Path,
+    relpaths: list[str],
+    *,
+    ignore_tests: bool,
+) -> list[dict]:
+    from skylos.rules.secrets import scan_ctx as secret_scan_ctx
+
+    findings: list[dict] = []
+    for relpath in relpaths:
+        src = _read_staged_text(project_root, relpath)
+        if src is None:
+            candidate = (project_root / relpath).resolve()
+            try:
+                src = candidate.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+        ctx = {
+            "relpath": relpath,
+            "lines": src.splitlines(True),
+            "tree": None,
+        }
+        findings.extend(list(secret_scan_ctx(ctx, ignore_tests=ignore_tests)))
+    return findings
+
+
 def _list_dirty_relevant_paths(project_root: Path, is_relevant_path) -> list[str]:
     result = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=all"],
@@ -289,7 +315,7 @@ def _finding_is_in_changed_lines(
 
 def _get_cached_changed_line_ranges(
     project_root: Path, staged_paths: list[str] | None = None
-) -> list[dict]:
+) -> list[dict] | None:
     cmd = ["git", "diff", "--cached", "--unified=0"]
     if staged_paths:
         cmd.extend(["--", *staged_paths])
@@ -299,15 +325,15 @@ def _get_cached_changed_line_ranges(
         text=True,
         cwd=project_root,
     )
-    if result.returncode != 0 or not result.stdout.strip():
-        return []
+    if result.returncode != 0:
+        return None
     return _parse_unified_diff_ranges(result.stdout)
 
 
 def _filter_precommit_findings_to_changed_lines(
-    findings: list[dict], changed_ranges: list[dict]
+    findings: list[dict], changed_ranges: list[dict] | None
 ) -> list[dict]:
-    if not changed_ranges:
+    if changed_ranges is None:
         return findings
 
     changed_range_index = _build_changed_range_index(changed_ranges)
@@ -3168,28 +3194,34 @@ def main() -> None:
 
                 staged_source_files = []
                 staged_config_files = []
-                staged_targets = set()
+                staged_test_files = []
+                analyzer_targets = set()
+                report_targets = set()
                 skipped_staged_files = 0
-                skipped_test_files = 0
                 for relpath in staged_candidates:
                     relpath_obj = Path(relpath)
                     if relpath_obj.suffix.lower() in source_exts:
                         if get_non_library_dir_kind(relpath_obj, project_root) == "test":
-                            skipped_test_files += 1
+                            staged_test_files.append(relpath)
+                            report_targets.add(
+                                str((project_root / relpath).resolve())
+                            )
                             continue
                         staged_source_files.append(relpath)
-                        staged_targets.add(str((project_root / relpath).resolve()))
+                        abs_path = str((project_root / relpath).resolve())
+                        analyzer_targets.add(abs_path)
+                        report_targets.add(abs_path)
                         continue
                     if _is_config_candidate(relpath_obj):
                         staged_config_files.append(relpath)
-                        staged_targets.add(str((project_root / relpath).resolve()))
+                        abs_path = str((project_root / relpath).resolve())
+                        analyzer_targets.add(abs_path)
+                        report_targets.add(abs_path)
                         continue
                     skipped_staged_files += 1
 
-                if not staged_targets:
+                if not report_targets:
                     notes = []
-                    if skipped_test_files:
-                        notes.append(f"skipped {skipped_test_files} staged test file(s)")
                     if skipped_staged_files:
                         notes.append(
                             f"skipped {skipped_staged_files} unsupported staged file(s)"
@@ -3206,11 +3238,12 @@ def main() -> None:
                     sys.exit(0)
 
                 changed_ranges = _get_cached_changed_line_ranges(
-                    project_root, staged_source_files + staged_config_files
+                    project_root,
+                    staged_source_files + staged_config_files + staged_test_files,
                 )
                 snapshot_dir = None
                 analysis_root = project_root
-                analysis_targets = staged_targets
+                analysis_targets = analyzer_targets
                 analysis_source_paths = [
                     str((project_root / relpath).resolve())
                     for relpath in staged_source_files
@@ -3263,58 +3296,56 @@ def main() -> None:
                             scope_parts.append(f"{len(staged_source_files)} source")
                         if staged_config_files:
                             scope_parts.append(f"{len(staged_config_files)} config")
+                        if staged_test_files:
+                            scope_parts.append(f"{len(staged_test_files)} test")
                         scope_desc = " and ".join(scope_parts)
                         skipped_note = (
                             f" Skipped {skipped_staged_files} unsupported staged file(s)."
                             if skipped_staged_files
                             else ""
                         )
-                        skipped_test_note = (
-                            " Skipped "
-                            f"{skipped_test_files} staged test file(s); local commit gate focuses on production source/config."
-                            if skipped_test_files
+                        staged_test_note = (
+                            " Staged test files are secrets-only in local commit checks."
+                            if staged_test_files
                             else ""
                         )
                         baseline_note = (
                             " Baseline filtering is active." if baseline else ""
                         )
                         mode_note = (
-                            " Config-only change detected: running secrets check only."
-                            if staged_config_files and not staged_source_files
+                            " Running secrets check only."
+                            if not staged_source_files
                             else ""
+                        )
+                        scope_note = (
+                            "Checks security, secrets, and quality on production source/config."
+                            if staged_source_files
+                            else "Checks secrets only."
                         )
                         console.print(
                             "[brand]Commit check:[/brand] "
                             f"reviewing {scope_desc} staged file(s). "
-                            "Checks security, secrets, and quality only."
+                            f"{scope_note}"
                             f"{mode_note}"
                             f"{snapshot_note}"
-                            f"{skipped_test_note}"
+                            f"{staged_test_note}"
                             f"{skipped_note}"
                             f"{baseline_note}"
                         )
 
-                    if staged_config_files and not staged_source_files:
-                        from skylos.rules.secrets import scan_ctx as secret_scan_ctx
+                    staged_test_secrets = _scan_staged_secret_files(
+                        project_root,
+                        staged_test_files,
+                        ignore_tests=False,
+                    )
 
-                        secrets = []
-                        for relpath in staged_config_files:
-                            src = _read_staged_text(project_root, relpath)
-                            if src is None:
-                                config_path = (project_root / relpath).resolve()
-                                try:
-                                    src = config_path.read_text(
-                                        encoding="utf-8", errors="ignore"
-                                    )
-                                except OSError:
-                                    continue
-                            ctx = {
-                                "relpath": relpath,
-                                "lines": src.splitlines(True),
-                                "tree": None,
-                            }
-                            secrets.extend(list(secret_scan_ctx(ctx)))
-
+                    if not staged_source_files:
+                        secrets = _scan_staged_secret_files(
+                            project_root,
+                            staged_config_files,
+                            ignore_tests=True,
+                        )
+                        secrets.extend(staged_test_secrets)
                         result = {
                             "unused_functions": [],
                             "unused_imports": [],
@@ -3365,6 +3396,9 @@ def main() -> None:
                             if isinstance(raw_result, str)
                             else raw_result
                         )
+                        if staged_test_secrets:
+                            result["secrets"] = list(result.get("secrets") or [])
+                            result["secrets"].extend(staged_test_secrets)
                         result = _remap_precommit_result_files(
                             result, analysis_root, project_root
                         )
@@ -3394,13 +3428,15 @@ def main() -> None:
                             item
                             for item in items
                             if str((project_root / item.get("file", "")).resolve())
-                            in staged_targets
+                            in report_targets
                         ]
 
                 staged_findings = normalize_findings(
                     result,
                     project_root,
-                    changed_files=staged_source_files + staged_config_files,
+                    changed_files=(
+                        staged_source_files + staged_config_files + staged_test_files
+                    ),
                     include_dead_code=False,
                 )
                 staged_findings = [

--- a/skylos/rules/quality/regression.py
+++ b/skylos/rules/quality/regression.py
@@ -9,7 +9,8 @@ and permission checks.
 from __future__ import annotations
 
 import re
-from pathlib import Path
+
+from skylos.constants import get_non_library_dir_kind
 
 RULE_ID = "SKY-L021"
 
@@ -110,12 +111,7 @@ _HASH_CALL_RE = re.compile(r"(?:hashlib\.)?(\w+)\(")
 
 
 def _is_test_file(file_path: str) -> bool:
-    base = Path(file_path).name
-    return (
-        base.startswith("test_")
-        or base.endswith("_test.py")
-        or base == "conftest.py"
-    )
+    return get_non_library_dir_kind(file_path) == "test"
 
 
 def detect_security_regressions(

--- a/test/test_cli_precommit.py
+++ b/test/test_cli_precommit.py
@@ -89,7 +89,7 @@ def test_agent_pre_commit_scans_only_staged_source_files(tmp_path):
         str(call.args[0]) for call in console.print.call_args_list if call.args
     )
     assert "Commit check:" in printed
-    assert "Checks security, secrets, and quality only." in printed
+    assert "Checks security, secrets, and quality on production source/config." in printed
     assert "Commit check progress:" in printed
     assert "[1/1] app.py" in printed
     assert "app.py:3" in printed
@@ -118,7 +118,7 @@ def test_agent_pre_commit_includes_staged_config_files(tmp_path):
     staged_blob = Mock(stdout="API_KEY=test\n", returncode=0)
     seen_ctx = {}
 
-    def fake_scan_ctx(ctx):
+    def fake_scan_ctx(ctx, **kwargs):
         seen_ctx["lines"] = list(ctx["lines"])
         return []
 
@@ -154,7 +154,8 @@ def test_agent_pre_commit_includes_staged_config_files(tmp_path):
         str(call.args[0]) for call in console.print.call_args_list if call.args
     )
     assert "reviewing 1 config staged file(s)" in printed
-    assert "Config-only change detected: running secrets check only." in printed
+    assert "Checks secrets only." in printed
+    assert "Running secrets check only." in printed
     assert "No staged security, secrets, or quality issues" in printed
 
 
@@ -334,30 +335,147 @@ def test_agent_pre_commit_handles_only_unsupported_staged_files(tmp_path):
     assert "skipped 1 unsupported staged file(s)" in printed.lower()
 
 
-def test_agent_pre_commit_skips_staged_test_files(tmp_path):
+def test_agent_pre_commit_scans_staged_test_files_for_secrets_only(tmp_path):
     repo = tmp_path / "repo"
     (repo / "test").mkdir(parents=True)
     (repo / "test" / "test_rules.py").write_text("def test_ok():\n    pass\n", encoding="utf-8")
 
     console = Mock()
     staged = Mock(stdout="test/test_rules.py\n", returncode=0)
+    cached_diff = Mock(
+        stdout=(
+            "diff --git a/test/test_rules.py b/test/test_rules.py\n"
+            "--- a/test/test_rules.py\n"
+            "+++ b/test/test_rules.py\n"
+            "@@ -1 +1 @@\n"
+        ),
+        returncode=0,
+    )
+    staged_blob = Mock(stdout="def test_ok():\n    pass\n", returncode=0)
+    seen_ignore_tests = []
+
+    def fake_scan_ctx(ctx, *, ignore_tests=True, **kwargs):
+        seen_ignore_tests.append(ignore_tests)
+        return []
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "show", ":test/test_rules.py"]:
+            return staged_blob
+        raise AssertionError(f"Unexpected command: {cmd}")
 
     with (
         patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
         patch("skylos.cli.Console", return_value=console),
         patch("skylos.cli.setup_logger"),
         patch("skylos.cli.find_project_root", return_value=repo),
-        patch("skylos.cli.subprocess.run", return_value=staged),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.rules.secrets.scan_ctx", side_effect=fake_scan_ctx),
+        patch("skylos.baseline.load_baseline", return_value=None),
     ):
         with pytest.raises(SystemExit) as exc_info:
             cli.main()
 
     assert exc_info.value.code == 0
+    assert seen_ignore_tests == [False]
     printed = " ".join(
         str(call.args[0]) for call in console.print.call_args_list if call.args
     )
-    assert "No staged source or config files to analyze" in printed
-    assert "skipped 1 staged test file(s)" in printed.lower()
+    assert "reviewing 1 test staged file(s)" in printed
+    assert "Checks secrets only." in printed
+    assert "Staged test files are secrets-only in local commit checks." in printed
+    assert "No staged security, secrets, or quality issues" in printed
+
+
+def test_agent_pre_commit_scans_staged_test_files_for_secrets_alongside_source(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    (repo / "test").mkdir()
+    (repo / "test" / "test_rules.py").write_text(
+        "API_KEY='real-secret'\n",
+        encoding="utf-8",
+    )
+
+    console = Mock()
+    staged = Mock(stdout="app.py\ntest/test_rules.py\n", returncode=0)
+    cached_diff = Mock(
+        stdout=(
+            "diff --git a/app.py b/app.py\n"
+            "--- a/app.py\n"
+            "+++ b/app.py\n"
+            "@@ -1 +1 @@\n"
+            "diff --git a/test/test_rules.py b/test/test_rules.py\n"
+            "--- a/test/test_rules.py\n"
+            "+++ b/test/test_rules.py\n"
+            "@@ -1 +1 @@\n"
+        ),
+        returncode=0,
+    )
+    unstaged = Mock(stdout="", returncode=0)
+    staged_blob = Mock(stdout="API_KEY='real-secret'\n", returncode=0)
+    result = {
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+
+    def fake_scan_ctx(ctx, *, ignore_tests=True, **kwargs):
+        assert ctx["relpath"] == "test/test_rules.py"
+        assert ignore_tests is False
+        return [
+            {
+                "rule_id": "SKY-S101",
+                "file": "test/test_rules.py",
+                "line": 1,
+                "severity": "CRITICAL",
+                "message": "Potential OpenAI secret detected",
+            }
+        ]
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return unstaged
+        if cmd == ["git", "show", ":test/test_rules.py"]:
+            return staged_blob
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+        patch("skylos.cli.find_project_root", return_value=repo),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)) as mock_analyze,
+        patch("skylos.rules.secrets.scan_ctx", side_effect=fake_scan_ctx),
+        patch("skylos.baseline.load_baseline", return_value=None),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 1
+    assert mock_analyze.call_args.args[0] == [str((repo / "app.py").resolve())]
+    printed = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "Potential OpenAI secret detected" in printed
+    assert "test/test_rules.py:1" in printed
+    assert "Staged test files are secrets-only in local commit checks." in printed
 
 
 def test_agent_pre_commit_filters_non_regression_findings_to_changed_lines(tmp_path):
@@ -439,4 +557,78 @@ def test_agent_pre_commit_filters_non_regression_findings_to_changed_lines(tmp_p
     )
     assert "app.py:3" in printed
     assert "TLS verification downgraded" in printed
+    assert "Old whole-file noise" not in printed
+
+
+def test_agent_pre_commit_deletion_only_diffs_drop_whole_file_noise(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("print('hi')\n", encoding="utf-8")
+
+    console = Mock()
+    staged = Mock(stdout="app.py\n", returncode=0)
+    cached_diff = Mock(
+        stdout=(
+            "diff --git a/app.py b/app.py\n"
+            "--- a/app.py\n"
+            "+++ b/app.py\n"
+            "@@ -3,1 +3,0 @@\n"
+            "-dangerous_call()\n"
+        ),
+        returncode=0,
+    )
+    unstaged = Mock(stdout="", returncode=0)
+    result = {
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-Q001",
+                "file": "app.py",
+                "line": 40,
+                "severity": "HIGH",
+                "message": "Old whole-file noise",
+            },
+            {
+                "rule_id": "SKY-L021",
+                "file": "app.py",
+                "line": 3,
+                "severity": "HIGH",
+                "message": "Security control regression: validation call was removed",
+            },
+        ],
+        "secrets": [],
+    }
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return unstaged
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+        patch("skylos.cli.find_project_root", return_value=repo),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.baseline.load_baseline", return_value=None),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 1
+    printed = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "validation call was removed" in printed
     assert "Old whole-file noise" not in printed

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -110,6 +110,14 @@ class TestTLSVerification:
         findings = detect_security_regressions(diff, "test_client.py")
         assert findings == []
 
+    def test_tests_directory_regressions_are_suppressed(self):
+        diff = _make_diff(
+            ["    resp = requests.get(url, verify=True)"],
+            ["    resp = requests.get(url, verify=False)"],
+        )
+        findings = detect_security_regressions(diff, "tests/example.py")
+        assert findings == []
+
 
 class TestCryptoDowngrade:
     def test_sha256_to_md5(self):


### PR DESCRIPTION
## Summary
  - keep staged test files on a secrets only path in local pre-commit
  - stop deletion only diffs from showing noise in local commit gate

## Verification
  - `pytest test/test_cli_precommit.py test/test_regression.py`