### PR TITLE
feat(security): add review evidence for llm security findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,25 @@ repos:
     hooks:
       - id: skylos-gate
         name: Skylos Staged Gate
-        entry: python3 -m skylos.cli agent pre-commit
-        language: system
+        entry: python -m skylos.cli
+        language: python
+        additional_dependencies:
+          - "inquirer>=3.0.3"
+          - "libcst>=1.8.2"
+          - "rich>=14.0.0"
+          - "textual>=1.0.0"
+          - "keyring>=25.6.0,!=3.4.2"
+          - "requests"
+          - "tree-sitter>=0.25.2"
+          - "tree-sitter-typescript>=0.23.2"
+          - "tree-sitter-go>=0.23.0"
+          - "tree-sitter-java>=0.23.0"
+          - "pyyaml"
+          - "networkx"
+          - "pyperclip"
+          - "ca9>=0.1.0"
+          - "mcp>=1.0.0"
         pass_filenames: false
         require_serial: true
-        args: ["."]
+        args: ["agent", "pre-commit", "."]
         stages: [pre-commit]

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -136,6 +136,16 @@ except (ImportError, OSError, ValueError):
     pass
 
 
+def _definition_module_and_class(defn):
+    if getattr(defn, "type", None) != "method" or "." not in defn.name:
+        return "", ""
+
+    parts = defn.name.split(".")
+    if len(parts) < 3:
+        return "", ""
+    return ".".join(parts[:-2]), parts[-2]
+
+
 def _resolve_analysis_root(path_like: Path) -> Path:
     current = path_like.resolve()
     if not current.is_dir():
@@ -760,6 +770,13 @@ class Skylos:
                     def_obj.references += 1
 
         used_attr_names = getattr(self, "_all_used_attr_names", set())
+        used_attr_context = getattr(self, "_all_used_attr_context", set())
+        same_class_private_attr_uses = set()
+        if used_attr_context:
+            for attr_name, mod, cls_ctx, _line_no in used_attr_context:
+                if cls_ctx and attr_name.startswith("_"):
+                    same_class_private_attr_uses.add((mod, cls_ctx, attr_name))
+
         if used_attr_names:
             for defn in self.defs.values():
                 if defn.references > 0:
@@ -770,11 +787,14 @@ class Skylos:
                     pass
                 else:
                     continue
+                if defn.type == "method" and defn.simple_name.startswith("_"):
+                    defn_mod, defn_cls = _definition_module_and_class(defn)
+                    if (defn_mod, defn_cls, defn.simple_name) in same_class_private_attr_uses:
+                        continue
                 if defn.simple_name in used_attr_names:
                     defn.references += 1
                     defn._attr_name_ref_count += 1
 
-        used_attr_context = getattr(self, "_all_used_attr_context", set())
         if used_attr_context:
             context_by_attr = defaultdict(list)
             for attr_name, mod, cls_ctx, line_no in used_attr_context:

--- a/skylos/api.py
+++ b/skylos/api.py
@@ -789,6 +789,10 @@ def _normalize_findings(
                 "_llm_challenged",
                 "_needs_review",
                 "_llm_uncertain",
+                "_ci_blocking",
+                "_security_evidence",
+                "_review_verdict",
+                "_review_reason",
             ):
                 val = finding.pop(meta_key, None)
                 if val is not None:

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -95,6 +95,36 @@ def run_pipeline(*args, **kwargs):
     return run_pipeline_impl(*args, **kwargs)
 
 
