### PR TITLE
test(security): add benchmark scorecard and broaden class coverage

### DIFF
--- a/agent_review_benchmarks/README.md
+++ b/agent_review_benchmarks/README.md
@@ -8,6 +8,7 @@ What it checks:
 - whether clean files stay quiet
 - whether review latency stays within a reasonable budget
 - how many Skylos API tokens the fast review lane spends per case
+- how security coverage is landing by benchmark class
 - how many Codex tokens are consumed during the head-to-head compare run
 
 What it does not check:
@@ -52,6 +53,8 @@ The checked-in suite is intentionally difficult. It includes:
 - FastAPI query-parameter SSRF with a nearby constant-url probe
 - open redirect with a nearby urlparse-guarded redirect helper
 - reflected XSS with a nearby escaped template path
+- unsafe pickle deserialization with a nearby JSON-only handler
+- unsafe tar extraction with a nearby member-validated extraction path
 
 Benchmark cases can optionally declare `scan.issue_types`, which lets the suite
 exercise stricter review lanes such as `["security_audit"]` instead of the

--- a/agent_review_benchmarks/fixtures/flask_archive_extraction/app.py
+++ b/agent_review_benchmarks/fixtures/flask_archive_extraction/app.py
@@ -1,0 +1,39 @@
+import tarfile
+from pathlib import Path
+
+from flask import Flask, request
+
+
+app = Flask(__name__)
+EXTRACT_ROOT = Path("/srv/bundles")
+
+
+def _target_within_root(root: Path, member_name: str) -> bool:
+    target = (root / member_name).resolve()
+    return target == root or str(target).startswith(f"{root}/")
+
+
+@app.post("/extract-bundle")
+def extract_bundle():
+    upload = request.files["bundle"]
+    archive_path = EXTRACT_ROOT / upload.filename
+    upload.save(archive_path)
+    with tarfile.open(archive_path) as bundle:
+        bundle.extractall(EXTRACT_ROOT)
+    return "ok"
+
+
+@app.post("/extract-bundle-safe")
+def extract_bundle_safe():
+    upload = request.files["bundle"]
+    archive_path = EXTRACT_ROOT / upload.filename
+    upload.save(archive_path)
+    root = EXTRACT_ROOT.resolve()
+    with tarfile.open(archive_path) as bundle:
+        safe_members = [
+            member
+            for member in bundle.getmembers()
+            if _target_within_root(root, member.name)
+        ]
+        bundle.extractall(root, members=safe_members)
+    return "ok"

--- a/agent_review_benchmarks/fixtures/flask_pickle_deserialization/app.py
+++ b/agent_review_benchmarks/fixtures/flask_pickle_deserialization/app.py
@@ -1,0 +1,23 @@
+import base64
+import json
+import pickle
+
+from flask import Flask, request
+
+
+app = Flask(__name__)
+
+
+@app.post("/restore-session")
+def restore_session():
+    payload = request.get_json(force=True)["payload"]
+    raw = base64.b64decode(payload)
+    session = pickle.loads(raw)
+    return {"keys": sorted(session)}
+
+
+@app.post("/restore-session-safe")
+def restore_session_safe():
+    payload = request.get_json(force=True)["payload"]
+    session = json.loads(payload)
+    return {"keys": sorted(session)}

