### PR TITLE
fix(python): fix critical logic gaps

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -297,7 +297,11 @@ class Skylos:
 
             try:
                 rust_files = _fast_discover(str(p), ext_list, simple_excludes)
-                all_files = [Path(f) for f in rust_files]
+                all_files = [
+                    Path(f)
+                    for f in rust_files
+                    if not should_exclude_path(Path(f), root, exclude_folders)
+                ]
             except Exception:
                 all_files = discover_source_files(
                     p, exts, exclude_folders=exclude_folders
@@ -1273,7 +1277,7 @@ class Skylos:
                 if circular_findings:
                     result["circular_dependencies"] = circular_findings
 
-                if enable_quality and "SKY-Q802" not in project_cfg.get("ignore", []):
+                if enable_quality:
                     try:
                         from skylos.architecture import get_architecture_findings
 
@@ -1298,8 +1302,23 @@ class Skylos:
                             module_files=mod_files,
                             module_trees=mod_trees,
                         )
+                        ignored_rules = set(project_cfg.get("ignore", []))
+                        if arch_findings:
+                            arch_findings = [
+                                f
+                                for f in arch_findings
+                                if f.get("rule_id") not in ignored_rules
+                            ]
                         if arch_findings:
                             all_quality.extend(arch_findings)
+                            from skylos.rules.quality.standards import enrich_finding
+
+                            for finding in arch_findings:
+                                enrich_finding(finding)
+                            result.setdefault("quality", []).extend(arch_findings)
+                            result["analysis_summary"]["quality_count"] = len(
+                                result.get("quality", []) or []
+                            )
                         if arch_summary:
                             result["architecture_metrics"] = arch_summary
                     except Exception:

--- a/skylos/rules/danger/calls.py
+++ b/skylos/rules/danger/calls.py
@@ -63,16 +63,36 @@ DANGEROUS_CALLS = {
 }
 
 
-def _qualified_name_from_call(node: ast.Call):
+def _resolve_expr_name(node: ast.AST, aliases=None, assigned_calls=None):
+    aliases = aliases or {}
+    assigned_calls = assigned_calls or {}
+    if isinstance(node, ast.Name):
+        return assigned_calls.get(node.id) or aliases.get(node.id) or node.id
+    if isinstance(node, ast.Attribute):
+        base = _resolve_expr_name(node.value, aliases, assigned_calls)
+        if base:
+            return f"{base}.{node.attr}"
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _qualified_name_from_call(node, aliases, assigned_calls)
+    return None
+
+
+def _qualified_name_from_call(node: ast.Call, aliases=None, assigned_calls=None):
     func = node.func
     parts = []
     while isinstance(func, ast.Attribute):
         parts.append(func.attr)
         func = func.value
     if isinstance(func, ast.Name):
-        parts.append(func.id)
+        parts.append(_resolve_expr_name(func, aliases, assigned_calls) or func.id)
         parts.reverse()
         return ".".join(parts)
+    if isinstance(func, ast.Call):
+        base = _qualified_name_from_call(func, aliases, assigned_calls)
+        if base:
+            parts.reverse()
+            return ".".join([base, *parts])
     return None
 
 
@@ -102,11 +122,20 @@ def _kw_equals(node: ast.Call, requirements):
     return True
 
 
-def _yaml_load_without_safeloader(node: ast.Call):
+def _is_safe_yaml_loader(value: ast.AST, aliases=None) -> bool:
+    name = _resolve_expr_name(value, aliases)
+    if not name:
+        return False
+    return name.split(".")[-1] in {"SafeLoader", "CSafeLoader"}
+
+
+def _yaml_load_without_safeloader(node: ast.Call, aliases=None):
     for kw in node.keywords or []:
         if kw.arg == "Loader":
-            if "SafeLoader" in ast.dump(kw.value):
+            if _is_safe_yaml_loader(kw.value, aliases):
                 return False
+    if len(node.args) >= 2 and _is_safe_yaml_loader(node.args[1], aliases):
+        return False
     return True
 
 
@@ -114,11 +143,83 @@ class DangerousCallsRule(SkylosRule):
     rule_id = "SKY-D200"
     name = "Dangerous Function Calls"
 
