### PR TITLE
test(security): add end-to-end benchmark cases

### DIFF
--- a/agent_review_benchmarks/README.md
+++ b/agent_review_benchmarks/README.md
@@ -43,3 +43,9 @@ The checked-in suite is intentionally difficult. It includes:
 - resource cleanup mistakes
 - duplicated branch conditions
 - tricky clean async/control-flow modules that should stay quiet
+- request-driven Flask SQL injection and shell-injection handlers
+- getter-based command injection with a nearby safe argv-based helper
+
+Benchmark cases can optionally declare `scan.issue_types`, which lets the suite
+exercise stricter review lanes such as `["security_audit"]` instead of the
+default mixed fast-review path.

--- a/agent_review_benchmarks/fixtures/flask_getter_shell/app.py
+++ b/agent_review_benchmarks/fixtures/flask_getter_shell/app.py
@@ -1,0 +1,22 @@
+from flask import Flask, request
+import subprocess
+
+
+app = Flask(__name__)
+
+
+@app.get("/tool")
+def run_tool():
+    cmd = request.args.get("cmd")
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True)
+
+
+@app.get("/safe-tool")
+def run_safe():
+    cmd = request.args.get("cmd", "pwd")
+    return subprocess.run(
+        ["/bin/echo", cmd],
+        check=False,
+        capture_output=True,
+        text=True,
+    )

