### PR TITLE
feat(docker): publish official GHCR image for Skylos CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,10 +3,17 @@
 __pycache__
 *.pyc
 node_modules
+.github
 .pytest_cache
 .mypy_cache
 .ruff_cache
 skylos-demo
+agent_review_benchmarks
+corpus
+editors
+quality_benchmarks
+rust
+test
 assets
 manual
 *.egg-info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ on:
         description: "Release tag to build and publish (for example v4.2.1)"
         required: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -77,3 +81,88 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "packaging>=24.2" "twine>=6.1.0"
           python -m twine upload --skip-existing dist/*
+
+  container:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/duriantaco/skylos
+      RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_REF }}
+
+      - name: Derive image metadata
+        id: meta
+        shell: bash
+        run: |
+          ref="${RELEASE_REF#refs/tags/}"
+          version="${ref#v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if [[ "$version" == *-* ]]; then
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stable=true" >> "$GITHUB_OUTPUT"
+            IFS='.' read -r major minor patch <<< "$version"
+            echo "major=$major" >> "$GITHUB_OUTPUT"
+            echo "minor=$minor" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build smoke image
+        run: docker build -t skylos:smoke .
+
+      - name: Smoke test CLI entrypoint
+        run: docker run --rm skylos:smoke --version
+
+      - name: Smoke test real scan
+        run: |
+          docker run --rm \
+            -v "$PWD/quality_benchmarks/fixtures/argument_overload:/work" \
+            -w /work \
+            skylos:smoke \
+            . --json --no-provenance > /tmp/skylos-smoke.json
+          grep -q '"unused_functions"' /tmp/skylos-smoke.json
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          STABLE: ${{ steps.meta.outputs.stable }}
+          MAJOR: ${{ steps.meta.outputs.major }}
+          MINOR: ${{ steps.meta.outputs.minor }}
+        run: |
+          revision="$(git rev-parse HEAD)"
+          tags=(
+            "--tag" "${IMAGE_NAME}:${VERSION}"
+          )
+          if [[ "$STABLE" == "true" ]]; then
+            tags+=(
+              "--tag" "${IMAGE_NAME}:${MAJOR}.${MINOR}"
+              "--tag" "${IMAGE_NAME}:${MAJOR}"
+              "--tag" "${IMAGE_NAME}:latest"
+            )
+          fi
+
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            "${tags[@]}" \
+            --label "org.opencontainers.image.title=skylos" \
+            --label "org.opencontainers.image.description=Open-source AI code security and static analysis for Python, TypeScript, and Go." \
+            --label "org.opencontainers.image.url=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.version=${VERSION}" \
+            --label "org.opencontainers.image.revision=${revision}" \
+            --push \
+            .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,16 +40,39 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ matrix.install_target == '.[llm]' && 'llm-extra' || 'default-install' }}
 
+  docker_smoke:
+    name: docker-smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t skylos:test .
+
+      - name: Check CLI version
+        run: docker run --rm skylos:test --version
+
+      - name: Run fixture scan
+        run: |
+          docker run --rm \
+            -v "$PWD/quality_benchmarks/fixtures/argument_overload:/work" \
+            -w /work \
+            skylos:test \
+            . --json --no-provenance > /tmp/skylos-docker-smoke.json
+          grep -q '"unused_functions"' /tmp/skylos-docker-smoke.json
+
   test:
     name: test
     runs-on: ubuntu-latest
-    needs: [test_matrix]
+    needs: [test_matrix, docker_smoke]
     if: ${{ always() }}
 
     steps:
       - name: Require matrix success
         run: |
-          if [ "${{ needs.test_matrix.result }}" != "success" ]; then
+          if [ "${{ needs.test_matrix.result }}" != "success" ] || [ "${{ needs.docker_smoke.result }}" != "success" ]; then
             echo "test_matrix result: ${{ needs.test_matrix.result }}"
+            echo "docker_smoke result: ${{ needs.docker_smoke.result }}"
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,30 @@
-FROM python:3.11-alpine
-WORKDIR /app
-COPY . .
-RUN pip install --no-cache-dir .
+FROM python:3.12-slim AS build
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /src
+
+COPY pyproject.toml README.md LICENSE ./
+COPY skylos ./skylos
+
+RUN python -m pip install --upgrade pip build && \
+    python -m build --wheel --outdir /dist
+
+FROM python:3.12-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /work
+
+COPY --from=build /dist/*.whl /tmp/dist/
+
+RUN python -m pip install /tmp/dist/*.whl && \
+    rm -rf /tmp/dist
+
 ENTRYPOINT ["skylos"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -182,6 +182,62 @@ If you are evaluating Skylos, start with the core workflow below. The LLM and AI
 - `verify` re-reviews surviving findings and records evidence such as `hypothesis`, `review_supported`, and `refuted`
 - a candidate ledger keeps stable finding IDs and stage transitions internally so later workflow/reporting layers can build on the same evidence model
 
+#### Example
+
+```python
+from fastapi import FastAPI, Request
+from urllib.parse import urlparse
+import httpx
+
+app = FastAPI()
+
+@app.get("/proxy")
+async def proxy(request: Request):
+    target = request.query_params.get("url")
+    return httpx.get(target).text
+
+@app.get("/safe")
+async def safe_proxy(request: Request):
+    target = request.query_params.get("url")
+    if urlparse(target).netloc not in {"internal.local"}:
+        target = "https://internal.local/health"
+    return httpx.get(target).text
+```
+
+```bash
+skylos agent scan . --security --format json -o security.json
+```
+
+```json
+{
+  "findings": [
+    {
+      "rule_id": "SKY-D216",
+      "severity": "critical",
+      "message": "Possible SSRF: tainted URL passed to HTTP client.",
+      "location": {
+        "file": "app.py",
+        "line": 10
+      },
+      "symbol": "proxy",
+      "metadata": {
+        "security_evidence": "review_supported",
+        "review_verdict": "SUPPORTED",
+        "review_reason": "challenge pass resolved the SSRF flow"
+      }
+    }
+  ],
+  "summary": "Found 1 issues: 1 critical"
+}
+```
+
+The same run also writes taskflow artifacts under `.skylos/runs/<run-id>/`:
+
+- `repo_map.json`
+- `candidates.json`
+- `verified.json`
+- `summary.json`
+
 ## Technical Debt Hotspots
 
 Use `skylos debt <path>` to rank structural debt hotspots without collapsing everything into a single urgency number.


### PR DESCRIPTION
## Summary

  Adds an official Docker image release path for Skylos CLI

  This PR:
  - switches root `Dockerfile` to a multi-stage wheel-based build
  - adds GHCR publish automation to tagged release workflow

  Official image target:
  - `ghcr.io/duriantaco/skylos`

## Why

  Issue: https://github.com/duriantaco/skylos/issues/229

## Validation

  - `docker build -t skylos:local .`
  - `docker run --rm skylos:local`
  - `docker run --rm skylos:local --version`