+    def __init__(self):
+        self.aliases: dict[str, str] = {}
+        self.assigned_calls_by_scope: dict[int, dict[str, str]] = {}
+        self._parents_annotated = False
+
+    def _annotate_parents(self, node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            child.parent = node
+            self._annotate_parents(child)
+
+    def _scope_key(self, node: ast.AST) -> int:
+        current = node
+        while current is not None:
+            if isinstance(
+                current,
+                (
+                    ast.Module,
+                    ast.FunctionDef,
+                    ast.AsyncFunctionDef,
+                    ast.ClassDef,
+                ),
+            ):
+                return id(current)
+            current = getattr(current, "parent", None)
+        return 0
+
+    def _assigned_calls_for(self, node: ast.AST) -> dict[str, str]:
+        return self.assigned_calls_by_scope.setdefault(self._scope_key(node), {})
+
+    def _track_import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".", 1)[0]
+            self.aliases[local] = alias.name
+
+    def _track_import_from(self, node: ast.ImportFrom) -> None:
+        if not node.module:
+            return
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            local = alias.asname or alias.name
+            self.aliases[local] = f"{node.module}.{alias.name}"
+
+    def _track_assign(self, node: ast.Assign) -> None:
+        if not isinstance(node.value, ast.Call):
+            return
+        assigned_calls = self._assigned_calls_for(node)
+        call_name = _qualified_name_from_call(
+            node.value, self.aliases, assigned_calls
+        )
+        if not call_name:
+            return
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                assigned_calls[target.id] = call_name
+
     def visit_node(self, node, context):
+        if isinstance(node, ast.Module) and not self._parents_annotated:
+            self._annotate_parents(node)
+            self._parents_annotated = True
+            self.assigned_calls_by_scope.setdefault(id(node), {})
+            return None
+        if isinstance(node, ast.Import):
+            self._track_import(node)
+            return None
+        if isinstance(node, ast.ImportFrom):
+            self._track_import_from(node)
+            return None
+        if isinstance(node, ast.Assign):
+            self._track_assign(node)
+            return None
         if not isinstance(node, ast.Call):
             return None
 
-        name = _qualified_name_from_call(node)
+        name = _qualified_name_from_call(
+            node, self.aliases, self._assigned_calls_for(node)
+        )
         if not name:
             return None
 
@@ -134,7 +235,7 @@ class DangerousCallsRule(SkylosRule):
             opts = tup[3] if len(tup) > 3 else None
 
             if rule_key == "yaml.load":
-                if not _yaml_load_without_safeloader(node):
+                if not _yaml_load_without_safeloader(node, self.aliases):
                     continue
 
             if opts and "kw_equals" in opts:

--- a/skylos/rules/danger/danger.py
+++ b/skylos/rules/danger/danger.py
@@ -34,6 +34,8 @@ class _DangerousCallsChecker(ast.NodeVisitor):
         self.file_path = file_path
         self.findings = findings
         self._symbol_stack = ["<module>"]
+        self.aliases = {}
+        self.assigned_calls_stack = [{}]
 
     def _current_symbol(self):
         if self._symbol_stack:
@@ -52,21 +54,53 @@ class _DangerousCallsChecker(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         self._symbol_stack.append(node.name)
+        self.assigned_calls_stack.append({})
         self.generic_visit(node)
+        self.assigned_calls_stack.pop()
         self._symbol_stack.pop()
 
     def visit_AsyncFunctionDef(self, node):
         self._symbol_stack.append(node.name)
+        self.assigned_calls_stack.append({})
         self.generic_visit(node)
+        self.assigned_calls_stack.pop()
         self._symbol_stack.pop()
 
     def visit_ClassDef(self, node):
         self._symbol_stack.append(node.name)
+        self.assigned_calls_stack.append({})
         self.generic_visit(node)
+        self.assigned_calls_stack.pop()
         self._symbol_stack.pop()
 
+    def visit_Import(self, node):
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".", 1)[0]
+            self.aliases[local] = alias.name
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        if node.module:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                local = alias.asname or alias.name
+                self.aliases[local] = f"{node.module}.{alias.name}"
+        self.generic_visit(node)
+
+    def visit_Assign(self, node):
+        if isinstance(node.value, ast.Call):
+            call_name = qualified_name_from_call(
+                node.value, self.aliases, self.assigned_calls_stack[-1]
+            )
+            if call_name:
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        self.assigned_calls_stack[-1][target.id] = call_name
+        self.generic_visit(node)
+
     def visit_Call(self, node):
