### PR TITLE
fix(ci): harden enterprise workflow generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ For methodology, commands, competitor rows, and caveats, see
 | Docker image | [Installation](https://docs.skylos.dev/installation) | run Skylos without a local Python install |
 | Skylos Cloud | [Cloud workflow](https://docs.skylos.dev/cloud-workflow) | optional upload and dashboard workflows |
 
+Generate a GitHub Actions workflow from the CLI:
+
+```bash
+skylos cicd init --upload
+skylos cicd init --upload --scan-path apps/api
+```
+
+The generated upload workflow uses GitHub OIDC, sends PR head commit/branch
+metadata, and supports monorepo subprojects through `--scan-path`.
+
 ## Documentation Map
 
 | Need | Read This |

--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
+import re
+import shlex
 from typing import Optional
 
 from rich.console import Console
@@ -14,6 +16,36 @@ ANALYSIS_FLAG_MAP: dict[str, str] = {
 }
 
 
+def _installed_skylos_version() -> str | None:
+    try:
+        from skylos import __version__
+
+        version = str(__version__).strip()
+    except Exception:
+        return None
+    return version or None
+
+
+def _skylos_install_command(version: str | None = None) -> str:
+    resolved = version if version is not None else _installed_skylos_version()
+    if resolved and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.!+~-]*", resolved):
+        return f"python -m pip install {shlex.quote(f'skylos=={resolved}')}"
+    return "python -m pip install skylos"
+
+
+def _shell_path(path: str | Path | None) -> str:
+    raw = str(path or ".").strip() or "."
+    if raw.startswith("-"):
+        raw = f"./{raw}"
+    return shlex.quote(raw)
+
+
+def _upload_env_block() -> str:
+    return """        env:
+          SKYLOS_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          SKYLOS_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}"""
+
+
 def generate_workflow(
     *,
     triggers: Optional[list[str]] = None,
@@ -25,11 +57,15 @@ def generate_workflow(
     use_claude_security: bool = False,
     use_upload: bool = False,
     use_defend: bool = False,
+    scan_path: str = ".",
+    skylos_version: str | None = None,
 ) -> str:
     triggers = triggers or ["pull_request", "push"]
     analysis_types = analysis_types or ["dead-code", "security", "quality", "secrets"]
 
     trigger_block = _build_trigger_block(triggers)
+    install_command = _skylos_install_command(skylos_version)
+    scan_target = _shell_path(scan_path)
     analysis_flags = " ".join(
         ANALYSIS_FLAG_MAP[t]
         for t in analysis_types
@@ -47,17 +83,17 @@ def generate_workflow(
         [
             '          if [ "${{ github.event_name }}" = "pull_request" ]; then',
             (
-                f"            skylos .{analysis_flags}{baseline_flag}{upload_flag} "
+                f"            skylos {scan_target}{analysis_flags}{baseline_flag}{upload_flag} "
                 f"--diff-base {pr_base_ref} --diff {pr_base_ref} "
                 "--json -o skylos-results.json"
             ),
             "          else",
-            f"            skylos .{analysis_flags}{baseline_flag}{upload_flag} --json -o skylos-results.json",
+            f"            skylos {scan_target}{analysis_flags}{baseline_flag}{upload_flag} --json -o skylos-results.json",
             "          fi",
         ]
     )
+    analysis_upload_env = f"\n{_upload_env_block()}" if use_upload else ""
 
-    llm_env = ""
     llm_step = ""
     if use_llm:
         model_str = model or "gpt-4.1"
@@ -71,21 +107,24 @@ def generate_workflow(
                 "",
                 "      - name: Skylos Agent Review (LLM)",
                 "        if: github.event_name == 'pull_request'",
-                f"        run: skylos agent review . --model {model_str} --format json -o skylos-llm-results.json",
+                (
+                    f"        run: skylos agent scan {scan_target} "
+                    f"--model {shlex.quote(model_str)} --changed --format json "
+                    "-o skylos-llm-results.json"
+                ),
                 "        env:",
                 "          SKYLOS_API_KEY: ${{ secrets.SKYLOS_API_KEY }}" + api_key_env,
             ]
         )
-        llm_env = """
-          SKYLOS_API_KEY: ${{ secrets.SKYLOS_API_KEY }}"""
-
     defend_step = ""
     if use_defend:
         defend_parts = [
             "",
             "      - name: AI Defense Check",
-            f"        run: skylos defend . --fail-on critical --min-score 70 --json -o defense-results.json{' --upload' if use_upload else ''}",
+            f"        run: skylos defend {scan_target} --fail-on critical --min-score 70 --json -o defense-results.json{' --upload' if use_upload else ''}",
         ]
+        if use_upload:
+            defend_parts.append(_upload_env_block())
         defend_step = "\n".join(defend_parts)
 
     permissions_block = """permissions:
@@ -110,6 +149,7 @@ def generate_workflow(
 
 jobs:
   skylos:
+    name: Skylos Quality Gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -123,12 +163,12 @@ jobs:
           python-version: '{python_version}'
 
       - name: Install Skylos
-        run: pip install skylos
+        run: {install_command}
 {sync_step}
 
       - name: Run Skylos Analysis
         run: |
-{analysis_run}
+{analysis_run}{analysis_upload_env}
 {llm_step}{defend_step}
       - name: Quality Gate
         if: always()
@@ -159,12 +199,12 @@ jobs:
     }"""
 
     if use_claude_security:
-        workflow += _build_claude_security_jobs(python_version)
+        workflow += _build_claude_security_jobs(python_version, install_command)
 
     return workflow
 
 
-def _build_claude_security_jobs(python_version: str) -> str:
+def _build_claude_security_jobs(python_version: str, install_command: str) -> str:
     return f"""
   claude-security:
     runs-on: ubuntu-latest
@@ -181,12 +221,14 @@ def _build_claude_security_jobs(python_version: str) -> str:
           direct_prompt: "/review --output-file claude-security-results.json"
 
       - name: Upload Claude Security Results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: claude-security-results
           path: claude-security-results.json
 
   upload-claude-findings:
+    if: always()
     runs-on: ubuntu-latest
     needs: [skylos, claude-security]
     steps:
@@ -199,7 +241,7 @@ def _build_claude_security_jobs(python_version: str) -> str:
           python-version: '{python_version}'
 
       - name: Install Skylos
-        run: pip install skylos
+        run: {install_command}
 
       - name: Download Claude Security Results
         uses: actions/download-artifact@v4

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+import subprocess
 
 
 def _cicd_load_results(args, *, console_factory):
@@ -34,6 +35,22 @@ def _cicd_load_results(args, *, console_factory):
     except Exception as e:
         console_factory().print(f"[bold red]Analysis failed: {e}[/bold red]")
         return None, 1
+
+
+def _default_workflow_output() -> str:
+    try:
+        root = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--show-toplevel"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.SubprocessError, OSError):
+        root = ""
+    base = Path(root) if root else Path.cwd()
+    return str(base / ".github" / "workflows" / "skylos.yml")
 
 
 def run_cicd_command(
@@ -85,7 +102,15 @@ def run_cicd_command(
         help="Include AI Defense check step (skylos defend)",
     )
     p_ci_init.add_argument(
-        "--output", "-o", default=".github/workflows/skylos.yml", help="Output path"
+        "--scan-path",
+        default=".",
+        help="Project path to scan inside the repository, e.g. apps/api",
+    )
+    p_ci_init.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output path (default: repo-root .github/workflows/skylos.yml)",
     )
 
     p_ci_gate = cicd_sub.add_parser("gate", help="Check quality gate (CI exit code)")
@@ -149,8 +174,9 @@ def run_cicd_command(
             use_claude_security=cicd_args.claude_security,
             use_upload=cicd_args.upload,
             use_defend=cicd_args.defend,
+            scan_path=cicd_args.scan_path,
         )
-        write_workflow(yaml_content, cicd_args.output)
+        write_workflow(yaml_content, cicd_args.output or _default_workflow_output())
         return 0
 
     if cicd_args.cicd_cmd == "gate":

--- a/skylos/suite.py
+++ b/skylos/suite.py
@@ -16,7 +16,7 @@ _DEAD_CODE_CATEGORIES = (
     "unused_parameters",
 )
 
-_DEFENSE_NOTE = "AI defense currently scans Python direct SDK integrations only."
+_DEFENSE_NOTE = "AI defense currently scans Python and TypeScript direct SDK integrations."
 
 
 def _empty_defense_payload(project_path: str) -> dict[str, Any]:
@@ -188,7 +188,7 @@ def run_suite(
     from skylos.defend.engine import run_defense_checks
     from skylos.defend.policy import compute_owasp_coverage, load_policy
     from skylos.defend.report import format_defense_json
-    from skylos.discover.detector import _collect_python_files, detect_integrations
+    from skylos.discover.detector import _collect_ai_files, detect_integrations
 
     analyzer_logger = logging.getLogger("Skylos")
     original_level = analyzer_logger.level
@@ -305,7 +305,7 @@ def run_suite(
         disable=output_json,
     ) as progress:
         progress.add_task("Scanning AI defenses...", total=None)
-        files = _collect_python_files(target_path, exclude)
+        files = _collect_ai_files(target_path, exclude)
         integrations, graph = detect_integrations(target_path, exclude_folders=exclude)
 
     if integrations:

--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -870,15 +870,18 @@ jobs:
           python-version: '3.11'
       
       - name: Install Skylos
-        run: pip install skylos
+        run: python -m pip install skylos
 
       - name: Pull Skylos Cloud Policy
         run: |
           skylos sync pull || echo "No Skylos Cloud policy available through GitHub OIDC; continuing with local config."
       
-      - name: Run Skylos Scan
+      - name: Run Skylos Scan & Upload
         run: |
-          skylos . --danger --upload --sha ${{ github.event.pull_request.head.sha }}
+          skylos . --danger --secrets --quality --upload
+        env:
+          SKYLOS_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          SKYLOS_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
 """
         workflow_path.write_text(workflow_content)
         print("  ✓ Created GitHub Actions (.github/workflows/skylos.yml)")
@@ -987,14 +990,17 @@ jobs:
           python-version: '3.11'
       
       - name: Install Skylos
-        run: pip install skylos
+        run: python -m pip install skylos
 
       - name: Pull Skylos Cloud Policy
         run: |
           skylos sync pull || echo "No Skylos Cloud policy available through GitHub OIDC; continuing with local config."
       
-      - name: Run Skylos Scan
-        run: skylos . --danger --gate
+      - name: Run Skylos Scan & Upload
+        run: skylos . --danger --secrets --quality --upload
+        env:
+          SKYLOS_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          SKYLOS_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
 """
         workflow_path.write_text(workflow_content)
         print("  ✓ Created workflow\n")

--- a/test/test_cicd_workflow.py
+++ b/test/test_cicd_workflow.py
@@ -65,11 +65,13 @@ def test_workflow_no_llm_by_default():
     content = generate_workflow()
     assert "SKYLOS_API_KEY" not in content
     assert "agent review" not in content
+    assert "agent scan" not in content
 
 
 def test_workflow_with_llm():
     content = generate_workflow(use_llm=True, model="claude-sonnet-4-5-20250929")
-    assert "agent review" in content
+    assert "agent scan" in content
+    assert "--changed" in content
     assert "claude-sonnet-4-5-20250929" in content
     assert "SKYLOS_API_KEY" in content
 
@@ -115,8 +117,11 @@ def test_workflow_with_upload():
     analysis_step = next(s for s in steps if s.get("name") == "Run Skylos Analysis")
     assert "skylos sync pull" in sync_step["run"]
     assert "--upload" in analysis_step["run"]
+    assert analysis_step["env"] == {
+        "SKYLOS_COMMIT": "${{ github.event.pull_request.head.sha || github.sha }}",
+        "SKYLOS_BRANCH": "${{ github.event.pull_request.head.ref || github.ref_name }}",
+    }
     assert "env" not in sync_step
-    assert "env" not in analysis_step
 
 
 def test_workflow_upload_with_llm():
@@ -125,6 +130,22 @@ def test_workflow_upload_with_llm():
     steps = parsed["jobs"]["skylos"]["steps"]
     analysis_step = next(s for s in steps if s.get("name") == "Run Skylos Analysis")
     assert "--upload" in analysis_step["run"]
-    assert "env" not in analysis_step
+    assert "SKYLOS_COMMIT" in analysis_step["env"]
     llm_step = next(s for s in steps if s.get("name") == "Skylos Agent Review (LLM)")
     assert "SKYLOS_API_KEY" in llm_step["env"]
+
+
+def test_workflow_scan_path_is_monorepo_aware():
+    content = generate_workflow(scan_path="apps/api", use_upload=True, use_defend=True)
+    assert "skylos apps/api" in content
+    assert "skylos defend apps/api" in content
+
+
+def test_workflow_prefixes_leading_dash_scan_path():
+    content = generate_workflow(scan_path="-service")
+    assert "skylos ./-service" in content
+
+
+def test_workflow_pins_installed_skylos_version():
+    content = generate_workflow(skylos_version="4.9.0")
+    assert "python -m pip install skylos==4.9.0" in content

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -101,7 +101,7 @@ def test_suite_json_outputs_combined_sections(tmp_path, capsys):
     assert payload["provenance"]["enabled"] is False
     assert (
         payload["defense"]["note"]
-        == "AI defense currently scans Python direct SDK integrations only."
+        == "AI defense currently scans Python and TypeScript direct SDK integrations."
     )
 
 

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -692,6 +692,10 @@ def test_cmd_setup_writes_workflow_that_syncs_cloud_policy(
     assert "Pull Skylos Cloud Policy" in workflow
     assert "skylos sync pull" in workflow
     assert "id-token: write" in workflow
+    assert "skylos . --danger --secrets --quality --upload" in workflow
+    assert "--sha" not in workflow
+    assert "SKYLOS_COMMIT" in workflow
+    assert "SKYLOS_BRANCH" in workflow
     assert "SKYLOS_TOKEN" not in workflow
 
 
@@ -718,4 +722,8 @@ def test_cmd_upgrade_installs_parity_only_pre_push_hook(monkeypatch, tmp_path, c
     assert "Pull Skylos Cloud Policy" in workflow
     assert "skylos sync pull" in workflow
     assert "id-token: write" in workflow
+    assert "skylos . --danger --secrets --quality --upload" in workflow
+    assert "--sha" not in workflow
+    assert "SKYLOS_COMMIT" in workflow
+    assert "SKYLOS_BRANCH" in workflow
     assert "SKYLOS_TOKEN" not in workflow


### PR DESCRIPTION
## Summary

- harden generated Skylos CI workflows for enterprise upload usage
- replace stale generated `skylos agent review` usage with `skylos agent scan`
- add monorepo `--scan-path` support and repo-root workflow output handling
- remove unsupported `--sha` from `skylos sync setup` workflows and send PR head commit/branch metadata through env vars
- clarify generated workflow usage in the README

## Tests

- `/Users/skylos/.venv/bin/python -m pytest -q test/test_cicd_workflow.py test/test_sync.py test/test_suite.py test/test_ingest.py::TestWorkflowClaudeSecurity test/test_discover_typescript.py`

## Manual Test

- `skylos cicd init --upload --scan-path apps/api`
- generated workflow should run `skylos apps/api --danger --quality --secrets --upload`
- generated workflow should set `SKYLOS_COMMIT` and `SKYLOS_BRANCH`