--- a/agent_review_benchmarks/fixtures/flask_handler_security/app.py
+++ b/agent_review_benchmarks/fixtures/flask_handler_security/app.py
@@ -1,0 +1,29 @@
+from flask import Flask, request
+import sqlite3
+import subprocess
+
+
+app = Flask(__name__)
+
+
+@app.get("/user")
+def user():
+    user_id = request.args.get("id")
+    query = "SELECT * FROM users WHERE id = %s" % user_id
+    return query
+
+
+@app.get("/ls")
+def ls():
+    cmd = request.args["cmd"]
+    return subprocess.check_output(cmd, shell=True)
+
+
+@app.get("/safe")
+def safe():
+    user_id = request.args.get("id")
+    conn = sqlite3.connect(":memory:")
+    return conn.execute(
+        "SELECT * FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchall()

--- a/agent_review_benchmarks/manifest.json
+++ b/agent_review_benchmarks/manifest.json
@@ -280,6 +280,58 @@
       }
     },
     {
+      "id": "flask-handler-security",
+      "path": "fixtures/flask_handler_security/app.py",
+      "description": "A Flask handler file should surface request-driven SQL injection and shell injection while keeping the parameterized handler quiet.",
+      "taxonomy": ["security", "control_flow", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from the manual security-audit regression where low-complexity Flask handlers were skipped before review."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["user", "ls"]
+        },
+        "absent": {
+          "security": ["safe"]
+        }
+      }
+    },
+    {
+      "id": "flask-getter-shell",
+      "path": "fixtures/flask_getter_shell/app.py",
+      "description": "Getter-based request access should still surface command injection when shell=True is used, while the argv-based helper stays quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from the manual request.args.get to subprocess.run(shell=True) regression."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["run_tool"]
+        },
+        "absent": {
+          "security": ["run_safe"]
+        }
+      }
+    },
+    {
       "id": "debt-hotspot-service",
       "path": "fixtures/debt_hotspot_service",
       "description": "A central service module imported by multiple entry surfaces should be surfaced as a debt hotspot when it is wide, branch-heavy, and swallows failures.",

--- a/skylos/agent_review_benchmark.py
+++ b/skylos/agent_review_benchmark.py
@@ -33,6 +33,8 @@ IMPORTANCE_WEIGHTS = {
 }
 
 DEFAULT_SCAN_MAX_FILES = 8
+ALLOWED_SCAN_ISSUE_TYPES = {"quality", "security", "security_audit"}
+SCAN_ISSUE_TYPES_FIELD = "issue_types"
 
 
 @dataclass(frozen=True)
@@ -129,6 +131,35 @@ def validate_manifest(
                 raise ValueError(
                     f"agent review benchmark case {case_id} scan.max_files must be a positive integer"
                 )
+        if isinstance(scan_cfg, dict) and SCAN_ISSUE_TYPES_FIELD in scan_cfg:
+            issue_types = scan_cfg.get(SCAN_ISSUE_TYPES_FIELD)
+            if not isinstance(issue_types, list) or not issue_types:
+                raise ValueError(
+                    f"agent review benchmark case {case_id} scan.issue_types must be a non-empty list"
+                )
+            invalid_issue_types = [
+                issue_type
+                for issue_type in issue_types
+                if not isinstance(issue_type, str) or not issue_type.strip()
+            ]
+            if invalid_issue_types:
+                raise ValueError(
+                    f"agent review benchmark case {case_id} scan.issue_types must only contain strings"
+                )
+            unsupported_issue_types = sorted(
+                {
+                    issue_type
+                    for issue_type in issue_types
+                    if issue_type not in ALLOWED_SCAN_ISSUE_TYPES
+                }
+            )
+            if unsupported_issue_types:
+                allowed = ", ".join(sorted(ALLOWED_SCAN_ISSUE_TYPES))
+                raise ValueError(
+                    "agent review benchmark case "
+                    f"{case_id} has unsupported scan.issue_types value "
+                    f"'{unsupported_issue_types[0]}'. Allowed: {allowed}"
+                )
 
         expect = case.get("expect")
         if not isinstance(expect, dict):
@@ -223,6 +254,7 @@ def _scan_case(
 ) -> dict[str, Any]:
     scan_cfg = case.get("scan") if isinstance(case, dict) else {}
     max_files = int((scan_cfg or {}).get("max_files") or DEFAULT_SCAN_MAX_FILES)
+    issue_types = list((scan_cfg or {}).get(SCAN_ISSUE_TYPES_FIELD) or [])
     prepared = prepare_case_scan(case_path, max_files=max_files)
 
     config = AnalyzerConfig(
@@ -239,7 +271,7 @@ def _scan_case(
         repo_context_map=prepared["repo_context_map"],
     )
     analyzer = SkylosLLM(config)
-    result = analyzer.analyze_files(prepared["files"])
+    result = analyzer.analyze_files(prepared["files"], issue_types=issue_types or None)
 
     symbols = {
         _normalize_symbol(getattr(finding, "symbol", None))

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -186,6 +186,16 @@ def _scan_staged_secret_files(
     return findings
 
 
+def _join_phrase(parts: list[str]) -> str:
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return parts[0]
+    if len(parts) == 2:
+        return " ".join((parts[0], "and", parts[1]))
+    return f"{', '.join(parts[:-1])}, {' '.join(('and', parts[-1]))}"
+
+
 def _list_dirty_relevant_paths(project_root: Path, is_relevant_path) -> list[str]:
     result = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=all"],
@@ -3239,15 +3249,20 @@ def main() -> None:
 
                 staged_source_files = []
                 staged_config_files = []
-                staged_test_files = []
+                staged_secret_only_files = {
+                    "test": [],
+                    "benchmark": [],
+                    "example": [],
+                }
                 analyzer_targets = set()
                 report_targets = set()
                 skipped_staged_files = 0
                 for relpath in staged_candidates:
                     relpath_obj = Path(relpath)
                     if relpath_obj.suffix.lower() in source_exts:
-                        if get_non_library_dir_kind(relpath_obj, project_root) == "test":
-                            staged_test_files.append(relpath)
+                        kind = get_non_library_dir_kind(relpath_obj, project_root)
+                        if kind in staged_secret_only_files:
+                            staged_secret_only_files[kind].append(relpath)
                             report_targets.add(
                                 str((project_root / relpath).resolve())
                             )
@@ -3284,7 +3299,13 @@ def main() -> None:
 
                 changed_ranges = _get_cached_changed_line_ranges(
                     project_root,
-                    staged_source_files + staged_config_files + staged_test_files,
+                    staged_source_files
+                    + staged_config_files
+                    + [
+                        relpath
+                        for paths in staged_secret_only_files.values()
+                        for relpath in paths
+                    ],
                 )
                 snapshot_dir = None
                 analysis_root = project_root
@@ -3341,17 +3362,25 @@ def main() -> None:
                             scope_parts.append(f"{len(staged_source_files)} source")
                         if staged_config_files:
                             scope_parts.append(f"{len(staged_config_files)} config")
-                        if staged_test_files:
-                            scope_parts.append(f"{len(staged_test_files)} test")
+                        for kind in ("test", "benchmark", "example"):
+                            paths = staged_secret_only_files[kind]
+                            if paths:
+                                scope_parts.append(f"{len(paths)} {kind}")
                         scope_desc = " and ".join(scope_parts)
                         skipped_note = (
                             f" Skipped {skipped_staged_files} unsupported staged file(s)."
                             if skipped_staged_files
                             else ""
                         )
+                        secret_only_kinds = [
+                            kind
+                            for kind in ("test", "benchmark", "example")
+                            if staged_secret_only_files[kind]
+                        ]
                         staged_test_note = (
-                            " Staged test files are secrets-only in local commit checks."
-                            if staged_test_files
+                            " Staged "
+                            f"{_join_phrase(secret_only_kinds)} files are secrets-only in local commit checks."
+                            if secret_only_kinds
                             else ""
                         )
                         baseline_note = (
@@ -3378,9 +3407,13 @@ def main() -> None:
                             f"{baseline_note}"
                         )
 
-                    staged_test_secrets = _scan_staged_secret_files(
+                    staged_secret_only_secrets = _scan_staged_secret_files(
                         project_root,
-                        staged_test_files,
+                        [
+                            relpath
+                            for paths in staged_secret_only_files.values()
+                            for relpath in paths
+                        ],
                         ignore_tests=False,
                     )
 
@@ -3390,7 +3423,7 @@ def main() -> None:
                             staged_config_files,
                             ignore_tests=True,
                         )
-                        secrets.extend(staged_test_secrets)
+                        secrets.extend(staged_secret_only_secrets)
                         result = {
                             "unused_functions": [],
                             "unused_imports": [],
@@ -3441,9 +3474,9 @@ def main() -> None:
                             if isinstance(raw_result, str)
                             else raw_result
                         )
-                        if staged_test_secrets:
+                        if staged_secret_only_secrets:
                             result["secrets"] = list(result.get("secrets") or [])
-                            result["secrets"].extend(staged_test_secrets)
+                            result["secrets"].extend(staged_secret_only_secrets)
                         result = _remap_precommit_result_files(
                             result, analysis_root, project_root
                         )
@@ -3480,7 +3513,13 @@ def main() -> None:
                     result,
                     project_root,
                     changed_files=(
-                        staged_source_files + staged_config_files + staged_test_files
+                        staged_source_files
+                        + staged_config_files
+                        + [
+                            relpath
+                            for paths in staged_secret_only_files.values()
+                            for relpath in paths
+                        ]
                     ),
                     include_dead_code=False,
                 )

--- a/skylos/constants.py
+++ b/skylos/constants.py
@@ -152,9 +152,14 @@ def get_non_library_dir_kind(p, project_root=None, extra_dirs=None) -> str | Non
         parts = str(p).replace("\\", "/").split("/")
 
     for part in parts:
-        kind = merged.get(part.lower())
+        lowered = part.lower()
+        kind = merged.get(lowered)
         if kind:
             return kind
+        if lowered.endswith("_benchmark") or lowered.endswith("_benchmarks"):
+            return "benchmark"
+        if lowered.endswith("_example") or lowered.endswith("_examples"):
+            return "example"
 
     basename = str(p).replace("\\", "/").rsplit("/", 1)[-1].lower()
     if (

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from skylos.llm.schemas import (
     IssueType,
     Severity,
 )
+from skylos.llm.security_verifier import annotate_security_finding
 
 
 def _security_scan_result(file_path: str) -> AnalysisResult:
@@ -49,6 +51,55 @@ def _make_security_scan_analyzer(result: AnalysisResult) -> SkylosLLM:
     analyzer = SkylosLLM(AnalyzerConfig(quiet=True))
     analyzer.analyze_files = MagicMock(return_value=result)
     return analyzer
+
+
+class _DeterministicSecurityAuditAgent:
+    def analyze(self, source, file_path, defs_map=None, context=None):
+        findings = []
+        for line_no, line in enumerate(source.splitlines(), start=1):
+            if "SELECT * FROM users WHERE id = %s" in line and "%" in line:
+                findings.append(
+                    Finding(
+                        rule_id="SKY-S001",
+                        issue_type=IssueType.SECURITY,
+                        severity=Severity.CRITICAL,
+                        message="SQL injection vulnerability: user input is directly interpolated into SQL query string.",
+                        location=CodeLocation(file=file_path, line=line_no),
+                        confidence=Confidence.HIGH,
+                    )
+                )
+            if (
+                "subprocess.check_output" in line or "subprocess.run" in line
+            ) and "shell=True" in line:
+                findings.append(
+                    Finding(
+                        rule_id="SKY-C011",
+                        issue_type=IssueType.SECURITY,
+                        severity=Severity.CRITICAL,
+                        message="Command injection vulnerability: untrusted user input passed to subprocess with shell=True.",
+                        location=CodeLocation(file=file_path, line=line_no),
+                        confidence=Confidence.HIGH,
+                    )
+                )
+        return findings
+
+
+def _supported_security_review(findings):
+    for finding in findings:
+        annotate_security_finding(
+            finding,
+            evidence="review_supported",
+            review_verdict="SUPPORTED",
+            review_reason="deterministic test review",
+            needs_review=True,
+            ci_blocking=False,
+        )
+    return {
+        "supported": len(findings),
+        "refuted": 0,
+        "undecided": 0,
+        "refuted_findings": [],
+    }
 
 
 def test_agent_review_passes_exclude_folders():
@@ -483,3 +534,144 @@ def test_security_audit_sarif_output_handles_supported_refuted_and_hypothesis(tm
     assert by_rule["SKY-L003"]["properties"]["security_evidence"] == "hypothesis"
     assert by_rule["SKY-L003"]["properties"]["review_verdict"] == "UNCERTAIN"
     assert by_rule["SKY-L003"]["properties"]["ci_blocking"] is False
+
+
+def test_security_audit_json_output_reports_vulnerable_repo_and_skips_safe_file(
+    tmp_path,
+):
+    vuln = tmp_path / "vuln_app.py"
+    vuln.write_text(
+        "from flask import Flask, request\n"
+        "import subprocess\n\n"
+        "app = Flask(__name__)\n\n"
+        "@app.get('/user')\n"
+        "def user():\n"
+        "    user_id = request.args.get('id')\n"
+        "    query = \"SELECT * FROM users WHERE id = %s\" % user_id\n"
+        "    return query\n\n"
+        "@app.get('/ls')\n"
+        "def ls():\n"
+        "    cmd = request.args['cmd']\n"
+        "    return subprocess.check_output(cmd, shell=True)\n",
+        encoding="utf-8",
+    )
+    safe = tmp_path / "safe_app.py"
+    safe.write_text(
+        "from flask import Flask, request\n"
+        "import sqlite3\n\n"
+        "app = Flask(__name__)\n\n"
+        "@app.get('/safe')\n"
+        "def safe():\n"
+        "    user_id = request.args.get('id')\n"
+        "    conn = sqlite3.connect(':memory:')\n"
+        "    return conn.execute(\"SELECT * FROM users WHERE id = ?\", (user_id,)).fetchall()\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 2
+    by_rule = {finding["rule_id"]: finding for finding in findings}
+    assert set(by_rule) == {"SKY-S001", "SKY-C011"}
+    assert all(Path(item["location"]["file"]).name == "vuln_app.py" for item in findings)
+    assert all(item["metadata"]["security_evidence"] == "review_supported" for item in findings)
+    assert all(item["metadata"]["review_verdict"] == "SUPPORTED" for item in findings)
+
+
+def test_security_audit_json_output_reports_getter_based_command_injection(tmp_path):
+    sample = tmp_path / "app.py"
+    sample.write_text(
+        "from flask import Flask, request\n"
+        "import subprocess\n\n"
+        "app = Flask(__name__)\n\n"
+        "@app.get('/run')\n"
+        "def run_cmd():\n"
+        "    cmd = request.args.get('cmd')\n"
+        "    return subprocess.run(cmd, shell=True)\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-C011"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"

--- a/test/test_agent_review_benchmark.py
+++ b/test/test_agent_review_benchmark.py
@@ -1,8 +1,10 @@
 import json
 from pathlib import Path
 
+import pytest
 import skylos.agent_review_benchmark as benchmark
 from skylos.agent_review_benchmark import (
+    ALLOWED_SCAN_ISSUE_TYPES,
     AGENT_REVIEW_TAXONOMY,
     format_summary,
     load_manifest,
@@ -10,6 +12,7 @@ from skylos.agent_review_benchmark import (
     run_manifest,
     validate_manifest,
 )
+from skylos.llm.schemas import AnalysisResult
 
 
 MANIFEST_PATH = (
@@ -21,13 +24,15 @@ def test_checked_in_agent_review_manifest_validates():
     manifest = load_manifest(MANIFEST_PATH)
     cases = validate_manifest(manifest, MANIFEST_PATH)
 
-    assert len(cases) >= 13
+    assert len(cases) >= 15
     assert {case["id"] for case in cases} >= {
         "complexity-hotspot",
         "inconsistent-return",
         "empty-error-handler",
         "clean-module",
         "cross-file-sql-injection",
+        "flask-handler-security",
+        "flask-getter-shell",
         "debt-hotspot-service",
         "repo-clean-service",
     }
@@ -163,3 +168,78 @@ def test_prepare_case_scan_directory_selects_repo_files(tmp_path):
     assert "service.py" in reviewed
     assert prepared["full_file_review"] is True
     assert str(service.resolve()) in prepared["repo_context_map"]
+
+
+def test_scan_case_passes_issue_types_into_analyzer(tmp_path, monkeypatch):
+    fixture = tmp_path / "app.py"
+    fixture.write_text("def run_tool():\n    return 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        benchmark,
+        "prepare_case_scan",
+        lambda case_path, max_files=benchmark.DEFAULT_SCAN_MAX_FILES: {
+            "project_root": tmp_path,
+            "files": [fixture],
+            "repo_context_map": {},
+            "full_file_review": True,
+        },
+    )
+
+    seen: dict[str, object] = {}
+
+    class FakeAnalyzer:
+        def __init__(self, config):
+            seen["config"] = config
+
+        def analyze_files(self, files, defs_map=None, static_findings=None, issue_types=None):
+            seen["files"] = list(files)
+            seen["issue_types"] = list(issue_types or [])
+            return AnalysisResult(findings=[], summary="No issues found", tokens_used=0)
+
+    monkeypatch.setattr(benchmark, "SkylosLLM", FakeAnalyzer)
+
+    result = benchmark._scan_case(
+        fixture,
+        model="gpt-4.1",
+        api_key="KEY",
+        provider=None,
+        base_url=None,
+        case={"scan": {"issue_types": ["security_audit"]}},
+    )
+
+    assert result["finding_count"] == 0
+    assert seen["files"] == [fixture]
+    assert seen["issue_types"] == ["security_audit"]
+
+
+def test_validate_manifest_rejects_unknown_scan_issue_type(tmp_path):
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text("def demo():\n    return 1\n", encoding="utf-8")
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "bad-scan-mode",
+                "path": "fixture.py",
+                "taxonomy": ["security"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "scan": {"issue_types": ["security_audit", "not_a_mode"]},
+                "expect": {"present": {}, "absent": {}},
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc:
+        validate_manifest(load_manifest(manifest_path), manifest_path)
+
+    assert "unsupported scan.issue_types value" in str(exc.value)
+    for allowed in ALLOWED_SCAN_ISSUE_TYPES:
+        assert allowed in str(exc.value)

--- a/test/test_cli_precommit.py
+++ b/test/test_cli_precommit.py
@@ -392,6 +392,75 @@ def test_agent_pre_commit_scans_staged_test_files_for_secrets_only(tmp_path):
     assert "No staged security, secrets, or quality issues" in printed
 
 
+def test_agent_pre_commit_scans_staged_benchmark_files_for_secrets_only(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "agent_review_benchmarks" / "fixtures").mkdir(parents=True)
+    bench_file = (
+        repo
+        / "agent_review_benchmarks"
+        / "fixtures"
+        / "demo"
+        / "app.py"
+    )
+    bench_file.parent.mkdir(parents=True)
+    bench_file.write_text("def demo():\n    pass\n", encoding="utf-8")
+
+    console = Mock()
+    staged = Mock(
+        stdout="agent_review_benchmarks/fixtures/demo/app.py\n",
+        returncode=0,
+    )
+    cached_diff = Mock(
+        stdout=(
+            "diff --git a/agent_review_benchmarks/fixtures/demo/app.py "
+            "b/agent_review_benchmarks/fixtures/demo/app.py\n"
+            "--- a/agent_review_benchmarks/fixtures/demo/app.py\n"
+            "+++ b/agent_review_benchmarks/fixtures/demo/app.py\n"
+            "@@ -1 +1 @@\n"
+        ),
+        returncode=0,
+    )
+    staged_blob = Mock(stdout="def demo():\n    pass\n", returncode=0)
+    seen_ignore_tests = []
+
+    def fake_scan_ctx(ctx, *, ignore_tests=True, **kwargs):
+        seen_ignore_tests.append(ignore_tests)
+        return []
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "show", ":agent_review_benchmarks/fixtures/demo/app.py"]:
+            return staged_blob
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+        patch("skylos.cli.find_project_root", return_value=repo),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.rules.secrets.scan_ctx", side_effect=fake_scan_ctx),
+        patch("skylos.baseline.load_baseline", return_value=None),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 0
+    assert seen_ignore_tests == [False]
+    printed = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "reviewing 1 benchmark staged file(s)" in printed
+    assert "Checks secrets only." in printed
+    assert "Staged benchmark files are secrets-only in local commit checks." in printed
+    assert "No staged security, secrets, or quality issues" in printed
+
+
 def test_agent_pre_commit_scans_staged_test_files_for_secrets_alongside_source(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -270,6 +270,12 @@ class TestHelperFunctions:
         assert (
             get_non_library_dir_kind("/project/benchmarks/bench_api.py") == "benchmark"
         )
+        assert (
+            get_non_library_dir_kind(
+                "/project/agent_review_benchmarks/fixtures/app.py"
+            )
+            == "benchmark"
+        )
         assert get_non_library_dir_kind("/project/src/app.py") is None
 
     def test_get_non_library_dir_kind_uses_project_relative_path(self):


### PR DESCRIPTION
## Summary
- add checked-in security benchmark cases for vulnerable Flask SQL injection and shell-injection handlers, plus safe neighboring handlers that should stay quiet
- teach the agent review benchmark harness to forward scan.issue_types so benchmark cases can exercise the real security_audit lane
- add end-to-end agent scan --security integration coverage for vulnerable repo and getter-based command-injection cases
- treat benchmark and example paths as non-production files in local pre-commit so intentionally vulnerable benchmark fixtures are checked for secrets only instead of blocking as production vulns

## Verification
- pytest -q test/test_agent_review_benchmark.py
- pytest -q test/test_agent_integration.py -k security_audit_json_output_reports_vulnerable_repo_and_skips_safe_file or security_audit_json_output_reports_getter_based_command_injection or security_audit_json_output_handles_supported_refuted_and_hypothesis or security_audit_sarif_output_handles_supported_refuted_and_hypothesis
- pytest -q test/test_cli_precommit.py test/test_constants.py test/test_agent_review_benchmark.py test/test_agent_integration.py test/test_pipeline.py test/test_security_verifier.py test/test_llm_analyzer.py test/test_llm_graph.py

## Why
- the manual vulnerable-repo test exposed a real gap in the security_audit path
- the code path has already been fixed
- this PR closes the remaining coverage gap by codifying those misses as checked-in benchmark and integration cases