### PR TITLE
test(security): expand benchmark corpus for web vulnerabilities

### DIFF
--- a/agent_review_benchmarks/README.md
+++ b/agent_review_benchmarks/README.md
@@ -45,7 +45,33 @@ The checked-in suite is intentionally difficult. It includes:
 - tricky clean async/control-flow modules that should stay quiet
 - request-driven Flask SQL injection and shell-injection handlers
 - getter-based command injection with a nearby safe argv-based helper
+- request-driven Flask SSRF with a nearby constant-url health probe
+- request-driven path traversal with a nearby fixed-path file reader
+- upload-path traversal with a nearby basename-sanitized handler
+- JWT verification bypass with a nearby algorithm-pinned decode helper
+- FastAPI query-parameter SSRF with a nearby constant-url probe
+- open redirect with a nearby urlparse-guarded redirect helper
+- reflected XSS with a nearby escaped template path
 
 Benchmark cases can optionally declare `scan.issue_types`, which lets the suite
 exercise stricter review lanes such as `["security_audit"]` instead of the
 default mixed fast-review path.
+
+Security cases should also declare `security_classes` so the corpus scales by
+major vulnerability family rather than by an unbounded list of one-off case
+names. The current class buckets are:
+
+- `sql_injection`
+- `command_injection`
+- `ssrf`
+- `path_traversal`
+- `file_upload`
+- `auth_bypass`
+- `xss`
+- `open_redirect`
+- `deserialization`
+- `archive_extraction`
+- `secrets_exposure`
+
+This keeps the benchmark representative instead of exhaustive: we want a few
+strong vulnerable/safe cases per class, not a thousand disconnected examples.

--- a/agent_review_benchmarks/fixtures/fastapi_query_ssrf/app.py
+++ b/agent_review_benchmarks/fixtures/fastapi_query_ssrf/app.py
@@ -1,0 +1,16 @@
+import httpx
+from fastapi import FastAPI, Request
+
+
+app = FastAPI()
+
+
+@app.get("/mirror")
+async def mirror_url(request: Request):
+    url = request.query_params.get("url")
+    return httpx.get(url).text
+
+
+@app.get("/status")
+async def fetch_status():
+    return httpx.get("https://status.internal.local/health").text

--- a/agent_review_benchmarks/fixtures/flask_open_redirect/app.py
+++ b/agent_review_benchmarks/fixtures/flask_open_redirect/app.py
@@ -1,0 +1,20 @@
+from urllib.parse import urlparse
+
+from flask import Flask, redirect, request
+
+
+app = Flask(__name__)
+
+
+@app.get("/go")
+def bounce():
+    target = request.args.get("next", "/")
+    return redirect(target)
+
+
+@app.get("/safe-go")
+def bounce_safe():
+    target = request.args.get("next", "/")
+    if urlparse(target).netloc:
+        target = "/"
+    return redirect(target)

