### PR TITLE
feat(languages): deepen js-ts reachability and entry discovery

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -110,6 +110,17 @@ _SECRET_CONFIG_SUFFIXES = {
     ".conf",
 }
 
+_TS_JS_SOURCE_EXTS = (
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
+)
+
 
 def _is_secret_config_candidate(path: Path) -> bool:
     name = path.name.lower()
@@ -214,8 +225,12 @@ class Skylos:
         ".go": "Go",
         ".ts": "TypeScript",
         ".tsx": "TypeScript",
+        ".mts": "TypeScript",
+        ".cts": "TypeScript",
         ".js": "JavaScript",
         ".jsx": "JavaScript",
+        ".mjs": "JavaScript",
+        ".cjs": "JavaScript",
         ".java": "Java",
     }
 
@@ -237,8 +252,20 @@ class Skylos:
             return [p], p.parent
 
         root = p
-        exts = {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".java"}
-        ext_list = ["py", "go", "ts", "tsx", "js", "jsx", "java"]
+        exts = {".py", ".go", *(_TS_JS_SOURCE_EXTS), ".java"}
+        ext_list = [
+            "py",
+            "go",
+            "ts",
+            "tsx",
+            "js",
+            "jsx",
+            "mts",
+            "cts",
+            "mjs",
+            "cjs",
+            "java",
+        ]
 
         # use rust file discovery when avail
         if _fast_discover is not None and os.path.isdir(str(p)):
@@ -315,7 +342,7 @@ class Skylos:
             all_exported_names.update(export_names)
 
         for def_name, def_obj in self.defs.items():
-            if str(def_obj.filename).endswith((".ts", ".tsx", ".js", ".jsx")):
+            if str(def_obj.filename).endswith(_TS_JS_SOURCE_EXTS):
                 continue
             if def_obj.simple_name in all_exported_names:
                 def_obj.is_exported = True
@@ -1492,7 +1519,7 @@ class Skylos:
                 if file_raw_imports:
                     if str(file).endswith(".py"):
                         all_raw_imports[file] = file_raw_imports
-                    elif str(file).endswith((".ts", ".tsx", ".js", ".jsx")):
+                    elif str(file).endswith(_TS_JS_SOURCE_EXTS):
                         ts_raw_imports[file] = file_raw_imports
 
                 if pattern_tracker_obj:
@@ -1510,9 +1537,7 @@ class Skylos:
                 for definition in defs:
                     if definition.type == "import":
                         key = f"{definition.filename}:{definition.name}"
-                    elif str(definition.filename).endswith(
-                        (".ts", ".tsx", ".js", ".jsx")
-                    ):
+                    elif str(definition.filename).endswith(_TS_JS_SOURCE_EXTS):
                         key = f"{definition.filename}:{definition.name}"
                     else:
                         key = definition.name