+def review_security_scan_result(*args, **kwargs):
+    from skylos.llm.security_verifier import (
+        SecurityVerifier,
+        annotate_security_finding,
+        is_security_finding,
+    )
+
+    result = kwargs.pop("result")
+    findings = []
+    for finding in list(result.findings):
+        if is_security_finding(finding):
+            annotate_security_finding(finding)
+            findings.append(finding)
+
+    if not findings:
+        return result
+
+    try:
+        verifier = SecurityVerifier(*args, **kwargs)
+        review = verifier.review_findings(findings)
+        refuted_ids = {id(finding) for finding in review["refuted_findings"]}
+        if refuted_ids:
+            result.findings = [
+                finding for finding in result.findings if id(finding) not in refuted_ids
+            ]
+    except Exception:
+        return result
+    return result
+
+
 def discover_source_files(*args, **kwargs):
     from skylos.file_discovery import (
         discover_source_files as discover_source_files_impl,
@@ -3715,10 +3745,22 @@ def main() -> None:
                 llm_result = analyzer.analyze_files(
                     files, issue_types=["security_audit"]
                 )
+                llm_result = review_security_scan_result(
+                    model=model,
+                    api_key=api_key,
+                    provider=provider,
+                    base_url=base_url,
+                    result=llm_result,
+                )
+                llm_result.summary = analyzer._generate_summary(llm_result)
                 analyzer.print_results(
                     llm_result, format=agent_args.format, output_file=agent_args.output
                 )
-                sys.exit(1 if llm_result.has_blockers else 0)
+                blockers_attr = getattr(llm_result, "has_blockers", False)
+                has_blockers = blockers_attr() if callable(blockers_attr) else bool(
+                    blockers_attr
+                )
+                sys.exit(1 if has_blockers else 0)
 
             changed_files = None
             if getattr(agent_args, "changed", False):

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib
 import json
 import sys
 import re
@@ -11,12 +12,6 @@ from skylos.constants import (
     parse_exclude_folders,
     DEFAULT_EXCLUDE_FOLDERS,
     get_non_library_dir_kind,
-)
-from skylos.codemods import (
-    remove_unused_import_cst,
-    remove_unused_function_cst,
-    comment_out_unused_import_cst,
-    comment_out_unused_function_cst,
 )
 from skylos.config import load_config
 from skylos.credentials import PROVIDERS
@@ -63,6 +58,26 @@ AGENT_PROVIDER_CHOICES = (
 )
 AGENT_PROVIDER_HELP = "Force LLM provider"
 AGENT_BASE_URL_HELP = "OpenAI-compatible base URL (Ollama/LM Studio/vLLM)"
+
+
+def _codemods_module():
+    return importlib.import_module("skylos.codemods")
+
+
+def remove_unused_import_cst(*args, **kwargs):
+    return _codemods_module().remove_unused_import_cst(*args, **kwargs)
+
+
+def remove_unused_function_cst(*args, **kwargs):
+    return _codemods_module().remove_unused_function_cst(*args, **kwargs)
+
+
+def comment_out_unused_import_cst(*args, **kwargs):
+    return _codemods_module().comment_out_unused_import_cst(*args, **kwargs)
+
+
+def comment_out_unused_function_cst(*args, **kwargs):
+    return _codemods_module().comment_out_unused_function_cst(*args, **kwargs)
 
 
 def run_analyze(*args, **kwargs):

--- a/skylos/llm/analyzer.py
+++ b/skylos/llm/analyzer.py
@@ -13,6 +13,8 @@ from skylos.config import load_config
 from skylos.llm.graph import CodeGraph
 from skylos.file_discovery import discover_source_files
 
+SECURITY_AUDIT_ISSUE = "security_audit"
+
 
 def _norm_path(path) -> str:
     try:
@@ -299,11 +301,20 @@ class SkylosLLM:
         modes = set()
         for issue_type in issue_types:
             name = str(issue_type).lower().strip()
-            if name in {"security", "security_audit"}:
+            if name in {"security", SECURITY_AUDIT_ISSUE}:
                 modes.add("security")
             if name == "quality":
                 modes.add("quality")
         return modes
+
+    @staticmethod
+    def _normalized_issue_types(issue_types=None):
+        return {str(t).lower().strip() for t in (issue_types or []) if str(t).strip()}
+
+    def _should_use_whole_file_review(self, file_norm, issue_types=None):
+        if self.config.full_file_review or file_norm in self.config.force_full_file_paths:
+            return True
+        return SECURITY_AUDIT_ISSUE in self._normalized_issue_types(issue_types)
 
     def _should_analyze_function(
         self, func_name, def_data, graph, *, issue_types=None, total_functions=0
@@ -368,14 +379,12 @@ class SkylosLLM:
         issue_types=None,
         **kwargs,
     ):
-        normalized_issue_types = {
-            str(t).lower().strip() for t in (issue_types or []) if str(t).strip()
-        }
+        normalized_issue_types = self._normalized_issue_types(issue_types)
 
         type_to_agent = {
             "security": "security",
             "quality": "quality",
-            "security_audit": "security_audit",
+            SECURITY_AUDIT_ISSUE: SECURITY_AUDIT_ISSUE,
         }
 
         if not issue_types:
@@ -391,7 +400,7 @@ class SkylosLLM:
                     agent_types.append("quality")
 
             if not agent_types:
-                agent_types = ["security_audit"]
+                agent_types = [SECURITY_AUDIT_ISSUE]
         else:
             # Fail fast if caller asks for dead_code through per-file analysis
             for t in issue_types:
@@ -412,7 +421,7 @@ class SkylosLLM:
                         agent_types.append(a)
 
             if not agent_types:
-                agent_types = ["security_audit"]
+                agent_types = [SECURITY_AUDIT_ISSUE]
 
         include_review_hints = any(
             agent_type in {"review", "quality"} for agent_type in agent_types
@@ -482,9 +491,8 @@ class SkylosLLM:
 
         all_findings = []
         file_norm = _norm_path(file_path)
-        force_full_file_review = file_norm in self.config.force_full_file_paths
 
-        if self.config.full_file_review or force_full_file_review:
+        if self._should_use_whole_file_review(file_norm, issue_types):
             all_findings = self._analyze_whole_file(
                 source,
                 str(file_path),
@@ -834,7 +842,7 @@ def analyze(path, model="gpt-4.1", issue_types=None, **kwargs):
 
 
 def audit(path, model="gpt-4.1", **kwargs):
-    return analyze(path, model=model, issue_types=["security_audit"], **kwargs)
+    return analyze(path, model=model, issue_types=[SECURITY_AUDIT_ISSUE], **kwargs)
 
 
 def fix(file_path, line, message, model="gpt-4.1"):

--- a/skylos/llm/graph.py
+++ b/skylos/llm/graph.py
@@ -12,8 +12,12 @@ class CodeGraph:
 
         self.taint_sources = {
             "request.args",
+            "request.args.get",
             "request.form",
+            "request.form.get",
             "request.json",
+            "request.json.get",
+            "request.get_json",
             "request.data",
             "input",
             "raw_input",
@@ -31,8 +35,10 @@ class CodeGraph:
             "exec",
             "subprocess.call",
             "subprocess.run",
+            "subprocess.check_output",
             "subprocess.Popen",
             "os.system",
+            "os.popen",
             "render_template_string",
             "open",
         }
@@ -369,6 +375,8 @@ class DataFlowVisitor(ast.NodeVisitor):
             for tgt in targets:
                 self.flows.append((src, tgt, node.lineno))
 
+        self.visit(node.value)
+
     def visit_AugAssign(self, node):
         if isinstance(node.target, ast.Name):
             target = node.target.id
@@ -377,9 +385,12 @@ class DataFlowVisitor(ast.NodeVisitor):
             for src in sources:
                 self.flows.append((src, target, node.lineno))
 
+        self.visit(node.value)
+
     def visit_Return(self, node):
         if node.value:
             self.returns.extend(self._extract_names(node.value))
+            self.visit(node.value)
 
     def visit_Call(self, node):
         call_name = self._get_call_name(node)
@@ -456,6 +467,14 @@ class DataFlowVisitor(ast.NodeVisitor):
                 names.add(chain)
 
         elif isinstance(node, ast.Call):
+            call_name = self._get_call_name(node)
+            if call_name in {
+                "request.args.get",
+                "request.form.get",
+                "request.json.get",
+                "request.get_json",
+            }:
+                names.add(call_name)
             for arg in node.args:
                 self._visit_for_names(arg, names)
             for keyword in node.keywords:

--- a/skylos/llm/schemas.py
+++ b/skylos/llm/schemas.py
@@ -68,6 +68,7 @@ class Finding:
         code_snippet: str | None = None,
         references: list[str] | None = None,
         symbol: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         self.rule_id = rule_id
         self.issue_type = issue_type
@@ -80,9 +81,10 @@ class Finding:
         self.code_snippet = code_snippet
         self.references = references or []
         self.symbol = symbol
+        self.metadata = metadata or {}
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "rule_id": self.rule_id,
             "issue_type": self.issue_type.value,
             "severity": self.severity.value,
@@ -95,8 +97,17 @@ class Finding:
             "references": self.references,
             "symbol": self.symbol,
         }
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        return data
 
     def to_sarif_result(self) -> dict[str, Any]:
+        properties = {
+            "confidence": self.confidence.value,
+            "issueType": self.issue_type.value,
+        }
+        if self.metadata:
+            properties.update(self.metadata)
         return {
             "ruleId": self.rule_id,
             "level": self._severity_to_sarif_level(),
@@ -112,10 +123,7 @@ class Finding:
                     }
                 }
             ],
-            "properties": {
-                "confidence": self.confidence.value,
-                "issueType": self.issue_type.value,
-            },
+            "properties": properties,
         }
 
     def _severity_to_sarif_level(self) -> str:
@@ -240,10 +248,24 @@ class AnalysisResult:
 
     def has_blockers(self) -> bool:
         if self.get_critical_count() > 0:
-            return True
+            for finding in self.findings:
+                if finding.severity != Severity.CRITICAL:
+                    continue
+                if self._finding_blocks_ci(finding):
+                    return True
         if self.get_high_count() > 0:
-            return True
+            for finding in self.findings:
+                if finding.severity != Severity.HIGH:
+                    continue
+                if self._finding_blocks_ci(finding):
+                    return True
         return False