--- a/agent_review_benchmarks/fixtures/flask_path_traversal/app.py
+++ b/agent_review_benchmarks/fixtures/flask_path_traversal/app.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from flask import Flask, request
+
+
+app = Flask(__name__)
+BASE_DIR = Path("/srv/data")
+
+
+@app.get("/download")
+def download_file():
+    filename = request.args.get("name")
+    target = BASE_DIR / filename
+    with open(target, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+@app.get("/help")
+def read_help():
+    with open(BASE_DIR / "help.txt", "r", encoding="utf-8") as handle:
+        return handle.read()

--- a/agent_review_benchmarks/fixtures/flask_reflected_xss/app.py
+++ b/agent_review_benchmarks/fixtures/flask_reflected_xss/app.py
@@ -1,0 +1,19 @@
+import html
+
+from flask import Flask, render_template_string, request
+
+
+app = Flask(__name__)
+
+
+@app.get("/profile")
+def profile():
+    name = request.args.get("name")
+    return render_template_string(f"<div>{name}</div>")
+
+
+@app.get("/safe-profile")
+def safe_profile():
+    name = request.args.get("name")
+    safe_name = html.escape(name)
+    return render_template_string("<div>{{ name }}</div>", name=safe_name)

--- a/agent_review_benchmarks/fixtures/flask_ssrf/app.py
+++ b/agent_review_benchmarks/fixtures/flask_ssrf/app.py
@@ -1,0 +1,16 @@
+from flask import Flask, request
+import requests
+
+
+app = Flask(__name__)
+
+
+@app.get("/avatar")
+def fetch_avatar():
+    target = request.args.get("url")
+    return requests.get(target, timeout=2).text
+
+
+@app.get("/health")
+def fetch_health():
+    return requests.get("https://status.internal.local/health", timeout=2).text

--- a/agent_review_benchmarks/fixtures/flask_upload_traversal/app.py
+++ b/agent_review_benchmarks/fixtures/flask_upload_traversal/app.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+from flask import Flask, request
+
+
+app = Flask(__name__)
+UPLOAD_DIR = Path("/srv/uploads")
+
+
+@app.post("/upload")
+def upload_file():
+    upload = request.files["file"]
+    filename = upload.filename
+    target = UPLOAD_DIR / filename
+    with open(target, "wb") as handle:
+        handle.write(upload.read())
+    return "ok"
+
+
+@app.post("/upload-safe")
+def upload_safe():
+    upload = request.files["file"]
+    safe_name = os.path.basename(upload.filename)
+    target = UPLOAD_DIR / safe_name
+    with open(target, "wb") as handle:
+        handle.write(upload.read())
+    return "ok"

--- a/agent_review_benchmarks/fixtures/jwt_insecure_decode/auth.py
+++ b/agent_review_benchmarks/fixtures/jwt_insecure_decode/auth.py
@@ -1,0 +1,9 @@
+import jwt
+
+
+def decode_session(token):
+    return jwt.decode(token, options={"verify_signature": False})
+
+
+def decode_signed_session(token, secret):
+    return jwt.decode(token, secret, algorithms=["HS256"])

--- a/agent_review_benchmarks/manifest.json
+++ b/agent_review_benchmarks/manifest.json
@@ -232,6 +232,7 @@
       "path": "fixtures/cross_file_sql_injection",
       "description": "A repo-style data flow should surface the query builder that interpolates untrusted input into SQL across files.",
       "taxonomy": ["security", "control_flow"],
+      "security_classes": ["sql_injection"],
       "importance": "critical",
       "source": {
         "repo": "https://github.com/pallets/flask",
@@ -258,6 +259,7 @@
       "path": "fixtures/shell_hook_runner",
       "description": "A repo-style CLI hook runner should surface shell injection on the dynamic command path but not on the allowlisted path.",
       "taxonomy": ["security", "maintainability"],
+      "security_classes": ["command_injection"],
       "importance": "critical",
       "source": {
         "repo": "https://github.com/pallets/click",
@@ -284,6 +286,7 @@
       "path": "fixtures/flask_handler_security/app.py",
       "description": "A Flask handler file should surface request-driven SQL injection and shell injection while keeping the parameterized handler quiet.",
       "taxonomy": ["security", "control_flow", "precision_guard"],
+      "security_classes": ["sql_injection", "command_injection"],
       "importance": "critical",
       "source": {
         "repo": "https://github.com/pallets/flask",
@@ -310,6 +313,7 @@
       "path": "fixtures/flask_getter_shell/app.py",
       "description": "Getter-based request access should still surface command injection when shell=True is used, while the argv-based helper stays quiet.",
       "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["command_injection"],
       "importance": "critical",
       "source": {
         "repo": "https://github.com/pallets/flask",
@@ -328,6 +332,195 @@
         },
         "absent": {
           "security": ["run_safe"]
+        }
+      }
+    },
+    {
+      "id": "flask-ssrf",
+      "path": "fixtures/flask_ssrf/app.py",
+      "description": "A Flask handler file should surface request-driven SSRF while keeping the constant-url health probe quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["ssrf"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from request.args URL fetches that should stay visible in the security audit lane."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["fetch_avatar"]
+        },
+        "absent": {
+          "security": ["fetch_health"]
+        }
+      }
+    },
+    {
+      "id": "flask-path-traversal",
+      "path": "fixtures/flask_path_traversal/app.py",
+      "description": "A Flask handler file should surface request-driven path traversal while keeping the fixed help-file reader quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["path_traversal"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from user-controlled filename joins that should surface under the owning handler."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["download_file"]
+        },
+        "absent": {
+          "security": ["read_help"]
+        }
+      }
+    },
+    {
+      "id": "flask-upload-traversal",
+      "path": "fixtures/flask_upload_traversal/app.py",
+      "description": "A Flask upload handler should surface request-driven filename traversal while keeping the basename-sanitized variant quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["path_traversal", "file_upload"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from file upload handlers that join unsanitized user filenames into a server-side upload path."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["upload_file"]
+        },
+        "absent": {
+          "security": ["upload_safe"]
+        }
+      }
+    },
+    {
+      "id": "jwt-insecure-decode",
+      "path": "fixtures/jwt_insecure_decode/auth.py",
+      "description": "A JWT helper should surface signature verification bypass while keeping the algorithm-pinned decode quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["auth_bypass"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/jpadilla/pyjwt",
+        "license": "MIT",
+        "notes": "Distilled from unsafe decode helpers that disable signature verification."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 10.0
+      },
+      "expect": {
+        "present": {
+          "security": ["decode_session"]
+        },
+        "absent": {
+          "security": ["decode_signed_session"]
+        }
+      }
+    },
+    {
+      "id": "fastapi-query-ssrf",
+      "path": "fixtures/fastapi_query_ssrf/app.py",
+      "description": "A FastAPI handler should surface query-parameter SSRF while keeping the constant health probe quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["ssrf"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/fastapi/fastapi",
+        "license": "MIT",
+        "notes": "Distilled from FastAPI request-driven URL fetches that should remain visible in the security audit lane."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["mirror_url"]
+        },
+        "absent": {
+          "security": ["fetch_status"]
+        }
+      }
+    },
+    {
+      "id": "flask-open-redirect",
+      "path": "fixtures/flask_open_redirect/app.py",
+      "description": "A Flask redirect handler should surface user-controlled redirect targets while keeping the urlparse-guarded variant quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["open_redirect"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from redirect handlers that forward a request parameter into redirect() without validation."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["bounce"]
+        },
+        "absent": {
+          "security": ["bounce_safe"]
+        }
+      }
+    },
+    {
+      "id": "flask-reflected-xss",
+      "path": "fixtures/flask_reflected_xss/app.py",
+      "description": "A Flask template handler should surface reflected XSS while keeping the escaped template variable path quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["xss"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from inline template rendering that embeds unescaped user input into HTML."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["profile"]
+        },
+        "absent": {
+          "security": ["safe_profile"]
         }
       }
     },

