### PR TITLE
fix(cli): honor strict scan exit codes

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2329,7 +2329,7 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Strict gate: fail if ANY issue is found",
+        help="Fail if ANY issue is found; with --gate, use strict gate rules",
     )
     parser.add_argument(
         "--tui",
@@ -2741,6 +2741,19 @@ def _format_concise_results(result: dict, *, root_path=None, limit=None) -> str:
     if not lines:
         return ""
     return "\n".join(lines) + "\n"
+
+
+def _strict_scan_exit_code(result: dict, args) -> int:
+    """Evaluate --strict when it is used without --gate."""
+    if not bool(getattr(args, "strict", False)):
+        return 0
+    if bool(getattr(args, "gate", False)) or bool(getattr(args, "force", False)):
+        return 0
+
+    from skylos.gatekeeper import check_gate
+
+    passed, _reasons = check_gate(result, {}, strict=True)
+    return 0 if passed else 1
 
 
 def _apply_config_driven_analysis_flags(args, project_cfg, console):
@@ -5098,6 +5111,10 @@ def main() -> None:
                 if exit_code:
                     raise SystemExit(exit_code)
 
+            strict_exit_code = _strict_scan_exit_code(result, args)
+            if strict_exit_code:
+                raise SystemExit(strict_exit_code)
+
             return
 
         if args.concise:
@@ -5152,6 +5169,10 @@ def main() -> None:
                 )
                 if exit_code:
                     raise SystemExit(exit_code)
+
+            strict_exit_code = _strict_scan_exit_code(result, args)
+            if strict_exit_code:
+                raise SystemExit(strict_exit_code)
             return
 
         if args.github:
@@ -5165,6 +5186,10 @@ def main() -> None:
                 )
                 if exit_code:
                     raise SystemExit(exit_code)
+
+            strict_exit_code = _strict_scan_exit_code(result, args)
+            if strict_exit_code:
+                raise SystemExit(strict_exit_code)
             return
 
     except Exception as e:
@@ -5316,6 +5341,10 @@ def main() -> None:
         quality_enabled=bool(quality_count),
         quality_count=quality_count,
     )
+
+    strict_exit_code = _strict_scan_exit_code(result, args)
+    if strict_exit_code:
+        raise SystemExit(strict_exit_code)
 
     if (not args.json) and _is_tty() and (not args.upload):
         total_findings = 0

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -964,6 +964,79 @@ def test_main_concise_clean_output_prints_nothing(monkeypatch):
     progress.assert_not_called()
 
 
+def test_main_json_strict_failure_exits_nonzero(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [{"name": "dead", "file": "app.py", "line": 1}],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", ".", "--json", "--strict", "--no-provenance"],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("builtins.print") as mock_print,
+    ):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+
+    assert e.value.code == 1
+    mock_print.assert_called_once_with(json.dumps(result))
+
+
+def test_main_strict_failure_renders_results_then_exits_nonzero(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [{"name": "dead", "file": "app.py", "line": 1}],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", ".", "--strict", "--no-provenance"],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.render_results") as render_results,
+        patch("skylos.cli.print_badge") as badge,
+    ):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+
+    assert e.value.code == 1
+    render_results.assert_called_once()
+    badge.assert_called_once()
+
+
 def test_main_llm_gate_failure_exits_nonzero(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},


### PR DESCRIPTION
## Summary
- make `--strict` fail with exit code 1 when a scan reports any finding, even without `--gate`
- preserve the normal formatted report before exiting nonzero
- keep the fix compatible with the newer `--format concise` output path from #279
- add regression coverage for JSON and formatted strict output paths

## Repro
Created the exact issue fixture:

```py
def unused_function() -> None:
    pass

class UnusedClass:
    """not used"""
```

Old v4.9.0 behavior at `b74b264`:
- command: `python -m skylos.cli --strict /tmp/skylos-issue-276/test.py`
- output reports 1 unused function and 1 unused class
- exit code: 0

Patched behavior on this branch:
- command: `python -m skylos.cli --strict /tmp/skylos-issue-276/test.py`
- output reports the same 1 unused function and 1 unused class
- exit code: 1

Also verified `--strict --gate` fails with `Strict mode: 2 issue(s) found` and exit code 1.

## Conflict Resolution
- rebased on current `origin/main` after #279 merged
- resolved conflicts in `skylos/cli.py` and `test/test_cli.py`
- preserved both the strict exit-code fix and concise output behavior

## Tests
- `.venv/bin/pytest -q test/test_cli.py::test_main_json_strict_failure_exits_nonzero test/test_cli.py::test_main_strict_failure_renders_results_then_exits_nonzero test/test_cli.py::test_main_concise_outputs_clickable_dead_code_and_exits_nonzero test/test_cli.py::test_main_concise_clean_output_prints_nothing test/test_cli.py::test_main_json_gate_failure_exits_nonzero test/test_cli.py::test_main_llm_gate_failure_exits_nonzero` -> 6 passed
- `.venv/bin/pytest -q test/test_cli.py test/test_gatekeeper.py test/test_gate_kwargs.py` -> 81 passed
- `git diff --check` -> passed
- GitHub Actions for this PR -> passed

Fixes #276
