### PR TITLE
fix(quality): detect duplicate branch logic

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -184,19 +184,19 @@ of receiving a score.
 | Security frozen | seeded dev | Bandit | TypeScript | 0 | 1 | 0 | 0 | 0 | 0 | N/A |
 | Security frozen | seeded dev | Bandit | Go | 0 | 2 | 0 | 0 | 0 | 0 | N/A |
 | Security frozen | OWASP Java dev | Skylos | Java | 240 | 0 | 105 | 0 | 15 | 120 | 94.37 |
-| Quality frozen | seeded dev | Skylos | Python | 1 | 0 | 0 | 0 | 1 | 1 | 55.0 |
+| Quality frozen | seeded dev | Skylos | Python | 1 | 0 | 1 | 0 | 0 | 1 | 100.0 |
 | Agent review frozen | seeded dev | Skylos | Python | 1 | 0 | 1 | 0 | 0 | 1 | 100.0 |
 
 These frozen results already show useful gaps to investigate before any public
-claim: the seeded Python quality duplicate-branch case is still missed, and
-OWASP Java still has request-wrapper interprocedural, LDAP injection, XPath
-injection, and property-driven weak-hash gaps. Frozen dead-code dev is now at
-full JavaScript, TypeScript, Go, and Java score; the remaining Python
+claim: OWASP Java still has request-wrapper interprocedural, LDAP injection,
+XPath injection, and property-driven weak-hash gaps. Frozen dead-code dev is
+now at full JavaScript, TypeScript, Go, and Java score; the remaining Python
 dead-code residuals are benchmark-label review items around duplicate
 dead-class method reporting and an unlabeled genuinely unreachable helper. The
 seeded security dev suite is now at full recall with one Python `urljoin`
-label-review false positive. Vulture is only comparable on the Python
-dead-code subset.
+label-review false positive. Frozen quality dev now passes the seeded Python
+duplicate-branch case without unlabeled false positives. Vulture is only
+comparable on the Python dead-code subset.
 
 Phase 2 Python security rerun on 2026-04-25 improved frozen `security.dev`
 overall from `TP=17 FP=5 FN=3 TN=9 score=78.15` to
@@ -240,6 +240,16 @@ Python moved from `TP=14 FP=1 FN=2 TN=11 score=90.38` to
 methods out of the reported finding set, so the frozen
 `dc-py-plugin-removed-method` label should be reviewed rather than forcing
 duplicate method output back into the analyzer.
+
+Phase 5 quality rerun on 2026-04-26 improved frozen `quality.dev` from
+`TP=0 FP=0 FN=1 TN=1 score=55.0` to
+`TP=1 FP=0 FN=0 TN=1 score=100.0`. The patch adds Python duplicate
+if/elif branch detection and fixes two precision/performance issues exposed by
+the frozen fixture: long `elif` chains no longer count as deep nesting, repeated
+dictionary key lookups no longer count as duplicate magic strings, and
+git-backed file discovery filters by extension before resolving every visible
+repository path. Root resolution also avoids accidentally treating a
+home-directory Git checkout as the project root for nested benchmark fixtures.
 
 ## Benchmark Rules
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ Languages are auto-detected by file extension. Mixed-language repos work out of 
 | Nesting depth | SKY-Q302 | Too many nested levels |
 | Function length | SKY-C304 | Function exceeds line limit |
 | Too many params | SKY-C303 | Function has too many parameters |
-| Duplicate condition | SKY-Q305 | Identical condition in if-else-if chain |
+| Duplicate branch | SKY-Q305 | Duplicate branch condition or body |
 | Await in loop | SKY-Q402 | `await` inside for/while loop |
 | Unreachable code | SKY-UC002 | Code after return/throw/break/continue |
 

