### PR TITLE
fix(java): make security flow analysis structured

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -182,17 +182,19 @@ of receiving a score.
 | Security frozen | seeded dev | Bandit | Python | 3 | 0 | 6 | 3 | 4 | 7 | 64.33 |
 | Security frozen | seeded dev | Bandit | TypeScript | 0 | 1 | 0 | 0 | 0 | 0 | N/A |
 | Security frozen | seeded dev | Bandit | Go | 0 | 2 | 0 | 0 | 0 | 0 | N/A |
-| Security frozen | OWASP Java dev | Skylos | Java | 240 | 0 | 17 | 0 | 103 | 120 | 61.38 |
+| Security frozen | OWASP Java dev | Skylos | Java | 240 | 0 | 105 | 0 | 15 | 120 | 94.37 |
 | Quality frozen | seeded dev | Skylos | Python | 1 | 0 | 0 | 0 | 1 | 1 | 55.0 |
 | Agent review frozen | seeded dev | Skylos | Python | 1 | 0 | 1 | 0 | 0 | 1 | 100.0 |
 
 These frozen results already show useful gaps to investigate before any public
 claim: Skylos currently misses Python and TypeScript reachability edges, has
 JavaScript dead-code false positives on route-registry exports, misses a Java
-unused method, misses the seeded Python quality duplicate-branch case, and
-misses most OWASP Java security-flow cases outside weak crypto/hash. The seeded
+unused method, misses the seeded Python quality duplicate-branch case, and has
+remaining OWASP Java gaps around request-wrapper interprocedural modeling, LDAP
+injection, XPath injection, and property-driven weak-hash resolution. The seeded
 security dev suite is now at full recall with one Python `urljoin` label-review
-false positive. Vulture is only comparable on the Python dead-code subset.
+false positive. Vulture is
+only comparable on the Python dead-code subset.
 
 Phase 2 Python security rerun on 2026-04-25 improved frozen `security.dev`
 overall from `TP=17 FP=5 FN=3 TN=9 score=78.15` to
@@ -211,6 +213,18 @@ Phase 2b TypeScript/Go security rerun on 2026-04-25 improved frozen
 `TP=4 FP=0 FN=1 TN=1 score=91.0` to `TP=5 FP=0 FN=0 TN=1 score=100.0`.
 Go moved from `TP=5 FP=1 FN=0 TN=1 score=84.17` to
 `TP=5 FP=0 FN=0 TN=2 score=100.0`.
+
+Phase 3 Java security rerun on 2026-04-25 improved frozen
+`security.owasp-java.dev` from `TP=17 FP=0 FN=103 TN=120 score=61.38` to
+`TP=105 FP=0 FN=15 TN=120 score=94.37`. The patch keeps the OWASP Java false
+positive count at zero while moving Java servlet security flow to a structured
+tree-sitter analyzer with the older regex-heavy scanner retained only as a
+failure fallback. Coverage includes cookies, weak randomness, command
+execution, SQL, LDAP, XPath, XSS, path traversal, and trust-boundary session
+writes. The previous `TP=109` exploratory result used an FP-prone unknown
+wrapper accessor shortcut and was rejected. Remaining Java misses are
+request-wrapper interprocedural flows, LDAP injection, XPath injection, and
+weak-hash algorithms loaded through project properties.
 
 ## Benchmark Rules
 
@@ -372,3 +386,10 @@ Latest full test run:
 ```text
 3324 passed, 4 skipped, 3 warnings
 ```
+## Latest Frozen OWASP Java Security Result
+
+Run: `security.owasp-java.dev` with Skylos Java structured flow analyzer as the primary path and legacy request/servlet scanner as failure fallback only. Unknown external request-wrapper accessors are not treated as tainted without a real same-project summary.
+
+| Tool | TP | FP | FN | TN | Score |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Skylos | 105 | 0 | 15 | 120 | 94.37 |

--- a/skylos/visitors/languages/java/danger.py
+++ b/skylos/visitors/languages/java/danger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import math
 import re
 from tree_sitter import Language, Query, QueryCursor
@@ -11,6 +12,7 @@ from skylos.constants import (
     MIN_SECRET_LENGTH,
     get_non_library_dir_kind,
 )
+from skylos.visitors.languages.java.flow import scan_java_security_flows
 
 try:
     JAVA_LANG: Language | None = Language(tsj.language())
