### PR TITLE
fix(release): restore release-please metadata flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,5 @@
 ## Changelog
 
-## [4.7.0](https://github.com/duriantaco/skylos/compare/v4.6.0...v4.7.0) (2026-04-26)
-
-
-### Features
-
-* **cloud:** support GitHub OIDC for tokenless CI sync workflows
-
-
-### Bug Fixes
-
-* **login:** reject unverified browser login callbacks before saving credentials
-
-
-### Documentation
-
-* **security:** document disclosure process and supported security contact
-
 ## [4.6.0](https://github.com/duriantaco/skylos/compare/v4.5.0...v4.6.0) (2026-04-26)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skylos"
-version = "4.7.0"
+version = "4.6.0"
 requires-python = ">=3.10"
 description = "Open-source AI code security and static analysis for Python, TypeScript, and Go. Finds dead code, secrets, vulnerabilities, and diff-aware regressions."
 authors = [{name = "Aaron Oh", email = "aaronoh2015@gmail.com"}]


### PR DESCRIPTION
## Summary
- remove the manual 4.7.0 changelog block from the feature PR merge
- restore pyproject.toml to 4.6.0 so Release Please owns the 4.7.0 release bump
- leave the tokenless CI auth feature changes intact

## Tests
- pytest -q test/test_login.py test/test_sync.py test/test_cicd_workflow.py test/test_ingest.py
- git diff --check

Do not merge release PR #258 until this lands and Release Please refreshes it.