--- a/editors/vscode/out/rules.js
+++ b/editors/vscode/out/rules.js
@@ -70,7 +70,7 @@ const RULES = {
     "SKY-P401": { name: "Memory risk: file.read()", severity: "LOW", category: "quality", description: "file.read()/readlines() loads entire file into RAM.", fix: "Read in chunks or iterate line by line.", language: "python" },
     "SKY-P402": { name: "Memory risk: read_csv", severity: "LOW", category: "quality", description: "pandas.read_csv() without chunksize loads entire file.", fix: "Use chunksize parameter for large files.", language: "python" },
     "SKY-P403": { name: "Nested loop (O(N^2))", severity: "LOW", category: "quality", description: "Nested loop detected; potential O(N^2) performance issue.", fix: "Consider using sets, dicts, or itertools for better performance." },
-    "SKY-Q305": { name: "Duplicate condition", severity: "MEDIUM", category: "quality", description: "Identical condition in if-else-if chain.", fix: "Remove or correct the duplicate condition.", language: "typescript" },
+    "SKY-Q305": { name: "Duplicate branch", severity: "MEDIUM", category: "quality", description: "Duplicate branch condition or body.", fix: "Remove or correct the duplicate branch logic." },
     "SKY-Q402": { name: "Await in loop", severity: "MEDIUM", category: "quality", description: "await expression inside a loop causes sequential execution.", fix: "Use Promise.all() for parallel execution.", language: "typescript" },
     "SKY-UC001": { name: "Unreachable code", severity: "MEDIUM", category: "quality", description: "Code after return/raise/break/continue is unreachable.", fix: "Remove unreachable code." },
     "SKY-UC002": { name: "Unreachable code (TS)", severity: "MEDIUM", category: "quality", description: "Code after return/throw/break/continue is unreachable.", fix: "Remove unreachable code.", language: "typescript" },

--- a/editors/vscode/src/rules.ts
+++ b/editors/vscode/src/rules.ts
@@ -86,7 +86,7 @@ const RULES: Record<string, RuleMeta> = {
   "SKY-P402": { name: "Memory risk: read_csv", severity: "LOW", category: "quality", description: "pandas.read_csv() without chunksize loads entire file.", fix: "Use chunksize parameter for large files.", language: "python" },
   "SKY-P403": { name: "Nested loop (O(N^2))", severity: "LOW", category: "quality", description: "Nested loop detected; potential O(N^2) performance issue.", fix: "Consider using sets, dicts, or itertools for better performance." },
 
-  "SKY-Q305": { name: "Duplicate condition", severity: "MEDIUM", category: "quality", description: "Identical condition in if-else-if chain.", fix: "Remove or correct the duplicate condition.", language: "typescript" },
+  "SKY-Q305": { name: "Duplicate branch", severity: "MEDIUM", category: "quality", description: "Duplicate branch condition or body.", fix: "Remove or correct the duplicate branch logic." },
   "SKY-Q402": { name: "Await in loop", severity: "MEDIUM", category: "quality", description: "await expression inside a loop causes sequential execution.", fix: "Use Promise.all() for parallel execution.", language: "typescript" },
   "SKY-UC001": { name: "Unreachable code", severity: "MEDIUM", category: "quality", description: "Code after return/raise/break/continue is unreachable.", fix: "Remove unreachable code." },
   "SKY-UC002": { name: "Unreachable code (TS)", severity: "MEDIUM", category: "quality", description: "Code after return/throw/break/continue is unreachable.", fix: "Remove unreachable code.", language: "typescript" },

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -53,6 +53,7 @@ from skylos.rules.quality.logic import (
     MutableDefaultRule,
     BareExceptRule,
     DangerousComparisonRule,
+    DuplicateBranchRule,
     TryBlockPatternsRule,
     UnusedExceptVarRule,
     ReturnConsistencyRule,
@@ -164,13 +165,21 @@ def _resolve_analysis_root(path_like: Path) -> Path:
     if not current.is_dir():
         current = current.parent
 
+    start = current
+    home = Path.home().resolve()
     probe = current
     for _ in range(20):
         if (probe / "pyproject.toml").exists():
+            if probe == home and start != home:
+                break
             return probe
         if (probe / "setup.py").exists():
+            if probe == home and start != home:
+                break
             return probe
         if (probe / ".git").exists():
+            if probe == home and start != home:
+                break
             return probe
         if probe.parent == probe:
             break
@@ -179,7 +188,9 @@ def _resolve_analysis_root(path_like: Path) -> Path:
     try:
         git_root = find_git_root(current)
         if git_root:
-            return Path(git_root).resolve()
+            resolved_git_root = Path(git_root).resolve()
+            if not (resolved_git_root == home and current != home):
+                return resolved_git_root
     except Exception:
         pass
 
@@ -2467,6 +2478,8 @@ def proc_file(
                 q_rules.append(BareExceptRule())
             if "SKY-L003" not in cfg["ignore"]:
                 q_rules.append(DangerousComparisonRule())
+            if "SKY-Q305" not in cfg["ignore"]:
+                q_rules.append(DuplicateBranchRule())
             if "SKY-L004" not in cfg["ignore"]:
                 q_rules.append(TryBlockPatternsRule(max_lines=15))
             if "SKY-L005" not in cfg["ignore"]:

--- a/skylos/file_discovery.py
+++ b/skylos/file_discovery.py
@@ -142,7 +142,7 @@ def list_git_visible_files(path: str | Path) -> list[Path] | None:
         rel_path = line.strip()
         if not rel_path:
             continue
-        files.append((root / rel_path).resolve())
+        files.append(root / rel_path)
 
     files.sort()
     return files
@@ -176,18 +176,18 @@ def discover_source_files(
             files = []
             seen = set()
             for file_path in [*git_files, *forced_includes]:
+                if file_path.suffix.lower() not in ext_set:
+                    continue
                 resolved = file_path.resolve()
                 if resolved in seen:
                     continue
                 seen.add(resolved)
-                if file_path.suffix.lower() not in ext_set:
-                    continue
                 if should_include_path(file_path, target, include_folders):
-                    files.append(file_path)
+                    files.append(resolved)
                     continue
                 if should_exclude_path(file_path, target, exclude_folders):
                     continue
-                files.append(file_path)
+                files.append(resolved)
             files.sort()
             return files
 

--- a/skylos/rules/quality/logic.py
+++ b/skylos/rules/quality/logic.py
@@ -164,6 +164,235 @@ def _walk_scope(nodes):
             stack.append(child)
 
 
+def _is_empty_branch_body(body: list[ast.stmt]) -> bool:
+    if not body:
+        return True
+
+    for stmt in body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if isinstance(stmt, ast.Expr):
+            value = stmt.value
+            if isinstance(value, ast.Constant) and value.value is ...:
+                continue
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                continue
+        return False
+    return True
+
+
+def _substantive_branch_statement_count(body: list[ast.stmt]) -> int:
+    count = 0
+    for stmt in body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if isinstance(stmt, ast.Expr):
+            value = stmt.value
+            if isinstance(value, ast.Constant) and value.value is ...:
+                continue
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                continue
+        count += 1
+    return count
+
+
+def _semantic_ast_key(node: ast.AST | list[ast.AST]) -> str:
+    if isinstance(node, list):
+        return "[" + ",".join(_semantic_ast_key(child) for child in node) + "]"
+    return ast.dump(node, annotate_fields=True, include_attributes=False)
+
+
+def _iter_function_scope_nodes(node: ast.FunctionDef | ast.AsyncFunctionDef):
+    stack = list(reversed(node.body))
+
+    while stack:
+        current = stack.pop()
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+
+        yield current
+
+        children = list(ast.iter_child_nodes(current))
+        stack.extend(reversed(children))
+
+
+def _build_parent_map(node: ast.AST) -> dict[int, ast.AST]:
+    parent_map = {}
+    for parent in ast.walk(node):
+        for child in ast.iter_child_nodes(parent):
+            parent_map[id(child)] = parent
+    return parent_map
+
+
+def _is_elif_node(node: ast.If, parent_map: dict[int, ast.AST]) -> bool:
+    parent = parent_map.get(id(node))
+    return (
+        isinstance(parent, ast.If)
+        and len(parent.orelse) == 1
+        and parent.orelse[0] is node
+    )
+
+
+def _branch_body_line(body: list[ast.stmt], fallback_line: int) -> int:
+    for stmt in body:
+        line = getattr(stmt, "lineno", None)
+        if line is not None:
+            return line
+    return fallback_line
+
+
+def _collect_if_chain(
+    node: ast.If,
+) -> list[tuple[ast.AST | None, list[ast.stmt], int]]:
+    branches = []
+    current = node
+
+    while isinstance(current, ast.If):
+        branches.append((current.test, current.body, current.lineno))
+        if len(current.orelse) == 1 and isinstance(current.orelse[0], ast.If):
+            current = current.orelse[0]
+        else:
+            if current.orelse:
+                branches.append(
+                    (
+                        None,
+                        current.orelse,
+                        _branch_body_line(current.orelse, current.lineno),
+                    )
+                )
+            break
+
+    return branches
+
+
+class DuplicateBranchRule(SkylosRule):
+    rule_id = "SKY-Q305"
+    name = "Duplicate Branch Logic"
+
+    def visit_node(self, node, context):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return None
+
+        filename = context.get("filename", "")
+        parent_map = _build_parent_map(node)
+        findings = []
+        reported = set()
+
+        for child in _iter_function_scope_nodes(node):
+            if not isinstance(child, ast.If):
+                continue
+            if _is_elif_node(child, parent_map):
+                continue
+
+            branches = _collect_if_chain(child)
+            if len(branches) < 2:
+                continue
+
+            findings.extend(
+                self._duplicate_condition_findings(
+                    node, branches, filename, reported
+                )
+            )
+            findings.extend(
+                self._duplicate_body_findings(node, branches, filename, reported)
+            )
+
+        return findings if findings else None
+
+    def _duplicate_condition_findings(
+        self,
+        func_node,
+        branches: list[tuple[ast.AST | None, list[ast.stmt], int]],
+        filename: str,
+        reported: set[tuple[str, int, str]],
+    ) -> list[dict]:
+        seen = {}
+        findings = []
+
+        for condition, _body, line in branches:
+            if condition is None:
+                continue
+            key = _semantic_ast_key(condition)
+            if key not in seen:
+                seen[key] = line
+                continue
+
+            report_key = ("condition", line, key)
+            if report_key in reported:
+                continue
+            reported.add(report_key)
+            findings.append(
+                self._make_finding(
+                    func_node,
+                    filename,
+                    line,
+                    "duplicate_condition",
+                    f"Function '{func_node.name}' repeats an if/elif condition first seen at line {seen[key]}.",
+                )
+            )
+
+        return findings
+
+    def _duplicate_body_findings(
+        self,
+        func_node,
+        branches: list[tuple[ast.AST | None, list[ast.stmt], int]],
+        filename: str,
+        reported: set[tuple[str, int, str]],
+    ) -> list[dict]:
+        seen = {}
+        findings = []
+
+        for _condition, body, line in branches:
+            if _is_empty_branch_body(body):
+                continue
+            if _substantive_branch_statement_count(body) < 2:
+                continue
+            if any(
+                kind == "condition" and seen_line == line
+                for kind, seen_line, _ in reported
+            ):
+                continue
+
+            key = _semantic_ast_key(body)
+            if key not in seen:
+                seen[key] = line
+                continue
+
+            report_key = ("body", line, key)
+            if report_key in reported:
+                continue
+            reported.add(report_key)
+            findings.append(
+                self._make_finding(
+                    func_node,
+                    filename,
+                    line,
+                    "duplicate_body",
+                    f"Function '{func_node.name}' has duplicate branch bodies first seen at line {seen[key]}.",
+                )
+            )
+
+        return findings
+
+    def _make_finding(self, func_node, filename, line, value, message):
+        return {
+            "rule_id": self.rule_id,
+            "kind": "quality",
+            "severity": "MEDIUM",
+            "type": "function",
+            "name": func_node.name,
+            "simple_name": func_node.name,
+            "value": value,
+            "threshold": 0,
+            "message": message,
+            "file": filename,
+            "basename": Path(filename).name,
+            "line": line,
+            "col": func_node.col_offset,
+        }
+
+
 def _is_function_level_try(node: ast.Try, parent_body: list[ast.stmt]) -> bool:
     if len(parent_body) == 1 and parent_body[0] is node:
         return True
@@ -2370,6 +2599,14 @@ class DuplicateStringLiteralRule(SkylosRule):
                     return True
         return False
 
+    def _is_structural_key_literal(self, node, parent_map):
+        parent = parent_map.get(id(node))
+        if isinstance(parent, ast.Subscript) and parent.slice is node:
+            return True
+        if isinstance(parent, ast.Dict) and node in parent.keys:
+            return True
+        return False
+
     def visit_node(self, node, context):
         if not isinstance(node, ast.Module):
             return None
@@ -2391,6 +2628,8 @@ class DuplicateStringLiteralRule(SkylosRule):
                 if len(child.value) < 5:
                     continue
                 if self._is_docstring(child, parent_map):
+                    continue
+                if self._is_structural_key_literal(child, parent_map):
                     continue
                 key = child.value
                 if key not in string_occurrences:

--- a/skylos/rules/quality/nesting.py
+++ b/skylos/rules/quality/nesting.py
@@ -18,7 +18,9 @@ def _max_depth(nodes, depth=0, is_function_body=False):
             branches = []
             if isinstance(node, ast.If):
                 branches.append(node.body)
-                if node.orelse:
+                if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
+                    max_depth = max(max_depth, _max_depth(node.orelse, depth))
+                elif node.orelse:
                     branches.append(node.orelse)
             elif isinstance(node, (ast.For, ast.While)):
                 branches.append(node.body)

--- a/skylos/rules/quality/standards.py
+++ b/skylos/rules/quality/standards.py
@@ -80,6 +80,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     # Complexity / structure
     "SKY-Q301": [{"id": "CWE-1121", "name": "Excessive McCabe Cyclomatic Complexity"}],
     "SKY-Q302": [{"id": "CWE-1124", "name": "Excessively Deep Nesting"}],
+    "SKY-Q305": [{"id": "CWE-670", "name": "Always-Incorrect Control Flow Implementation"}],
     "SKY-Q306": [{"id": "CWE-1121", "name": "Excessive McCabe Cyclomatic Complexity"}],
     "SKY-L021": [
         {"id": "CWE-693", "name": "Protection Mechanism Failure"},
@@ -113,6 +114,7 @@ STANDARD_REFS: dict[str, list[str]] = {
     "SKY-Q301": ["ISO/IEC 5055:2021 §6.3.4", "McCabe Cyclomatic Complexity"],
     "SKY-Q306": ["SonarQube S3776", "Cognitive Complexity"],
     "SKY-Q302": ["ISO/IEC 5055:2021 §6.3.5"],
+    "SKY-Q305": ["Control-flow correctness: duplicate branch condition/body"],
     "SKY-Q501": ["CK Metrics: WMC (Weighted Methods per Class)"],
     "SKY-Q701": ["CK Metrics: CBO (Coupling Between Objects)", "ISO/IEC 9126"],
     "SKY-Q702": ["CK Metrics: LCOM (Lack of Cohesion of Methods)", "ISO/IEC 9126"],

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -10,7 +10,7 @@ from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.penalties import apply_penalties
 
-from skylos.analyzer import Skylos, proc_file, analyze
+from skylos.analyzer import Skylos, proc_file, analyze, _resolve_analysis_root
 
 
 @pytest.fixture
@@ -1785,6 +1785,18 @@ def test_changed_files_scans_dotenv_for_secrets(tmp_path):
 
 
 class TestRepoPhantomReferences:
+    def test_resolve_analysis_root_ignores_home_git_root_without_project_marker(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        case_root = tmp_path / "benchmarks" / "case"
+        case_root.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        assert _resolve_analysis_root(case_root) == case_root
+
     def test_analyze_flags_imported_local_module_member_call(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
         pkg = tmp_path / "app"

--- a/test/test_fast_parity.py
+++ b/test/test_fast_parity.py
@@ -48,7 +48,9 @@ def _run_dead_code_parity_scans_in_subprocess(target: Path) -> tuple[dict, dict]
         if cache_dir.exists():
             shutil.rmtree(cache_dir)
 
-        result_fast = json.loads(Skylos().analyze(target, exclude_folders=exclude))
+        result_fast = json.loads(
+            Skylos().analyze(target, exclude_folders=exclude, grep_verify=False)
+        )
 
         if cache_dir.exists():
             shutil.rmtree(cache_dir)
@@ -64,7 +66,9 @@ def _run_dead_code_parity_scans_in_subprocess(target: Path) -> tuple[dict, dict]
         import skylos.circular_deps as circ_mod
         circ_mod._fast_find_cycles = None
 
-        result_py = json.loads(Skylos().analyze(target, exclude_folders=exclude))
+        result_py = json.loads(
+            Skylos().analyze(target, exclude_folders=exclude, grep_verify=False)
+        )
         print(json.dumps({"fast": result_fast, "python": result_py}))
         """
     )

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -3,6 +3,7 @@ from skylos.rules.quality.logic import (
     MutableDefaultRule,
     BareExceptRule,
     DangerousComparisonRule,
+    DuplicateBranchRule,
     BroadExceptionRule,
 )
 
@@ -170,6 +171,100 @@ if x is None:
         rule = DangerousComparisonRule()
         findings = check_code(rule, code)
         assert len(findings) == 0
+
+
+class TestDuplicateBranchRule:
+    def test_duplicate_elif_condition(self):
+        code = """
+def reconcile_account(event):
+    if event["kind"] == "credit":
+        return event["amount"]
+    elif event["kind"] == "debit":
+        return -event["amount"]
+    elif event["kind"] == "fee":
+        return -event["amount"]
+    elif event["kind"] == "fee":
+        return -event["amount"]
+    return 0
+"""
+        rule = DuplicateBranchRule()
+        findings = check_code(rule, code)
+        assert len(findings) == 1
+        assert findings[0]["rule_id"] == "SKY-Q305"
+        assert findings[0]["name"] == "reconcile_account"
+        assert findings[0]["value"] == "duplicate_condition"
+
+    def test_duplicate_branch_body(self):
+        code = """
+def resolve_status(order):
+    if order.is_cancelled:
+        status = "closed"
+        return status
+    elif order.is_refunded:
+        status = "closed"
+        return status
+    return "open"
+"""
+        rule = DuplicateBranchRule()
+        findings = check_code(rule, code)
+        assert len(findings) == 1
+        assert findings[0]["rule_id"] == "SKY-Q305"
+        assert findings[0]["value"] == "duplicate_body"
+
+    def test_duplicate_if_else_body(self):
+        code = """
+def render_status(enabled):
+    if enabled:
+        label = "active"
+        return label.upper()
+    else:
+        label = "active"
+        return label.upper()
+"""
+        rule = DuplicateBranchRule()
+        findings = check_code(rule, code)
+        assert len(findings) == 1
+        assert findings[0]["rule_id"] == "SKY-Q305"
+        assert findings[0]["name"] == "render_status"
+        assert findings[0]["value"] == "duplicate_body"
+
+    def test_separate_functions_do_not_match_each_other(self):
+        code = """
+def first(flag):
+    if flag:
+        return "same"
+    return "different"
+
+def second(flag):
+    if flag:
+        return "same"
+    return "different"
+"""
+        rule = DuplicateBranchRule()
+        findings = check_code(rule, code)
+        assert findings == []
+
+    def test_nested_function_is_separate_scope(self):
+        code = """
+def outer(flag):
+    if flag:
+        return "outer"
+
+    def inner(value):
+        if value == 1:
+            result = "same"
+            return result
+        elif value == 2:
+            result = "same"
+            return result
+        return "other"
+
+    return inner(1)
+"""
+        rule = DuplicateBranchRule()
+        findings = check_code(rule, code)
+        assert len(findings) == 1
+        assert findings[0]["name"] == "inner"
 
 
 class TestBroadExceptionRule:

--- a/test/test_nesting.py
+++ b/test/test_nesting.py
@@ -87,6 +87,23 @@ def outer():
         findings = check_code(rule, code)
         assert len(findings) == 0
 
+    def test_elif_chain_is_not_nested(self):
+        code = """
+def classify(value):
+    if value == "a":
+        return 1
+    elif value == "b":
+        return 2
+    elif value == "c":
+        return 3
+    elif value == "d":
+        return 4
+    return 0
+"""
+        rule = NestingRule(threshold=1)
+        findings = check_code(rule, code)
+        assert findings == []
+
     def test_try_except_finally(self):
         code = """
 def complex_try():

--- a/test/test_quality_rules.py
+++ b/test/test_quality_rules.py
@@ -467,6 +467,19 @@ def f():
         findings = check_code(rule, code)
         assert not any(f["rule_id"] == "SKY-L027" for f in findings)
 
+    def test_repeated_dict_key_access_ok(self):
+        code = """
+def f(event):
+    total = event["amount"]
+    total += event["amount"]
+    total += event["amount"]
+    total += event["amount"]
+    return total
+"""
+        rule = DuplicateStringLiteralRule()
+        findings = check_code(rule, code)
+        assert not any(f["rule_id"] == "SKY-L027" for f in findings)
+
 
 # --- SKY-L028: Too Many Returns ---
 


### PR DESCRIPTION
## Summary

  - Add Python `SKY-Q305` duplicate branch detection for repeated `if`/`elif` conditions and duplicate branch bodies, including final `else` bodies
  - Reduce quality false positives from `elif` chains being counted as deep nesting and repeated dict/subscript keys being counted as duplicate strings
  - Fix quality benchmark latency by avoiding accidental promotion of nested benchmark fixtures to the home-directory Git/project root