@@ -149,6 +151,87 @@ _REQUEST_INLINE_SOURCE_PATTERN = re.compile(
 _CONTROL_FLOW_HINTS = ("throw ", "return", "continue", "break")
 _STARTSWITH_CALL_PATTERN = re.compile(
     r"(?P<receiver>[A-Za-z_][\w.()]+)\.startsWith\s*\((?P<arg>[^)]*)\)"
+)
+
+_JAVA_ASSIGNMENT_PATTERN = re.compile(
+    r"(?:(?:final)\s+)?(?:[\w.<>\[\],?]+\s+)?(?P<var>[A-Za-z_]\w*)\s*=\s*(?P<expr>[^;]+);"
+)
+_JAVA_CONST_INT_PATTERN = re.compile(
+    r"\b(?:final\s+)?(?:int|long)\s+(?P<var>[A-Za-z_]\w*)\s*=\s*(?P<value>-?\d+)\s*;"
+)
+_JAVA_ENHANCED_FOR_PATTERN = re.compile(
+    r"\bfor\s*\([^:;]+?\b(?P<var>[A-Za-z_]\w*)\s*:\s*(?P<src>[A-Za-z_]\w*)\s*\)"
+)
+_JAVA_REQUEST_SOURCE_RE = re.compile(
+    r"\b(?:request|req)\.(?:getParameter|getPathInfo|getHeader|getHeaders|getHeaderNames|getParameterMap|getParameterValues|getParameterNames|getCookies|getQueryString)\s*\("
+)
+_JAVA_COOKIE_CREATION_RE = re.compile(
+    r"\b(?:javax\.servlet\.http\.)?Cookie\s+(?P<var>[A-Za-z_]\w*)\s*=\s*new\s+(?:javax\.servlet\.http\.)?Cookie\s*\("
+)
+_JAVA_LIST_ADD_RE = re.compile(r"\b(?P<var>[A-Za-z_]\w*)\.add\s*\((?P<expr>.*)\)\s*;")
+_JAVA_LIST_GET_RE = re.compile(r"\b(?P<var>[A-Za-z_]\w*)\.get\s*\((?P<index>\d+)\)")
+_JAVA_LIST_REMOVE_RE = re.compile(r"\b(?P<var>[A-Za-z_]\w*)\.remove\s*\((?P<index>\d+)\)")
+_JAVA_MAP_PUT_RE = re.compile(
+    r"\b(?P<var>[A-Za-z_]\w*)\.put\s*\(\s*\"(?P<key>[^\"]+)\"\s*,\s*(?P<expr>.*)\)\s*;"
+)
+_JAVA_MAP_GET_RE = re.compile(r"\b(?P<var>[A-Za-z_]\w*)\.get\s*\(\s*\"(?P<key>[^\"]+)\"\s*\)")
+_JAVA_METHOD_CALL_RE = re.compile(
+    r"\b(?P<receiver>[A-Za-z_]\w*)\.(?P<method>[A-Za-z_]\w*)\s*\((?P<args>.*)\)\s*;"
+)
+_JAVA_METHOD_INVOCATION_RE = re.compile(
+    r"(?:\b(?P<receiver>[A-Za-z_]\w*)|new\s+(?P<new_class>[\w.]+)\s*\([^)]*\))\.(?P<method>[A-Za-z_]\w*)\s*\((?P<args>[^;]*)\)"
+)
+_JAVA_PROCESS_BUILDER_RE = re.compile(
+    r"\b(?:ProcessBuilder|java\.lang\.ProcessBuilder)\s+(?P<var>[A-Za-z_]\w*)\s*=\s*new\s+(?:ProcessBuilder|java\.lang\.ProcessBuilder)\s*\((?P<args>.*)\)\s*;"
+)
+_JAVA_NEW_OBJECT_RE = re.compile(
+    r"\b(?:[\w.<>\[\],?]+\s+)?(?P<var>[A-Za-z_]\w*)\s*=\s*new\s+(?P<class>[\w.]+)\s*\((?P<args>[^;]*)\)\s*;"
+)
+_JAVA_PATH_SINK_HINTS = (
+    "new FileInputStream(",
+    "new java.io.FileInputStream(",
+    "new FileOutputStream(",
+    "new java.io.FileOutputStream(",
+    "new FileReader(",
+    "new java.io.FileReader(",
+    "new File(",
+    "new java.io.File(",
+    "Files.readAllBytes(",
+    "java.nio.file.Files.readAllBytes(",
+    "Files.readString(",
+    "java.nio.file.Files.readString(",
+    "Files.newInputStream(",
+    "java.nio.file.Files.newInputStream(",
+    "Files.newOutputStream(",
+    "java.nio.file.Files.newOutputStream(",
+    "Files.write(",
+    "java.nio.file.Files.write(",
+    "Files.writeString(",
+    "java.nio.file.Files.writeString(",
+    "Paths.get(",
+    "java.nio.file.Paths.get(",
+)
+_JAVA_SQL_SINK_ARGS = {
+    ".prepareCall(": (0,),
+    ".prepareStatement(": (0,),
+    ".executeQuery(": (0,),
+    ".executeUpdate(": (0,),
+    ".execute(": (0,),
+}
+_JAVA_LDAP_SINK_ARGS = {
+    ".search(": (1,),
+}
+_JAVA_XPATH_SINK_ARGS = {
+    ".evaluate(": (0,),
+    ".compile(": (0,),
+}
+_JAVA_XSS_WRITER_METHODS = (".print(", ".println(", ".printf(", ".format(", ".write(")
+_JAVA_XSS_SANITIZER_HINTS = (
+    "encodeForHTML(",
+    "encodeForHtml(",
+    "Encode.forHtml(",
+    "escapeHtml(",
+    "htmlEscape(",
 )
 
 _SECRET_PREFIXES = (
@@ -423,6 +506,493 @@ def _iter_sink_calls(
     return calls
 
 
+def _first_tainted_names(expr: str, tainted_vars: set[str]) -> set[str]:
+    return _names_in_line(expr, tainted_vars)
+
+
+def _expr_uses_taint(expr: str, tainted_vars: set[str]) -> bool:
+    return bool(_first_tainted_names(expr, tainted_vars))
+
+
+def _expr_has_java_request_source(expr: str) -> bool:
+    return bool(_JAVA_REQUEST_SOURCE_RE.search(expr))
+
+
+def _expr_has_xss_sanitizer(expr: str) -> bool:
+    return any(hint in expr for hint in _JAVA_XSS_SANITIZER_HINTS)
+
+
+def _java_class_base(class_name: str | None) -> str | None:
+    if not class_name:
+        return None
+    return class_name.rsplit(".", 1)[-1]
+
+
+def _java_arg_count(args: str) -> int:
+    args = args.strip()
+    if not args:
+        return 0
+    depth = 0
+    count = 1
+    in_string: str | None = None
+    escaped = False
+    for ch in args:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == in_string:
+                in_string = None
+            continue
+        if ch in {"'", '"'}:
+            in_string = ch
+        elif ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth = max(depth - 1, 0)
+        elif ch == "," and depth == 0:
+            count += 1
+    return count
+
+
+def _class_name_for_method(node, source_bytes: bytes) -> str | None:
+    current = node.parent
+    while current is not None:
+        if current.type in {
+            "class_declaration",
+            "interface_declaration",
+            "enum_declaration",
+            "record_declaration",
+        }:
+            name_node = current.child_by_field_name("name")
+            if name_node is not None:
+                return _get_text(source_bytes, name_node)
+            return None
+        current = current.parent
+    return None
+
+
+def _java_assignment_matches(line: str) -> list[tuple[str, str]]:
+    assignments: list[tuple[str, str]] = []
+    for match in _JAVA_ASSIGNMENT_PATTERN.finditer(line):
+        var = match.group("var")
+        expr = match.group("expr").strip()
+        if var in {"if", "for", "while", "switch", "return"}:
+            continue
+        assignments.append((var, expr))
+    return assignments
+
+
+def _java_statement_text(lines: list[str], start_idx: int, max_lines: int = 8) -> str:
+    parts: list[str] = []
+    for line in lines[start_idx : min(len(lines), start_idx + max_lines)]:
+        parts.append(line.strip())
+        if ";" in line:
+            break
+    return " ".join(parts)
+
+
+def _split_java_ternary(expr: str) -> tuple[str, str, str] | None:
+    question_idx = expr.find("?")
+    if question_idx < 0:
+        return None
+
+    depth = 0
+    for idx in range(question_idx + 1, len(expr)):
+        ch = expr[idx]
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif ch == ":" and depth == 0:
+            return (
+                expr[:question_idx].strip(),
+                expr[question_idx + 1 : idx].strip(),
+                expr[idx + 1 :].strip(),
+            )
+    return None
+
+
+def _eval_java_constant_condition(expr: str, constants: dict[str, int]) -> bool | None:
+    candidate = expr
+    for name, value in constants.items():
+        candidate = re.sub(rf"\b{re.escape(name)}\b", str(value), candidate)
+    candidate = candidate.replace("&&", " and ").replace("||", " or ")
+    candidate = re.sub(r"!\s*(?!=)", " not ", candidate)
+    try:
+        parsed = ast.parse(candidate, mode="eval")
+        value = _eval_java_constant_ast(parsed.body)
+        return bool(value) if isinstance(value, (bool, int, float)) else None
+    except Exception:
+        return None
+
+
+def _eval_java_constant_ast(node: ast.AST) -> bool | int | float:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (bool, int, float)):
+        return node.value
+    if isinstance(node, ast.UnaryOp):
+        operand = _eval_java_constant_ast(node.operand)
+        if isinstance(node.op, ast.Not):
+            return not bool(operand)
+        if isinstance(node.op, ast.USub):
+            return -operand
+        if isinstance(node.op, ast.UAdd):
+            return +operand
+    if isinstance(node, ast.BoolOp):
+        values = [bool(_eval_java_constant_ast(value)) for value in node.values]
+        if isinstance(node.op, ast.And):
+            return all(values)
+        if isinstance(node.op, ast.Or):
+            return any(values)
+    if isinstance(node, ast.BinOp):
+        left = _eval_java_constant_ast(node.left)
+        right = _eval_java_constant_ast(node.right)
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+        if isinstance(node.op, ast.Mult):
+            return left * right
+        if isinstance(node.op, ast.Div):
+            return left / right
+        if isinstance(node.op, ast.FloorDiv):
+            return left // right
+        if isinstance(node.op, ast.Mod):
+            return left % right
+        if isinstance(node.op, ast.BitAnd):
+            return int(left) & int(right)
+        if isinstance(node.op, ast.BitOr):
+            return int(left) | int(right)
+    if isinstance(node, ast.Compare):
+        left = _eval_java_constant_ast(node.left)
+        for op, comparator in zip(node.ops, node.comparators, strict=True):
+            right = _eval_java_constant_ast(comparator)
+            if isinstance(op, ast.Lt):
+                ok = left < right
+            elif isinstance(op, ast.LtE):
+                ok = left <= right
+            elif isinstance(op, ast.Gt):
+                ok = left > right
+            elif isinstance(op, ast.GtE):
+                ok = left >= right
+            elif isinstance(op, ast.Eq):
+                ok = left == right
+            elif isinstance(op, ast.NotEq):
+                ok = left != right
+            else:
+                raise ValueError("unsupported comparison")
+            if not ok:
+                return False
+            left = right
+        return True
+    raise ValueError("unsupported constant expression")
+
+
+def _select_static_java_ternary_branch(
+    expr: str, constants: dict[str, int]
+) -> str | None:
+    ternary = _split_java_ternary(expr)
+    if not ternary:
+        return None
+    condition, true_expr, false_expr = ternary
+    value = _eval_java_constant_condition(condition, constants)
+    if value is None:
+        return None
+    return true_expr if value else false_expr
+
+
+def _expr_is_java_tainted(
+    expr: str,
+    tainted_vars: set[str],
+) -> bool:
+    if _expr_has_java_request_source(expr):
+        return True
+    if _expr_uses_taint(expr, tainted_vars):
+        return True
+    return False
+
+
+def _expr_is_java_tainted_with_context(
+    expr: str,
+    tainted_vars: set[str],
+    request_wrappers: set[str],
+    object_types: dict[str, str],
+    helper_summaries: dict[tuple[str | None, str, int], tuple[bool, bool]],
+) -> bool:
+    if _expr_is_java_tainted(expr, tainted_vars):
+        return True
+
+    for match in _JAVA_METHOD_INVOCATION_RE.finditer(expr):
+        args = match.group("args")
+        args_tainted = _expr_is_java_tainted_with_context(
+            args, tainted_vars, request_wrappers, object_types, helper_summaries
+        )
+        summary_taint = _java_method_call_summary_taint(
+            match, args_tainted, request_wrappers, object_types, helper_summaries
+        )
+        if summary_taint is not None:
+            if summary_taint:
+                return True
+            continue
+
+        if args_tainted:
+            return True
+
+    return False
+
+
+def _java_method_call_summary_taint(
+    match,
+    args_tainted: bool,
+    request_wrappers: set[str],
+    object_types: dict[str, str],
+    helper_summaries: dict[tuple[str | None, str, int], tuple[bool, bool]],
+) -> bool | None:
+    method = match.group("method")
+    receiver = match.group("receiver")
+    new_class = _java_class_base(match.group("new_class"))
+    receiver_class = object_types.get(receiver or "") if receiver else new_class
+    summary = helper_summaries.get((receiver_class, method, _java_arg_count(match.group("args"))))
+
+    if summary is not None:
+        returns_request_source, returns_arg_taint = summary
+        return returns_request_source or (returns_arg_taint and args_tainted)
+
+    return None
+
+
+def _extract_java_method_signature(method_text: str) -> tuple[str | None, list[str]]:
+    header = method_text.split("{", 1)[0]
+    name_match = re.search(r"\b(?P<name>[A-Za-z_]\w*)\s*\((?P<params>[^)]*)\)", header)
+    if not name_match:
+        return None, []
+    params: list[str] = []
+    for raw_param in name_match.group("params").split(","):
+        cleaned = raw_param.strip()
+        if not cleaned:
+            continue
+        cleaned = re.sub(r"@\w+(?:\([^)]*\))?\s*", "", cleaned)
+        cleaned = cleaned.replace("final ", "")
+        param_match = re.search(r"([A-Za-z_]\w*)\s*(?:\[\])?$", cleaned)
+        if param_match:
+            params.append(param_match.group(1))
+    return name_match.group("name"), params
+
+
+def _java_expr_taint_with_collections(
+    expr: str,
+    tainted_vars: set[str],
+    map_entries: dict[tuple[str, str], tuple[bool, bool]],
+    list_entries: dict[str, list[tuple[bool, bool]]],
+) -> bool:
+    map_get_match = _JAVA_MAP_GET_RE.search(expr)
+    if map_get_match:
+        entry = map_entries.get((map_get_match.group("var"), map_get_match.group("key")))
+        if entry is not None:
+            return entry[0]
+    list_get_match = _JAVA_LIST_GET_RE.search(expr)
+    if list_get_match:
+        entries = list_entries.get(list_get_match.group("var"), [])
+        index = int(list_get_match.group("index"))
+        if 0 <= index < len(entries):
+            return entries[index][0]
+    return _expr_is_java_tainted(expr, tainted_vars)
+
+
+def _java_method_returns_tainted_param(method_text: str, params: list[str]) -> bool:
+    tainted_vars = set(params)
+    constants: dict[str, int] = {}
+    map_entries: dict[tuple[str, str], tuple[bool, bool]] = {}
+    list_entries: dict[str, list[tuple[bool, bool]]] = {}
+    skip_else_assignments: set[str] = set()
+    conditional_tainted_assignments: set[str] = set()
+
+    for raw_line in method_text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+
+        const_match = _JAVA_CONST_INT_PATTERN.search(stripped)
+        if const_match:
+            constants[const_match.group("var")] = int(const_match.group("value"))
+
+        inline_if_match = re.search(
+            r"\bif\s*\((?P<condition>.*)\)\s*(?P<var>[A-Za-z_]\w*)\s*=\s*(?P<expr>[^;]+);",
+            stripped,
+        )
+        if inline_if_match:
+            value = _eval_java_constant_condition(
+                inline_if_match.group("condition"), constants
+            )
+            var = inline_if_match.group("var")
+            expr = inline_if_match.group("expr").strip()
+            if value is None:
+                if _java_expr_taint_with_collections(
+                    expr, tainted_vars, map_entries, list_entries
+                ):
+                    tainted_vars.add(var)
+                    conditional_tainted_assignments.add(var)
+                continue
+            if value is True:
+                if _java_expr_taint_with_collections(
+                    expr, tainted_vars, map_entries, list_entries
+                ):
+                    tainted_vars.add(var)
+                else:
+                    tainted_vars.discard(var)
+                skip_else_assignments.add(var)
+                continue
+
+        inline_else_match = re.search(
+            r"\belse\s+(?P<var>[A-Za-z_]\w*)\s*=\s*(?P<expr>[^;]+);",
+            stripped,
+        )
+        if inline_else_match and inline_else_match.group("var") in skip_else_assignments:
+            skip_else_assignments.discard(inline_else_match.group("var"))
+            continue
+        if (
+            inline_else_match
+            and inline_else_match.group("var") in conditional_tainted_assignments
+        ):
+            conditional_tainted_assignments.discard(inline_else_match.group("var"))
+            continue
+
+        list_add_match = _JAVA_LIST_ADD_RE.search(stripped)
+        if list_add_match:
+            list_var = list_add_match.group("var")
+            list_expr = list_add_match.group("expr")
+            list_tainted = _java_expr_taint_with_collections(
+                list_expr, tainted_vars, map_entries, list_entries
+            )
+            list_entries.setdefault(list_var, []).append((list_tainted, False))
+
+        list_remove_match = _JAVA_LIST_REMOVE_RE.search(stripped)
+        if list_remove_match:
+            list_var = list_remove_match.group("var")
+            index = int(list_remove_match.group("index"))
+            entries = list_entries.get(list_var)
+            if entries and 0 <= index < len(entries):
+                entries.pop(index)
+
+        map_put_match = _JAVA_MAP_PUT_RE.search(stripped)
+        if map_put_match:
+            map_entries[(map_put_match.group("var"), map_put_match.group("key"))] = (
+                _java_expr_taint_with_collections(
+                    map_put_match.group("expr"),
+                    tainted_vars,
+                    map_entries,
+                    list_entries,
+                ),
+                False,
+            )
+
+        return_match = re.search(r"\breturn\s+(?P<expr>[^;]+);", stripped)
+        if return_match and _java_expr_taint_with_collections(
+            return_match.group("expr"), tainted_vars, map_entries, list_entries
+        ):
+            return True
+
+        for var, expr in _java_assignment_matches(stripped):
+            selected_branch = _select_static_java_ternary_branch(expr, constants)
+            if selected_branch is not None:
+                expr = selected_branch
+            if _java_expr_taint_with_collections(
+                expr, tainted_vars, map_entries, list_entries
+            ):
+                tainted_vars.add(var)
+            else:
+                tainted_vars.discard(var)
+
+    return False
+
+
+def _collect_java_helper_summaries(
+    root_node, source_bytes: bytes
+) -> dict[tuple[str | None, str, int], tuple[bool, bool]]:
+    summaries: dict[tuple[str | None, str, int], tuple[bool, bool]] = {}
+    for node in _iter_nodes(root_node):
+        if node.type != "method_declaration":
+            continue
+        method_text = _get_text(source_bytes, node)
+        name, params = _extract_java_method_signature(method_text)
+        if not name:
+            continue
+        class_name = _class_name_for_method(node, source_bytes)
+        returns_request_source = _java_method_returns_tainted_param(method_text, [])
+        returns_arg_taint = (
+            _java_method_returns_tainted_param(method_text, params) if params else False
+        )
+        summaries[(class_name, name, len(params))] = (
+            returns_request_source,
+            returns_arg_taint,
+        )
+    return summaries
+
+
+def _line_has_unsanitized_xss_taint(
+    line: str, tainted_vars: set[str], xss_sanitized_vars: set[str]
+) -> bool:
+    if _expr_has_xss_sanitizer(line):
+        return False
+    tainted_names = _names_in_line(line, tainted_vars)
+    return any(name not in xss_sanitized_vars for name in tainted_names)
+
+
+def _add_java_flow_finding(
+    findings: list[dict],
+    seen: set[tuple[str, int, str]],
+    *,
+    rule_id: str,
+    severity: str,
+    message: str,
+    file_path: str,
+    line: int,
+    category: str | None = None,
+    cwe: str | None = None,
+) -> None:
+    key = (rule_id, line, category or "")
+    if key in seen:
+        return
+    seen.add(key)
+    finding = {
+        "rule_id": rule_id,
+        "severity": severity,
+        "message": message,
+        "file": str(file_path),
+        "line": line,
+        "col": 0,
+    }
+    if category:
+        finding["category"] = category
+    if cwe:
+        finding["cwe"] = cwe
+    findings.append(finding)
+
+
+def _extend_unique_findings(findings: list[dict], new_findings: list[dict]) -> None:
+    seen = {
+        (
+            finding.get("rule_id"),
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("category", ""),
+        )
+        for finding in findings
+    }
+    for finding in new_findings:
+        key = (
+            finding.get("rule_id"),
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("category", ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        findings.append(finding)
+
+
 def _sink_tainted_names(
     args: list[str],
     names: set[str],
@@ -601,6 +1171,480 @@ def _scan_request_path_traversal(root_node, file_path: str, source_bytes: bytes)
     return findings
 
 
+def _scan_servlet_security_flows(
+    root_node,
+    file_path: str,
+    source_bytes: bytes,
+    helper_summaries: dict[tuple[str | None, str, int], tuple[bool, bool]],
+) -> list[dict]:
+    findings: list[dict] = []
+    seen: set[tuple[str, int, str]] = set()
+
+    for node in _iter_nodes(root_node):
+        if node.type not in {"method_declaration", "constructor_declaration"}:
+            continue
+
+        method_text = _get_text(source_bytes, node)
+        if not any(
+            hint in method_text
+            for hint in (
+                "request.",
+                "req.",
+                "Cookie",
+                "ProcessBuilder",
+                "new File(",
+                "new java.io.File(",
+                "java.util.Random",
+                "Math.random",
+                "getWriter()",
+                "getSession()",
+                "prepareStatement",
+                "prepareCall",
+                ".search(",
+                ".evaluate(",
+                ".compile(",
+            )
+        ):
+            continue
+
+        lines = method_text.splitlines()
+        tainted_vars: set[str] = set()
+        xss_sanitized_vars: set[str] = set()
+        constants: dict[str, int] = {}
+        tainted_collections: set[str] = set()
+        tainted_process_builders: set[str] = set()
+        cookie_vars: set[str] = set()
+        insecure_cookie_vars: set[str] = set()
+        request_wrappers: set[str] = set()
+        object_types: dict[str, str] = {}
+        skip_else_assignments: set[str] = set()
+        conditional_tainted_assignments: set[str] = set()
+        map_entries: dict[tuple[str, str], tuple[bool, bool]] = {}
+        list_entries: dict[str, list[tuple[bool, bool]]] = {}
+        pending_assignment: tuple[str, list[str]] | None = None
+
+        def expr_tainted(expr: str) -> bool:
+            return _expr_is_java_tainted_with_context(
+                expr, tainted_vars, request_wrappers, object_types, helper_summaries
+            )
+
+        for line_offset, line in enumerate(lines):
+            line_no = node.start_point[0] + line_offset + 1
+            stripped = line.strip()
+            statement_text = _java_statement_text(lines, line_offset)
+            if not stripped or stripped.startswith("//"):
+                continue
+
+            const_match = _JAVA_CONST_INT_PATTERN.search(stripped)
+            if const_match:
+                constants[const_match.group("var")] = int(const_match.group("value"))
+
+            object_match = _JAVA_NEW_OBJECT_RE.search(stripped)
+            if object_match:
+                object_args = object_match.group("args")
+                object_var = object_match.group("var")
+                object_class = _java_class_base(object_match.group("class"))
+                if object_class:
+                    object_types[object_var] = object_class
+                if re.search(r"\b(?:request|req)\b", object_args) or expr_tainted(
+                    object_args
+                ):
+                    request_wrappers.add(object_var)
+                else:
+                    request_wrappers.discard(object_var)
+
+            for_match = _JAVA_ENHANCED_FOR_PATTERN.search(stripped)
+            if for_match and for_match.group("src") in tainted_vars:
+                tainted_vars.add(for_match.group("var"))
+
+            inline_if_match = re.search(
+                r"\bif\s*\((?P<condition>.*)\)\s*(?P<var>[A-Za-z_]\w*)\s*=\s*(?P<expr>[^;]+);",
+                stripped,
+            )
+            if inline_if_match:
+                value = _eval_java_constant_condition(
+                    inline_if_match.group("condition"), constants
+                )
+                var = inline_if_match.group("var")
+                expr = inline_if_match.group("expr").strip()
+                if value is None:
+                    if expr_tainted(expr):
+                        tainted_vars.add(var)
+                        if _expr_has_xss_sanitizer(expr):
+                            xss_sanitized_vars.add(var)
+                        else:
+                            xss_sanitized_vars.discard(var)
+                        conditional_tainted_assignments.add(var)
+                    continue
+                if value is True:
+                    if expr_tainted(expr):
+                        tainted_vars.add(var)
+                        if _expr_has_xss_sanitizer(expr):
+                            xss_sanitized_vars.add(var)
+                        else:
+                            xss_sanitized_vars.discard(var)
+                    else:
+                        tainted_vars.discard(var)
+                        xss_sanitized_vars.discard(var)
+                    skip_else_assignments.add(var)
+                    continue
+
+            inline_else_match = re.search(
+                r"\belse\s+(?P<var>[A-Za-z_]\w*)\s*=\s*(?P<expr>[^;]+);",
+                stripped,
+            )
+            if inline_else_match and inline_else_match.group("var") in skip_else_assignments:
+                skip_else_assignments.discard(inline_else_match.group("var"))
+                continue
+            if (
+                inline_else_match
+                and inline_else_match.group("var") in conditional_tainted_assignments
+            ):
+                conditional_tainted_assignments.discard(inline_else_match.group("var"))
+                continue
+
+            cookie_match = _JAVA_COOKIE_CREATION_RE.search(stripped)
+            if cookie_match:
+                cookie_vars.add(cookie_match.group("var"))
+
+            method_match = _JAVA_METHOD_CALL_RE.search(stripped)
+            if method_match:
+                receiver = method_match.group("receiver")
+                method = method_match.group("method")
+                args = method_match.group("args")
+                if method == "setSecure" and receiver in cookie_vars:
+                    if "false" in args.lower():
+                        insecure_cookie_vars.add(receiver)
+                    elif "true" in args.lower():
+                        insecure_cookie_vars.discard(receiver)
+                elif method == "addCookie" and _expr_uses_taint(args, insecure_cookie_vars):
+                    _add_java_flow_finding(
+                        findings,
+                        seen,
+                        rule_id="SKY-D252",
+                        severity="HIGH",
+                        message="Cookie is added with Secure disabled. Set Secure before sending sensitive cookies.",
+                        file_path=file_path,
+                        line=line_no,
+                        category="cookie_security",
+                        cwe="CWE-614",
+                    )
+                elif method == "command" and (
+                    expr_tainted(args)
+                    or _expr_uses_taint(args, tainted_collections)
+                ):
+                    tainted_process_builders.add(receiver)
+                elif method == "start" and receiver in tainted_process_builders:
+                    _add_java_flow_finding(
+                        findings,
+                        seen,
+                        rule_id="SKY-D212",
+                        severity="CRITICAL",
+                        message="ProcessBuilder starts a shell command built from servlet-controlled data. Use fixed argv elements and validate inputs.",
+                        file_path=file_path,
+                        line=line_no,
+                        cwe="CWE-78",
+                    )
+
+            builder_match = _JAVA_PROCESS_BUILDER_RE.search(stripped)
+            if builder_match:
+                builder_var = builder_match.group("var")
+                builder_args = builder_match.group("args")
+                if expr_tainted(builder_args) or _expr_uses_taint(
+                    builder_args, tainted_collections
+                ):
+                    tainted_process_builders.add(builder_var)
+
+            list_add_match = _JAVA_LIST_ADD_RE.search(stripped)
+            if list_add_match:
+                list_var = list_add_match.group("var")
+                list_expr = list_add_match.group("expr")
+                list_tainted = expr_tainted(list_expr)
+                list_xss_safe = _expr_has_xss_sanitizer(list_expr) or (
+                    _first_tainted_names(list_expr, tainted_vars)
+                    and _first_tainted_names(list_expr, tainted_vars) <= xss_sanitized_vars
+                )
+                list_entries.setdefault(list_var, []).append((list_tainted, list_xss_safe))
+                if list_tainted:
+                    tainted_collections.add(list_var)
+
+            list_remove_match = _JAVA_LIST_REMOVE_RE.search(stripped)
+            if list_remove_match:
+                list_var = list_remove_match.group("var")
+                index = int(list_remove_match.group("index"))
+                entries = list_entries.get(list_var)
+                if entries and 0 <= index < len(entries):
+                    entries.pop(index)
+                    if not any(item[0] for item in entries):
+                        tainted_collections.discard(list_var)
+
+            map_put_match = _JAVA_MAP_PUT_RE.search(stripped)
+            if map_put_match:
+                map_expr = map_put_match.group("expr")
+                map_tainted = expr_tainted(map_expr)
+                map_xss_safe = _expr_has_xss_sanitizer(map_expr) or (
+                    _first_tainted_names(map_expr, tainted_vars)
+                    and _first_tainted_names(map_expr, tainted_vars) <= xss_sanitized_vars
+                )
+                map_entries[(map_put_match.group("var"), map_put_match.group("key"))] = (
+                    map_tainted,
+                    map_xss_safe,
+                )
+
+            selected_assignments: list[tuple[str, str]]
+            if pending_assignment is not None:
+                pending_var, pending_parts = pending_assignment
+                pending_parts.append(stripped)
+                if ";" not in stripped:
+                    continue
+                selected_assignments = [
+                    (pending_var, " ".join(pending_parts).rstrip(";").strip())
+                ]
+                pending_assignment = None
+            else:
+                pending_match = re.search(
+                    r"(?:(?:final)\s+)?(?:[\w.<>\[\],?]+\s+)?(?P<var>[A-Za-z_]\w*)\s*=\s*$",
+                    stripped,
+                )
+                if pending_match:
+                    pending_assignment = (pending_match.group("var"), [])
+                    continue
+                selected_assignments = _java_assignment_matches(stripped)
+
+            for var, expr in selected_assignments:
+                selected_branch = _select_static_java_ternary_branch(expr, constants)
+                if selected_branch is not None:
+                    expr = selected_branch
+
+                map_get_match = _JAVA_MAP_GET_RE.search(expr)
+                list_get_match = _JAVA_LIST_GET_RE.search(expr)
+                collection_xss_safe = False
+                if map_get_match:
+                    entry = map_entries.get(
+                        (map_get_match.group("var"), map_get_match.group("key"))
+                    )
+                    if entry is None:
+                        is_tainted = expr_tainted(expr)
+                    else:
+                        is_tainted, collection_xss_safe = entry
+                elif list_get_match:
+                    entries = list_entries.get(list_get_match.group("var"), [])
+                    index = int(list_get_match.group("index"))
+                    if 0 <= index < len(entries):
+                        is_tainted, collection_xss_safe = entries[index]
+                    else:
+                        is_tainted = expr_tainted(expr)
+                else:
+                    invocation = _JAVA_METHOD_INVOCATION_RE.search(expr)
+                    summary_taint = None
+                    if invocation is not None:
+                        args_tainted = expr_tainted(invocation.group("args"))
+                        summary_taint = _java_method_call_summary_taint(
+                            invocation,
+                            args_tainted,
+                            request_wrappers,
+                            object_types,
+                            helper_summaries,
+                        )
+                    is_tainted = (
+                        summary_taint if summary_taint is not None else expr_tainted(expr)
+                    )
+                if is_tainted:
+                    tainted_names = _first_tainted_names(expr, tainted_vars)
+                    tainted_vars.add(var)
+                    if collection_xss_safe or _expr_has_xss_sanitizer(expr) or (
+                        tainted_names and tainted_names <= xss_sanitized_vars
+                    ):
+                        xss_sanitized_vars.add(var)
+                    else:
+                        xss_sanitized_vars.discard(var)
+                else:
+                    tainted_vars.discard(var)
+                    xss_sanitized_vars.discard(var)
+                    tainted_collections.discard(var)
+                    tainted_process_builders.discard(var)
+
+                if (
+                    is_tainted
+                    and (
+                        ".prepareCall(" in expr
+                        or ".prepareStatement(" in expr
+                        or ".executeQuery(" in expr
+                        or ".executeUpdate(" in expr
+                        or ".execute(" in expr
+                        or ".queryForObject(" in expr
+                        or ".queryForRowSet(" in expr
+                        or ".query(" in expr
+                    )
+                ):
+                    _add_java_flow_finding(
+                        findings,
+                        seen,
+                        rule_id="SKY-D211",
+                        severity="CRITICAL",
+                        message="SQL query uses servlet-controlled data. Use parameterized queries with fixed SQL.",
+                        file_path=file_path,
+                        line=line_no,
+                        cwe="CWE-89",
+                    )
+
+            if (
+                ("Math.random()" in stripped or "new java.util.Random().next" in stripped or "new Random().next" in stripped)
+                and "SecureRandom" not in stripped
+                and any(token in method_text for token in ("rememberMe", "getSession()", "new Cookie("))
+            ):
+                _add_java_flow_finding(
+                    findings,
+                    seen,
+                    rule_id="SKY-D250",
+                    severity="HIGH",
+                    message="Weak random value is used in security-sensitive token or session material. Use SecureRandom.",
+                    file_path=file_path,
+                    line=line_no,
+                    category="weak_random",
+                    cwe="CWE-330",
+                )
+
+            if (
+                any(hint in stripped for hint in _JAVA_PATH_SINK_HINTS)
+                and expr_tainted(stripped)
+                and not (
+                    ("new File(" in stripped or "new java.io.File(" in stripped)
+                    and not any(
+                        sink in stripped
+                        for sink in (
+                            "FileInputStream(",
+                            "FileOutputStream(",
+                            "FileReader(",
+                            "Files.",
+                            "java.nio.file.Files.",
+                        )
+                    )
+                    and any(hint in method_text for hint in _REQUEST_GUARD_HINTS)
+                    and "startsWith(" in method_text
+                )
+                and not _has_named_path_guard(
+                    lines[: line_offset + 1],
+                    _first_tainted_names(stripped, tainted_vars),
+                    _REQUEST_GUARD_HINTS,
+                    line_offset,
+                )
+            ):
+                _add_java_flow_finding(
+                    findings,
+                    seen,
+                    rule_id="SKY-D215",
+                    severity="HIGH",
+                    message="Servlet-controlled path reaches a filesystem sink without canonical path validation.",
+                    file_path=file_path,
+                    line=line_no,
+                    cwe="CWE-22",
+                )
+
+            if ".exec(" in statement_text and (
+                expr_tainted(statement_text)
+                or _expr_uses_taint(statement_text, tainted_collections)
+            ):
+                _add_java_flow_finding(
+                    findings,
+                    seen,
+                    rule_id="SKY-D212",
+                    severity="CRITICAL",
+                    message="Process execution uses servlet-controlled data. Use fixed argv elements and validate inputs.",
+                    file_path=file_path,
+                    line=line_no,
+                    cwe="CWE-78",
+                )
+
+            if (
+                ".prepareCall(" in stripped
+                or ".prepareStatement(" in stripped
+                or ".executeQuery(" in stripped
+                or ".executeUpdate(" in stripped
+                or ".execute(" in stripped
+                or ".queryForObject(" in stripped
+                or ".queryForRowSet(" in stripped
+                or ".query(" in stripped
+            ):
+                if expr_tainted(statement_text):
+                    _add_java_flow_finding(
+                        findings,
+                        seen,
+                        rule_id="SKY-D211",
+                        severity="CRITICAL",
+                        message="SQL query uses servlet-controlled data. Use parameterized queries with fixed SQL.",
+                        file_path=file_path,
+                        line=line_no,
+                        cwe="CWE-89",
+                    )
+
+            if ".search(" in stripped and expr_tainted(stripped):
+                _add_java_flow_finding(
+                    findings,
+                    seen,
+                    rule_id="SKY-D240",
+                    severity="CRITICAL",
+                    message="LDAP search filter uses servlet-controlled data. Escape LDAP filter values or use safe APIs.",
+                    file_path=file_path,
+                    line=line_no,
+                    category="ldap_injection",
+                    cwe="CWE-90",
+                )
+
+            if (
+                (".evaluate(" in stripped or ".compile(" in stripped)
+                and expr_tainted(stripped)
+            ):
+                _add_java_flow_finding(
+                    findings,
+                    seen,
+                    rule_id="SKY-D241",
+                    severity="CRITICAL",
+                    message="XPath expression uses servlet-controlled data. Use fixed expressions or strict allowlists.",
+                    file_path=file_path,
+                    line=line_no,
+                    category="xpath_injection",
+                    cwe="CWE-643",
+                )
+
+            if (
+                "getWriter()" in stripped
+                and any(method in stripped for method in _JAVA_XSS_WRITER_METHODS)
+                and _line_has_unsanitized_xss_taint(
+                    stripped, tainted_vars, xss_sanitized_vars
+                )
+            ):
+                _add_java_flow_finding(
+                    findings,
+                    seen,
+                    rule_id="SKY-D226",
+                    severity="HIGH",
+                    message="Servlet response writes untrusted data without HTML encoding.",
+                    file_path=file_path,
+                    line=line_no,
+                    cwe="CWE-79",
+                )
+
+            if (
+                "getSession()" in stripped
+                and (".setAttribute(" in stripped or ".putValue(" in stripped)
+                and expr_tainted(stripped)
+            ):
+                _add_java_flow_finding(
+                    findings,
+                    seen,
+                    rule_id="SKY-D253",
+                    severity="HIGH",
+                    message="Servlet-controlled data crosses into HTTP session state.",
+                    file_path=file_path,
+                    line=line_no,
+                    category="trust_boundary",
+                    cwe="CWE-501",
+                )
+
+    return findings
+
+
 def scan_danger(root_node, file_path: str, lang: Language | None = None) -> list[dict]:
     findings: list[dict] = []
     if lang is None:
@@ -609,7 +1653,6 @@ def scan_danger(root_node, file_path: str, lang: Language | None = None) -> list
         return []
 
     source_bytes: bytes = root_node.text
-
     simple_captures = _run_batch(root_node, lang, "danger_simple", _SIMPLE_PATTERN)
 
     for node in simple_captures.get("rt_method", []):
@@ -697,7 +1740,24 @@ def scan_danger(root_node, file_path: str, lang: Language | None = None) -> list
         )
 
     findings.extend(_scan_archive_extraction(root_node, file_path, source_bytes))
-    findings.extend(_scan_request_path_traversal(root_node, file_path, source_bytes))
+    try:
+        _extend_unique_findings(
+            findings,
+            scan_java_security_flows(root_node, file_path, source_bytes),
+        )
+    except Exception:
+        # Compatibility fallback only: keep the previous text scanners available
+        # for parser/analyzer failures, but do not use them as normal coverage.
+        helper_summaries = _collect_java_helper_summaries(root_node, source_bytes)
+        _extend_unique_findings(
+            findings, _scan_request_path_traversal(root_node, file_path, source_bytes)
+        )
+        _extend_unique_findings(
+            findings,
+            _scan_servlet_security_flows(
+                root_node, file_path, source_bytes, helper_summaries
+            ),
+        )
 
     is_test_file = get_non_library_dir_kind(file_path) == "test"
     string_captures = _run_batch(root_node, lang, "danger_strings", _STRING_PATTERN)

--- a/skylos/visitors/languages/java/flow.py
+++ b/skylos/visitors/languages/java/flow.py
@@ -1,0 +1,1511 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+REQUEST_SOURCE_METHODS = {
+    "getParameter",
+    "getPathInfo",
+    "getHeader",
+    "getHeaders",
+    "getHeaderNames",
+    "getParameterMap",
+    "getParameterValues",
+    "getParameterNames",
+    "getCookies",
+    "getQueryString",
+}
+
+REQUEST_PARAM_ANNOTATIONS = {
+    "RequestParam",
+    "PathVariable",
+    "RequestHeader",
+    "CookieValue",
+}
+
+REQUEST_TYPES = {
+    "HttpServletRequest",
+    "ServletRequest",
+}
+
+PATH_NORMALIZER_METHODS = {
+    "normalize",
+    "toRealPath",
+    "getCanonicalPath",
+    "getCanonicalFile",
+}
+
+CONTROL_FLOW_STMTS = {
+    "throw_statement",
+    "return_statement",
+    "break_statement",
+    "continue_statement",
+}
+
+SQL_SINKS = {
+    "prepareCall": (0,),
+    "prepareStatement": (0,),
+    "executeQuery": (0,),
+    "executeUpdate": (0,),
+    "execute": (0,),
+    "queryForObject": (0,),
+    "queryForRowSet": (0,),
+    "query": (0,),
+}
+
+LDAP_SINKS = {"search": (1,)}
+XPATH_SINKS = {"evaluate": (0,), "compile": (0,)}
+XSS_WRITER_METHODS = {"print", "println", "printf", "format", "write"}
+XSS_SANITIZER_METHODS = {
+    "encodeForHTML",
+    "encodeForHtml",
+    "forHtml",
+    "escapeHtml",
+    "htmlEscape",
+}
+
+FILES_PATH_METHODS = {
+    "readAllBytes": (0,),
+    "readString": (0,),
+    "newInputStream": (0,),
+    "newOutputStream": (0,),
+    "write": (0,),
+    "writeString": (0,),
+    "copy": (0, 1),
+}
+
+PATH_CONSTRUCTOR_TYPES = {
+    "FileInputStream": (0,),
+    "FileReader": (0,),
+    "FileOutputStream": (0,),
+}
+
+
+@dataclass(frozen=True)
+class JavaTaint:
+    tainted: bool = False
+    xss_safe: bool = False
+
+    @staticmethod
+    def combine(values: list["JavaTaint"]) -> "JavaTaint":
+        tainted = any(value.tainted for value in values)
+        if not tainted:
+            return JavaTaint()
+        return JavaTaint(
+            tainted=True,
+            xss_safe=all(value.xss_safe for value in values if value.tainted),
+        )
+
+
+@dataclass
+class JavaFlowState:
+    request_vars: set[str] = field(default_factory=set)
+    tainted_vars: set[str] = field(default_factory=set)
+    xss_safe_vars: set[str] = field(default_factory=set)
+    constants: dict[str, int | bool | str] = field(default_factory=dict)
+    object_types: dict[str, str] = field(default_factory=dict)
+    map_entries: dict[tuple[str, str], JavaTaint] = field(default_factory=dict)
+    list_entries: dict[str, list[JavaTaint]] = field(default_factory=dict)
+    tainted_collections: set[str] = field(default_factory=set)
+    tainted_process_builders: set[str] = field(default_factory=set)
+    cookie_vars: set[str] = field(default_factory=set)
+    insecure_cookie_vars: set[str] = field(default_factory=set)
+    normalized_path_vars: set[str] = field(default_factory=set)
+    guarded_path_vars: set[str] = field(default_factory=set)
+    canonical_string_vars: set[str] = field(default_factory=set)
+    slash_terminated_vars: set[str] = field(default_factory=set)
+    canonical_path_sources: dict[str, set[str]] = field(default_factory=dict)
+    pending_path_objects: dict[str, int] = field(default_factory=dict)
+
+    def copy(self) -> "JavaFlowState":
+        return JavaFlowState(
+            request_vars=set(self.request_vars),
+            tainted_vars=set(self.tainted_vars),
+            xss_safe_vars=set(self.xss_safe_vars),
+            constants=dict(self.constants),
+            object_types=dict(self.object_types),
+            map_entries=dict(self.map_entries),
+            list_entries={key: list(value) for key, value in self.list_entries.items()},
+            tainted_collections=set(self.tainted_collections),
+            tainted_process_builders=set(self.tainted_process_builders),
+            cookie_vars=set(self.cookie_vars),
+            insecure_cookie_vars=set(self.insecure_cookie_vars),
+            normalized_path_vars=set(self.normalized_path_vars),
+            guarded_path_vars=set(self.guarded_path_vars),
+            canonical_string_vars=set(self.canonical_string_vars),
+            slash_terminated_vars=set(self.slash_terminated_vars),
+            canonical_path_sources={
+                key: set(value) for key, value in self.canonical_path_sources.items()
+            },
+            pending_path_objects=dict(self.pending_path_objects),
+        )
+
+    def merge_from(self, left: "JavaFlowState", right: "JavaFlowState") -> None:
+        self.tainted_vars = left.tainted_vars | right.tainted_vars
+        self.xss_safe_vars = left.xss_safe_vars & right.xss_safe_vars
+        self.constants = {
+            name: value
+            for name, value in left.constants.items()
+            if right.constants.get(name) == value
+        }
+        self.object_types = {
+            name: value
+            for name, value in left.object_types.items()
+            if right.object_types.get(name) == value
+        }
+        self.map_entries = self._merge_map_entries(left.map_entries, right.map_entries)
+        self.list_entries = self._merge_list_entries(left.list_entries, right.list_entries)
+        self.tainted_collections = left.tainted_collections | right.tainted_collections
+        self.tainted_process_builders = (
+            left.tainted_process_builders | right.tainted_process_builders
+        )
+        self.cookie_vars = left.cookie_vars | right.cookie_vars
+        self.insecure_cookie_vars = left.insecure_cookie_vars | right.insecure_cookie_vars
+        self.normalized_path_vars = left.normalized_path_vars | right.normalized_path_vars
+        self.guarded_path_vars = left.guarded_path_vars & right.guarded_path_vars
+        self.canonical_string_vars = left.canonical_string_vars | right.canonical_string_vars
+        self.slash_terminated_vars = left.slash_terminated_vars | right.slash_terminated_vars
+        self.canonical_path_sources = {
+            **left.canonical_path_sources,
+            **right.canonical_path_sources,
+        }
+        self.pending_path_objects = {
+            name: min(
+                left.pending_path_objects.get(name, right.pending_path_objects.get(name, 0)),
+                right.pending_path_objects.get(name, left.pending_path_objects.get(name, 0)),
+            )
+            for name in set(left.pending_path_objects) | set(right.pending_path_objects)
+        }
+
+    def _merge_map_entries(
+        self,
+        left: dict[tuple[str, str], JavaTaint],
+        right: dict[tuple[str, str], JavaTaint],
+    ) -> dict[tuple[str, str], JavaTaint]:
+        merged = {}
+        for key in set(left) | set(right):
+            values = [value for value in (left.get(key), right.get(key)) if value is not None]
+            merged[key] = JavaTaint.combine(values)
+        return merged
+
+    def _merge_list_entries(
+        self,
+        left: dict[str, list[JavaTaint]],
+        right: dict[str, list[JavaTaint]],
+    ) -> dict[str, list[JavaTaint]]:
+        merged = {}
+        for key in set(left) | set(right):
+            left_items = left.get(key, [])
+            right_items = right.get(key, [])
+            size = max(len(left_items), len(right_items))
+            merged[key] = [
+                JavaTaint.combine(
+                    [
+                        value
+                        for value in (
+                            left_items[index] if index < len(left_items) else None,
+                            right_items[index] if index < len(right_items) else None,
+                        )
+                        if value is not None
+                    ]
+                )
+                for index in range(size)
+            ]
+        return merged
+
+
+@dataclass(frozen=True)
+class JavaHelperSummary:
+    returns_request_source: bool = False
+    returns_arg_taint: bool = False
+
+
+class JavaSecurityFlowAnalyzer:
+    def __init__(self, root_node, file_path: str, source_bytes: bytes) -> None:
+        self.root_node = root_node
+        self.file_path = file_path
+        self.source = source_bytes
+        self.findings: list[dict] = []
+        self.seen: set[tuple[str, int, str]] = set()
+        self.helper_summaries: dict[
+            tuple[str | None, str, int], JavaHelperSummary
+        ] = {}
+
+    def scan(self) -> list[dict]:
+        self.helper_summaries = self._collect_helper_summaries()
+        for method in self._method_nodes():
+            self._scan_method(method)
+        return self.findings
+
+    def _scan_method(self, method_node) -> None:
+        state = self._initial_state(method_node)
+        body = method_node.child_by_field_name("body")
+        if body is None:
+            return
+        for statement in self._block_statements(body):
+            self._process_statement(statement, state)
+        self._flush_pending_path_objects(state)
+
+    def _initial_state(self, method_node) -> JavaFlowState:
+        state = JavaFlowState()
+        for param in self._formal_parameters(method_node):
+            name = self._param_name(param)
+            if not name:
+                continue
+            type_name = self._simple_name(self._param_type(param))
+            annotations = self._annotation_names(param)
+            if type_name in REQUEST_TYPES or name in {"request", "req"}:
+                state.request_vars.add(name)
+            if annotations & REQUEST_PARAM_ANNOTATIONS:
+                state.tainted_vars.add(name)
+        return state
+
+    def _collect_helper_summaries(
+        self,
+    ) -> dict[tuple[str | None, str, int], JavaHelperSummary]:
+        summaries: dict[tuple[str | None, str, int], JavaHelperSummary] = {}
+        request_fields = self._collect_request_fields()
+        for method in self._method_nodes():
+            if method.type != "method_declaration":
+                continue
+            name = self._method_name(method)
+            if not name:
+                continue
+            params = [self._param_name(param) for param in self._formal_parameters(method)]
+            param_names = [param for param in params if param]
+            class_name = self._class_name_for_node(method)
+            class_request_fields = request_fields.get(class_name, set())
+            returns_request_source = self._method_returns_taint(
+                method, [], class_request_fields
+            )
+            returns_arg_taint = self._method_returns_taint(method, param_names)
+            summaries[(class_name, name, len(param_names))] = JavaHelperSummary(
+                returns_request_source=returns_request_source,
+                returns_arg_taint=returns_arg_taint,
+            )
+        return summaries
+
+    def _collect_request_fields(self) -> dict[str | None, set[str]]:
+        fields: dict[str | None, set[str]] = {}
+        for declaration in self._iter_nodes(self.root_node):
+            if declaration.type != "field_declaration":
+                continue
+            type_node = declaration.child_by_field_name("type")
+            if self._simple_name(self._text(type_node)) not in REQUEST_TYPES:
+                continue
+            class_name = self._class_name_for_node(declaration)
+            for declarator in self._children_of_type(declaration, "variable_declarator"):
+                name_node = declarator.child_by_field_name("name")
+                if name_node is not None:
+                    fields.setdefault(class_name, set()).add(self._text(name_node))
+        return fields
+
+    def _method_returns_taint(
+        self,
+        method_node,
+        seed_params: list[str],
+        request_fields: set[str] | None = None,
+    ) -> bool:
+        state = self._initial_state(method_node)
+        if request_fields:
+            state.request_vars.update(request_fields)
+        state.tainted_vars.update(seed_params)
+        body = method_node.child_by_field_name("body")
+        if body is None:
+            return False
+        return self._block_returns_taint(body, state)
+
+    def _block_returns_taint(self, block_node, state: JavaFlowState) -> bool:
+        for statement in self._block_statements(block_node):
+            if statement.type == "return_statement":
+                expr = self._first_expression_child(statement)
+                if expr is not None and self._expr_facts(expr, state).tainted:
+                    return True
+                continue
+            if statement.type == "if_statement":
+                condition = statement.child_by_field_name("condition")
+                selected = self._eval_condition(condition, state)
+                consequence = statement.child_by_field_name("consequence")
+                alternative = statement.child_by_field_name("alternative")
+                if selected is True:
+                    if consequence is not None and self._statement_returns_taint(
+                        consequence, state.copy()
+                    ):
+                        return True
+                elif selected is False:
+                    if alternative is not None and self._statement_returns_taint(
+                        alternative, state.copy()
+                    ):
+                        return True
+                else:
+                    if consequence is not None and self._statement_returns_taint(
+                        consequence, state.copy()
+                    ):
+                        return True
+                    if alternative is not None and self._statement_returns_taint(
+                        alternative, state.copy()
+                    ):
+                        return True
+                continue
+            self._process_statement(statement, state, collect_findings=False)
+        return False
+
+    def _statement_returns_taint(self, statement, state: JavaFlowState) -> bool:
+        if statement.type == "return_statement":
+            expr = self._first_expression_child(statement)
+            return expr is not None and self._expr_facts(expr, state).tainted
+        if statement.type == "block":
+            return self._block_returns_taint(statement, state)
+        self._process_statement(statement, state, collect_findings=False)
+        return False
+
+    def _process_statement(
+        self, statement, state: JavaFlowState, *, collect_findings: bool = True
+    ) -> None:
+        if statement.type == "block":
+            for child in self._block_statements(statement):
+                self._process_statement(child, state, collect_findings=collect_findings)
+            return
+
+        if statement.type == "local_variable_declaration":
+            for declarator in self._children_of_type(statement, "variable_declarator"):
+                self._process_variable_declarator(
+                    declarator, state, collect_findings=collect_findings
+                )
+            return
+
+        if statement.type == "expression_statement":
+            expr = self._first_expression_child(statement)
+            if expr is not None:
+                self._process_expression_statement(
+                    expr, state, collect_findings=collect_findings
+                )
+            return
+
+        if statement.type == "return_statement":
+            if collect_findings:
+                self._scan_expression_effects(statement, state)
+            return
+
+        if statement.type == "if_statement":
+            self._process_if_statement(
+                statement, state, collect_findings=collect_findings
+            )
+            return
+
+        if statement.type in {"switch_expression", "switch_statement"}:
+            self._process_switch(
+                statement, state, collect_findings=collect_findings
+            )
+            return
+
+        if statement.type == "enhanced_for_statement":
+            self._process_enhanced_for(
+                statement, state, collect_findings=collect_findings
+            )
+            return
+
+        if collect_findings:
+            self._scan_expression_effects(statement, state)
+        for child in statement.children:
+            if child.type.endswith("_statement") or child.type in {
+                "block",
+                "local_variable_declaration",
+            }:
+                self._process_statement(child, state, collect_findings=collect_findings)
+
+    def _process_expression_statement(
+        self, expr, state: JavaFlowState, *, collect_findings: bool
+    ) -> None:
+        if expr.type == "assignment_expression":
+            self._process_assignment(expr, state, collect_findings=collect_findings)
+            return
+        if collect_findings:
+            self._scan_expression_effects(expr, state)
+
+    def _process_variable_declarator(
+        self, declarator, state: JavaFlowState, *, collect_findings: bool
+    ) -> None:
+        name_node = declarator.child_by_field_name("name")
+        value_node = declarator.child_by_field_name("value")
+        if name_node is None or value_node is None:
+            return
+        name = self._text(name_node)
+        if collect_findings:
+            self._scan_expression_effects(value_node, state)
+        self._assign_var(name, value_node, state)
+
+    def _process_assignment(
+        self, assignment, state: JavaFlowState, *, collect_findings: bool
+    ) -> None:
+        left = assignment.child_by_field_name("left")
+        right = assignment.child_by_field_name("right")
+        if right is None:
+            return
+        if collect_findings:
+            self._scan_expression_effects(right, state)
+        name = self._assignment_target_name(left)
+        if name:
+            self._assign_var(name, right, state)
+
+    def _assign_var(self, name: str, value_node, state: JavaFlowState) -> None:
+        state.guarded_path_vars.discard(name)
+        state.pending_path_objects.pop(name, None)
+
+        const_value = self._eval_constant(value_node, state)
+        if const_value is not None:
+            state.constants[name] = const_value
+        else:
+            state.constants.pop(name, None)
+
+        object_type = self._object_creation_type(value_node)
+        if object_type:
+            state.object_types[name] = object_type
+            if object_type == "Cookie":
+                state.cookie_vars.add(name)
+            object_args = self._object_creation_args(value_node)
+            if object_type == "ProcessBuilder" and (
+                self._args_tainted(object_args, state)
+                or self._args_mention_names(object_args, state.tainted_collections)
+            ):
+                state.tainted_process_builders.add(name)
+            if object_type == "File":
+                facts = self._expr_facts(value_node, state)
+                if facts.tainted:
+                    state.pending_path_objects[name] = self._line(value_node)
+        else:
+            state.object_types.pop(name, None)
+
+        facts = self._expr_facts(value_node, state)
+        if facts.tainted:
+            state.tainted_vars.add(name)
+            if facts.xss_safe:
+                state.xss_safe_vars.add(name)
+            else:
+                state.xss_safe_vars.discard(name)
+        else:
+            state.tainted_vars.discard(name)
+            state.xss_safe_vars.discard(name)
+            state.tainted_collections.discard(name)
+            state.tainted_process_builders.discard(name)
+
+        if self._expr_has_normalizer(value_node):
+            state.normalized_path_vars.add(name)
+            if self._expr_has_canonical_path(value_node):
+                state.canonical_string_vars.add(name)
+                source_name = self._first_receiver_for_call(value_node, "getCanonicalPath")
+                if source_name:
+                    state.canonical_path_sources[name] = {source_name}
+                if self._expr_is_slash_terminated_base(value_node):
+                    state.slash_terminated_vars.add(name)
+                else:
+                    state.slash_terminated_vars.discard(name)
+        else:
+            state.normalized_path_vars.discard(name)
+            state.canonical_string_vars.discard(name)
+            state.slash_terminated_vars.discard(name)
+            state.canonical_path_sources.pop(name, None)
+
+    def _process_if_statement(
+        self, node, state: JavaFlowState, *, collect_findings: bool
+    ) -> None:
+        guarded_after = self._path_guards_from_if(node, state)
+        condition = node.child_by_field_name("condition")
+        selected = self._eval_condition(condition, state)
+        consequence = node.child_by_field_name("consequence")
+        alternative = node.child_by_field_name("alternative")
+
+        if selected is True:
+            if consequence is not None:
+                self._process_statement(
+                    consequence, state, collect_findings=collect_findings
+                )
+        elif selected is False:
+            if alternative is not None:
+                self._process_statement(
+                    alternative, state, collect_findings=collect_findings
+                )
+        else:
+            left = state.copy()
+            right = state.copy()
+            if consequence is not None:
+                self._process_statement(
+                    consequence, left, collect_findings=collect_findings
+                )
+            if alternative is not None:
+                self._process_statement(
+                    alternative, right, collect_findings=collect_findings
+                )
+            state.merge_from(left, right)
+
+        state.guarded_path_vars.update(guarded_after)
+        for name in guarded_after:
+            state.pending_path_objects.pop(name, None)
+
+    def _process_enhanced_for(
+        self, node, state: JavaFlowState, *, collect_findings: bool
+    ) -> None:
+        name = None
+        name_node = node.child_by_field_name("name")
+        value = node.child_by_field_name("value")
+        if name_node is not None:
+            name = self._text(name_node)
+        if name and value is not None and self._expr_facts(value, state).tainted:
+            state.tainted_vars.add(name)
+        body = node.child_by_field_name("body")
+        if body is not None:
+            self._process_statement(body, state, collect_findings=collect_findings)
+
+    def _process_switch(
+        self, node, state: JavaFlowState, *, collect_findings: bool
+    ) -> None:
+        body = node.child_by_field_name("body")
+        if body is None:
+            if collect_findings:
+                self._scan_expression_effects(node, state)
+            return
+
+        groups = [
+            child for child in body.children if child.type == "switch_block_statement_group"
+        ]
+        if not groups:
+            return
+
+        condition_value = self._eval_constant(node.child_by_field_name("condition"), state)
+        if condition_value is not None:
+            selected_index = self._select_switch_group_index(
+                groups, condition_value, state
+            )
+            if selected_index is not None:
+                for group in groups[selected_index:]:
+                    stop = False
+                    for child in group.children:
+                        if child.type == "switch_label":
+                            continue
+                        self._process_statement(
+                            child, state, collect_findings=collect_findings
+                        )
+                        if child.type in {"break_statement", "return_statement", "throw_statement"}:
+                            stop = True
+                            break
+                    if stop:
+                        break
+                return
+
+        merged_state: JavaFlowState | None = None
+        for group in groups:
+            branch_state = state.copy()
+            for child in group.children:
+                if child.type == "switch_label":
+                    continue
+                self._process_statement(
+                    child, branch_state, collect_findings=collect_findings
+                )
+            if merged_state is None:
+                merged_state = branch_state
+            else:
+                next_state = state.copy()
+                next_state.merge_from(merged_state, branch_state)
+                merged_state = next_state
+
+        if merged_state is not None:
+            state.merge_from(merged_state, merged_state)
+
+    def _select_switch_group_index(
+        self, groups: list, condition_value: int | bool | str, state: JavaFlowState
+    ) -> int | None:
+        default_index = None
+        for index, group in enumerate(groups):
+            for label in [child for child in group.children if child.type == "switch_label"]:
+                if self._text(label).lstrip().startswith("default"):
+                    default_index = index
+                    continue
+                label_expr = self._first_expression_child(label)
+                label_value = self._eval_constant(label_expr, state)
+                if label_value == condition_value:
+                    return index
+        return default_index
+
+    def _scan_expression_effects(self, node, state: JavaFlowState) -> None:
+        for child in self._iter_nodes(node):
+            if child.type == "method_invocation":
+                self._process_method_effects(child, state)
+                self._process_method_sinks(child, state)
+            elif child.type == "object_creation_expression":
+                self._process_constructor_sinks(child, state)
+                self._process_weak_random(child, state)
+
+    def _process_method_effects(self, call, state: JavaFlowState) -> None:
+        method = self._call_name(call)
+        receiver = self._receiver_name(call)
+        args = self._call_args(call)
+
+        if method == "add" and receiver and args:
+            value = self._expr_facts(args[0], state)
+            state.list_entries.setdefault(receiver, []).append(value)
+            if value.tainted:
+                state.tainted_collections.add(receiver)
+            return
+
+        if method == "remove" and receiver and args:
+            index = self._eval_constant(args[0], state)
+            if isinstance(index, int):
+                entries = state.list_entries.get(receiver)
+                if entries and 0 <= index < len(entries):
+                    entries.pop(index)
+                    if not any(entry.tainted for entry in entries):
+                        state.tainted_collections.discard(receiver)
+            return
+
+        if method == "put" and receiver and len(args) >= 2:
+            key = self._string_literal_value(args[0])
+            if key is not None:
+                state.map_entries[(receiver, key)] = self._expr_facts(args[1], state)
+            return
+
+        if method == "setSecure" and receiver in state.cookie_vars and args:
+            value = self._eval_constant(args[0], state)
+            if value is False:
+                state.insecure_cookie_vars.add(receiver)
+            elif value is True:
+                state.insecure_cookie_vars.discard(receiver)
+            return
+
+        if (
+            method == "command"
+            and receiver
+            and (
+                self._args_tainted(args, state)
+                or self._args_mention_names(args, state.tainted_collections)
+            )
+        ):
+            state.tainted_process_builders.add(receiver)
+            return
+
+    def _process_method_sinks(self, call, state: JavaFlowState) -> None:
+        method = self._call_name(call)
+        args = self._call_args(call)
+        line = self._line(call)
+
+        if method == "addCookie" and self._args_mention_names(
+            args, state.insecure_cookie_vars
+        ):
+            self._add_finding(
+                "SKY-D252",
+                "HIGH",
+                "Cookie is added with Secure disabled. Set Secure before sending sensitive cookies.",
+                line,
+                category="cookie_security",
+                cwe="CWE-614",
+            )
+
+        if method == "start":
+            receiver = self._receiver_name(call)
+            if receiver in state.tainted_process_builders:
+                self._add_finding(
+                    "SKY-D212",
+                    "CRITICAL",
+                    "ProcessBuilder starts a shell command built from servlet-controlled data. Use fixed argv elements and validate inputs.",
+                    line,
+                    cwe="CWE-78",
+                )
+
+        if method == "exec" and (
+            self._args_tainted(args, state)
+            or self._args_mention_names(args, state.tainted_collections)
+        ):
+            self._add_finding(
+                "SKY-D212",
+                "CRITICAL",
+                "Process execution uses servlet-controlled data. Use fixed argv elements and validate inputs.",
+                line,
+                cwe="CWE-78",
+            )
+
+        if method in SQL_SINKS and self._sink_args_tainted(args, SQL_SINKS[method], state):
+            self._add_finding(
+                "SKY-D211",
+                "CRITICAL",
+                "SQL query uses servlet-controlled data. Use parameterized queries with fixed SQL.",
+                line,
+                cwe="CWE-89",
+            )
+
+        if method in LDAP_SINKS and self._sink_args_tainted(
+            args, LDAP_SINKS[method], state
+        ):
+            self._add_finding(
+                "SKY-D240",
+                "CRITICAL",
+                "LDAP search filter uses servlet-controlled data. Escape LDAP filter values or use safe APIs.",
+                line,
+                category="ldap_injection",
+                cwe="CWE-90",
+            )
+
+        if method in XPATH_SINKS and self._sink_args_tainted(
+            args, XPATH_SINKS[method], state
+        ):
+            self._add_finding(
+                "SKY-D241",
+                "CRITICAL",
+                "XPath expression uses servlet-controlled data. Use fixed expressions or strict allowlists.",
+                line,
+                category="xpath_injection",
+                cwe="CWE-643",
+            )
+
+        if (
+            method in XSS_WRITER_METHODS
+            and self._receiver_chain_has_call(call, "getWriter")
+            and any(self._expr_facts(arg, state).tainted and not self._expr_facts(arg, state).xss_safe for arg in args)
+        ):
+            self._add_finding(
+                "SKY-D226",
+                "HIGH",
+                "Servlet response writes untrusted data without HTML encoding.",
+                line,
+                cwe="CWE-79",
+            )
+
+        if (
+            method in {"setAttribute", "putValue"}
+            and self._receiver_chain_has_call(call, "getSession")
+            and self._args_tainted(args, state)
+        ):
+            self._add_finding(
+                "SKY-D253",
+                "HIGH",
+                "Servlet-controlled data crosses into HTTP session state.",
+                line,
+                category="trust_boundary",
+                cwe="CWE-501",
+            )
+
+        if self._is_files_path_sink(call):
+            positions = FILES_PATH_METHODS.get(method, ())
+            if self._path_sink_tainted(call, args, positions, state):
+                self._add_finding(
+                    "SKY-D215",
+                    "HIGH",
+                    "Servlet-controlled path reaches a filesystem sink without canonical path validation.",
+                    line,
+                    cwe="CWE-22",
+                )
+
+        self._process_weak_random(call, state)
+
+    def _process_constructor_sinks(self, node, state: JavaFlowState) -> None:
+        class_name = self._object_creation_type(node)
+        args = self._object_creation_args(node)
+        if class_name in PATH_CONSTRUCTOR_TYPES and self._path_sink_tainted(
+            node, args, PATH_CONSTRUCTOR_TYPES[class_name], state
+        ):
+            self._add_finding(
+                "SKY-D215",
+                "HIGH",
+                "Servlet-controlled path reaches a filesystem sink without canonical path validation.",
+                self._line(node),
+                cwe="CWE-22",
+            )
+
+    def _process_weak_random(self, node, state: JavaFlowState) -> None:
+        if not self._is_weak_random_call(node):
+            return
+        method = self._enclosing_method(node)
+        if method is None:
+            return
+        if not self._method_has_security_token_context(method):
+            return
+        self._add_finding(
+            "SKY-D250",
+            "HIGH",
+            "Weak random value is used in security-sensitive token or session material. Use SecureRandom.",
+            self._line(node),
+            category="weak_random",
+            cwe="CWE-330",
+        )
+
+    def _expr_facts(self, node, state: JavaFlowState) -> JavaTaint:
+        if node is None:
+            return JavaTaint()
+
+        if node.type == "identifier":
+            name = self._text(node)
+            return JavaTaint(
+                tainted=name in state.tainted_vars,
+                xss_safe=name in state.xss_safe_vars,
+            )
+
+        if node.type in {
+            "string_literal",
+            "decimal_integer_literal",
+            "hex_integer_literal",
+            "octal_integer_literal",
+            "binary_integer_literal",
+            "true",
+            "false",
+            "null_literal",
+        }:
+            return JavaTaint()
+
+        if node.type == "parenthesized_expression":
+            child = self._first_expression_child(node)
+            return self._expr_facts(child, state) if child is not None else JavaTaint()
+
+        if node.type == "cast_expression":
+            return JavaTaint.combine(
+                [self._expr_facts(child, state) for child in node.children[-1:]]
+            )
+
+        if node.type == "assignment_expression":
+            right = node.child_by_field_name("right")
+            return self._expr_facts(right, state) if right is not None else JavaTaint()
+
+        if node.type == "ternary_expression":
+            condition = node.child_by_field_name("condition")
+            consequence = node.child_by_field_name("consequence")
+            alternative = node.child_by_field_name("alternative")
+            selected = self._eval_condition(condition, state)
+            if selected is True and consequence is not None:
+                return self._expr_facts(consequence, state)
+            if selected is False and alternative is not None:
+                return self._expr_facts(alternative, state)
+            values = []
+            if consequence is not None:
+                values.append(self._expr_facts(consequence, state))
+            if alternative is not None:
+                values.append(self._expr_facts(alternative, state))
+            return JavaTaint.combine(values)
+
+        if node.type == "method_invocation":
+            return self._method_call_facts(node, state)
+
+        if node.type == "object_creation_expression":
+            args = self._object_creation_args(node)
+            if self._args_mention_names(args, state.tainted_collections):
+                return JavaTaint(tainted=True)
+            return JavaTaint.combine(
+                [self._expr_facts(arg, state) for arg in args]
+            )
+
+        if node.type == "array_access":
+            values = [self._expr_facts(child, state) for child in node.children]
+            return JavaTaint.combine(values)
+
+        values = []
+        for child in node.children:
+            if child.is_named:
+                values.append(self._expr_facts(child, state))
+        return JavaTaint.combine(values)
+
+    def _method_call_facts(self, call, state: JavaFlowState) -> JavaTaint:
+        method = self._call_name(call)
+        args = self._call_args(call)
+
+        if self._is_request_source_call(call, state):
+            return JavaTaint(tainted=True)
+
+        if method in XSS_SANITIZER_METHODS:
+            facts = JavaTaint.combine([self._expr_facts(arg, state) for arg in args])
+            return JavaTaint(tainted=facts.tainted, xss_safe=facts.tainted)
+
+        receiver = self._receiver_name(call)
+        if method == "get" and receiver and args:
+            key = self._string_literal_value(args[0])
+            if key is not None and (receiver, key) in state.map_entries:
+                return state.map_entries[(receiver, key)]
+            index = self._eval_constant(args[0], state)
+            if isinstance(index, int):
+                entries = state.list_entries.get(receiver, [])
+                if 0 <= index < len(entries):
+                    return entries[index]
+
+        summary = self._helper_summary_for_call(call, state)
+        if summary is not None:
+            if summary.returns_request_source:
+                return JavaTaint(tainted=True)
+            if summary.returns_arg_taint:
+                return JavaTaint.combine([self._expr_facts(arg, state) for arg in args])
+            return JavaTaint()
+
+        values = [self._expr_facts(arg, state) for arg in args]
+        receiver_node = call.child_by_field_name("object")
+        if receiver_node is not None:
+            values.append(self._expr_facts(receiver_node, state))
+        return JavaTaint.combine(values)
+
+    def _helper_summary_for_call(
+        self, call, state: JavaFlowState
+    ) -> JavaHelperSummary | None:
+        method = self._call_name(call)
+        args = self._call_args(call)
+        receiver = self._receiver_name(call)
+        receiver_class = None
+        if receiver:
+            receiver_class = state.object_types.get(receiver)
+        if receiver_class is None:
+            object_node = call.child_by_field_name("object")
+            if object_node is not None and object_node.type == "object_creation_expression":
+                receiver_class = self._object_creation_type(object_node)
+        if receiver_class is None and call.child_by_field_name("object") is None:
+            receiver_class = self._class_name_for_node(call)
+        return self.helper_summaries.get((receiver_class, method, len(args)))
+
+    def _is_request_source_call(self, call, state: JavaFlowState) -> bool:
+        method = self._call_name(call)
+        if method not in REQUEST_SOURCE_METHODS:
+            return False
+        receiver = self._receiver_name(call)
+        if receiver in state.request_vars:
+            return True
+        return receiver in {"request", "req"}
+
+    def _path_sink_tainted(
+        self, sink_node, args: list, positions: tuple[int, ...], state: JavaFlowState
+    ) -> bool:
+        for pos in positions:
+            if pos >= len(args):
+                continue
+            arg = args[pos]
+            facts = self._expr_facts(arg, state)
+            if not facts.tainted:
+                continue
+            names = self._tainted_identifiers(arg, state)
+            if names and self._path_arg_guarded(sink_node, names, state):
+                continue
+            return True
+        return False
+
+    def _path_arg_guarded(
+        self, sink_node, names: set[str], state: JavaFlowState
+    ) -> bool:
+        if names and names <= state.guarded_path_vars:
+            return True
+        current = sink_node.parent
+        while current is not None:
+            if current.type == "if_statement":
+                guarded = self._positive_path_guard_names(current, state)
+                if names and names <= guarded and self._is_in_consequence(sink_node, current):
+                    return True
+            current = current.parent
+        return False
+
+    def _path_guards_from_if(self, node, state: JavaFlowState) -> set[str]:
+        condition = node.child_by_field_name("condition")
+        consequence = node.child_by_field_name("consequence")
+        if condition is None or consequence is None:
+            return set()
+        if not self._statement_always_exits(consequence, state):
+            return set()
+        guards = set()
+        for call in self._calls_named(condition, "startsWith"):
+            receiver = self._receiver_name(call)
+            if not receiver:
+                continue
+            if not self._is_negative_guard_condition(condition):
+                continue
+            if not self._is_simple_startswith_guard_condition(condition):
+                continue
+            if self._is_safe_path_guard_call(call, state):
+                guards.add(receiver)
+                guards.update(state.canonical_path_sources.get(receiver, set()))
+        return guards
+
+    def _positive_path_guard_names(self, node, state: JavaFlowState) -> set[str]:
+        condition = node.child_by_field_name("condition")
+        if (
+            condition is None
+            or self._is_negative_guard_condition(condition)
+            or not self._is_simple_startswith_guard_condition(condition)
+        ):
+            return set()
+        guards = set()
+        for call in self._calls_named(condition, "startsWith"):
+            receiver = self._receiver_name(call)
+            if receiver and self._is_safe_path_guard_call(call, state):
+                guards.add(receiver)
+                guards.update(state.canonical_path_sources.get(receiver, set()))
+        return guards
+
+    def _is_safe_path_guard_call(self, call, state: JavaFlowState) -> bool:
+        receiver = self._receiver_name(call)
+        if not receiver:
+            return False
+        args = self._call_args(call)
+        arg = self._text(args[0]).strip() if args else ""
+        receiver_safe = (
+            receiver in state.normalized_path_vars
+            or receiver in state.canonical_string_vars
+            or self._expr_has_normalizer(call.child_by_field_name("object"))
+        )
+        if not receiver_safe:
+            return False
+        if receiver in state.canonical_string_vars:
+            arg_name = arg if arg.isidentifier() else ""
+            if arg_name in state.canonical_string_vars:
+                return arg_name in state.slash_terminated_vars
+        return True
+
+    def _flush_pending_path_objects(self, state: JavaFlowState) -> None:
+        for name, line in sorted(state.pending_path_objects.items(), key=lambda item: item[1]):
+            if name in state.guarded_path_vars:
+                continue
+            self._add_finding(
+                "SKY-D215",
+                "HIGH",
+                "Servlet-controlled path reaches a filesystem sink without canonical path validation.",
+                line,
+                cwe="CWE-22",
+            )
+
+    def _is_files_path_sink(self, call) -> bool:
+        method = self._call_name(call)
+        if method not in FILES_PATH_METHODS:
+            return False
+        receiver = self._receiver_text(call)
+        base = self._simple_name(receiver)
+        return base in {"Files", "java.nio.file.Files"} or receiver.endswith(".Files")
+
+    def _args_tainted(self, args: list, state: JavaFlowState) -> bool:
+        return any(self._expr_facts(arg, state).tainted for arg in args)
+
+    def _sink_args_tainted(
+        self, args: list, positions: tuple[int, ...], state: JavaFlowState
+    ) -> bool:
+        return any(
+            pos < len(args) and self._expr_facts(args[pos], state).tainted
+            for pos in positions
+        )
+
+    def _args_mention_names(self, args: list, names: set[str]) -> bool:
+        return any(self._identifier_names(arg) & names for arg in args)
+
+    def _tainted_identifiers(self, node, state: JavaFlowState) -> set[str]:
+        return self._identifier_names(node) & state.tainted_vars
+
+    def _expr_has_normalizer(self, node) -> bool:
+        if node is None:
+            return False
+        return any(
+            self._call_name(call) in PATH_NORMALIZER_METHODS
+            for call in self._method_calls(node)
+        )
+
+    def _expr_has_canonical_path(self, node) -> bool:
+        if node is None:
+            return False
+        return any(self._call_name(call) == "getCanonicalPath" for call in self._method_calls(node))
+
+    def _expr_is_slash_terminated_base(self, node) -> bool:
+        text = self._text(node)
+        return (
+            "File.separator" in text
+            or "java.io.File.separator" in text
+            or '"/"' in text
+            or '"\\\\"' in text
+            or "separatorChar" in text
+        )
+
+    def _is_weak_random_call(self, node) -> bool:
+        if node.type == "method_invocation":
+            method = self._call_name(node)
+            receiver = self._receiver_text(node)
+            if receiver in {"Math", "java.lang.Math"} and method == "random":
+                return True
+            if method.startswith("next") and "SecureRandom" not in self._text(node):
+                object_node = node.child_by_field_name("object")
+                if object_node is not None and "Random" in self._text(object_node):
+                    return True
+        if node.type == "object_creation_expression":
+            return self._object_creation_type(node) == "Random"
+        return False
+
+    def _method_has_security_token_context(self, method_node) -> bool:
+        for node in self._iter_nodes(method_node):
+            if node.type == "identifier":
+                name = self._text(node)
+                if any(token in name.lower() for token in ("token", "session", "remember")):
+                    return True
+            elif node.type == "string_literal":
+                value = self._text(node).lower()
+                if any(token in value for token in ("token", "session", "rememberme")):
+                    return True
+            elif node.type == "method_invocation" and self._call_name(node) == "getSession":
+                return True
+        return False
+
+    def _eval_condition(self, node, state: JavaFlowState) -> bool | None:
+        value = self._eval_constant(node, state)
+        return value if isinstance(value, bool) else None
+
+    def _eval_constant(self, node, state: JavaFlowState) -> int | bool | str | None:
+        if node is None:
+            return None
+        if node.type == "parenthesized_expression":
+            child = self._first_expression_child(node)
+            return self._eval_constant(child, state)
+        if node.type == "string_literal":
+            return self._string_literal_value(node)
+        if node.type == "character_literal":
+            text = self._text(node)
+            if len(text) >= 3 and text[0] == "'" and text[-1] == "'":
+                return text[1:-1]
+            return None
+        if node.type == "decimal_integer_literal":
+            try:
+                return int(self._text(node).replace("_", ""))
+            except ValueError:
+                return None
+        if node.type == "true":
+            return True
+        if node.type == "false":
+            return False
+        if node.type == "identifier":
+            return state.constants.get(self._text(node))
+        if node.type == "unary_expression":
+            child = self._first_expression_child(node)
+            text = self._text(node).strip()
+            value = self._eval_constant(child, state)
+            if text.startswith("!") and isinstance(value, bool):
+                return not value
+            if text.startswith("-") and isinstance(value, int):
+                return -value
+            return None
+        if node.type == "binary_expression":
+            left = self._eval_constant(node.child_by_field_name("left"), state)
+            right = self._eval_constant(node.child_by_field_name("right"), state)
+            op = self._text(node.child_by_field_name("operator"))
+            return self._eval_binary(left, op, right)
+        if node.type == "method_invocation" and self._call_name(node) == "charAt":
+            receiver = self._receiver_name(node)
+            args = self._call_args(node)
+            if receiver and args:
+                receiver_value = state.constants.get(receiver)
+                index = self._eval_constant(args[0], state)
+                if isinstance(receiver_value, str) and isinstance(index, int):
+                    if 0 <= index < len(receiver_value):
+                        return receiver_value[index]
+        return None
+
+    def _eval_binary(
+        self, left: int | bool | str | None, op: str, right: int | bool | str | None
+    ) -> int | bool | str | None:
+        if left is None or right is None:
+            return None
+        try:
+            if op == "+" and (isinstance(left, str) or isinstance(right, str)):
+                return str(left) + str(right)
+            if op == "+" and isinstance(left, int) and isinstance(right, int):
+                return left + right
+            if op == "-" and isinstance(left, int) and isinstance(right, int):
+                return left - right
+            if op == "*" and isinstance(left, int) and isinstance(right, int):
+                return left * right
+            if op == "/" and isinstance(left, int) and isinstance(right, int) and right:
+                return left // right
+            if op == "%" and isinstance(left, int) and isinstance(right, int) and right:
+                return left % right
+            if op == ">":
+                return left > right
+            if op == ">=":
+                return left >= right
+            if op == "<":
+                return left < right
+            if op == "<=":
+                return left <= right
+            if op == "==":
+                return left == right
+            if op == "!=":
+                return left != right
+            if op == "&&" and isinstance(left, bool) and isinstance(right, bool):
+                return left and right
+            if op == "||" and isinstance(left, bool) and isinstance(right, bool):
+                return left or right
+        except Exception:
+            return None
+        return None
+
+    def _is_negative_guard_condition(self, node) -> bool:
+        text = self._text(node)
+        return (
+            text.strip().startswith("(!")
+            or "== false" in text
+            or "false ==" in text
+            or text.strip().startswith("!")
+        )
+
+    def _is_simple_startswith_guard_condition(self, node) -> bool:
+        text = self._text(node)
+        return "&&" not in text and "||" not in text and len(self._calls_named(node, "startsWith")) == 1
+
+    def _statement_always_exits(self, node, state: JavaFlowState) -> bool:
+        if node.type in CONTROL_FLOW_STMTS:
+            return True
+        if node.type == "block":
+            for statement in self._block_statements(node):
+                if self._statement_always_exits(statement, state):
+                    return True
+            return False
+        if node.type == "if_statement":
+            condition = node.child_by_field_name("condition")
+            selected = self._eval_condition(condition, state)
+            consequence = node.child_by_field_name("consequence")
+            alternative = node.child_by_field_name("alternative")
+            if selected is True:
+                return consequence is not None and self._statement_always_exits(
+                    consequence, state
+                )
+            if selected is False:
+                return alternative is not None and self._statement_always_exits(
+                    alternative, state
+                )
+            return (
+                consequence is not None
+                and alternative is not None
+                and self._statement_always_exits(consequence, state)
+                and self._statement_always_exits(alternative, state)
+            )
+        return False
+
+    def _is_in_consequence(self, node, if_node) -> bool:
+        consequence = if_node.child_by_field_name("consequence")
+        current = node
+        while current is not None:
+            if self._same_node(current, consequence):
+                return True
+            if self._same_node(current, if_node):
+                return False
+            current = current.parent
+        return False
+
+    def _receiver_chain_has_call(self, call, method_name: str) -> bool:
+        receiver = call.child_by_field_name("object")
+        if receiver is None:
+            return False
+        return any(
+            node.type == "method_invocation" and self._call_name(node) == method_name
+            for node in self._iter_nodes(receiver)
+        )
+
+    def _calls_named(self, node, method_name: str) -> list:
+        return [
+            call
+            for call in self._method_calls(node)
+            if self._call_name(call) == method_name
+        ]
+
+    def _first_receiver_for_call(self, node, method_name: str) -> str | None:
+        for call in self._calls_named(node, method_name):
+            receiver = self._receiver_name(call)
+            if receiver:
+                return receiver
+        return None
+
+    def _method_calls(self, node) -> list:
+        if node is None:
+            return []
+        return [child for child in self._iter_nodes(node) if child.type == "method_invocation"]
+
+    def _identifier_names(self, node) -> set[str]:
+        if node is None:
+            return set()
+        return {
+            self._text(child)
+            for child in self._iter_nodes(node)
+            if child.type == "identifier"
+        }
+
+    def _same_node(self, left, right) -> bool:
+        if left is None or right is None:
+            return False
+        return (
+            left.type == right.type
+            and left.start_byte == right.start_byte
+            and left.end_byte == right.end_byte
+        )
+
+    def _method_nodes(self) -> list:
+        return [
+            node
+            for node in self._iter_nodes(self.root_node)
+            if node.type in {"method_declaration", "constructor_declaration"}
+        ]
+
+    def _iter_nodes(self, node):
+        stack = [node]
+        while stack:
+            current = stack.pop()
+            yield current
+            stack.extend(reversed(current.children))
+
+    def _block_statements(self, block_node) -> list:
+        return [child for child in block_node.children if child.is_named]
+
+    def _children_of_type(self, node, type_name: str) -> list:
+        return [child for child in self._iter_nodes(node) if child.type == type_name]
+
+    def _formal_parameters(self, method_node) -> list:
+        params = method_node.child_by_field_name("parameters")
+        if params is None:
+            return []
+        return [child for child in params.children if child.type == "formal_parameter"]
+
+    def _param_name(self, param) -> str | None:
+        name = param.child_by_field_name("name")
+        return self._text(name) if name is not None else None
+
+    def _param_type(self, param) -> str:
+        type_node = param.child_by_field_name("type")
+        return self._text(type_node) if type_node is not None else ""
+
+    def _annotation_names(self, node) -> set[str]:
+        names = set()
+        for child in node.children:
+            if child.type != "modifiers":
+                continue
+            for modifier in child.children:
+                if modifier.type not in {"marker_annotation", "annotation"}:
+                    continue
+                name = modifier.child_by_field_name("name")
+                if name is not None:
+                    names.add(self._simple_name(self._text(name)))
+        return names
+
+    def _method_name(self, method_node) -> str | None:
+        name = method_node.child_by_field_name("name")
+        return self._text(name) if name is not None else None
+
+    def _class_name_for_node(self, node) -> str | None:
+        current = node.parent
+        while current is not None:
+            if current.type in {
+                "class_declaration",
+                "interface_declaration",
+                "enum_declaration",
+                "record_declaration",
+            }:
+                name = current.child_by_field_name("name")
+                return self._text(name) if name is not None else None
+            current = current.parent
+        return None
+
+    def _enclosing_method(self, node):
+        current = node.parent
+        while current is not None:
+            if current.type in {"method_declaration", "constructor_declaration"}:
+                return current
+            current = current.parent
+        return None
+
+    def _call_name(self, call) -> str:
+        name = call.child_by_field_name("name")
+        return self._text(name) if name is not None else ""
+
+    def _receiver_text(self, call) -> str:
+        receiver = call.child_by_field_name("object")
+        return self._text(receiver) if receiver is not None else ""
+
+    def _receiver_name(self, call) -> str | None:
+        receiver = call.child_by_field_name("object")
+        if receiver is not None and receiver.type == "identifier":
+            return self._text(receiver)
+        return None
+
+    def _call_args(self, call) -> list:
+        args = call.child_by_field_name("arguments")
+        return self._argument_children(args)
+
+    def _object_creation_type(self, node) -> str | None:
+        if node is None or node.type != "object_creation_expression":
+            return None
+        type_node = node.child_by_field_name("type")
+        if type_node is None:
+            return None
+        return self._simple_name(self._text(type_node))
+
+    def _object_creation_args(self, node) -> list:
+        args = node.child_by_field_name("arguments")
+        return self._argument_children(args)
+
+    def _argument_children(self, args_node) -> list:
+        if args_node is None:
+            return []
+        return [
+            child
+            for child in args_node.children
+            if child.is_named and child.type not in {"line_comment", "block_comment"}
+        ]
+
+    def _first_expression_child(self, node):
+        for child in node.children:
+            if child.is_named:
+                return child
+        return None
+
+    def _assignment_target_name(self, node) -> str | None:
+        if node is None:
+            return None
+        if node.type == "identifier":
+            return self._text(node)
+        if node.type == "field_access":
+            field = node.child_by_field_name("field")
+            return self._text(field) if field is not None else None
+        return None
+
+    def _string_literal_value(self, node) -> str | None:
+        if node is None or node.type != "string_literal":
+            return None
+        text = self._text(node)
+        if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+            return text[1:-1]
+        return None
+
+    def _simple_name(self, name: str) -> str:
+        if not name:
+            return ""
+        return name.replace("[]", "").split("<", 1)[0].rsplit(".", 1)[-1]
+
+    def _text(self, node) -> str:
+        if node is None:
+            return ""
+        return self.source[node.start_byte : node.end_byte].decode(
+            "utf-8", errors="replace"
+        )
+
+    def _line(self, node) -> int:
+        return node.start_point[0] + 1
+
+    def _add_finding(
+        self,
+        rule_id: str,
+        severity: str,
+        message: str,
+        line: int,
+        *,
+        category: str | None = None,
+        cwe: str | None = None,
+    ) -> None:
+        key = (rule_id, line, category or "")
+        if key in self.seen:
+            return
+        self.seen.add(key)
+        finding = {
+            "rule_id": rule_id,
+            "severity": severity,
+            "message": message,
+            "file": str(self.file_path),
+            "line": line,
+            "col": 0,
+        }
+        if category:
+            finding["category"] = category
+        if cwe:
+            finding["cwe"] = cwe
+        self.findings.append(finding)
+
+
+def scan_java_security_flows(root_node, file_path: str, source_bytes: bytes) -> list[dict]:
+    if root_node is None:
+        return []
+    return JavaSecurityFlowAnalyzer(root_node, file_path, source_bytes).scan()

--- a/test/test_java_security.py
+++ b/test/test_java_security.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from skylos.visitors.languages.java.core import JavaCore
+from skylos.visitors.languages.java.flow import scan_java_security_flows
 from skylos.visitors.languages.java import scan_java_file
 
 
@@ -11,8 +13,21 @@ def _scan_java(tmp_path: Path, code: str) -> list[dict]:
     return scan_java_file(str(file_path), {})[7]
 
 
+def _scan_java_primary_flow(tmp_path: Path, code: str) -> list[dict]:
+    file_path = tmp_path / "App.java"
+    source = code.encode("utf-8")
+    file_path.write_bytes(source)
+    core = JavaCore(str(file_path), source)
+    core.scan()
+    return scan_java_security_flows(core.root_node, str(file_path), source)
+
+
 def _rule_ids(findings: list[dict]) -> set[str]:
     return {finding["rule_id"] for finding in findings}
+
+
+def _categories(findings: list[dict]) -> set[str]:
+    return {finding.get("category", "") for finding in findings}
 
 
 def test_object_input_stream_flags(tmp_path):
@@ -539,4 +554,836 @@ class App {
 }
 """,
     )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_insecure_cookie_secure_false_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void issue(HttpServletResponse response) {
+    Cookie cookie = new Cookie("sid", "value");
+    cookie.setSecure(false);
+    cookie.setHttpOnly(true);
+    response.addCookie(cookie);
+  }
+}
+""",
+    )
+    assert "SKY-D252" in _rule_ids(findings)
+
+
+def test_secure_cookie_is_not_flagged(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void issue(HttpServletResponse response) {
+    Cookie cookie = new Cookie("sid", "value");
+    cookie.setSecure(true);
+    cookie.setHttpOnly(true);
+    response.addCookie(cookie);
+  }
+}
+""",
+    )
+    assert "SKY-D252" not in _rule_ids(findings)
+
+
+def test_java_random_remember_me_cookie_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void issue(HttpServletRequest request, HttpServletResponse response) {
+    String token = Long.toString(new java.util.Random().nextLong());
+    Cookie rememberMe = new Cookie("rememberMe", token);
+    rememberMe.setSecure(true);
+    request.getSession().setAttribute("rememberMe", token);
+    response.addCookie(rememberMe);
+  }
+}
+""",
+    )
+    assert "SKY-D250" in _rule_ids(findings)
+
+
+def test_secure_random_remember_me_cookie_is_not_flagged(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void issue(HttpServletRequest request, HttpServletResponse response) {
+    java.security.SecureRandom random = new java.security.SecureRandom();
+    String token = Long.toString(random.nextLong());
+    Cookie rememberMe = new Cookie("rememberMe", token);
+    rememberMe.setSecure(true);
+    request.getSession().setAttribute("rememberMe", token);
+    response.addCookie(rememberMe);
+  }
+}
+""",
+    )
+    assert "SKY-D250" not in _rule_ids(findings)
+
+
+def test_process_builder_command_list_with_tainted_shell_string_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    String param = request.getHeader("cmd");
+    List<String> args = new ArrayList<String>();
+    args.add("sh");
+    args.add("-c");
+    args.add("echo " + param);
+    ProcessBuilder pb = new ProcessBuilder();
+    pb.command(args);
+    pb.start();
+  }
+}
+""",
+    )
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_process_builder_constant_command_is_not_flagged(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    String param = request.getHeader("cmd");
+    List<String> args = new ArrayList<String>();
+    args.add("sh");
+    args.add("-c");
+    args.add("echo safe");
+    ProcessBuilder pb = new ProcessBuilder();
+    pb.command(args);
+    pb.start();
+  }
+}
+""",
+    )
+    assert "SKY-D212" not in _rule_ids(findings)
+
+
+def test_tainted_sql_variable_prepare_call_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, java.sql.Connection connection) throws Exception {
+    String param = request.getParameter("proc");
+    String sql = "{call " + param + "}";
+    java.sql.CallableStatement statement = connection.prepareCall(sql);
+    statement.executeQuery();
+  }
+}
+""",
+    )
+    assert "SKY-D211" in _rule_ids(findings)
+
+
+def test_parameterized_sql_constant_query_is_not_flagged(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, java.sql.Connection connection) throws Exception {
+    String param = request.getParameter("id");
+    java.sql.PreparedStatement statement = connection.prepareStatement(
+        "select * from users where id = ?"
+    );
+    statement.setString(1, param);
+    statement.executeQuery();
+  }
+}
+""",
+    )
+    assert "SKY-D211" not in _rule_ids(findings)
+
+
+def test_tainted_ldap_filter_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, javax.naming.directory.InitialDirContext ctx) throws Exception {
+    String param = request.getHeader("uid");
+    String filter = "(uid=" + param + ")";
+    ctx.search("ou=users", filter, new javax.naming.directory.SearchControls());
+  }
+}
+""",
+    )
+    assert "ldap_injection" in _categories(findings)
+
+
+def test_tainted_xpath_expression_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, javax.xml.xpath.XPath xpath, Object doc) throws Exception {
+    String param = request.getParameter("path");
+    String expression = "/users/user[name='" + param + "']";
+    xpath.evaluate(expression, doc);
+  }
+}
+""",
+    )
+    assert "xpath_injection" in _categories(findings)
+
+
+def test_tainted_writer_output_flags_xss(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    String param = request.getHeader("name");
+    response.getWriter().println(param);
+  }
+}
+""",
+    )
+    assert "SKY-D226" in _rule_ids(findings)
+
+
+def test_html_encoded_writer_output_is_not_flagged_xss(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    String param = request.getHeader("name");
+    response.getWriter().println(org.owasp.esapi.ESAPI.encoder().encodeForHTML(param));
+  }
+}
+""",
+    )
+    assert "SKY-D226" not in _rule_ids(findings)
+
+
+def test_tainted_session_attribute_flags_trust_boundary(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) {
+    String param = request.getParameter("user");
+    request.getSession().setAttribute("userid", param);
+  }
+}
+""",
+    )
+    assert "trust_boundary" in _categories(findings)
+
+
+def test_constant_session_attribute_is_not_trust_boundary(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) {
+    String param = request.getParameter("user");
+    String safe = "fixed";
+    request.getSession().setAttribute("userid", safe);
+  }
+}
+""",
+    )
+    assert "trust_boundary" not in _categories(findings)
+
+
+def test_cookie_value_path_traversal_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    Cookie[] cookies = request.getCookies();
+    Cookie cookie = cookies[0];
+    String file = cookie.getValue();
+    FileInputStream stream = new FileInputStream(new File(file));
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_parameter_map_writer_output_flags_xss(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    Map<String, String[]> map = request.getParameterMap();
+    String param = "";
+    if (!map.isEmpty()) {
+      String[] values = map.get("name");
+      if (values != null) param = values[0];
+    }
+    response.getWriter().printf(param, "x");
+  }
+}
+""",
+    )
+    assert "SKY-D226" in _rule_ids(findings)
+
+
+def test_map_get_tainted_value_flags_command_and_safe_key_is_safe(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    String param = request.getHeader("cmd");
+    HashMap<String, Object> values = new HashMap<String, Object>();
+    values.put("safe", "echo ok");
+    values.put("user", param);
+    String command = (String) values.get("user");
+    Runtime.getRuntime().exec("sh -c " + command);
+  }
+}
+""",
+    )
+    assert "SKY-D212" in _rule_ids(findings)
+
+    safe_findings = _scan_java(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    String param = request.getHeader("cmd");
+    HashMap<String, Object> values = new HashMap<String, Object>();
+    values.put("safe", "echo ok");
+    values.put("user", param);
+    String command = (String) values.get("safe");
+    Runtime.getRuntime().exec("sh -c " + command);
+  }
+}
+""",
+    )
+    assert "SKY-D212" not in _rule_ids(safe_findings)
+
+
+def test_list_remove_then_tainted_get_flags_xss(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    String param = request.getHeader("name");
+    List<String> values = new ArrayList<String>();
+    values.add("safe");
+    values.add(param);
+    values.remove(0);
+    String rendered = values.get(0);
+    response.getWriter().format(rendered, "x");
+  }
+}
+""",
+    )
+    assert "SKY-D226" in _rule_ids(findings)
+
+
+def test_separate_class_get_the_parameter_path_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class RequestCarrier {
+  private HttpServletRequest request;
+  RequestCarrier(HttpServletRequest request) { this.request = request; }
+  String readParameter(String name) { return request.getParameter(name); }
+}
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    RequestCarrier carrier = new RequestCarrier(request);
+    String file = carrier.readParameter("file");
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_helper_method_name_alone_is_not_treated_as_request_source(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class RequestCarrier {
+  RequestCarrier(HttpServletRequest request) {}
+  String getTheParameter(String name) { return name; }
+}
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    RequestCarrier carrier = new RequestCarrier(request);
+    String file = carrier.getTheParameter("file");
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_request_backed_no_arg_safe_helper_is_not_tainted_by_name(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class RequestCarrier {
+  RequestCarrier(HttpServletRequest request) {}
+  String getPath() { return "fixed.txt"; }
+}
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    RequestCarrier carrier = new RequestCarrier(request);
+    String file = carrier.getPath();
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_helper_summary_is_class_aware_for_same_method_name(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class UnsafeCarrier {
+  private HttpServletRequest request;
+  UnsafeCarrier(HttpServletRequest request) { this.request = request; }
+  String readParameter(String name) { return request.getParameter(name); }
+}
+
+class SafeCarrier {
+  SafeCarrier(HttpServletRequest request) {}
+  String readParameter(String name) { return "fixed.txt"; }
+}
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    SafeCarrier carrier = new SafeCarrier(request);
+    String file = carrier.readParameter("file");
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_helper_summary_is_overload_aware(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class Carrier {
+  private HttpServletRequest request;
+  Carrier(HttpServletRequest request) { this.request = request; }
+  String getPath() { return request.getParameter("file"); }
+  String getPath(String ignored) { return "fixed.txt"; }
+}
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    Carrier carrier = new Carrier(request);
+    String file = carrier.getPath("ignored");
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_static_safe_branch_from_wrapper_source_is_not_flagged(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class SeparateClassRequest {
+  SeparateClassRequest(HttpServletRequest request) {}
+  String getTheParameter(String name) { return name; }
+}
+
+class App {
+  void run(HttpServletRequest request) {
+    SeparateClassRequest scr = new SeparateClassRequest(request);
+    String param = scr.getTheParameter("user");
+    int num = 106;
+    String key = (7 * 18) + num > 200 ? "fixed" : param;
+    request.getSession().setAttribute(key, "value");
+  }
+}
+""",
+    )
+    assert "trust_boundary" not in _categories(findings)
+
+
+def test_spring_jdbc_query_for_object_tainted_sql_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) {
+    String param = request.getParameter("password");
+    String sql = "select id from users where password='" + param + "'";
+    Object result = DatabaseHelper.JDBCtemplate.queryForObject(
+        sql, Object.class
+    );
+  }
+}
+""",
+    )
+    assert "SKY-D211" in _rule_ids(findings)
+
+
+def test_primary_java_flow_handles_core_security_without_fallback(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.nio.file.*;
+import javax.servlet.http.*;
+
+class App {
+  String run(HttpServletRequest request, HttpServletResponse response, java.sql.Connection connection) throws Exception {
+    String name = request.getHeader("name");
+    response.getWriter().println(name);
+
+    String table = request.getParameter("table");
+    String sql = "select * from " + table;
+    connection.prepareStatement(sql);
+
+    Path base = Paths.get("/srv/data");
+    Path target = base.resolve(request.getParameter("file")).normalize();
+    if (!target.startsWith(base)) {
+      throw new IllegalArgumentException("bad path");
+    }
+    return Files.readString(target);
+  }
+}
+""",
+    )
+    assert "SKY-D226" in _rule_ids(findings)
+    assert "SKY-D211" in _rule_ids(findings)
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_primary_java_flow_helper_summary_is_class_and_arity_aware(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class UnsafeCarrier {
+  private HttpServletRequest request;
+  UnsafeCarrier(HttpServletRequest request) { this.request = request; }
+  String readParameter(String name) { return request.getParameter(name); }
+}
+
+class SafeCarrier {
+  SafeCarrier(HttpServletRequest request) {}
+  String readParameter(String name) { return "fixed.txt"; }
+}
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    SafeCarrier carrier = new SafeCarrier(request);
+    String file = carrier.readParameter("file");
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+    unsafe_findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class UnsafeCarrier {
+  private HttpServletRequest request;
+  UnsafeCarrier(HttpServletRequest request) { this.request = request; }
+  String readParameter(String name) { return request.getParameter(name); }
+}
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    UnsafeCarrier carrier = new UnsafeCarrier(request);
+    String file = carrier.readParameter("file");
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(unsafe_findings)
+
+
+def test_primary_java_flow_path_guard_requires_dominating_exit(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.nio.file.*;
+import javax.servlet.http.*;
+
+class App {
+  String read(HttpServletRequest request, boolean debug) throws Exception {
+    Path base = Paths.get("/srv/data");
+    Path target = base.resolve(request.getParameter("file")).normalize();
+    if (!target.startsWith(base)) {
+      if (debug) return "debug";
+    }
+    return Files.readString(target);
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_primary_java_flow_path_guard_rejects_partial_boolean_guard(tmp_path):
+    negative_findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.nio.file.*;
+import javax.servlet.http.*;
+
+class App {
+  String read(HttpServletRequest request, boolean allowUnsafe) throws Exception {
+    Path base = Paths.get("/srv/data");
+    Path target = base.resolve(request.getParameter("file")).normalize();
+    if (!target.startsWith(base) && allowUnsafe) {
+      throw new IllegalArgumentException("bad path");
+    }
+    return Files.readString(target);
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(negative_findings)
+
+    positive_findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.nio.file.*;
+import javax.servlet.http.*;
+
+class App {
+  String read(HttpServletRequest request, boolean allowUnsafe) throws Exception {
+    Path base = Paths.get("/srv/data");
+    Path target = base.resolve(request.getParameter("file")).normalize();
+    if (target.startsWith(base) || allowUnsafe) {
+      return Files.readString(target);
+    }
+    throw new IllegalArgumentException("bad path");
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(positive_findings)
+
+
+def test_primary_java_flow_resolves_unqualified_same_class_helper(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class App {
+  String read(HttpServletRequest request, String name) {
+    return request.getParameter(name);
+  }
+
+  void run(HttpServletRequest request) throws Exception {
+    String file = read(request, "file");
+    File target = new File(file);
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_primary_java_flow_treats_cookie_values_as_request_tainted(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    Cookie[] cookies = request.getCookies();
+    String file = "fallback.txt";
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        file = cookie.getValue();
+        break;
+      }
+    }
+    FileInputStream stream = new FileInputStream(new File(file));
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_primary_java_flow_switch_taint_reaches_process_builder_list(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    String param = request.getParameter("cmd");
+    String command;
+    switch (request.getParameter("mode")) {
+      case "user":
+        command = param;
+        break;
+      default:
+        command = "echo safe";
+        break;
+    }
+    List<String> args = new ArrayList<String>();
+    args.add("sh");
+    args.add("-c");
+    args.add(command);
+    ProcessBuilder pb = new ProcessBuilder(args);
+    pb.start();
+  }
+}
+""",
+    )
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_primary_java_flow_constant_switch_uses_selected_branch(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import java.util.*;
+import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request) throws Exception {
+    String param = request.getParameter("cmd");
+    String command;
+    String guess = "ABC";
+    char switchTarget = guess.charAt(1);
+    switch (switchTarget) {
+      case 'A':
+        command = param;
+        break;
+      case 'B':
+        command = "echo safe";
+        break;
+      default:
+        command = param;
+        break;
+    }
+    List<String> args = new ArrayList<String>();
+    args.add("sh");
+    args.add("-c");
+    args.add(command);
+    ProcessBuilder pb = new ProcessBuilder(args);
+    pb.start();
+  }
+}
+""",
+    )
+    assert "SKY-D212" not in _rule_ids(findings)
+
+
+def test_primary_java_flow_request_backed_same_project_wrapper_accessors(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, javax.naming.directory.InitialDirContext ctx) throws Exception {
+    SeparateClassRequest scr = new SeparateClassRequest(request);
+    String param = scr.getTheParameter("uid");
+    String filter = "(uid=" + param + ")";
+    ctx.search("ou=users", filter, new javax.naming.directory.SearchControls());
+  }
+}
+
+class SeparateClassRequest {
+  private HttpServletRequest request;
+
+  SeparateClassRequest(HttpServletRequest request) {
+    this.request = request;
+  }
+
+  String getTheParameter(String name) {
+    return request.getParameter(name);
+  }
+}
+""",
+    )
+    assert "ldap_injection" in _categories(findings)
+
+
+def test_primary_java_flow_unknown_external_wrapper_accessors_are_not_sources(tmp_path):
+    findings = _scan_java_primary_flow(
+        tmp_path,
+        """import javax.servlet.http.*;
+
+class App {
+  void run(HttpServletRequest request, javax.naming.directory.InitialDirContext ctx) throws Exception {
+    AuditContext audit = new AuditContext(request);
+    String timeout = audit.getQueryTimeout();
+    String prefix = audit.getPathPrefix();
+    ctx.search("ou=users", timeout, new javax.naming.directory.SearchControls());
+    java.io.FileInputStream stream = new java.io.FileInputStream(prefix);
+  }
+}
+""",
+    )
+    assert "ldap_injection" not in _categories(findings)
     assert "SKY-D215" not in _rule_ids(findings)


### PR DESCRIPTION
## Summary

  - add a structured tree-sitter Java security flow analyzer as the primary Java security path
  - add Java regression coverage for request taint propagation, guarded path traversal, switch/list command flow, cookie taint, wrapper summaries, and unknown wrapper precision
  - update benchmark docs with the frozen OWASP Java result

## Validation

    - `/Users/skylos/.venv/bin/python -m pytest test/test_java_security.py test/test_security_benchmark.py`
    - `/Users/skylos/.venv/bin/python -m pytest -q`