-        name = qualified_name_from_call(node)
+        name = qualified_name_from_call(node, self.aliases, self.assigned_calls_stack[-1])
         if name:
             for rule_key, tup in DANGEROUS_CALLS.items():
                 rule_id, severity, message = tup[0], tup[1], tup[2]
@@ -78,7 +112,9 @@ class _DangerousCallsChecker(ast.NodeVisitor):
                 if not _matches_rule(name, rule_key):
                     continue
 
-                if rule_key == "yaml.load" and not _yaml_load_without_safeloader(node):
+                if rule_key == "yaml.load" and not _yaml_load_without_safeloader(
+                    node, self.aliases
+                ):
                     continue
 
                 if (

--- a/skylos/rules/danger/danger_net/ssrf_flow.py
+++ b/skylos/rules/danger/danger_net/ssrf_flow.py
@@ -97,6 +97,12 @@ def _has_safe_base_url(node):
     return False
 
 
+def _tainted_url_is_ssrf_relevant(checker, node):
+    if isinstance(node, ast.JoinedStr) and _has_safe_base_url(node):
+        return False
+    return checker.is_tainted(node)
+
+
 def _is_interpolated_string(node):
     if isinstance(node, ast.JoinedStr):
         if _has_safe_base_url(node):
@@ -166,7 +172,9 @@ class _SSRFFlowChecker(TaintVisitor):
             if func in self.HTTP_METHODS and node.args:
                 if self._is_likely_http_receiver(node):
                     url_arg = node.args[0]
-                    if _is_interpolated_string(url_arg) or self.is_tainted(url_arg):
+                    if _is_interpolated_string(url_arg) or _tainted_url_is_ssrf_relevant(
+                        self, url_arg
+                    ):
                         self.findings.append(
                             {
                                 "rule_id": "SKY-D216",
@@ -181,7 +189,9 @@ class _SSRFFlowChecker(TaintVisitor):
 
         if qn and qn.endswith(".urlopen") and node.args:
             url_arg = node.args[0]
-            if _is_interpolated_string(url_arg) or self.is_tainted(url_arg):
+            if _is_interpolated_string(url_arg) or _tainted_url_is_ssrf_relevant(
+                self, url_arg
+            ):
                 self.findings.append(
                     {
                         "rule_id": "SKY-D216",

--- a/skylos/rules/danger/danger_sql/sql_flow.py
+++ b/skylos/rules/danger/danger_sql/sql_flow.py
@@ -54,17 +54,55 @@ def _qualified_name_from_call(node):
     return None
 
 
-def _is_interpolated_string(node):
+def _is_static_string_expr(node: ast.AST) -> bool:
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, str)
+
     if isinstance(node, ast.JoinedStr):
+        for value in node.values:
+            if isinstance(value, ast.Constant):
+                continue
+            if isinstance(value, ast.FormattedValue) and isinstance(
+                value.value, ast.Constant
+            ):
+                continue
+            return False
         return True
-    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Mod)):
-        return True
+
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _is_static_string_expr(node.left) and _is_static_string_expr(node.right)
+
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+        if not _is_static_string_expr(node.left):
+            return False
+        right = node.right
+        if isinstance(right, ast.Tuple):
+            return all(_is_static_string_expr(elt) for elt in right.elts)
+        return _is_static_string_expr(right)
+
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and node.func.attr == "format"
     ):
-        return True
+        return _is_static_string_expr(node.func.value) and all(
+            _is_static_string_expr(arg) for arg in node.args
+        ) and all(_is_static_string_expr(k.value) for k in node.keywords)
+
+    return False
+
+
+def _is_interpolated_string(node):
+    if isinstance(node, ast.JoinedStr):
+        return not _is_static_string_expr(node)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Mod)):
+        return not _is_static_string_expr(node)
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "format"
+    ):
+        return not _is_static_string_expr(node)
     return False
 
 
