### PR TITLE
fix(python): improve security flow precision and recall

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -176,7 +176,7 @@ of receiving a score.
 | Dead code frozen | seeded dev | Vulture | Go | 0 | 1 | 0 | 0 | 0 | 0 | N/A |
 | Dead code frozen | seeded dev | Vulture | Java | 0 | 1 | 0 | 0 | 0 | 0 | N/A |
 | Dead code frozen | seeded dev | Ruff | Python | 4 | 0 | 0 | 0 | 16 | 11 | 55.0 |
-| Security frozen | seeded dev | Skylos | Python | 3 | 0 | 8 | 4 | 2 | 7 | 72.06 |
+| Security frozen | seeded dev | Skylos | Python | 3 | 0 | 10 | 1 | 0 | 7 | 94.32 |
 | Security frozen | seeded dev | Skylos | TypeScript | 1 | 0 | 4 | 0 | 1 | 1 | 91.0 |
 | Security frozen | seeded dev | Skylos | Go | 2 | 0 | 5 | 1 | 0 | 1 | 84.17 |
 | Security frozen | seeded dev | Bandit | Python | 3 | 0 | 6 | 3 | 4 | 7 | 64.33 |
@@ -189,10 +189,21 @@ of receiving a score.
 These frozen results already show useful gaps to investigate before any public
 claim: Skylos currently misses Python and TypeScript reachability edges, has
 JavaScript dead-code false positives on route-registry exports, misses a Java
-unused method, has seeded security false positives around sanitized/safe flows,
-misses the seeded Python quality duplicate-branch case, and misses most OWASP
-Java security-flow cases outside weak crypto/hash. Vulture is only comparable on
-the Python dead-code subset.
+unused method, still has seeded security gaps in TypeScript SSRF and Go command
+precision, misses the seeded Python quality duplicate-branch case, and misses
+most OWASP Java security-flow cases outside weak crypto/hash. Vulture is only
+comparable on the Python dead-code subset.
+
+Phase 2 Python security rerun on 2026-04-25 improved frozen `security.dev`
+overall from `TP=17 FP=5 FN=3 TN=9 score=78.15` to
+`TP=19 FP=2 FN=1 TN=9 score=90.78`. Python moved from
+`TP=8 FP=4 FN=2 TN=7 score=72.06` to
+`TP=10 FP=1 FN=0 TN=7 score=94.32`. The remaining Python FP is
+`seed-python-path-ssrf-redirect`'s fixed-host `urljoin` negative label:
+`urljoin("https://cdn.example.com/", f"{user_id}.png")` can still be overridden
+by `https://...` or `//...` user input, so the detector keeps flagging it and
+the label should be reviewed in the next benchmark version instead of being
+suppressed in the analyzer.
 
 ## Benchmark Rules
 

--- a/skylos/rules/danger/calls.py
+++ b/skylos/rules/danger/calls.py
@@ -1,4 +1,5 @@
 import ast