@@ -2140,7 +2165,7 @@ def proc_file(
 
     cfg = load_config(file)
 
-    if str(file).endswith((".ts", ".tsx", ".js", ".jsx")):
+    if str(file).endswith(_TS_JS_SOURCE_EXTS):
         out = scan_typescript_file(file, cfg)
         if isinstance(out, tuple) and len(out) < 13:
             return (*out, *([None] * (13 - len(out))))

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -3298,7 +3298,19 @@ def main() -> None:
                 import subprocess as _sp
                 from skylos.baseline import filter_new_findings, load_baseline
 
-                source_exts = {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".java"}
+                source_exts = {
+                    ".py",
+                    ".go",
+                    ".ts",
+                    ".tsx",
+                    ".js",
+                    ".jsx",
+                    ".mts",
+                    ".cts",
+                    ".mjs",
+                    ".cjs",
+                    ".java",
+                }
                 config_exts = {
                     ".yaml",
                     ".yml",

--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import fnmatch
+import glob
 import json
 import os
+import re
+import shlex
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
+from tree_sitter import Language, Parser
+import tree_sitter_typescript as tsts
 
 from skylos.file_discovery import should_exclude_path
 
@@ -24,17 +31,67 @@ from .resolve import (
 _NEXTJS_CONVENTION_EXPORTS = NEXTJS_CONVENTION_EXPORTS
 _NEXTJS_CONVENTION_FILES = NEXTJS_CONVENTION_FILES
 _is_nextjs_convention_file = is_nextjs_convention_file
-_TS_JS_EXTENSIONS = (".ts", ".tsx", ".js", ".jsx")
+_TS_JS_EXTENSIONS = (".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs")
 _TS_JS_ENTRY_SUFFIXES = (
     ".ts",
     ".tsx",
     ".js",
     ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
     "/index.ts",
     "/index.tsx",
     "/index.js",
     "/index.jsx",
+    "/index.mts",
+    "/index.cts",
+    "/index.mjs",
+    "/index.cjs",
 )
+_ENTRY_FILE_SUFFIXES = (
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
+)
+
+_PLAYWRIGHT_CONFIG_FILES = frozenset(
+    {
+        "playwright.config.ts",
+        "playwright.config.js",
+        "playwright.config.mts",
+        "playwright.config.mjs",
+    }
+)
+
+try:
+    _ENTRY_TS_LANG: Language | None = Language(tsts.language_typescript())
+except Exception:
+    _ENTRY_TS_LANG = None
+
+try:
+    _ENTRY_TSX_LANG: Language | None = Language(tsts.language_tsx())
+except Exception:
+    _ENTRY_TSX_LANG = None
+
+_ENTRY_PARSER_CACHE: dict[int, Parser] = {}
+_CONFIG_OBJECT_CALLS = frozenset({"defineConfig", "defineProject", "defineWorkspace"})
+_RUNNER_CONFIG_TOOLS = frozenset({"vite", "vitest", "playwright"})
+_STRING_FRAGMENT_TYPES = frozenset({"string_fragment", "escape_sequence"})
+
+
+@dataclass(frozen=True)
+class _TsEntryDiscovery:
+    file: str
+    kind: str
+    reason: str
+    scope: str
 
 
 def resolve_ts_module(source: str, importer: str, monorepo_resolver=None) -> str | None:
@@ -48,10 +105,30 @@ def resolve_ts_module(source: str, importer: str, monorepo_resolver=None) -> str
     candidates: list[str] = []
     if target.endswith(".js"):
         candidates.extend(
-            [target[:-3] + ".ts", target[:-3] + ".tsx", target, target[:-3] + ".jsx"]
+            [
+                target[:-3] + ".ts",
+                target[:-3] + ".tsx",
+                target[:-3] + ".mts",
+                target[:-3] + ".cts",
+                target,
+                target[:-3] + ".jsx",
+            ]
         )
     elif target.endswith(".jsx"):
         candidates.extend([target[:-4] + ".tsx", target[:-4] + ".js", target])
+    elif target.endswith((".mjs", ".cjs")):
+        base_no_ext = target.rsplit(".", 1)[0]
+        candidates.extend(
+            [
+                base_no_ext + ".mts",
+                base_no_ext + ".cts",
+                base_no_ext + ".ts",
+                base_no_ext + ".tsx",
+                base_no_ext + ".js",
+                base_no_ext + ".jsx",
+                target,
+            ]
+        )
     else:
         candidates.append(target)
 
@@ -73,6 +150,7 @@ def build_ts_import_graph(ts_raw_imports: dict, defs: dict, monorepo_resolver=No
     consumed_exports = defaultdict(set)
     wildcard_edges = defaultdict(set)
     importers_of = defaultdict(set)
+    consume_all_exports: set[str] = set()
 
     for importer_file, raw_imports in ts_raw_imports.items():
         for imp in raw_imports:
@@ -81,6 +159,8 @@ def build_ts_import_graph(ts_raw_imports: dict, defs: dict, monorepo_resolver=No
             )
             if resolved:
                 importers_of[resolved].add(str(importer_file))
+                if imp.get("consume_all_exports"):
+                    consume_all_exports.add(resolved)
                 for name in imp["names"]:
                     if name == "*":
                         wildcard_edges[str(importer_file)].add(resolved)
@@ -92,6 +172,13 @@ def build_ts_import_graph(ts_raw_imports: dict, defs: dict, monorepo_resolver=No
                     target_key = f"{resolved}:{name}"
                     if target_key in defs:
                         defs[target_key].references += 1
+
+    for resolved in consume_all_exports:
+        for defn in defs.values():
+            if str(defn.filename) != resolved or defn.type == "import":
+                continue
+            consumed_exports[resolved].add(defn.simple_name)
+            defn.references = max(defn.references, 1)
 
     _resolve_wildcard_consumed(consumed_exports, wildcard_edges, defs)
     _resolve_reexport_aliases(consumed_exports, ts_raw_imports, defs, monorepo_resolver)
@@ -240,10 +327,18 @@ _TEST_SUFFIXES = (
     ".test.tsx",
     ".test.js",
     ".test.jsx",
+    ".test.mts",
+    ".test.cts",
+    ".test.mjs",
+    ".test.cjs",
     ".spec.ts",
     ".spec.tsx",
     ".spec.js",
     ".spec.jsx",
+    ".spec.mts",
+    ".spec.cts",
+    ".spec.mjs",
+    ".spec.cjs",
 )
 
 _CONFIG_FILES = frozenset(
@@ -278,6 +373,10 @@ _CONFIG_FILES = frozenset(
         "vite.config.mts",
         "vite.config.js",
         "vite.config.mjs",
+        "playwright.config.ts",
+        "playwright.config.js",
+        "playwright.config.mts",
+        "playwright.config.mjs",
     }
 )
 
@@ -287,10 +386,26 @@ _TS_ENTRY_FILES = frozenset(
         "index.tsx",
         "index.js",
         "index.jsx",
+        "index.mts",
+        "index.cts",
+        "index.mjs",
+        "index.cjs",
         "main.ts",
         "main.tsx",
         "main.js",
         "main.jsx",
+        "main.mts",
+        "main.cts",
+        "main.mjs",
+        "main.cjs",
+        "cli.ts",
+        "cli.tsx",
+        "cli.js",
+        "cli.jsx",
+        "cli.mts",
+        "cli.cts",
+        "cli.mjs",
+        "cli.cjs",
     }
 )
 
@@ -314,6 +429,35 @@ def _is_ts_entry_or_infra(sf: str) -> bool:
     if basename in _CONFIG_FILES:
         return True
     return False
+
+
+def _is_ts_dev_or_test_root(sf: str) -> bool:
+    if sf.endswith(_TEST_SUFFIXES) or "/__tests__/" in sf:
+        return True
+    if "/test/" in sf or "/tests/" in sf:
+        return True
+    if "/bench/" in sf or "/benchmark/" in sf or "/benchmarks/" in sf:
+        return True
+    if sf.endswith(".d.ts"):
+        return True
+    if "/scripts/" in sf:
+        return True
+    basename = os.path.basename(sf)
+    if basename in _CONFIG_FILES or basename in _PLAYWRIGHT_CONFIG_FILES:
+        return True
+    return False
+
+
+def _classify_entry_scope(file_path: str, kind: str, reason: str) -> str:
+    if reason in {"package-entry", "package-script", "default-root"}:
+        if kind == "heuristic" and _is_ts_dev_or_test_root(file_path):
+            return "dev"
+        return "prod"
+    if reason.endswith("-config"):
+        return "dev"
+    if reason.startswith("vitest-") or reason.startswith("playwright-"):
+        return "dev"
+    return "prod"
 
 
 def _resolve_exclude_root(files, project_root: str | None) -> Path | None:
@@ -361,6 +505,522 @@ def _read_json_file(path: str) -> dict:
     except (json.JSONDecodeError, OSError):
         pass
     return {}
+
+
+def _entry_parser_for_path(path: str) -> Parser | None:
+    suffix = Path(path).suffix.lower()
+    lang = _ENTRY_TSX_LANG if suffix in {".js", ".jsx", ".tsx"} else _ENTRY_TS_LANG
+    if lang is None:
+        return None
+
+    lang_id = id(lang)
+    if lang_id not in _ENTRY_PARSER_CACHE:
+        _ENTRY_PARSER_CACHE[lang_id] = Parser(lang)
+    return _ENTRY_PARSER_CACHE[lang_id]
+
+
+def _load_entry_config_ast(path: str) -> tuple[bytes, object] | tuple[None, None]:
+    parser = _entry_parser_for_path(path)
+    if parser is None:
+        return None, None
+
+    try:
+        source = Path(path).read_bytes()
+    except OSError:
+        return None, None
+
+    tree = parser.parse(source)
+    return source, tree.root_node
+
+
+def _iter_ts_nodes(root_node):
+    stack = [root_node]
+    while stack:
+        node = stack.pop()
+        yield node
+        stack.extend(reversed(node.children))
+
+
+def _node_text(source: bytes, node) -> str:
+    return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _string_node_value(source: bytes, node) -> str | None:
+    if node is None or node.type != "string":
+        return None
+    parts = [
+        _node_text(source, child)
+        for child in node.children
+        if child.type in _STRING_FRAGMENT_TYPES
+    ]
+    if parts:
+        return "".join(parts)
+    text = _node_text(source, node)
+    return text.strip("'\"")
+
+
+def _pair_key_text(source: bytes, pair_node) -> str | None:
+    if pair_node.type != "pair" or len(pair_node.named_children) < 2:
+        return None
+    key_node = pair_node.named_children[0]
+    if key_node.type in {"property_identifier", "identifier"}:
+        return _node_text(source, key_node)
+    if key_node.type == "string":
+        return _string_node_value(source, key_node)
+    return None
+
+
+def _pair_value_node(pair_node):
+    if pair_node.type != "pair" or len(pair_node.named_children) < 2:
+        return None
+    return pair_node.named_children[1]
+
+
+def _iter_object_pairs(object_node):
+    if object_node is None or object_node.type != "object":
+        return
+    for child in object_node.children:
+        if child.type == "pair":
+            yield child
+
+
+def _find_config_root_objects(source: bytes, root_node) -> list:
+    objects: list = []
+    for node in _iter_ts_nodes(root_node):
+        if node.type != "call_expression":
+            continue
+        function_node = node.child_by_field_name("function")
+        if function_node is None:
+            continue
+        function_name = _node_text(source, function_node)
+        if function_name not in _CONFIG_OBJECT_CALLS:
+            continue
+        arguments = node.child_by_field_name("arguments")
+        if arguments is None:
+            continue
+        for child in arguments.named_children:
+            if child.type == "object":
+                objects.append(child)
+    if objects:
+        return objects
+
+    top_level_objects: list = []
+    for node in _iter_ts_nodes(root_node):
+        if node.type != "object":
+            continue
+        parent = node.parent
+        if parent is None or parent.type in {
+            "program",
+            "export_statement",
+            "assignment_expression",
+            "variable_declarator",
+            "parenthesized_expression",
+        }:
+            top_level_objects.append(node)
+    return top_level_objects
+
+
+def _find_object_path_values(source: bytes, objects: list, path: tuple[str, ...]) -> list:
+    current = list(objects)
+    for index, segment in enumerate(path):
+        next_nodes = []
+        for object_node in current:
+            if object_node.type != "object":
+                continue
+            for pair_node in _iter_object_pairs(object_node):
+                if _pair_key_text(source, pair_node) != segment:
+                    continue
+                value_node = _pair_value_node(pair_node)
+                if value_node is not None:
+                    next_nodes.append(value_node)
+        if not next_nodes:
+            return []
+        if index == len(path) - 1:
+            return next_nodes
+        current = [node for node in next_nodes if node.type == "object"]
+    return []
+
+
+def _collect_string_literals(source: bytes, node) -> list[str]:
+    values: list[str] = []
+    if node is None:
+        return values
+    if node.type == "string":
+        value = _string_node_value(source, node)
+        if value:
+            values.append(value)
+        return values
+    for child in node.named_children:
+        values.extend(_collect_string_literals(source, child))
+    return values
+
+
+def _resolve_relative_entry_file(base_dir: str, candidate: str, ts_files: set[str]) -> str | None:
+    resolved = _resolve_path_target(base_dir, candidate)
+    if not resolved:
+        return None
+    real_path = os.path.realpath(resolved)
+    if real_path in ts_files:
+        return real_path
+    return None
+
+
+def _expand_relative_entry_glob(base_dir: str, pattern: str, ts_files: set[str]) -> set[str]:
+    matches: set[str] = set()
+    for candidate in glob.glob(os.path.join(base_dir, pattern), recursive=True):
+        real_path = os.path.realpath(candidate)
+        if real_path in ts_files:
+            matches.add(real_path)
+    return matches
+
+
+def _resolve_config_root_base(source: bytes, objects: list, default_base_dir: str) -> str:
+    root_values = _find_object_path_values(source, objects, ("root",))
+    for node in root_values:
+        for value in _collect_string_literals(source, node):
+            if os.path.isabs(value):
+                return os.path.normpath(value)
+            return os.path.normpath(os.path.join(default_base_dir, value))
+    return default_base_dir
+
+
+def _literal_entries_from_nodes(
+    source: bytes,
+    nodes: list,
+    base_dir: str,
+    ts_files: set[str],
+    allow_glob: bool = False,
+) -> set[str]:
+    matches: set[str] = set()
+    for node in nodes:
+        for literal in _collect_string_literals(source, node):
+            if not literal:
+                continue
+            if allow_glob and any(char in literal for char in "*?[]"):
+                matches.update(_expand_relative_entry_glob(base_dir, literal, ts_files))
+                continue
+            resolved = _resolve_relative_entry_file(base_dir, literal, ts_files)
+            if resolved:
+                matches.add(resolved)
+    return matches
+
+
+def _discover_vite_config_entries(
+    config_path: str, ts_files: set[str], default_base_dir: str
+) -> set[str]:
+    source, root_node = _load_entry_config_ast(config_path)
+    if source is None or root_node is None:
+        return set()
+
+    objects = _find_config_root_objects(source, root_node)
+    if not objects:
+        return set()
+
+    base_dir = _resolve_config_root_base(source, objects, default_base_dir)
+
+    matches: set[str] = set()
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("build", "lib", "entry")),
+            base_dir,
+            ts_files,
+        )
+    )
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("build", "rollupOptions", "input")),
+            base_dir,
+            ts_files,
+        )
+    )
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("optimizeDeps", "entries")),
+            base_dir,
+            ts_files,
+            allow_glob=True,
+        )
+    )
+    return matches
+
+
+def _discover_vitest_config_entries(
+    config_path: str, ts_files: set[str], default_base_dir: str
+) -> set[str]:
+    source, root_node = _load_entry_config_ast(config_path)
+    if source is None or root_node is None:
+        return set()
+
+    objects = _find_config_root_objects(source, root_node)
+    if not objects:
+        return set()
+
+    base_dir = _resolve_config_root_base(source, objects, default_base_dir)
+
+    matches: set[str] = set()
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("test", "include")),
+            base_dir,
+            ts_files,
+            allow_glob=True,
+        )
+    )
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("test", "setupFiles")),
+            base_dir,
+            ts_files,
+        )
+    )
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("test", "globalSetup")),
+            base_dir,
+            ts_files,
+        )
+    )
+    return matches
+
+
+def _discover_playwright_config_entries(config_path: str, ts_files: set[str]) -> set[str]:
+    source, root_node = _load_entry_config_ast(config_path)
+    if source is None or root_node is None:
+        return set()
+
+    objects = _find_config_root_objects(source, root_node)
+    if not objects:
+        return set()
+
+    config_dir = os.path.dirname(config_path)
+    test_dir = config_dir
+    test_dir_values = _find_object_path_values(source, objects, ("testDir",))
+    for node in test_dir_values:
+        literals = _collect_string_literals(source, node)
+        if literals:
+            test_dir = os.path.normpath(os.path.join(config_dir, literals[0]))
+            break
+
+    matches: set[str] = {
+        real_path
+        for real_path in ts_files
+        if os.path.commonpath([real_path, os.path.realpath(test_dir)]) == os.path.realpath(test_dir)
+    }
+
+    pattern_values = _find_object_path_values(source, objects, ("testMatch",))
+    if pattern_values:
+        filtered: set[str] = set()
+        patterns: list[str] = []
+        for node in pattern_values:
+            patterns.extend(_collect_string_literals(source, node))
+        for real_path in matches:
+            relative = os.path.relpath(real_path, os.path.realpath(test_dir)).replace(os.sep, "/")
+            if any(fnmatch.fnmatch(relative, pattern) or fnmatch.fnmatch(os.path.basename(relative), pattern) for pattern in patterns):
+                filtered.add(real_path)
+        matches = filtered
+
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("globalSetup",)),
+            config_dir,
+            ts_files,
+        )
+    )
+    matches.update(
+        _literal_entries_from_nodes(
+            source,
+            _find_object_path_values(source, objects, ("globalTeardown",)),
+            config_dir,
+            ts_files,
+        )
+    )
+    return matches
+
+
+def _infer_script_tool(tokens: list[str]) -> str | None:
+    for token in tokens:
+        base = os.path.basename(token)
+        if base in _RUNNER_CONFIG_TOOLS:
+            return base
+    return None
+
+
+def _token_file_candidate(package_root: str, token: str) -> str | None:
+    if not token or token.startswith("-"):
+        return None
+    cleaned = token.strip().strip("'\"")
+    if not cleaned or cleaned.startswith("$") or "://" in cleaned:
+        return None
+
+    normalized = cleaned.split("?", 1)[0].split("#", 1)[0]
+    if os.path.isabs(normalized):
+        candidate = os.path.normpath(normalized)
+    else:
+        candidate = os.path.normpath(os.path.join(package_root, normalized))
+    if os.path.isfile(candidate):
+        return candidate
+    return None
+
+
+def _discover_script_entry_candidates(
+    package_root: str,
+) -> tuple[set[str], dict[str, tuple[str, str]]]:
+    data = _read_json_file(os.path.join(package_root, "package.json"))
+    scripts = data.get("scripts")
+    if not isinstance(scripts, dict):
+        return set(), {}
+
+    direct_files: set[str] = set()
+    config_files: dict[str, tuple[str, str]] = {}
+
+    for command in scripts.values():
+        if not isinstance(command, str):
+            continue
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            tokens = command.split()
+        if not tokens:
+            continue
+
+        tool = _infer_script_tool(tokens)
+        for index, token in enumerate(tokens):
+            config_path: str | None = None
+            if token in {"--config", "-c"} and index + 1 < len(tokens):
+                config_path = _token_file_candidate(package_root, tokens[index + 1])
+            elif token.startswith("--config="):
+                config_path = _token_file_candidate(
+                    package_root, token.split("=", 1)[1]
+                )
+            if config_path:
+                config_files[os.path.realpath(config_path)] = (
+                    tool or "vite",
+                    package_root,
+                )
+
+            file_candidate = _token_file_candidate(package_root, token)
+            if not file_candidate:
+                continue
+            if Path(file_candidate).suffix.lower() in _ENTRY_FILE_SUFFIXES:
+                direct_files.add(os.path.realpath(file_candidate))
+
+    return direct_files, config_files
+
+
+def _iter_entry_discoveries(
+    ts_files: set[str],
+    project_root: str | None = None,
+    workspace_inventory=None,
+    exclude_folders=None,
+) -> list[_TsEntryDiscovery]:
+    discoveries: list[_TsEntryDiscovery] = []
+
+    for tf in sorted(ts_files):
+        if os.path.basename(tf) in _TS_ENTRY_FILES or _is_ts_entry_or_infra(tf):
+            reason = "default-root"
+            discoveries.append(
+                _TsEntryDiscovery(
+                    tf,
+                    "heuristic",
+                    reason,
+                    _classify_entry_scope(tf, "heuristic", reason),
+                )
+            )
+
+    if not project_root or workspace_inventory is None:
+        return discoveries
+
+    package_roots = set(_workspace_package_roots(workspace_inventory))
+    package_roots.update(
+        _discover_referenced_package_roots(
+            list(ts_files),
+            project_root,
+            workspace_inventory,
+            exclude_folders=exclude_folders,
+        )
+    )
+
+    custom_config_tools: dict[str, tuple[str, str]] = {}
+    for package_root in package_roots:
+        for entry_file in _discover_package_entry_files(str(package_root)):
+            if entry_file in ts_files:
+                reason = "package-entry"
+                discoveries.append(
+                    _TsEntryDiscovery(
+                        entry_file,
+                        "package",
+                        reason,
+                        _classify_entry_scope(entry_file, "package", reason),
+                    )
+                )
+
+        script_entries, script_configs = _discover_script_entry_candidates(str(package_root))
+        for entry_file in script_entries:
+            if entry_file in ts_files:
+                reason = "package-script"
+                discoveries.append(
+                    _TsEntryDiscovery(
+                        entry_file,
+                        "script",
+                        reason,
+                        _classify_entry_scope(entry_file, "script", reason),
+                    )
+                )
+        custom_config_tools.update(script_configs)
+
+    default_configs: dict[str, tuple[str, str]] = {}
+    for package_root in package_roots:
+        for config_name in _PLAYWRIGHT_CONFIG_FILES | _CONFIG_FILES:
+            candidate = os.path.join(str(package_root), config_name)
+            if os.path.isfile(candidate):
+                default_configs[os.path.realpath(candidate)] = (
+                    "playwright"
+                    if os.path.basename(candidate) in _PLAYWRIGHT_CONFIG_FILES
+                    else ("vitest" if "vitest" in os.path.basename(candidate) else "vite"),
+                    str(package_root),
+                )
+
+    config_tools = {**default_configs, **custom_config_tools}
+    for config_path, (tool, base_dir) in config_tools.items():
+        if config_path in ts_files:
+            reason = f"{tool}-config"
+            discoveries.append(
+                _TsEntryDiscovery(
+                    config_path,
+                    "config",
+                    reason,
+                    _classify_entry_scope(config_path, "config", reason),
+                )
+            )
+        if tool == "vitest":
+            entry_files = _discover_vitest_config_entries(
+                config_path, ts_files, base_dir
+            )
+        elif tool == "playwright":
+            entry_files = _discover_playwright_config_entries(config_path, ts_files)
+        else:
+            entry_files = _discover_vite_config_entries(
+                config_path, ts_files, base_dir
+            )
+        for entry_file in sorted(entry_files):
+            reason = f"{tool}-derived-root"
+            discoveries.append(
+                _TsEntryDiscovery(
+                    entry_file,
+                    "config",
+                    reason,
+                    _classify_entry_scope(entry_file, "config", reason),
+                )
+            )
+
+    return discoveries
 
 
 def _iter_package_entry_targets(entry):