@@ -189,9 +227,7 @@ class _SQLFlowChecker(TaintVisitor):
 
         return False
 
-    def visit_FunctionDef(self, node):
-        self._push()
-
+    def _record_passthrough_function(self, node):
         param_names = {a.arg for a in node.args.args}
         for statement in node.body:
             if isinstance(statement, ast.Return) and statement.value is not None:
@@ -199,21 +235,13 @@ class _SQLFlowChecker(TaintVisitor):
                     self.passthrough_functions.add(_func_name(node))
                     break
 
-        self.generic_visit(node)
-        self._pop()
+    def visit_FunctionDef(self, node):
+        self._record_passthrough_function(node)
+        super().visit_FunctionDef(node)
 
     def visit_AsyncFunctionDef(self, node):
-        self._push()
-
-        param_names = {a.arg for a in node.args.args}
-        for statement in node.body:
-            if isinstance(statement, ast.Return) and statement.value is not None:
-                if _is_passthrough_return(statement.value, param_names):
-                    self.passthrough_functions.add(_func_name(node))
-                    break
-
-        self.generic_visit(node)
-        self._pop()
+        self._record_passthrough_function(node)
+        super().visit_AsyncFunctionDef(node)
 
     def visit_Call(self, node):
         qual_name = _qualified_name_from_call(node)
@@ -242,9 +270,7 @@ class _SQLFlowChecker(TaintVisitor):
                         }
                     )
                 else:
-                    is_literal = isinstance(query_expr, ast.Constant) and isinstance(
-                        query_expr.value, str
-                    )
+                    is_literal = _is_static_string_expr(query_expr)
                     if not is_literal and not is_parameterized_query(node, query_expr):
                         self.findings.append(
                             {

--- a/skylos/rules/danger/danger_sql/sql_raw_flow.py
+++ b/skylos/rules/danger/danger_sql/sql_raw_flow.py
@@ -22,17 +22,47 @@ def _qualified_name(node: ast.Call):
     return None
 
 
-def _is_interpolated_string(n: ast.AST):
+def _is_static_string_expr(n: ast.AST) -> bool:
+    if isinstance(n, ast.Constant):
+        return isinstance(n.value, str)
     if isinstance(n, ast.JoinedStr):
+        for value in n.values:
+            if isinstance(value, ast.Constant):
+                continue
+            if isinstance(value, ast.FormattedValue) and isinstance(
+                value.value, ast.Constant
+            ):
+                continue
+            return False
         return True
-    if isinstance(n, ast.BinOp) and isinstance(n.op, (ast.Add, ast.Mod)):
-        return True
+    if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Add):
+        return _is_static_string_expr(n.left) and _is_static_string_expr(n.right)
+    if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Mod):
+        if not _is_static_string_expr(n.left):
+            return False
+        if isinstance(n.right, ast.Tuple):
+            return all(_is_static_string_expr(elt) for elt in n.right.elts)
+        return _is_static_string_expr(n.right)
     if (
         isinstance(n, ast.Call)
         and isinstance(n.func, ast.Attribute)
         and n.func.attr == "format"
     ):
-        return True
+        return _is_static_string_expr(n.func.value) and all(
+            _is_static_string_expr(arg) for arg in n.args
+        ) and all(_is_static_string_expr(k.value) for k in n.keywords)
+    return False
+
+
+def _is_interpolated_string(n: ast.AST):
+    if isinstance(n, (ast.JoinedStr, ast.BinOp)):
+        return not _is_static_string_expr(n)
+    if (
+        isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "format"
+    ):
+        return not _is_static_string_expr(n)
     return False
 
 

--- a/skylos/rules/danger/taint.py
+++ b/skylos/rules/danger/taint.py
@@ -109,7 +109,9 @@ class TaintVisitor(ast.NodeVisitor):
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "format"
         ):