+import re
 from skylos.rules.base import SkylosRule
 
 DANGEROUS_CALLS = {
@@ -18,6 +19,48 @@ DANGEROUS_CALLS = {
     "yaml.load": ("SKY-D206", "HIGH", "yaml.load without SafeLoader"),
     "hashlib.md5": ("SKY-D207", "MEDIUM", "Weak hash (MD5)"),
     "hashlib.sha1": ("SKY-D208", "MEDIUM", "Weak hash (SHA1)"),
+    "random.random": (
+        "SKY-D250",
+        "MEDIUM",
+        "Weak random source; use secrets or os.urandom for security-sensitive values",
+        {"weak_random": True},
+    ),
+    "random.randint": (
+        "SKY-D250",
+        "MEDIUM",
+        "Weak random source; use secrets or os.urandom for security-sensitive values",
+        {"weak_random": True},
+    ),
+    "random.randrange": (
+        "SKY-D250",
+        "MEDIUM",
+        "Weak random source; use secrets or os.urandom for security-sensitive values",
+        {"weak_random": True},
+    ),
+    "random.choice": (
+        "SKY-D250",
+        "MEDIUM",
+        "Weak random source; use secrets or os.urandom for security-sensitive values",
+        {"weak_random": True},
+    ),
+    "random.choices": (
+        "SKY-D250",
+        "MEDIUM",
+        "Weak random source; use secrets or os.urandom for security-sensitive values",
+        {"weak_random": True},
+    ),
+    "random.randbytes": (
+        "SKY-D250",
+        "MEDIUM",
+        "Weak random source; use secrets or os.urandom for security-sensitive values",
+        {"weak_random": True},
+    ),
+    "random.getrandbits": (
+        "SKY-D250",
+        "MEDIUM",
+        "Weak random source; use secrets or os.urandom for security-sensitive values",
+        {"weak_random": True},
+    ),
     "subprocess.*": (
         "SKY-D209",
         "HIGH",
@@ -139,6 +182,120 @@ def _yaml_load_without_safeloader(node: ast.Call, aliases=None):
     return True
 
 
+_WEAK_RANDOM_SECURITY_KEYWORDS = {
+    "api_key",
+    "apikey",
+    "auth",
+    "cookie",
+    "credential",
+    "csrf",
+    "jwt",
+    "nonce",
+    "otp",
+    "password",
+    "passwd",
+    "pwd",
+    "salt",
+    "secret",
+    "session",
+    "signature",
+    "signing",
+    "token",
+}
+
+
+def _identifier_tokens(name: str | None) -> set[str]:
+    raw = str(name or "").strip()
+    if not raw:
+        return set()
+    snake = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", raw)
+    return {
+        part.lower()
+        for part in re.split(r"[^A-Za-z0-9]+|_", snake)
+        if part
+    }
+
+
+def _name_looks_security_sensitive(name: str | None) -> bool:
+    tokens = _identifier_tokens(name)
+    if not tokens:
+        return False
+    if "api" in tokens and "key" in tokens:
+        return True
+    return bool(tokens & _WEAK_RANDOM_SECURITY_KEYWORDS)
+
+
+def _target_looks_security_sensitive(target: ast.AST) -> bool:
+    if isinstance(target, ast.Name):
+        return _name_looks_security_sensitive(target.id)
+    if isinstance(target, ast.Attribute):
+        return _name_looks_security_sensitive(target.attr)
+    if isinstance(target, ast.Subscript):
+        if isinstance(target.slice, ast.Constant) and isinstance(target.slice.value, str):
+            return _name_looks_security_sensitive(target.slice.value)
+        return _target_looks_security_sensitive(target.value)
+    return False
+
+
+def _enclosing_function_name(node: ast.AST) -> str | None:
+    current = getattr(node, "parent", None)
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return current.name
+        current = getattr(current, "parent", None)
+    return None
+
+
+def _weak_random_has_security_context(
+    node: ast.Call, current_symbol: str | None = None
+) -> bool:
+    if _name_looks_security_sensitive(current_symbol):
+        return True
+
+    function_name = _enclosing_function_name(node)
+    if _name_looks_security_sensitive(function_name):
+        return True
+
+    current: ast.AST = node
+    while True:
+        parent = getattr(current, "parent", None)
+        if parent is None:
+            return False
+
+        if isinstance(parent, ast.Assign):
+            return any(_target_looks_security_sensitive(t) for t in parent.targets)
+
+        if isinstance(parent, ast.AnnAssign):
+            return _target_looks_security_sensitive(parent.target)
+
+        if isinstance(parent, ast.keyword):
+            if _name_looks_security_sensitive(parent.arg):
+                return True
+            current = parent
+            continue
+
+        if isinstance(parent, ast.Return):
+            return _name_looks_security_sensitive(_enclosing_function_name(parent))
+
+        if isinstance(
+            parent,
+            (
+                ast.BinOp,
+                ast.BoolOp,
+                ast.Call,
+                ast.Compare,
+                ast.FormattedValue,
+                ast.IfExp,
+                ast.JoinedStr,
+                ast.UnaryOp,
+            ),
+        ):
+            current = parent
+            continue
+
+        return False
+
+
 class DangerousCallsRule(SkylosRule):
     rule_id = "SKY-D200"
     name = "Dangerous Function Calls"
@@ -240,6 +397,10 @@ class DangerousCallsRule(SkylosRule):
 
             if opts and "kw_equals" in opts:
                 if not _kw_equals(node, opts["kw_equals"]):
+                    continue
+
+            if opts and opts.get("weak_random"):
+                if not _weak_random_has_security_context(node):
                     continue
 
             findings.append(

--- a/skylos/rules/danger/danger.py
+++ b/skylos/rules/danger/danger.py
@@ -22,6 +22,7 @@ from .calls import (
     _matches_rule,
     _kw_equals,
     _qualified_name_from_call as qualified_name_from_call,
+    _weak_random_has_security_context,
     _yaml_load_without_safeloader,
 )
 
@@ -36,6 +37,12 @@ class _DangerousCallsChecker(ast.NodeVisitor):
         self._symbol_stack = ["<module>"]
         self.aliases = {}
         self.assigned_calls_stack = [{}]
+        self._parents_annotated = False
+
+    def _annotate_parents(self, node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            child.parent = node
+            self._annotate_parents(child)
 
     def _current_symbol(self):
         if self._symbol_stack:
@@ -72,6 +79,12 @@ class _DangerousCallsChecker(ast.NodeVisitor):
         self.generic_visit(node)
         self.assigned_calls_stack.pop()
         self._symbol_stack.pop()
+
+    def visit_Module(self, node):
+        if not self._parents_annotated:
+            self._annotate_parents(node)
+            self._parents_annotated = True
+        self.generic_visit(node)
 
     def visit_Import(self, node):
         for alias in node.names:
@@ -123,6 +136,12 @@ class _DangerousCallsChecker(ast.NodeVisitor):
                     and not _kw_equals(node, opts["kw_equals"])
                 ):
                     continue
+
+                if opts and opts.get("weak_random"):
+                    if not _weak_random_has_security_context(
+                        node, self._current_symbol()
+                    ):
+                        continue
 
                 self.findings.append(
                     {

--- a/skylos/rules/danger/danger_fs/path_flow.py
+++ b/skylos/rules/danger/danger_fs/path_flow.py
@@ -33,10 +33,146 @@ def _is_interpolated_string(node):
     return False
 
 
+def _expr_name(node):
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        parts.reverse()
+        return ".".join(parts)
+    return None
+
+
+def _is_path_constructor_call(node):
+    if not isinstance(node, ast.Call):
+        return False
+    name = _expr_name(node.func)
+    return name in {
+        "Path",
+        "PurePath",
+        "PosixPath",
+        "WindowsPath",
+        "pathlib.Path",
+        "pathlib.PurePath",
+        "pathlib.PosixPath",
+        "pathlib.WindowsPath",
+    }
+
+
+def _is_path_name_projection(node):
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "name"
+        and _is_path_constructor_call(node.value)
+    )
+
+
 class _PathFlowChecker(TaintVisitor):
     FILE_OPEN_FUNCS = {"open"}
     OS_FILE_FUNCS = {"open", "unlink", "remove", "mkdir", "rmdir", "makedirs"}
     SHUTIL_FUNCS = {"copy", "copy2", "copytree", "move", "rmtree"}
+    PATHLIB_SINK_METHODS = {
+        "open",
+        "read_bytes",
+        "read_text",
+        "write_bytes",
+        "write_text",
+        "unlink",
+        "mkdir",
+        "rmdir",
+        "rename",
+        "replace",
+    }
+
+    def __init__(self, file_path, findings, sanitizers=None):
+        super().__init__(file_path, findings, sanitizers=sanitizers)
+        self.path_like_stack = [{}]
+
+    def _push(self):
+        super()._push()
+        self.path_like_stack.append({})
+
+    def _pop(self):
+        super()._pop()
+        if self.path_like_stack:
+            self.path_like_stack.pop()
+
+    def _set_path_like(self, name, path_like):
+        if not self.path_like_stack:
+            self.path_like_stack.append({})
+        self.path_like_stack[-1][name] = bool(path_like)
+
+    def _get_path_like(self, name):
+        for env in reversed(self.path_like_stack):
+            if name in env:
+                return env[name]
+        return False
+
+    def _taint_params(self, fn: ast.AST):
+        super()._taint_params(fn)
+        args = []
+        if hasattr(fn, "args") and fn.args:
+            args.extend(getattr(fn.args, "posonlyargs", []) or [])
+            args.extend(getattr(fn.args, "args", []) or [])
+            args.extend(getattr(fn.args, "kwonlyargs", []) or [])
+
+            if fn.args.vararg:
+                args.append(fn.args.vararg)
+            if fn.args.kwarg:
+                args.append(fn.args.kwarg)
+
+        for arg in args:
+            name = getattr(arg, "arg", None)
+            if name and name not in {"self", "cls"}:
+                self._set_path_like(name, False)
+
+    def _is_path_like_expr(self, node):
+        if _is_path_constructor_call(node):
+            return True
+        if isinstance(node, ast.Name):
+            return self._get_path_like(node.id)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            return self._is_path_like_expr(node.left) or self._is_path_like_expr(
+                node.right
+            )
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in {
+                "absolute",
+                "expanduser",
+                "joinpath",
+                "resolve",
+                "with_name",
+                "with_suffix",
+            }:
+                return self._is_path_like_expr(node.func.value)
+        return False
+
+    def is_tainted(self, node):
+        if _is_path_name_projection(node):
+            return False
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            return self.is_tainted(node.left) or self.is_tainted(node.right)
+        return super().is_tainted(node)
+
+    def visit_Assign(self, node):
+        t = self.is_tainted(node.value)
+        path_like = self._is_path_like_expr(node.value)
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Name):
+                self._set(tgt.id, t)
+                self._set_path_like(tgt.id, path_like)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node):
+        if node.value:
+            t = self.is_tainted(node.value)
+            path_like = self._is_path_like_expr(node.value)
+            if isinstance(node.target, ast.Name):
+                self._set(node.target.id, t)
+                self._set_path_like(node.target.id, path_like)
+        self.generic_visit(node)
 
     def _flag_if_tainted_path(self, node, path_expr):
         is_interp = _is_interpolated_string(path_expr)
@@ -57,6 +193,13 @@ class _PathFlowChecker(TaintVisitor):
 
     def visit_Call(self, node: ast.Call):
         qn = _qualified_name(node)
+
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in self.PATHLIB_SINK_METHODS
+            and self._is_path_like_expr(node.func.value)
+        ):
+            self._flag_if_tainted_path(node, node.func.value)
 
         if qn and qn in self.FILE_OPEN_FUNCS and node.args:
             self._flag_if_tainted_path(node, node.args[0])

--- a/skylos/rules/danger/danger_hallucination/dependency_hallucination.py
+++ b/skylos/rules/danger/danger_hallucination/dependency_hallucination.py
@@ -84,6 +84,8 @@ FROM_RE = re.compile(r"^\s*from\s+([A-Za-z_][\w\.]*)\s+import\b", re.MULTILINE)
 
 REQ_LINE_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
 
+DEPENDENCY_MANIFEST_FILENAMES = ("requirements.txt", "pyproject.toml", "setup.py")
+
 
 def _normalize_name(name):
     if name is None:
@@ -539,6 +541,31 @@ def _parse_setup_py(path):
     return deps, project_name
 
 
+def _has_dependency_manifest_context(repo_root):
+    current = repo_root
+
+    for _ in range(5):
+        try:
+            for filename in DEPENDENCY_MANIFEST_FILENAMES:
+                if (current / filename).exists():
+                    return True
+
+            req_dir = current / "requirements"
+            if req_dir.exists() and req_dir.is_dir():
+                for req_file in req_dir.glob("*.txt"):
+                    if req_file.exists():
+                        return True
+        except Exception:
+            return False
+
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    return False
+
+
 def _collect_declared_deps(repo_root):
     deps = set()
     project_name = None
@@ -699,6 +726,9 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
     stdlib = _get_stdlib_modules()
     local_modules = _collect_local_modules(repo_root)
     declared_deps = _collect_declared_deps(repo_root)
+    dependency_manifest_context = bool(
+        declared_deps
+    ) or _has_dependency_manifest_context(repo_root)
     private_allow = _load_private_allowlist()
 
     installed_mapping = _build_installed_module_mapping()
@@ -734,6 +764,9 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
                 if known_dists & declared_deps:
                     continue
 
+                if not dependency_manifest_context:
+                    continue
+
                 line = _find_import_line(src, mod)
                 dist_hint = ", ".join(sorted(known_dists))
                 findings.append(
@@ -767,6 +800,9 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
                 mapped_normalized = _normalize_name(mapped_dist)
 
                 if mapped_normalized in declared_deps:
+                    continue
+
+                if not dependency_manifest_context:
                     continue
 
                 line = _find_import_line(src, mod)
@@ -816,7 +852,7 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
                         "symbol": mod,
                     }
                 )
-            elif pypi_status == "exists":
+            elif pypi_status == "exists" and dependency_manifest_context:
                 findings.append(
                     {
                         "rule_id": RULE_ID_UNDECLARED,
@@ -831,7 +867,7 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
                         "symbol": mod,
                     }
                 )
-            else:
+            elif dependency_manifest_context:
                 findings.append(
                     {
                         "rule_id": RULE_ID_UNDECLARED,

--- a/skylos/rules/danger/danger_net/ssrf_flow.py
+++ b/skylos/rules/danger/danger_net/ssrf_flow.py
@@ -97,8 +97,96 @@ def _has_safe_base_url(node):
     return False
 
 
+def _constant_string(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _has_absolute_host(value):
+    if not isinstance(value, str) or "://" not in value:
+        return False
+    scheme, rest = value.split("://", 1)
+    host = rest.split("/", 1)[0]
+    return bool(scheme and host)
+
+
+def _leftmost_constant_prefix(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                return value.value
+            if isinstance(value, ast.FormattedValue):
+                return ""
+        return ""
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _leftmost_constant_prefix(node.left)
+    return ""
+
+
+def _urljoin_target_can_override_host(node):
+    literal = _constant_string(node)
+    if literal is not None:
+        return literal.startswith(("http://", "https://", "//"))
+
+    prefix = _leftmost_constant_prefix(node)
+    if prefix.startswith(("http://", "https://", "//")):
+        return True
+
+    if isinstance(node, ast.JoinedStr):
+        return any(
+            isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+            and ("://" in value.value or value.value.startswith("//"))
+            for value in node.values
+        )
+
+    return False
+
+
+def _urljoin_target_is_host_constrained(node):
+    literal = _constant_string(node)
+    if literal is not None:
+        return not _urljoin_target_can_override_host(node)
+
+    prefix = _leftmost_constant_prefix(node)
+    if not prefix:
+        return False
+    if prefix.startswith(("http://", "https://", "//")):
+        return False
+    if prefix.startswith(("/", "\\")):
+        return False
+    if ":" in prefix:
+        return False
+    if "/" not in prefix and "\\" not in prefix:
+        return False
+    if "://" in prefix:
+        return False
+    return True
+
+
+def _is_fixed_host_urljoin(node):
+    if not isinstance(node, ast.Call):
+        return False
+    qn = _qualified_name_from_call(node)
+    if qn not in {"urljoin", "urllib.parse.urljoin"}:
+        return False
+    if len(node.args) < 2:
+        return False
+
+    base = _constant_string(node.args[0])
+    if not _has_absolute_host(base):
+        return False
+
+    return _urljoin_target_is_host_constrained(node.args[1])
+
+
 def _tainted_url_is_ssrf_relevant(checker, node):
     if isinstance(node, ast.JoinedStr) and _has_safe_base_url(node):
+        return False
+    if _is_fixed_host_urljoin(node):
         return False
     return checker.is_tainted(node)
 
@@ -127,6 +215,13 @@ class _SSRFFlowChecker(TaintVisitor):
     def __init__(self, file_path, findings, sanitizers=None):
         super().__init__(file_path, findings, sanitizers=sanitizers)
         self.http_names: set[str] = set()
+
+    def is_tainted(self, node):
+        if isinstance(node, ast.JoinedStr) and _has_safe_base_url(node):
+            return False
+        if _is_fixed_host_urljoin(node):
+            return False
+        return super().is_tainted(node)
 
     def visit_Import(self, node):
         for alias in node.names:

--- a/test/test_dangerous.py
+++ b/test/test_dangerous.py
@@ -85,6 +85,50 @@ def test_requests_verify_false(tmp_path):
     assert "SKY-D210" in _rule_ids(out)
 
 
+def test_random_random_flags_weak_security_random(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_random.py",
+        "import random\n"
+        "def weak_token():\n"
+        "    return str(random.random())\n",
+    )
+    assert "SKY-D250" in _rule_ids(out)
+
+
+def test_secrets_token_urlsafe_is_not_weak_random(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_secrets.py",
+        "import secrets\n"
+        "def strong_token():\n"
+        "    return secrets.token_urlsafe(16)\n",
+    )
+    assert "SKY-D250" not in _rule_ids(out)
+
+
+def test_random_choice_for_non_security_value_is_not_weak_random(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_random_color.py",
+        "import random\n"
+        "def pick_color():\n"
+        "    return random.choice(['red', 'blue'])\n",
+    )
+    assert "SKY-D250" not in _rule_ids(out)
+
+
+def test_random_in_author_named_function_is_not_weak_random(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_random_author.py",
+        "import random\n"
+        "def build_author_slug():\n"
+        "    return str(random.random())\n",
+    )
+    assert "SKY-D250" not in _rule_ids(out)
+
+
 def test_subprocess_alias_shell_true_flags(tmp_path):
     out = _scan_one(
         tmp_path,

--- a/test/test_hallucination_dependency.py
+++ b/test/test_hallucination_dependency.py
@@ -160,6 +160,10 @@ def test_scan_ignores_stdlib_local_declared_private(monkeypatch, tmp_path):
 def test_scan_installed_but_undeclared_emits_dist_hint(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\ndependencies = []\n',
+        encoding="utf-8",
+    )
 
     f = _write_py(
         repo / "a.py",
@@ -195,6 +199,28 @@ def test_scan_installed_but_undeclared_emits_dist_hint(monkeypatch, tmp_path):
     assert "other" in one["message"]
 
 
+def test_scan_without_dependency_manifest_suppresses_undeclared_import(
+    monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    f = _write_py(repo / "a.py", "import installedmod\n")
+
+    monkeypatch.setattr(dep, "_get_stdlib_modules", lambda: set())
+    monkeypatch.setattr(dep, "_collect_local_modules", lambda root: set())
+    monkeypatch.setattr(dep, "_collect_declared_deps", lambda root: set())
+    monkeypatch.setattr(dep, "_load_private_allowlist", lambda: set())
+    monkeypatch.setattr(
+        dep,
+        "_build_installed_module_mapping",
+        lambda: {"installedmod": {"installed-dist"}},
+    )
+
+    finds = dep.scan_python_dependency_hallucinations(repo, [f])
+
+    assert _extract_single(finds, dep.RULE_ID_UNDECLARED) == []
+
+
 def test_scan_pypi_missing_should_emit_hallucination(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -224,6 +250,10 @@ def test_scan_pypi_missing_should_emit_hallucination(monkeypatch, tmp_path):
 def test_scan_cache_is_written_when_modified(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\ndependencies = []\n',
+        encoding="utf-8",
+    )
 
     f = _write_py(repo / "x.py", "import somepkg\n")
 
@@ -253,6 +283,10 @@ def test_scan_cache_is_written_when_modified(monkeypatch, tmp_path):
 def test_scan_does_not_write_cache_when_not_modified(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\ndependencies = []\n',
+        encoding="utf-8",
+    )
 
     f = _write_py(repo / "x.py", "import somepkg\n")
 

--- a/test/test_path_traversal.py
+++ b/test/test_path_traversal.py
@@ -37,3 +37,55 @@ def test_open_constant_ok(tmp_path):
     code = "def f():\n    open('README.md', 'r')\n"
     out = _scan_one(tmp_path, "pt_ok.py", code)
     assert "SKY-D215" not in _rule_ids(out)
+
+
+def test_pathlib_read_text_tainted_join_flags(tmp_path):
+    code = (
+        "from pathlib import Path\n"
+        "BASE = Path('/srv/uploads')\n"
+        "def f(name):\n"
+        "    return (BASE / name).read_text(encoding='utf-8')\n"
+    )
+    out = _scan_one(tmp_path, "pt_pathlib_read.py", code)
+    assert "SKY-D215" in _rule_ids(out)
+
+
+def test_pathlib_name_projection_sanitizes_path_join(tmp_path):
+    code = (
+        "from pathlib import Path\n"
+        "BASE = Path('/srv/uploads')\n"
+        "def f(raw):\n"
+        "    name = Path(raw).name\n"
+        "    return (BASE / name).read_text(encoding='utf-8')\n"
+    )
+    out = _scan_one(tmp_path, "pt_pathlib_name_safe.py", code)
+    assert "SKY-D215" not in _rule_ids(out)
+
+
+def test_string_replace_on_tainted_value_is_not_path_sink(tmp_path):
+    code = "def f(raw):\n    return raw.replace('x', 'y')\n"
+    out = _scan_one(tmp_path, "pt_string_replace_safe.py", code)
+    assert "SKY-D215" not in _rule_ids(out)
+
+
+def test_path_like_global_shadowed_by_string_assignment(tmp_path):
+    code = (
+        "from pathlib import Path\n"
+        "p = Path('/srv/uploads')\n"
+        "def f(raw):\n"
+        "    p = raw\n"
+        "    return p.replace('x', 'y')\n"
+    )
+    out = _scan_one(tmp_path, "pt_path_like_shadow_assign.py", code)
+    assert "SKY-D215" not in _rule_ids(out)
+
+
+def test_path_like_global_shadowed_by_parameter(tmp_path):
+    code = (
+        "from pathlib import Path\n"
+        "p = Path('/srv/uploads')\n"
+        "def f(p):\n"
+        "    return p.replace('x', 'y')\n"
+    )
+    out = _scan_one(tmp_path, "pt_path_like_shadow_param.py", code)
+    assert "SKY-D215" not in _rule_ids(out)

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -53,3 +53,75 @@ def test_requests_fixed_host_interpolated_path_ok(tmp_path):
     )
     out = _scan_one(tmp_path, "ssrf_fixed_host.py", code)
     assert "SKY-D216" not in _rule_ids(out)
+
+
+def test_requests_fixed_host_urljoin_path_ok(tmp_path):
+    code = (
+        "from urllib.parse import urljoin\n"
+        "import requests\n"
+        "def f(user_id):\n"
+        "    url = urljoin('https://cdn.example.com/', f'avatars/{user_id}.png')\n"
+        "    requests.get(url, timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_urljoin_fixed_host.py", code)
+    assert "SKY-D216" not in _rule_ids(out)
+
+
+def test_requests_urljoin_bare_tainted_target_flags(tmp_path):
+    code = (
+        "from urllib.parse import urljoin\n"
+        "import requests\n"
+        "def f(path):\n"
+        "    url = urljoin('https://cdn.example.com/', path)\n"
+        "    requests.get(url, timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_urljoin_bare_target.py", code)
+    assert "SKY-D216" in _rule_ids(out)
+
+
+def test_requests_urljoin_slash_prefixed_tainted_target_flags(tmp_path):
+    code = (
+        "from urllib.parse import urljoin\n"
+        "import requests\n"
+        "def f(path):\n"
+        "    url = urljoin('https://cdn.example.com/', '/' + path)\n"
+        "    requests.get(url, timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_urljoin_slash_target.py", code)
+    assert "SKY-D216" in _rule_ids(out)
+
+
+def test_requests_urljoin_scheme_prefixed_tainted_target_flags(tmp_path):
+    code = (
+        "from urllib.parse import urljoin\n"
+        "import requests\n"
+        "def f(path):\n"
+        "    url = urljoin('https://cdn.example.com/', 'https:' + path)\n"
+        "    requests.get(url, timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_urljoin_scheme_target.py", code)
+    assert "SKY-D216" in _rule_ids(out)
+
+
+def test_requests_urljoin_partial_scheme_tainted_target_flags(tmp_path):
+    code = (
+        "from urllib.parse import urljoin\n"
+        "import requests\n"
+        "def f(path):\n"
+        "    url = urljoin('https://cdn.example.com/', 'http' + path)\n"
+        "    requests.get(url, timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_urljoin_partial_scheme_target.py", code)
+    assert "SKY-D216" in _rule_ids(out)
+
+
+def test_requests_urljoin_absolute_tainted_target_flags(tmp_path):
+    code = (
+        "from urllib.parse import urljoin\n"
+        "import requests\n"
+        "def f(host):\n"
+        "    url = urljoin('https://cdn.example.com/', 'https://' + host)\n"
+        "    requests.get(url, timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_urljoin_host_override.py", code)
+    assert "SKY-D216" in _rule_ids(out)


### PR DESCRIPTION
## Summary

  - Improve Python security recall and precision against frozen `security.dev`.
  - Add `SKY-D250` weak-random detection for security-sensitive Python random usage.
  - Detect tainted pathlib filesystem flows such as `Path(...) / user_input` reaching `read_text()`.
  - Preserve safe path handling for `Path(raw).name` / basename-style sanitization.
  - Tighten Python SSRF handling around `urljoin()` so only host-constrained relative prefixes are suppressed.
  - Reduce dependency hallucination `SKY-D223` noise when scanning manifest-less fixture/snippet roots.