@@ -480,6 +1140,7 @@ def _discover_ts_reachability_entry_files(
     project_root: str | None = None,
     workspace_inventory=None,
     exclude_folders=None,
+    include_dev_roots: bool = True,
 ) -> set[str]:
     exclude_root = _resolve_exclude_root(files, project_root)
     ts_files = {
@@ -491,29 +1152,18 @@ def _discover_ts_reachability_entry_files(
     if not ts_files:
         return set()
 
-    entry_files = {
-        tf
-        for tf in ts_files
-        if os.path.basename(tf) in _TS_ENTRY_FILES or _is_ts_entry_or_infra(tf)
-    }
-
-    if not project_root or workspace_inventory is None:
-        return entry_files
-
-    package_roots = set(_workspace_package_roots(workspace_inventory))
-    package_roots.update(
-        _discover_referenced_package_roots(
-            files,
-            project_root,
-            workspace_inventory,
-            exclude_folders=exclude_folders,
-        )
+    discoveries = _iter_entry_discoveries(
+        ts_files,
+        project_root=project_root,
+        workspace_inventory=workspace_inventory,
+        exclude_folders=exclude_folders,
     )
-
-    for package_root in package_roots:
-        entry_files.update(_discover_package_entry_files(str(package_root)))
-
-    return entry_files & ts_files
+    return {
+        discovery.file
+        for discovery in discoveries
+        if discovery.file in ts_files
+        and (include_dev_roots or discovery.scope == "prod")
+    }
 
 
 def _is_ts_reachability_root(path: str, entry_files: set[str]) -> bool:
@@ -609,6 +1259,7 @@ def find_unused_ts_exports(
         project_root=project_root,
         workspace_inventory=workspace_inventory,
         exclude_folders=exclude_folders,
+        include_dev_roots=False,
     )
 
     api_surface = set()

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import glob
+import os
 from pathlib import Path
 
 from tree_sitter import Language, Parser, Query, QueryCursor
@@ -93,6 +95,11 @@ _IMPORTS_PATTERN = """
 (import_clause (identifier) @import_name)
 (import_clause (namespace_import (identifier) @import_name))
 """
+
+_RAW_IMPORT_FILE_EXTENSIONS = frozenset(
+    {".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"}
+)
+_DYNAMIC_GLOB_METHODS = frozenset({"glob", "globEager"})
 
 
 def _get_query(lang: Language, key: str, pattern: str) -> Query | None:
@@ -348,6 +355,7 @@ class TypeScriptCore:
 
     def _scan_raw_imports(self) -> None:
         self.raw_imports: list[dict] = []
+        self._raw_import_seen: set[tuple[str, int, bool]] = set()
         c = self._defs_captures
 
         for src_node in c.get("import_src", []):
@@ -375,6 +383,8 @@ class TypeScriptCore:
                         "line": src_node.start_point[0] + 1,
                     }
                 )
+
+        self._scan_dynamic_raw_imports()
 
     def _extract_import_names_from_stmt(self, import_stmt) -> list[str]:
         names = []
@@ -421,6 +431,139 @@ class TypeScriptCore:
                 else:
                     names.append("*")
         return names if names else ["*"]
+
+    def _iter_nodes(self, root_node):
+        stack = [root_node]
+        while stack:
+            node = stack.pop()
+            yield node
+            stack.extend(reversed(node.children))
+
+    def _string_literal_value(self, node) -> str | None:
+        if node is None or node.type != "string":
+            return None
+        return self._get_text(node).strip("'\"")
+
+    def _append_raw_import(
+        self, source_path: str, line: int, consume_all_exports: bool = False
+    ) -> None:
+        key = (source_path, line, consume_all_exports)
+        if key in self._raw_import_seen:
+            return
+        self._raw_import_seen.add(key)
+        self.raw_imports.append(
+            {
+                "source": source_path,
+                "names": ["*"],
+                "line": line,
+                "consume_all_exports": consume_all_exports,
+            }
+        )
+
+    def _relative_source_for_match(self, matched_path: str) -> str:
+        relative = os.path.relpath(matched_path, os.path.dirname(self.file_path))
+        normalized = relative.replace(os.sep, "/")
+        if normalized.startswith("."):
+            return normalized
+        return f"./{normalized}"
+
+    def _string_sources_from_node(self, node) -> list[str]:
+        if node is None:
+            return []
+        if node.type == "string":
+            value = self._string_literal_value(node)
+            return [value] if value else []
+        if node.type == "array":
+            sources: list[str] = []
+            for child in node.named_children:
+                value = self._string_literal_value(child)
+                if value:
+                    sources.append(value)
+            return sources
+        return []
+
+    def _glob_import_sources(self, node) -> list[str]:
+        matches: list[str] = []
+        for pattern in self._string_sources_from_node(node):
+            if not pattern:
+                continue
+            if os.path.isabs(pattern):
+                full_pattern = pattern
+            else:
+                full_pattern = os.path.join(os.path.dirname(self.file_path), pattern)
+            for matched in glob.glob(full_pattern, recursive=True):
+                if not os.path.isfile(matched):
+                    continue
+                if Path(matched).suffix.lower() not in _RAW_IMPORT_FILE_EXTENSIONS:
+                    continue
+                matches.append(
+                    self._relative_source_for_match(os.path.realpath(matched))
+                )
+        return matches
+
+    def _scan_dynamic_raw_imports(self) -> None:
+        if not self.root_node:
+            return
+
+        for node in self._iter_nodes(self.root_node):
+            if node.type != "call_expression":
+                continue
+
+            function_node = node.child_by_field_name("function")
+            arguments_node = node.child_by_field_name("arguments")
+            if function_node is None or arguments_node is None:
+                continue
+            if not arguments_node.named_children:
+                continue
+
+            first_arg = arguments_node.named_children[0]
+            line = node.start_point[0] + 1
+
+            if function_node.type == "import":
+                for source_path in self._string_sources_from_node(first_arg):
+                    self._append_raw_import(
+                        source_path, line, consume_all_exports=True
+                    )
+                continue
+
+            if function_node.type != "member_expression":
+                continue
+
+            object_node = function_node.child_by_field_name("object")
+            property_node = function_node.child_by_field_name("property")
+            if object_node is None or property_node is None:
+                continue
+
+            property_name = self._get_text(property_node)
+
+            if (
+                object_node.type == "identifier"
+                and self._get_text(object_node) == "require"
+                and property_name == "resolve"
+            ):
+                for source_path in self._string_sources_from_node(first_arg):
+                    self._append_raw_import(
+                        source_path, line, consume_all_exports=True
+                    )
+                continue
+
+            if object_node.type != "meta_property":
+                continue
+            if self._get_text(object_node) != "import.meta":
+                continue
+
+            if property_name == "resolve":
+                for source_path in self._string_sources_from_node(first_arg):
+                    self._append_raw_import(
+                        source_path, line, consume_all_exports=True
+                    )
+                continue
+
+            if property_name in _DYNAMIC_GLOB_METHODS:
+                for source_path in self._glob_import_sources(first_arg):
+                    self._append_raw_import(
+                        source_path, line, consume_all_exports=True
+                    )
 
     def _build_call_graph(self) -> None:
         self.call_pairs: list[tuple[str, str]] = []

--- a/skylos/visitors/languages/typescript/resolve.py
+++ b/skylos/visitors/languages/typescript/resolve.py
@@ -15,10 +15,18 @@ _SOURCE_FILE_SUFFIXES = (
     ".tsx",
     ".js",
     ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
     "/index.ts",
     "/index.tsx",
     "/index.js",
     "/index.jsx",
+    "/index.mts",
+    "/index.cts",
+    "/index.mjs",
+    "/index.cjs",
 )
 
 
@@ -257,6 +265,8 @@ def _candidate_package_targets(target: str) -> list[str]:
             [
                 base_target[:-3] + ".ts",
                 base_target[:-3] + ".tsx",
+                base_target[:-3] + ".mts",
+                base_target[:-3] + ".cts",
                 base_target[:-3] + ".jsx",
             ]
         )
