### PR TITLE
fix(cli, quality): honor gate exits and ignore annotation strings

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2616,7 +2616,31 @@ def _build_main_scan_context(args):
         logger=logger,
         console=console,
         final_exclude_folders=final_exclude_folders,
+        config=project_cfg,
     )
+
+
+def _formatted_output_gate_exit_code(
+    result: dict,
+    config: dict,
+    args,
+    *,
+    provenance=None,
+) -> int:
+    """Evaluate --gate for output modes that must not print gate UI."""
+    from skylos.gatekeeper import build_summary_markdown, check_gate, write_github_summary
+
+    config = config or {}
+    gate_cfg = config.get("gate") or {}
+    strict = bool(getattr(args, "strict", False) or gate_cfg.get("strict", False))
+    passed, reasons = check_gate(result, config, strict=strict, provenance=provenance)
+
+    if bool(getattr(args, "summary", False)):
+        write_github_summary(build_summary_markdown(result, passed, reasons))
+
+    if passed or bool(getattr(args, "force", False)):
+        return 0
+    return 1
 
 
 def _apply_config_driven_analysis_flags(args, project_cfg, console):
@@ -4563,6 +4587,7 @@ def main() -> None:
     logger = context.logger
     console = context.console
     final_exclude_folders = context.final_exclude_folders
+    config = context.config
 
     if _print_main_scan_banner(args, console, final_exclude_folders):
         return
@@ -4948,6 +4973,16 @@ def main() -> None:
                 if passed is False and not args.force:
                     raise SystemExit(1)
 
+            if args.gate:
+                exit_code = _formatted_output_gate_exit_code(
+                    result,
+                    config,
+                    args,
+                    provenance=prov_report,
+                )
+                if exit_code:
+                    raise SystemExit(exit_code)
+
             return
 
         if args.llm:
@@ -4958,17 +4993,34 @@ def main() -> None:
                     console.print(f"[good]LLM report written to {args.output}[/good]")
             else:
                 print(llm_report)
+
+            if args.gate:
+                exit_code = _formatted_output_gate_exit_code(
+                    result,
+                    config,
+                    args,
+                    provenance=prov_report,
+                )
+                if exit_code:
+                    raise SystemExit(exit_code)
             return
 
         if args.github:
             _emit_github_annotations(result)
+            if args.gate:
+                exit_code = _formatted_output_gate_exit_code(
+                    result,
+                    config,
+                    args,
+                    provenance=prov_report,
+                )
+                if exit_code:
+                    raise SystemExit(exit_code)
             return
 
     except Exception as e:
         logger.error(f"Error during analysis: {e}")
         sys.exit(1)
-
-    config = load_config(project_root)
 
     if args.gate:
         should_upload_gate = bool(getattr(args, "upload", False)) and not bool(

--- a/skylos/rules/quality/logic.py
+++ b/skylos/rules/quality/logic.py
@@ -2509,6 +2509,34 @@ class DuplicateStringLiteralRule(SkylosRule):
             return True
         return False
 
+    def _is_annotation_literal(self, node, parent_map):
+        current = node
+        type_alias_node = getattr(ast, "TypeAlias", None)
+
+        while True:
+            parent = parent_map.get(id(current))
+            if parent is None:
+                return False
+
+            if isinstance(parent, ast.arg) and parent.annotation is current:
+                return True
+
+            if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if parent.returns is current:
+                    return True
+
+            if isinstance(parent, ast.AnnAssign) and parent.annotation is current:
+                return True
+
+            if (
+                type_alias_node is not None
+                and isinstance(parent, type_alias_node)
+                and parent.value is current
+            ):
+                return True
+
+            current = parent
+
     def visit_node(self, node, context):
         if not isinstance(node, ast.Module):
             return None
@@ -2532,6 +2560,8 @@ class DuplicateStringLiteralRule(SkylosRule):
                 if self._is_docstring(child, parent_map):
                     continue
                 if self._is_structural_key_literal(child, parent_map):
+                    continue
+                if self._is_annotation_literal(child, parent_map):
                     continue
                 key = child.value
                 if key not in string_occurrences:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -840,6 +840,93 @@ def test_main_json_upload_calls_upload_report_quiet(monkeypatch):
     assert "provenance_summary" in printed_payload
 
 
+def test_main_json_gate_failure_exits_nonzero(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-Q001",
+                "file": "app.py",
+                "line": 1,
+                "severity": "LOW",
+                "message": "quality issue",
+            }
+        ],
+        "secrets": [],
+    }
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", ".", "--json", "--gate", "--strict", "--no-provenance"],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("builtins.print") as mock_print,
+    ):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+
+    assert e.value.code == 1
+    mock_print.assert_called_once_with(json.dumps(result))
+
+
+def test_main_llm_gate_failure_exits_nonzero(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-Q001",
+                "file": "app.py",
+                "line": 1,
+                "severity": "LOW",
+                "message": "quality issue",
+            }
+        ],
+        "secrets": [],
+    }
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", ".", "--llm", "--gate", "--strict", "--no-provenance"],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("builtins.print") as mock_print,
+    ):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+
+    assert e.value.code == 1
+    assert mock_print.call_args.args[0].startswith("# Skylos Report")
+
+
 def test_main_upload_gate_failed_does_not_exit_when_forced(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},

