### PR TITLE
refactor(debt): reduce debt report formatter complexity

### DIFF
--- a/skylos/debt/report.py
+++ b/skylos/debt/report.py
@@ -5,14 +5,7 @@ import json
 from skylos.debt.result import DebtSnapshot
 
 
-def format_debt_table(snapshot: DebtSnapshot, *, top: int | None = None) -> str:
-    summary = snapshot.summary or {}
-    baseline = summary.get("baseline") or {}
-    scope = summary.get("scope") or {}
-    hotspot_scope = scope.get("hotspots", "project")
-    project_hotspot_count = int(
-        summary.get("project_hotspot_count") or len(snapshot.hotspots)
-    )
+def _ordered_hotspots(snapshot: DebtSnapshot, top: int | None) -> list:
     ordered = sorted(
         snapshot.hotspots,
         key=lambda hotspot: (
@@ -21,66 +14,123 @@ def format_debt_table(snapshot: DebtSnapshot, *, top: int | None = None) -> str:
             hotspot.file,
         ),
     )
-    hotspots = ordered[:top] if top else ordered
+    return ordered[:top] if top else ordered
 
-    lines = []
-    lines.append("")
-    lines.append("Skylos Technical Debt Report")
+
+def _summary_lines(
+    snapshot: DebtSnapshot,
+    *,
+    hotspot_scope: str,
+    project_hotspot_count: int,
+) -> list[str]:
     if hotspot_scope == "changed":