@@ -264,7 +274,16 @@ def _candidate_package_targets(target: str) -> list[str]:
         candidates.extend([base_target[:-4] + ".tsx", base_target[:-4] + ".js"])
     elif base_target.endswith(".mjs") or base_target.endswith(".cjs"):
         base_no_ext = base_target.rsplit(".", 1)[0]
-        candidates.extend([base_no_ext + ".ts", base_no_ext + ".js"])
+        candidates.extend(
+            [
+                base_no_ext + ".mts",
+                base_no_ext + ".cts",
+                base_no_ext + ".ts",
+                base_no_ext + ".tsx",
+                base_no_ext + ".js",
+                base_no_ext + ".jsx",
+            ]
+        )
 
     ordered: list[str] = []
     seen: set[str] = set()
@@ -404,10 +423,18 @@ def _resolve_from_pkg_dir(pkg_dir: str, subpath: str | None = None) -> str | Non
         "src/index.tsx",
         "src/index.js",
         "src/index.jsx",
+        "src/index.mts",
+        "src/index.cts",
+        "src/index.mjs",
+        "src/index.cjs",
         "index.ts",
         "index.tsx",
         "index.js",
         "index.jsx",
+        "index.mts",
+        "index.cts",
+        "index.mjs",
+        "index.cjs",
     ):
         candidate = os.path.join(pkg_dir, entry)
         if os.path.isfile(candidate):

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -192,7 +192,19 @@ class TestSkylos:
 
         mock_discover.assert_called_once_with(
             mock_dir,
-            {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".java"},
+            {
+                ".py",
+                ".go",
+                ".ts",
+                ".tsx",
+                ".js",
+                ".jsx",
+                ".mts",
+                ".cts",
+                ".mjs",
+                ".cjs",
+                ".java",
+            },
             exclude_folders=None,
         )
         assert files == mock_files