--- a/skylos/agent_review_benchmark.py
+++ b/skylos/agent_review_benchmark.py
@@ -25,6 +25,20 @@ AGENT_REVIEW_TAXONOMY: dict[str, str] = {
     "technical_debt": "Repo hotspots with high fan-in, wide APIs, and thin resilience.",
 }
 
+SECURITY_BENCHMARK_CLASSES: dict[str, str] = {
+    "sql_injection": "Tainted input reaches SQL/query construction or execution.",
+    "command_injection": "Untrusted input reaches a shell or command-execution sink.",
+    "ssrf": "Untrusted input reaches an outbound HTTP or network fetch sink.",
+    "path_traversal": "Untrusted path segments reach filesystem read/write/delete sinks.",
+    "file_upload": "User-controlled uploads or filenames reach unsafe storage/serving paths.",
+    "auth_bypass": "Authentication or token verification is disabled or trivially bypassed.",
+    "xss": "Untrusted content reaches HTML/JS rendering without contextual escaping.",
+    "open_redirect": "Untrusted URL input reaches redirect/navigation sinks.",
+    "deserialization": "Untrusted data reaches unsafe deserialize/load primitives.",
+    "archive_extraction": "Archive extraction or unpack flows allow path escape or overwrite.",
+    "secrets_exposure": "Secrets, credentials, or agent config are exposed or mishandled.",
+}
+
 IMPORTANCE_WEIGHTS = {
     "low": 1.0,
     "medium": 1.0,
@@ -120,6 +134,26 @@ def validate_manifest(
                 f"agent review benchmark case {case_id} must declare source metadata"
             )
 
+        security_classes = case.get("security_classes", [])
+        if security_classes not in (None, []) and not isinstance(security_classes, list):
+            raise ValueError(
+                f"agent review benchmark case {case_id} security_classes must be a list when provided"
+            )
+        if isinstance(security_classes, list):
+            invalid_security_classes = [
+                label
+                for label in security_classes
+                if not isinstance(label, str)
+                or not label.strip()
+                or label not in SECURITY_BENCHMARK_CLASSES
+            ]
+            if invalid_security_classes:
+                allowed = ", ".join(sorted(SECURITY_BENCHMARK_CLASSES))
+                raise ValueError(
+                    f"agent review benchmark case {case_id} has unknown security class "
+                    f"'{invalid_security_classes[0]}'. Allowed: {allowed}"
+                )
+
         scan_cfg = case.get("scan", {})
         if scan_cfg and not isinstance(scan_cfg, dict):
             raise ValueError(
@@ -187,6 +221,12 @@ def validate_manifest(
                         raise ValueError(
                             f"agent review benchmark case {case_id} {mode_name}.{category} has invalid symbol"
                         )
+
+        security_present = (expect.get("present") or {}).get("security") or []
+        if "security" in taxonomy and security_present and not security_classes:
+            raise ValueError(
+                f"agent review benchmark case {case_id} must declare security_classes when it expects present security findings"
+            )
 
     return cases
 

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -56,7 +57,28 @@ def _make_security_scan_analyzer(result: AnalysisResult) -> SkylosLLM:
 class _DeterministicSecurityAuditAgent:
     def analyze(self, source, file_path, defs_map=None, context=None):
         findings = []
+        tainted_vars = set()
         for line_no, line in enumerate(source.splitlines(), start=1):
+            if re.match(r"^\s*(async\s+def|def)\s+\w+\s*\(", line):
+                tainted_vars.clear()
+            assign = re.match(r"^\s*([A-Za-z_]\w*)\s*=", line)
+            lhs = assign.group(1) if assign else None
+            rhs = line.split("=", 1)[1] if lhs and "=" in line else line
+            if lhs and (
+                "request.args.get(" in rhs
+                or "request.args[" in rhs
+                or "request.get_json(" in rhs
+                or "request.query_params.get(" in rhs
+                or "request.files[" in rhs
+                or "request.files.get(" in rhs
+            ):
+                tainted_vars.add(lhs)
+            elif lhs and any(
+                re.search(rf"\b{re.escape(name)}\b", rhs) for name in tainted_vars
+            ):
+                tainted_vars.add(lhs)
+            elif lhs:
+                tainted_vars.discard(lhs)
             if "SELECT * FROM users WHERE id = %s" in line and "%" in line:
                 findings.append(
                     Finding(
@@ -68,6 +90,104 @@ class _DeterministicSecurityAuditAgent:
                         confidence=Confidence.HIGH,
                     )
                 )
+            if "redirect(" in line and (
+                "request.args" in line
+                or "request.GET" in line
+                or any(
+                    re.search(rf"\b{re.escape(name)}\b", line)
+                    for name in tainted_vars
+                )
+            ):
+                findings.append(
+                    Finding(
+                        rule_id="SKY-D230",
+                        issue_type=IssueType.SECURITY,
+                        severity=Severity.CRITICAL,
+                        message="Possible open redirect: user-controlled URL passed to redirect.",
+                        location=CodeLocation(file=file_path, line=line_no),
+                        confidence=Confidence.HIGH,
+                    )
+                )
+            if "render_template_string(" in line and (
+                any(
+                    re.search(rf"\b{re.escape(name)}\b", line)
+                    for name in tainted_vars
+                )
+                or "request.args" in line
+            ) and "{{" not in line:
+                findings.append(
+                    Finding(
+                        rule_id="SKY-D228",
+                        issue_type=IssueType.SECURITY,
+                        severity=Severity.CRITICAL,
+                        message="XSS (HTML built from unescaped user input)",
+                        location=CodeLocation(file=file_path, line=line_no),
+                        confidence=Confidence.HIGH,
+                    )
+                )
+            if (
+                "requests.get(" in line
+                or "requests.post(" in line
+                or "httpx.get(" in line
+                or "httpx.post(" in line
+                or "urllib.request.urlopen(" in line
+            ) and (
+                "request.args" in line
+                or any(
+                    re.search(rf"\b{re.escape(name)}\b", line)
+                    for name in tainted_vars
+                )
+            ):
+                findings.append(
+                    Finding(
+                        rule_id="SKY-D216",
+                        issue_type=IssueType.SECURITY,
+                        severity=Severity.CRITICAL,
+                        message="Possible SSRF: tainted URL passed to HTTP client.",
+                        location=CodeLocation(file=file_path, line=line_no),
+                        confidence=Confidence.HIGH,
+                    )
+                )
+            if "jwt.decode(" in line and (
+                "verify=False" in line
+                or "verify_signature': False" in line
+                or 'verify_signature": False' in line
+                or "algorithms=['none']" in line
+                or 'algorithms=["none"]' in line
+            ):
+                findings.append(
+                    Finding(
+                        rule_id="SKY-D232",
+                        issue_type=IssueType.SECURITY,
+                        severity=Severity.CRITICAL,
+                        message="JWT verification disabled or unsafe algorithm accepted.",
+                        location=CodeLocation(file=file_path, line=line_no),
+                        confidence=Confidence.HIGH,
+                    )
+                )
+            if ("open(" in line or ".read_text(" in line) and (
+                "request.args" in line
+                or any(
+                    re.search(rf"\b{re.escape(name)}\b", line)
+                    for name in tainted_vars
+                )
+            ):
+                findings.append(
+                    Finding(
+                        rule_id="SKY-D215",
+                        issue_type=IssueType.SECURITY,
+                        severity=Severity.CRITICAL,
+                        message="Possible path traversal: tainted filesystem path.",
+                        location=CodeLocation(file=file_path, line=line_no),
+                        confidence=Confidence.HIGH,
+                    )
+                )
+            if lhs and (
+                "os.path.basename(" in rhs
+                or ".name" in rhs
+                or ".resolve()" in rhs
+            ):
+                tainted_vars.discard(lhs)
             if (
                 "subprocess.check_output" in line or "subprocess.run" in line
             ) and "shell=True" in line:
@@ -673,5 +793,476 @@ def test_security_audit_json_output_reports_getter_based_command_injection(tmp_p
     findings = payload["findings"]
     assert len(findings) == 1
     assert findings[0]["rule_id"] == "SKY-C011"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"
+
+
+def test_security_audit_json_output_reports_ssrf_and_skips_safe_handler(tmp_path):
+    sample = tmp_path / "app.py"
+    sample.write_text(
+        "from flask import Flask, request\n"
+        "import requests\n\n"
+        "app = Flask(__name__)\n\n"
+        "@app.get('/avatar')\n"
+        "def fetch_avatar():\n"
+        "    url = request.args.get('url')\n"
+        "    return requests.get(url, timeout=2).text\n\n"
+        "@app.get('/health')\n"
+        "def fetch_health():\n"
+        "    return requests.get('https://status.internal.local/health', timeout=2).text\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-D216"
+    assert Path(findings[0]["location"]["file"]).name == "app.py"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"
+
+
+def test_security_audit_json_output_reports_path_traversal_and_skips_fixed_path(
+    tmp_path,
+):
+    sample = tmp_path / "app.py"
+    sample.write_text(
+        "from flask import Flask, request\n"
+        "from pathlib import Path\n\n"
+        "app = Flask(__name__)\n"
+        "BASE = Path('/srv/data')\n\n"
+        "@app.get('/download')\n"
+        "def download_file():\n"
+        "    filename = request.args.get('name')\n"
+        "    target = BASE / filename\n"
+        "    with open(target, 'r', encoding='utf-8') as handle:\n"
+        "        return handle.read()\n\n"
+        "@app.get('/help')\n"
+        "def read_help():\n"
+        "    with open(BASE / 'help.txt', 'r', encoding='utf-8') as handle:\n"
+        "        return handle.read()\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-D215"
+    assert Path(findings[0]["location"]["file"]).name == "app.py"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"
+
+
+def test_security_audit_json_output_reports_upload_traversal_and_skips_sanitized_path(
+    tmp_path,
+):
+    sample = tmp_path / "app.py"
+    sample.write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "from flask import Flask, request\n\n"
+        "app = Flask(__name__)\n"
+        "UPLOAD_DIR = Path('/srv/uploads')\n\n"
+        "@app.post('/upload')\n"
+        "def upload_file():\n"
+        "    upload = request.files['file']\n"
+        "    filename = upload.filename\n"
+        "    target = UPLOAD_DIR / filename\n"
+        "    with open(target, 'wb') as handle:\n"
+        "        handle.write(upload.read())\n"
+        "    return 'ok'\n\n"
+        "@app.post('/upload-safe')\n"
+        "def upload_safe():\n"
+        "    upload = request.files['file']\n"
+        "    safe_name = os.path.basename(upload.filename)\n"
+        "    target = UPLOAD_DIR / safe_name\n"
+        "    with open(target, 'wb') as handle:\n"
+        "        handle.write(upload.read())\n"
+        "    return 'ok'\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-D215"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"
+
+
+def test_security_audit_json_output_reports_jwt_verification_bypass_and_skips_safe_decode(
+    tmp_path,
+):
+    sample = tmp_path / "auth.py"
+    sample.write_text(
+        "import jwt\n\n"
+        "def decode_session(token):\n"
+        "    return jwt.decode(token, options={'verify_signature': False})\n\n"
+        "def decode_signed_session(token, secret):\n"
+        "    return jwt.decode(token, secret, algorithms=['HS256'])\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-D232"
+    assert Path(findings[0]["location"]["file"]).name == "auth.py"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"
+
+
+def test_security_audit_json_output_reports_fastapi_ssrf_and_skips_constant_probe(
+    tmp_path,
+):
+    sample = tmp_path / "app.py"
+    sample.write_text(
+        "import httpx\n"
+        "from fastapi import FastAPI, Request\n\n"
+        "app = FastAPI()\n\n"
+        "@app.get('/mirror')\n"
+        "async def mirror_url(request: Request):\n"
+        "    url = request.query_params.get('url')\n"
+        "    return httpx.get(url).text\n\n"
+        "@app.get('/status')\n"
+        "async def fetch_status():\n"
+        "    return httpx.get('https://status.internal.local/health').text\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-D216"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"
+
+
+def test_security_audit_json_output_reports_open_redirect_and_skips_guarded_redirect(
+    tmp_path,
+):
+    sample = tmp_path / "app.py"
+    sample.write_text(
+        "from urllib.parse import urlparse\n"
+        "from flask import Flask, redirect, request\n\n"
+        "app = Flask(__name__)\n\n"
+        "@app.get('/go')\n"
+        "def bounce():\n"
+        "    target = request.args.get('next', '/')\n"
+        "    return redirect(target)\n\n"
+        "@app.get('/safe-go')\n"
+        "def bounce_safe():\n"
+        "    target = request.args.get('next', '/')\n"
+        "    if urlparse(target).netloc:\n"
+        "        target = '/'\n"
+        "    return redirect(target)\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-D230"
+    assert findings[0]["metadata"]["security_evidence"] == "review_supported"
+    assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"
+
+
+def test_security_audit_json_output_reports_xss_and_skips_escaped_template(
+    tmp_path,
+):
+    sample = tmp_path / "app.py"
+    sample.write_text(
+        "import html\n"
+        "from flask import Flask, request, render_template_string\n\n"
+        "app = Flask(__name__)\n\n"
+        "@app.get('/profile')\n"
+        "def profile():\n"
+        "    name = request.args.get('name')\n"
+        "    return render_template_string(f'<div>{name}</div>')\n\n"
+        "@app.get('/safe-profile')\n"
+        "def safe_profile():\n"
+        "    name = request.args.get('name')\n"
+        "    safe_name = html.escape(name)\n"
+        "    return render_template_string('<div>{{ name }}</div>', name=safe_name)\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "security.json"
+
+    def _create_agent(agent_type, config=None):
+        assert agent_type == "security_audit"
+        return _DeterministicSecurityAuditAgent()
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.llm.analyzer.create_agent", side_effect=_create_agent),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_supported_security_review,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-D228"
     assert findings[0]["metadata"]["security_evidence"] == "review_supported"
     assert findings[0]["metadata"]["review_verdict"] == "SUPPORTED"

--- a/test/test_agent_review_benchmark.py
+++ b/test/test_agent_review_benchmark.py
@@ -6,6 +6,7 @@ import skylos.agent_review_benchmark as benchmark
 from skylos.agent_review_benchmark import (
     ALLOWED_SCAN_ISSUE_TYPES,
     AGENT_REVIEW_TAXONOMY,
+    SECURITY_BENCHMARK_CLASSES,
     format_summary,
     load_manifest,
     prepare_case_scan,
@@ -24,7 +25,7 @@ def test_checked_in_agent_review_manifest_validates():
     manifest = load_manifest(MANIFEST_PATH)
     cases = validate_manifest(manifest, MANIFEST_PATH)
 
-    assert len(cases) >= 15
+    assert len(cases) >= 22
     assert {case["id"] for case in cases} >= {
         "complexity-hotspot",
         "inconsistent-return",
@@ -33,12 +34,35 @@ def test_checked_in_agent_review_manifest_validates():
         "cross-file-sql-injection",
         "flask-handler-security",
         "flask-getter-shell",
+        "flask-ssrf",
+        "flask-path-traversal",
+        "flask-upload-traversal",
+        "jwt-insecure-decode",
+        "fastapi-query-ssrf",
+        "flask-open-redirect",
+        "flask-reflected-xss",
         "debt-hotspot-service",
         "repo-clean-service",
     }
 
     labels = {label for case in cases for label in case["taxonomy"]}
     assert labels <= set(AGENT_REVIEW_TAXONOMY)
+    security_labels = {
+        label
+        for case in cases
+        for label in case.get("security_classes", [])
+    }
+    assert security_labels <= set(SECURITY_BENCHMARK_CLASSES)
+    assert security_labels >= {
+        "sql_injection",
+        "command_injection",
+        "ssrf",
+        "path_traversal",
+        "file_upload",
+        "auth_bypass",
+        "open_redirect",
+        "xss",
+    }
 
 
 def test_agent_review_runner_reports_symbol_and_budget_failures(tmp_path, monkeypatch):
@@ -243,3 +267,66 @@ def test_validate_manifest_rejects_unknown_scan_issue_type(tmp_path):
     assert "unsupported scan.issue_types value" in str(exc.value)
     for allowed in ALLOWED_SCAN_ISSUE_TYPES:
         assert allowed in str(exc.value)
+
+
+def test_validate_manifest_rejects_unknown_security_class(tmp_path):
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text("def demo(user_input):\n    return user_input\n", encoding="utf-8")
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "bad-security-class",
+                "path": "fixture.py",
+                "taxonomy": ["security"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "security_classes": ["not_a_class"],
+                "expect": {"present": {"security": ["demo"]}, "absent": {}},
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc:
+        validate_manifest(load_manifest(manifest_path), manifest_path)
+
+    assert "unknown security class" in str(exc.value)
+    for allowed in SECURITY_BENCHMARK_CLASSES:
+        assert allowed in str(exc.value)
+
+
+def test_validate_manifest_requires_security_class_for_positive_security_case(tmp_path):
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text("def demo(user_input):\n    return user_input\n", encoding="utf-8")
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "missing-security-class",
+                "path": "fixture.py",
+                "taxonomy": ["security"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "expect": {"present": {"security": ["demo"]}, "absent": {}},
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc:
+        validate_manifest(load_manifest(manifest_path), manifest_path)
+
+    assert "must declare security_classes" in str(exc.value)


### PR DESCRIPTION
## Summary
  - expand the security benchmark corpus with class-tagged cases for SSRF, path traversal, upload traversal, JWT verification bypass, open redirect, reflected XSS, and FastAPI request-driven SSRF
  - add end-to-end `agent scan --security` integration coverage for those vulnerable and safe handler patterns
  - require positive security benchmark cases to declare `security_classes` so the corpus scales by vulnerability family instead of one-off case names

## Verification
  - `pytest -q test/test_agent_review_benchmark.py`
  - `pytest -q test/test_agent_integration.py test/test_pipeline.py test/test_security_verifier.py test/test_llm_analyzer.py test/test_llm_graph.py`