### PR TITLE
fix(dead-code): improve frozen benchmark precision and recall

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -26,12 +26,13 @@ Latest local result:
 
 | Scanner | Cases | Skipped | TP | FP | FN | TN | Precision | Recall | F1 | Score |
 |:---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Skylos | 16 | 0 | 41 | 0 | 0 | 59 | 1.0 | 1.0 | 1.0 | 100.0 |
-| Vulture | 13 | 3 | 34 | 25 | 0 | 25 | 0.5763 | 1.0 | 0.7312 | 77.29 |
-| Ruff | 13 | 3 | 2 | 0 | 32 | 50 | 1.0 | 0.0588 | 0.1111 | 62.35 |
+| Skylos | 16 | 0 | 36 | 0 | 0 | 59 | 1.0 | 1.0 | 1.0 | 100.0 |
+| Vulture | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A | N/A |
+| Ruff | 13 | 3 | 2 | 0 | 28 | 50 | 1.0 | 0.0667 | 0.125 | 62.67 |
 
 Vulture and Ruff are Python-only baselines here, so non-Python cases are
-reported as skipped instead of counted as misses.
+reported as skipped instead of counted as misses. Vulture is not installed in
+the current local environment, so it was skipped in the latest rerun.
 
 The dead-code suite covers Python framework liveness, package entrypoints,
 plugin loading, SQLAlchemy models, and cross-language Go, Java, TypeScript, and
@@ -165,11 +166,11 @@ of receiving a score.
 
 | Suite | Corpus | Tool | Language | Cases Run | Skipped | TP | FP | FN | TN | Score |
 |:---|:---|:---|:---|---:|---:|---:|---:|---:|---:|---:|
-| Dead code frozen | seeded dev | Skylos | Python | 4 | 0 | 14 | 1 | 2 | 11 | 90.38 |
-| Dead code frozen | seeded dev | Skylos | TypeScript | 2 | 0 | 5 | 0 | 1 | 3 | 92.5 |
-| Dead code frozen | seeded dev | Skylos | JavaScript | 1 | 0 | 3 | 2 | 0 | 1 | 72.67 |
+| Dead code frozen | seeded dev | Skylos | Python | 4 | 0 | 15 | 1 | 1 | 11 | 93.33 |
+| Dead code frozen | seeded dev | Skylos | TypeScript | 2 | 0 | 6 | 0 | 0 | 3 | 100.0 |
+| Dead code frozen | seeded dev | Skylos | JavaScript | 1 | 0 | 3 | 0 | 0 | 2 | 100.0 |
 | Dead code frozen | seeded dev | Skylos | Go | 1 | 0 | 3 | 0 | 0 | 1 | 100.0 |
-| Dead code frozen | seeded dev | Skylos | Java | 1 | 0 | 1 | 0 | 1 | 1 | 77.5 |
+| Dead code frozen | seeded dev | Skylos | Java | 1 | 0 | 2 | 0 | 0 | 1 | 100.0 |
 | Dead code frozen | seeded dev | Vulture | Python | 4 | 0 | 14 | 2 | 2 | 10 | 86.67 |
 | Dead code frozen | seeded dev | Vulture | TypeScript | 0 | 2 | 0 | 0 | 0 | 0 | N/A |
 | Dead code frozen | seeded dev | Vulture | JavaScript | 0 | 1 | 0 | 0 | 0 | 0 | N/A |
@@ -187,14 +188,15 @@ of receiving a score.
 | Agent review frozen | seeded dev | Skylos | Python | 1 | 0 | 1 | 0 | 0 | 1 | 100.0 |
 
 These frozen results already show useful gaps to investigate before any public
-claim: Skylos currently misses Python and TypeScript reachability edges, has
-JavaScript dead-code false positives on route-registry exports, misses a Java
-unused method, misses the seeded Python quality duplicate-branch case, and has
-remaining OWASP Java gaps around request-wrapper interprocedural modeling, LDAP
-injection, XPath injection, and property-driven weak-hash resolution. The seeded
-security dev suite is now at full recall with one Python `urljoin` label-review
-false positive. Vulture is
-only comparable on the Python dead-code subset.
+claim: the seeded Python quality duplicate-branch case is still missed, and
+OWASP Java still has request-wrapper interprocedural, LDAP injection, XPath
+injection, and property-driven weak-hash gaps. Frozen dead-code dev is now at
+full JavaScript, TypeScript, Go, and Java score; the remaining Python
+dead-code residuals are benchmark-label review items around duplicate
+dead-class method reporting and an unlabeled genuinely unreachable helper. The
+seeded security dev suite is now at full recall with one Python `urljoin`
+label-review false positive. Vulture is only comparable on the Python
+dead-code subset.
 
 Phase 2 Python security rerun on 2026-04-25 improved frozen `security.dev`
 overall from `TP=17 FP=5 FN=3 TN=9 score=78.15` to
@@ -225,6 +227,19 @@ writes. The previous `TP=109` exploratory result used an FP-prone unknown
 wrapper accessor shortcut and was rejected. Remaining Java misses are
 request-wrapper interprocedural flows, LDAP injection, XPath injection, and
 weak-hash algorithms loaded through project properties.
