### PR TITLE
feat(debt): show saved history

### DIFF
--- a/skylos/commands/debt_cmd.py
+++ b/skylos/commands/debt_cmd.py
@@ -81,6 +81,17 @@ def run_debt_command(
         help="Append the current debt summary to the history log",
     )
     debt_parser.add_argument(
+        "--show-history",
+        action="store_true",
+        help="Show saved debt history without running a new scan",
+    )
+    debt_parser.add_argument(
+        "--history-limit",
+        type=int,
+        default=None,
+        help="Maximum number of saved history entries to show",
+    )
+    debt_parser.add_argument(
         "--policy",
         dest="policy_file",
         help="Path to skylos-debt.yaml policy file",
@@ -108,9 +119,12 @@ def run_debt_command(
         append_history as append_debt_history,
         augment_hotspots_with_advisories,
         compare_to_baseline as compare_debt_baseline,
+        format_debt_history_json,
+        format_debt_history_table,
         format_debt_json,
         format_debt_table,
         load_baseline as load_debt_baseline,
+        load_history as load_debt_history,
         load_policy as load_debt_policy,
         run_debt_analysis,
         save_baseline as save_debt_baseline,
@@ -135,6 +149,44 @@ def run_debt_command(
             f"[red]Error: --agent-top must be > 0, got {debt_args.agent_top}[/red]"
         )
         return 1
+    if debt_args.history_limit is not None and debt_args.history_limit <= 0:
+        console.print(
+            f"[red]Error: --history-limit must be > 0, got {debt_args.history_limit}[/red]"
+        )
+        return 1
+
+    if debt_args.show_history:
+        try:
+            history_entries = load_debt_history(target)
+        except ValueError as e:
+            console.print(f"[red]Error reading debt history: {e}[/red]")
+            return 1
+
+        if debt_args.output_json:
+            visible_entries = (
+                history_entries[-debt_args.history_limit :]
+                if debt_args.history_limit
+                else history_entries
+            )
+            output = format_debt_history_json(visible_entries)
+        else:
+            output = format_debt_history_table(
+                history_entries,
+                limit=debt_args.history_limit,
+            )
+
+        if debt_args.output_file:
+            try:
+                Path(debt_args.output_file).write_text(output, encoding="utf-8")  # skylos: ignore[SKY-D215]
+            except OSError as e:
+                console.print(f"[red]Error writing output file: {e}[/red]")
+                return 1
+            console.print(f"[green]Output written to {debt_args.output_file}[/green]")
+        elif debt_args.output_json:
+            print(output)
+        else:
+            console.print(output)
+        return 0
 
     exclude = set(
         parse_exclude_folders_func(

--- a/skylos/debt/__init__.py
+++ b/skylos/debt/__init__.py
@@ -3,10 +3,16 @@ from skylos.debt.baseline import (
     annotate_hotspots,
     compare_to_baseline,
     load_baseline,
+    load_history,
     save_baseline,
 )
 from skylos.debt.policy import DebtPolicy, load_policy
-from skylos.debt.report import format_debt_json, format_debt_table
+from skylos.debt.report import (
+    format_debt_history_json,
+    format_debt_history_table,
+    format_debt_json,
+    format_debt_table,
+)
 from skylos.debt.result import (
     DebtAdvisory,
     DebtHotspot,
@@ -56,8 +62,11 @@ __all__ = [
     "DebtSignal",
     "DebtSnapshot",
     "format_debt_json",
+    "format_debt_history_json",
+    "format_debt_history_table",
     "format_debt_table",
     "load_baseline",
+    "load_history",
     "load_policy",
     "run_debt_analysis",
     "save_baseline",

--- a/skylos/debt/baseline.py
+++ b/skylos/debt/baseline.py
@@ -9,6 +9,7 @@ from skylos.debt.scoring import refresh_hotspot_priority
 BASELINE_DIR = ".skylos"
 BASELINE_FILE = "debt_baseline.json"
 HISTORY_FILE = "debt_history.jsonl"
+HISTORY_HOTSPOT_LIMIT = 5
 
 
 def _baseline_path(project_root: str | Path) -> Path:
@@ -62,6 +63,49 @@ def load_baseline(project_root: str | Path) -> dict | None:
     if not path.exists():
         return None
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_history(project_root: str | Path) -> list[dict]:
+    path = _history_path(project_root)
+    if not path.exists():
+        return []
+
+    entries = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_number, line in enumerate(lines, 1):
+        raw = line.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{line_number}: invalid JSON") from exc
+        if not isinstance(entry, dict):
+            raise ValueError(f"{path}:{line_number}: expected JSON object")
+        entries.append(entry)
+    return entries
+
+
+def _history_hotspots(snapshot: DebtSnapshot) -> list[dict]:
+    source_hotspots = snapshot.all_hotspots or snapshot.hotspots
+    ordered = sorted(
+        source_hotspots,
+        key=lambda hotspot: (
+            -float(getattr(hotspot, "priority_score", hotspot.score)),
+            -float(hotspot.score),
+            hotspot.file,
+        ),
+    )
+    return [
+        {
+            "file": hotspot.file,
+            "score": hotspot.score,
+            "priority_score": hotspot.priority_score,
+            "signal_count": hotspot.signal_count,
+            "primary_dimension": hotspot.primary_dimension,
+        }
+        for hotspot in ordered[:HISTORY_HOTSPOT_LIMIT]
+    ]
 
 
 def annotate_hotspots(
@@ -132,6 +176,7 @@ def append_history(project_root: str | Path, snapshot: DebtSnapshot) -> Path:
         "project": snapshot.project,
         "score": snapshot.score.to_dict(),
         "summary": _summary_for_project_persistence(snapshot),
+        "hotspots": _history_hotspots(snapshot),
     }
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(entry) + "\n")

--- a/skylos/debt/report.py
+++ b/skylos/debt/report.py
@@ -136,3 +136,111 @@ def format_debt_table(snapshot: DebtSnapshot, *, top: int | None = None) -> str:
 
 def format_debt_json(snapshot: DebtSnapshot) -> str:
     return json.dumps(snapshot.to_dict(), indent=2)
+
+
+def _history_score_pct(entry: dict) -> int | None:
+    score_pct = (entry.get("score") or {}).get("score_pct")
+    if score_pct is None or isinstance(score_pct, bool):
+        return None
+    try:
+        return int(score_pct)
+    except (TypeError, ValueError):
+        return None
+
+
+def _history_value(score: dict, key: str) -> str:
+    value = score.get(key)
+    return "-" if value is None else str(value)
+
+
+def _history_row(entry: dict, previous_score: int | None) -> tuple[str, int | None]:
+    score = entry.get("score") or {}
+    score_pct = _history_score_pct(entry)
+    score_text = "-" if score_pct is None else f"{score_pct}%"
+    delta_text = (
+        "-"
+        if score_pct is None or previous_score is None
+        else f"{score_pct - previous_score:+d}"
+    )
+    line = (
+        f"{str(entry.get('timestamp') or '-'):<32} "
+        f"{score_text:>6} "
+        f"{delta_text:>6} "
+        f"{_history_value(score, 'risk_rating'):<10} "
+        f"{_history_value(score, 'hotspot_count'):>8} "
+        f"{_history_value(score, 'signal_count'):>8}"
+    )
+    return line, score_pct
+
+
+def _history_hotspots(entry: dict) -> list[dict]:
+    hotspots = entry.get("hotspots") or []
+    if not isinstance(hotspots, list):
+        return []
+    return [hotspot for hotspot in hotspots if isinstance(hotspot, dict)]
+
+
+def _history_hotspot_value(hotspot: dict, key: str) -> str:
+    value = hotspot.get(key)
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def _history_hotspot_line(index: int, hotspot: dict) -> str:
+    return (
+        f"  {index}. {_history_hotspot_value(hotspot, 'file')} | "
+        f"score={_history_hotspot_value(hotspot, 'score')} | "
+        f"signals={_history_hotspot_value(hotspot, 'signal_count')} | "
+        f"{_history_hotspot_value(hotspot, 'primary_dimension')}"
+    )
+
+
+def _latest_hotspot_lines(entry: dict) -> list[str]:
+    hotspots = _history_hotspots(entry)
+    lines = ["", "Latest Top Hotspots:"]
+    if not hotspots:
+        lines.append("  Not recorded in saved history.")
+        return lines
+    lines.extend(
+        _history_hotspot_line(index, hotspot)
+        for index, hotspot in enumerate(hotspots, 1)
+    )
+    return lines
+
+
+def format_debt_history_table(
+    entries: list[dict],
+    *,
+    limit: int | None = None,
+) -> str:
+    if not entries:
+        return "\nSkylos Debt History\nNo debt history found."
+
+    visible = entries[-limit:] if limit else entries
+    lines = [
+        "",
+        "Skylos Debt History",
+        f"Entries: {len(visible)} shown ({len(entries)} total)",
+        "",
+        "Timestamp                         Score  Delta Risk       Hotspots  Signals",
+    ]
+    first_visible_index = len(entries) - len(visible)
+    previous_score = (
+        _history_score_pct(entries[first_visible_index - 1])
+        if first_visible_index > 0
+        else None
+    )
+    for entry in visible:
+        line, score_pct = _history_row(entry, previous_score)
+        lines.append(line)
+        if score_pct is not None:
+            previous_score = score_pct
+    lines.extend(_latest_hotspot_lines(visible[-1]))
+    return "\n".join(lines)
+
+
+def format_debt_history_json(entries: list[dict]) -> str:
+    return json.dumps({"history": entries}, indent=2)

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -12,14 +12,23 @@ from skylos.debt.advisor import (
     _user_prompt,
     augment_hotspots_with_advisories,
 )
-from skylos.debt.baseline import compare_to_baseline, save_baseline
+from skylos.debt.baseline import (
+    append_history,
+    compare_to_baseline,
+    load_history,
+    save_baseline,
+)
 from skylos.debt.engine import (
     build_debt_snapshot,
     collect_debt_signals,
     run_debt_analysis,
 )
 from skylos.debt.policy import _parse_policy, load_policy
-from skylos.debt.report import format_debt_table
+from skylos.debt.report import (
+    format_debt_history_json,
+    format_debt_history_table,
+    format_debt_table,
+)
 from skylos.debt.result import (
     DebtAdvisory,
     DebtHotspot,
@@ -240,6 +249,23 @@ def test_save_baseline_normalizes_changed_scope_to_project(tmp_path):
 
     assert payload["summary"]["scope"]["hotspots"] == "project"
     assert "baseline" not in payload["summary"]
+
+
+def test_load_history_reads_saved_jsonl_entries(tmp_path):
+    snapshot = _snapshot(str(tmp_path))
+
+    append_history(tmp_path, snapshot)
+    entries = load_history(tmp_path)
+
+    assert len(entries) == 1
+    assert entries[0]["timestamp"] == "2026-03-28T00:00:00+00:00"
+    assert entries[0]["score"]["score_pct"] == 93
+    assert entries[0]["hotspots"][0]["file"] == "app/services.py"
+    assert entries[0]["hotspots"][0]["score"] == 14.0
+
+
+def test_load_history_returns_empty_for_missing_history(tmp_path):
+    assert load_history(tmp_path) == []
 
 
 def test_parse_policy_accepts_gate_and_report():
@@ -521,6 +547,67 @@ def test_format_debt_table_orders_by_priority_and_applies_top_limit():
     assert "app/services.py" not in rendered
 
 
+def test_format_debt_history_table_renders_deltas_and_limit():
+    entries = [
+        {
+            "timestamp": "2026-03-28T00:00:00+00:00",
+            "score": {
+                "score_pct": 93,
+                "risk_rating": "LOW",
+                "hotspot_count": 1,
+                "signal_count": 1,
+            },
+        },
+        {
+            "timestamp": "2026-03-29T00:00:00+00:00",
+            "score": {
+                "score_pct": 90,
+                "risk_rating": "MODERATE",
+                "hotspot_count": 2,
+                "signal_count": 4,
+            },
+            "hotspots": [
+                {
+                    "file": "app/core.py",
+                    "score": 18.0,
+                    "signal_count": 3,
+                    "primary_dimension": "complexity",
+                }
+            ],
+        },
+    ]
+
+    rendered = format_debt_history_table(entries)
+    limited = format_debt_history_table(entries, limit=1)
+
+    assert "Skylos Debt History" in rendered
+    assert "Entries: 2 shown (2 total)" in rendered
+    assert "2026-03-29T00:00:00+00:00" in rendered
+    assert "-3" in rendered
+    assert "Entries: 1 shown (2 total)" in limited
+    assert "-3" in limited
+    assert "Latest Top Hotspots:" in limited
+    assert "app/core.py | score=18.00 | signals=3 | complexity" in limited
+    assert "2026-03-28T00:00:00+00:00" not in limited
+
+
+def test_format_debt_history_table_handles_old_entries_without_hotspots():
+    entries = [{"timestamp": "2026-03-28T00:00:00+00:00", "score": {}}]
+
+    rendered = format_debt_history_table(entries)
+
+    assert "Latest Top Hotspots:" in rendered
+    assert "Not recorded in saved history." in rendered
+
+
+def test_format_debt_history_json_wraps_entries():
+    entries = [{"timestamp": "2026-03-28T00:00:00+00:00", "score": {}}]
+
+    payload = json.loads(format_debt_history_json(entries))
+
+    assert payload == {"history": entries}
+
+
 def test_cli_debt_json_outputs_snapshot_and_exits_zero(tmp_path, monkeypatch):
     snapshot = _snapshot(str(tmp_path))
     monkeypatch.setattr(sys, "argv", ["skylos", "debt", str(tmp_path), "--json"])
@@ -728,3 +815,98 @@ def test_cli_debt_history_requires_project_root_scan(tmp_path, monkeypatch):
     mock_history.assert_not_called()
     message = mock_console.print.call_args.args[0]
     assert "--history only supports project-root scans" in message
+
+
+def test_cli_debt_show_history_reads_history_without_scanning(tmp_path, monkeypatch):
+    history_dir = tmp_path / ".skylos"
+    history_dir.mkdir()
+    (history_dir / "debt_history.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-03-28T00:00:00+00:00",
+                "score": {
+                    "score_pct": 93,
+                    "risk_rating": "LOW",
+                    "hotspot_count": 1,
+                    "signal_count": 1,
+                },
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "timestamp": "2026-03-29T00:00:00+00:00",
+                "score": {
+                    "score_pct": 90,
+                    "risk_rating": "MODERATE",
+                    "hotspot_count": 2,
+                    "signal_count": 4,
+                },
+                "hotspots": [
+                    {
+                        "file": "app/core.py",
+                        "score": 18.0,
+                        "signal_count": 3,
+                        "primary_dimension": "complexity",
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "debt", str(tmp_path), "--show-history", "--history-limit", "1"],
+    )
+    mock_console = Mock()
+
+    with (
+        patch("skylos.debt.run_debt_analysis") as mock_scan,
+        patch("skylos.cli.Console", return_value=mock_console),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    mock_scan.assert_not_called()
+    output = mock_console.print.call_args.args[0]
+    assert "Skylos Debt History" in output
+    assert "Entries: 1 shown (2 total)" in output
+    assert "2026-03-29T00:00:00+00:00" in output
+    assert "app/core.py | score=18.00 | signals=3 | complexity" in output
+    assert "2026-03-28T00:00:00+00:00" not in output
+
+
+def test_cli_debt_show_history_json_outputs_saved_entries(tmp_path, monkeypatch):
+    history_dir = tmp_path / ".skylos"
+    history_dir.mkdir()
+    (history_dir / "debt_history.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-03-28T00:00:00+00:00",
+                "score": {"score_pct": 93},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "debt", str(tmp_path), "--show-history", "--json"],
+    )
+
+    with (
+        patch("skylos.debt.run_debt_analysis") as mock_scan,
+        patch("builtins.print") as mock_print,
+        patch("skylos.cli.Console", return_value=Mock()),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    mock_scan.assert_not_called()
+    payload = json.loads(mock_print.call_args.args[0])
+    assert payload["history"][0]["score"]["score_pct"] == 93


### PR DESCRIPTION
## Summary

  - add `skylos debt . --show-history` to read saved debt history without running a new scan
  - add `--history-limit <n>` for limiting saved history output
  - include latest top hotspot files in newly saved debt history entries
  - keep old history entries readable even when hotspot details were not recorded

## What Changed

  `--history` now stores a compact list of the latest top hotspot files in `.skylos/
  debt_history.jsonl`.

  `--show-history` prints the saved score trend plus the latest recorded hotspot files, for
  example:

  ```text
  Latest Top Hotspots:
    1. skylos/cli.py | score=36.50 | signals=6 | maintainability
    2. skylos/analyzer.py | score=35.00 | signals=5 | complexity

  --show-history --json returns the saved history entries as JSON.

## Tests

  - pytest test/test_debt.py
  - pytest test/test_cli_refactor_guardrails.py test/test_cli.py