### PR TITLE
feat(upload): add family-aware cloud uploads and debt reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ If you are evaluating Skylos, start with the core workflow below. The LLM and AI
 | **AI Defense: CI Gate** | `skylos defend . --fail-on critical --min-score 70` | Block PRs with critical AI defense gaps |
 | **Whitelist** | `skylos whitelist 'handle_*'` | Suppress known dynamic patterns |
 
+### Cloud Uploads
+
+| Objective | Command | What uploads |
+| :--- | :--- | :--- |
+| **Upload one code scan** | `skylos . --danger --quality --upload` | One `Code Scan` with `danger`, `quality`, and `dead_code` data |
+| **Upload one defense scan** | `skylos defend . --upload` | One `AI Defense` scan |
+| **Upload one debt scan** | `skylos debt . --upload` | One `Technical Debt` scan |
+| **Upload the full suite** | `skylos suite . --upload` | Separate `Code Scan`, `AI Defense`, and `Technical Debt` scans linked as one suite bundle |
+| **Upload everything except danger** | `skylos suite . --upload --families static,defense,debt --static-categories quality,secrets,dead_code,dependency` | Code/debt/defense uploads without `danger` findings in the code-scan payload |
+
+Skylos now prints an explicit upload manifest before every non-JSON upload so it is clear which scan family is being sent.
+
 ### Security Taskflow
 
 `skylos agent scan . --security` now runs as an internal security taskflow instead of a single opaque LLM pass:
@@ -253,6 +265,9 @@ skylos debt .
 # Review only changed hotspots without distorting the project score
 skylos debt . --changed
 
+# Upload debt results to Skylos Cloud
+skylos debt . --upload
+
 # Compare the current project against a saved debt baseline
 skylos debt . --baseline
 
