### PR TITLE
feat(cli): add upload session metadata

### DIFF
--- a/skylos/api.py
+++ b/skylos/api.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 from typing import Any
+from uuid import uuid4
 
 from skylos.constants import (
     NETWORK_TIMEOUT_SHORT,
@@ -444,6 +445,22 @@ def _legacy_inline_upload_limit_bytes() -> int:
 
 def _json_size_bytes(payload: Any) -> int:
     return len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+
+
+def _cli_version() -> str | None:
+    try:
+        from skylos import __version__
+
+        return str(__version__)
+    except Exception:
+        return None
+
+
+def _new_upload_client_session_id() -> str:
+    override = os.getenv("SKYLOS_UPLOAD_SESSION_ID", "").strip()
+    if override:
+        return override
+    return f"cli-{uuid4()}"
 
 
 def _sha256_file(path: Path) -> str:
@@ -1084,6 +1101,8 @@ def _build_report_metadata(
     project_id=None,
     scan_bundle_id=None,
     project_root=None,
+    upload_client_session_id=None,
+    cli_version=None,
 ) -> dict[str, Any]:
     metadata = {
         "commit_hash": commit_hash,
@@ -1094,6 +1113,9 @@ def _build_report_metadata(
         "analysis_mode": analysis_mode,
         "ai_code": ai_code if ai_code and ai_code.get("detected") else None,
         "provenance": provenance_data,
+        "upload_client_session_id": upload_client_session_id
+        or _new_upload_client_session_id(),
+        "cli_version": cli_version or _cli_version(),
     }
     if grade_data:
         metadata["grade"] = grade_data
@@ -1756,6 +1778,9 @@ def upload_defense_report(defense_json_str, quiet=False, scan_bundle_id=None) ->
         "commit_hash": commit,
         "branch": branch,
         "actor": actor,
+        "ci": ci,
+        "upload_client_session_id": _new_upload_client_session_id(),
+        "cli_version": _cli_version(),
         "tool": "skylos-defend",
         "summary": {},
         "findings": [],

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -386,6 +386,8 @@ class TestSkylosApi(unittest.TestCase):
 
     @patch("skylos.api.SarifExporter")
     @patch("skylos.api.get_project_token")
+    @patch("skylos.api._cli_version", return_value="4.7.0")
+    @patch("skylos.api._new_upload_client_session_id", return_value="cli-session-1")
     @patch(
         "skylos.api.get_git_info",
         return_value=(
@@ -398,7 +400,14 @@ class TestSkylosApi(unittest.TestCase):
     @patch("skylos.api.get_git_root", return_value=None)
     @patch("requests.post")
     def test_upload_report_includes_ci_metadata(
-        self, mock_post, _, _mock_git_info, mock_token, mock_exporter
+        self,
+        mock_post,
+        _,
+        _mock_git_info,
+        _mock_session,
+        _mock_version,
+        mock_token,
+        mock_exporter,
     ):
         mock_token.return_value = "token"
         resp = MagicMock()
@@ -418,6 +427,8 @@ class TestSkylosApi(unittest.TestCase):
         self.assertEqual(payload["actor"], "jenkins-bot")
         self.assertEqual(payload["ci"]["provider"], "jenkins")
         self.assertEqual(payload["ci"]["pr_number"], 99)
+        self.assertEqual(payload["upload_client_session_id"], "cli-session-1")
+        self.assertEqual(payload["cli_version"], "4.7.0")
 
     @patch("skylos.provenance.analyze_provenance")
     @patch("skylos.api._load_repo_link", return_value={"project_id": "proj-1"})


### PR DESCRIPTION
## Summary
- include a per-upload client session id in CLI uploads
- include the CLI version in upload payloads
- send the same upload metadata for defense uploads
- support Cloud scan attribution for user, project key, and CI upload paths

## Verification
- pytest -q test/test_api.py test/test_sync.py test/test_login.py test/test_cicd_workflow.py test/test_ingest.py test/test_credits.py: 195 passed
- staged gate passed during commit
- git diff --check: passed