### PR TITLE
feat(languages): harden java canonical path guard checks

### DIFF
--- a/skylos/visitors/languages/java/danger.py
+++ b/skylos/visitors/languages/java/danger.py
@@ -147,6 +147,9 @@ _REQUEST_INLINE_SOURCE_PATTERN = re.compile(
 )
 
 _CONTROL_FLOW_HINTS = ("throw ", "return", "continue", "break")
+_STARTSWITH_CALL_PATTERN = re.compile(
+    r"(?P<receiver>[A-Za-z_][\w.()]+)\.startsWith\s*\((?P<arg>[^)]*)\)"
+)
 
 _SECRET_PREFIXES = (
     "sk-",
@@ -257,23 +260,87 @@ def _guard_without_braces_contains_sink(
     return False
 
 
+def _collect_canonical_string_vars(lines: list[str]) -> tuple[set[str], set[str]]:
+    canonical_vars: set[str] = set()
+    slash_terminated_vars: set[str] = set()
+
+    for line in lines:
+        match = _LOCAL_ALIAS_PATTERN.match(line)
+        if not match:
+            continue
+        var = match.group("var")
+        expr = match.group("expr")
+        if "getCanonicalPath(" not in expr:
+            continue
+        canonical_vars.add(var)
+        if _expr_is_slash_terminated_base(expr):
+            slash_terminated_vars.add(var)
+
+    return canonical_vars, slash_terminated_vars
+
+
+def _expr_is_slash_terminated_base(expr: str) -> bool:
+    return any(
+        token in expr
+        for token in (
+            "File.separator",
+            "java.io.File.separator",
+            '"/"',
+            '"\\\\"',
+            "separatorChar",
+        )
+    )
+
+
+def _line_has_safe_startswith_guard(
+    line: str, canonical_vars: set[str], slash_terminated_vars: set[str]
+) -> bool:
+    for match in _STARTSWITH_CALL_PATTERN.finditer(line):
+        receiver = match.group("receiver").strip()
+        arg = match.group("arg").strip()
+        receiver_is_canonical_string = (
+            receiver in canonical_vars or "getCanonicalPath()" in receiver
+        )
+        arg_is_canonical_string = arg in canonical_vars or "getCanonicalPath()" in arg
+
+        if receiver_is_canonical_string and arg_is_canonical_string:
+            if arg in slash_terminated_vars or _expr_is_slash_terminated_base(arg):
+                return True
+            continue
+
+        return True
+
+    return False
+
+
 def _has_named_path_guard(
     lines: list[str], names: set[str], hints: tuple[str, ...], sink_idx: int
 ) -> bool:
     has_normalize = False
+    canonical_vars, slash_terminated_vars = _collect_canonical_string_vars(lines)
+    known_guard_vars = canonical_vars | slash_terminated_vars
 
     for idx, line in enumerate(lines):
         mentioned = _names_in_line(line, names)
-        if not mentioned:
+        startswith_line = "startsWith(" in line or "starts_with(" in line
+        if not mentioned and not (
+            has_normalize
+            and startswith_line
+            and _line_mentions_names(line, known_guard_vars)
+        ):
             continue
         if any(hint in line for hint in hints):
             has_normalize = True
         if (
             has_normalize
             and "if" in line
-            and ("startsWith(" in line or "starts_with(" in line)
+            and startswith_line
             and ("!" in line or "== false" in line or "false ==" in line)
         ):
+            if not _line_has_safe_startswith_guard(
+                line, canonical_vars, slash_terminated_vars
+            ):
+                continue
             trailing = "\n".join(lines[idx : min(len(lines), idx + 4)])
             if any(token in trailing for token in _CONTROL_FLOW_HINTS):
                 return True
@@ -281,10 +348,13 @@ def _has_named_path_guard(
             idx <= sink_idx
             and has_normalize
             and "if" in line
-            and ("startsWith(" in line or "starts_with(" in line)
+            and startswith_line
             and "!" not in line
             and "== false" not in line
             and "false ==" not in line
+            and _line_has_safe_startswith_guard(
+                line, canonical_vars, slash_terminated_vars
+            )
             and (
                 _guard_block_contains_sink(lines, idx, sink_idx)
                 or _guard_without_braces_contains_sink(lines, idx, sink_idx)

--- a/test/test_java_security.py
+++ b/test/test_java_security.py
@@ -98,6 +98,58 @@ class App {
     assert "SKY-D215" not in _rule_ids(findings)
 
 
+def test_archive_extraction_canonical_string_prefix_without_separator_still_flags(
+    tmp_path,
+):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import java.util.zip.*;
+
+class App {
+  void unzip(ZipInputStream zis, File destDir) throws Exception {
+    ZipEntry entry;
+    while ((entry = zis.getNextEntry()) != null) {
+      File file = new File(destDir, entry.getName());
+      String targetPath = file.getCanonicalPath();
+      String basePath = destDir.getCanonicalPath();
+      if (!targetPath.startsWith(basePath)) {
+        throw new IOException("bad zip");
+      }
+      FileOutputStream fos = new FileOutputStream(file);
+    }
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_archive_extraction_canonical_string_prefix_with_separator_is_safe(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import java.util.zip.*;
+
+class App {
+  void unzip(ZipInputStream zis, File destDir) throws Exception {
+    ZipEntry entry;
+    while ((entry = zis.getNextEntry()) != null) {
+      File file = new File(destDir, entry.getName());
+      String targetPath = file.getCanonicalPath();
+      String basePath = destDir.getCanonicalPath() + File.separator;
+      if (!targetPath.startsWith(basePath)) {
+        throw new IOException("bad zip");
+      }
+      FileOutputStream fos = new FileOutputStream(file);
+    }
+  }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
 def test_archive_extraction_mixed_safe_and_unsafe_still_flags(tmp_path):
     findings = _scan_java(
         tmp_path,
@@ -214,6 +266,52 @@ class App {
       throw new IllegalArgumentException("bad path");
     }
     return Files.readString(target);
+  }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_request_path_canonical_string_prefix_without_separator_still_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.HttpServletRequest;
+
+class App {
+  String read(HttpServletRequest request) throws Exception {
+    File base = new File("/srv/data");
+    File target = new File(base, request.getParameter("file"));
+    String targetPath = target.getCanonicalPath();
+    String basePath = base.getCanonicalPath();
+    if (!targetPath.startsWith(basePath)) {
+      throw new IllegalArgumentException("bad path");
+    }
+    return new BufferedReader(new FileReader(target)).readLine();
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_request_path_canonical_string_prefix_with_separator_is_safe(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.HttpServletRequest;
+
+class App {
+  String read(HttpServletRequest request) throws Exception {
+    File base = new File("/srv/data");
+    File target = new File(base, request.getParameter("file"));
+    String targetPath = target.getCanonicalPath();
+    String basePath = base.getCanonicalPath() + File.separator;
+    if (!targetPath.startsWith(basePath)) {
+      throw new IllegalArgumentException("bad path");
+    }
+    return new BufferedReader(new FileReader(target)).readLine();
   }
 }
 """,


### PR DESCRIPTION
## Summary
  - harden Java path and archive traversal guard handling around canonical string prefix checks
  - stop treating `getCanonicalPath().startsWith(basePath)` as safe when the base path is not
  slash-terminated
  - keep safe `Path.startsWith(...)` flows and slash-terminated canonical string guards accepted
  - apply the strict guard logic to both request-controlled filesystem access and archive
  extraction

## Testing
  - `pytest -q test/test_java_security.py`
  - `pytest -q test/test_java_security.py test/test_security_taskflow.py test/test_security_verifier.py test/test_mcp_security.py test/test_provenance_security.py test/test_path_traversal.py`

  ## Manual Smoke
  - ran `skylos.cli --danger --json` against a temp Java repo with one unsafe and one safe
  canonical-prefix handler
  - confirmed the unsafe handler was flagged with `SKY-D215`
  - confirmed the slash-terminated safe handler was not flagged