@@ -261,6 +276,8 @@ skylos debt . --save-baseline
 ```
 
 Debt policy files such as `skylos-debt.yaml` are discovered from the scan target upward, and explicit CLI flags like `--top` override policy defaults.
+
+Debt uploads land in Skylos Cloud as their own `Technical Debt` scan family. They do not get mixed into the recurring code issue inbox.
 
 ### Demo
 [![Skylos demo](https://img.youtube.com/vi/BjMdSP2zZl8/0.jpg)](https://www.youtube.com/watch?v=BjMdSP2zZl8)
@@ -316,6 +333,9 @@ skylos defend . --fail-on critical --min-score 70
 
 # JSON output for dashboards and pipelines
 skylos defend . --json -o defense-report.json
+
+# Upload defense results to Skylos Cloud
+skylos defend . --upload
 
 # Filter by OWASP LLM Top 10 category
 skylos defend . --owasp LLM01,LLM04

--- a/skylos/api.py
+++ b/skylos/api.py
@@ -852,7 +852,11 @@ def _normalize_result_sections(
 
 
 def _prepare_report_upload(
-    result_json, *, is_forced=False, analysis_mode="static"
+    result_json,
+    *,
+    is_forced=False,
+    analysis_mode="static",
+    scan_bundle_id=None,
 ) -> PreparedReportUpload:
     commit, branch, actor, ci = get_git_info()
     git_root = get_git_root()
@@ -869,7 +873,11 @@ def _prepare_report_upload(
     core_payload = exporter.generate()
 
     ai_code = detect_ai_code(git_root)
-    provenance_data = _detect_report_provenance_data(git_root)
+    if isinstance(result_json, dict) and "provenance" in result_json:
+        raw_provenance = result_json.get("provenance")
+        provenance_data = raw_provenance if isinstance(raw_provenance, dict) else None
+    else:
+        provenance_data = _detect_report_provenance_data(git_root)
 
     definitions = result_json.get("definitions")
     grade_data = result_json.get("grade") if isinstance(result_json, dict) else None
@@ -887,6 +895,7 @@ def _prepare_report_upload(
         provenance_data=provenance_data,
         grade_data=grade_data,
         project_id=project_id,
+        scan_bundle_id=scan_bundle_id,
     )
     core_payload.update(metadata)
     legacy_payload = _build_legacy_payload(core_payload, definitions)
@@ -900,6 +909,79 @@ def _prepare_report_upload(
         scan_summary=scan_summary,
         grade_data=grade_data,
         legacy_payload_size_bytes=_json_size_bytes(legacy_payload),
+    )
+
+
+def _coerce_debt_snapshot_dict(debt_report) -> dict[str, Any]:
+    if isinstance(debt_report, dict):
+        return dict(debt_report)
+    to_dict = getattr(debt_report, "to_dict", None)
+    if callable(to_dict):
+        payload = to_dict()
+        if isinstance(payload, dict):
+            return dict(payload)
+    raise TypeError("Debt report must be a dict or expose to_dict().")
+
+
+def _prepare_debt_upload(
+    debt_report, *, is_forced=False, scan_bundle_id=None
+) -> PreparedReportUpload:
+    commit, branch, actor, ci = get_git_info()
+    git_root = get_git_root()
+    link = _load_repo_link(git_root)
+    project_id = link.get("project_id")
+
+    debt_payload = _coerce_debt_snapshot_dict(debt_report)
+    debt_score = debt_payload.get("score") or {}
+    debt_hotspots = debt_payload.get("hotspots") or []
+    debt_summary = debt_payload.get("summary") or {}
+
+    metadata = _build_report_metadata(
+        commit_hash=commit,
+        branch=branch,
+        actor=actor,
+        is_forced=is_forced,
+        ci=ci,
+        analysis_mode="debt",
+        project_id=project_id,
+        scan_bundle_id=scan_bundle_id,
+    )
+
+    core_payload = {
+        "tool": "skylos-debt",
+        "summary": {
+            "debt_score_pct": int(debt_score.get("score_pct") or 100),
+            "debt_hotspots": len(debt_hotspots),
+            "debt_signals": int(debt_score.get("signal_count") or 0),
+            "files_scanned": int(debt_payload.get("files_scanned") or 0),
+            "total_loc": int(debt_payload.get("total_loc") or 0),
+        },
+        "findings": [],
+        "debt_score": debt_score,
+        "debt_summary": debt_summary,
+        "debt_hotspots": debt_hotspots,
+        "debt_version": debt_payload.get("version"),
+        "debt_timestamp": debt_payload.get("timestamp"),
+    }
+    core_payload.update(metadata)
+
+    scan_summary = {
+        "finding_count": 0,
+        "sarif_result_count": 0,
+        "sarif_rule_count": 0,
+        "definitions_count": 0,
+        "debt_hotspot_count": len(debt_hotspots),
+        "debt_signal_count": int(debt_score.get("signal_count") or 0),
+    }
+
+    return PreparedReportUpload(
+        legacy_payload=dict(core_payload),
+        core_payload=core_payload,
+        definitions_payload=None,
+        metadata=metadata,
+        scan_summary=scan_summary,
+        grade_data=None,
+        legacy_payload_size_bytes=_json_size_bytes(core_payload),
     )
 
 
@@ -938,6 +1020,7 @@ def _build_report_metadata(
     provenance_data=None,
     grade_data=None,
     project_id=None,
+    scan_bundle_id=None,
 ) -> dict[str, Any]:
     metadata = {
         "commit_hash": commit_hash,
@@ -953,6 +1036,8 @@ def _build_report_metadata(
         metadata["grade"] = grade_data
     if project_id:
         metadata["project_id"] = project_id
+    if scan_bundle_id:
+        metadata["scan_bundle_id"] = str(scan_bundle_id)
     return metadata
 
 
@@ -1435,7 +1520,12 @@ def upload_report_v2(
 
 
 def upload_report(
-    result_json, is_forced=False, quiet=False, strict=False, analysis_mode="static"
+    result_json,
+    is_forced=False,
+    quiet=False,
+    strict=False,
+    analysis_mode="static",
+    scan_bundle_id=None,
 ) -> dict:
     token = get_project_token()
     if not token:
@@ -1454,6 +1544,7 @@ def upload_report(
         result_json,
         is_forced=is_forced,
         analysis_mode=analysis_mode,
+        scan_bundle_id=scan_bundle_id,
     )
 
     if _should_use_legacy_inline_report_upload(prepared):
@@ -1492,6 +1583,70 @@ def upload_report(
     return upload_result
 
 
+def upload_debt_report(
+    debt_report,
+    *,
+    is_forced=False,
+    quiet=False,
+    strict=False,
+    scan_bundle_id=None,
+) -> dict:
+    token = get_project_token()
+    if not token:
+        return {
+            "success": False,
+            "error": "No token found. Run 'skylos login' or 'skylos project use', or set SKYLOS_TOKEN.",
+        }
+
+    if not quiet:
+        info = get_project_info(token)
+        if info and info.get("ok"):
+            project_name = info.get("project", {}).get("name", "Unknown")
+            print(f"Uploading to: {project_name}")
+
+    prepared = _prepare_debt_upload(
+        debt_report,
+        is_forced=is_forced,
+        scan_bundle_id=scan_bundle_id,
+    )
+
+    if _should_use_legacy_inline_report_upload(prepared):
+        return upload_report_legacy(
+            token,
+            prepared.legacy_payload,
+            grade_data=prepared.grade_data,
+            quiet=quiet,
+            strict=strict,
+            is_forced=is_forced,
+            initial_message="Uploading debt results...",
+        )
+
+    upload_result = upload_report_v2(
+        token,
+        prepared,
+        quiet=quiet,
+        strict=strict,
+        is_forced=is_forced,
+    )
+    if _should_retry_with_degraded_large_upload(upload_result):
+        if not quiet:
+            print(
+                " Skylos Cloud artifact upload unavailable; retrying condensed compatibility upload...",
+                end="",
+                flush=True,
+            )
+        return upload_report_legacy(
+            token,
+            prepared.core_payload,
+            grade_data=prepared.grade_data,
+            quiet=quiet,
+            strict=strict,
+            is_forced=is_forced,
+            initial_message="Uploading debt results...",
+        )
+    return upload_result
+
+
 def _should_use_legacy_inline_report_upload(
     prepared: PreparedReportUpload,
 ) -> bool:
@@ -1506,7 +1661,7 @@ def _should_retry_with_degraded_large_upload(upload_result: dict[str, Any]) -> b
     )
 
 
-def upload_defense_report(defense_json_str, quiet=False) -> dict:
+def upload_defense_report(defense_json_str, quiet=False, scan_bundle_id=None) -> dict:
     """Upload defense scan results to the cloud dashboard."""
     token = get_project_token()
     if not token:
@@ -1543,6 +1698,8 @@ def upload_defense_report(defense_json_str, quiet=False) -> dict:
 
     if link.get("project_id"):
         payload["project_id"] = link["project_id"]
+    if scan_bundle_id:
+        payload["scan_bundle_id"] = str(scan_bundle_id)
 
     response, last_err = _post_report_payload(
         token,

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -792,6 +792,34 @@ def _print_upload_destination(console: Console, project_root: Path):
     return has_link, using_env
 
 
+def _selected_main_upload_static_categories(args) -> list[str]:
+    categories = ["dead_code"]
+    if getattr(args, "danger", False):
+        categories.append("danger")
+    if getattr(args, "quality", False):
+        categories.append("quality")
+    if getattr(args, "secrets", False):
+        categories.append("secrets")
+    if getattr(args, "sca", False):
+        categories.append("dependency")
+    return categories
+
+
+def _print_main_upload_manifest(console: Console, args, result) -> None:
+    from skylos.upload_manifest import build_code_scan_manifest, print_upload_manifest
+
+    print_upload_manifest(
+        console,
+        [
+            build_code_scan_manifest(
+                _selected_main_upload_static_categories(args),
+                provenance_attached=bool((result or {}).get("provenance")),
+            )
+        ],
+        auto_upload=not getattr(args, "_explicit_upload_requested", False),
+    )
+
+
 def _render_upload_failure(console: Console, upload_resp: dict[str, object]) -> None:
     code = str(upload_resp.get("code") or "")
     err = str(upload_resp.get("error") or "").strip()
@@ -1967,6 +1995,7 @@ def _run_clean_command(argv):
 
 def run_debt_command(argv):
     from skylos.commands.debt_cmd import run_debt_command as run_debt_command_impl
+    from skylos.api import upload_debt_report
 
     return run_debt_command_impl(
         argv,
@@ -1975,6 +2004,7 @@ def run_debt_command(argv):
         resolve_llm_runtime_func=resolve_llm_runtime,
         parse_exclude_folders_func=parse_exclude_folders,
         load_config_func=load_config,
+        upload_debt_report_func=upload_debt_report,
     )
 
 
@@ -1989,7 +2019,11 @@ def run_defend_command(argv):
 
 
 def run_suite_command(argv):
-    from skylos.api import get_git_root
+    from skylos.api import (
+        get_git_root,
+        upload_debt_report,
+        upload_defense_report,
+    )
     from skylos.commands.suite_cmd import run_suite_command as run_suite_command_impl
 
     return run_suite_command_impl(
@@ -2000,6 +2034,9 @@ def run_suite_command(argv):
         load_config_func=load_config,
         run_analyze_func=run_analyze,
         get_git_root_func=get_git_root,
+        upload_report_func=upload_report,
+        upload_defense_report_func=upload_defense_report,
+        upload_debt_report_func=upload_debt_report,
     )
 
 
@@ -2234,12 +2271,12 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
     parser.add_argument(
         "--upload",
         action="store_true",
-        help="Upload results to skylos.dev dashboard",
+        help="Upload this code scan to Skylos Cloud",
     )
     parser.add_argument(
         "--no-upload",
         action="store_true",
-        help="Skip automatic upload even if connected to Skylos Cloud",
+        help="Skip automatic code-scan upload even if connected to Skylos Cloud",
     )
     parser.add_argument(
         "--verify",
@@ -4483,6 +4520,7 @@ def main() -> None:
 
     parser = _build_main_parser()
     args = _parse_main_cli_args(parser, sys.argv[1:])
+    args._explicit_upload_requested = bool(getattr(args, "upload", False))
     context = _build_main_scan_context(args)
     project_root = context.project_root
     logger = context.logger
@@ -4677,6 +4715,7 @@ def main() -> None:
                 console.print(f"[warn]Verification failed: {e}[/warn]")
 
         prov_report = None
+        result["provenance"] = None
         _skip_provenance = getattr(args, "no_provenance", False)
         if not _skip_provenance:
             try:
@@ -4726,6 +4765,7 @@ def main() -> None:
                 ai_stats = compute_ai_security_stats(all_annotatable)
                 result["ai_security_stats"] = ai_stats
                 result["provenance_summary"] = prov_report.summary
+                result["provenance"] = prov_report.to_dict()
 
                 result_json = json.dumps(result)
 
@@ -4836,6 +4876,26 @@ def main() -> None:
                 pathlib.Path(args.output).write_text(result_json)
             else:
                 print(result_json)
+
+            if args.upload:
+                upload_resp = upload_report(
+                    result,
+                    is_forced=args.force,
+                    strict=args.strict,
+                    quiet=True,
+                )
+                if not upload_resp.get("success"):
+                    raise SystemExit(1)
+
+                passed = upload_resp.get("quality_gate_passed")
+                if passed is None:
+                    passed = (upload_resp.get("quality_gate") or {}).get(
+                        "passed", True
+                    )
+
+                if passed is False and not args.force:
+                    raise SystemExit(1)
+
             return
 
         if args.llm:
@@ -4861,6 +4921,7 @@ def main() -> None:
     if args.gate:
         if not args.json:
             _print_upload_destination(console, project_root)
+            _print_main_upload_manifest(console, args, result)
 
         upload_resp = upload_report(result, is_forced=args.force, strict=args.strict)
         if not upload_resp.get("success"):
@@ -5117,10 +5178,13 @@ def main() -> None:
                 console.print("[dim]Run 'skylos credits' to check your balance.[/dim]")
                 return
 
+        _print_main_upload_manifest(console, args, result)
         upload_resp = upload_report(result, is_forced=args.force, strict=args.strict)
 
         if not upload_resp.get("success"):
             _render_upload_failure(console, upload_resp)
+            if getattr(args, "_explicit_upload_requested", False):
+                raise SystemExit(1)
         else:
             passed = upload_resp.get("quality_gate_passed")
             if passed is None:

--- a/skylos/commands/debt_cmd.py
+++ b/skylos/commands/debt_cmd.py
@@ -10,6 +10,7 @@ def run_debt_command(
     resolve_llm_runtime_func,
     parse_exclude_folders_func,
     load_config_func,
+    upload_debt_report_func,
 ) -> int:
     debt_parser = argparse.ArgumentParser(
         prog="skylos debt",
@@ -21,6 +22,11 @@ def run_debt_command(
     )
     debt_parser.add_argument(
         "-o", "--output", dest="output_file", help="Write output to file"
+    )
+    debt_parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload technical debt results to Skylos Cloud dashboard",
     )
     debt_parser.add_argument(
         "--top",
@@ -263,7 +269,28 @@ def run_debt_command(
     else:
         console.print(output)
 
-    exit_code = 0
+    upload_failed = False
+    if debt_args.upload:
+        if not debt_args.output_json:
+            from skylos.upload_manifest import (
+                build_debt_manifest,
+                print_upload_manifest,
+            )
+
+            print_upload_manifest(console, [build_debt_manifest()])
+
+        upload_result = upload_debt_report_func(
+            snapshot,
+            quiet=debt_args.output_json,
+        )
+        if not upload_result.get("success"):
+            upload_failed = True
+            if not debt_args.output_json:
+                console.print(
+                    f"[red]Upload failed: {upload_result.get('error', 'Unknown')}[/red]"
+                )
+
+    exit_code = 1 if upload_failed else 0
     min_score = debt_args.min_score
     if policy and policy.gate_min_score is not None and min_score is None:
         min_score = policy.gate_min_score

--- a/skylos/commands/defend_cmd.py
+++ b/skylos/commands/defend_cmd.py
@@ -214,16 +214,30 @@ def run_defend_command(
     else:
         console.print(output)
 
+    upload_failed = False
     if def_args.upload:
-        from skylos.api import upload_defense_report
-
-        upload_result = upload_defense_report(json_output)
-        if not upload_result.get("success"):
-            console.print(
-                f"[red]Upload failed: {upload_result.get('error', 'Unknown')}[/red]"
+        if not def_args.output_json:
+            from skylos.upload_manifest import (
+                build_defense_manifest,
+                print_upload_manifest,
             )
 
-    exit_code = 0
+            print_upload_manifest(console, [build_defense_manifest()])
+
+        from skylos.api import upload_defense_report
+
+        upload_result = upload_defense_report(
+            json_output,
+            quiet=def_args.output_json,
+        )
+        if not upload_result.get("success"):
+            upload_failed = True
+            if not def_args.output_json:
+                console.print(
+                    f"[red]Upload failed: {upload_result.get('error', 'Unknown')}[/red]"
+                )
+
+    exit_code = 1 if upload_failed else 0
 
     fail_on = def_args.fail_on
     if policy and policy.gate_fail_on and not fail_on:

--- a/skylos/commands/suite_cmd.py
+++ b/skylos/commands/suite_cmd.py
@@ -1,9 +1,90 @@
 from __future__ import annotations
 
 import argparse
+import json
+import uuid
 from pathlib import Path
 
 from skylos.suite import format_suite_json, format_suite_table, run_suite
+
+_VALID_UPLOAD_FAMILIES = ("static", "defense", "debt")
+_VALID_STATIC_UPLOAD_CATEGORIES = (
+    "danger",
+    "quality",
+    "secrets",
+    "dead_code",
+    "dependency",
+)
+
+
+def _parse_csv_selection(raw: str | None, valid_values: tuple[str, ...]) -> list[str]:
+    if not raw:
+        return list(valid_values)
+
+    selected = []
+    seen = set()
+    valid_set = set(valid_values)
+    for item in str(raw).split(","):
+        normalized = item.strip().lower()
+        if not normalized:
+            continue
+        if normalized not in valid_set:
+            valid_text = ", ".join(valid_values)
+            raise ValueError(
+                f"Invalid selection '{normalized}'. Expected one of: {valid_text}"
+            )
+        if normalized not in seen:
+            seen.add(normalized)
+            selected.append(normalized)
+    return selected
+
+
+def _build_static_upload_result(
+    static_result: dict,
+    static_categories: list[str],
+) -> dict:
+    category_set = set(static_categories)
+    payload = {
+        "analysis_summary": static_result.get("analysis_summary") or {},
+    }
+    if "provenance" in static_result:
+        payload["provenance"] = static_result.get("provenance")
+    if static_result.get("provenance_summary") is not None:
+        payload["provenance_summary"] = static_result.get("provenance_summary")
+    if static_result.get("ai_security_stats") is not None:
+        payload["ai_security_stats"] = static_result.get("ai_security_stats")
+
+    if "danger" in category_set:
+        payload["danger"] = list(static_result.get("danger") or [])
+    if "quality" in category_set:
+        payload["quality"] = list(static_result.get("quality") or [])
+        if static_result.get("architecture_metrics") is not None:
+            payload["architecture_metrics"] = static_result.get("architecture_metrics")
+    if "secrets" in category_set:
+        payload["secrets"] = list(static_result.get("secrets") or [])
+    if "dependency" in category_set:
+        payload["dependency_vulnerabilities"] = list(
+            static_result.get("dependency_vulnerabilities") or []
+        )
+    if "dead_code" in category_set:
+        for key in (
+            "unused_functions",
+            "unused_imports",
+            "unused_classes",
+            "unused_variables",
+            "unused_parameters",
+            "unused_files",
+        ):
+            payload[key] = list(static_result.get(key) or [])
+
+    return payload
+
+
+def _static_upload_failed_quality_gate(upload_result: dict) -> bool:
+    passed = upload_result.get("quality_gate_passed")
+    if passed is None:
+        passed = (upload_result.get("quality_gate") or {}).get("passed", True)
+    return passed is False
 
 
 def run_suite_command(
@@ -15,6 +96,9 @@ def run_suite_command(
     load_config_func,
     run_analyze_func,
     get_git_root_func,
+    upload_report_func,
+    upload_defense_report_func,
+    upload_debt_report_func,
 ) -> int:
     suite_parser = argparse.ArgumentParser(
         prog="skylos suite",
@@ -53,6 +137,27 @@ def run_suite_command(
         action="store_true",
         help="Disable automatic AI provenance summary",
     )
+    suite_parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload selected scan families to Skylos Cloud as separate scans in one suite bundle",
+    )
+    suite_parser.add_argument(
+        "--families",
+        default="static,defense,debt",
+        help=(
+            "Comma-separated upload families for --upload. "
+            "Choices: static,defense,debt"
+        ),
+    )
+    suite_parser.add_argument(
+        "--static-categories",
+        default="danger,quality,secrets,dead_code,dependency",
+        help=(
+            "Comma-separated code-scan categories to upload inside the static family. "
+            "Choices: danger,quality,secrets,dead_code,dependency"
+        ),
+    )
 
     suite_args = suite_parser.parse_args(argv)
     console = console_factory()
@@ -76,6 +181,19 @@ def run_suite_command(
     )
     if suite_args.exclude:
         exclude.update(suite_args.exclude)
+
+    try:
+        selected_families = _parse_csv_selection(
+            suite_args.families,
+            _VALID_UPLOAD_FAMILIES,
+        )
+        selected_static_categories = _parse_csv_selection(
+            suite_args.static_categories,
+            _VALID_STATIC_UPLOAD_CATEGORIES,
+        )
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        return 1
 
     try:
         report = run_suite(
@@ -111,5 +229,93 @@ def run_suite_command(
         print(output)
     else:
         console.print(output)
+
+    if not suite_args.upload:
+        return 0
+
+    upload_failures = 0
+    scan_bundle_id = (
+        str(uuid.uuid4()) if len(selected_families) > 1 else None
+    )
+
+    if not suite_args.output_json:
+        from skylos.upload_manifest import (
+            build_code_scan_manifest,
+            build_defense_manifest,
+            build_debt_manifest,
+            print_upload_manifest,
+        )
+
+        manifest_families = []
+        if "static" in selected_families:
+            manifest_families.append(
+                build_code_scan_manifest(
+                    selected_static_categories,
+                    provenance_attached=bool(
+                        ((report.get("static") or {}).get("provenance"))
+                    ),
+                )
+            )
+        if "defense" in selected_families:
+            manifest_families.append(build_defense_manifest())
+        if "debt" in selected_families:
+            manifest_families.append(build_debt_manifest())
+        print_upload_manifest(
+            console,
+            manifest_families,
+            bundle_id=scan_bundle_id,
+        )
+
+    if "static" in selected_families:
+        static_upload_result = _build_static_upload_result(
+            report.get("static") or {},
+            selected_static_categories,
+        )
+        static_upload = upload_report_func(
+            static_upload_result,
+            quiet=suite_args.output_json,
+            scan_bundle_id=scan_bundle_id,
+        )
+        if not static_upload.get("success"):
+            upload_failures += 1
+            if not suite_args.output_json:
+                console.print(
+                    f"[red]Static upload failed: {static_upload.get('error', 'Unknown')}[/red]"
+                )
+        elif _static_upload_failed_quality_gate(static_upload):
+            upload_failures += 1
+            if not suite_args.output_json:
+                console.print(
+                    "[red]Static upload failed the Skylos Cloud quality gate.[/red]"
+                )
+
+    if "defense" in selected_families:
+        defense_upload = upload_defense_report_func(
+            json.dumps(report.get("defense") or {}),
+            quiet=suite_args.output_json,
+            scan_bundle_id=scan_bundle_id,
+        )
+        if not defense_upload.get("success"):
+            upload_failures += 1
+            if not suite_args.output_json:
+                console.print(
+                    f"[red]Defense upload failed: {defense_upload.get('error', 'Unknown')}[/red]"
+                )
+
+    if "debt" in selected_families:
+        debt_upload = upload_debt_report_func(
+            report.get("debt") or {},
+            quiet=suite_args.output_json,
+            scan_bundle_id=scan_bundle_id,
+        )
+        if not debt_upload.get("success"):
+            upload_failures += 1
+            if not suite_args.output_json:
+                console.print(
+                    f"[red]Debt upload failed: {debt_upload.get('error', 'Unknown')}[/red]"
+                )
+
+    if upload_failures:
+        return 1
 
     return 0

--- a/skylos/suite.py
+++ b/skylos/suite.py
@@ -243,6 +243,7 @@ def run_suite(
         "summary": None,
         "ai_security_stats": None,
     }
+    static_result["provenance"] = None
     if not no_provenance:
         try:
             from skylos.file_discovery import find_git_root
@@ -272,6 +273,7 @@ def run_suite(
             ai_stats = compute_ai_security_stats(annotatable)
             static_result["ai_security_stats"] = ai_stats
             static_result["provenance_summary"] = provenance_report.summary
+            static_result["provenance"] = provenance_report.to_dict()
             provenance_section.update(
                 {
                     "available": True,

--- a/skylos/upload_manifest.py
+++ b/skylos/upload_manifest.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class UploadFamilyManifest:
+    label: str
+    tool: str
+    includes: list[str] = field(default_factory=list)
+    excludes: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+_CODE_CATEGORY_LABELS = {
+    "danger": "security (danger)",
+    "quality": "quality",
+    "secrets": "secrets",
+    "dead_code": "dead code",
+    "dependency": "dependency",
+}
+
+
+def build_code_scan_manifest(
+    static_categories: list[str] | tuple[str, ...] | set[str],
+    *,
+    provenance_attached: bool,
+) -> UploadFamilyManifest:
+    ordered = [
+        _CODE_CATEGORY_LABELS[key]
+        for key in ("dead_code", "danger", "quality", "secrets", "dependency")
+        if key in set(static_categories)
+    ]
+    notes = [
+        "AI provenance attached to the code scan."
+        if provenance_attached
+        else "AI provenance not attached."
+    ]
+    return UploadFamilyManifest(
+        label="Code Scan",
+        tool="skylos",
+        includes=ordered,
+        excludes=["AI defense", "technical debt"],
+        notes=notes,
+    )
+
+
+def build_defense_manifest() -> UploadFamilyManifest:
+    return UploadFamilyManifest(
+        label="AI Defense",
+        tool="skylos-defend",
+        includes=[
+            "defense score",
+            "ops score",
+            "OWASP coverage",
+            "defense findings",
+            "integration inventory",
+        ],
+        excludes=["code scan findings", "technical debt"],
+    )
+
+
+def build_debt_manifest() -> UploadFamilyManifest:
+    return UploadFamilyManifest(
+        label="Technical Debt",
+        tool="skylos-debt",
+        includes=[
+            "debt score",
+            "hotspots",
+            "baseline status",
+            "signal evidence",
+        ],
+        excludes=["code scan findings", "AI defense"],
+    )
+
+
+def print_upload_manifest(
+    console,
+    families: list[UploadFamilyManifest],
+    *,
+    auto_upload: bool = False,
+    bundle_id: str | None = None,
+) -> None:
+    if not families:
+        return
+
+    from rich.panel import Panel
+
+    count = len(families)
+    lines = [
+        "[bold]Upload manifest[/bold]",
+        (
+            f"  {'Auto-uploading' if auto_upload else 'Uploading'} "
+            f"{count} cloud scan{'s' if count != 1 else ''}."
+        ),
+    ]
+
+    if count > 1:
+        lines.append(
+            (
+                "  [dim]Each selected family uploads as a separate cloud scan inside one suite bundle.[/dim]"
+                if bundle_id
+                else "  [dim]Each selected family uploads as a separate cloud scan.[/dim]"
+            )
+        )
+    if bundle_id:
+        lines.append(f"  [dim]Bundle id:[/dim] {bundle_id}")
+
+    for family in families:
+        lines.extend(
+            [
+                "",
+                f"  [bold]{family.label}[/bold] [dim]({family.tool})[/dim]",
+                "  includes: " + ", ".join(family.includes),
+            ]
+        )
+        if family.excludes:
+            lines.append("  excludes: " + ", ".join(family.excludes))
+        for note in family.notes:
+            lines.append("  note: " + note)
+
+    console.print(
+        Panel(
+            "\n".join(lines),
+            border_style="blue",
+            padding=(1, 2),
+        )
+    )

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -11,6 +11,7 @@ import skylos.api as api
 from skylos.api import (
     upload_report,
     upload_defense_report,
+    upload_debt_report,
     extract_snippet,
     get_git_info,
     _detect_ci,
@@ -132,6 +133,52 @@ class TestSkylosApi(unittest.TestCase):
         args, kwargs = mock_post.call_args
         payload = kwargs["json"]
         self.assertEqual(payload["tool"], "skylos-defend")
+
+    @patch("skylos.api.get_project_token")
+    @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
+    @patch("skylos.api.get_git_root", return_value=None)
+    @patch("requests.post")
+    def test_upload_debt_report_sends_debt_payload(
+        self, mock_post, _mock_root, _mock_git_info, mock_token
+    ):
+        mock_token.return_value = "token"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"scanId": "scan_debt_123"}
+        mock_post.return_value = mock_response
+
+        result = upload_debt_report(
+            {
+                "version": "1.0",
+                "timestamp": "2026-04-23T00:00:00+00:00",
+                "project": "/repo",
+                "files_scanned": 7,
+                "total_loc": 321,
+                "score": {
+                    "score_pct": 84,
+                    "signal_count": 9,
+                    "hotspot_count": 2,
+                },
+                "summary": {"dimensions": {"architecture": 2}},
+                "hotspots": [{"fingerprint": "hotspot:app.py", "file": "app.py"}],
+            },
+            quiet=True,
+            scan_bundle_id="bundle-123",
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["scan_id"], "scan_debt_123")
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["tool"], "skylos-debt")
+        self.assertEqual(payload["analysis_mode"], "debt")
+        self.assertEqual(payload["scan_bundle_id"], "bundle-123")
+        self.assertEqual(payload["summary"]["debt_score_pct"], 84)
+        self.assertEqual(payload["summary"]["debt_hotspots"], 1)
+        self.assertEqual(payload["summary"]["files_scanned"], 7)
+        self.assertEqual(payload["debt_summary"], {"dimensions": {"architecture": 2}})
+        self.assertEqual(payload["debt_hotspots"][0]["file"], "app.py")
+        self.assertNotIn("project_path", payload)
 
     def test_extract_snippet_valid(self):
         content = "line1\nline2\nline3\nline4\nline5\n"
@@ -398,6 +445,44 @@ class TestSkylosApi(unittest.TestCase):
 
         finding = mock_exporter.call_args[0][0][0]
         self.assertNotIn("metadata", finding)
+        self.assertIsNone(prepared.metadata["provenance"])
+
+    @patch("skylos.api._detect_report_provenance_data")
+    @patch("skylos.api._load_repo_link", return_value={})
+    @patch("skylos.api.detect_ai_code", return_value={"detected": False})
+    @patch("skylos.api.SarifExporter")
+    @patch("skylos.api._get_blame_map", return_value={})
+    @patch(
+        "skylos.api._normalize_result_sections",
+        return_value=[{"file_path": "app.py", "line_number": 5, "message": "oops"}],
+    )
+    @patch("skylos.api.get_git_root", return_value="/repo")
+    @patch("skylos.api.get_git_info", return_value=("abc123", "main", "actor", {}))
+    def test_prepare_report_upload_respects_explicit_null_provenance(
+        self,
+        _mock_git_info,
+        _mock_root,
+        _mock_normalize,
+        _mock_blame,
+        mock_exporter,
+        _mock_ai,
+        _mock_link,
+        mock_detect_provenance,
+    ):
+        mock_exporter.return_value.generate.return_value = {
+            "version": "2.1.0",
+            "runs": [],
+        }
+
+        prepared = api._prepare_report_upload(
+            {
+                "danger": [{"file": "app.py", "line": 5, "message": "oops"}],
+                "provenance": None,
+            },
+            analysis_mode="static",
+        )
+
+        mock_detect_provenance.assert_not_called()
         self.assertIsNone(prepared.metadata["provenance"])
 
     @patch("skylos.api.get_project_token")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -785,6 +785,57 @@ def test_main_upload_gate_failed_exits_when_not_forced(monkeypatch):
         assert e.value.code == 1
 
 
+def test_main_json_upload_calls_upload_report_quiet(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+
+    monkeypatch.setattr(cli.sys, "argv", ["skylos", ".", "--json", "--upload"])
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch(
+            "skylos.cli.upload_report",
+            return_value={"success": True, "quality_gate_passed": True},
+        ) as mock_upload,
+        patch("builtins.print") as mock_print,
+    ):
+        cli.main()
+
+    mock_upload.assert_called_once()
+    upload_result = mock_upload.call_args.args[0]
+    assert upload_result["analysis_summary"] == {"total_files": 1}
+    assert upload_result["danger"] == []
+    assert upload_result["quality"] == []
+    assert upload_result["secrets"] == []
+    assert "provenance_summary" in upload_result
+    assert mock_upload.call_args.kwargs == {
+        "is_forced": False,
+        "strict": False,
+        "quiet": True,
+    }
+    mock_print.assert_called_once()
+    printed_payload = json.loads(mock_print.call_args.args[0])
+    assert printed_payload["analysis_summary"] == {"total_files": 1}
+    assert printed_payload["danger"] == []
+    assert printed_payload["quality"] == []
+    assert printed_payload["secrets"] == []
+    assert "provenance_summary" in printed_payload
+
+
 def test_main_upload_gate_failed_does_not_exit_when_forced(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -661,7 +661,7 @@ def test_defend_command_json_upload_formats_once(tmp_path):
 
     assert exit_code == 0
     mock_json.assert_called_once()
-    mock_upload.assert_called_once_with(json_payload)
+    mock_upload.assert_called_once_with(json_payload, quiet=True)
     mock_print.assert_called_once_with(json_payload)
 
 

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -539,6 +539,29 @@ def test_cli_debt_json_outputs_snapshot_and_exits_zero(tmp_path, monkeypatch):
     assert payload["hotspots"][0]["file"] == "app/services.py"
 
 
+def test_cli_debt_json_upload_uses_quiet_mode(tmp_path, monkeypatch):
+    snapshot = _snapshot(str(tmp_path))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "debt", str(tmp_path), "--json", "--upload"],
+    )
+
+    with (
+        patch("skylos.debt.run_debt_analysis", return_value=snapshot),
+        patch("skylos.api.upload_debt_report", return_value={"success": True}) as mock_upload,
+        patch("builtins.print") as mock_print,
+        patch("skylos.cli.Console", return_value=Mock()),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    mock_upload.assert_called_once_with(snapshot, quiet=True)
+    payload = json.loads(mock_print.call_args.args[0])
+    assert payload["score"]["score_pct"] == 93
+
+
 def test_cli_debt_with_agent_includes_advisory_in_json(tmp_path, monkeypatch):
     snapshot = _snapshot(str(tmp_path))
     monkeypatch.setattr(

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -12,6 +12,10 @@ def _console_factory():
     return Console(file=io.StringIO(), force_terminal=False, color_system=None)
 
 
+def _noop_upload(*_args, **_kwargs):
+    return {"success": True}
+
+
 def _static_result(project_root: str) -> dict:
     return {
         "analysis_summary": {"total_files": 3, "total_loc": 120},
@@ -80,6 +84,9 @@ def test_suite_json_outputs_combined_sections(tmp_path, capsys):
             load_config_func=lambda _path: {},
             run_analyze_func=lambda *_args, **_kwargs: json.dumps(static_result),
             get_git_root_func=lambda: None,
+            upload_report_func=_noop_upload,
+            upload_defense_report_func=_noop_upload,
+            upload_debt_report_func=_noop_upload,
         )
 
     assert exit_code == 0
@@ -110,6 +117,9 @@ def test_suite_rejects_file_paths(tmp_path):
         load_config_func=lambda _path: {},
         run_analyze_func=lambda *_args, **_kwargs: "{}",
         get_git_root_func=lambda: None,
+        upload_report_func=_noop_upload,
+        upload_defense_report_func=_noop_upload,
+        upload_debt_report_func=_noop_upload,
     )
 
     assert exit_code == 1
@@ -138,3 +148,123 @@ def test_main_suite_subcommand_calls_run_suite_and_exits(monkeypatch):
     assert runner.call_args.kwargs["load_config_func"] is cli.load_config
     assert runner.call_args.kwargs["run_analyze_func"] is cli.run_analyze
     assert callable(runner.call_args.kwargs["get_git_root_func"])
+    assert callable(runner.call_args.kwargs["upload_report_func"])
+    assert callable(runner.call_args.kwargs["upload_defense_report_func"])
+    assert callable(runner.call_args.kwargs["upload_debt_report_func"])
+
+
+def test_suite_json_upload_passes_quiet_and_selected_categories(tmp_path, capsys):
+    static_result = _static_result(str(tmp_path))
+    static_upload = patch(
+        "skylos.commands.suite_cmd.run_suite",
+        return_value={
+            "static": static_result,
+            "debt": {
+                "score": {"score_pct": 82, "signal_count": 4},
+                "hotspots": [{"file": "app.py"}],
+                "summary": {},
+            },
+            "defense": {"summary": {"score_pct": 100}},
+            "provenance": {"enabled": False},
+            "summary": {
+                "static": {
+                    "dead_code": 1,
+                    "security": 1,
+                    "quality": 1,
+                    "secrets": 1,
+                }
+            },
+        },
+    )
+
+    with (
+        static_upload,
+        patch("skylos.commands.suite_cmd.format_suite_json", return_value='{"ok":true}'),
+    ):
+        uploaded = {}
+
+        def _upload_static(payload, **kwargs):
+            uploaded["static_payload"] = payload
+            uploaded["static_kwargs"] = kwargs
+            return {"success": True}
+
+        def _upload_defense(payload, **kwargs):
+            uploaded["defense_payload"] = payload
+            uploaded["defense_kwargs"] = kwargs
+            return {"success": True}
+
+        def _upload_debt(payload, **kwargs):
+            uploaded["debt_payload"] = payload
+            uploaded["debt_kwargs"] = kwargs
+            return {"success": True}
+
+        exit_code = run_suite_command(
+            [
+                str(tmp_path),
+                "--json",
+                "--upload",
+                "--families",
+                "static,debt",
+                "--static-categories",
+                "quality,dead_code",
+            ],
+            console_factory=_console_factory,
+            progress_factory=Progress,
+            parse_exclude_folders_func=lambda **kwargs: [],
+            load_config_func=lambda _path: {},
+            run_analyze_func=lambda *_args, **_kwargs: json.dumps(static_result),
+            get_git_root_func=lambda: None,
+            upload_report_func=_upload_static,
+            upload_defense_report_func=_upload_defense,
+            upload_debt_report_func=_upload_debt,
+        )
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.strip() == '{"ok":true}'
+    assert uploaded["static_kwargs"]["quiet"] is True
+    assert uploaded["debt_kwargs"]["quiet"] is True
+    assert uploaded["static_kwargs"]["scan_bundle_id"]
+    assert uploaded["debt_kwargs"]["scan_bundle_id"]
+    assert (
+        uploaded["static_kwargs"]["scan_bundle_id"]
+        == uploaded["debt_kwargs"]["scan_bundle_id"]
+    )
+    assert "defense_payload" not in uploaded
+    assert "danger" not in uploaded["static_payload"]
+    assert "quality" in uploaded["static_payload"]
+    assert "unused_functions" in uploaded["static_payload"]
+
+
+def test_suite_upload_exits_nonzero_when_static_quality_gate_fails(tmp_path):
+    static_result = _static_result(str(tmp_path))
+
+    with (
+        patch(
+            "skylos.commands.suite_cmd.run_suite",
+            return_value={
+                "static": static_result,
+                "debt": {"score": {}, "hotspots": [], "summary": {}},
+                "defense": {"summary": {"score_pct": 100}},
+                "provenance": {"enabled": False},
+                "summary": {"static": {}},
+            },
+        ),
+        patch("skylos.commands.suite_cmd.format_suite_table", return_value="suite"),
+    ):
+        exit_code = run_suite_command(
+            [str(tmp_path), "--upload", "--families", "static"],
+            console_factory=_console_factory,
+            progress_factory=Progress,
+            parse_exclude_folders_func=lambda **kwargs: [],
+            load_config_func=lambda _path: {},
+            run_analyze_func=lambda *_args, **_kwargs: json.dumps(static_result),
+            get_git_root_func=lambda: None,
+            upload_report_func=lambda *_args, **_kwargs: {
+                "success": True,
+                "quality_gate_passed": False,
+            },
+            upload_defense_report_func=_noop_upload,
+            upload_debt_report_func=_noop_upload,
+        )
+
+    assert exit_code == 1

--- a/test/test_upload_manifest.py
+++ b/test/test_upload_manifest.py
@@ -1,0 +1,63 @@
+import io
+
+from rich.console import Console
+
+from skylos.upload_manifest import (
+    build_code_scan_manifest,
+    build_debt_manifest,
+    print_upload_manifest,
+)
+
+
+def _render_manifest(*families, auto_upload=False, bundle_id=None):
+    output = io.StringIO()
+    console = Console(
+        file=output,
+        force_terminal=False,
+        color_system=None,
+        width=160,
+    )
+    print_upload_manifest(
+        console,
+        list(families),
+        auto_upload=auto_upload,
+        bundle_id=bundle_id,
+    )
+    return output.getvalue()
+
+
+def test_code_scan_manifest_lists_selected_categories_and_provenance():
+    manifest = build_code_scan_manifest(
+        ["dead_code", "danger", "quality"],
+        provenance_attached=True,
+    )
+
+    rendered = _render_manifest(manifest)
+
+    assert "Code Scan" in rendered
+    assert "security (danger)" in rendered
+    assert "quality" in rendered
+    assert "dead code" in rendered
+    assert "AI provenance attached to the code scan." in rendered
+    assert "technical debt" in rendered
+
+
+def test_manifest_renders_suite_bundle_note_when_bundle_id_present():
+    rendered = _render_manifest(
+        build_code_scan_manifest(["dead_code"], provenance_attached=False),
+        build_debt_manifest(),
+        bundle_id="bundle-123",
+    )
+
+    assert "Uploading 2 cloud scans." in rendered
+    assert "suite bundle" in rendered
+    assert "Bundle id: bundle-123" in rendered
+
+
+def test_manifest_marks_auto_upload_explicitly():
+    rendered = _render_manifest(
+        build_code_scan_manifest(["dead_code"], provenance_attached=False),
+        auto_upload=True,
+    )
+
+    assert "Auto-uploading 1 cloud scan." in rendered


### PR DESCRIPTION
## Summary
- make cloud upload families explicit in the Skylos CLI
- add upload manifests for code, defense, debt, and suite uploads
- add `skylos debt --upload` and `skylos suite --upload --families ... --static-categories ...`
- keep JSON upload paths machine-readable with quiet upload behavior
- fail suite uploads when the static cloud quality gate fails
- stop debt uploads from sending local project paths
- document the upload model and examples in the README

## Tests
- `pytest -q test/test_api.py test/test_suite.py test/test_upload_manifest.py`
- `pytest -q test/test_api.py test/test_cli.py test/test_debt.py test/test_suite.py test/test_cli_refactor_guardrails.py test/test_upload_manifest.py test/test_credits.py`