### PR TITLE
feat(security): add challenge pass for uncertain findings

### DIFF
--- a/skylos/llm/security_taskflow.py
+++ b/skylos/llm/security_taskflow.py
@@ -22,6 +22,7 @@ REPO_MAP_STAGE = "repo_map"
 ENTRY_POINTS_STAGE = "entry_points"
 AUDIT_STAGE = "audit"
 VERIFY_STAGE = "verify"
+CHALLENGE_STAGE = "challenge"
 FINALIZE_STAGE = "finalize"
 MAX_PREFERRED_AUDIT_TARGETS = 12
 REVIEW_RESULT_KEY = "result"
@@ -438,6 +439,17 @@ def _finding_metadata(finding: Any) -> dict[str, Any]:
     return dict(getattr(finding, "metadata", None) or {})
 
 
+def _finding_evidence(finding: Any) -> str:
+    metadata = _finding_metadata(finding)
+    return str(metadata.get("security_evidence") or HYPOTHESIS_EVIDENCE)
+
+
+def _finding_review_verdict(finding: Any) -> str | None:
+    metadata = _finding_metadata(finding)
+    verdict = metadata.get("review_verdict")
+    return str(verdict).upper() if verdict else None
+
+
 def _candidate_fingerprint(finding: Any) -> str:
     raw = "|".join(
         [
@@ -491,18 +503,48 @@ def _build_candidate_ledger(findings: list[Any]) -> list[SecurityFindingCandidat
     return ledger
 
 
-def _update_candidate_ledger(ledger: list[SecurityFindingCandidate], findings: list[Any]) -> None:
+def _update_candidate_ledger(
+    ledger: list[SecurityFindingCandidate],
+    findings: list[Any],
+    *,
+    stage: str,
+) -> None:
     by_fingerprint = {candidate.fingerprint: candidate for candidate in ledger}
     for finding in findings:
         candidate = by_fingerprint.get(_candidate_fingerprint(finding))
         if candidate is None:
             continue
-        event = _candidate_event(VERIFY_STAGE, finding)
+        event = _candidate_event(stage, finding)
         candidate.state = event.state
         candidate.evidence = event.evidence
         candidate.review_verdict = event.review_verdict
         candidate.review_reason = event.review_reason
         candidate.history.append(event)
+
+
+def _refresh_run_counts(run: SecurityTaskflowRun) -> None:
+    run.candidate_count = len(run.candidate_ledger)
+    run.supported_count = sum(
+        1 for candidate in run.candidate_ledger if candidate.state == "review_supported"
+    )
+    run.refuted_count = sum(
+        1 for candidate in run.candidate_ledger if candidate.state == "refuted"
+    )
+    run.hypothesis_count = sum(
+        1
+        for candidate in run.candidate_ledger
+        if candidate.state not in {"review_supported", "refuted"}
+    )
+    run.final_finding_count = len(run.result.findings) if run.result is not None else 0
+
+
+def _challenge_candidates(findings: list[Any]) -> list[Any]:
+    return [
+        finding
+        for finding in findings
+        if _finding_evidence(finding) == HYPOTHESIS_EVIDENCE
+        or _finding_review_verdict(finding) == "UNCERTAIN"
+    ]
 
 
 def _build_repo_map(
@@ -723,6 +765,34 @@ def review_security_analysis_result(
     return _review_result_payload(result, findings, verifier_result)
 
 
+def challenge_security_analysis_result(
+    *,
+    result: AnalysisResult,
+    findings: list[Any],
+    model: str,
+    api_key: str | None,
+    provider: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, Any]:
+    challengers = _challenge_candidates(findings)
+    challenge = _security_review_defaults(result, challengers)
+    if not challengers:
+        return challenge
+
+    try:
+        verifier = SecurityVerifier(
+            model=model,
+            api_key=api_key,
+            provider=provider,
+            base_url=base_url,
+        )
+        verifier_result = verifier.challenge_findings(challengers)
+    except Exception:
+        return challenge
+
+    return _review_result_payload(result, challengers, verifier_result)
+
+
 def _build_taskflow_run(
     project_root: Path,
     files: list[Path],
@@ -762,23 +832,42 @@ def _build_taskflow_run(
 
 
 def _apply_review_to_run(run: SecurityTaskflowRun, review: dict[str, Any]) -> None:
-    run.candidate_count = int(review[CANDIDATE_COUNT_KEY])
-    run.supported_count = int(review[SUPPORTED_KEY])
-    run.refuted_count = int(review[REFUTED_KEY])
-    run.hypothesis_count = int(review[UNDECIDED_KEY])
     run.result = review[REVIEW_RESULT_KEY]
-    _update_candidate_ledger(run.candidate_ledger, review[REVIEWED_CANDIDATES_KEY])
-    run.final_finding_count = len(run.result.findings)
+    _update_candidate_ledger(
+        run.candidate_ledger,
+        review[REVIEWED_CANDIDATES_KEY],
+        stage=VERIFY_STAGE,
+    )
+    _refresh_run_counts(run)
     run.add_stage(
         AUDIT_STAGE,
         files_analyzed=len(run.scanned_files),
-        candidate_findings=run.candidate_count,
+        candidate_findings=len(run.candidate_ledger),
     )
     run.add_stage(
         VERIFY_STAGE,
-        supported=run.supported_count,
-        refuted=run.refuted_count,
-        hypothesis=run.hypothesis_count,
+        supported=int(review[SUPPORTED_KEY]),
+        refuted=int(review[REFUTED_KEY]),
+        hypothesis=int(review[UNDECIDED_KEY]),
+    )
+
+
+def _apply_challenge_to_run(run: SecurityTaskflowRun, challenge: dict[str, Any]) -> None:
+    challenged = challenge[REVIEWED_CANDIDATES_KEY]
+    if challenged:
+        run.result = challenge[REVIEW_RESULT_KEY]
+        _update_candidate_ledger(
+            run.candidate_ledger,
+            challenged,
+            stage=CHALLENGE_STAGE,
+        )
+        _refresh_run_counts(run)
+    run.add_stage(
+        CHALLENGE_STAGE,
+        challenged=len(challenged),
+        supported=int(challenge[SUPPORTED_KEY]),
+        refuted=int(challenge[REFUTED_KEY]),
+        hypothesis=int(challenge[UNDECIDED_KEY]),
     )
 
 
@@ -805,6 +894,15 @@ def run_security_taskflow(
         base_url=base_url,
     )
     _apply_review_to_run(run, review)
+    challenge = challenge_security_analysis_result(
+        result=run.result,
+        findings=review[REVIEWED_CANDIDATES_KEY],
+        model=model,
+        api_key=api_key,
+        provider=provider,
+        base_url=base_url,
+    )
+    _apply_challenge_to_run(run, challenge)
     run.result.summary = str(analyzer._generate_summary(run.result))
     run.add_stage(
         FINALIZE_STAGE,

--- a/skylos/llm/security_verifier.py
+++ b/skylos/llm/security_verifier.py
@@ -25,6 +25,8 @@ SUPPORTED_COUNT = "supported"
 REFUTED_COUNT = "refuted"
 UNDECIDED_COUNT = "undecided"
 REFUTED_FINDINGS_KEY = "refuted_findings"
+REVIEW_MODE = "review"
+CHALLENGE_MODE = "challenge"
 
 REVIEW_DECISION_SCHEMA = {
     "type": "object",
@@ -223,6 +225,19 @@ class SecurityVerifier:
     def review_findings(
         self, findings: list[Finding | dict[str, Any]]
     ) -> dict[str, Any]:
+        return self._review_findings(findings, mode=REVIEW_MODE)
+
+    def challenge_findings(
+        self, findings: list[Finding | dict[str, Any]]
+    ) -> dict[str, Any]:
+        return self._review_findings(findings, mode=CHALLENGE_MODE)
+
+    def _review_findings(
+        self,
+        findings: list[Finding | dict[str, Any]],
+        *,
+        mode: str,
+    ) -> dict[str, Any]:
         reviewable = [finding for finding in findings if is_security_finding(finding)]
         for finding in reviewable:
             annotate_security_finding(finding)
@@ -231,7 +246,7 @@ class SecurityVerifier:
         result = _new_review_result(len(reviewable), len(reviewed))
         grouped = _group_findings_by_file(reviewed)
         for file_path, file_findings in grouped.items():
-            self._review_file(file_path, file_findings, result)
+            self._review_file(file_path, file_findings, result, mode=mode)
         return result
 
     def _review_file(
@@ -239,6 +254,8 @@ class SecurityVerifier:
         file_path: str,
         findings: list[Finding | dict[str, Any]],
         result: dict[str, Any],
+        *,
+        mode: str,
     ) -> None:
         source = _read_source(file_path)
         if source is None:
@@ -246,7 +263,13 @@ class SecurityVerifier:
             return
 
         for batch in _iter_batches(findings, self.batch_size):
-            self._review_batch_into_result(batch, source, file_path, result)
+            self._review_batch_into_result(
+                batch,
+                source,
+                file_path,
+                result,
+                mode=mode,
+            )
 
     def _review_batch_into_result(
         self,
@@ -254,8 +277,10 @@ class SecurityVerifier:
         source: str,
         file_path: str,
         result: dict[str, Any],
+        *,
+        mode: str,
     ) -> None:
-        decisions = self._review_batch(findings, source, file_path)
+        decisions = self._review_batch(findings, source, file_path, mode=mode)
         if not decisions:
             result[UNDECIDED_COUNT] += len(findings)
             return
@@ -305,9 +330,16 @@ class SecurityVerifier:
         findings: list[Finding | dict[str, Any]],
         source: str,
         file_path: str,
+        *,
+        mode: str,
     ) -> list[dict[str, str]]:
-        user = self._build_review_prompt(findings, source.splitlines(), file_path)
-        response = self._request_review(user)
+        user = self._build_review_prompt(
+            findings,
+            source.splitlines(),
+            file_path,
+            mode=mode,
+        )
+        response = self._request_review(user, mode=mode)
         return self._normalize_decisions(response, len(findings))
 
     def _build_review_prompt(
@@ -315,21 +347,37 @@ class SecurityVerifier:
         findings: list[Finding | dict[str, Any]],
         lines: list[str],
         file_path: str,
+        *,
+        mode: str,
     ) -> str:
         blocks = [
             self._build_review_block(index, finding, lines)
             for index, finding in enumerate(findings, start=1)
         ]
+        opening = self._prompt_opening(mode, len(findings), file_path)
         return "\n\n".join(
             [
-                f"Review {len(findings)} candidate security finding(s) from {file_path}.",
-                "Each candidate is independent. Ignore any prior scan confidence.",
+                opening,
+                self._prompt_guidance(mode),
                 "",
                 "\n\n".join(blocks),
                 "",
                 'Return JSON with shape: {"reviews":[{"id":1,"verdict":"SUPPORTED|REFUTED|UNCERTAIN","reason":"brief reason"}]}',
             ]
         )
+
+    def _prompt_opening(self, mode: str, count: int, file_path: str) -> str:
+        if mode == CHALLENGE_MODE:
+            return f"Challenge {count} uncertain security finding(s) from {file_path}."
+        return f"Review {count} candidate security finding(s) from {file_path}."
+
+    def _prompt_guidance(self, mode: str) -> str:
+        if mode == CHALLENGE_MODE:
+            return (
+                "Each candidate was previously left uncertain. Re-check the shown code and "
+                "commit to SUPPORTED or REFUTED when the local context is enough."
+            )
+        return "Each candidate is independent. Ignore any prior scan confidence."
 
     def _build_review_block(
         self, index: int, finding: Finding | dict[str, Any], lines: list[str]
@@ -358,8 +406,30 @@ class SecurityVerifier:
         ]
         return "\n".join(context_lines)
 
-    def _request_review(self, user: str) -> str | None:
-        system = """You are Skylos Security Verifier.
+    def _request_review(self, user: str, *, mode: str) -> str | None:
+        system = self._system_prompt(mode)
+        try:
+            return self.get_adapter().complete(
+                system,
+                user,
+                response_format=REVIEW_DECISION_FORMAT,
+            )
+        except Exception:
+            return None
+
+    def _system_prompt(self, mode: str) -> str:
+        if mode == CHALLENGE_MODE:
+            return """You are Skylos Security Challenger.
+Your job is to re-check previously uncertain security findings using only the code context provided.
+
+Verdicts:
+- SUPPORTED: the finding is plausibly real based on the shown code
+- REFUTED: the finding is not supported by the shown code, or the code appears safe
+- UNCERTAIN: the context is still insufficient to decide
+
+Try to resolve uncertainty when the shown code is enough. Use UNCERTAIN only if the evidence genuinely remains incomplete.
+Respond with JSON only."""
+        return """You are Skylos Security Verifier.
 Your job is to re-review candidate security findings using only the code context provided.
 
 Verdicts:
@@ -369,14 +439,6 @@ Verdicts:
 
 Be conservative. If the context is incomplete, return UNCERTAIN.
 Respond with JSON only."""
-        try:
-            return self.get_adapter().complete(
-                system,
-                user,
-                response_format=REVIEW_DECISION_FORMAT,
-            )
-        except Exception:
-            return None
 
     def _normalize_decisions(
         self, response: str | None, expected_count: int

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -566,6 +566,17 @@ def test_security_audit_json_output_handles_supported_refuted_and_hypothesis(tmp
             "refuted_findings": [findings[1]],
         }
 
+    def _challenge(findings):
+        findings[0].metadata["security_evidence"] = "hypothesis"
+        findings[0].metadata["review_verdict"] = "UNCERTAIN"
+        findings[0].metadata["review_reason"] = "still not enough local context"
+        return {
+            "supported": 0,
+            "refuted": 0,
+            "undecided": len(findings),
+            "refuted_findings": [],
+        }
+
     with (
         patch(
             "skylos.cli.resolve_llm_runtime",
@@ -578,6 +589,10 @@ def test_security_audit_json_output_handles_supported_refuted_and_hypothesis(tmp
         patch(
             "skylos.llm.security_verifier.SecurityVerifier.review_findings",
             side_effect=_review,
+        ),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.challenge_findings",
+            side_effect=_challenge,
         ),
         patch(
             "sys.argv",
@@ -639,6 +654,17 @@ def test_security_audit_sarif_output_handles_supported_refuted_and_hypothesis(tm
             "refuted_findings": [findings[1]],
         }
 
+    def _challenge(findings):
+        findings[0].metadata["security_evidence"] = "hypothesis"
+        findings[0].metadata["review_verdict"] = "UNCERTAIN"
+        findings[0].metadata["review_reason"] = "still not enough local context"
+        return {
+            "supported": 0,
+            "refuted": 0,
+            "undecided": len(findings),
+            "refuted_findings": [],
+        }
+
     with (
         patch(
             "skylos.cli.resolve_llm_runtime",
@@ -651,6 +677,10 @@ def test_security_audit_sarif_output_handles_supported_refuted_and_hypothesis(tm
         patch(
             "skylos.llm.security_verifier.SecurityVerifier.review_findings",
             side_effect=_review,
+        ),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.challenge_findings",
+            side_effect=_challenge,
         ),
         patch(
             "sys.argv",
@@ -686,6 +716,82 @@ def test_security_audit_sarif_output_handles_supported_refuted_and_hypothesis(tm
     assert by_rule["SKY-L003"]["properties"]["security_evidence"] == "hypothesis"
     assert by_rule["SKY-L003"]["properties"]["review_verdict"] == "UNCERTAIN"
     assert by_rule["SKY-L003"]["properties"]["ci_blocking"] is False
+
+
+def test_security_audit_json_output_challenge_pass_resolves_uncertain_finding(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+    output = tmp_path / "security.json"
+
+    analyzer = _make_security_scan_analyzer(_security_scan_result(str(sample)))
+
+    def _review(findings):
+        findings[0].metadata["security_evidence"] = "hypothesis"
+        findings[0].metadata["review_verdict"] = "UNCERTAIN"
+        findings[0].metadata["review_reason"] = "not enough local context"
+        return {
+            "supported": 0,
+            "refuted": 0,
+            "undecided": 1,
+            "refuted_findings": [],
+        }
+
+    def _challenge(findings):
+        findings[0].metadata["security_evidence"] = "review_supported"
+        findings[0].metadata["review_verdict"] = "SUPPORTED"
+        findings[0].metadata["review_reason"] = "challenge resolved the local data flow"
+        return {
+            "supported": 1,
+            "refuted": 0,
+            "undecided": 0,
+            "refuted_findings": [],
+        }
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.cli.discover_source_files", return_value=[sample]),
+        patch("skylos.cli.SkylosLLM", return_value=analyzer),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.review_findings",
+            side_effect=_review,
+        ),
+        patch(
+            "skylos.llm.security_verifier.SecurityVerifier.challenge_findings",
+            side_effect=_challenge,
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(tmp_path),
+                "--security",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    findings = payload["findings"]
+    assert len(findings) == 3
+    by_rule = {finding["rule_id"]: finding for finding in findings}
+    assert by_rule["SKY-L001"]["metadata"]["security_evidence"] == "review_supported"
+    assert by_rule["SKY-L001"]["metadata"]["review_verdict"] == "SUPPORTED"
 
 
 def test_security_audit_json_output_reports_vulnerable_repo_and_skips_safe_file(

--- a/test/test_security_taskflow.py
+++ b/test/test_security_taskflow.py
@@ -13,6 +13,7 @@ from skylos.llm.schemas import (
 )
 from skylos.llm.security_taskflow import (
     AUDIT_STAGE,
+    CHALLENGE_STAGE,
     ENTRY_POINTS_STAGE,
     FINALIZE_STAGE,
     REPO_MAP_STAGE,
@@ -94,6 +95,7 @@ def test_run_security_taskflow_builds_repo_context_and_entry_points(tmp_path):
         ENTRY_POINTS_STAGE,
         AUDIT_STAGE,
         VERIFY_STAGE,
+        CHALLENGE_STAGE,
         FINALIZE_STAGE,
     ]
     assert run.candidate_ledger == []
@@ -316,3 +318,77 @@ def test_run_security_taskflow_writes_run_artifacts(tmp_path):
     assert summary_payload["final_finding_count"] == 1
     assert summary_payload["stages"][-1]["name"] == FINALIZE_STAGE
     assert summary_payload["artifact_write_error"] is None
+
+
+def test_run_security_taskflow_challenges_uncertain_findings(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("print('hi')\n", encoding="utf-8")
+    findings = [_security_finding(str(app), 1, "SKY-L001")]
+    analyzer = _FakeAnalyzer(AnalysisResult(findings=findings, files_analyzed=1))
+
+    def _review(found):
+        annotate_security_finding(
+            found[0],
+            evidence="hypothesis",
+            review_verdict="UNCERTAIN",
+            review_reason="not enough local context",
+            needs_review=True,
+            ci_blocking=False,
+        )
+        return {
+            "supported": 0,
+            "refuted": 0,
+            "undecided": 1,
+            "refuted_findings": [],
+        }
+
+    def _challenge(found):
+        annotate_security_finding(
+            found[0],
+            evidence="review_supported",
+            review_verdict="SUPPORTED",
+            review_reason="challenge found enough local evidence",
+            needs_review=True,
+            ci_blocking=False,
+        )
+        return {
+            "supported": 1,
+            "refuted": 0,
+            "undecided": 0,
+            "refuted_findings": [],
+        }
+
+    with (
+        patch(
+            "skylos.llm.security_taskflow.SecurityVerifier.review_findings",
+            side_effect=_review,
+        ),
+        patch(
+            "skylos.llm.security_taskflow.SecurityVerifier.challenge_findings",
+            side_effect=_challenge,
+        ),
+    ):
+        run = run_security_taskflow(
+            path=tmp_path,
+            files=[app],
+            analyzer=analyzer,
+            model="gpt-4.1",
+            api_key="k",
+        )
+
+    assert run.supported_count == 1
+    assert run.refuted_count == 0
+    assert run.hypothesis_count == 0
+    candidate = run.candidate_ledger[0]
+    assert candidate.state == "review_supported"
+    assert candidate.review_verdict == "SUPPORTED"
+    assert [event.stage for event in candidate.history] == [
+        AUDIT_STAGE,
+        VERIFY_STAGE,
+        CHALLENGE_STAGE,
+    ]
+    assert candidate.history[1].evidence == "hypothesis"
+    assert candidate.history[2].evidence == "review_supported"
+    assert run.stages[-2].name == CHALLENGE_STAGE
+    assert run.stages[-2].details["challenged"] == 1
+    assert run.stages[-2].details["supported"] == 1


### PR DESCRIPTION
 ## Summary
  - add a dedicated challenge pass for security findings that remain uncertain after verify
  - only challenge surviving `hypothesis` / `UNCERTAIN` candidates instead of running reviews again
  - record the extra `challenge` stage in the taskflow ledger
  - keep the existing JSON/SARIF contract compatible while allowing uncertain findings to be resolved to supported

  ## Verification
  - `pytest test/test_security_taskflow.py test/test_security_verifier.py`
  - `pytest test/test_agent_integration.py -k "security_audit"`
  - `pytest test/test_agent_review_benchmark.py test/test_agent_integration.py test/test_security_taskflow.py test/test_security_verifier.py test/test_pipeline.py test/test_llm_analyzer.py test/test_llm_graph.py test/test_cli.py`
  - `/Users/skylos/.venv/bin/python -m pre_commit run skylos-gate --files skylos/llm/security_verifier.py skylos/llm/security_taskflow.py test/test_security_taskflow.py test/test_agent_integration.py`

  ## Why
  - uncertain security findings still had no bounded second-pass path