-        lines.append(
-            f"Scanned: {snapshot.files_scanned} files | "
-            f"Total LOC: {snapshot.total_loc} | "
-            f"Hotspots: {len(snapshot.hotspots)} shown ({project_hotspot_count} project total) | "
-            f"Score: {snapshot.score.score_pct}% ({snapshot.score.risk_rating}, project scope)"
-        )
-        lines.append("View: changed files only")
-    else:
-        lines.append(
+        return [
+            (
+                f"Scanned: {snapshot.files_scanned} files | "
+                f"Total LOC: {snapshot.total_loc} | "
+                f"Hotspots: {len(snapshot.hotspots)} shown ({project_hotspot_count} project total) | "
+                f"Score: {snapshot.score.score_pct}% ({snapshot.score.risk_rating}, project scope)"
+            ),
+            "View: changed files only",
+        ]
+
+    return [
+        (
             f"Scanned: {snapshot.files_scanned} files | "
             f"Total LOC: {snapshot.total_loc} | "
             f"Hotspots: {len(snapshot.hotspots)} | "
             f"Score: {snapshot.score.score_pct}% ({snapshot.score.risk_rating})"
         )
-    if baseline:
-        lines.append(
-            "Baseline: "
-            f"{baseline.get('new', 0)} new | "
-            f"{baseline.get('worsened', 0)} worsened | "
-            f"{baseline.get('improved', 0)} improved | "
-            f"{baseline.get('unchanged', 0)} unchanged | "
-            f"{baseline.get('resolved', 0)} resolved"
+    ]
+
+
+def _baseline_line(baseline: dict) -> str:
+    return (
+        "Baseline: "
+        f"{baseline.get('new', 0)} new | "
+        f"{baseline.get('worsened', 0)} worsened | "
+        f"{baseline.get('improved', 0)} improved | "
+        f"{baseline.get('unchanged', 0)} unchanged | "
+        f"{baseline.get('resolved', 0)} resolved"
+    )
+
+
+def _empty_hotspot_line(hotspot_scope: str) -> str:
+    if hotspot_scope == "changed":
+        return "No debt hotspots found in changed files."
+    return "No debt hotspots found."
+
+
+def _hotspot_status(hotspot) -> str:
+    status = hotspot.baseline_status
+    if hotspot.score_delta:
+        return f"{status} ({hotspot.score_delta:+.2f})"
+    return status
+
+
+def _signal_lines(hotspot) -> list[str]:
+    return [
+        f"    - [{signal.rule_id}] {signal.message} (points={signal.points:.2f})"
+        for signal in hotspot.signals[:3]
+    ]
+
+
+def _advisory_lines(hotspot) -> list[str]:
+    if not hotspot.advisory:
+        return []
+
+    lines = [f"    advisor: {hotspot.advisory.summary}"]
+    lines.extend(
+        f"      step: {step}" for step in hotspot.advisory.refactor_steps[:2]
+    )
+    return lines
+
+
+def _hotspot_lines(index: int, hotspot) -> list[str]:
+    dimensions = ", ".join(sorted({signal.dimension for signal in hotspot.signals}))
+    lines = [
+        (
+            f"{index:>2}. {hotspot.file} | score={hotspot.score:.2f} | "
+            f"priority={hotspot.priority_score:.2f} | "
+            f"signals={hotspot.signal_count} | dimensions={dimensions} | "
+            f"{_hotspot_status(hotspot)}"
         )
+    ]
+    lines.extend(_signal_lines(hotspot))
+    lines.extend(_advisory_lines(hotspot))
+    return lines
+
+
+def format_debt_table(snapshot: DebtSnapshot, *, top: int | None = None) -> str:
+    summary = snapshot.summary or {}
+    baseline = summary.get("baseline") or {}
+    scope = summary.get("scope") or {}
+    hotspot_scope = scope.get("hotspots", "project")
+    project_hotspot_count = int(
+        summary.get("project_hotspot_count") or len(snapshot.hotspots)
+    )
+    hotspots = _ordered_hotspots(snapshot, top)
+
+    lines = ["", "Skylos Technical Debt Report"]
+    lines.extend(
+        _summary_lines(
+            snapshot,
+            hotspot_scope=hotspot_scope,
+            project_hotspot_count=project_hotspot_count,
+        )
+    )
+    if baseline:
+        lines.append(_baseline_line(baseline))
 
     if not hotspots:
         lines.append("")
-        if hotspot_scope == "changed":
-            lines.append("No debt hotspots found in changed files.")
-        else:
-            lines.append("No debt hotspots found.")
+        lines.append(_empty_hotspot_line(hotspot_scope))
         return "\n".join(lines)
 
     lines.append("")
     lines.append("Top Hotspots:")
     for index, hotspot in enumerate(hotspots, 1):
-        dimensions = ", ".join(sorted({signal.dimension for signal in hotspot.signals}))
-        status = hotspot.baseline_status
-        if hotspot.score_delta:
-            status = f"{status} ({hotspot.score_delta:+.2f})"
-
-        lines.append(
-            f"{index:>2}. {hotspot.file} | score={hotspot.score:.2f} | "
-            f"priority={hotspot.priority_score:.2f} | "
-            f"signals={hotspot.signal_count} | dimensions={dimensions} | {status}"
-        )
-        for signal in hotspot.signals[:3]:
-            lines.append(
-                f"    - [{signal.rule_id}] {signal.message} "
-                f"(points={signal.points:.2f})"
-            )
-        if hotspot.advisory:
-            lines.append(f"    advisor: {hotspot.advisory.summary}")
-            for step in hotspot.advisory.refactor_steps[:2]:
-                lines.append(f"      step: {step}")
+        lines.extend(_hotspot_lines(index, hotspot))
     return "\n".join(lines)
 
 

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -13,6 +13,7 @@ from skylos.debt.engine import (
     run_debt_analysis,
 )
 from skylos.debt.policy import _parse_policy, load_policy
+from skylos.debt.report import format_debt_table
 from skylos.debt.result import (
     DebtAdvisory,
     DebtHotspot,
@@ -308,6 +309,90 @@ def test_augment_hotspots_with_advisories_sets_advisory(tmp_path):
         == "The hotspot concentrates branching logic in one service function."
     )
     assert snapshot.hotspots[0].advisory.refactor_steps[0].startswith("Extract")
+
+
+def test_format_debt_table_renders_changed_scope_empty_state_and_baseline():
+    snapshot = _snapshot("/repo")
+    snapshot.hotspots = []
+    snapshot.summary["scope"] = {"score": "project", "hotspots": "changed"}
+    snapshot.summary["project_hotspot_count"] = 3
+    snapshot.summary["baseline"] = {
+        "new": 1,
+        "worsened": 2,
+        "improved": 0,
+        "unchanged": 4,
+        "resolved": 1,
+    }
+
+    rendered = format_debt_table(snapshot)
+
+    assert "Skylos Technical Debt Report" in rendered
+    assert "Hotspots: 0 shown (3 project total)" in rendered
+    assert "View: changed files only" in rendered
+    assert "Baseline: 1 new | 2 worsened | 0 improved | 4 unchanged | 1 resolved" in rendered
+    assert "No debt hotspots found in changed files." in rendered
+
+
+def test_format_debt_table_renders_hotspot_advisory_and_delta():
+    snapshot = _snapshot("/repo")
+    hotspot = snapshot.hotspots[0]
+    hotspot.priority_score = 16.5
+    hotspot.baseline_status = "worsened"
+    hotspot.score_delta = 1.25
+    hotspot.advisory = DebtAdvisory(
+        summary="Split summary and detail formatting into helpers.",
+        root_cause="One function owns several output branches.",
+        refactor_steps=[
+            "Extract summary line builders.",
+            "Move hotspot rendering into a helper.",
+            "Keep advisory formatting isolated.",
+        ],
+    )
+
+    rendered = format_debt_table(snapshot)
+
+    assert (
+        "1. app/services.py | score=14.00 | priority=16.50 | "
+        "signals=1 | dimensions=complexity | worsened (+1.25)"
+    ) in rendered
+    assert "advisor: Split summary and detail formatting into helpers." in rendered
+    assert "step: Extract summary line builders." in rendered
+    assert "step: Move hotspot rendering into a helper." in rendered
+    assert "step: Keep advisory formatting isolated." not in rendered
+
+
+def test_format_debt_table_orders_by_priority_and_applies_top_limit():
+    snapshot = _snapshot("/repo")
+    hotspot = snapshot.hotspots[0]
+    hotspot.priority_score = 10.0
+
+    second_signal = DebtSignal(
+        fingerprint="maintainability:SKY-L027:app/core.py:8:app.core",
+        dimension="maintainability",
+        rule_id="SKY-L027",
+        severity="MEDIUM",
+        file="app/core.py",
+        line=8,
+        subject="app.core",
+        message="String literal repeated 5 times (threshold: 3)",
+        points=9.0,
+    )
+    second_hotspot = DebtHotspot(
+        fingerprint="hotspot:app/core.py",
+        file="app/core.py",
+        score=9.0,
+        signal_count=1,
+        dimension_count=1,
+        primary_dimension="maintainability",
+        priority_score=18.0,
+        signals=[second_signal],
+    )
+    snapshot.hotspots.append(second_hotspot)
+
+    rendered = format_debt_table(snapshot, top=1)
+
+    assert "1. app/core.py | score=9.00 | priority=18.00" in rendered
+    assert "app/services.py" not in rendered
 
 
 def test_cli_debt_json_outputs_snapshot_and_exits_zero(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
  - split `skylos.debt.report.format_debt_table` into focused helper functions
  - keep the debt report output unchanged while reducing formatter complexity

## Verification
  - `pytest -q test/test_debt.py`
  - `skylos debt skylos/debt/report.py --top 5`