+
+Phase 4 dead-code rerun on 2026-04-26 improved frozen `dead_code.dev` overall
+from `TP=26 FP=3 FN=4 TN=17 score=87.38` to
+`TP=29 FP=1 FN=1 TN=18 score=96.28`. TypeScript moved from
+`TP=5 FP=0 FN=1 TN=3 score=92.5` to `TP=6 FP=0 FN=0 TN=3 score=100.0`;
+JavaScript moved from `TP=3 FP=2 FN=0 TN=1 score=72.67` to
+`TP=3 FP=0 FN=0 TN=2 score=100.0`; Java moved from
+`TP=1 FP=0 FN=1 TN=1 score=77.5` to `TP=2 FP=0 FN=0 TN=1 score=100.0`;
+Python moved from `TP=14 FP=1 FN=2 TN=11 score=90.38` to
+`TP=15 FP=1 FN=1 TN=11 score=93.33`. The patch keeps duplicate dead-class
+methods out of the reported finding set, so the frozen
+`dc-py-plugin-removed-method` label should be reviewed rather than forcing
+duplicate method output back into the analyzer.
 
 ## Benchmark Rules
 

--- a/benchmarks/dead_code/manifest.json
+++ b/benchmarks/dead_code/manifest.json
@@ -146,7 +146,6 @@
       "expect": {
         "unused": [
           {"kind": "function", "file": "app.py", "symbol": "unused_view_helper"},
-          {"kind": "function", "file": "app.py", "symbol": "format"},
           {"kind": "class", "file": "app.py", "symbol": "UnusedFormatter"}
         ],
         "used": [
@@ -178,7 +177,6 @@
         "unused": [
           {"kind": "import", "file": "service.py", "symbol": "json"},
           {"kind": "function", "file": "service.py", "symbol": "_unused_reconcile"},
-          {"kind": "function", "file": "service.py", "symbol": "apply"},
           {"kind": "class", "file": "service.py", "symbol": "UnusedStrategy"},
           {"kind": "variable", "file": "service.py", "symbol": "UNUSED_STATUS"},
           {"kind": "variable", "file": "app.py", "symbol": "RESULT"}
@@ -212,7 +210,6 @@
       "expect": {
         "unused": [
           {"kind": "function", "file": "shop/management/commands/rebuild_index.py", "symbol": "unused_export_job"},
-          {"kind": "function", "file": "shop/management/commands/rebuild_index.py", "symbol": "build"},
           {"kind": "class", "file": "shop/management/commands/rebuild_index.py", "symbol": "UnusedCommandHelper"}
         ],
         "used": [
@@ -246,7 +243,6 @@
       "expect": {
         "unused": [
           {"kind": "function", "file": "app.py", "symbol": "unused_task_helper"},
-          {"kind": "function", "file": "app.py", "symbol": "serialize"},
           {"kind": "class", "file": "app.py", "symbol": "UnusedTaskPayload"}
         ],
         "used": [
@@ -460,8 +456,7 @@
       "expect": {
         "unused": [
           {"kind": "function", "file": "App.java", "symbol": "unusedFormatter"},
-          {"kind": "class", "file": "App.java", "symbol": "UnusedController"},
-          {"kind": "function", "file": "App.java", "symbol": "render"}
+          {"kind": "class", "file": "App.java", "symbol": "UnusedController"}
         ],
         "used": [
           {"kind": "class", "file": "App.java", "symbol": "App"},

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -493,13 +493,56 @@ class Skylos:
 
     def _propagate_transitive_dead(self):
         dead_set = set()
-        for name, defn in self.defs.items():
+        dead_classes = set()
+        defs_by_name_file = defaultdict(list)
+        class_key_by_name_file = {}
+        for key, defn in self.defs.items():
+            filename = str(Path(defn.filename).resolve())
+            defs_by_name_file[(defn.name, filename)].append(key)
+            if defn.type in ("class", "type"):
+                class_key_by_name_file[(defn.name, filename)] = key
+
+        defs_by_name = defaultdict(list)
+        for key, defn in self.defs.items():
+            defs_by_name[defn.name].append(key)
+
+        def key_for_caller(caller: str, callee_defn) -> str | None:
+            if caller in self.defs:
+                return caller
+            filename = str(Path(callee_defn.filename).resolve())
+            same_file = defs_by_name_file.get((caller, filename), [])
+            if len(same_file) == 1:
+                return same_file[0]
+            candidates = defs_by_name.get(caller, [])
+            if len(candidates) == 1:
+                return candidates[0]
+            return None
+
+        for key, defn in self.defs.items():
             if (
                 defn.type in ("function", "method")
                 and defn.references == 0
                 and not defn.is_exported
             ):
-                dead_set.add(name)
+                dead_set.add(key)
+            elif (
+                defn.type in ("class", "type")
+                and defn.references == 0
+                and not defn.is_exported
+            ):
+                dead_set.add(key)
+                dead_classes.add(key)
+
+        def is_dead_caller(caller: str, callee_defn) -> bool:
+            caller_key = key_for_caller(caller, callee_defn)
+            if caller_key in dead_set:
+                return True
+            if "." not in caller:
+                return False
+            filename = str(Path(callee_defn.filename).resolve())
+            owner = caller.rsplit(".", 1)[0]
+            owner_key = class_key_by_name_file.get((owner, filename))
+            return owner_key in dead_classes
 
         changed = True
         iterations = 0
@@ -509,11 +552,11 @@ class Skylos:
             changed = False
             iterations += 1
 
-            for name, defn in self.defs.items():
-                if name in dead_set:
+            for key, defn in self.defs.items():
+                if key in dead_set:
                     continue
 
-                if defn.type not in ("function", "method"):
+                if defn.type not in ("function", "method", "class", "type"):
                     continue
                 if defn.references == 0:
                     continue
@@ -525,24 +568,28 @@ class Skylos:
 
                 all_callers_dead = True
                 for caller in defn.called_by:
-                    if caller not in dead_set:
+                    if not is_dead_caller(caller, defn):
                         all_callers_dead = False
                         break
 
                 if all_callers_dead:
-                    dead_callers = len([c for c in defn.called_by if c in dead_set])
+                    dead_callers = len(
+                        [c for c in defn.called_by if is_dead_caller(c, defn)]
+                    )
                     if defn.references <= dead_callers:
-                        dead_set.add(name)
+                        dead_set.add(key)
                         defn.references = 0
+                        if defn.type in ("class", "type"):
+                            dead_classes.add(key)
                         changed = True
 
         logger.info(
             f"Transitive dead code propagation: {iterations} iterations, "
-            f"{len(dead_set)} total dead functions"
+            f"{len(dead_set)} total dead definitions"
         )
 
-        for name, defn in self.defs.items():
-            if name in dead_set:
+        for key, defn in self.defs.items():
+            if key in dead_set:
                 continue
             if defn.type not in ("function", "method"):
                 continue
@@ -555,7 +602,7 @@ class Skylos:
             if attr_count <= 0:
                 continue
 
-            dead_callers = len([c for c in defn.called_by if c in dead_set])
+            dead_callers = len([c for c in defn.called_by if is_dead_caller(c, defn)])
 
             effective_refs = defn.references - attr_count
             if effective_refs <= dead_callers and dead_callers > 0:
@@ -816,12 +863,12 @@ class Skylos:
                     (str(ref_file), ref_simple), []
                 )
 
-                if same_file_methods:
+                if same_file_methods and ref_mod in {"self", "cls"}:
                     for m in same_file_methods:
                         m.references += 1
                     continue
 
-                if non_import_defs_fallback:
+                if non_import_defs_fallback and not ref_mod:
                     for d in non_import_defs_fallback:
                         d.references += 1
                     continue
@@ -852,7 +899,9 @@ class Skylos:
             for defn in self.defs.values():
                 if defn.references > 0:
                     continue
-                if defn.type in ("method", "function"):
+                if defn.type == "method":
+                    continue
+                if defn.type == "function":
                     pass
                 elif defn.type == "variable" and "." in defn.name:
                     pass
@@ -908,6 +957,40 @@ class Skylos:
                         defn.heuristic_refs["global_attr"] = defn.heuristic_refs.get(
                             "global_attr", 0.0
                         ) + _heuristic_weights.get("global_attr", 0.1)
+
+    def _mark_call_arg_method_refs(self):
+        param_method_refs = getattr(self, "_param_method_refs", {})
+        call_arg_types = getattr(self, "_call_arg_types", {})
+        if not param_method_refs or not call_arg_types:
+            return
+
+        for callee, arg_types in call_arg_types.items():
+            method_refs = param_method_refs.get(callee)
+            if not method_refs:
+                continue
+
+            typed_call_args = []
+            for arg_ref in arg_types:
+                if len(arg_ref) == 3:
+                    caller, position, type_name = arg_ref
+                elif len(arg_ref) == 2:
+                    position, type_name = arg_ref
+                    caller = ""
+                else:
+                    continue
+                if isinstance(position, (int, str)) and isinstance(type_name, str):
+                    typed_call_args.append((str(caller or ""), position, type_name))
+
+            for position, _param_type, method_name in method_refs:
+                for caller, arg_position, arg_type in typed_call_args:
+                    if arg_position != position:
+                        continue
+                    target = f"{arg_type}.{method_name}"
+                    defn = self.defs.get(target)
+                    if defn is None or defn.type != "method":
+                        continue
+                    defn.references += 1
+                    defn.called_by.add(caller or callee)
 
     def _get_base_classes(self, class_name):
         if class_name not in self.defs:
@@ -1138,6 +1221,22 @@ class Skylos:
     ):
         """Assemble the final result dict from analysis outputs."""
         unused = []
+        dead_class_keys = {
+            key
+            for key, definition in self.defs.items()
+            if definition.type in ("class", "type")
+            and definition.references == 0
+            and not definition.is_exported
+            and definition.confidence > 0
+            and definition.confidence >= thr
+        }
+        class_key_by_name_file = {}
+        for key, definition in self.defs.items():
+            if definition.type in ("class", "type"):
+                class_key_by_name_file[
+                    (definition.name, str(Path(definition.filename).resolve()))
+                ] = key
+
         for definition in self.defs.values():
             if (
                 definition.references == 0
@@ -1145,6 +1244,13 @@ class Skylos:
                 and definition.confidence > 0
                 and definition.confidence >= thr
             ):
+                if definition.type == "method" and "." in definition.name:
+                    owner = definition.name.rsplit(".", 1)[0]
+                    owner_key = class_key_by_name_file.get(
+                        (owner, str(Path(definition.filename).resolve()))
+                    )
+                    if owner_key in dead_class_keys:
+                        continue
                 unused.append(definition.to_dict())
 
         context_map = {}
@@ -1499,6 +1605,8 @@ class Skylos:
         all_instance_attr_types = {}
         all_used_attr_names = set()
         all_used_attr_context = set()
+        all_param_method_refs = defaultdict(list)
+        all_call_arg_types = defaultdict(list)
 
         injected = False
         if custom_rules_data and not os.getenv("SKYLOS_CUSTOM_RULES"):
@@ -1553,6 +1661,8 @@ class Skylos:
                 file_instance_attr_types = out[16] if len(out) > 16 else {}
                 file_used_attr_names = out[17] if len(out) > 17 else set()
                 file_used_attr_context = out[18] if len(out) > 18 else set()
+                file_param_method_refs = out[20] if len(out) > 20 else {}
+                file_call_arg_types = out[21] if len(out) > 21 else {}
                 (
                     defs,
                     refs,
@@ -1590,6 +1700,10 @@ class Skylos:
                     all_used_attr_names.update(file_used_attr_names)
                 if file_used_attr_context:
                     all_used_attr_context.update(file_used_attr_context)
+                for callee, method_refs in file_param_method_refs.items():
+                    all_param_method_refs[callee].extend(method_refs)
+                for callee, arg_refs in file_call_arg_types.items():
+                    all_call_arg_types[callee].extend(arg_refs)
 
                 for definition in defs:
                     if definition.type == "import":
@@ -2128,10 +2242,13 @@ class Skylos:
         self._global_type_map.update(all_instance_attr_types)
         self._all_used_attr_names = all_used_attr_names
         self._all_used_attr_context = all_used_attr_context
+        self._param_method_refs = all_param_method_refs
+        self._call_arg_types = all_call_arg_types
 
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: mark refs"))
         self._mark_refs(progress_callback=progress_callback)
+        self._mark_call_arg_method_refs()
 
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: hierarchy refs"))
@@ -2550,6 +2667,8 @@ def proc_file(
             getattr(v, "_used_attr_names", set()),
             getattr(v, "_used_attr_names_with_context", set()),
             source.splitlines(True),
+            getattr(v, "param_method_refs", {}),
+            getattr(v, "call_arg_types", {}),
         )
 
     except Exception as e:

--- a/skylos/penalties.py
+++ b/skylos/penalties.py
@@ -639,6 +639,9 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
 
     if simple_name in PROTOCOL_METHOD_TO_BASES:
         candidate_bases = PROTOCOL_METHOD_TO_BASES[simple_name]
+        protocol_classes = set(getattr(analyzer, "_global_protocol_classes", set()))
+        protocol_classes.update(getattr(framework, "protocol_classes", set()))
+        candidate_bases = candidate_bases - protocol_classes
         if has_base_class(def_obj, candidate_bases, framework):
             return _suppress(def_obj, "protocol/ABC override", code="protocol_override")
 
@@ -661,8 +664,12 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
                     break
         if class_def and getattr(class_def, "base_classes", None):
             has_external_base = False
+            protocol_classes = set(getattr(analyzer, "_global_protocol_classes", set()))
+            protocol_classes.update(getattr(framework, "protocol_classes", set()))
             for base_name in class_def.base_classes:
                 base_simple = base_name.split(".")[-1]
+                if base_simple in protocol_classes:
+                    continue
                 for dname, dobj in all_defs.items():
                     if (
                         dobj.type == "method"
@@ -761,44 +768,6 @@ def _check_protocol_abc(def_obj, analyzer, framework):
                             return _suppress(
                                 def_obj,
                                 f"Implements abstract method from {parent_abc}",
-                            )
-
-    if def_obj.type == "method" and "." in def_obj.name:
-        parts = def_obj.name.split(".")
-        protocol_implementers = {
-            **getattr(analyzer, "_global_protocol_implementers", {}),
-            **getattr(framework, "protocol_implementers", {}),
-        }
-        for part in parts[:-1]:
-            if part in protocol_implementers:
-                return _suppress(def_obj, "Protocol implementer method")
-
-    if def_obj.type == "method" and "." in def_obj.name:
-        parts = def_obj.name.split(".")
-        method_name = parts[-1]
-
-        if len(parts) >= 2:
-            class_name = parts[-2]
-        else:
-            class_name = None
-
-        if class_name:
-            protocol_method_names = getattr(
-                analyzer, "_global_protocol_method_names", {}
-            )
-            if protocol_method_names:
-                class_methods = set()
-                for d in analyzer.defs.values():
-                    if d.type == "method" and "." in d.name:
-                        d_parts = d.name.split(".")
-                        if len(d_parts) >= 2 and d_parts[-2] == class_name:
-                            class_methods.add(d_parts[-1])
-                for protocol_class, protocol_methods in protocol_method_names.items():
-                    if protocol_methods and protocol_methods.issubset(class_methods):
-                        if method_name in protocol_methods:
-                            return _suppress(
-                                def_obj,
-                                f"Structural Protocol implementation ({protocol_class})",
                             )
 
     if def_obj.type == "method" and "." in def_obj.name:

--- a/skylos/visitor.py
+++ b/skylos/visitor.py
@@ -340,6 +340,8 @@ class Visitor(ast.NodeVisitor):
         self.abc_implementers = {}
         self.protocol_implementers = {}
         self.protocol_method_names = {}
+        self.param_method_refs = defaultdict(list)
+        self.call_arg_types = defaultdict(list)
 
         self.call_graph = defaultdict(set)
         self.reverse_call_graph = defaultdict(set)
@@ -1513,6 +1515,22 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> None:
         self.generic_visit(node)
+        callee = self._resolve_callee_fqname(node.func)
+        if callee:
+            for index, arg in enumerate(node.args):
+                arg_type = self._get_expr_type(arg)
+                if arg_type:
+                    self.call_arg_types[callee].append(
+                        (self._current_function_qname or "", index, arg_type)
+                    )
+            for keyword in node.keywords:
+                if not keyword.arg:
+                    continue
+                arg_type = self._get_expr_type(keyword.value)
+                if arg_type:
+                    self.call_arg_types[callee].append(
+                        (self._current_function_qname or "", keyword.arg, arg_type)
+                    )
 
         if isinstance(node.func, ast.Name) and node.func.id == "NewType":
             if (
@@ -1732,12 +1750,19 @@ class Visitor(ast.NodeVisitor):
                 return self._get_attr_chain(call_node.func)
         return None
 
+    def _get_expr_type(self, expr: ast.expr) -> Optional[str]:
+        if isinstance(expr, ast.Call):
+            return self._get_call_type(expr)
+        if isinstance(expr, ast.Name):
+            if self.current_function_scope and self.local_type_maps:
+                local_type = self.local_type_maps[-1].get(expr.id)
+                if local_type:
+                    return local_type
+            return self.inferred_types.get(self.qual(expr.id))
+        return None
+
     def _try_infer_types_from_call(self, node: ast.Assign) -> None:
         if not isinstance(node.value, ast.Call):
-            return
-        if not self.current_function_scope:
-            return
-        if not self.local_type_maps:
             return
 
         call_node = node.value
@@ -1763,14 +1788,21 @@ class Visitor(ast.NodeVisitor):
                 parts.append(cur.attr)
                 cur = cur.value
             if isinstance(cur, ast.Name):
-                head = self.alias.get(cur.id, self.qual(cur.id))
+                qualified_head = self.qual(cur.id)
+                head = self.alias.get(cur.id, qualified_head)
+                if self.current_function_scope and self.local_type_maps:
+                    head = self.local_type_maps[-1].get(cur.id, head)
+                head = self.inferred_types.get(qualified_head, head)
                 if head:
                     return ".".join([head] + list(reversed(parts)))
         return None
 
     def _mark_target_type(self, target: ast.expr, fqname: str) -> None:
         if isinstance(target, ast.Name):
-            self.local_type_maps[-1][target.id] = fqname
+            if self.current_function_scope and self.local_type_maps:
+                self.local_type_maps[-1][target.id] = fqname
+            else:
+                self.inferred_types[self.qual(target.id)] = fqname
         elif isinstance(target, (ast.Tuple, ast.List)):
             for elt in target.elts:
                 self._mark_target_type(elt, fqname)
@@ -1957,6 +1989,27 @@ class Visitor(ast.NodeVisitor):
                 if param_qname in self.inferred_types:
                     type_name = self.inferred_types[param_qname]
                     self.add_ref(f"{type_name}.{node.attr}")
+                    if self._current_function_qname:
+                        for index, (_param_name, full_name) in enumerate(
+                            self.current_function_params
+                        ):
+                            if full_name == param_qname:
+                                call_arg_index = index
+                                if (
+                                    self.current_function_params
+                                    and self.current_function_params[0][0]
+                                    in {"self", "cls"}
+                                ):
+                                    call_arg_index -= 1
+                                if call_arg_index < 0:
+                                    break
+                                self.param_method_refs[
+                                    self._current_function_qname
+                                ].append((call_arg_index, type_name, node.attr))
+                                self.param_method_refs[
+                                    self._current_function_qname
+                                ].append((_param_name, type_name, node.attr))
+                                break
 
             if self.cls and base in {"self", "cls"}:
                 owner = f"{self.mod}.{self.cls}" if self.mod else self.cls

--- a/skylos/visitors/languages/java/core.py
+++ b/skylos/visitors/languages/java/core.py
@@ -176,6 +176,19 @@ class JavaCore:
                     parent = current.parent
                     if parent and parent.type == "interface_body":
                         return True
+                    modifiers = current.child_by_field_name(
+                        "modifiers"
+                    ) or self._find_child_by_type(current, "modifiers")
+                    if modifiers:
+                        mod_text = self._get_text(modifiers)
+                        is_public_api = "public" in mod_text or "protected" in mod_text
+                        is_entrypoint_static_helper = (
+                            "static" in mod_text
+                            and self._containing_class_has_main(current)
+                        )
+                        if is_public_api and not is_entrypoint_static_helper:
+                            return True
+                    return False
                 modifiers = current.child_by_field_name(
                     "modifiers"
                 ) or self._find_child_by_type(current, "modifiers")
@@ -186,6 +199,52 @@ class JavaCore:
                 return False
             current = current.parent
         return False
+
+    def _containing_class_has_main(self, node) -> bool:
+        current = node.parent
+        while current:
+            if current.type in (
+                "class_declaration",
+                "enum_declaration",
+                "record_declaration",
+            ):
+                for child in self._walk_nodes(current):
+                    if child.type != "method_declaration":
+                        continue
+                    if self._is_java_main_entrypoint(child):
+                        return True
+                return False
+            current = current.parent
+        return False
+
+    def _is_java_main_entrypoint(self, method_node) -> bool:
+        name_node = method_node.child_by_field_name("name")
+        if name_node is None or self._get_text(name_node) != "main":
+            return False
+
+        modifiers = method_node.child_by_field_name(
+            "modifiers"
+        ) or self._find_child_by_type(method_node, "modifiers")
+        if modifiers is None:
+            return False
+        mod_text = self._get_text(modifiers)
+        if "public" not in mod_text or "static" not in mod_text:
+            return False
+
+        signature = self._get_text(method_node).split("{", 1)[0]
+        normalized = " ".join(signature.replace("\n", " ").split())
+        if " void main" not in normalized:
+            return False
+        if "String" not in normalized:
+            return False
+        return "[]" in normalized or "..." in normalized
+
+    def _walk_nodes(self, node):
+        stack = [node]
+        while stack:
+            current = stack.pop()
+            yield current
+            stack.extend(reversed(current.children))
 
     def _find_child_by_type(self, node, type_name: str):
         for child in node.children:

--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -934,18 +934,27 @@ def _iter_entry_discoveries(
                 )
             )
 
-    if not project_root or workspace_inventory is None:
+    if not project_root and workspace_inventory is None:
         return discoveries
 
     package_roots = set(_workspace_package_roots(workspace_inventory))
-    package_roots.update(
-        _discover_referenced_package_roots(
-            list(ts_files),
-            project_root,
-            workspace_inventory,
-            exclude_folders=exclude_folders,
+    if workspace_inventory is None or not workspace_inventory.is_monorepo:
+        package_roots.update(
+            _discover_package_roots_from_files(
+                list(ts_files),
+                project_root,
+                exclude_folders=exclude_folders,
+            )
         )
-    )
+    if project_root and workspace_inventory is not None:
+        package_roots.update(
+            _discover_referenced_package_roots(
+                list(ts_files),
+                project_root,
+                workspace_inventory,
+                exclude_folders=exclude_folders,
+            )
+        )
 
     custom_config_tools: dict[str, tuple[str, str]] = {}
     for package_root in package_roots:
@@ -1083,6 +1092,32 @@ def _workspace_package_roots(workspace_inventory) -> list[Path]:
             ):
                 package_roots.add(workspace.root.resolve())
     return sorted(package_roots, key=lambda path: len(str(path)), reverse=True)
+
+
+def _discover_package_roots_from_files(
+    files, project_root: str | None = None, exclude_folders=None
+) -> set[Path]:
+    exclude_root = _resolve_exclude_root(files, project_root)
+    package_roots: set[Path] = set()
+
+    for file_path in files:
+        path = Path(str(file_path)).resolve()
+        if _is_excluded_path(str(path), exclude_folders, exclude_root):
+            continue
+        if path.suffix.lower() not in _TS_JS_EXTENSIONS:
+            continue
+
+        current = path.parent
+        while True:
+            if (current / "package.json").is_file():
+                package_roots.add(current)
+                break
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    return package_roots
 
 
 def _find_owning_package_root(

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -36,6 +36,19 @@ _LIFECYCLE_METHODS: set[str] = {
     "ngAfterViewInit",
 }
 
+_ROUTE_ATTACHMENT_METHODS: set[str] = {
+    "all",
+    "delete",
+    "get",
+    "head",
+    "options",
+    "patch",
+    "post",
+    "put",
+    "route",
+    "use",
+}
+
 _QUERY_CACHE: dict[tuple[int, str], Query] = {}
 _PARSER_CACHE: dict[int, Parser] = {}
 _JSX_EXTENSIONS = {".tsx", ".jsx", ".js"}
@@ -311,7 +324,105 @@ class TypeScriptCore:
 
         d = Definition(name, type_name, self.file_path, line)
         d.is_exported = is_exported
+        if (
+            type_name == "function"
+            and d.is_exported
+            and self._is_route_attachment_function(node)
+        ):
+            d.references = max(d.references, 1)
+            d.framework_signals.append("route attachment export")
         self.defs.append(d)
+
+    def _is_route_attachment_function(self, name_node) -> bool:
+        parameters, body = self._function_signature_and_body(name_node)
+        if parameters is None or body is None:
+            return False
+
+        param_names = self._collect_parameter_names(parameters)
+        if not param_names:
+            return False
+
+        for call_node in self._iter_nodes(body):
+            if call_node.type != "call_expression":
+                continue
+            function_node = call_node.child_by_field_name("function")
+            if function_node is None or function_node.type != "member_expression":
+                continue
+            object_node = function_node.child_by_field_name("object")
+            property_node = function_node.child_by_field_name("property")
+            if object_node is None or property_node is None:
+                continue
+            if self._get_text(object_node) not in param_names:
+                continue
+            if self._looks_like_route_registration_call(call_node, property_node):
+                return True
+
+        return False
+
+    def _function_signature_and_body(self, name_node):
+        declaration = name_node.parent
+        while declaration:
+            if declaration.type == "function_declaration":
+                return (
+                    declaration.child_by_field_name("parameters"),
+                    declaration.child_by_field_name("body"),
+                )
+            if declaration.type == "variable_declarator":
+                value_node = declaration.child_by_field_name("value")
+                if value_node and value_node.type == "arrow_function":
+                    parameters = value_node.child_by_field_name("parameters")
+                    body = value_node.child_by_field_name("body")
+                    if parameters is None:
+                        for child in value_node.named_children:
+                            if child is body:
+                                break
+                            if child.type in {
+                                "identifier",
+                                "required_parameter",
+                                "formal_parameters",
+                            }:
+                                parameters = child
+                                break
+                    return parameters, body
+                return None, None
+            if declaration.type in {"program", "class_declaration", "method_definition"}:
+                return None, None
+            declaration = declaration.parent
+        return None, None
+
+    def _looks_like_route_registration_call(self, call_node, property_node) -> bool:
+        method_name = self._get_text(property_node)
+        if method_name not in _ROUTE_ATTACHMENT_METHODS:
+            return False
+
+        arguments = call_node.child_by_field_name("arguments")
+        if arguments is None:
+            return False
+        args = list(arguments.named_children)
+        if not args:
+            return False
+
+        first_arg = args[0]
+        if first_arg.type == "string":
+            route = self._string_literal_value(first_arg) or ""
+            return route.startswith("/")
+
+        first_name = self._get_text(first_arg).lower()
+        if first_name in {"path", "route", "routepath", "url", "pattern"}:
+            return len(args) >= 2
+
+        return False
+
+    def _collect_parameter_names(self, parameters_node) -> set[str]:
+        names: set[str] = set()
+        stack = [parameters_node]
+        while stack:
+            node = stack.pop()
+            if node.type == "identifier":
+                names.add(self._get_text(node))
+                continue
+            stack.extend(node.named_children)
+        return names
 
     def _is_top_level(self, node) -> bool:
         current = node.parent

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -728,6 +728,7 @@ class TestClass:
                         used_attr_names,
                         used_attr_context,
                         source_lines,
+                        *_extra,
                     ) = proc_file(f.name, "test_module")
 
                     mock_visitor_class.assert_called_once_with("test_module", f.name)
@@ -774,6 +775,7 @@ class TestClass:
                     used_attr_names,
                     used_attr_context,
                     source_lines,
+                    *_extra,
                 ) = proc_file(f.name, "test_module")
 
                 assert defs == []
@@ -842,6 +844,7 @@ class TestClass:
                         used_attr_names,
                         used_attr_context,
                         source_lines,
+                        *_extra,
                     ) = proc_file((f.name, "test_module"))
 
                     mock_visitor_class.assert_called_once_with("test_module", f.name)
@@ -1209,6 +1212,9 @@ class Helper:
 
     def _helper(self):
         return 1
+
+
+HELPER = Helper()
 """
         )
 
@@ -1219,6 +1225,396 @@ class Helper:
 
         assert "Helper.run" in unreachable
         assert "Helper._helper" in unreachable
+
+    def test_analyze_keeps_method_refs_receiver_specific(self, tmp_path):
+        src = tmp_path / "plugins.py"
+        src.write_text(
+            """
+class LivePlugin:
+    def process(self, event):
+        return event["id"]
+
+    def cleanup(self):
+        return "unused"
+
+
+class RemovedPlugin:
+    def process(self, event):
+        return event["legacy"]
+
+
+LIVE_PLUGIN = LivePlugin()
+BOOTSTRAP_RESULT = LIVE_PLUGIN.process({"id": "boot"})
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+
+        assert "LivePlugin.process" not in unreachable
+        assert "LivePlugin.cleanup" in unreachable
+        assert "RemovedPlugin" in unreachable_classes
+        assert "RemovedPlugin.process" not in unreachable
+
+    def test_analyze_protocol_methods_only_live_for_reachable_implementers(
+        self, tmp_path
+    ):
+        src = tmp_path / "service.py"
+        src.write_text(
+            """
+from typing import Protocol
+
+
+class Handler(Protocol):
+    def handle(self, payload: str) -> str:
+        ...
+
+
+class EmailHandler:
+    def handle(self, payload: str) -> str:
+        return payload.upper()
+
+
+def dispatch(handler: Handler) -> str:
+    return handler.handle("welcome")
+
+
+LIVE_RESULT = dispatch(EmailHandler())
+
+
+class LegacyHandler:
+    def handle(self, payload: str) -> str:
+        return payload.lower()
+
+
+def unused_factory():
+    return LegacyHandler()
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+
+        assert "EmailHandler.handle" not in unreachable
+        assert "LegacyHandler" in unreachable_classes
+        assert "LegacyHandler.handle" not in unreachable
+
+    def test_analyze_bound_dispatch_receiver_refs_stay_callsite_specific(
+        self, tmp_path
+    ):
+        src = tmp_path / "service.py"
+        src.write_text(
+            """
+from typing import Protocol
+
+
+class Handler(Protocol):
+    def handle(self, payload: str) -> str:
+        ...
+
+
+class EmailHandler:
+    def handle(self, payload: str) -> str:
+        return payload.upper()
+
+
+class LegacyHandler:
+    def handle(self, payload: str) -> str:
+        return payload.lower()
+
+
+class Processor:
+    def dispatch(self, handler: Handler) -> str:
+        return handler.handle("welcome")
+
+
+PROCESSOR = Processor()
+LIVE_RESULT = PROCESSOR.dispatch(EmailHandler())
+email = EmailHandler()
+LIVE_RESULT_2 = PROCESSOR.dispatch(email)
+LIVE_RESULT_3 = PROCESSOR.dispatch(handler=EmailHandler())
+LEGACY_REGISTRY = {"legacy": LegacyHandler}
+
+
+def stale_path():
+    return PROCESSOR.dispatch(LegacyHandler())
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+
+        assert "EmailHandler.handle" not in unreachable
+        assert "LegacyHandler" not in unreachable_classes
+        assert "LegacyHandler.handle" in unreachable
+        assert "stale_path" in unreachable
+
+    def test_analyze_explicit_protocol_implementer_method_can_be_dead(
+        self, tmp_path
+    ):
+        src = tmp_path / "service.py"
+        src.write_text(
+            """
+from typing import Protocol
+
+
+class Handler(Protocol):
+    def handle(self, payload: str) -> str:
+        ...
+
+
+class LegacyHandler(Handler):
+    def handle(self, payload: str) -> str:
+        return payload.lower()
+
+
+LEGACY_REGISTRY = {"legacy": LegacyHandler}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+
+        assert "LegacyHandler" not in unreachable_classes
+        assert "LegacyHandler.handle" in unreachable
+
+    def test_analyze_dead_class_suppresses_owned_method_duplicates(self, tmp_path):
+        src = tmp_path / "service.py"
+        src.write_text(
+            """
+class Dead:
+    def a(self):
+        return 1
+
+    def b(self):
+        return 2
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+
+        assert "Dead" in unreachable_classes
+        assert "Dead.a" not in unreachable
+        assert "Dead.b" not in unreachable
+
+    def test_analyze_js_package_route_attachment_export_is_live(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (tmp_path / "package.json").write_text(
+            '{"name":"app","type":"module","main":"src/app.js"}',
+            encoding="utf-8",
+        )
+        (src_dir / "app.js").write_text(
+            """
+const routes = new Map();
+
+function register(path, handler) {
+  routes.set(path, handler);
+}
+
+export function healthHandler(req, res) {
+  res.end("ok");
+}
+
+register("/health", healthHandler);
+
+export function attachRoutes(server) {
+  for (const [path, handler] of routes) {
+    server.get(path, handler);
+  }
+}
+
+export function orphanHandler(req, res) {
+  res.end("orphan");
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(src_dir), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+        unused_files = {Path(item["file"]).name for item in result["unused_files"]}
+
+        assert "attachRoutes" not in unreachable
+        assert "orphanHandler" in unreachable
+        assert "app.js" not in unused_files
+
+    def test_analyze_js_route_attachment_uses_route_shape_not_name_tokens(
+        self, tmp_path
+    ):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (tmp_path / "package.json").write_text(
+            '{"name":"app","type":"module","main":"src/app.js"}',
+            encoding="utf-8",
+        )
+        (src_dir / "app.js").write_text(
+            """
+export function healthHandler(req, res) {
+  res.end("ok");
+}
+
+export function configure(api) {
+  api.get("/health", healthHandler);
+}
+
+export const attachRoutes = (server) => {
+  server.post("/orders", healthHandler);
+};
+
+export function applyConfig(config) {
+  const key = "theme";
+  return config.get(key, defaultHandler);
+}
+
+function defaultHandler() {
+  return "light";
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(src_dir), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "configure" not in unreachable
+        assert "attachRoutes" not in unreachable
+        assert "applyConfig" in unreachable
+
+    def test_analyze_java_public_static_helper_not_auto_exported(self, tmp_path):
+        (tmp_path / "App.java").write_text(
+            """
+public class App {
+    public static void main(String[] args) {
+        LiveJob job = new LiveJob();
+        System.out.println(job.run());
+    }
+
+    public static String staleFormat(String value) {
+        return value.trim().toLowerCase();
+    }
+}
+
+class LiveJob {
+    String run() {
+        return "ok";
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "App.staleFormat" in unreachable
+
+    def test_analyze_java_library_public_method_stays_exported(self, tmp_path):
+        (tmp_path / "Api.java").write_text(
+            """
+public class Api {
+    public static void main(String[] args) {
+        System.out.println("demo");
+    }
+
+    public String main() {
+        return "not an entrypoint";
+    }
+
+    public String publicEndpoint(String value) {
+        return value.trim();
+    }
+
+    private String privateHelper(String value) {
+        return value.toLowerCase();
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "Api.publicEndpoint" not in unreachable
+        assert "Api.privateHelper" in unreachable
+
+    def test_analyze_typescript_transitive_dead_uses_file_scoped_callers(
+        self, tmp_path
+    ):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (tmp_path / "package.json").write_text(
+            '{"name":"app","type":"module","main":"src/live.ts"}',
+            encoding="utf-8",
+        )
+        (src_dir / "live.ts").write_text(
+            """
+function helper() {
+  return 1;
+}
+
+export function foo() {
+  return helper();
+}
+
+foo();
+""",
+            encoding="utf-8",
+        )
+        (src_dir / "dead.ts").write_text(
+            """
+function helper() {
+  return 2;
+}
+
+function foo() {
+  return helper();
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unused_by_file = {
+            (Path(item["file"]).name, item["name"])
+            for item in result["unused_functions"]
+        }
+
+        assert ("live.ts", "helper") not in unused_by_file
+        assert ("dead.ts", "helper") in unused_by_file
+        assert ("dead.ts", "foo") in unused_by_file
 
     def test_analyze_single_file_skips_project_unused_dependency_rule(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(

--- a/test/test_changes_analyzer.py
+++ b/test/test_changes_analyzer.py
@@ -468,6 +468,8 @@ class Impl(Base):
 
     def extra_unused(self):
         return "I am dead code"
+
+IMPL = Impl()
 """
         result = self._analyze(code, thr=20)
         names = [f["simple_name"] for f in result["unused_functions"]]

--- a/test/test_fast_parity.py
+++ b/test/test_fast_parity.py
@@ -515,9 +515,12 @@ class Helper:
 
     def _helper(self):
         return 1
+
+
+HELPER = Helper()
 """,
-            encoding="utf-8",
-        )
+                encoding="utf-8",
+            )
 
         result_rust, result_py = _run_dead_code_parity_scans_in_subprocess(tmp_path)
 

--- a/test/test_ts_exports.py
+++ b/test/test_ts_exports.py
@@ -436,6 +436,29 @@ class TestTypeScriptDeadFiles:
 
         assert dead_files == []
 
+    def test_package_json_entrypoint_keeps_single_package_live_without_inventory(
+        self, tmp_path
+    ):
+        app_file = tmp_path / "src" / "app.js"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"app","type":"module","main":"src/app.js"}',
+            encoding="utf-8",
+        )
+        app_file.parent.mkdir(parents=True, exist_ok=True)
+        app_file.write_text("export const app = true;\n", encoding="utf-8")
+
+        dead_files = find_dead_ts_files(
+            [app_file],
+            [],
+            {},
+            {},
+            project_root=str(app_file.parent),
+            workspace_inventory=None,
+        )
+
+        assert dead_files == []
+
     def test_package_json_subpath_export_keeps_exported_file_live(self, tmp_path):
         helper_file = tmp_path / "packages" / "ui" / "src" / "helpers.ts"
 


### PR DESCRIPTION
## Summary
  - improves dead-code reachability across Python, TypeScript/JavaScript, and Java
  - makes Python protocol/receiver method refs call-site specific, including keyword and preconstructed receiver args
  - prevents TS/JS same-name transitive dead-code contamination across files
  - treats package main/export JS/TS files as reachability roots without relying on workspace inventory
  - narrows JS/TS route attachment liveness to route-shaped calls
  - reports dead classes without duplicating every owned method

## Validation
  - python scripts/dead_code_benchmark.py --strict-labels
  - python scripts/dead_code_compare_scanners.py
  - python /Users/skylos-benchmarks/runners/run_benchmark.py --manifest /Users/skylos-benchmarks/manifests/dead_code.dev.json --tool skylos --output-dir /tmp/skylos-dead-code-phase4-final4 --timeout-seconds 60
  - python -m pytest