@@ -451,7 +463,7 @@ class TestAnalyze:
             (root / "main.py").write_text(
                 "def hello():\n    return 1\n", encoding="utf-8"
             )
-            (root / "app.js").write_text(
+            (root / "app.mjs").write_text(
                 "export function runUnsafe(input) {\n"
                 "  eval(input);\n"
                 "}\n"
@@ -473,6 +485,22 @@ class TestAnalyze:
     @patch("skylos.analyzer.scan_typescript_file")
     def test_proc_file_dispatches_js_to_typescript_scanner(self, mock_scan):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+            f.write("export function run() { return 1; }\n")
+            f.flush()
+
+            mock_scan.return_value = tuple(range(13))
+
+            try:
+                result = proc_file(f.name, "test_module")
+            finally:
+                Path(f.name).unlink()
+
+        mock_scan.assert_called_once()
+        assert result == tuple(range(13))
+
+    @patch("skylos.analyzer.scan_typescript_file")
+    def test_proc_file_dispatches_mjs_to_typescript_scanner(self, mock_scan):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
             f.write("export function run() { return 1; }\n")
             f.flush()
 

--- a/test/test_ts_exports.py
+++ b/test/test_ts_exports.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from skylos.visitor import Definition
+from skylos.visitors.languages.typescript import scan_typescript_file
 from skylos.visitors.languages.typescript.workspace import (
     discover_workspace_inventory,
 )
@@ -21,6 +22,10 @@ def _make_def(name, typ, filename, line=1, exported=False):
     d = Definition(name, typ, filename, line)
     d.is_exported = exported
     return d
+
+
+def _scan_raw_imports(*paths: Path) -> dict[str, list[dict]]:
+    return {str(path): scan_typescript_file(str(path))[12] for path in paths}
 
 
 # ---------- Aliased import consumption ----------
@@ -349,6 +354,27 @@ class TestTypeScriptDeadFiles:
         dead_files = find_dead_ts_files(files, [], importers_of, {})
         assert dead_files == []
 
+    def test_main_mjs_is_treated_as_entrypoint(self, tmp_path):
+        main_file = tmp_path / "src" / "main.mjs"
+        helper_file = tmp_path / "src" / "helper.mjs"
+
+        helper_file.parent.mkdir(parents=True, exist_ok=True)
+        main_file.write_text("import './helper.mjs';\n", encoding="utf-8")
+        helper_file.write_text("export const helper = true;\n", encoding="utf-8")
+
+        _, wildcard_edges, importers_of = build_ts_import_graph(
+            _scan_raw_imports(main_file, helper_file),
+            {},
+        )
+        dead_files = find_dead_ts_files(
+            [main_file, helper_file],
+            [],
+            importers_of,
+            wildcard_edges,
+        )
+
+        assert dead_files == []
+
     def test_nextjs_special_files_are_treated_as_entrypoints(self, tmp_path):
         template_file = tmp_path / "app" / "template.tsx"
         global_not_found_file = tmp_path / "app" / "global-not-found.tsx"
@@ -436,6 +462,240 @@ class TestTypeScriptDeadFiles:
 
         assert dead_files == []
 
+    def test_package_json_script_entrypoint_keeps_cli_graph_live(self, tmp_path):
+        cli_file = tmp_path / "src" / "cli.ts"
+        helper_file = tmp_path / "src" / "helpers.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root","scripts":{"dev":"tsx src/cli.ts"}}',
+            encoding="utf-8",
+        )
+        cli_file.parent.mkdir(parents=True, exist_ok=True)
+        cli_file.write_text("import './helpers';\n", encoding="utf-8")
+        helper_file.write_text("export const helper = () => 1;\n", encoding="utf-8")
+
+        inventory = discover_workspace_inventory(tmp_path)
+        dead_files = find_dead_ts_files(
+            [cli_file, helper_file],
+            [],
+            {str(helper_file): {str(cli_file)}},
+            {},
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert dead_files == []
+
+    def test_vite_config_lib_entries_keep_nonstandard_entries_live(self, tmp_path):
+        lib_entry = tmp_path / "src" / "library-entry.ts"
+        worker_entry = tmp_path / "src" / "worker-entry.ts"
+        helper_file = tmp_path / "src" / "helpers.ts"
+        vite_config = tmp_path / "vite.config.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root"}',
+            encoding="utf-8",
+        )
+        lib_entry.parent.mkdir(parents=True, exist_ok=True)
+        vite_config.write_text(
+            """
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        library: "src/library-entry.ts",
+        worker: "src/worker-entry.ts",
+      },
+    },
+  },
+});
+""",
+            encoding="utf-8",
+        )
+        lib_entry.write_text("import './helpers';\n", encoding="utf-8")
+        worker_entry.write_text("export const worker = true;\n", encoding="utf-8")
+        helper_file.write_text("export const helper = () => 1;\n", encoding="utf-8")
+
+        inventory = discover_workspace_inventory(tmp_path)
+        dead_files = find_dead_ts_files(
+            [vite_config, lib_entry, worker_entry, helper_file],
+            [],
+            {str(helper_file): {str(lib_entry)}},
+            {},
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert dead_files == []
+
+    def test_vitest_custom_config_include_keeps_matching_file_live(self, tmp_path):
+        vitest_config = tmp_path / "tooling" / "vitest.workspace.ts"
+        check_file = tmp_path / "checks" / "login.ts"
+        helper_file = tmp_path / "src" / "support.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root","scripts":{"test":"vitest --config tooling/vitest.workspace.ts"}}',
+            encoding="utf-8",
+        )
+        vitest_config.parent.mkdir(parents=True, exist_ok=True)
+        check_file.parent.mkdir(parents=True, exist_ok=True)
+        helper_file.parent.mkdir(parents=True, exist_ok=True)
+
+        vitest_config.write_text(
+            """
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["checks/**/*.ts"],
+  },
+});
+""",
+            encoding="utf-8",
+        )
+        check_file.write_text("import '../src/support';\n", encoding="utf-8")
+        helper_file.write_text("export const support = true;\n", encoding="utf-8")
+
+        inventory = discover_workspace_inventory(tmp_path)
+        dead_files = find_dead_ts_files(
+            [vitest_config, check_file, helper_file],
+            [],
+            {str(helper_file): {str(check_file)}},
+            {},
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert dead_files == []
+
+    def test_playwright_custom_config_testdir_keeps_matching_file_live(self, tmp_path):
+        playwright_config = tmp_path / "tooling" / "playwright.e2e.ts"
+        test_file = tmp_path / "browser" / "login.ts"
+        helper_file = tmp_path / "src" / "driver.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root","scripts":{"e2e":"playwright test --config tooling/playwright.e2e.ts"}}',
+            encoding="utf-8",
+        )
+        playwright_config.parent.mkdir(parents=True, exist_ok=True)
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        helper_file.parent.mkdir(parents=True, exist_ok=True)
+
+        playwright_config.write_text(
+            """
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "../browser",
+});
+""",
+            encoding="utf-8",
+        )
+        test_file.write_text("import '../src/driver';\n", encoding="utf-8")
+        helper_file.write_text("export const driver = true;\n", encoding="utf-8")
+
+        inventory = discover_workspace_inventory(tmp_path)
+        dead_files = find_dead_ts_files(
+            [playwright_config, test_file, helper_file],
+            [],
+            {str(helper_file): {str(test_file)}},
+            {},
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert dead_files == []
+
+    def test_dynamic_import_keeps_module_graph_live(self, tmp_path):
+        app_file = tmp_path / "src" / "main.ts"
+        feature_file = tmp_path / "src" / "feature.ts"
+        helper_file = tmp_path / "src" / "helper.ts"
+
+        helper_file.parent.mkdir(parents=True, exist_ok=True)
+        app_file.write_text("async function load() { await import('./feature'); }\n", encoding="utf-8")
+        feature_file.write_text("import './helper';\nexport const feature = true;\n", encoding="utf-8")
+        helper_file.write_text("export const helper = true;\n", encoding="utf-8")
+
+        _, wildcard_edges, importers_of = build_ts_import_graph(
+            _scan_raw_imports(app_file, feature_file, helper_file),
+            {},
+        )
+        dead_files = find_dead_ts_files(
+            [app_file, feature_file, helper_file],
+            [],
+            importers_of,
+            wildcard_edges,
+        )
+
+        assert dead_files == []
+
+    def test_require_resolve_keeps_module_live(self, tmp_path):
+        app_file = tmp_path / "src" / "main.ts"
+        feature_file = tmp_path / "src" / "feature.ts"
+
+        feature_file.parent.mkdir(parents=True, exist_ok=True)
+        app_file.write_text("const target = require.resolve('./feature');\n", encoding="utf-8")
+        feature_file.write_text("export const feature = true;\n", encoding="utf-8")
+
+        _, wildcard_edges, importers_of = build_ts_import_graph(
+            _scan_raw_imports(app_file, feature_file),
+            {},
+        )
+        dead_files = find_dead_ts_files(
+            [app_file, feature_file],
+            [],
+            importers_of,
+            wildcard_edges,
+        )
+
+        assert dead_files == []
+
+    def test_import_meta_resolve_keeps_module_live(self, tmp_path):
+        app_file = tmp_path / "src" / "main.ts"
+        feature_file = tmp_path / "src" / "feature.ts"
+
+        feature_file.parent.mkdir(parents=True, exist_ok=True)
+        app_file.write_text("const target = import.meta.resolve('./feature');\n", encoding="utf-8")
+        feature_file.write_text("export const feature = true;\n", encoding="utf-8")
+
+        _, wildcard_edges, importers_of = build_ts_import_graph(
+            _scan_raw_imports(app_file, feature_file),
+            {},
+        )
+        dead_files = find_dead_ts_files(
+            [app_file, feature_file],
+            [],
+            importers_of,
+            wildcard_edges,
+        )
+
+        assert dead_files == []
+
+    def test_import_meta_glob_keeps_matched_routes_live(self, tmp_path):
+        app_file = tmp_path / "src" / "main.ts"
+        route_file = tmp_path / "src" / "routes" / "index.ts"
+        helper_file = tmp_path / "src" / "routes" / "helper.ts"
+
+        route_file.parent.mkdir(parents=True, exist_ok=True)
+        app_file.write_text("const routes = import.meta.glob('./routes/**/*.ts');\n", encoding="utf-8")
+        route_file.write_text("import './helper';\nexport const route = true;\n", encoding="utf-8")
+        helper_file.write_text("export const helper = true;\n", encoding="utf-8")
+
+        _, wildcard_edges, importers_of = build_ts_import_graph(
+            _scan_raw_imports(app_file, route_file, helper_file),
+            {},
+        )
+        dead_files = find_dead_ts_files(
+            [app_file, route_file, helper_file],
+            [],
+            importers_of,
+            wildcard_edges,
+        )
+
+        assert dead_files == []
+
 
 class TestTypeScriptUnusedExports:
     def test_package_json_entrypoint_export_is_not_flagged(self, tmp_path):
@@ -467,3 +727,192 @@ class TestTypeScriptUnusedExports:
         )
 
         assert findings == []
