### PR TITLE
feat(languages): add php foundation support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
     "tree-sitter-typescript>=0.23.2",
     "tree-sitter-go>=0.23.0",
     "tree-sitter-java>=0.23.0",
+    "tree-sitter-php>=0.24.1",
     "pyyaml",
     "networkx",
     "pyperclip",

--- a/skylos/agent_center.py
+++ b/skylos/agent_center.py
@@ -34,7 +34,7 @@ from skylos.agent_payload import (
 
 STATE_DIR = ".skylos"
 STATE_FILE = "agent_state.json"
-SUPPORTED_EXTENSIONS = {".py", ".go", ".ts", ".tsx", ".js", ".jsx"}
+SUPPORTED_EXTENSIONS = {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".php"}
 
 
 def run_analyze(*args, **kwargs):

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -21,6 +21,7 @@ from skylos.constants import AUTO_CALLED, MARKREFS_TICK_DEFAULT
 
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.visitors.test_aware import TestAwareVisitor
+from skylos.visitors.languages.php import scan_php_file
 from skylos.visitors.languages.typescript import scan_typescript_file
 from skylos.visitors.languages.typescript.analysis import (
     build_ts_import_graph,
@@ -120,6 +121,7 @@ _TS_JS_SOURCE_EXTS = (
     ".mjs",
     ".cjs",
 )
+_PHP_SOURCE_EXTS = (".php",)
 
 
 def _is_secret_config_candidate(path: Path) -> bool:
@@ -232,6 +234,7 @@ class Skylos:
         ".mjs": "JavaScript",
         ".cjs": "JavaScript",
         ".java": "Java",
+        ".php": "PHP",
     }
 
     def _count_languages(self, files) -> dict[str, int]:
@@ -252,7 +255,7 @@ class Skylos:
             return [p], p.parent
 
         root = p
-        exts = {".py", ".go", *(_TS_JS_SOURCE_EXTS), ".java"}
+        exts = {".py", ".go", *(_TS_JS_SOURCE_EXTS), ".java", *(_PHP_SOURCE_EXTS)}
         ext_list = [
             "py",
             "go",
@@ -265,6 +268,7 @@ class Skylos:
             "mjs",
             "cjs",
             "java",
+            "php",
         ]
 
         # use rust file discovery when avail
@@ -2179,6 +2183,12 @@ def proc_file(
 
     if str(file).endswith(".java"):
         out = scan_java_file(file, cfg)
+        if isinstance(out, tuple) and len(out) < 13:
+            return (*out, *([None] * (13 - len(out))))
+        return out[:13]
+
+    if str(file).endswith(".php"):
+        out = scan_php_file(file, cfg)
         if isinstance(out, tuple) and len(out) < 13:
             return (*out, *([None] * (13 - len(out))))
         return out[:13]

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2256,7 +2256,7 @@ def _rules_validate(console, path_str):
 
 def _build_main_parser():
     parser = argparse.ArgumentParser(
-        description="Find dead code, secrets, and risky flows in Python, TypeScript, and Go",
+        description="Find dead code, secrets, and risky flows in Python, JS/TS, Go, Java, and PHP",
         epilog="""
 Run 'skylos commands' for a full list of all available commands.
 Run 'skylos tour' for a guided walkthrough of capabilities.
@@ -3310,6 +3310,7 @@ def main() -> None:
                     ".mjs",
                     ".cjs",
                     ".java",
+                    ".php",
                 }
                 config_exts = {
                     ".yaml",

--- a/skylos/cli_shared.py
+++ b/skylos/cli_shared.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 def get_git_changed_files(root_path):
-    supported_exts = {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".java"}
+    supported_exts = {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".java", ".php"}
 
     def _collect_supported(output, repo_root):
         files = []

--- a/skylos/grader.py
+++ b/skylos/grader.py
@@ -60,6 +60,7 @@ _COMMENT_PREFIXES: dict[str, str] = {
     ".go": "//",
     ".js": "//",
     ".jsx": "//",
+    ".php": "//",
 }
 
 

--- a/skylos/grep_verify.py
+++ b/skylos/grep_verify.py
@@ -42,6 +42,7 @@ _PYTHON_EXTS = {".py", ".pyi"}
 _TS_EXTS = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"}
 _GO_EXTS = {".go"}
 _JAVA_EXTS = {".java"}
+_PHP_EXTS = {".php"}
 _RUST_EXTS = {".rs"}
 
 _ALL_SOURCE_GLOBS = [
@@ -55,6 +56,7 @@ _ALL_SOURCE_GLOBS = [
     "*.cjs",
     "*.go",
     "*.java",
+    "*.php",
     "*.rs",
     "*.rst",
     "*.md",
@@ -71,6 +73,7 @@ _LANG_GLOBS: dict[str, list[str]] = {
     "typescript": ["*.ts", "*.tsx", "*.js", "*.jsx", "*.mjs", "*.cjs"],
     "go": ["*.go"],
     "java": ["*.java"],
+    "php": ["*.php"],
     "rust": ["*.rs"],
 }
 
@@ -85,6 +88,8 @@ def detect_language(file_path: str) -> str:
         return "go"
     if ext in _JAVA_EXTS:
         return "java"
+    if ext in _PHP_EXTS:
+        return "php"
     if ext in _RUST_EXTS:
         return "rust"
     return "python"
@@ -240,6 +245,17 @@ def module_candidates(file_path: str, project_root: str | Path) -> list[str]:
                 break
         return [".".join(parts)] if parts else []
 
+    elif lang == "php":
+        if not rel.endswith(".php"):
+            return []
+        stem = rel[:-4]
+        parts = [p for p in stem.split("/") if p]
+        if not parts:
+            return []
+        if parts[0] in {"src", "app", "lib"} and len(parts) > 1:
+            parts = parts[1:]
+        return list(dict.fromkeys(["/".join(parts), ".".join(parts)]))
+
     elif lang == "rust":
         if not rel.endswith(".rs"):
             return []
@@ -316,6 +332,17 @@ def is_definition_line(grep_line: str, finding: dict) -> bool:
         f"private void {simple_name}",
         f"public void {simple_name}",
         f"protected void {simple_name}",
+        # PHP
+        f"function {simple_name}",
+        f"class {simple_name}",
+        f"interface {simple_name}",
+        f"trait {simple_name}",
+        f"private function {simple_name}",
+        f"public function {simple_name}",
+        f"protected function {simple_name}",
+        f"private ${simple_name}",
+        f"public ${simple_name}",
+        f"protected ${simple_name}",
         # Rust
         f"fn {simple_name}",
         f"pub fn {simple_name}",
@@ -446,6 +473,20 @@ def _deterministic_suppress_java(finding: dict) -> bool:
     return False
 
 
+def _deterministic_suppress_php(finding: dict) -> bool:
+    simple_name = finding.get("simple_name", finding.get("name", ""))
+    file_path = str(finding.get("file", "")).lower()
+
+    if simple_name in {"__construct", "__destruct", "__invoke", "__toString"}:
+        return True
+
+    if "/tests/" in file_path or file_path.endswith("test.php"):
+        if simple_name.startswith("test") or simple_name in {"setUp", "tearDown"}:
+            return True
+
+    return False
+
+
 def _deterministic_suppress_rust(finding: dict) -> bool:
     simple_name = finding.get("simple_name", finding.get("name", ""))
     decorators = finding.get("decorators", [])
@@ -472,6 +513,8 @@ def _deterministic_suppress_multilang(finding: dict) -> bool:
         return _deterministic_suppress_go(finding)
     elif lang == "java":
         return _deterministic_suppress_java(finding)
+    elif lang == "php":
+        return _deterministic_suppress_php(finding)
     elif lang == "rust":
         return _deterministic_suppress_rust(finding)
     return False

--- a/skylos/llm/cleanup_orchestrator.py
+++ b/skylos/llm/cleanup_orchestrator.py
@@ -32,7 +32,7 @@ SKIP_DIRS = {
     ".coverage",
 }
 
-CODE_EXTENSIONS = {".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".java"}
+CODE_EXTENSIONS = {".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".java", ".php"}
 
 MAX_FILE_SIZE = 100_000  # bytes
 MAX_FILE_LINES = 2000

--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -41,6 +41,7 @@ ALLOWED_FILE_SUFFIXES = (
     ".js",
     ".jsx",
     ".go",
+    ".php",
 )
 
 PROVIDER_PATTERNS = [

--- a/skylos/visitors/languages/php/__init__.py
+++ b/skylos/visitors/languages/php/__init__.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .core import PhpCore
+from .danger import scan_danger
+
+
+class DummyVisitor:
+    def __init__(
+        self,
+        *,
+        is_test_file: bool = False,
+        test_decorated_lines: set[int] | None = None,
+    ) -> None:
+        self.is_test_file = is_test_file
+        self.test_decorated_lines = test_decorated_lines or set()
+        self.dataclass_fields: set[str] = set()
+        self.pydantic_models: set[str] = set()
+        self.class_defs: dict = {}
+        self.first_read_lineno: dict = {}
+        self.framework_decorated_lines: set[int] = set()
+        self.detected_frameworks: set[str] = set()
+
+
+def scan_php_file(file_path: str, config: dict | None = None) -> tuple:
+    if config is None:
+        config = {}
+
+    try:
+        path = Path(file_path)
+        if path.suffix.lower() != ".php":
+            raise ValueError("unsupported PHP path")
+        source = path.read_bytes()
+    except Exception:
+        return (
+            [],
+            [],
+            set(),
+            set(),
+            DummyVisitor(),
+            DummyVisitor(),
+            [],
+            [],
+            [],
+            None,
+            None,
+            config,
+            [],
+        )
+
+    core = PhpCore(str(path), source)
+    core.scan()
+
+    visitor = DummyVisitor(
+        is_test_file=core.is_test_file,
+        test_decorated_lines=core.test_decorated_lines,
+    )
+    findings = scan_danger(core.root_node, str(path), source)
+
+    return (
+        core.defs,
+        core.refs,
+        set(),
+        set(),
+        visitor,
+        DummyVisitor(),
+        [],
+        findings,
+        [],
+        None,
+        None,
+        config,
+        core.raw_imports,
+    )
+
+
+__all__ = ["scan_php_file"]

--- a/skylos/visitors/languages/php/core.py
+++ b/skylos/visitors/languages/php/core.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tree_sitter import Language, Parser
+try:
+    import tree_sitter_php as tsphp
+except ImportError:
+    tsphp = None
+
+from skylos.visitor import Definition
+
+try:
+    PHP_LANG: Language | None = (
+        Language(tsphp.language_php()) if tsphp is not None else None
+    )
+except Exception:
+    PHP_LANG = None
+
+_PARSER_CACHE: dict[int, Parser] = {}
+
+_MAGIC_METHODS = {
+    "__construct",
+    "__destruct",
+    "__invoke",
+    "__toString",
+    "__get",
+    "__set",
+    "__isset",
+    "__unset",
+    "__sleep",
+    "__wakeup",
+    "__serialize",
+    "__unserialize",
+    "__call",
+    "__callStatic",
+    "__clone",
+    "__debugInfo",
+}
+
+_PHPUNIT_LIFECYCLE = {
+    "setUp",
+    "tearDown",
+    "setUpBeforeClass",
+    "tearDownAfterClass",
+}
+
+_IMPORT_EXPR_TYPES = {
+    "include_expression",
+    "include_once_expression",
+    "require_expression",
+    "require_once_expression",
+}
+
+
+def _get_parser(lang: Language) -> Parser:
+    lang_id = id(lang)
+    if lang_id not in _PARSER_CACHE:
+        _PARSER_CACHE[lang_id] = Parser(lang)
+    return _PARSER_CACHE[lang_id]
+
+
+def _is_test_path(file_path: str | Path) -> bool:
+    lower = str(file_path).lower().replace("\\", "/")
+    return "/tests/" in lower or lower.endswith("test.php") or lower.endswith("tests.php")
+
+
+class PhpCore:
+    def __init__(self, file_path: str, source_bytes: bytes) -> None:
+        self.file_path: str = file_path
+        self.source: bytes = source_bytes
+        self.defs: list[Definition] = []
+        self.refs: list[tuple[str, str]] = []
+        self.imports: list[dict[str, str | int]] = []
+        self.raw_imports: list[dict[str, object]] = []
+        self.call_pairs: list[tuple[str, str]] = []
+        self.test_decorated_lines: set[int] = set()
+        self.lang: Language | None = PHP_LANG
+        self.is_test_file = _is_test_path(file_path)
+        self._seen_refs: set[tuple[str, int]] = set()
+
+        if self.lang:
+            self.parser = _get_parser(self.lang)
+            self.tree = self.parser.parse(source_bytes)
+            self.root_node = self.tree.root_node
+        else:
+            self.tree = None
+            self.root_node = None
+
+    def _get_text(self, node) -> str:
+        return self.source[node.start_byte : node.end_byte].decode("utf-8", "ignore")
+
+    def _children_of_type(self, node, type_name: str) -> list:
+        return [child for child in node.children if child.type == type_name]
+
+    def _child_by_type(self, node, type_name: str):
+        for child in node.children:
+            if child.type == type_name:
+                return child
+        return None
+
+    def _node_name_text(self, node) -> str:
+        if node is None:
+            return ""
+        text = self._get_text(node).strip()
+        if node.type == "variable_name":
+            return text.lstrip("$")
+        return text
+
+    def _qualified_symbol(self, name: str, namespace: str) -> str:
+        return f"{namespace}.{name}" if namespace else name
+
+    def _visibility(self, node, *, default_public: bool = True) -> str:
+        for child in node.children:
+            if child.type == "visibility_modifier":
+                return self._get_text(child).strip()
+        return "public" if default_public else ""
+
+    def _is_publicish(self, node, *, default_public: bool = True) -> bool:
+        return self._visibility(node, default_public=default_public) in {
+            "public",
+            "protected",
+        }
+
+    def _is_magic_or_test_entrypoint(
+        self, method_name: str, class_bases: list[str], line: int
+    ) -> bool:
+        if method_name in _MAGIC_METHODS or method_name in _PHPUNIT_LIFECYCLE:
+            self.test_decorated_lines.add(line)
+            return True
+        if self.is_test_file and method_name.startswith("test"):
+            self.test_decorated_lines.add(line)
+            return True
+        if any(base.endswith("TestCase") for base in class_bases):
+            if method_name.startswith("test") or method_name in _PHPUNIT_LIFECYCLE:
+                self.test_decorated_lines.add(line)
+                return True
+        return False
+
+    def _add_ref(
+        self, name: str, start_byte: int, *, current_callable: str | None
+    ) -> None:
+        if not name:
+            return
+        simple = name.split("\\")[-1].split(".")[-1].lstrip("$")
+        if not simple:
+            return
+        if current_callable and simple == current_callable.split(".")[-1]:
+            return
+        key = (simple, start_byte)
+        if key in self._seen_refs:
+            return
+        self._seen_refs.add(key)
+        self.refs.append((simple, self.file_path))
+        if current_callable:
+            self.call_pairs.append((current_callable, simple))
+
+    def _extract_literal_path(self, node) -> str | None:
+        if node is None:
+            return None
+        if node.type == "string":
+            return self._get_text(node).strip("\"'")
+        if node.type == "parenthesized_expression":
+            for child in node.children:
+                if child.type not in {"(", ")"}:
+                    return self._extract_literal_path(child)
+            return None
+        if node.type == "binary_expression":
+            parts = []
+            for child in node.children:
+                if child.type == ".":
+                    continue
+                child_value = self._extract_literal_path(child)
+                if child_value is None:
+                    return None
+                parts.append(child_value)
+            return "".join(parts)
+        if node.type == "magic_constant" and self._get_text(node).strip() == "__DIR__":
+            return "__DIR__/"
+        return None
+
+    def scan(self) -> None:
+        if not self.root_node:
+            return
+        self._scan_block(
+            self.root_node,
+            namespace="",
+            current_class=None,
+            current_callable=None,
+            class_bases=[],
+        )
+        self._build_call_graph()
+
+    def _scan_block(
+        self,
+        node,
+        *,
+        namespace: str,
+        current_class: str | None,
+        current_callable: str | None,
+        class_bases: list[str],
+    ) -> None:
+        active_namespace = namespace
+        for child in node.children:
+            if child.type == "namespace_definition":
+                ns_node = self._child_by_type(child, "namespace_name")
+                active_namespace = self._node_name_text(ns_node).replace("\\", ".")
+                continue
+
+            if child.type in {
+                "class_declaration",
+                "interface_declaration",
+                "trait_declaration",
+            }:
+                self._scan_class_like(child, namespace=active_namespace)
+                continue
+
+            if child.type == "function_definition":
+                self._scan_function(child, namespace=active_namespace)
+                continue
+
+            if child.type == "namespace_use_declaration":
+                self._scan_use_imports(child)
+                continue
+
+            if child.type in _IMPORT_EXPR_TYPES:
+                self._scan_include_import(child)
+
+            self._scan_refs_in_node(child, current_callable=current_callable)
+            self._scan_block(
+                child,
+                namespace=active_namespace,
+                current_class=current_class,
+                current_callable=current_callable,
+                class_bases=class_bases,
+            )
+
+    def _scan_class_like(self, node, *, namespace: str) -> None:
+        name_node = self._child_by_type(node, "name")
+        class_name = self._node_name_text(name_node)
+        if not class_name:
+            return
+        qualified = self._qualified_symbol(class_name, namespace)
+        line = name_node.start_point[0] + 1 if name_node else node.start_point[0] + 1
+        class_def = Definition(qualified, "class", self.file_path, line)
+
+        bases: list[str] = []
+        for base_clause in self._children_of_type(node, "base_clause"):
+            for child in base_clause.children:
+                if child.type in {"name", "qualified_name"}:
+                    base_name = self._node_name_text(child).replace("\\", ".")
+                    bases.append(base_name)
+                    self._add_ref(base_name, child.start_byte, current_callable=None)
+        for iface_clause in self._children_of_type(node, "class_interface_clause"):
+            for child in iface_clause.children:
+                if child.type in {"name", "qualified_name"}:
+                    iface_name = self._node_name_text(child).replace("\\", ".")
+                    bases.append(iface_name)
+                    self._add_ref(iface_name, child.start_byte, current_callable=None)
+
+        class_def.base_classes = bases
+        self.defs.append(class_def)
+
+        declaration_list = self._child_by_type(node, "declaration_list")
+        if declaration_list is None:
+            return
+
+        for child in declaration_list.children:
+            if child.type == "use_declaration":
+                for name_child in child.children:
+                    if name_child.type in {"name", "qualified_name"}:
+                        self._add_ref(
+                            self._node_name_text(name_child),
+                            name_child.start_byte,
+                            current_callable=None,
+                        )
+                continue
+
+            if child.type == "property_declaration":
+                self._scan_property_declaration(child, current_class=qualified)
+                continue
+
+            if child.type == "method_declaration":
+                self._scan_method(child, current_class=qualified, class_bases=bases)
+                continue
+
+            self._scan_refs_in_node(child, current_callable=None)
+
+    def _scan_property_declaration(self, node, *, current_class: str) -> None:
+        is_exported = self._is_publicish(node, default_public=False)
+        for prop in self._children_of_type(node, "property_element"):
+            name_node = self._child_by_type(prop, "variable_name")
+            if not name_node:
+                continue
+            prop_name = self._node_name_text(name_node)
+            line = name_node.start_point[0] + 1
+            d = Definition(
+                f"{current_class}.{prop_name}",
+                "variable",
+                self.file_path,
+                line,
+            )
+            d.is_exported = is_exported
+            self.defs.append(d)
+
+    def _scan_method(self, node, *, current_class: str, class_bases: list[str]) -> None:
+        name_node = self._child_by_type(node, "name")
+        method_name = self._node_name_text(name_node)
+        if not method_name:
+            return
+        line = name_node.start_point[0] + 1
+        qualified = f"{current_class}.{method_name}"
+        implicit_entrypoint = self._is_magic_or_test_entrypoint(
+            method_name, class_bases, line
+        )
+
+        d = Definition(qualified, "method", self.file_path, line)
+        d.is_exported = self._is_publicish(node) or implicit_entrypoint
+        self.defs.append(d)
+
+        params = self._child_by_type(node, "formal_parameters")
+        if params is not None:
+            for child in params.children:
+                if child.type != "property_promotion_parameter":
+                    continue
+                var_node = self._child_by_type(child, "variable_name")
+                if not var_node:
+                    continue
+                prop_name = self._node_name_text(var_node)
+                prop_def = Definition(
+                    f"{current_class}.{prop_name}",
+                    "variable",
+                    self.file_path,
+                    var_node.start_point[0] + 1,
+                )
+                prop_def.is_exported = self._is_publicish(child, default_public=False)
+                self.defs.append(prop_def)
+
+        body = self._child_by_type(node, "compound_statement")
+        if body is not None:
+            self._scan_block(
+                body,
+                namespace="",
+                current_class=current_class,
+                current_callable=qualified,
+                class_bases=class_bases,
+            )
+
+    def _scan_function(self, node, *, namespace: str) -> None:
+        name_node = self._child_by_type(node, "name")
+        func_name = self._node_name_text(name_node)
+        if not func_name:
+            return
+        qualified = self._qualified_symbol(func_name, namespace)
+        line = name_node.start_point[0] + 1
+        d = Definition(qualified, "function", self.file_path, line)
+        d.is_exported = self.is_test_file and func_name.startswith("test")
+        self.defs.append(d)
+
+        body = self._child_by_type(node, "compound_statement")
+        if body is not None:
+            self._scan_block(
+                body,
+                namespace=namespace,
+                current_class=None,
+                current_callable=qualified,
+                class_bases=[],
+            )
+
+    def _scan_use_imports(self, node) -> None:
+        names: list[str] = []
+        line = node.start_point[0] + 1
+        for clause in self._children_of_type(node, "namespace_use_clause"):
+            target_node = self._child_by_type(clause, "qualified_name")
+            alias_node = self._child_by_type(clause, "name")
+            target = self._node_name_text(target_node)
+            alias = self._node_name_text(alias_node) or target.split("\\")[-1]
+            if not alias:
+                continue
+            d = Definition(alias, "import", self.file_path, line)
+            self.defs.append(d)
+            self.imports.append(
+                {"name": alias, "file": str(self.file_path), "line": line}
+            )
+            names.append(alias)
+        if names:
+            self.raw_imports.append({"source": "use", "names": names, "line": line})
+
+    def _scan_include_import(self, node) -> None:
+        expr = None
+        for child in node.children:
+            if child.type not in {"include", "include_once", "require", "require_once"}:
+                expr = child
+                break
+        source_text = ""
+        if expr is not None:
+            source_text = self._extract_literal_path(expr) or self._get_text(expr).strip()
+        self.raw_imports.append(
+            {"source": source_text, "names": [], "line": node.start_point[0] + 1}
+        )
+
+    def _scan_refs_in_node(self, node, *, current_callable: str | None) -> None:
+        if node.type == "function_call_expression":
+            name_node = self._child_by_type(node, "name")
+            self._add_ref(
+                self._node_name_text(name_node),
+                node.start_byte,
+                current_callable=current_callable,
+            )
+            return
+
+        if node.type in {"member_call_expression", "scoped_call_expression"}:
+            name_node = self._child_by_type(node, "name")
+            self._add_ref(
+                self._node_name_text(name_node),
+                node.start_byte,
+                current_callable=current_callable,
+            )
+            return
+
+        if node.type == "object_creation_expression":
+            for child in node.children:
+                if child.type in {"name", "qualified_name"}:
+                    self._add_ref(
+                        self._node_name_text(child),
+                        node.start_byte,
+                        current_callable=None,
+                    )
+                    break
+            return
+
+        if node.type in {
+            "member_access_expression",
+            "scoped_property_access_expression",
+        }:
+            name_node = self._child_by_type(node, "name")
+            self._add_ref(
+                self._node_name_text(name_node),
+                node.start_byte,
+                current_callable=None,
+            )
+            return
+
+        if node.type in {"base_clause", "class_interface_clause", "use_declaration"}:
+            for child in node.children:
+                if child.type in {"name", "qualified_name"}:
+                    self._add_ref(
+                        self._node_name_text(child),
+                        child.start_byte,
+                        current_callable=None,
+                    )
+
+    def _build_call_graph(self) -> None:
+        name_to_def: dict[str, Definition] = {}
+        for d in self.defs:
+            name_to_def[d.name] = d
+            name_to_def.setdefault(d.simple_name, d)
+
+        for caller, callee in self.call_pairs:
+            caller_def = name_to_def.get(caller)
+            callee_def = name_to_def.get(callee)
+            if caller_def and callee_def and caller_def is not callee_def:
+                caller_def.calls.add(callee_def.name)
+                callee_def.called_by.add(caller_def.name)

--- a/skylos/visitors/languages/php/danger.py
+++ b/skylos/visitors/languages/php/danger.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_SUPERGLOBALS = {
+    "$_GET",
+    "$_POST",
+    "$_REQUEST",
+    "$_COOKIE",
+    "$_FILES",
+}
+
+_FILE_SINKS = {"file_get_contents", "fopen", "readfile", "unlink", "file"}
+_SANITIZERS = {"basename"}
+
+
+def scan_danger(root_node, file_path: str, source: bytes) -> list[dict]:
+    if root_node is None:
+        return []
+
+    findings: list[dict] = []
+
+    def text(node) -> str:
+        return source[node.start_byte : node.end_byte].decode("utf-8", "ignore")
+
+    def child_by_type(node, type_name: str):
+        for child in node.children:
+            if child.type == type_name:
+                return child
+        return None
+
+    def is_superglobal_var(node) -> bool:
+        return node is not None and node.type == "variable_name" and text(node).strip() in _SUPERGLOBALS
+
+    def is_tainted_expr(node, tainted_vars: set[str]) -> bool:
+        if node is None:
+            return False
+        if is_superglobal_var(node):
+            return True
+        if node.type == "variable_name":
+            return text(node).strip().lstrip("$") in tainted_vars
+        if node.type == "function_call_expression":
+            name_node = child_by_type(node, "name")
+            call_name = text(name_node).strip().lstrip("\\") if name_node else ""
+            if call_name in _SANITIZERS:
+                return False
+        return any(is_tainted_expr(child, tainted_vars) for child in node.children)
+
+    def extract_assignment(node):
+        if node.type == "assignment_expression":
+            return node
+        for child in node.children:
+            found = extract_assignment(child)
+            if found is not None:
+                return found
+        return None
+
+    def handle_assignment(node, tainted_vars: set[str]):
+        assign = extract_assignment(node)
+        if assign is None:
+            return
+        lhs = assign.child_by_field_name("left")
+        rhs = assign.child_by_field_name("right")
+        if lhs is None or rhs is None:
+            parts = [child for child in assign.children if child.type != "="]
+            if len(parts) >= 2:
+                lhs, rhs = parts[0], parts[1]
+        if lhs is None or rhs is None:
+            return
+        if lhs.type == "variable_name":
+            name = text(lhs).strip().lstrip("$")
+            if is_tainted_expr(rhs, tainted_vars):
+                tainted_vars.add(name)
+            else:
+                tainted_vars.discard(name)
+
+    def add_finding(rule_id: str, message: str, node) -> None:
+        findings.append(
+            {
+                "rule_id": rule_id,
+                "severity": "HIGH",
+                "message": message,
+                "file": str(Path(file_path)),
+                "line": node.start_point[0] + 1,
+                "col": node.start_point[1],
+                "category": "danger",
+            }
+        )
+
+    def walk_scope(node, tainted_vars: set[str]) -> None:
+        for child in node.children:
+            if child.type in {"function_definition", "method_declaration"}:
+                body = child_by_type(child, "compound_statement")
+                if body is not None:
+                    walk_scope(body, set())
+                continue
+
+            handle_assignment(child, tainted_vars)
+
+            if child.type == "function_call_expression":
+                name_node = child_by_type(child, "name")
+                call_name = text(name_node).strip().lstrip("\\") if name_node else ""
+                args = child_by_type(child, "arguments")
+                first_arg = None
+                if args is not None:
+                    for arg_child in args.children:
+                        if arg_child.type not in {"(", ")", ","}:
+                            first_arg = arg_child
+                            break
+
+                if call_name == "unserialize" and first_arg is not None and is_tainted_expr(first_arg, tainted_vars):
+                    add_finding(
+                        "SKY-D204",
+                        "unserialize on user-controlled data is unsafe and can lead to code execution.",
+                        child,
+                    )
+
+                if call_name in _FILE_SINKS and first_arg is not None and is_tainted_expr(first_arg, tainted_vars):
+                    add_finding(
+                        "SKY-D215",
+                        "Request-controlled path reaches a filesystem sink without path validation.",
+                        child,
+                    )
+
+            if child.type in _IMPORT_EXPR_TYPES:
+                expr = None
+                for expr_child in child.children:
+                    if expr_child.type not in {"include", "include_once", "require", "require_once"}:
+                        expr = expr_child
+                        break
+                if expr is not None and is_tainted_expr(expr, tainted_vars):
+                    add_finding(
+                        "SKY-D215",
+                        "Request-controlled path reaches a filesystem sink without path validation.",
+                        child,
+                    )
+
+            walk_scope(child, tainted_vars)
+
+    walk_scope(root_node, set())
+
+    return _dedupe_findings(findings)
+
+
+_IMPORT_EXPR_TYPES = {
+    "include_expression",
+    "include_once_expression",
+    "require_expression",
+    "require_once_expression",
+}
+
+
+def _dedupe_findings(findings: list[dict]) -> list[dict]:
+    seen: set[tuple[str, str, int]] = set()
+    deduped: list[dict] = []
+    for finding in findings:
+        key = (finding["rule_id"], finding["file"], finding["line"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(finding)
+    return deduped

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -204,6 +204,7 @@ class TestSkylos:
                 ".mjs",
                 ".cjs",
                 ".java",
+                ".php",
             },
             exclude_folders=None,
         )
@@ -482,6 +483,29 @@ class TestAnalyze:
         }
         mock_log_info.assert_any_call("Analyzing 2 files...")
 
+    @patch("skylos.analyzer.logger.info")
+    def test_analyze_mixed_languages_includes_php_in_summary(self, mock_log_info):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "main.py").write_text(
+                "def hello():\n    return 1\n", encoding="utf-8"
+            )
+            (root / "index.php").write_text(
+                "<?php\nfunction helper($x) { return trim($x); }\nhelper('hi');\n",
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), conf=0)
+
+        result = json.loads(result_json)
+
+        assert result["analysis_summary"]["total_files"] == 2
+        assert result["analysis_summary"]["languages"] == {
+            "PHP": 1,
+            "Python": 1,
+        }
+        mock_log_info.assert_any_call("Analyzing 2 files...")
+
     @patch("skylos.analyzer.scan_typescript_file")
     def test_proc_file_dispatches_js_to_typescript_scanner(self, mock_scan):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
@@ -502,6 +526,22 @@ class TestAnalyze:
     def test_proc_file_dispatches_mjs_to_typescript_scanner(self, mock_scan):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
             f.write("export function run() { return 1; }\n")
+            f.flush()
+
+            mock_scan.return_value = tuple(range(13))
+
+            try:
+                result = proc_file(f.name, "test_module")
+            finally:
+                Path(f.name).unlink()
+
+        mock_scan.assert_called_once()
+        assert result == tuple(range(13))
+
+    @patch("skylos.analyzer.scan_php_file")
+    def test_proc_file_dispatches_php_to_php_scanner(self, mock_scan):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".php", delete=False) as f:
+            f.write("<?php function run() { return 1; }\n")
             f.flush()
 
             mock_scan.return_value = tuple(range(13))

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -544,6 +544,9 @@ class TestDetectLanguage:
     def test_java(self):
         assert detect_language("App.java") == "java"
 
+    def test_php(self):
+        assert detect_language("index.php") == "php"
+
     def test_rust(self):
         assert detect_language("lib.rs") == "rust"
 
@@ -590,6 +593,13 @@ class TestModuleCandidatesMultiLang:
         candidates = module_candidates(str(f), str(tmp_path))
         assert "utils" in candidates
 
+    def test_php_module(self, tmp_path):
+        f = tmp_path / "src" / "Controller" / "UserController.php"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.touch()
+        candidates = module_candidates(str(f), str(tmp_path))
+        assert "Controller.UserController" in candidates
+
 
 class TestIsDefinitionLineMultiLang:
     def test_ts_function(self):
@@ -631,6 +641,12 @@ class TestIsDefinitionLineMultiLang:
     def test_java_class(self):
         finding = {"file": "/repo/App.java", "line": 3, "simple_name": "App"}
         assert is_definition_line("/repo/App.java:3:public class App {", finding)
+
+    def test_php_method(self):
+        finding = {"file": "/repo/App.php", "line": 7, "simple_name": "helper"}
+        assert is_definition_line(
+            "/repo/App.php:7:    private function helper($x) {", finding
+        )
 
 
 class TestDeterministicSuppressMultiLang:
@@ -699,6 +715,10 @@ class TestSourceGlobs:
     def test_go_globs(self):
         globs = source_globs_for_language("go")
         assert "*.go" in globs
+
+    def test_php_globs(self):
+        globs = source_globs_for_language("php")
+        assert "*.php" in globs
 
     def test_unknown_defaults_python(self):
         globs = source_globs_for_language("unknown")

--- a/test/test_php.py
+++ b/test/test_php.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.visitors.languages.php import scan_php_file
+
+
+def _scan_php(tmp_path: Path, code: str, filename: str = "App.php") -> tuple:
+    file_path = tmp_path / filename
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(code, encoding="utf-8")
+    return scan_php_file(str(file_path), {})
+
+
+def test_php_scanner_collects_defs_refs_and_raw_imports(tmp_path):
+    defs, refs, _, _, visitor, _, quality, danger, _, _, _, _, raw_imports = _scan_php(
+        tmp_path,
+        """<?php
+namespace App\\Http;
+
+use Foo\\Bar;
+use Foo\\Baz as Quux;
+
+class UserController {
+    private string $name;
+    public function __construct(private Repo $repo) {}
+    private function helper($x) { return $this->name; }
+    public function show() { return self::fmt($this->helper($_GET['id'])); }
+    private static function fmt($x) { return trim($x); }
+}
+
+function topLevel($x) { return trim($x); }
+
+require 'bootstrap.php';
+""",
+    )
+
+    def_names = {d.name for d in defs}
+    ref_names = {r[0] for r in refs}
+    exported = {d.name for d in defs if d.is_exported}
+
+    assert "App.Http.UserController" in def_names
+    assert "App.Http.UserController.helper" in def_names
+    assert "App.Http.UserController.fmt" in def_names
+    assert "App.Http.UserController.name" in def_names
+    assert "App.Http.UserController.repo" in def_names
+    assert "App.Http.topLevel" in def_names
+    assert "Bar" in def_names
+    assert "Quux" in def_names
+
+    assert "helper" in ref_names
+    assert "fmt" in ref_names
+    assert "name" in ref_names
+    assert "trim" in ref_names
+
+    assert "App.Http.UserController.__construct" in exported
+    assert "App.Http.UserController.show" in exported
+    assert "App.Http.UserController.helper" not in exported
+
+    assert visitor.is_test_file is False
+    assert quality == []
+    assert danger == []
+    assert raw_imports == [
+        {"source": "use", "names": ["Bar"], "line": 4},
+        {"source": "use", "names": ["Quux"], "line": 5},
+        {"source": "bootstrap.php", "names": [], "line": 17},
+    ]
+
+
+def test_php_private_property_and_static_method_references_are_recorded(tmp_path):
+    defs, refs, *_ = _scan_php(
+        tmp_path,
+        """<?php
+class Demo {
+    private string $name;
+    public function run() {
+        return self::fmt($this->name);
+    }
+    private static function fmt($x) { return trim($x); }
+}
+""",
+    )
+
+    def_names = {d.name for d in defs}
+    ref_names = {r[0] for r in refs}
+
+    assert "Demo.name" in def_names
+    assert "Demo.fmt" in def_names
+    assert "name" in ref_names
+    assert "fmt" in ref_names
+
+
+def test_php_test_file_marks_phpunit_style_methods_as_test_related(tmp_path):
+    defs, _, _, _, visitor, _, _, _, _, _, _, _, _ = _scan_php(
+        tmp_path,
+        """<?php
+class UserTest extends TestCase {
+    public function setUp(): void {}
+    public function test_it_works(): void {}
+}
+""",
+        filename="tests/UserTest.php",
+    )
+
+    def_names = {d.name for d in defs}
+    exported = {d.name for d in defs if d.is_exported}
+
+    assert "UserTest.setUp" in def_names
+    assert "UserTest.test_it_works" in def_names
+    assert "UserTest.setUp" in exported
+    assert "UserTest.test_it_works" in exported
+    assert visitor.is_test_file is True
+    assert visitor.test_decorated_lines

--- a/test/test_php_security.py
+++ b/test/test_php_security.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.visitors.languages.php import scan_php_file
+
+
+def _scan_php_findings(tmp_path: Path, code: str) -> list[dict]:
+    file_path = tmp_path / "app.php"
+    file_path.write_text(code, encoding="utf-8")
+    return scan_php_file(str(file_path), {})[7]
+
+
+def _rule_ids(findings: list[dict]) -> set[str]:
+    return {finding["rule_id"] for finding in findings}
+
+
+def test_unserialize_on_superglobal_flags(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+unserialize($_POST['data']);
+""",
+    )
+    assert "SKY-D204" in _rule_ids(findings)
+
+
+def test_unserialize_on_tainted_assignment_flags(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+$payload = $_REQUEST['payload'];
+unserialize($payload);
+""",
+    )
+    assert "SKY-D204" in _rule_ids(findings)
+
+
+def test_request_controlled_include_flags(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+include $_GET['tpl'];
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_request_controlled_file_sink_flags(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+$path = $_GET['path'];
+file_get_contents($path);
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_fixed_path_file_sink_is_safe(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+file_get_contents('/srv/data/report.txt');
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_basename_sanitized_file_sink_is_safe(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+$name = $_GET['name'];
+file_get_contents('/srv/data/' . basename($name));
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_taint_does_not_leak_across_methods_with_same_local_name(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+class Demo {
+    public function unsafe() {
+        $payload = $_POST['payload'];
+        return unserialize($payload);
+    }
+
+    public function safe() {
+        $payload = '/srv/data/report.txt';
+        return file_get_contents($payload);
+    }
+}
+""",
+    )
+    assert _rule_ids(findings) == {"SKY-D204"}

--- a/test/test_secrets_nonpy.py
+++ b/test/test_secrets_nonpy.py
@@ -22,6 +22,9 @@ class TestAllowedSuffixes:
     def test_go_suffix_allowed(self):
         assert ".go" in ALLOWED_FILE_SUFFIXES
 
+    def test_php_suffix_allowed(self):
+        assert ".php" in ALLOWED_FILE_SUFFIXES
+
 
 class TestEnvFileScanning:
     def test_detects_aws_key_in_env(self):


### PR DESCRIPTION
## Summary
  - add PHP discovery and analyzer dispatch across the main Skylos pipeline
  - add new PHP visitor lane with tree-sitter-based defs/refs/import extraction and basic call graph wiring
  - add baseline PHP dead-code support for functions, classes, private methods, private
  properties, promoted properties, and include/require raw import edges
  - add baseline PHP security checks for unsafe deserialization and request-controlled file paths
  - extend analyzer, grep-verify, secrets, grading, and cleanup helper surfaces so PHP
  participates consistently across the repo

  ## Testing
  - `pytest -q test/test_php.py test/test_php_security.py`
  - `pytest -q test/test_php.py test/test_php_security.py test/test_analyzer.py test/test_grep_verify.py test/test_secrets_nonpy.py test/test_java_security.py test/test_go_security.py test/test_typescript.py test/test_typescript_framework.py`

  ## Manual Smoke
  - ran `skylos.cli --danger --json` against a temp PHP repo with unsafe and safe controller
  patterns
  - confirmed `SKY-D204` on `unserialize($_POST['payload'])`
  - confirmed `SKY-D215` on request-controlled `file_get_contents($path)`
  - confirmed a dead private method was reported while live private-helper calls stayed alive
  - confirmed the safe `basename(...)` file path case stayed quiet