### PR TITLE
fix(cli): repair display severity filtering

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1305,11 +1305,11 @@ def _apply_display_filters(result, severity=None, category=None, file_filter=Non
                         break
 
                 if has_severity:
-                    filtered = []
+                    severity_filtered = []
                     for item in kept:
                         if _passes_severity(item):
-                            filtered.append(item)
-                    kept = filtered
+                            severity_filtered.append(item)
+                    kept = severity_filtered
 
         filtered[key] = kept
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -451,6 +451,54 @@ def test_shorten_path_non_pathlike_returns_str():
     assert cli._shorten_path(123) == "123"
 
 
+def test_apply_display_filters_severity_filters_without_crashing():
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "quality": [
+            {"severity": "LOW", "file": "src/a.py", "message": "low"},
+            {"severity": "MEDIUM", "file": "src/b.py", "message": "medium"},
+            {"severity": "HIGH", "file": "src/c.py", "message": "high"},
+        ],
+        "danger": [],
+        "secrets": [],
+        "unused_functions": [{"name": "unused", "file": "src/a.py", "line": 1}],
+    }
+
+    filtered = cli._apply_display_filters(result, severity="medium")
+
+    assert filtered["quality"] == [
+        {"severity": "MEDIUM", "file": "src/b.py", "message": "medium"},
+        {"severity": "HIGH", "file": "src/c.py", "message": "high"},
+    ]
+    assert filtered["unused_functions"] == result["unused_functions"]
+    assert filtered["analysis_summary"] == result["analysis_summary"]
+
+
+def test_apply_display_filters_combines_category_file_and_severity():
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "quality": [
+            {"severity": "HIGH", "file": "src/keep.py", "message": "keep"},
+            {"severity": "LOW", "file": "src/keep.py", "message": "drop severity"},
+            {"severity": "HIGH", "file": "src/drop.py", "message": "drop file"},
+        ],
+        "danger": [
+            {"severity": "HIGH", "file": "src/keep.py", "message": "drop category"}
+        ],
+        "secrets": [],
+        "unused_functions": [],
+    }
+
+    filtered = cli._apply_display_filters(
+        result, severity="medium", category="quality", file_filter="keep.py"
+    )
+
+    assert filtered["quality"] == [
+        {"severity": "HIGH", "file": "src/keep.py", "message": "keep"}
+    ]
+    assert filtered["danger"] == []
+
+
 def test_comment_out_unused_import_handles_exception_and_returns_false():
     with (
         patch("pathlib.Path.read_text", return_value="import os\n"),


### PR DESCRIPTION
## Summary

- fix `--severity` display filtering crash in `_apply_display_filters()`
- keep existing severity/category/file filtering behavior unchanged
- add regression coverage for severity filtering and combined filters

## Repro

The crash happened because `filtered` starts as the result dictionary, but inside the severity filter block it was reused as a list.

Buggy code path:

```py
filtered = copy.copy(result)
...
filtered = []
...
filtered[key] = kept
```

After `filtered` became a list, `filtered[key] = kept` could crash.

The fix keeps the severity-filtered list in a separate variable:

```py
severity_filtered = []
```

Changed code:

- `skylos/cli.py:1308`

## Tests

- `pytest -q test/test_cli.py::test_apply_display_filters_severity_filters_without_crashing test/test_cli.py::test_apply_display_filters_combines_category_file_and_severity` -> 2 passed
- `pytest -q test/test_cli.py` -> 52 passed
- `ruff check skylos/cli.py` -> passed

Note: full `ruff check skylos/cli.py test/test_cli.py` still reports pre-existing unused `logger` variables in `test/test_cli.py:45` and `test/test_cli.py:57`; this PR leaves those unrelated lines untouched.