### PR TITLE
refactor(debt): reduce advisor complexity

### DIFF
--- a/skylos/debt/advisor.py
+++ b/skylos/debt/advisor.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from skylos.adapters.litellm_adapter import LiteLLMAdapter
 from skylos.debt.result import DebtAdvisory, DebtHotspot
 
+_CONFIDENCE_LEVELS = ("low", "medium", "high")
+_DEFAULT_CONFIDENCE = _CONFIDENCE_LEVELS[1]
+
 ADVISORY_RESPONSE_SCHEMA = {
     "type": "object",
     "additionalProperties": False,
@@ -29,7 +32,7 @@ ADVISORY_RESPONSE_SCHEMA = {
             "items": {"type": "string"},
             "maxItems": 4,
         },
-        "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
+        "confidence": {"type": "string", "enum": list(_CONFIDENCE_LEVELS)},
     },
 }
 
@@ -76,36 +79,51 @@ def _safe_excerpt(path: Path, line: int, radius: int = 3, max_chars: int = 1200)
     return excerpt
 
 
+def _signal_prompt_lines(hotspot: DebtHotspot) -> list[str]:
+    lines = []
+    for signal in hotspot.signals[:5]:
+        lines.append(
+            f"- [{signal.rule_id}] {signal.message} | "
+            f"severity={signal.severity} | points={signal.points:.2f}"
+        )
+    return lines
+
+
+def _excerpt_sections(hotspot: DebtHotspot, *, project_root: Path) -> list[str]:
+    sections = []
+    for signal in hotspot.signals[:3]:
+        file_path = project_root / signal.file
+        excerpt = _safe_excerpt(file_path, signal.line)
+        if excerpt:
+            sections.append(f"[{signal.file}:{signal.line}]\n{excerpt}")
+    return sections
+
+
+def _architecture_summary(architecture_metrics: dict | None) -> str:
+    if not architecture_metrics:
+        return ""
+
+    system_metrics = architecture_metrics.get("system_metrics") or {}
+    if not system_metrics:
+        return ""
+
+    return (
+        "Architecture context:\n"
+        f"- mean_distance={system_metrics.get('mean_distance')}\n"
+        f"- architecture_fitness={system_metrics.get('architecture_fitness')}\n"
+        f"- dip_violations={system_metrics.get('dip_violations')}\n"
+    )
+
+
 def _user_prompt(
     hotspot: DebtHotspot,
     *,
     project_root: Path,
     architecture_metrics: dict | None = None,
 ) -> str:
-    signal_lines = []
-    for signal in hotspot.signals[:5]:
-        signal_lines.append(
-            f"- [{signal.rule_id}] {signal.message} | "
-            f"severity={signal.severity} | points={signal.points:.2f}"
-        )
-
-    excerpts = []
-    for signal in hotspot.signals[:3]:
-        file_path = project_root / signal.file
-        excerpt = _safe_excerpt(file_path, signal.line)
-        if excerpt:
-            excerpts.append(f"[{signal.file}:{signal.line}]\n{excerpt}")
-
-    arch_summary = ""
-    if architecture_metrics:
-        system_metrics = architecture_metrics.get("system_metrics") or {}
-        if system_metrics:
-            arch_summary = (
-                "Architecture context:\n"
-                f"- mean_distance={system_metrics.get('mean_distance')}\n"
-                f"- architecture_fitness={system_metrics.get('architecture_fitness')}\n"
-                f"- dip_violations={system_metrics.get('dip_violations')}\n"
-            )
+    signal_lines = _signal_prompt_lines(hotspot)
+    excerpts = _excerpt_sections(hotspot, project_root=project_root)
+    arch_summary = _architecture_summary(architecture_metrics)
 
     return f"""Explain the following technical debt hotspot.
 
@@ -130,21 +148,59 @@ Respond with:
 - root_cause: one short paragraph grounded in the evidence
 - refactor_steps: 2-5 ordered steps
 - remediation_notes: 1-4 cautions or validation notes
-- confidence: low|medium|high
+- confidence: {'|'.join(_CONFIDENCE_LEVELS)}
 """