+
+    def _finding_blocks_ci(self, finding: Finding) -> bool:
+        metadata = dict(getattr(finding, "metadata", None) or {})
+        if "ci_blocking" in metadata:
+            return bool(metadata["ci_blocking"])
+        return True
 
 
 ISSUE_TYPE_VALUES = []

--- a/skylos/llm/security_verifier.py
+++ b/skylos/llm/security_verifier.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from .agents import AgentConfig, create_llm_adapter
+from .schemas import Finding, IssueType, normalize_json_response_text
+
+REVIEWS_KEY = "reviews"
+ID_KEY = "id"
+VERDICT_KEY = "verdict"
+REASON_KEY = "reason"
+SUPPORTED_VERDICT = "SUPPORTED"
+REFUTED_VERDICT = "REFUTED"
+UNCERTAIN_VERDICT = "UNCERTAIN"
+LLM_SOURCE = "llm"
+SECURITY_CATEGORY = "security"
+MEDIUM_CONFIDENCE = "medium"
+REVIEW_SUPPORTED_EVIDENCE = "review_supported"
+DEFAULT_SECURITY_EVIDENCE = "hypothesis"
+REFUTED_EVIDENCE = "refuted"
+SUPPORTED_COUNT = "supported"
+REFUTED_COUNT = "refuted"
+UNDECIDED_COUNT = "undecided"
+REFUTED_FINDINGS_KEY = "refuted_findings"
+
+REVIEW_DECISION_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [REVIEWS_KEY],
+    "properties": {
+        REVIEWS_KEY: {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [ID_KEY, VERDICT_KEY, REASON_KEY],
+                "properties": {
+                    ID_KEY: {"type": "integer", "minimum": 1},
+                    VERDICT_KEY: {
+                        "type": "string",
+                        "enum": [
+                            SUPPORTED_VERDICT,
+                            REFUTED_VERDICT,
+                            UNCERTAIN_VERDICT,
+                        ],
+                    },
+                    REASON_KEY: {"type": "string"},
+                },
+            },
+        }
+    },
+}
+
+REVIEW_DECISION_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "skylos_security_verifier",
+        "schema": REVIEW_DECISION_SCHEMA,
+        "strict": True,
+    },
+}
+
+
+def _set_if_present(mapping: dict[str, Any], key: str, value: str | None) -> None:
+    if value:
+        mapping[key] = value
+
+
+def _review_metadata(
+    *,
+    evidence: str,
+    review_verdict: str | None,
+    review_reason: str | None,
+    needs_review: bool,
+    ci_blocking: bool,
+) -> dict[str, Any]:
+    metadata = {
+        "source": LLM_SOURCE,
+        "category": SECURITY_CATEGORY,
+        "confidence": MEDIUM_CONFIDENCE,
+        "needs_review": needs_review,
+        "ci_blocking": ci_blocking,
+        "security_evidence": evidence,
+    }
+    _set_if_present(metadata, "review_verdict", review_verdict)
+    _set_if_present(metadata, "review_reason", review_reason)
+    return metadata
+
+
+def annotate_security_finding(
+    finding: Finding | dict[str, Any],
+    *,
+    evidence: str = DEFAULT_SECURITY_EVIDENCE,
+    review_verdict: str | None = None,
+    review_reason: str | None = None,
+    needs_review: bool = True,
+    ci_blocking: bool = False,
+) -> Finding | dict[str, Any]:
+    metadata = _review_metadata(
+        evidence=evidence,
+        review_verdict=review_verdict,
+        review_reason=review_reason,
+        needs_review=needs_review,
+        ci_blocking=ci_blocking,
+    )
+    if isinstance(finding, dict):
+        finding["_source"] = metadata["source"]
+        finding["_category"] = metadata["category"]
+        finding["_confidence"] = metadata["confidence"]
+        finding["_needs_review"] = metadata["needs_review"]
+        finding["_ci_blocking"] = metadata["ci_blocking"]
+        finding["_security_evidence"] = metadata["security_evidence"]
+        _set_if_present(finding, "_review_verdict", review_verdict)
+        _set_if_present(finding, "_review_reason", review_reason)
+        return finding
+
+    existing = dict(getattr(finding, "metadata", None) or {})
+    existing.update(metadata)
+    finding.metadata = existing
+    return finding
+
+
+def is_security_finding(finding: Finding | dict[str, Any]) -> bool:
+    if isinstance(finding, dict):
+        category = str(finding.get("_category") or finding.get("category") or "").lower()
+        issue_type = str(finding.get("issue_type") or "").lower()
+        return category == SECURITY_CATEGORY or issue_type == SECURITY_CATEGORY
+    return finding.issue_type == IssueType.SECURITY
+
+
+def _get_file_path(finding: Finding | dict[str, Any]) -> str:
+    if isinstance(finding, dict):
+        location = finding.get("location") or {}
+        return str(finding.get("file") or location.get("file") or "unknown")
+    return str(finding.location.file)
+
+
+def _get_line_number(finding: Finding | dict[str, Any]) -> int:
+    if isinstance(finding, dict):
+        location = finding.get("location") or {}
+        return int(finding.get("line") or location.get("line") or 1)
+    return int(finding.location.line)
+
+
+def _get_rule_id(finding: Finding | dict[str, Any]) -> str:
+    return str(finding.get("rule_id") if isinstance(finding, dict) else finding.rule_id)
+
+
+def _get_severity(finding: Finding | dict[str, Any]) -> str:
+    if isinstance(finding, dict):
+        return str(finding.get("severity") or MEDIUM_CONFIDENCE)
+    severity = finding.severity
+    return severity.value if hasattr(severity, "value") else str(severity)
+
+
+def _get_message(finding: Finding | dict[str, Any]) -> str:
+    return str(finding.get("message") if isinstance(finding, dict) else finding.message)
+
+
+def _new_review_result(reviewable_count: int, reviewed_count: int) -> dict[str, Any]:
+    return {
+        SUPPORTED_COUNT: 0,
+        REFUTED_COUNT: 0,
+        UNDECIDED_COUNT: max(0, reviewable_count - reviewed_count),
+        REFUTED_FINDINGS_KEY: [],
+    }
+
+
+def _group_findings_by_file(
+    findings: list[Finding | dict[str, Any]],
+) -> dict[str, list[Finding | dict[str, Any]]]:
+    grouped: dict[str, list[Finding | dict[str, Any]]] = defaultdict(list)
+    for finding in findings:
+        grouped[_get_file_path(finding)].append(finding)
+    return grouped
+
+
+def _iter_batches(
+    findings: list[Finding | dict[str, Any]], batch_size: int
+) -> list[list[Finding | dict[str, Any]]]:
+    return [
+        findings[start : start + batch_size]
+        for start in range(0, len(findings), batch_size)
+    ]
+
+
+def _read_source(file_path: str) -> str | None:
+    try:
+        return Path(file_path).read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+class SecurityVerifier:
+    def __init__(
+        self,
+        *,
+        model: str,
+        api_key: str | None,
+        provider: str | None = None,
+        base_url: str | None = None,
+        max_review: int = 25,
+        batch_size: int = 5,
+    ) -> None:
+        config = AgentConfig(model=model, api_key=api_key, stream=False)
+        config.provider = provider
+        config.base_url = base_url
+        config.max_tokens = 4096
+        config.temperature = 0.0
+        self.config = config
+        self.max_review = max_review
+        self.batch_size = batch_size
+        self._adapter = None
+
+    def get_adapter(self):
+        if self._adapter is None:
+            self._adapter = create_llm_adapter(self.config)
+        return self._adapter
+
+    def review_findings(
+        self, findings: list[Finding | dict[str, Any]]
+    ) -> dict[str, Any]:
+        reviewable = [finding for finding in findings if is_security_finding(finding)]
+        for finding in reviewable:
+            annotate_security_finding(finding)
+
+        reviewed = reviewable[: self.max_review]
+        result = _new_review_result(len(reviewable), len(reviewed))
+        grouped = _group_findings_by_file(reviewed)
+        for file_path, file_findings in grouped.items():
+            self._review_file(file_path, file_findings, result)
+        return result
+
+    def _review_file(
+        self,
+        file_path: str,
+        findings: list[Finding | dict[str, Any]],
+        result: dict[str, Any],
+    ) -> None:
+        source = _read_source(file_path)
+        if source is None:
+            result[UNDECIDED_COUNT] += len(findings)
+            return
+
+        for batch in _iter_batches(findings, self.batch_size):
+            self._review_batch_into_result(batch, source, file_path, result)
+
+    def _review_batch_into_result(
+        self,
+        findings: list[Finding | dict[str, Any]],
+        source: str,
+        file_path: str,
+        result: dict[str, Any],
+    ) -> None:
+        decisions = self._review_batch(findings, source, file_path)
+        if not decisions:
+            result[UNDECIDED_COUNT] += len(findings)
+            return
+
+        for finding, decision in zip(findings, decisions):
+            self._apply_review_decision(finding, decision, result)
+
+    def _apply_review_decision(
+        self,
+        finding: Finding | dict[str, Any],
+        decision: dict[str, str],
+        result: dict[str, Any],
+    ) -> None:
+        verdict = str(decision.get(VERDICT_KEY) or UNCERTAIN_VERDICT).upper()
+        reason = str(decision.get(REASON_KEY) or "").strip() or None
+        if verdict == SUPPORTED_VERDICT:
+            annotate_security_finding(
+                finding,
+                evidence=REVIEW_SUPPORTED_EVIDENCE,
+                review_verdict=verdict,
+                review_reason=reason,
+            )
+            result[SUPPORTED_COUNT] += 1
+            return
+
+        if verdict == REFUTED_VERDICT:
+            annotate_security_finding(
+                finding,
+                evidence=REFUTED_EVIDENCE,
+                review_verdict=verdict,
+                review_reason=reason,
+            )
+            result[REFUTED_COUNT] += 1
+            result[REFUTED_FINDINGS_KEY].append(finding)
+            return
+
+        annotate_security_finding(
+            finding,
+            evidence=DEFAULT_SECURITY_EVIDENCE,
+            review_verdict=UNCERTAIN_VERDICT,
+            review_reason=reason,
+        )
+        result[UNDECIDED_COUNT] += 1
+
+    def _review_batch(
+        self,
+        findings: list[Finding | dict[str, Any]],
+        source: str,
+        file_path: str,
+    ) -> list[dict[str, str]]:
+        user = self._build_review_prompt(findings, source.splitlines(), file_path)
+        response = self._request_review(user)
+        return self._normalize_decisions(response, len(findings))
+
+    def _build_review_prompt(
+        self,
+        findings: list[Finding | dict[str, Any]],
+        lines: list[str],
+        file_path: str,
+    ) -> str:
+        blocks = [
+            self._build_review_block(index, finding, lines)
+            for index, finding in enumerate(findings, start=1)
+        ]
+        return "\n\n".join(
+            [
+                f"Review {len(findings)} candidate security finding(s) from {file_path}.",
+                "Each candidate is independent. Ignore any prior scan confidence.",
+                "",
+                "\n\n".join(blocks),
+                "",
+                'Return JSON with shape: {"reviews":[{"id":1,"verdict":"SUPPORTED|REFUTED|UNCERTAIN","reason":"brief reason"}]}',
+            ]
+        )
+
+    def _build_review_block(
+        self, index: int, finding: Finding | dict[str, Any], lines: list[str]
+    ) -> str:
+        line_num = _get_line_number(finding)
+        context = self._build_context(line_num, lines)
+        return "\n".join(
+            [
+                f"### Candidate {index}",
+                f"- Rule: {_get_rule_id(finding)}",
+                f"- Severity: {_get_severity(finding)}",
+                f"- Line: {line_num}",
+                f"- Message: {_get_message(finding)}",
+                "",
+                "Code context:",
+                context,
+            ]
+        )
+
+    def _build_context(self, line_num: int, lines: list[str]) -> str:
+        start = max(0, line_num - 6)
+        end = min(len(lines), line_num + 5)
+        context_lines = [
+            f"{index + 1:4d}{' >>> ' if index == line_num - 1 else '     '}{lines[index]}"
+            for index in range(start, end)
+        ]
+        return "\n".join(context_lines)
+
+    def _request_review(self, user: str) -> str | None:
+        system = """You are Skylos Security Verifier.
+Your job is to re-review candidate security findings using only the code context provided.
+
+Verdicts:
+- SUPPORTED: the finding is plausibly real based on the shown code
+- REFUTED: the finding is not supported by the shown code, or the code appears safe
+- UNCERTAIN: the context is insufficient to decide
+
+Be conservative. If the context is incomplete, return UNCERTAIN.
+Respond with JSON only."""
+        try:
+            return self.get_adapter().complete(
+                system,
+                user,
+                response_format=REVIEW_DECISION_FORMAT,
+            )
+        except Exception:
+            return None
+
+    def _normalize_decisions(
+        self, response: str | None, expected_count: int
+    ) -> list[dict[str, str]]:
+        reviews = self._parse_reviews(response)
+        if reviews is None:
+            return []
+
+        review_map = self._review_map(reviews)
+        return [
+            self._normalized_decision(review_map.get(index), reviews, index)
+            for index in range(1, expected_count + 1)
+        ]
+
+    def _parse_reviews(self, response: str | None) -> list[dict[str, Any]] | None:
+        if not response:
+            return None
+        try:
+            payload = json.loads(normalize_json_response_text(response))
+        except Exception:
+            return None
+
+        reviews = payload.get(REVIEWS_KEY) if isinstance(payload, dict) else None
+        return reviews if isinstance(reviews, list) else None
+
+    def _review_map(self, reviews: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+        return {
+            int(review.get(ID_KEY)): review
+            for review in reviews
+            if isinstance(review, dict) and isinstance(review.get(ID_KEY), int)
+        }
+
+    def _normalized_decision(
+        self,
+        review: dict[str, Any] | None,
+        reviews: list[dict[str, Any]],
+        index: int,
+    ) -> dict[str, str]:
+        fallback = reviews[index - 1] if index - 1 < len(reviews) else None
+        choice = review if isinstance(review, dict) else fallback
+        if not isinstance(choice, dict):
+            return {VERDICT_KEY: UNCERTAIN_VERDICT, REASON_KEY: ""}
+        return {
+            VERDICT_KEY: str(choice.get(VERDICT_KEY) or UNCERTAIN_VERDICT).upper(),
+            REASON_KEY: str(choice.get(REASON_KEY) or ""),
+        }

--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -9,6 +9,10 @@ from concurrent.futures import as_completed
 from skylos.config import load_config
 from skylos.file_discovery import discover_source_files
 from skylos.llm.repo_activation import build_repo_activation_index
+from skylos.llm.security_verifier import (
+    SecurityVerifier,
+    annotate_security_finding,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -700,6 +704,8 @@ def run_pipeline(
                     "_needs_review": True,
                     "_ci_blocking": False,
                 }
+                if issue_type == "security":
+                    annotate_security_finding(llm_finding)
                 results.append(llm_finding)
 
             console.print(
@@ -760,6 +766,7 @@ def run_pipeline(
             all_findings.append(f)
 
     llm_only_count = 0
+    llm_security_only = []
     for llm_f in phase_2b_findings:
         dup = _find_duplicate(llm_f, all_findings)
         if dup is not None:
@@ -770,6 +777,40 @@ def run_pipeline(
         else:
             all_findings.append(llm_f)
             llm_only_count += 1
+            if (
+                llm_f.get("_source") == "llm"
+                and llm_f.get("_category") == "security"
+            ):
+                llm_security_only.append(llm_f)
+
+    if llm_security_only:
+        console.print(
+            "[brand]Phase 2c:[/brand] Re-reviewing unmatched LLM-only security findings..."
+        )
+        verifier = SecurityVerifier(
+            model=model,
+            api_key=api_key,
+            provider=getattr(agent_args, "provider", None),
+            base_url=getattr(agent_args, "base_url", None),
+        )
+        try:
+            review = verifier.review_findings(llm_security_only)
+        except Exception as exc:
+            console.print(
+                f"[warn]Security re-review unavailable: {exc}. Keeping findings as hypothesis.[/warn]"
+            )
+        else:
+            refuted_ids = {id(finding) for finding in review["refuted_findings"]}
+            if refuted_ids:
+                all_findings = [
+                    finding for finding in all_findings if id(finding) not in refuted_ids
+                ]
+            console.print(
+                f"[good]✓ Security re-review:[/good] "
+                f"{review['supported']} supported, "
+                f"{review['refuted']} refuted, "
+                f"{review['undecided']} left as hypothesis"
+            )
 
     enrich_findings = [f for f in all_findings if not f.get("fixed_code")]
     if (

--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -526,6 +526,25 @@ def cmd_pull():
         sys.exit(1)
 
 
+PRECOMMIT_HOOK_DEPENDENCIES = [
+    "inquirer>=3.0.3",
+    "libcst>=1.8.2",
+    "rich>=14.0.0",
+    "textual>=1.0.0",
+    "keyring>=25.6.0,!=3.4.2",
+    "requests",
+    "tree-sitter>=0.25.2",
+    "tree-sitter-typescript>=0.23.2",
+    "tree-sitter-go>=0.23.0",
+    "tree-sitter-java>=0.23.0",
+    "pyyaml",
+    "networkx",
+    "pyperclip",
+    "ca9>=0.1.0",
+    "mcp>=1.0.0",
+]
+
+
 def create_precommit_config():
     precommit_path = Path(".pre-commit-config.yaml")
 
@@ -533,7 +552,11 @@ def create_precommit_config():
         print("  ⚠️  .pre-commit-config.yaml already exists (skipping)")
         return False
 
-    config_content = """# Skylos pre-commit configuration
+    dependency_lines = "\n".join(
+        f'          - "{dependency}"' for dependency in PRECOMMIT_HOOK_DEPENDENCIES
+    )
+
+    config_content = f"""# Skylos pre-commit configuration
 # Fast staged-only local hook.
 # Checks security, secrets, and quality in staged source/config files.
 # Full repo and diff-aware enforcement runs in CI.
@@ -543,11 +566,13 @@ repos:
     hooks:
       - id: skylos-gate
         name: Skylos Staged Gate
-        entry: python3 -m skylos.cli agent pre-commit
-        language: system
+        entry: python -m skylos.cli
+        language: python
+        additional_dependencies:
+{dependency_lines}
         pass_filenames: false
         require_serial: true
-        args: ["."]
+        args: ["agent", "pre-commit", "."]
         stages: [pre-commit]
 """
 

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -1,6 +1,54 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from skylos.llm.analyzer import AnalyzerConfig, SkylosLLM
+from skylos.llm.schemas import (
+    AnalysisResult,
+    CodeLocation,
+    Confidence,
+    Finding,
+    IssueType,
+    Severity,
+)
+
+
+def _security_scan_result(file_path: str) -> AnalysisResult:
+    return AnalysisResult(
+        findings=[
+            Finding(
+                rule_id="SKY-L001",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                message="Possible SQL injection",
+                location=CodeLocation(file=file_path, line=1),
+                confidence=Confidence.HIGH,
+            ),
+            Finding(
+                rule_id="SKY-L002",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                message="Possible command injection",
+                location=CodeLocation(file=file_path, line=2),
+                confidence=Confidence.HIGH,
+            ),
+            Finding(
+                rule_id="SKY-L003",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                message="Possible SSRF",
+                location=CodeLocation(file=file_path, line=3),
+                confidence=Confidence.HIGH,
+            ),
+        ],
+        files_analyzed=1,
+    )
+
+
+def _make_security_scan_analyzer(result: AnalysisResult) -> SkylosLLM:
+    analyzer = SkylosLLM(AnalyzerConfig(quiet=True))
+    analyzer.analyze_files = MagicMock(return_value=result)
+    return analyzer
 
 
 def test_agent_review_passes_exclude_folders():
@@ -289,3 +337,149 @@ def test_security_audit_passes_provider_and_base_url_into_analyzer_config(tmp_pa
     kwargs = mock_build.call_args.kwargs
     assert kwargs["provider"] == "anthropic"
     assert kwargs["base_url"] == "https://custom.endpoint"
+
+
+def test_security_audit_json_output_handles_supported_refuted_and_hypothesis(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+    output = tmp_path / "security.json"
+
+    analyzer = _make_security_scan_analyzer(_security_scan_result(str(sample)))
+
+    def _review(findings):
+        findings[0].metadata["security_evidence"] = "review_supported"
+        findings[0].metadata["review_verdict"] = "SUPPORTED"
+        findings[0].metadata["review_reason"] = "source reaches string-built query"
+        findings[1].metadata["security_evidence"] = "refuted"
+        findings[1].metadata["review_verdict"] = "REFUTED"
+        findings[1].metadata["review_reason"] = "input is constrained"
+        findings[2].metadata["security_evidence"] = "hypothesis"
+        findings[2].metadata["review_verdict"] = "UNCERTAIN"
+        findings[2].metadata["review_reason"] = "not enough local context"
+        return {
+            "supported": 1,
+            "refuted": 1,
+            "undecided": 1,
+            "refuted_findings": [findings[1]],
+        }
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.cli.discover_source_files", return_value=[sample]),
+        patch("skylos.cli.SkylosLLM", return_value=analyzer),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 2
+
+    by_rule = {finding["rule_id"]: finding for finding in findings}
+    assert "SKY-L002" not in by_rule
+    assert by_rule["SKY-L001"]["metadata"]["security_evidence"] == "review_supported"
+    assert by_rule["SKY-L001"]["metadata"]["review_verdict"] == "SUPPORTED"
+    assert by_rule["SKY-L001"]["metadata"]["ci_blocking"] is False
+    assert by_rule["SKY-L003"]["metadata"]["security_evidence"] == "hypothesis"
+    assert by_rule["SKY-L003"]["metadata"]["review_verdict"] == "UNCERTAIN"
+    assert by_rule["SKY-L003"]["metadata"]["ci_blocking"] is False
+
+
+def test_security_audit_sarif_output_handles_supported_refuted_and_hypothesis(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+    output = tmp_path / "security.sarif"
+
+    analyzer = _make_security_scan_analyzer(_security_scan_result(str(sample)))
+
+    def _review(findings):
+        findings[0].metadata["security_evidence"] = "review_supported"
+        findings[0].metadata["review_verdict"] = "SUPPORTED"
+        findings[0].metadata["review_reason"] = "source reaches string-built query"
+        findings[1].metadata["security_evidence"] = "refuted"
+        findings[1].metadata["review_verdict"] = "REFUTED"
+        findings[1].metadata["review_reason"] = "input is constrained"
+        findings[2].metadata["security_evidence"] = "hypothesis"
+        findings[2].metadata["review_verdict"] = "UNCERTAIN"
+        findings[2].metadata["review_reason"] = "not enough local context"
+        return {
+            "supported": 1,
+            "refuted": 1,
+            "undecided": 1,
+            "refuted_findings": [findings[1]],
+        }
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.cli.discover_source_files", return_value=[sample]),
+        patch("skylos.cli.SkylosLLM", return_value=analyzer),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "sarif",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    results = payload["runs"][0]["results"]
+    assert len(results) == 2
+
+    by_rule = {result["ruleId"]: result for result in results}
+    assert "SKY-L002" not in by_rule
+    assert by_rule["SKY-L001"]["properties"]["security_evidence"] == "review_supported"
+    assert by_rule["SKY-L001"]["properties"]["review_verdict"] == "SUPPORTED"
+    assert by_rule["SKY-L001"]["properties"]["ci_blocking"] is False
+    assert by_rule["SKY-L003"]["properties"]["security_evidence"] == "hypothesis"
+    assert by_rule["SKY-L003"]["properties"]["review_verdict"] == "UNCERTAIN"
+    assert by_rule["SKY-L003"]["properties"]["ci_blocking"] is False

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1034,6 +1034,29 @@ event.listens_for(Engine, "connect")(on_connect)
         assert "dbapi_connection" not in unused_parameters
         assert "connection_record" not in unused_parameters
 
+    def test_analyze_marks_private_helper_dead_when_only_called_by_dead_method(
+        self, tmp_path
+    ):
+        src = tmp_path / "helper.py"
+        src.write_text(
+            """
+class Helper:
+    def run(self):
+        return self._helper()
+
+    def _helper(self):
+        return 1
+"""
+        )
+
+        result_json = analyze(str(tmp_path), conf=0)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "Helper.run" in unreachable
+        assert "Helper._helper" in unreachable
+
     def test_analyze_single_file_skips_project_unused_dependency_rule(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "demo"\ndependencies = ["requests", "rich"]\n',

--- a/test/test_fast_parity.py
+++ b/test/test_fast_parity.py
@@ -505,6 +505,32 @@ class Result:
 
 
 class TestEndToEndParity:
+    def test_dead_private_helper_method_parity(self, tmp_path):
+        src = tmp_path / "helper.py"
+        src.write_text(
+            """
+class Helper:
+    def run(self):
+        return self._helper()
+
+    def _helper(self):
+        return 1
+""",
+            encoding="utf-8",
+        )
+
+        result_rust, result_py = _run_dead_code_parity_scans_in_subprocess(tmp_path)
+
+        def _names(result):
+            return {f["name"] for f in result.get("unused_functions", [])}
+
+        rust_names = _names(result_rust)
+        py_names = _names(result_py)
+
+        assert "Helper.run" in rust_names
+        assert "Helper._helper" in rust_names
+        assert rust_names == py_names
+
     def test_dead_code_findings_match(self):
         result_rust, result_py = _run_dead_code_parity_scans_in_subprocess(SKYLOS_PKG)
 

--- a/test/test_llm_analyzer.py
+++ b/test/test_llm_analyzer.py
@@ -364,6 +364,69 @@ def test_full_file_review_bypasses_function_filter(tmp_path, monkeypatch):
     assert seen_sources[0][2] == ["quality"]
 
 
+def test_security_audit_uses_whole_file_review_even_without_full_file_mode(
+    tmp_path, monkeypatch
+):
+    fp = tmp_path / "app.py"
+    source = (
+        "from flask import request\n\n"
+        "def user():\n"
+        "    query = \"SELECT * FROM users WHERE id = %s\" % request.args['id']\n"
+        "    return query\n"
+    )
+    fp.write_text(source, encoding="utf-8")
+
+    cfg = AnalyzerConfig(
+        quiet=True,
+        enable_security=True,
+        enable_quality=False,
+        full_file_review=False,
+    )
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    seen_sources = []
+
+    def fake_analyze_whole_file(
+        source,
+        file_path,
+        defs_map=None,
+        chunk_start_line=1,
+        issue_types=None,
+        **kwargs,
+    ):
+        seen_sources.append((source, file_path, issue_types))
+        return [mk_finding(file=file_path, line=3, issue_type=IssueType.SECURITY)]
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_analyze_whole_file)
+
+    out = llm.analyze_file(fp, issue_types=["security_audit"])
+
+    assert len(out) == 1
+    assert len(seen_sources) == 1
+    assert seen_sources[0][0] == source
+    assert seen_sources[0][1] == str(fp)
+    assert seen_sources[0][2] == ["security_audit"]
+
+
+def test_security_selector_flags_flask_request_get_route():
+    source = (
+        "from flask import request\n"
+        "import subprocess\n\n"
+        "def ls():\n"
+        "    cmd = request.args.get('cmd')\n"
+        "    return subprocess.run(cmd, shell=True)\n"
+    )
+
+    graph = analyzer_mod.CodeGraph()
+    graph.build(source)
+
+    cfg = AnalyzerConfig(quiet=True, enable_security=True, enable_quality=False)
+    llm = SkylosLLM(cfg)
+
+    assert llm._should_analyze_security_function("ls", graph.definitions["ls"], graph)
+
+
 def test_full_file_review_uses_combined_review_agent_when_security_and_quality_enabled(
     tmp_path, monkeypatch
 ):

--- a/test/test_llm_graph.py
+++ b/test/test_llm_graph.py
@@ -1,0 +1,39 @@
+from skylos.llm.graph import CodeGraph
+
+
+def test_find_taint_paths_detects_request_args_get_to_subprocess_run():
+    source = (
+        "from flask import request\n"
+        "import subprocess\n\n"
+        "def ls():\n"
+        "    cmd = request.args.get('cmd')\n"
+        "    return subprocess.run(cmd, shell=True)\n"
+    )
+
+    graph = CodeGraph()
+    graph.build(source)
+
+    paths = graph.find_taint_paths("ls")
+
+    assert paths
+    assert any(path["sink_type"] == "subprocess.run" for path in paths)
+    assert any(path["source"].endswith("request.args.get") for path in paths)
+
+
+def test_find_taint_paths_detects_request_args_subscript_to_check_output():
+    source = (
+        "from flask import request\n"
+        "import subprocess\n\n"
+        "def dump_user():\n"
+        "    query = request.args['id']\n"
+        "    return subprocess.check_output(query, shell=True)\n"
+    )
+
+    graph = CodeGraph()
+    graph.build(source)
+
+    paths = graph.find_taint_paths("dump_user")
+
+    assert paths
+    assert any(path["sink_type"] == "subprocess.check_output" for path in paths)
+    assert any(path["source"].endswith("request.args") for path in paths)

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -134,6 +134,7 @@ P_CREATE_DC_AGENT = "skylos.llm.agents.create_dead_code_agent"
 P_AGENTCFG = "skylos.llm.agents.AgentConfig"
 P_PROGRESS = "rich.progress.Progress"
 P_STATIC_FN = "skylos.pipeline.run_static_on_files"
+P_SECURITY_VERIFIER = "skylos.pipeline.SecurityVerifier"
 
 
 class TestNorm:
@@ -778,8 +779,15 @@ class TestPipelinePhase2b:
             patch(P_STATIC_FN, return_value=_empty_result()),
             patch(P_PROGRESS),
             patch(P_LLM) as mock_llm,
+            patch(P_SECURITY_VERIFIER) as mock_verifier,
         ):
             mock_llm.return_value.analyze_files.return_value = llm_result
+            mock_verifier.return_value.review_findings.return_value = {
+                "supported": 0,
+                "refuted": 0,
+                "undecided": len(llm_findings_list),
+                "refuted_findings": [],
+            }
 
             findings = run_pipeline(
                 path=str(proj),
@@ -801,6 +809,7 @@ class TestPipelinePhase2b:
         assert len(llm) == 1
         assert llm[0]["_needs_review"] is True
         assert llm[0]["_ci_blocking"] is False
+        assert llm[0]["_security_evidence"] == "hypothesis"
 
     def test_llm_dead_code_discoveries_included(self, tmp_path):
         findings = self._run_with_llm_findings(
@@ -855,8 +864,15 @@ class TestPipelinePhase2b:
             patch(P_STATIC_FN, return_value=_fresh_static()),
             patch(P_PROGRESS),
             patch(P_LLM) as mock_llm,
+            patch(P_SECURITY_VERIFIER) as mock_verifier,
         ):
             mock_llm.return_value.analyze_files.return_value = llm_result
+            mock_verifier.return_value.review_findings.return_value = {
+                "supported": 0,
+                "refuted": 0,
+                "undecided": 0,
+                "refuted_findings": [],
+            }
 
             findings = run_pipeline(
                 path=str(proj),
@@ -867,8 +883,79 @@ class TestPipelinePhase2b:
                 changed_files=[str(proj / "a.py")],
             )
 
+        mock_verifier.return_value.review_findings.assert_not_called()
         llm_only = [f for f in findings if f["_source"] == "llm"]
         assert len(llm_only) == 0
+
+    def test_unmatched_security_findings_use_rereview_metadata(self, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+
+        llm_result = MagicMock()
+        llm_result.findings = [_llm_finding(issue_type="security")]
+
+        with (
+            patch(P_STATIC_FN, return_value=_empty_result()),
+            patch(P_PROGRESS),
+            patch(P_LLM) as mock_llm,
+            patch(P_SECURITY_VERIFIER) as mock_verifier,
+        ):
+            mock_llm.return_value.analyze_files.return_value = llm_result
+
+            def _review(findings):
+                findings[0]["_security_evidence"] = "review_supported"
+                findings[0]["_review_verdict"] = "SUPPORTED"
+                return {
+                    "supported": 1,
+                    "refuted": 0,
+                    "undecided": 0,
+                    "refuted_findings": [],
+                }
+
+            mock_verifier.return_value.review_findings.side_effect = _review
+
+            findings = run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(skip_verification=True),
+                console=_console(),
+                changed_files=[str(proj / "a.py")],
+            )
+
+        llm = [f for f in findings if f["_source"] == "llm"]
+        assert llm[0]["_security_evidence"] == "review_supported"
+        assert llm[0]["_review_verdict"] == "SUPPORTED"
+
+    def test_security_rereview_failure_keeps_hypothesis(self, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+
+        llm_result = MagicMock()
+        llm_result.findings = [_llm_finding(issue_type="security")]
+
+        with (
+            patch(P_STATIC_FN, return_value=_empty_result()),
+            patch(P_PROGRESS),
+            patch(P_LLM) as mock_llm,
+            patch(P_SECURITY_VERIFIER) as mock_verifier,
+        ):
+            mock_llm.return_value.analyze_files.return_value = llm_result
+            mock_verifier.return_value.review_findings.side_effect = RuntimeError("down")
+
+            findings = run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(skip_verification=True),
+                console=_console(),
+                changed_files=[str(proj / "a.py")],
+            )
+
+        llm = [f for f in findings if f["_source"] == "llm"]
+        assert llm[0]["_security_evidence"] == "hypothesis"
 
     def test_static_only_skips_llm_analysis(self, tmp_path):
         proj = tmp_path / "proj"
@@ -1226,10 +1313,17 @@ class TestPipelineOutput:
             patch(P_STATIC_FN, return_value=_fresh_static()),
             patch(P_PROGRESS),
             patch(P_LLM) as mock_llm,
+            patch(P_SECURITY_VERIFIER) as mock_verifier,
         ):
             mock_llm.return_value.analyze_files.return_value = MagicMock(
                 findings=[_llm_finding(issue_type="security")]
             )
+            mock_verifier.return_value.review_findings.return_value = {
+                "supported": 0,
+                "refuted": 0,
+                "undecided": 1,
+                "refuted_findings": [],
+            }
 
             findings = run_pipeline(
                 path=str(proj),
@@ -1253,10 +1347,17 @@ class TestPipelineOutput:
             patch(P_STATIC_FN, return_value=_fresh_static()),
             patch(P_PROGRESS),
             patch(P_LLM) as mock_llm,
+            patch(P_SECURITY_VERIFIER) as mock_verifier,
         ):
             mock_llm.return_value.analyze_files.return_value = MagicMock(
                 findings=[_llm_finding(issue_type="security")]
             )
+            mock_verifier.return_value.review_findings.return_value = {
+                "supported": 0,
+                "refuted": 0,
+                "undecided": 1,
+                "refuted_findings": [],
+            }
 
             findings = run_pipeline(
                 path=str(proj),
@@ -1470,10 +1571,17 @@ class TestPipelineIntegration:
             patch(P_LLM) as mock_llm,
             patch(P_CREATE_DC_AGENT, return_value=mock_agent),
             patch(P_AGENTCFG),
+            patch(P_SECURITY_VERIFIER) as mock_verifier,
         ):
             mock_llm.return_value.analyze_files.return_value = MagicMock(
                 findings=[llm_sec]
             )
+            mock_verifier.return_value.review_findings.return_value = {
+                "supported": 1,
+                "refuted": 0,
+                "undecided": 0,
+                "refuted_findings": [],
+            }
 
             findings = run_pipeline(
                 path=str(proj),

--- a/test/test_security_verifier.py
+++ b/test/test_security_verifier.py
@@ -1,0 +1,138 @@
+from unittest.mock import patch
+
+import skylos.api as api
+from skylos.cli import review_security_scan_result
+from skylos.llm.schemas import (
+    AnalysisResult,
+    CodeLocation,
+    Confidence,
+    Finding,
+    IssueType,
+    Severity,
+)
+
+
+def _security_finding(*, line=3, severity=Severity.HIGH):
+    return Finding(
+        rule_id="SKY-L001",
+        issue_type=IssueType.SECURITY,
+        severity=severity,
+        message="Possible SQL injection",
+        location=CodeLocation(file="app.py", line=line),
+        confidence=Confidence.HIGH,
+    )
+
+
+def test_review_security_scan_result_marks_findings_review_only():
+    finding = _security_finding()
+    result = AnalysisResult(findings=[finding], files_analyzed=1)
+
+    with patch(
+        "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+        return_value={
+            "supported": 0,
+            "refuted": 0,
+            "undecided": 1,
+            "refuted_findings": [],
+        },
+    ):
+        out = review_security_scan_result(
+            model="gpt-4.1",
+            api_key="k",
+            provider=None,
+            base_url=None,
+            result=result,
+        )
+
+    metadata = out.findings[0].metadata
+    assert metadata["security_evidence"] == "hypothesis"
+    assert metadata["needs_review"] is True
+    assert metadata["ci_blocking"] is False
+    assert out.has_blockers() is False
+
+
+def test_review_security_scan_result_filters_refuted_findings():
+    finding = _security_finding()
+    result = AnalysisResult(findings=[finding], files_analyzed=1)
+
+    with patch(
+        "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+        return_value={
+            "supported": 0,
+            "refuted": 1,
+            "undecided": 0,
+            "refuted_findings": [finding],
+        },
+    ):
+        out = review_security_scan_result(
+            model="gpt-4.1",
+            api_key="k",
+            provider=None,
+            base_url=None,
+            result=result,
+        )
+
+    assert out.findings == []
+
+
+def test_supported_review_only_findings_stay_non_blocking():
+    finding = _security_finding()
+    result = AnalysisResult(findings=[finding], files_analyzed=1)
+
+    def _supported(_findings):
+        _findings[0].metadata["security_evidence"] = "review_supported"
+        _findings[0].metadata["review_verdict"] = "SUPPORTED"
+        return {
+            "supported": 1,
+            "refuted": 0,
+            "undecided": 0,
+            "refuted_findings": [],
+        }
+
+    with patch(
+        "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+        side_effect=_supported,
+    ):
+        out = review_security_scan_result(
+            model="gpt-4.1",
+            api_key="k",
+            provider=None,
+            base_url=None,
+            result=result,
+        )
+
+    metadata = out.findings[0].metadata
+    assert metadata["security_evidence"] == "review_supported"
+    assert metadata["review_verdict"] == "SUPPORTED"
+    assert out.has_blockers() is False
+
+
+def test_normalize_findings_preserves_security_review_metadata():
+    normalized = api._normalize_findings(
+        [
+            {
+                "file": "app.py",
+                "line": 8,
+                "message": "Possible SQL injection",
+                "rule_id": "SKY-L001",
+                "severity": "HIGH",
+                "_source": "llm",
+                "_confidence": "medium",
+                "_needs_review": True,
+                "_ci_blocking": False,
+                "_security_evidence": "review_supported",
+                "_review_verdict": "SUPPORTED",
+                "_review_reason": "query is built from request data",
+            }
+        ],
+        "SECURITY",
+        "/repo",
+        extract_metadata=True,
+    )
+
+    metadata = normalized[0]["metadata"]
+    assert metadata["source"] == "llm"
+    assert metadata["needs_review"] is True
+    assert metadata["ci_blocking"] is False
+    assert metadata["security_evidence"] == "review_supported"
+    assert metadata["review_verdict"] == "SUPPORTED"

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -514,8 +514,12 @@ def test_create_precommit_config_limits_gate_to_pre_commit(tmp_path, monkeypatch
     assert "Fast staged-only local hook." in content
     assert "Full repo and diff-aware enforcement runs in CI." in content
     assert "stages: [pre-commit]" in content
-    assert "python3 -m skylos.cli agent pre-commit" in content
-    assert 'args: ["."]' in content
+    assert "entry: python -m skylos.cli" in content
+    assert "language: python" in content
+    assert "additional_dependencies:" in content
+    assert '- "rich>=14.0.0"' in content
+    assert '- "libcst>=1.8.2"' in content
+    assert 'args: ["agent", "pre-commit", "."]' in content
     assert "--gate" not in content
 
 


### PR DESCRIPTION
## Summary
  - attach additive review metadata to LLM-only security findings, including evidence state, verifier verdict, and non-blocking review status
  - preserve that metadata through JSON, SARIF, and API normalization paths

  ## Verification
  - `pytest -q test/test_pipeline.py test/test_security_verifier.py`
  - `pytest -q test/test_agent_integration.py`
  - `pytest -q test/test_pipeline.py test/test_security_verifier.py test/test_agent_integration.py test/test_api.py test/test_llm_analyzer.py test/test_cli.py`