### PR TITLE
feat(upload): add monorepo routing and sonar import

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,24 @@ If you are evaluating Skylos, start with the core workflow below. The LLM and AI
 
 Skylos now prints an explicit upload manifest before every non-JSON upload so it is clear which scan family is being sent.
 
+For monorepos, run Skylos from the service root you want to own in Cloud, for example `cd apps/api && skylos suite . --upload`. The CLI sends the repo-relative project root (`apps/api`) with the upload so Skylos Cloud can route the scan to the matching `repo + project root` binding instead of mixing all services in one project.
+
+### SonarQube Migration
+
+If you already have `sonar-project.properties`, generate a Skylos migration report:
+
+```bash
+skylos sonar import sonar-project.properties
+```
+
+Write the mapped Skylos exclusion/gate config:
+
+```bash
+skylos sonar import sonar-project.properties --write-config
+```
+
+The first importer maps Sonar project metadata, `sonar.sources`, test paths, and common exclusion keys into a Skylos migration report plus `.skylos/config.yaml`. Quality profiles, issue history, and coverage thresholds still require manual review.
+
 ### Security Taskflow
 
 `skylos agent scan . --security` now runs as an internal security taskflow instead of a single opaque LLM pass:
@@ -1062,6 +1080,7 @@ Release roles, prerequisites, branch protection guidance, semantic type policy, 
 | `skylos debt <path>` | Technical debt hotspot analysis with baseline-aware prioritization |
 | `skylos discover <path>` | Map LLM/AI integrations in your codebase |
 | `skylos defend <path>` | Check LLM integrations for missing defenses |
+| `skylos sonar import <file>` | Convert `sonar-project.properties` into a Skylos migration report/config |
 
 ### AI Agent
 

--- a/skylos/api.py
+++ b/skylos/api.py
@@ -207,7 +207,7 @@ def get_project_token() -> str | None:
     repo_root = _get_repo_root_for_link()
     link_path = repo_root / LINK_FILE
     link = _read_json(link_path) or {}
-    linked_project_id = link.get("project_id") or link.get("projectId")
+    linked_project_id = _linked_project_id_for_current_path(link, repo_root)
 
     creds = _read_json(GLOBAL_CREDS_FILE) or {}
 
@@ -304,6 +304,31 @@ def _load_repo_link(git_root):
         return json.loads(open(p, "r", encoding="utf-8").read() or "{}")
     except (OSError, json.JSONDecodeError, ValueError):
         return {}
+
+
+def _current_repo_subpath(git_root) -> str:
+    try:
+        if not git_root:
+            return ""
+        from skylos.project_context import repo_subpath_for_project
+
+        return repo_subpath_for_project(Path.cwd(), git_root)
+    except Exception:
+        return ""
+
+
+def _linked_project_id_for_current_path(link: dict, git_root) -> str | None:
+    repo_subpath = _current_repo_subpath(git_root)
+    projects = link.get("projects") if isinstance(link, dict) else None
+    if isinstance(projects, dict):
+        entry = projects.get(repo_subpath)
+        if isinstance(entry, dict):
+            project_id = entry.get("project_id") or entry.get("projectId")
+            if project_id:
+                return str(project_id)
+
+    project_id = link.get("project_id") or link.get("projectId")
+    return str(project_id) if project_id else None
 
 
 def get_git_info() -> tuple[str, str, str, dict]:
@@ -860,6 +885,7 @@ def _prepare_report_upload(
 ) -> PreparedReportUpload:
     commit, branch, actor, ci = get_git_info()
     git_root = get_git_root()