+
+
+def _strip_code_fence(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = stripped.split("\n", 1)[1]
+        stripped = stripped.rsplit("```", 1)[0].strip()
+    return stripped
 
 
 def _parse_json_object(raw: str) -> dict | None:
     text = (raw or "").strip()
     if not text:
         return None
-    if text.startswith("```"):
-        text = text.split("\n", 1)[1]
-        text = text.rsplit("```", 1)[0].strip()
+    text = _strip_code_fence(text)
     try:
         return json.loads(text)
     except Exception:
         return None
+
+
+def _clean_string_items(items) -> list[str]:
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _normalize_confidence(value: str) -> str:
+    confidence = str(value or _DEFAULT_CONFIDENCE).strip().lower()
+    if confidence not in _CONFIDENCE_LEVELS:
+        return _DEFAULT_CONFIDENCE
+    return confidence
+
+
+def _advisory_from_payload(payload: dict, *, model: str) -> DebtAdvisory | None:
+    if not isinstance(payload, dict):
+        return None
+
+    summary = str(payload.get("summary") or "").strip()
+    root_cause = str(payload.get("root_cause") or "").strip()
+    if not summary or not root_cause:
+        return None
+
+    return DebtAdvisory(
+        summary=summary,
+        root_cause=root_cause,
+        refactor_steps=_clean_string_items(payload.get("refactor_steps") or [])[:5],
+        remediation_notes=_clean_string_items(payload.get("remediation_notes") or [])[
+            :4
+        ],
+        confidence=_normalize_confidence(payload.get("confidence")),
+        model=model,
+    )
 
 
 class DebtAdvisor:
@@ -181,36 +237,7 @@ class DebtAdvisor:
             response_format=ADVISORY_RESPONSE_FORMAT,
         )
         payload = _parse_json_object(raw)