+
+    def test_package_json_script_entry_export_is_not_flagged(self, tmp_path):
+        cli_file = tmp_path / "src" / "cli.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root","scripts":{"dev":"tsx src/cli.ts"}}',
+            encoding="utf-8",
+        )
+        cli_file.parent.mkdir(parents=True, exist_ok=True)
+        cli_file.write_text("export function run() { return true; }\n", encoding="utf-8")
+
+        inventory = discover_workspace_inventory(tmp_path)
+        defn = _make_def("run", "function", str(cli_file), exported=True)
+        defn.references = 1
+        defn.is_exported = False
+
+        findings = find_unused_ts_exports(
+            [defn],
+            {},
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert findings == []
+
+    def test_default_cli_mts_export_is_not_flagged(self, tmp_path):
+        cli_file = tmp_path / "src" / "cli.mts"
+
+        cli_file.parent.mkdir(parents=True, exist_ok=True)
+        cli_file.write_text(
+            "export function runCli() { return true; }\n", encoding="utf-8"
+        )
+
+        defn = _make_def("runCli", "function", str(cli_file), exported=True)
+        defn.references = 1
+        defn.is_exported = False
+
+        findings = find_unused_ts_exports(
+            [defn],
+            {},
+            files=[str(cli_file)],
+        )
+
+        assert findings == []
+
+    def test_vite_config_entry_export_is_not_flagged(self, tmp_path):
+        vite_config = tmp_path / "vite.config.ts"
+        entry_file = tmp_path / "src" / "library-entry.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root"}',
+            encoding="utf-8",
+        )
+        entry_file.parent.mkdir(parents=True, exist_ok=True)
+        vite_config.write_text(
+            """
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "src/library-entry.ts",
+    },
+  },
+});
+""",
+            encoding="utf-8",
+        )
+        entry_file.write_text(
+            "export function buildLibrary() { return true; }\n",
+            encoding="utf-8",
+        )
+
+        inventory = discover_workspace_inventory(tmp_path)
+        defn = _make_def("buildLibrary", "function", str(entry_file), exported=True)
+        defn.references = 1
+        defn.is_exported = False
+
+        findings = find_unused_ts_exports(
+            [defn],
+            {},
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert findings == []
+
+    def test_vitest_root_export_is_still_flagged_as_dev_only(self, tmp_path):
+        vitest_config = tmp_path / "tooling" / "vitest.workspace.ts"
+        check_file = tmp_path / "checks" / "login.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root","scripts":{"test":"vitest --config tooling/vitest.workspace.ts"}}',
+            encoding="utf-8",
+        )
+        vitest_config.parent.mkdir(parents=True, exist_ok=True)
+        check_file.parent.mkdir(parents=True, exist_ok=True)
+        vitest_config.write_text(
+            """
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["checks/**/*.ts"],
+  },
+});
+""",
+            encoding="utf-8",
+        )
+        check_file.write_text(
+            "export function runCheck() { return true; }\n", encoding="utf-8"
+        )
+
+        inventory = discover_workspace_inventory(tmp_path)
+        defn = _make_def("runCheck", "function", str(check_file), exported=True)
+        defn.references = 1
+        defn.is_exported = False
+
+        findings = find_unused_ts_exports(
+            [defn],
+            {},
+            files=[str(vitest_config), str(check_file)],
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert len(findings) == 1
+        assert findings[0]["name"] == "runCheck"
+
+    def test_playwright_root_export_is_still_flagged_as_dev_only(self, tmp_path):
+        playwright_config = tmp_path / "tooling" / "playwright.e2e.ts"
+        test_file = tmp_path / "browser" / "login.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root","scripts":{"e2e":"playwright test --config tooling/playwright.e2e.ts"}}',
+            encoding="utf-8",
+        )
+        playwright_config.parent.mkdir(parents=True, exist_ok=True)
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        playwright_config.write_text(
+            """
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "../browser",
+});
+""",
+            encoding="utf-8",
+        )
+        test_file.write_text(
+            "export function runBrowserTest() { return true; }\n",
+            encoding="utf-8",
+        )
+
+        inventory = discover_workspace_inventory(tmp_path)
+        defn = _make_def(
+            "runBrowserTest", "function", str(test_file), exported=True
+        )
+        defn.references = 1
+        defn.is_exported = False
+
+        findings = find_unused_ts_exports(
+            [defn],
+            {},
+            files=[str(playwright_config), str(test_file)],
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert len(findings) == 1
+        assert findings[0]["name"] == "runBrowserTest"
+
+    def test_dynamic_import_consumes_all_exports_for_unused_export_detection(self, tmp_path):
+        app_file = tmp_path / "src" / "main.ts"
+        feature_file = tmp_path / "src" / "feature.ts"
+
+        feature_file.parent.mkdir(parents=True, exist_ok=True)
+        app_file.write_text("async function load() { await import('./feature'); }\n", encoding="utf-8")
+        feature_file.write_text("export function renderFeature() { return true; }\n", encoding="utf-8")
+
+        defn = _make_def("renderFeature", "function", str(feature_file), exported=True)
+        defs = {f"{feature_file}:renderFeature": defn}
+
+        consumed, _, _ = build_ts_import_graph(
+            _scan_raw_imports(app_file, feature_file),
+            defs,
+        )
+
+        assert "renderFeature" in consumed[str(feature_file)]

--- a/test/test_typescript_resolve.py
+++ b/test/test_typescript_resolve.py
@@ -156,6 +156,42 @@ def test_build_ts_import_graph_resolves_extensionless_js_imports(tmp_path):
     assert importers_of[str(helper_file)] == {str(app_file)}
 
 
+def test_build_ts_import_graph_resolves_extensionless_mts_imports(tmp_path):
+    app_file = tmp_path / "src" / "app.mts"
+    helper_file = tmp_path / "src" / "helper.mts"
+
+    _write(app_file, "import { helper } from './helper';\nhelper();\n")
+    _write(helper_file, "export function helper() { return 1; }\n")
+
+    defs = {f"{helper_file}:helper": _make_def("helper", str(helper_file))}
+    ts_raw_imports = {
+        str(app_file): [{"source": "./helper", "names": ["helper"], "line": 1}]
+    }
+
+    consumed, _, importers_of = build_ts_import_graph(ts_raw_imports, defs)
+
+    assert consumed[str(helper_file)] == {"helper"}
+    assert importers_of[str(helper_file)] == {str(app_file)}
+
+
+def test_build_ts_import_graph_resolves_mjs_import_to_mts_source(tmp_path):
+    app_file = tmp_path / "src" / "app.mts"
+    helper_file = tmp_path / "src" / "helper.mts"
+
+    _write(app_file, "import { helper } from './helper.mjs';\nhelper();\n")
+    _write(helper_file, "export function helper() { return 1; }\n")
+
+    defs = {f"{helper_file}:helper": _make_def("helper", str(helper_file))}
+    ts_raw_imports = {
+        str(app_file): [{"source": "./helper.mjs", "names": ["helper"], "line": 1}]
+    }
+
+    consumed, _, importers_of = build_ts_import_graph(ts_raw_imports, defs)
+
+    assert consumed[str(helper_file)] == {"helper"}
+    assert importers_of[str(helper_file)] == {str(app_file)}
+
+
 def test_package_local_tsconfig_paths_override_root_in_monorepo(tmp_path):
     app_dir = tmp_path / "packages" / "app"
     importer = app_dir / "src" / "index.ts"
@@ -193,6 +229,35 @@ def test_package_local_tsconfig_paths_override_root_in_monorepo(tmp_path):
 
     assert resolver.resolve("@app/components/Button", str(importer)) == str(
         local_target
+    )
+
+
+def test_workspace_package_exports_mjs_target_resolves_to_mts_source(tmp_path):
+    ui_dir = tmp_path / "packages" / "ui"
+    app_file = tmp_path / "packages" / "app" / "src" / "index.ts"
+
+    _write(
+        tmp_path / "package.json",
+        json.dumps({"name": "@workspace/root", "workspaces": ["packages/*"]}),
+    )
+    _write(
+        ui_dir / "package.json",
+        json.dumps(
+            {
+                "name": "@workspace/ui",
+                "exports": {
+                    ".": "./dist/index.mjs",
+                },
+            }
+        ),
+    )
+    _write(ui_dir / "src" / "index.mts", 'export const Button = () => "button";')
+    _write(app_file, "export const main = 1;\n")
+
+    resolver = MonorepoResolver(str(tmp_path))
+
+    assert resolver.resolve("@workspace/ui", str(app_file)) == str(
+        ui_dir / "src" / "index.mts"
     )
 
 


### PR DESCRIPTION
 ## Summary
  - deepen JS/TS reachability by adding entry discovery from `package.json` scripts and package entry fields
  - parse Vite, Vitest, and Playwright config files to derive real entry roots
  - add dynamic graph edges for `import()`, `require.resolve()`, `import.meta.resolve()`, and `import.meta.glob()`
  - add default-root support for `cli` and `mts/cts/mjs/cjs` participation across reachability, resolution, analyzer discovery, and CLI filtering
  - separate production API roots from dev or test roots so Vitest and Playwright entries keep files live without suppressing real unused export results

## Testing
  - `pytest -q test/test_ts_exports.py test/test_typescript_resolve.py test/test_analyzer.py`
  - `pytest -q test/test_ts_exports.py test/test_typescript_workspace.py test/test_typescript_resolve.py test/test_typescript_framework.py test/test_typescript_expanded.pytest/test_typescript.py test/test_analyzer.py test/test_ts_danger_nextjs.py test/test_discover_typescript.py test/test_defend_typescript.py`

## Manual Smoke
  - ran `skylos.cli --json` against a temp Vite-style repo