+    project_root = _infer_upload_project_root(result_json, git_root)
 
     all_findings = _normalize_result_sections(
         result_json,
@@ -896,6 +922,7 @@ def _prepare_report_upload(
         grade_data=grade_data,
         project_id=project_id,
         scan_bundle_id=scan_bundle_id,
+        project_root=project_root,
     )
     core_payload.update(metadata)
     legacy_payload = _build_legacy_payload(core_payload, definitions)
@@ -928,6 +955,7 @@ def _prepare_debt_upload(
 ) -> PreparedReportUpload:
     commit, branch, actor, ci = get_git_info()
     git_root = get_git_root()
+    project_root = _infer_upload_project_root(debt_report, git_root)
     link = _load_repo_link(git_root)
     project_id = link.get("project_id")
 
@@ -945,6 +973,7 @@ def _prepare_debt_upload(
         analysis_mode="debt",
         project_id=project_id,
         scan_bundle_id=scan_bundle_id,
+        project_root=project_root,
     )
 
     core_payload = {
@@ -1008,6 +1037,39 @@ def _detect_report_provenance_data(git_root):
     return provenance_data
 
 
+def _infer_upload_project_root(payload, git_root) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+
+    candidates = []
+    for key in ("project_root", "repo_subpath"):
+        if key in payload:
+            candidates.append(payload.get(key))
+    summary = payload.get("analysis_summary")
+    if isinstance(summary, dict) and "project_root" in summary:
+        candidates.append(summary.get("project_root"))
+    if "project" in payload:
+        candidates.append(payload.get("project"))
+
+    try:
+        from skylos.project_context import normalize_repo_subpath, repo_subpath_for_project
+    except Exception:
+        return None
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, str):
+            if candidate.strip() == "":
+                return ""
+            if Path(candidate).is_absolute():
+                return repo_subpath_for_project(candidate, git_root)
+            normalized = normalize_repo_subpath(candidate)
+            if normalized is not None:
+                return normalized
+    return None
+
+
 def _build_report_metadata(
     *,
     commit_hash,
@@ -1021,6 +1083,7 @@ def _build_report_metadata(
     grade_data=None,
     project_id=None,
     scan_bundle_id=None,
+    project_root=None,
 ) -> dict[str, Any]:
     metadata = {
         "commit_hash": commit_hash,
@@ -1038,6 +1101,8 @@ def _build_report_metadata(
         metadata["project_id"] = project_id
     if scan_bundle_id:
         metadata["scan_bundle_id"] = str(scan_bundle_id)
+    if project_root is not None:
+        metadata["project_root"] = str(project_root)
     return metadata
 
 
@@ -1391,6 +1456,7 @@ def _build_report_complete_payload(
     init_data: dict[str, Any],
     uploaded_artifacts: dict[str, dict[str, Any]],
     skipped_artifacts: list[dict[str, Any]],
+    metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload = {
         "upload_protocol_version": UPLOAD_PROTOCOL_VERSION,
@@ -1398,6 +1464,8 @@ def _build_report_complete_payload(
         "upload_id": init_data.get("upload_id") or init_data.get("uploadId"),
         "artifacts": uploaded_artifacts,
     }
+    if metadata and "project_root" in metadata:
+        payload["project_root"] = metadata["project_root"]
     if skipped_artifacts:
         payload["skipped_artifacts"] = skipped_artifacts
     return payload
@@ -1495,6 +1563,7 @@ def upload_report_v2(
             init_data,
             uploaded_artifacts,
             skipped_artifacts,
+            prepared.metadata,
         )
 
         complete_response, last_err = _post_json_with_retries(
@@ -1679,6 +1748,7 @@ def upload_defense_report(defense_json_str, quiet=False, scan_bundle_id=None) ->
 
     commit, branch, actor, ci = get_git_info()
     git_root = get_git_root()
+    project_root = _infer_upload_project_root(defense_data, git_root)
 
     link = _load_repo_link(git_root)
 
@@ -1695,6 +1765,8 @@ def upload_defense_report(defense_json_str, quiet=False, scan_bundle_id=None) ->
         "defense_findings": defense_data.get("findings", []),
         "defense_integrations": defense_data.get("integrations", []),
     }
+    if project_root is not None:
+        payload["project_root"] = project_root
 
     if link.get("project_id"):
         payload["project_id"] = link["project_id"]

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2193,6 +2193,26 @@ def _run_project_command(argv):
     return run_project_command(argv)
 
 
+def _run_sonar_command(argv):
+    from skylos.commands.sonar_cmd import run_sonar_command
+
+    return run_sonar_command(argv, console_factory=Console)
+
+
+def _attach_upload_project_context(result: dict, project_root: pathlib.Path) -> None:
+    try:
+        from skylos.api import get_git_root as _get_git_root
+        from skylos.project_context import project_context_for_upload
+
+        upload_context = project_context_for_upload(project_root, _get_git_root())
+        result["project_root"] = upload_context["project_root"]
+        result.setdefault("analysis_summary", {})["project_root"] = upload_context[
+            "project_root"
+        ]
+    except Exception:
+        pass
+
+
 def _run_removed_city_command(_argv):
     console = Console()
     console.print("[bold red]Error:[/bold red] `skylos city` has been removed.")
@@ -2225,6 +2245,7 @@ EARLY_COMMAND_HANDLERS = {
     "login": "_run_login_command",
     "sync": "_run_sync_command",
     "project": "_run_project_command",
+    "sonar": "_run_sonar_command",
     "city": "_run_removed_city_command",
     "suite": "run_suite_command",
     "discover": "_run_discover_command",
@@ -4891,6 +4912,7 @@ def main() -> None:
                 print(result_json)
 
             if args.upload:
+                _attach_upload_project_context(result, project_root)
                 upload_resp = upload_report(
                     result,
                     is_forced=args.force,
@@ -4936,6 +4958,7 @@ def main() -> None:
             _print_upload_destination(console, project_root)
             _print_main_upload_manifest(console, args, result)
 
+        _attach_upload_project_context(result, project_root)
         upload_resp = upload_report(result, is_forced=args.force, strict=args.strict)
         if not upload_resp.get("success"):
             _render_upload_failure(console, upload_resp)
@@ -5192,6 +5215,7 @@ def main() -> None:
                 return
 
         _print_main_upload_manifest(console, args, result)
+        _attach_upload_project_context(result, project_root)
         upload_resp = upload_report(result, is_forced=args.force, strict=args.strict)
 
         if not upload_resp.get("success"):

--- a/skylos/commands/sonar_cmd.py
+++ b/skylos/commands/sonar_cmd.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def run_sonar_command(argv: list[str], *, console_factory) -> int:
+    parser = argparse.ArgumentParser(
+        prog="skylos sonar",
+        description="Migrate a SonarQube/SonarCloud project configuration into Skylos.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    import_parser = subparsers.add_parser(
+        "import",
+        help="Import sonar-project.properties and generate a Skylos migration plan.",
+    )
+    import_parser.add_argument(
+        "properties_file",
+        nargs="?",
+        default="sonar-project.properties",
+        help="Path to sonar-project.properties",
+    )
+    import_parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Write migration report JSON to this path.",
+    )
+    import_parser.add_argument(
+        "--write-config",
+        action="store_true",
+        help="Write mapped Skylos config to .skylos/config.yaml next to the Sonar properties file.",
+    )
+    import_parser.add_argument(
+        "--config-output",
+        default=None,
+        help="Override the Skylos config output path used with --write-config.",
+    )
+
+    args = parser.parse_args(argv)
+    if args.command != "import":
+        parser.print_help()
+        return 2
+
+    from skylos.sonar_import import (
+        build_sonar_migration_plan,
+        format_migration_plan_json,
+        parse_sonar_properties,
+        write_skylos_yaml_config,
+    )
+
+    console = console_factory()
+    properties_path = Path(args.properties_file).resolve()
+    if not properties_path.exists() or not properties_path.is_file():
+        console.print(f"[red]Sonar properties file not found: {properties_path}[/red]")
+        return 1
+
+    properties = parse_sonar_properties(properties_path)
+    plan = build_sonar_migration_plan(properties)
+    report_json = format_migration_plan_json(plan)
+
+    if args.output:
+        output_path = Path(args.output).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(report_json + "\n", encoding="utf-8")
+        console.print(f"[green]Sonar migration report written:[/green] {output_path}")
+    else:
+        console.print(report_json)
+
+    if args.write_config:
+        config_path = (
+            Path(args.config_output).resolve()
+            if args.config_output
+            else properties_path.parent / ".skylos" / "config.yaml"
+        )
+        write_skylos_yaml_config(config_path, plan["skylos"]["config"])
+        console.print(f"[green]Skylos config written:[/green] {config_path}")
+
+    return 0
+

--- a/skylos/file_discovery.py
+++ b/skylos/file_discovery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from fnmatch import fnmatchcase
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
@@ -26,6 +27,22 @@ def should_exclude_path(
         exclude_normalized = exclude_folder.replace("\\", "/").rstrip("/")
 
         if "*" in exclude_normalized:
+            patterns = {exclude_normalized}
+            if exclude_normalized.startswith("**/"):
+                patterns.add(exclude_normalized[3:])
+            if exclude_normalized.endswith("/**"):
+                patterns.add(exclude_normalized[:-3])
+            if exclude_normalized.startswith("**/") and exclude_normalized.endswith("/**"):
+                patterns.add(exclude_normalized[3:-3])
+
+            for pattern in patterns:
+                if rel_path_str == pattern or fnmatchcase(rel_path_str, pattern):
+                    return True
+                if pattern.endswith("/**"):
+                    directory = pattern[:-3]
+                    if rel_path_str == directory or rel_path_str.startswith(directory + "/"):
+                        return True
+
             suffix = exclude_normalized.replace("*", "")
             for part in path_parts:
                 if part.endswith(suffix):

--- a/skylos/login.py
+++ b/skylos/login.py
@@ -6,7 +6,7 @@ import socket
 import subprocess
 import time
 import webbrowser
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import requests
 
@@ -16,12 +16,13 @@ TIMEOUT_SECONDS = 300
 
 
 class LoginResult:
-    def __init__(self, token, project_id, project_name, org_name, plan):
+    def __init__(self, token, project_id, project_name, org_name, plan, repo_subpath=""):
         self.token = token
         self.project_id = project_id
         self.project_name = project_name
         self.org_name = org_name
         self.plan = plan
+        self.repo_subpath = repo_subpath or ""
 
 
 def _find_free_port():
@@ -65,6 +66,25 @@ def _get_repo_url():
         return url
     except Exception:
         return None
+
+
+def _get_repo_subpath():
+    try:
+        git_root = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--show-toplevel"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+        if not git_root:
+            return ""
+        from skylos.project_context import repo_subpath_for_project
+
+        return repo_subpath_for_project(os.getcwd(), git_root)
+    except Exception:
+        return ""
 
 
 class _CallbackHandler(http.server.BaseHTTPRequestHandler):
@@ -130,6 +150,7 @@ def browser_login(console=None, base_url=None):
     port = _find_free_port()
     repo_name = _get_repo_name() or ""
     repo_url = _get_repo_url() or ""
+    repo_path = _get_repo_subpath()
     state = secrets.token_urlsafe(24)
 
     _CallbackHandler.result = None
@@ -138,7 +159,7 @@ def browser_login(console=None, base_url=None):
     server = http.server.HTTPServer(("127.0.0.1", port), _CallbackHandler)
     server.timeout = 5
 
-    connect_url = f"{base_url}/cli/connect?port={port}&repo={repo_name}&repo_url={repo_url}&state={state}"
+    connect_url = f"{base_url}/cli/connect?{urlencode({'port': port, 'repo': repo_name, 'repo_url': repo_url, 'repo_path': repo_path, 'state': state})}"
 
     if console:
         console.print("\n[bold]Opening browser to connect to Skylos Cloud...[/bold]")
@@ -246,6 +267,7 @@ def manual_token_fallback(console=None):
         project_name=project.get("name", "Unknown"),
         org_name=org.get("name", "My Workspace"),
         plan=info.get("plan", "free"),
+        repo_subpath=project.get("repo_subpath", ""),
     )
 
 
@@ -260,6 +282,7 @@ def _save_login_result(result, base_url=None):
         project_name=result.project_name,
         org_name=result.org_name,
         plan=result.plan,
+        repo_subpath=result.repo_subpath,
     )
 
     _write_link(
@@ -268,6 +291,7 @@ def _save_login_result(result, base_url=None):
         project_name=result.project_name,
         org_name=result.org_name,
         plan=result.plan,
+        repo_subpath=result.repo_subpath,
         base_url=base_url or DEFAULT_BASE_URL,
     )
 
@@ -291,6 +315,7 @@ def get_current_connection(base_url=None):
         project_name=project.get("name", "Unknown"),
         org_name=info.get("organization", {}).get("name", "My Workspace"),
         plan=info.get("plan", "free"),
+        repo_subpath=project.get("repo_subpath", ""),
     )
 
 
@@ -300,6 +325,8 @@ def _print_connected_result(result, console=None):
         console.print(f"  Project:      {result.project_name}")
         console.print(f"  Organization: {result.org_name}")
         console.print(f"  Plan:         {result.plan.capitalize()}")
+        if result.repo_subpath:
+            console.print(f"  Project root: {result.repo_subpath}")
         console.print(f"\n  Scans will auto-upload on every run.")
         console.print(f"  Use [bold]--no-upload[/bold] to skip.")
         console.print(
@@ -310,6 +337,8 @@ def _print_connected_result(result, console=None):
         print(f"  Project:      {result.project_name}")
         print(f"  Organization: {result.org_name}")
         print(f"  Plan:         {result.plan.capitalize()}")
+        if result.repo_subpath:
+            print(f"  Project root: {result.repo_subpath}")
         print(f"\n  Scans will auto-upload on every run.")
         print(f"  Use --no-upload to skip.")
         print(f"\n  For MCP/AI agents: export SKYLOS_API_KEY={result.token}")
@@ -392,6 +421,7 @@ def _parse_callback_request(path: str, *, expected_state: str | None):
             project_name=params.get("project_name", ["Unknown"])[0] or "Unknown",
             org_name=params.get("org_name", ["My Workspace"])[0] or "My Workspace",
             plan=params.get("plan", ["free"])[0] or "free",
+            repo_subpath=params.get("repo_subpath", [""])[0] or "",
         ),
     )
 
@@ -433,4 +463,5 @@ def _verify_login_result(token: str, *, base_url: str) -> LoginResult | None:
         project_name=project.get("name", "Unknown"),
         org_name=org.get("name", "My Workspace"),
         plan=info.get("plan", "free"),
+        repo_subpath=project.get("repo_subpath", ""),
     )

--- a/skylos/project_context.py
+++ b/skylos/project_context.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def normalize_repo_subpath(value) -> str | None:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw or raw in {".", "./"}:
+        return ""
+
+    normalized = raw.replace("\\", "/").strip("/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    if not normalized:
+        return ""
+    if len(normalized) > 300:
+        return None
+
+    segments = normalized.split("/")
+    for segment in segments:
+        if not segment or segment in {".", ".."}:
+            return None
+        if any(ord(ch) < 32 or ord(ch) == 127 for ch in segment):
+            return None
+    return "/".join(segments)
+
+
+def repo_subpath_for_project(project_path, git_root=None) -> str:
+    if not project_path:
+        return ""
+
+    root = Path(git_root).resolve() if git_root else None
+    target = Path(project_path).resolve()
+    if target.is_file():
+        target = target.parent
+
+    if not root:
+        return ""
+
+    try:
+        rel = target.relative_to(root)
+    except ValueError:
+        return ""
+
+    normalized = normalize_repo_subpath(rel.as_posix())
+    return normalized or ""
+
+
+def project_context_for_upload(project_path, git_root=None) -> dict[str, str]:
+    return {"project_root": repo_subpath_for_project(project_path, git_root)}
+

--- a/skylos/sonar_import.py
+++ b/skylos/sonar_import.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+EXCLUSION_KEYS = (
+    "sonar.exclusions",
+    "sonar.coverage.exclusions",
+    "sonar.test.exclusions",
+    "sonar.cpd.exclusions",
+)
+
+
+def parse_sonar_properties(path: str | Path) -> dict[str, str]:
+    props_path = Path(path)
+    lines = props_path.read_text(encoding="utf-8").splitlines()
+    logical_lines: list[str] = []
+    pending = ""
+
+    for raw in lines:
+        stripped = raw.strip()
+        if not pending and (not stripped or stripped.startswith("#") or stripped.startswith("!")):
+            continue
+
+        continued = stripped.endswith("\\") and not stripped.endswith("\\\\")
+        chunk = stripped[:-1].rstrip() if continued else stripped
+        pending = f"{pending}{chunk}" if pending else chunk
+        if continued:
+            continue
+        if pending:
+            logical_lines.append(pending)
+        pending = ""
+
+    if pending:
+        logical_lines.append(pending)
+
+    properties: dict[str, str] = {}
+    for line in logical_lines:
+        parsed = _parse_property_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if key:
+            properties[key] = value
+    return properties
+
+
+def _parse_property_line(line: str) -> tuple[str, str] | None:
+    escaped = False
+    for idx, char in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char in {"=", ":"}:
+            return _clean_key_value(line[:idx], line[idx + 1 :])
+
+    parts = line.split(None, 1)
+    if len(parts) == 2:
+        return _clean_key_value(parts[0], parts[1])
+    return None
+
+
+def _clean_key_value(key: str, value: str) -> tuple[str, str]:
+    return key.strip(), _unescape_property(value.strip())
+
+
+def _unescape_property(value: str) -> str:
+    return (
+        value.replace("\\:", ":")
+        .replace("\\=", "=")
+        .replace("\\,", ",")
+        .replace("\\ ", " ")
+        .replace("\\\\", "\\")
+    )
+
+
+def split_sonar_list(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def build_sonar_migration_plan(properties: dict[str, str]) -> dict[str, Any]:
+    source_paths = split_sonar_list(properties.get("sonar.sources")) or ["."]
+    test_paths = split_sonar_list(properties.get("sonar.tests"))
+    exclusions: list[str] = []
+    seen_exclusions: set[str] = set()
+
+    for key in EXCLUSION_KEYS:
+        for item in split_sonar_list(properties.get(key)):
+            if item in seen_exclusions:
+                continue
+            seen_exclusions.add(item)
+            exclusions.append(item)
+
+    config: dict[str, Any] = {
+        "exclude": exclusions,
+        "gate": {
+            "enabled": True,
+            "mode": "zero-new",
+        },
+    }
+
+    notes = [
+        "Review Sonar quality profiles manually; Skylos does not import Sonar rule activation yet.",
+        "Coverage thresholds are not imported into Skylos gates in this first migration slice.",
+    ]
+    if test_paths:
+        notes.append("Sonar test paths are preserved in the report for review, not scanned as a separate Skylos family.")
+
+    return {
+        "sonar": {
+            "project_key": properties.get("sonar.projectKey"),
+            "project_name": properties.get("sonar.projectName"),
+            "sources": source_paths,
+            "tests": test_paths,
+            "exclusions": exclusions,
+        },
+        "skylos": {
+            "recommended_command": f"skylos {source_paths[0]} --danger --quality --upload",
+            "suite_command": f"skylos suite {source_paths[0]} --upload",
+            "config": config,
+        },
+        "manual_review": notes,
+    }
+
+
+def write_skylos_yaml_config(path: str | Path, config: dict[str, Any]) -> Path:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError("Writing YAML requires PyYAML.") from exc
+
+    output_path.write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=False),
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def format_migration_plan_json(plan: dict[str, Any]) -> str:
+    return json.dumps(plan, indent=2)
+

--- a/skylos/suite.py
+++ b/skylos/suite.py
@@ -236,6 +236,17 @@ def run_suite(
         pass
 
     debt_snapshot = build_debt_snapshot(static_result, project_root=target_path)
+    try:
+        from skylos.project_context import project_context_for_upload
+
+        git_root = get_git_root_func() if get_git_root_func else None
+        upload_context = project_context_for_upload(target_path, git_root)
+        static_result["project_root"] = upload_context["project_root"]
+        static_result.setdefault("analysis_summary", {})["project_root"] = (
+            upload_context["project_root"]
+        )
+    except Exception:
+        upload_context = {"project_root": ""}
 
     provenance_section: dict[str, Any] = {
         "enabled": not no_provenance,
@@ -326,6 +337,7 @@ def run_suite(
     return {
         "version": "1.0",
         "project": str(target_path),
+        "project_root": upload_context["project_root"],
         "summary": {
             "files_scanned": int(
                 (static_result.get("analysis_summary") or {}).get("total_files") or 0

--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -85,9 +85,12 @@ def _linked_project_id(repo_root: Path):
         return None
     try:
         data = json.loads(p.read_text() or "{}")
-        return data.get("project_id")
     except Exception:
         return None
+    repo_subpath = _current_repo_subpath(repo_root)
+    subpath_entry = _project_entry_for_subpath(data, repo_subpath)
+    project_id = subpath_entry.get("project_id") or data.get("project_id")
+    return str(project_id).strip() if project_id else None
 
 
 def _read_link(repo_root: Path):
@@ -100,12 +103,41 @@ def _read_link(repo_root: Path):
         return {}
 
 
+def _normalize_repo_subpath_value(value) -> str:
+    try:
+        from skylos.project_context import normalize_repo_subpath
+
+        normalized = normalize_repo_subpath(value)
+        return normalized or ""
+    except Exception:
+        return str(value or "").strip("/")
+
+
+def _current_repo_subpath(repo_root: Path) -> str:
+    try:
+        from skylos.project_context import repo_subpath_for_project
+
+        return repo_subpath_for_project(Path.cwd(), repo_root)
+    except Exception:
+        return ""
+
+
+def _project_entry_for_subpath(link: dict, repo_subpath: str) -> dict:
+    projects = link.get("projects")
+    if isinstance(projects, dict):
+        entry = projects.get(repo_subpath)
+        if isinstance(entry, dict):
+            return entry
+    return {}
+
+
 def _write_link(
     repo_root: Path,
     project_id,
     project_name=None,
     org_name=None,
     plan=None,
+    repo_subpath=None,
     *,
     base_url=None,
 ):
@@ -113,9 +145,12 @@ def _write_link(
     skylos_dir.mkdir(parents=True, exist_ok=True)
 
     link_path = skylos_dir / LINK_FILE
+    existing = _read_link(repo_root)
+    normalized_subpath = _normalize_repo_subpath_value(repo_subpath)
     payload = {
         "project_id": str(project_id),
         "linked_at": _utc_now_iso(),
+        "repo_subpath": normalized_subpath,
     }
     if base_url:
         payload["base_url"] = str(base_url).rstrip("/")
@@ -125,6 +160,18 @@ def _write_link(
         payload["org_name"] = org_name
     if plan:
         payload["plan"] = str(plan).lower()
+    projects = existing.get("projects") if isinstance(existing, dict) else {}
+    if not isinstance(projects, dict):
+        projects = {}
+    projects[normalized_subpath] = {
+        "project_id": str(project_id),
+        "project_name": project_name,
+        "org_name": org_name,
+        "plan": str(plan).lower() if plan else None,
+        "repo_subpath": normalized_subpath,
+        "linked_at": payload["linked_at"],
+    }
+    payload["projects"] = projects
     # if folder_id:
     #     payload["folder_id"] = str(folder_id)
     # if folder_name:
@@ -170,7 +217,9 @@ def get_token():
     return None
 
 
-def save_token(token, project_id=None, project_name=None, org_name=None, plan=None):
+def save_token(
+    token, project_id=None, project_name=None, org_name=None, plan=None, repo_subpath=None
+):
     data = _load_creds()
     now = _utc_now_iso()
 
@@ -191,6 +240,8 @@ def save_token(token, project_id=None, project_name=None, org_name=None, plan=No
             tokens[pid]["project_name"] = project_name
         if org_name:
             tokens[pid]["org_name"] = org_name
+        if repo_subpath is not None:
+            tokens[pid]["repo_subpath"] = _normalize_repo_subpath_value(repo_subpath)
 
         data["tokens"] = tokens
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -71,6 +71,56 @@ class TestSkylosApi(unittest.TestCase):
             "No token found. Run 'skylos login' or 'skylos project use', or set SKYLOS_TOKEN.",
         )
 
+    def test_get_project_token_uses_repo_subpath_link(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = api.Path(td) / "repo"
+            api_dir = repo / "apps" / "api"
+            web_dir = repo / "apps" / "web"
+            api_dir.mkdir(parents=True)
+            web_dir.mkdir(parents=True)
+            link_dir = repo / ".skylos"
+            link_dir.mkdir()
+            (link_dir / "link.json").write_text(
+                json.dumps(
+                    {
+                        "project_id": "proj-web",
+                        "projects": {
+                            "apps/api": {"project_id": "proj-api"},
+                            "apps/web": {"project_id": "proj-web"},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            creds = api.Path(td) / "credentials.json"
+            creds.write_text(
+                json.dumps(
+                    {
+                        "tokens": {
+                            "proj-api": {"token": "TOK_API"},
+                            "proj-web": {"token": "TOK_WEB"},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            cwd = os.getcwd()
+            try:
+                os.chdir(api_dir)
+                with patch.dict(os.environ, {"SKYLOS_TOKEN": ""}, clear=False), patch(
+                    "skylos.api._try_github_oidc_token", return_value=None
+                ), patch(
+                    "skylos.api._get_repo_root_for_link", return_value=repo
+                ), patch(
+                    "skylos.api.GLOBAL_CREDS_FILE", creds
+                ), patch(
+                    "skylos.api.get_key", return_value=None
+                ):
+                    self.assertEqual(api.get_project_token(), "TOK_API")
+            finally:
+                os.chdir(cwd)
+
     @patch("subprocess.check_output")
     @patch("skylos.api.get_project_token")
     @patch("requests.post")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -817,7 +817,11 @@ def test_main_json_upload_calls_upload_report_quiet(monkeypatch):
 
     mock_upload.assert_called_once()
     upload_result = mock_upload.call_args.args[0]
-    assert upload_result["analysis_summary"] == {"total_files": 1}
+    assert upload_result["project_root"] == ""
+    assert upload_result["analysis_summary"] == {
+        "total_files": 1,
+        "project_root": "",
+    }
     assert upload_result["danger"] == []
     assert upload_result["quality"] == []
     assert upload_result["secrets"] == []

--- a/test/test_file_discovery.py
+++ b/test/test_file_discovery.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from skylos.file_discovery import should_exclude_path
+
+
+def test_should_exclude_path_honors_sonar_style_globs(tmp_path: Path):
+    root = tmp_path / "repo"
+    generated = root / "src" / "generated" / "client.py"
+    dist = root / "dist" / "bundle.js"
+    generated.parent.mkdir(parents=True)
+    dist.parent.mkdir(parents=True)
+    generated.write_text("", encoding="utf-8")
+    dist.write_text("", encoding="utf-8")
+
+    assert should_exclude_path(generated, root, ["**/generated/**"])
+    assert should_exclude_path(dist, root, ["dist/**"])

--- a/test/test_project_context.py
+++ b/test/test_project_context.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from skylos.project_context import normalize_repo_subpath, repo_subpath_for_project
+
+
+def test_normalize_repo_subpath():
+    assert normalize_repo_subpath("") == ""
+    assert normalize_repo_subpath("/apps//api/") == "apps/api"
+    assert normalize_repo_subpath("apps\\api") == "apps/api"
+    assert normalize_repo_subpath("apps/../api") is None
+
+
+def test_repo_subpath_for_project_returns_repo_relative_path(tmp_path: Path):
+    repo = tmp_path / "repo"
+    service = repo / "apps" / "api"
+    service.mkdir(parents=True)
+
+    assert repo_subpath_for_project(service, repo) == "apps/api"
+    assert repo_subpath_for_project(repo, repo) == ""
+

--- a/test/test_sonar_import.py
+++ b/test/test_sonar_import.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from skylos.sonar_import import (
+    build_sonar_migration_plan,
+    parse_sonar_properties,
+    split_sonar_list,
+)
+
+
+def test_parse_sonar_properties_handles_comments_and_lists(tmp_path: Path):
+    props = tmp_path / "sonar-project.properties"
+    props.write_text(
+        "\n".join(
+            [
+                "# comment",
+                "sonar.projectKey = acme-api",
+                "sonar.sources=src,apps/api",
+                "sonar.exclusions=**/generated/**, dist/**",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = parse_sonar_properties(props)
+
+    assert parsed["sonar.projectKey"] == "acme-api"
+    assert parsed["sonar.sources"] == "src,apps/api"
+    assert split_sonar_list(parsed["sonar.exclusions"]) == [
+        "**/generated/**",
+        "dist/**",
+    ]
+
+
+def test_build_sonar_migration_plan_maps_sources_and_exclusions():
+    plan = build_sonar_migration_plan(
+        {
+            "sonar.projectKey": "acme-api",
+            "sonar.projectName": "Acme API",
+            "sonar.sources": "apps/api",
+            "sonar.tests": "apps/api/tests",
+            "sonar.exclusions": "**/generated/**",
+            "sonar.coverage.exclusions": "**/migrations/**",
+        }
+    )
+
+    assert plan["sonar"]["project_key"] == "acme-api"
+    assert plan["skylos"]["recommended_command"] == "skylos apps/api --danger --quality --upload"
+    assert plan["skylos"]["suite_command"] == "skylos suite apps/api --upload"
+    assert plan["skylos"]["config"]["exclude"] == [
+        "**/generated/**",
+        "**/migrations/**",
+    ]
+

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -99,6 +99,38 @@ def test_save_token_writes_file(isolated_creds):
         assert (creds_file.parent.stat().st_mode & 0o777) == 0o700
 
 
+def test_get_token_uses_repo_subpath_link(isolated_creds, monkeypatch, tmp_path):
+    _, creds_file = isolated_creds
+    repo = tmp_path / "repo"
+    api_dir = repo / "apps" / "api"
+    web_dir = repo / "apps" / "web"
+    api_dir.mkdir(parents=True)
+    web_dir.mkdir(parents=True)
+
+    syncmod._write_link(
+        repo,
+        "proj-api",
+        project_name="API",
+        repo_subpath="apps/api",
+    )
+    syncmod._write_link(
+        repo,
+        "proj-web",
+        project_name="Web",
+        repo_subpath="apps/web",
+    )
+    syncmod.save_token("TOK_API", project_id="proj-api", repo_subpath="apps/api")
+    syncmod.save_token("TOK_WEB", project_id="proj-web", repo_subpath="apps/web")
+
+    monkeypatch.setattr(syncmod, "_find_repo_root", lambda: repo)
+
+    monkeypatch.chdir(api_dir)
+    assert syncmod.get_token() == "TOK_API"
+
+    monkeypatch.chdir(web_dir)
+    assert syncmod.get_token() == "TOK_WEB"
+
+
 def test_clear_token(isolated_creds):
     _, creds_file = isolated_creds
     creds_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- send repo-relative project_root metadata on scan, suite, defense, debt, JSON, and artifact uploads
- preserve local Skylos tokens per monorepo subpath so apps/api and apps/web do not overwrite each other
- add skylos sonar import for sonar-project.properties migration reports/config and support Sonar-style exclusion globs

## Tests
- /Users/skylos/.venv/bin/python -m pytest -q test/test_project_context.py test/test_sonar_import.py test/test_file_discovery.py test/test_sync.py test/test_api.py test/test_suite.py
- /Users/skylos/.venv/bin/python -m py_compile skylos/login.py skylos/api.py skylos/cli.py skylos/sync.py skylos/suite.py skylos/sonar_import.py skylos/commands/sonar_cmd.py skylos/project_context.py skylos/file_discovery.py
- Skylos Staged Gate passed during commit