-        if not isinstance(payload, dict):
-            return None
-
-        summary = str(payload.get("summary") or "").strip()
-        root_cause = str(payload.get("root_cause") or "").strip()
-        refactor_steps = [
-            str(item).strip()
-            for item in (payload.get("refactor_steps") or [])
-            if str(item).strip()
-        ]
-        remediation_notes = [
-            str(item).strip()
-            for item in (payload.get("remediation_notes") or [])
-            if str(item).strip()
-        ]
-        confidence = str(payload.get("confidence") or "medium").strip().lower()
-
-        if not summary or not root_cause:
-            return None
-        if confidence not in {"low", "medium", "high"}:
-            confidence = "medium"
-
-        return DebtAdvisory(
-            summary=summary,
-            root_cause=root_cause,
-            refactor_steps=refactor_steps[:5],
-            remediation_notes=remediation_notes[:4],
-            confidence=confidence,
-            model=self.model,
-        )
+        return _advisory_from_payload(payload, model=self.model)
 
 
 def augment_hotspots_with_advisories(

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock, patch
 import pytest
 
 import skylos.cli as cli
-from skylos.debt.advisor import augment_hotspots_with_advisories
+from skylos.debt.advisor import (
+    DebtAdvisor,
+    _parse_json_object,
+    _safe_excerpt,
+    _user_prompt,
+    augment_hotspots_with_advisories,
+)
 from skylos.debt.baseline import compare_to_baseline, save_baseline
 from skylos.debt.engine import (
     build_debt_snapshot,
@@ -309,6 +315,125 @@ def test_augment_hotspots_with_advisories_sets_advisory(tmp_path):
         == "The hotspot concentrates branching logic in one service function."
     )
     assert snapshot.hotspots[0].advisory.refactor_steps[0].startswith("Extract")
+
+
+def test_safe_excerpt_returns_context_and_missing_file_is_empty(tmp_path):
+    services = tmp_path / "app.py"
+    services.write_text(
+        "line 1\n"
+        "line 2\n"
+        "line 3\n"
+        "line 4\n"
+        "line 5\n",
+        encoding="utf-8",
+    )
+
+    excerpt = _safe_excerpt(services, 3, radius=1)
+
+    assert excerpt == "2: line 2\n3: line 3\n4: line 4"
+    assert _safe_excerpt(tmp_path / "missing.py", 3) == ""
+
+
+def test_parse_json_object_handles_plain_fenced_and_invalid_payloads():
+    assert _parse_json_object('{"summary":"ok"}') == {"summary": "ok"}
+    assert _parse_json_object('```json\n{"summary":"ok"}\n```') == {
+        "summary": "ok"
+    }
+    assert _parse_json_object("not json") is None
+    assert _parse_json_object("") is None
+
+
+def test_user_prompt_includes_signals_architecture_and_excerpt(tmp_path):
+    services = tmp_path / "app" / "services.py"
+    services.parent.mkdir(parents=True)
+    services.write_text(
+        "\n".join(f"line {idx}" for idx in range(1, 31)) + "\n",
+        encoding="utf-8",
+    )
+    snapshot = _snapshot(str(tmp_path))
+
+    prompt = _user_prompt(
+        snapshot.hotspots[0],
+        project_root=tmp_path,
+        architecture_metrics={
+            "system_metrics": {
+                "mean_distance": 1.2,
+                "architecture_fitness": 0.8,
+                "dip_violations": 3,
+            }
+        },
+    )
+
+    assert "Hotspot:" in prompt
+    assert "- [SKY-Q301] Cyclomatic complexity is 18 (threshold: 10)" in prompt
+    assert "Architecture context:" in prompt
+    assert "- mean_distance=1.2" in prompt
+    assert "[app/services.py:20]" in prompt
+
+
+def test_debt_advisor_summarize_hotspot_normalizes_payload(tmp_path):
+    services = tmp_path / "app" / "services.py"
+    services.parent.mkdir(parents=True)
+    services.write_text(
+        "def process_order(order):\n"
+        "    if order:\n"
+        "        return order\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+    snapshot = _snapshot(str(tmp_path))
+    advisor = DebtAdvisor(model="gpt-4.1")
+    advisor.adapter = Mock(
+        complete=Mock(
+            return_value=json.dumps(
+                {
+                    "summary": "The hotspot concentrates branching logic.",
+                    "root_cause": "Control flow and responsibility are mixed.",
+                    "refactor_steps": ["Extract validation.", "", "Split branches."],
+                    "remediation_notes": ["Keep regression coverage.", ""],
+                    "confidence": "BOGUS",
+                }
+            )
+        )
+    )
+
+    advisory = advisor.summarize_hotspot(snapshot.hotspots[0], project_root=tmp_path)
+
+    assert advisory is not None
+    assert advisory.confidence == "medium"
+    assert advisory.refactor_steps == ["Extract validation.", "Split branches."]
+    assert advisory.remediation_notes == ["Keep regression coverage."]
+
+
+def test_debt_advisor_summarize_hotspot_returns_none_for_incomplete_payload(tmp_path):
+    services = tmp_path / "app" / "services.py"
+    services.parent.mkdir(parents=True)
+    services.write_text(
+        "def process_order(order):\n"
+        "    if order:\n"
+        "        return order\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+    snapshot = _snapshot(str(tmp_path))
+    advisor = DebtAdvisor(model="gpt-4.1")
+    advisor.adapter = Mock(
+        complete=Mock(
+            return_value=json.dumps(
+                {
+                    "summary": "",
+                    "root_cause": "Control flow and responsibility are mixed.",
+                    "refactor_steps": [],
+                    "remediation_notes": [],
+                    "confidence": "low",
+                }
+            )
+        )
+    )
+
+    advisory = advisor.summarize_hotspot(snapshot.hotspots[0], project_root=tmp_path)
+
+    assert advisory is None
 
 
 def test_format_debt_table_renders_changed_scope_empty_state_and_baseline():

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -371,6 +371,13 @@ def test_user_prompt_includes_signals_architecture_and_excerpt(tmp_path):
     assert "[app/services.py:20]" in prompt
 
 
+def _stub_debt_advisor(payload: str, *, model: str = "gpt-4.1") -> DebtAdvisor:
+    advisor = DebtAdvisor.__new__(DebtAdvisor)
+    advisor.model = model
+    advisor.adapter = Mock(complete=Mock(return_value=payload))
+    return advisor
+
+
 def test_debt_advisor_summarize_hotspot_normalizes_payload(tmp_path):
     services = tmp_path / "app" / "services.py"
     services.parent.mkdir(parents=True)
@@ -382,18 +389,15 @@ def test_debt_advisor_summarize_hotspot_normalizes_payload(tmp_path):
         encoding="utf-8",
     )
     snapshot = _snapshot(str(tmp_path))
-    advisor = DebtAdvisor(model="gpt-4.1")
-    advisor.adapter = Mock(
-        complete=Mock(
-            return_value=json.dumps(
-                {
-                    "summary": "The hotspot concentrates branching logic.",
-                    "root_cause": "Control flow and responsibility are mixed.",
-                    "refactor_steps": ["Extract validation.", "", "Split branches."],
-                    "remediation_notes": ["Keep regression coverage.", ""],
-                    "confidence": "BOGUS",
-                }
-            )
+    advisor = _stub_debt_advisor(
+        json.dumps(
+            {
+                "summary": "The hotspot concentrates branching logic.",
+                "root_cause": "Control flow and responsibility are mixed.",
+                "refactor_steps": ["Extract validation.", "", "Split branches."],
+                "remediation_notes": ["Keep regression coverage.", ""],
+                "confidence": "BOGUS",
+            }
         )
     )
 
@@ -416,18 +420,15 @@ def test_debt_advisor_summarize_hotspot_returns_none_for_incomplete_payload(tmp_
         encoding="utf-8",
     )
     snapshot = _snapshot(str(tmp_path))
-    advisor = DebtAdvisor(model="gpt-4.1")
-    advisor.adapter = Mock(
-        complete=Mock(
-            return_value=json.dumps(
-                {
-                    "summary": "",
-                    "root_cause": "Control flow and responsibility are mixed.",
-                    "refactor_steps": [],
-                    "remediation_notes": [],
-                    "confidence": "low",
-                }
-            )
+    advisor = _stub_debt_advisor(
+        json.dumps(
+            {
+                "summary": "",
+                "root_cause": "Control flow and responsibility are mixed.",
+                "refactor_steps": [],
+                "remediation_notes": [],
+                "confidence": "low",
+            }
         )
     )
 


### PR DESCRIPTION
## Summary
  - split `skylos.debt.advisor` into smaller helper paths for prompt fragments, excerpt collection, JSON cleanup, and advisory normalization
  - reduce the `skylos/debt/advisor.py` debt hotspot

## Verification
  - `pytest -q test/test_debt.py`
  - `skylos debt skylos/debt/advisor.py --top 5`