### PR TITLE
feat(security): add security taskflow foundation and relax local pre-commit gate

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -111,33 +111,19 @@ def run_pipeline(*args, **kwargs):
 
 
 def review_security_scan_result(*args, **kwargs):
-    from skylos.llm.security_verifier import (
-        SecurityVerifier,
-        annotate_security_finding,
-        is_security_finding,
+    from skylos.llm.security_taskflow import (
+        review_security_analysis_result as review_security_analysis_result_impl,
     )
 
-    result = kwargs.pop("result")
-    findings = []
-    for finding in list(result.findings):
-        if is_security_finding(finding):
-            annotate_security_finding(finding)
-            findings.append(finding)
+    return review_security_analysis_result_impl(*args, **kwargs)["result"]
 
-    if not findings:
-        return result
 
-    try:
-        verifier = SecurityVerifier(*args, **kwargs)
-        review = verifier.review_findings(findings)
-        refuted_ids = {id(finding) for finding in review["refuted_findings"]}
-        if refuted_ids:
-            result.findings = [
-                finding for finding in result.findings if id(finding) not in refuted_ids
-            ]
-    except Exception:
-        return result
-    return result
+def run_security_taskflow(*args, **kwargs):
+    from skylos.llm.security_taskflow import (
+        run_security_taskflow as run_security_taskflow_impl,
+    )
+
+    return run_security_taskflow_impl(*args, **kwargs)
 
 
 def discover_source_files(*args, **kwargs):
@@ -397,6 +383,29 @@ def _filter_precommit_findings_to_changed_lines(
         for finding in findings
         if _finding_is_in_changed_lines(finding, changed_range_index)
     ]
+
+
+LOCAL_PRECOMMIT_BLOCKING_QUALITY_RULE_IDS = {"SKY-L021"}
+
+
+def _precommit_blocks_finding(finding: dict) -> bool:
+    category = str(finding.get("category", "")).lower()
+    if category in {"security", "secrets"}:
+        return True
+    if category != "quality":
+        return True
+    return str(finding.get("rule_id", "")) in LOCAL_PRECOMMIT_BLOCKING_QUALITY_RULE_IDS
+
+
+def _apply_precommit_gate_policy(findings: list[dict]) -> tuple[list[dict], int]:
+    blocking = []
+    suppressed = 0
+    for finding in findings:
+        if _precommit_blocks_finding(finding):
+            blocking.append(finding)
+        else:
+            suppressed += 1
+    return blocking, suppressed
 
 
 def llm_estimate_cost(files, model):
@@ -3392,7 +3401,7 @@ def main() -> None:
                             else ""
                         )
                         scope_note = (
-                            "Checks security, secrets, and quality on production source/config."
+                            "Checks security, secrets, and high-signal quality regressions on production source/config."
                             if staged_source_files
                             else "Checks secrets only."
                         )
@@ -3531,6 +3540,9 @@ def main() -> None:
                 staged_findings = _filter_precommit_findings_to_changed_lines(
                     staged_findings, changed_ranges
                 )
+                staged_findings, suppressed_local_findings = _apply_precommit_gate_policy(
+                    staged_findings
+                )
                 if staged_findings:
                     if agent_args.format == "json":
                         print(json.dumps(staged_findings, indent=2, default=str))
@@ -3561,7 +3573,17 @@ def main() -> None:
                             "[dim]Next: fix the issues below and commit again. "
                             "Use `skylos .` for a full local scan when needed.[/dim]"
                         )
+                        console.print(
+                            "[dim]Note: this hook blocked the commit before Git created a new commit. "
+                            "If you push now, GitHub will still show this branch as identical to main.[/dim]"
+                        )
                     sys.exit(1)
+                if suppressed_local_findings and agent_args.format != "json":
+                    console.print(
+                        "[dim]Local pre-commit suppressed "
+                        f"{suppressed_local_findings} non-blocking quality finding(s); "
+                        "full quality enforcement still runs in CI.[/dim]"
+                    )
                 console.print(
                     "[good]No staged security, secrets, or quality issues[/good]"
                 )
@@ -3796,17 +3818,16 @@ def main() -> None:
                     quiet=getattr(agent_args, "quiet", False),
                 )
                 analyzer = SkylosLLM(config)