--- a/test/test_quality_standards.py
+++ b/test/test_quality_standards.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 import ast
-import json
 import textwrap
-
-import pytest
 
 from skylos.rules.quality.standards import (
     CWE_MAP,
@@ -144,6 +141,49 @@ def baz():
     pass
 '''
         assert self._run(code) is None
+
+    def test_skips_quoted_return_annotations(self):
+        code = """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    class ForwardThing:
+        pass
+
+
+def foo() -> "ForwardThing | None":
+    return None
+"""
+        assert self._run(code, threshold=1) is None
+
+    def test_skips_quoted_argument_and_variable_annotations(self):
+        code = """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    class ForwardThing:
+        pass
+
+
+def foo(item: "ForwardThing") -> None:
+    selected: "ForwardThing | None" = item
+    return None
+"""
+        assert self._run(code, threshold=1) is None
+
+    def test_skips_nested_quoted_annotations(self):
+        code = """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    class ForwardThing:
+        pass
+
+
+def foo() -> list["ForwardThing"]:
+    return []
+"""
+        assert self._run(code, threshold=1) is None
 
     def test_below_threshold(self):
         code = """


### PR DESCRIPTION
## Summary

Fixed 2 bugs for issues #273 and #274.

  1. `--gate --strict` now fails correctly when used with `--json` or `--llm`.
  2. `SKY-L027` should not flag quoted Python type annotations like `-> "Foo | None"` as duplicate strings.

## What Changed

### 1. Gate failures with formatted output

Happened because the CLI returned immediately after printing JSON or LLM output.. So it never
reached the gate checking code. Fixed it by adding gate check for formatted output modes. JSON/LLM output is still printed normally, but the process now exits 1 when the gate fails.

### 2. Quoted annotations flagged by SKY-L027

Annotation could be reported as a duplicate string:

```
  def foo() -> "Foo | None":
      return None
```

The bug happened because DuplicateStringLiteralRule walked every ast.Constant(str) and counted it unless it was a docstring or structural key.

The fix skips string constants that are part of:

  - return annotations
  - function argument annotations
  - variable annotations
  - nested annotations like list["Foo"]
  - Python type aliases

## Manual Verification

### Issue #273

Ran:
```
python -m skylos.cli benchmarks/quality/fixtures/long_function --gate --strict --quality --json --no-provenance
python -m skylos.cli benchmarks/quality/fixtures/long_function --gate --strict --quality --llm --no-provenance
```

Result:

Found the findings and exited with code 1.

### Issue #274

Created the issue repro with duplicate_strings = 1:

```
 from typing import TYPE_CHECKING

  if TYPE_CHECKING:
      type Foo = int | float


  def foo() -> "Foo | None":
      return None
```

and  ran:

```
python -m skylos.cli /tmp/skylos-274-repro/repro.py --quality --llm --no-provenance
python -m skylos.cli /tmp/skylos-274-repro/repro.py --quality --json --no-provenance
```

Result:

SKY-L027 was not reported

## Tests
```
- pytest -q test/test_cli.py test/test_cicd_gate.py test/test_gate_kwargs.py test/test_quality_standards.py test/test_quality_rules.py
- python -m ruff check skylos/cli.py
- python -m ruff check skylos/rules/quality/logic.py test/test_quality_standards.py
```