-            return True
+            return self.is_tainted(node.func.value) or any(
+                self.is_tainted(arg) for arg in node.args
+            ) or any(self.is_tainted(k.value) for k in node.keywords)
 
         if (
             isinstance(node, ast.Call)

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -237,6 +237,29 @@ class TestSkylos:
         assert root == project.resolve()
         assert files == [keep_file.resolve()]
 
+    def test_get_python_files_fast_discovery_honors_nested_excludes(
+        self, skylos, tmp_path, monkeypatch
+    ):
+        project = tmp_path / "proj"
+        legacy_dir = project / "src" / "legacy"
+        modern_dir = project / "src" / "modern"
+        legacy_dir.mkdir(parents=True)
+        modern_dir.mkdir(parents=True)
+        legacy_file = legacy_dir / "old.py"
+        legacy_file.write_text("def old_dead():\n    pass\n", encoding="utf-8")
+        keep_file = modern_dir / "keep.py"
+        keep_file.write_text("def keep():\n    return 1\n", encoding="utf-8")
+
+        def fake_fast_discover(root, extensions, excludes):
+            return [str(legacy_file), str(keep_file)]
+
+        monkeypatch.setattr("skylos.analyzer._fast_discover", fake_fast_discover)
+
+        files, root = skylos._get_python_files(project, exclude_folders=["src/legacy"])
+
+        assert root == project.resolve()
+        assert files == [keep_file]
+
     def test_mark_exports_in_init(self, skylos):
         mock_def1 = Mock()
         mock_def1.in_init = True
@@ -521,6 +544,32 @@ class TestAnalyze:
 
         mock_scan.assert_called_once()
         assert result == tuple(range(13))
+
+    def test_analyze_quality_includes_architecture_findings(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "abstract_mod.py").write_text(
+                "from abc import ABC\n"
+                "import concrete_mod\n"
+                "class Base(ABC):\n"
+                "    pass\n"
+                "class Base2(ABC):\n"
+                "    pass\n",
+                encoding="utf-8",
+            )
+            (root / "concrete_mod.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        assert result.get("architecture_metrics")
+        assert any(
+            f.get("rule_id") in {"SKY-Q802", "SKY-Q803", "SKY-Q804"}
+            for f in result.get("quality", [])
+        )
+        assert result["analysis_summary"]["quality_count"] == len(
+            result.get("quality", [])
+        )
 
     @patch("skylos.analyzer.scan_typescript_file")
     def test_proc_file_dispatches_mjs_to_typescript_scanner(self, mock_scan):

--- a/test/test_dangerous.py
+++ b/test/test_dangerous.py
@@ -1,5 +1,8 @@
+import ast
 from pathlib import Path
+from skylos.linter import LinterVisitor
 from skylos.rules.danger.danger import scan_ctx
+from skylos.rules.danger.calls import DangerousCallsRule
 
 
 def _write(tmp_path: Path, name, code):
@@ -18,6 +21,12 @@ def _rule_ids(findings):
 def _scan_one(tmp_path: Path, name, code):
     file_path = _write(tmp_path, name, code)
     return scan_ctx(tmp_path, [file_path])
+
+
+def _scan_dangerous_calls_rule(code):
+    linter = LinterVisitor([DangerousCallsRule()], "rule_direct.py")
+    linter.visit(ast.parse(code))
+    return linter.findings
 
 
 def test_eval(tmp_path):
@@ -76,6 +85,70 @@ def test_requests_verify_false(tmp_path):
     assert "SKY-D210" in _rule_ids(out)
 
 
+def test_subprocess_alias_shell_true_flags(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_subproc_alias.py",
+        "import subprocess as sp\nsp.run('echo hi', shell=True)\n",
+    )
+    assert "SKY-D209" in _rule_ids(out)
+
+
+def test_subprocess_imported_run_shell_true_flags(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_subproc_from.py",
+        "from subprocess import run\nrun('echo hi', shell=True)\n",
+    )
+    assert "SKY-D209" in _rule_ids(out)
+
+
+def test_requests_session_verify_false_flags(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_requests_session.py",
+        "import requests\nrequests.Session().get('https://x', verify=False)\n",
+    )
+    assert "SKY-D210" in _rule_ids(out)
+
+
+def test_requests_assigned_session_verify_false_flags(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_requests_assigned_session.py",
+        "import requests\ns = requests.Session()\ns.get('https://x', verify=False)\n",
+    )
+    assert "SKY-D210" in _rule_ids(out)
+
+
+def test_dangerous_calls_rule_resolves_alias_and_assigned_session():
+    findings = _scan_dangerous_calls_rule(
+        "import subprocess as sp\n"
+        "from subprocess import run\n"
+        "import requests\n"
+        "sp.run('echo hi', shell=True)\n"
+        "run('echo hi', shell=True)\n"
+        "s = requests.Session()\n"
+        "s.get('https://x', verify=False)\n"
+    )
+    ids = _rule_ids(findings)
+    assert "SKY-D209" in ids
+    assert "SKY-D210" in ids
+
+
+def test_assigned_session_does_not_leak_across_functions(tmp_path):
+    code = (
+        "import requests\n"
+        "def build():\n"
+        "    s = requests.Session()\n"
+        "    return s\n"
+        "def use(s):\n"
+        "    s.get('https://x', verify=False)\n"
+    )
+    out = _scan_one(tmp_path, "requests_session_scope.py", code)
+    assert "SKY-D210" not in _rule_ids(out)
+
+
 def test_yaml_safe_loader_does_not_trigger(tmp_path):
     code = (
         "import yaml\n"
@@ -83,6 +156,12 @@ def test_yaml_safe_loader_does_not_trigger(tmp_path):
         "yaml.load('a: 1', Loader=SafeLoader)\n"
     )
     out = _scan_one(tmp_path, "b_yaml_safe.py", code)
+    assert "SKY-D206" not in _rule_ids(out)
+
+
+def test_yaml_positional_safe_loader_does_not_trigger(tmp_path):
+    code = "import yaml\nyaml.load('a: 1', yaml.SafeLoader)\n"
+    out = _scan_one(tmp_path, "b_yaml_safe_positional.py", code)
     assert "SKY-D206" not in _rule_ids(out)
 
 
@@ -114,6 +193,24 @@ def f(cur, name):
     cur.execute("SELECT * FROM users WHERE name = %s", (name,))
 """
     out = _scan_one(tmp_path, "sql_param_ok.py", code)
+    assert "SKY-D211" not in _rule_ids(out)
+
+
+def test_sql_execute_tainted_query_with_params_flags(tmp_path):
+    code = """
+def f(cur, query, params):
+    cur.execute(query, params)
+"""
+    out = _scan_one(tmp_path, "sql_tainted_query_params.py", code)
+    assert "SKY-D211" in _rule_ids(out)
+
+
+def test_sql_constant_format_query_ok(tmp_path):
+    code = """
+def f(cur):
+    cur.execute("SELECT * FROM users WHERE role = {}".format("admin"))
+"""
+    out = _scan_one(tmp_path, "sql_constant_format.py", code)
     assert "SKY-D211" not in _rule_ids(out)
 
 

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -43,3 +43,13 @@ def test_requests_constant_url_ok(tmp_path):
     )
     out = _scan_one(tmp_path, "ssrf_ok.py", code)
     assert "SKY-D216" not in _rule_ids(out)
+
+
+def test_requests_fixed_host_interpolated_path_ok(tmp_path):
+    code = (
+        "import requests\n"
+        "def f(user_id):\n"
+        "    requests.get(f'https://api.example.com/users/{user_id}', timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_fixed_host.py", code)
+    assert "SKY-D216" not in _rule_ids(out)


### PR DESCRIPTION
## Summary

  Fixes several confirmed analyzer logic gaps and FP/FN paths:

  - Honor slash-containing excludes like src/legacy after Rust fast file discovery
  - Detect tainted SQL query parameters
  - Avoid false positives for statically built SQL strings such as constant .format() calls
  - Resolve dangerous-call aliases and chained receivers:
      - import subprocess as sp; sp.run(..., shell=True)
      - from subprocess import run; run(..., shell=True)
      - requests.Session().get(..., verify=False)
      - assigned session receivers within scope
  - Avoid FP for positional yaml.SafeLoader
  - Include architecture quality findings in result["quality"] and update quality_count

## Validation

  - pytest -q