--- a/agent_review_benchmarks/manifest.json
+++ b/agent_review_benchmarks/manifest.json
@@ -525,6 +525,60 @@
       }
     },
     {
+      "id": "flask-pickle-deserialization",
+      "path": "fixtures/flask_pickle_deserialization/app.py",
+      "description": "A Flask handler should surface unsafe pickle deserialization on request data while keeping the JSON-only path quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["deserialization"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from request handlers that feed user-controlled bytes into pickle.loads."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["restore_session"]
+        },
+        "absent": {
+          "security": ["restore_session_safe"]
+        }
+      }
+    },
+    {
+      "id": "flask-archive-extraction",
+      "path": "fixtures/flask_archive_extraction/app.py",
+      "description": "A Flask upload handler should surface unsafe archive extraction while keeping the validated member path quiet.",
+      "taxonomy": ["security", "precision_guard"],
+      "security_classes": ["archive_extraction"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/flask",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from upload handlers that unpack tar archives without validating member paths."
+      },
+      "scan": {
+        "issue_types": ["security_audit"]
+      },
+      "budget": {
+        "max_seconds": 12.0
+      },
+      "expect": {
+        "present": {
+          "security": ["extract_bundle"]
+        },
+        "absent": {
+          "security": ["extract_bundle_safe"]
+        }
+      }
+    },
+    {
       "id": "debt-hotspot-service",
       "path": "fixtures/debt_hotspot_service",
       "description": "A central service module imported by multiple entry surfaces should be surfaced as a debt hotspot when it is wide, branch-heavy, and swallows failures.",

--- a/scripts/compare_codex_skylos_agent_review.py
+++ b/scripts/compare_codex_skylos_agent_review.py
@@ -69,6 +69,9 @@ def _score(
 ):
     present = _expected_symbols(case, "present")
     absent = _expected_symbols(case, "absent")
+    is_clean_precision_guard = "precision_guard" in (case.get("taxonomy") or []) and not (
+        present
+    )
 
     present_total = len(present)
     present_matched = len(found_symbols & present)
@@ -76,7 +79,7 @@ def _score(
     absent_total = len(absent)
     absent_violations = len(found_symbols & absent)
 
-    if "precision_guard" in (case.get("taxonomy") or []):
+    if is_clean_precision_guard:
         absent_total += 1
         if finding_count > 0:
             absent_violations += 1

--- a/skylos/agent_review_benchmark.py
+++ b/skylos/agent_review_benchmark.py
@@ -331,6 +331,17 @@ def _count_expectations(expectations: dict[str, list[str]]) -> int:
     return sum(len(items) for items in expectations.values())
 
 
+def _dedupe_labels(labels: list[str] | None) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for label in labels or []:
+        if label in seen:
+            continue
+        seen.add(label)
+        ordered.append(label)
+    return ordered
+
+
 def _evaluate_expectations(case: dict[str, Any], symbols: set[str], finding_count: int):
     expect = case.get("expect", {})
     present = expect.get("present", {}) or {}
@@ -461,6 +472,7 @@ def run_case(
         "id": case["id"],
         "importance": case.get("importance", "high"),
         "taxonomy": list(case.get("taxonomy") or []),
+        "security_classes": _dedupe_labels(case.get("security_classes")),
         "elapsed_seconds": round(elapsed_seconds, 4),
         "finding_count": scan_result["finding_count"],
         "symbols": scan_result["symbols"],
@@ -477,6 +489,55 @@ def run_case(
         ),
         "failures": [failure.to_dict() for failure in failures],
     }
+
+
+def _build_security_scorecard(
+    case_results: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    totals: dict[str, dict[str, float]] = {}
+
+    for case in case_results:
+        labels = _dedupe_labels(case.get("security_classes"))
+        if not labels:
+            continue
+
+        weight = IMPORTANCE_WEIGHTS[case["importance"]]
+        case_failed = 1.0 if case.get("failures") else 0.0
+        case_passed = 0.0 if case_failed else 1.0
+
+        for label in labels:
+            bucket = totals.setdefault(
+                label,
+                {
+                    "case_count": 0.0,
+                    "pass_count": 0.0,
+                    "failed_case_count": 0.0,
+                    "weight": 0.0,
+                    "overall_score": 0.0,
+                },
+            )
+            bucket["case_count"] += 1
+            bucket["pass_count"] += case_passed
+            bucket["failed_case_count"] += case_failed
+            bucket["weight"] += weight
+            bucket["overall_score"] += case["scores"]["overall_score"] * weight
+
+    scorecard = {}
+    for label, bucket in sorted(totals.items()):
+        case_count = int(bucket["case_count"])
+        pass_count = int(bucket["pass_count"])
+        scorecard[label] = {
+            "description": SECURITY_BENCHMARK_CLASSES[label],
+            "case_count": case_count,
+            "pass_count": pass_count,
+            "failed_case_count": int(bucket["failed_case_count"]),
+            "pass_rate": round(pass_count / case_count, 4) if case_count else 0.0,
+            "weighted_score": round(
+                bucket["overall_score"] / (bucket["weight"] or 1.0), 2
+            ),
+        }
+
+    return scorecard
 
 
 def run_manifest(
@@ -535,10 +596,12 @@ def run_manifest(
             "overall_score": 0.0,
         }
 
+    pass_count = sum(1 for case in case_results if not case["failures"])
     return {
         "manifest": str(Path(manifest_path).resolve()),
         "model": model,
         "case_count": len(case_results),
+        "pass_count": pass_count,
         "failure_count": sum(len(case["failures"]) for case in case_results),
         "total_elapsed_seconds": round(total_elapsed, 4),
         "total_tokens_used": total_tokens,
@@ -546,6 +609,7 @@ def run_manifest(
         if case_results
         else 0.0,
         "scores": scores,
+        "security_scorecard": _build_security_scorecard(case_results),
         "cases": case_results,
     }
 
@@ -566,6 +630,13 @@ def format_summary(summary: dict[str, Any]) -> str:
         f"Agent review benchmark avg tokens/case: {summary.get('avg_tokens_per_case', 0.0)}",
         f"Agent review benchmark total time: {summary['total_elapsed_seconds']:.4f}s",
     ]
+    if summary.get("security_scorecard"):
+        lines.append("Security classes:")
+        for label, bucket in sorted(summary["security_scorecard"].items()):
+            lines.append(
+                f"  {label}: cases={bucket['case_count']} pass={bucket['pass_count']} "
+                f"fail={bucket['failed_case_count']} score={bucket['weighted_score']}"
+            )
     for case in summary["cases"]:
         status = "PASS" if not case["failures"] else "FAIL"
         lines.append(

--- a/skylos/agent_review_benchmark.py
+++ b/skylos/agent_review_benchmark.py
@@ -346,6 +346,9 @@ def _evaluate_expectations(case: dict[str, Any], symbols: set[str], finding_coun
     expect = case.get("expect", {})
     present = expect.get("present", {}) or {}
     absent = expect.get("absent", {}) or {}
+    is_clean_precision_guard = "precision_guard" in (case.get("taxonomy") or []) and not (
+        present
+    )
 
     failures: list[AgentReviewBenchmarkFailure] = []
     present_total = _count_expectations(present)
@@ -384,7 +387,7 @@ def _evaluate_expectations(case: dict[str, Any], symbols: set[str], finding_coun
                             )
                         )
 
-    if "precision_guard" in (case.get("taxonomy") or []) and finding_count > 0:
+    if is_clean_precision_guard and finding_count > 0:
         absent_total += 1
         absent_violations += 1
         failures.append(

--- a/test/test_agent_review_benchmark.py
+++ b/test/test_agent_review_benchmark.py
@@ -246,6 +246,109 @@ def test_run_manifest_builds_security_scorecard(tmp_path, monkeypatch):
     }
 
 
+def test_precision_guard_allows_expected_positive_findings(tmp_path, monkeypatch):
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text("def restore_session():\n    return 1\n", encoding="utf-8")
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "mixed-security-case",
+                "path": "fixture.py",
+                "taxonomy": ["security", "precision_guard"],
+                "security_classes": ["deserialization"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "budget": {"max_seconds": 1.0},
+                "expect": {
+                    "present": {"security": ["restore_session"]},
+                    "absent": {"security": ["restore_session_safe"]},
+                },
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.setattr(
+        benchmark,
+        "_scan_case",
+        lambda case_path, model, api_key, provider, base_url, case=None: {
+            "finding_count": 1,
+            "symbols": ["restore_session"],
+            "summary": "Found 1 issue",
+            "tokens_used": 13,
+            "reviewed_files": [str(case_path)],
+        },
+    )
+
+    ticks = iter([0.0, 0.1])
+    monkeypatch.setattr(benchmark.time, "perf_counter", lambda: next(ticks))
+
+    summary = run_manifest(manifest_path, model="gpt-4.1", api_key="KEY")
+
+    assert summary["pass_count"] == 1
+    assert summary["failure_count"] == 0
+    assert summary["cases"][0]["failures"] == []
+    assert summary["cases"][0]["scores"]["overall_score"] == 100.0
+
+
+def test_precision_guard_still_rejects_findings_for_clean_case(tmp_path, monkeypatch):
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text("def normalize_name():\n    return 'ok'\n", encoding="utf-8")
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "clean-precision-case",
+                "path": "fixture.py",
+                "taxonomy": ["precision_guard"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "budget": {"max_seconds": 1.0},
+                "expect": {
+                    "present": {},
+                    "absent": {"quality": ["normalize_name"]},
+                },
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.setattr(
+        benchmark,
+        "_scan_case",
+        lambda case_path, model, api_key, provider, base_url, case=None: {
+            "finding_count": 1,
+            "symbols": ["normalize_name"],
+            "summary": "Found 1 issue",
+            "tokens_used": 13,
+            "reviewed_files": [str(case_path)],
+        },
+    )
+
+    ticks = iter([0.0, 0.1])
+    monkeypatch.setattr(benchmark.time, "perf_counter", lambda: next(ticks))
+
+    summary = run_manifest(manifest_path, model="gpt-4.1", api_key="KEY")
+
+    assert summary["pass_count"] == 0
+    assert summary["failure_count"] == 2
+    assert {failure["mode"] for failure in summary["cases"][0]["failures"]} == {
+        "absent",
+        "precision_guard",
+    }
 def test_prepare_case_scan_directory_selects_repo_files(tmp_path):
     proj = tmp_path / "case"
     tests = proj / "tests"

--- a/test/test_agent_review_benchmark.py
+++ b/test/test_agent_review_benchmark.py
@@ -25,7 +25,7 @@ def test_checked_in_agent_review_manifest_validates():
     manifest = load_manifest(MANIFEST_PATH)
     cases = validate_manifest(manifest, MANIFEST_PATH)
 
-    assert len(cases) >= 22
+    assert len(cases) >= 24
     assert {case["id"] for case in cases} >= {
         "complexity-hotspot",
         "inconsistent-return",
@@ -41,6 +41,8 @@ def test_checked_in_agent_review_manifest_validates():
         "fastapi-query-ssrf",
         "flask-open-redirect",
         "flask-reflected-xss",
+        "flask-pickle-deserialization",
+        "flask-archive-extraction",
         "debt-hotspot-service",
         "repo-clean-service",
     }
@@ -62,6 +64,8 @@ def test_checked_in_agent_review_manifest_validates():
         "auth_bypass",
         "open_redirect",
         "xss",
+        "deserialization",
+        "archive_extraction",
     }
 
 
@@ -118,6 +122,7 @@ def test_agent_review_runner_reports_symbol_and_budget_failures(tmp_path, monkey
 def test_format_summary_includes_agent_metrics():
     summary = {
         "case_count": 1,
+        "pass_count": 1,
         "failure_count": 0,
         "model": "gpt-4.1",
         "total_elapsed_seconds": 0.25,
@@ -129,10 +134,21 @@ def test_format_summary_includes_agent_metrics():
         },
         "total_tokens_used": 99,
         "avg_tokens_per_case": 99.0,
+        "security_scorecard": {
+            "sql_injection": {
+                "description": SECURITY_BENCHMARK_CLASSES["sql_injection"],
+                "case_count": 1,
+                "pass_count": 1,
+                "failed_case_count": 0,
+                "pass_rate": 1.0,
+                "weighted_score": 100.0,
+            }
+        },
         "cases": [
             {
                 "id": "empty-error-handler",
                 "importance": "critical",
+                "security_classes": [],
                 "elapsed_seconds": 0.25,
                 "scores": {"overall_score": 100.0},
                 "tokens_used": 99,
@@ -147,7 +163,87 @@ def test_format_summary_includes_agent_metrics():
     assert "Agent review benchmark score: 100.0/100" in rendered
     assert "Agent review benchmark model: gpt-4.1" in rendered
     assert "Agent review benchmark total tokens: 99" in rendered
+    assert "sql_injection: cases=1 pass=1 fail=0 score=100.0" in rendered
     assert "symbols: parse_payload" in rendered
+
+
+def test_run_manifest_builds_security_scorecard(tmp_path, monkeypatch):
+    first = tmp_path / "pickle_case.py"
+    second = tmp_path / "archive_case.py"
+    first.write_text("def restore_session():\n    return 1\n", encoding="utf-8")
+    second.write_text("def extract_bundle():\n    return 1\n", encoding="utf-8")
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "pickle-case",
+                "path": "pickle_case.py",
+                "taxonomy": ["security"],
+                "security_classes": ["deserialization", "archive_extraction"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "budget": {"max_seconds": 1.0},
+                "expect": {"present": {"security": ["restore_session"]}, "absent": {}},
+            },
+            {
+                "id": "archive-case",
+                "path": "archive_case.py",
+                "taxonomy": ["security"],
+                "security_classes": ["archive_extraction"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "budget": {"max_seconds": 1.0},
+                "expect": {"present": {"security": ["extract_bundle"]}, "absent": {}},
+            },
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.setattr(
+        benchmark,
+        "_scan_case",
+        lambda case_path, model, api_key, provider, base_url, case=None: {
+            "finding_count": 1 if case["id"] == "pickle-case" else 0,
+            "symbols": ["restore_session"] if case["id"] == "pickle-case" else [],
+            "summary": "ok",
+            "tokens_used": 11,
+            "reviewed_files": [str(case_path)],
+        },
+    )
+
+    ticks = iter([0.0, 0.1, 0.2, 0.3])
+    monkeypatch.setattr(benchmark.time, "perf_counter", lambda: next(ticks))
+
+    summary = run_manifest(manifest_path, model="gpt-4.1", api_key="KEY")
+
+    assert summary["pass_count"] == 1
+    assert summary["failure_count"] == 1
+    assert summary["security_scorecard"]["deserialization"] == {
+        "description": SECURITY_BENCHMARK_CLASSES["deserialization"],
+        "case_count": 1,
+        "pass_count": 1,
+        "failed_case_count": 0,
+        "pass_rate": 1.0,
+        "weighted_score": 100.0,
+    }
+    assert summary["security_scorecard"]["archive_extraction"] == {
+        "description": SECURITY_BENCHMARK_CLASSES["archive_extraction"],
+        "case_count": 2,
+        "pass_count": 1,
+        "failed_case_count": 1,
+        "pass_rate": 0.5,
+        "weighted_score": 75.0,
+    }
 
 
 def test_prepare_case_scan_directory_selects_repo_files(tmp_path):

--- a/test/test_agent_review_compare.py
+++ b/test/test_agent_review_compare.py
@@ -1,4 +1,4 @@
-from scripts.compare_codex_skylos_agent_review import _extract_codex_usage
+from scripts.compare_codex_skylos_agent_review import _extract_codex_usage, _score
 
 
 def test_extract_codex_usage_parses_turn_completed_usage():
@@ -34,3 +34,39 @@ def test_extract_codex_usage_ignores_non_json_lines():
         "cached_input_tokens": 2,
         "output_tokens": 5,
     }
+
+
+def test_score_allows_expected_positive_findings_for_mixed_precision_guard_case():
+    case = {
+        "taxonomy": ["security", "precision_guard"],
+        "budget": {"max_seconds": 1.0},
+        "expect": {
+            "present": {"security": ["restore_session"]},
+            "absent": {"security": ["restore_session_safe"]},
+        },
+    }
+
+    score = _score({"restore_session"}, 1, case, elapsed_seconds=0.1)
+
+    assert score == {
+        "recall": 1.0,
+        "absence_guard": 1.0,
+        "latency": 1.0,
+        "overall_score": 100.0,
+    }
+
+
+def test_score_keeps_clean_precision_guard_strict():
+    case = {
+        "taxonomy": ["precision_guard"],
+        "budget": {"max_seconds": 1.0},
+        "expect": {
+            "present": {},
+            "absent": {"quality": ["normalize_name"]},
+        },
+    }
+
+    score = _score({"normalize_name"}, 1, case, elapsed_seconds=0.1)
+
+    assert score["absence_guard"] == 0.0
+    assert score["overall_score"] == 65.0


### PR DESCRIPTION
## Summary
  - add a security scorecard to the agent review benchmark summary
  - add `deserialization` and `archive_extraction` benchmark cases with vulnerable/safe fixtures
  -  fix `precision_guard` scoring for mixed benchmark cases so expected positive findings are not penalized as `no_findings`

  ## Tests
  - `pytest -q test/test_agent_review_benchmark.py`
  - `pytest -q test/test_quality_benchmark.py`
  - `pytest -q test/test_agent_review_compare.py`
  - `pytest -q test/test_corpus_ci.py -k "not checked_in_corpus_passes"`
  - `pytest -q test/test_security_taskflow.py test/test_security_verifier.py test/test_mcp_security.py test/test_provenance_security.py test/test_cmd_injection.py test/test_path_traversal.py test/test_ssrf.py test/test_sql_injection.py test/test_xss_flow.py test/test_jwt_flow.py test/test_redirect_flow.py`