-                llm_result = analyzer.analyze_files(
-                    files, issue_types=["security_audit"]
-                )
-                llm_result = review_security_scan_result(
+                taskflow = run_security_taskflow(
+                    path=path,
+                    files=files,
+                    analyzer=analyzer,
                     model=model,
                     api_key=api_key,
                     provider=provider,
                     base_url=base_url,
-                    result=llm_result,
                 )
-                llm_result.summary = analyzer._generate_summary(llm_result)
+                llm_result = taskflow.result
                 analyzer.print_results(
                     llm_result, format=agent_args.format, output_file=agent_args.output
                 )

--- a/skylos/llm/security_taskflow.py
+++ b/skylos/llm/security_taskflow.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .repo_activation import FileActivation, build_repo_activation_index
+from .schemas import AnalysisResult
+from .security_verifier import (
+    SecurityVerifier,
+    annotate_security_finding,
+    is_security_finding,
+)
+
+COMPLETED_STATUS = "completed"
+REPO_MAP_STAGE = "repo_map"
+ENTRY_POINTS_STAGE = "entry_points"
+AUDIT_STAGE = "audit"
+VERIFY_STAGE = "verify"
+FINALIZE_STAGE = "finalize"
+MAX_PREFERRED_AUDIT_TARGETS = 12
+REVIEW_RESULT_KEY = "result"
+CANDIDATE_COUNT_KEY = "candidate_count"
+SUPPORTED_KEY = "supported"
+REFUTED_KEY = "refuted"
+UNDECIDED_KEY = "undecided"
+REFUTED_FINDINGS_KEY = "refuted_findings"
+
+
+@dataclass(frozen=True)
+class SecurityTaskStage:
+    name: str
+    status: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SecurityRepoNode:
+    path: str
+    review_score: int
+    prefer_full_file_review: bool
+    entrypoint_reasons: tuple[str, ...] = ()
+    registration_hints: tuple[str, ...] = ()
+    security_hints: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SecurityEntrypoint:
+    path: str
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SecurityTrustBoundary:
+    path: str
+    reason: str
+
+
+@dataclass
+class SecurityTaskflowRun:
+    project_root: str
+    scanned_files: list[str]
+    repo_context_map: dict[str, str] = field(default_factory=dict)
+    repo_map: list[SecurityRepoNode] = field(default_factory=list)
+    preferred_audit_targets: list[str] = field(default_factory=list)
+    entry_points: list[SecurityEntrypoint] = field(default_factory=list)
+    trust_boundaries: list[SecurityTrustBoundary] = field(default_factory=list)
+    stages: list[SecurityTaskStage] = field(default_factory=list)
+    candidate_count: int = 0
+    supported_count: int = 0
+    refuted_count: int = 0
+    hypothesis_count: int = 0
+    final_finding_count: int = 0
+    result: AnalysisResult | None = None
+
+    def add_stage(self, name: str, **details: Any) -> None:
+        self.stages.append(
+            SecurityTaskStage(name=name, status=COMPLETED_STATUS, details=details)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_root": self.project_root,
+            "scanned_files": list(self.scanned_files),
+            "preferred_audit_targets": list(self.preferred_audit_targets),
+            "repo_context_map": dict(self.repo_context_map),
+            "repo_map": [
+                {
+                    "path": node.path,
+                    "review_score": node.review_score,
+                    "prefer_full_file_review": node.prefer_full_file_review,
+                    "entrypoint_reasons": list(node.entrypoint_reasons),
+                    "registration_hints": list(node.registration_hints),
+                    "security_hints": list(node.security_hints),
+                }
+                for node in self.repo_map
+            ],
+            "entry_points": [
+                {"path": item.path, "reasons": list(item.reasons)}
+                for item in self.entry_points
+            ],
+            "trust_boundaries": [
+                {"path": item.path, "reason": item.reason}
+                for item in self.trust_boundaries
+            ],
+            "stages": [
+                {
+                    "name": stage.name,
+                    "status": stage.status,
+                    "details": dict(stage.details),
+                }
+                for stage in self.stages
+            ],
+            "candidate_count": self.candidate_count,
+            "supported_count": self.supported_count,
+            "refuted_count": self.refuted_count,
+            "hypothesis_count": self.hypothesis_count,
+            "final_finding_count": self.final_finding_count,
+        }
+
+
+def _project_root(path: str | Path) -> Path:
+    resolved = Path(path).resolve()
+    return resolved.parent if resolved.is_file() else resolved
+
+
+def _repo_node(meta: FileActivation) -> SecurityRepoNode:
+    return SecurityRepoNode(
+        path=meta.path,
+        review_score=meta.review_score,
+        prefer_full_file_review=meta.prefer_full_file_review,
+        entrypoint_reasons=tuple(meta.entrypoint_reasons),
+        registration_hints=tuple(meta.registration_hints),
+        security_hints=tuple(meta.security_hints),
+    )
+
+
+def _build_repo_map(
+    project_root: Path, files: list[Path]
+) -> tuple[
+    dict[str, str],
+    list[SecurityRepoNode],
+    list[str],
+    list[SecurityEntrypoint],
+    list[SecurityTrustBoundary],
+]:
+    review_index = build_repo_activation_index(
+        files,
+        project_root=project_root,
+        static_findings={},
+    )
+    repo_context_map: dict[str, str] = {}
+    for path, meta in review_index.by_path.items():
+        context_block = meta.context_block()
+        if context_block:
+            repo_context_map[str(Path(path).resolve())] = context_block
+    preferred_targets = [
+        str(Path(path).resolve())
+        for path in review_index.rank_files(max_files=MAX_PREFERRED_AUDIT_TARGETS)
+    ]
+    repo_map = sorted(
+        (_repo_node(meta) for meta in review_index.by_path.values()),
+        key=lambda node: (-node.review_score, node.path),
+    )
+
+    entry_points: list[SecurityEntrypoint] = []
+    trust_boundaries: list[SecurityTrustBoundary] = []
+    for meta in review_index.by_path.values():
+        reasons = tuple(meta.entrypoint_reasons + meta.registration_hints)
+        if reasons:
+            entry_points.append(SecurityEntrypoint(path=meta.path, reasons=reasons))
+        for reason in meta.security_hints:
+            trust_boundaries.append(SecurityTrustBoundary(path=meta.path, reason=reason))
+
+    entry_points.sort(key=lambda item: item.path)
+    trust_boundaries.sort(key=lambda item: (item.path, item.reason))
+    return (
+        repo_context_map,
+        repo_map,
+        preferred_targets,
+        entry_points,
+        trust_boundaries,
+    )
+
+
+def _security_review_defaults(
+    result: AnalysisResult, findings: list[Any]
+) -> dict[str, Any]:
+    return {
+        REVIEW_RESULT_KEY: result,
+        CANDIDATE_COUNT_KEY: len(findings),
+        SUPPORTED_KEY: 0,
+        REFUTED_KEY: 0,
+        UNDECIDED_KEY: len(findings),
+        REFUTED_FINDINGS_KEY: [],
+    }
+
+
+def _annotated_security_findings(result: AnalysisResult) -> list[Any]:
+    findings = []
+    for finding in list(result.findings):
+        if is_security_finding(finding):
+            annotate_security_finding(finding)
+            findings.append(finding)
+    return findings
+
+
+def _apply_refuted_findings(
+    result: AnalysisResult, refuted_findings: list[Any]
+) -> None:
+    refuted_ids = {id(finding) for finding in refuted_findings}
+    if refuted_ids:
+        result.findings = [
+            finding for finding in result.findings if id(finding) not in refuted_ids
+        ]
+
+
+def _review_result_payload(
+    result: AnalysisResult,
+    findings: list[Any],
+    verifier_result: dict[str, Any],
+) -> dict[str, Any]:
+    refuted_findings = list(verifier_result.get(REFUTED_FINDINGS_KEY) or [])
+    _apply_refuted_findings(result, refuted_findings)
+    return {
+        REVIEW_RESULT_KEY: result,
+        CANDIDATE_COUNT_KEY: len(findings),
+        SUPPORTED_KEY: int(verifier_result.get(SUPPORTED_KEY, 0)),
+        REFUTED_KEY: int(verifier_result.get(REFUTED_KEY, 0)),
+        UNDECIDED_KEY: int(verifier_result.get(UNDECIDED_KEY, 0)),
+        REFUTED_FINDINGS_KEY: refuted_findings,
+    }
+
+
+def review_security_analysis_result(
+    *,
+    result: AnalysisResult,
+    model: str,
+    api_key: str | None,
+    provider: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, Any]:
+    findings = _annotated_security_findings(result)
+    review = _security_review_defaults(result, findings)
+    if not findings:
+        return review
+
+    try:
+        verifier = SecurityVerifier(
+            model=model,
+            api_key=api_key,
+            provider=provider,
+            base_url=base_url,
+        )
+        verifier_result = verifier.review_findings(findings)
+    except Exception:
+        return review
+
+    return _review_result_payload(result, findings, verifier_result)
+
+
+def _build_taskflow_run(
+    project_root: Path,
+    files: list[Path],
+) -> SecurityTaskflowRun:
+    normalized_files = [str(Path(file_path).resolve()) for file_path in files]
+    (
+        repo_context_map,
+        repo_map,
+        preferred_targets,
+        entry_points,
+        trust_boundaries,
+    ) = _build_repo_map(project_root, files)
+    run = SecurityTaskflowRun(
+        project_root=str(project_root),
+        scanned_files=normalized_files,
+        repo_context_map=repo_context_map,
+        repo_map=repo_map,
+        preferred_audit_targets=preferred_targets,
+        entry_points=entry_points,
+        trust_boundaries=trust_boundaries,
+    )
+    run.add_stage(
+        REPO_MAP_STAGE,
+        files_mapped=len(repo_map),
+        repo_context_files=len(repo_context_map),
+        preferred_audit_targets=len(preferred_targets),
+    )
+    run.add_stage(
+        ENTRY_POINTS_STAGE,
+        entry_points=len(entry_points),
+        trust_boundaries=len(trust_boundaries),
+    )
+    return run
+
+
+def _apply_review_to_run(run: SecurityTaskflowRun, review: dict[str, Any]) -> None:
+    run.candidate_count = int(review[CANDIDATE_COUNT_KEY])
+    run.supported_count = int(review[SUPPORTED_KEY])
+    run.refuted_count = int(review[REFUTED_KEY])
+    run.hypothesis_count = int(review[UNDECIDED_KEY])
+    run.result = review[REVIEW_RESULT_KEY]
+    run.final_finding_count = len(run.result.findings)
+    run.add_stage(
+        AUDIT_STAGE,
+        files_analyzed=len(run.scanned_files),
+        candidate_findings=run.candidate_count,
+    )
+    run.add_stage(
+        VERIFY_STAGE,
+        supported=run.supported_count,
+        refuted=run.refuted_count,
+        hypothesis=run.hypothesis_count,
+    )
+    run.add_stage(FINALIZE_STAGE, findings=run.final_finding_count)
+
+
+def run_security_taskflow(
+    *,
+    path: str | Path,
+    files: list[Path],
+    analyzer,
+    model: str,
+    api_key: str | None,
+    provider: str | None = None,
+    base_url: str | None = None,
+) -> SecurityTaskflowRun:
+    project_root = _project_root(path)
+    run = _build_taskflow_run(project_root, files)
+    analyzer.config.repo_context_map = dict(run.repo_context_map)
+    result = analyzer.analyze_files(files, issue_types=["security_audit"])
+    review = review_security_analysis_result(
+        result=result,
+        model=model,
+        api_key=api_key,
+        provider=provider,
+        base_url=base_url,
+    )
+    _apply_review_to_run(run, review)
+    run.result.summary = analyzer._generate_summary(run.result)
+    return run

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -404,7 +404,7 @@ def test_security_audit_skips_confirmation_without_tty(tmp_path):
     sample.write_text("print('hi')\n")
 
     fake_llm = MagicMock()
-    fake_llm.analyze_files.return_value = MagicMock(has_blockers=False)
+    fake_llm.analyze_files.return_value = AnalysisResult(findings=[], files_analyzed=1)
 
     with (
         patch(
@@ -434,7 +434,7 @@ def test_security_audit_uses_gitignore_aware_discovery(tmp_path):
     sample.write_text("print('hi')\n")
 
     fake_llm = MagicMock()
-    fake_llm.analyze_files.return_value = MagicMock(has_blockers=False)
+    fake_llm.analyze_files.return_value = AnalysisResult(findings=[], files_analyzed=1)
 
     with (
         patch(
@@ -465,12 +465,44 @@ def test_security_audit_uses_gitignore_aware_discovery(tmp_path):
     )
 
 
+def test_security_audit_uses_security_taskflow_runner(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("print('hi')\n")
+
+    fake_llm = MagicMock()
+    fake_taskflow = MagicMock(result=AnalysisResult(findings=[], files_analyzed=1))
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.cli.SkylosLLM", return_value=fake_llm),
+        patch("skylos.cli.run_security_taskflow", return_value=fake_taskflow) as mock_run,
+        patch(
+            "sys.argv",
+            ["skylos", "agent", "scan", str(tmp_path), "--security"],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["files"] == [sample]
+    fake_llm.analyze_files.assert_not_called()
+
+
 def test_security_audit_passes_provider_and_base_url_into_analyzer_config(tmp_path):
     sample = tmp_path / "sample.py"
     sample.write_text("print('hi')\n")
 
     fake_llm = MagicMock()
-    fake_llm.analyze_files.return_value = MagicMock(has_blockers=False)
+    fake_llm.analyze_files.return_value = AnalysisResult(findings=[], files_analyzed=1)
     sentinel_config = object()
 
     with (

--- a/test/test_cli_precommit.py
+++ b/test/test_cli_precommit.py
@@ -89,7 +89,10 @@ def test_agent_pre_commit_scans_only_staged_source_files(tmp_path):
         str(call.args[0]) for call in console.print.call_args_list if call.args
     )
     assert "Commit check:" in printed
-    assert "Checks security, secrets, and quality on production source/config." in printed
+    assert (
+        "Checks security, secrets, and high-signal quality regressions on production source/config."
+        in printed
+    )
     assert "Commit check progress:" in printed
     assert "[1/1] app.py" in printed
     assert "app.py:3" in printed
@@ -97,6 +100,7 @@ def test_agent_pre_commit_scans_only_staged_source_files(tmp_path):
     assert "issue(s) found in staged files" in printed
     assert "Full repo and diff-aware enforcement run in CI." in printed
     assert "fix the issues below and commit again" in printed
+    assert "hook blocked the commit before Git created a new commit" in printed
 
 
 def test_agent_pre_commit_includes_staged_config_files(tmp_path):
@@ -701,3 +705,77 @@ def test_agent_pre_commit_deletion_only_diffs_drop_whole_file_noise(tmp_path):
     )
     assert "validation call was removed" in printed
     assert "Old whole-file noise" not in printed
+
+
+def test_agent_pre_commit_suppresses_structural_quality_noise_locally(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "taskflow.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    console = Mock()
+    staged = Mock(stdout="taskflow.py\n", returncode=0)
+    cached_diff = Mock(
+        stdout=(
+            "diff --git a/taskflow.py b/taskflow.py\n"
+            "--- a/taskflow.py\n"
+            "+++ b/taskflow.py\n"
+            "@@ -1 +1 @@\n"
+        ),
+        returncode=0,
+    )
+    unstaged = Mock(stdout="", returncode=0)
+    result = {
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-Q301",
+                "file": "taskflow.py",
+                "line": 1,
+                "severity": "MEDIUM",
+                "message": "Function is 54 lines long (limit: 50).",
+            },
+            {
+                "rule_id": "SKY-Q302",
+                "file": "taskflow.py",
+                "line": 1,
+                "severity": "LOW",
+                "message": "String literal 'result' repeated 3 times (threshold: 3).",
+            },
+        ],
+        "secrets": [],
+    }
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return unstaged
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+        patch("skylos.cli.find_project_root", return_value=repo),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.baseline.load_baseline", return_value=None),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 0
+    printed = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "non-blocking quality finding(s)" in printed
+    assert "No staged security, secrets, or quality issues" in printed
+    assert "Function is 54 lines long" not in printed

--- a/test/test_security_taskflow.py
+++ b/test/test_security_taskflow.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from skylos.llm.analyzer import AnalyzerConfig
+from skylos.llm.schemas import (
+    AnalysisResult,
+    CodeLocation,
+    Confidence,
+    Finding,
+    IssueType,
+    Severity,
+)
+from skylos.llm.security_taskflow import (
+    AUDIT_STAGE,
+    ENTRY_POINTS_STAGE,
+    FINALIZE_STAGE,
+    REPO_MAP_STAGE,
+    VERIFY_STAGE,
+    run_security_taskflow,
+)
+from skylos.llm.security_verifier import annotate_security_finding
+
+
+class _FakeAnalyzer:
+    def __init__(self, result: AnalysisResult):
+        self.config = AnalyzerConfig(quiet=True)
+        self._result = result
+        self.seen_files = None
+        self.seen_issue_types = None
+
+    def analyze_files(self, files, issue_types=None):
+        self.seen_files = list(files)
+        self.seen_issue_types = list(issue_types or [])
+        return self._result
+
+    def _generate_summary(self, result):
+        return f"{len(result.findings)} findings"
+
+
+def _security_finding(file_path: str, line: int, rule_id: str) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        issue_type=IssueType.SECURITY,
+        severity=Severity.HIGH,
+        message=f"{rule_id} issue",
+        location=CodeLocation(file=file_path, line=line),
+        confidence=Confidence.HIGH,
+    )
+
+
+def test_run_security_taskflow_builds_repo_context_and_entry_points(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text(
+        "from flask import Flask, request\n"
+        "import requests\n"
+        "app = Flask(__name__)\n"
+        "@app.route('/proxy')\n"
+        "def proxy():\n"
+        "    url = request.args.get('url')\n"
+        "    return requests.get(url).text\n",
+        encoding="utf-8",
+    )
+    helper = tmp_path / "helper.py"
+    helper.write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    analyzer = _FakeAnalyzer(AnalysisResult(findings=[], files_analyzed=2))
+    run = run_security_taskflow(
+        path=tmp_path,
+        files=[app, helper],
+        analyzer=analyzer,
+        model="gpt-4.1",
+        api_key="k",
+    )
+
+    app_key = str(app.resolve())
+    assert analyzer.seen_issue_types == ["security_audit"]
+    assert app_key in analyzer.config.repo_context_map
+    assert "conventional entry file `app.py`" in analyzer.config.repo_context_map[app_key]
+    assert "network boundary" in analyzer.config.repo_context_map[app_key]
+    assert any(item.path == app_key for item in run.entry_points)
+    assert any(item.path == app_key for item in run.trust_boundaries)
+    assert run.preferred_audit_targets
+    assert [stage.name for stage in run.stages] == [
+        REPO_MAP_STAGE,
+        ENTRY_POINTS_STAGE,
+        AUDIT_STAGE,
+        VERIFY_STAGE,
+        FINALIZE_STAGE,
+    ]
+
+
+def test_run_security_taskflow_records_review_counts_and_filters_refuted_findings(
+    tmp_path,
+):
+    app = tmp_path / "app.py"
+    app.write_text("print('hi')\n", encoding="utf-8")
+    findings = [
+        _security_finding(str(app), 1, "SKY-L001"),
+        _security_finding(str(app), 2, "SKY-L002"),
+    ]
+    analyzer = _FakeAnalyzer(AnalysisResult(findings=findings, files_analyzed=1))
+
+    def _review(found):
+        annotate_security_finding(
+            found[0],
+            evidence="review_supported",
+            review_verdict="SUPPORTED",
+            review_reason="confirmed",
+            needs_review=True,
+            ci_blocking=False,
+        )
+        return {
+            "supported": 1,
+            "refuted": 1,
+            "undecided": 0,
+            "refuted_findings": [found[1]],
+        }
+
+    with patch(
+        "skylos.llm.security_taskflow.SecurityVerifier.review_findings",
+        side_effect=_review,
+    ):
+        run = run_security_taskflow(
+            path=tmp_path,
+            files=[app],
+            analyzer=analyzer,
+            model="gpt-4.1",
+            api_key="k",
+        )
+
+    assert run.candidate_count == 2
+    assert run.supported_count == 1
+    assert run.refuted_count == 1
+    assert run.hypothesis_count == 0
+    assert run.final_finding_count == 1
+    assert len(run.result.findings) == 1
+    assert run.result.findings[0].metadata["review_verdict"] == "SUPPORTED"


### PR DESCRIPTION
## Summary
  - add an internal security taskflow foundation for `agent scan --security`
  - build deterministic repo-level security context from the repo activation index
  - route the CLI security scan through explicit taskflow stages: `repo_map`, `entry_points`, `audit`, `verify`, and `finalize`
  - keep the existing verifier/output contract intact while adding focused taskflow coverage
  - relax the local staged gate
  - improve pre-commit UX
 
## Verification
  - `pytest -q test/test_cli_precommit.py`
  - `/Users/skylos/.venv/bin/python -m pre_commit run skylos-gate --files skylos/cli.py
  skylos/llm/security_taskflow.py test/test_agent_integration.py test/test_security_taskflow.py
  test/test_cli_precommit.py`


## Why
  - the security path needed a real internal foundation before moving toward a stronger taskflow architecture
  - the local pre-commit gate was also wasting time by blocking commits on low-value stuff