### PR TITLE
feat(security): flag mixed-script paths

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2273,15 +2273,17 @@ class Skylos:
                     )
 
                     injection_candidates = list(files)
+                    injection_root = Path(
+                        path[0] if isinstance(path, (list, tuple)) else path
+                    ).resolve()
+                    if injection_root.is_file():
+                        injection_root = injection_root.parent
                     if changed_files is not None:
                         injection_candidates = [Path(f) for f in changed_files]
                     else:
                         seen_injection_files = {
                             str(Path(f).resolve()) for f in injection_candidates
                         }
-                        injection_root = Path(
-                            path[0] if isinstance(path, (list, tuple)) else path
-                        ).resolve()
                         if injection_root.is_dir():
                             for dirpath, dirnames, filenames in os.walk(injection_root):
                                 dirnames[:] = [
@@ -2300,7 +2302,11 @@ class Skylos:
                                     seen_injection_files.add(fkey)
                                     injection_candidates.append(fpath)
                     for f in injection_candidates:
-                        inj_hits = _injection_scan_file(f)
+                        try:
+                            scan_path = Path(f).resolve().relative_to(injection_root)
+                        except ValueError:
+                            scan_path = None
+                        inj_hits = _injection_scan_file(f, scan_path=scan_path)
                         if inj_hits:
                             all_dangers.extend(inj_hits)
                 except Exception:

--- a/skylos/injection_scanner.py
+++ b/skylos/injection_scanner.py
@@ -98,7 +98,7 @@ _PROMPT_KEYS_RE = re.compile(
 )
 
 
-def scan_file(filepath: str | Path) -> list[dict]:
+def scan_file(filepath: str | Path, *, scan_path: str | Path | None = None) -> list[dict]:
     filepath = Path(filepath)
     if not filepath.is_file():
         return []
@@ -116,10 +116,11 @@ def scan_file(filepath: str | Path) -> list[dict]:
     except OSError:
         return []
 
-    if not source.strip():
-        return []
-
     findings: list[dict] = []
+    _add_path_homoglyph_findings(findings, filepath, scan_path or filepath.name)
+
+    if not source.strip():
+        return findings
 
     _, zero_width_hits = strip_zero_width(source)
     for char_hex, line_no in zero_width_hits:
@@ -137,27 +138,7 @@ def scan_file(filepath: str | Path) -> list[dict]:
             )
         )
 
-    homoglyphs = detect_homoglyphs(source)
-    if homoglyphs:
-        seen_lines: set[int] = set()
-        for char, ascii_like, line_no in homoglyphs:
-            if line_no in seen_lines:
-                continue
-            seen_lines.add(line_no)
-            char_hex = f"U+{ord(char):04X}"
-            findings.append(
-                _make_finding(
-                    filepath,
-                    line_no,
-                    "mixed_script",
-                    "MEDIUM",
-                    char_hex,
-                    f"{char}→{ascii_like}",
-                    f"Non-ASCII character '{char}' (U+{ord(char):04X}) visually resembles "
-                    f"ASCII '{ascii_like}'. Mixed-script text can hide instructions "
-                    f"from human reviewers while remaining readable to AI agents.",
-                )
-            )
+    _add_source_homoglyph_findings(findings, filepath, source)
 
     segments = _extract_segments(source, ext, filepath)
 
@@ -244,7 +225,7 @@ def scan_directory(
         if any(p in all_excludes or p.startswith(".") for p in parts[:-1]):
             continue
 
-        findings.extend(scan_file(filepath))
+        findings.extend(scan_file(filepath, scan_path=rel))
 
     return findings
 
@@ -323,6 +304,52 @@ def _extract_segments(
                         segments.append((value, line_no, "env_value"))
 
     return segments
+
+
+def _add_path_homoglyph_findings(
+    findings: list[dict], filepath: Path, scan_path: str | Path
+) -> None:
+    path_text = Path(scan_path).as_posix()
+    for char, ascii_like, _line_no in detect_homoglyphs(path_text):
+        char_hex = f"U+{ord(char):04X}"
+        findings.append(
+            _make_finding(
+                filepath,
+                1,
+                "mixed_script_path",
+                "MEDIUM",
+                char_hex,
+                f"{char}→{ascii_like}",
+                f"Non-ASCII character '{char}' (U+{ord(char):04X}) in path "
+                f"'{path_text}' visually resembles ASCII '{ascii_like}'. "
+                f"Mixed-script paths can hide lookalike modules from human reviewers.",
+            )
+        )
+        return
+
+
+def _add_source_homoglyph_findings(
+    findings: list[dict], filepath: Path, source: str
+) -> None:
+    seen_lines: set[int] = set()
+    for char, ascii_like, line_no in detect_homoglyphs(source):
+        if line_no in seen_lines:
+            continue
+        seen_lines.add(line_no)
+        char_hex = f"U+{ord(char):04X}"
+        findings.append(
+            _make_finding(
+                filepath,
+                line_no,
+                "mixed_script",
+                "MEDIUM",
+                char_hex,
+                f"{char}→{ascii_like}",
+                f"Non-ASCII character '{char}' (U+{ord(char):04X}) visually resembles "
+                f"ASCII '{ascii_like}'. Mixed-script text can hide instructions "
+                f"from human reviewers while remaining readable to AI agents.",
+            )
+        )
 
 
 def _adjust_severity(

--- a/test/test_injection_scanner.py
+++ b/test/test_injection_scanner.py
@@ -386,3 +386,54 @@ class TestScanHomoglyphs:
             assert len(mixed) >= 1
         finally:
             os.unlink(path)
+
+    def test_cyrillic_in_import_statement(self):
+        path = _write_temp("import p\u0430ypal\n")
+        try:
+            findings = scan_file(path)
+            mixed = [f for f in findings if f["type"] == "mixed_script"]
+            assert len(mixed) >= 1
+            assert mixed[0]["line"] == 1
+        finally:
+            os.unlink(path)
+
+    def test_cyrillic_in_filename(self):
+        tmp_dir = tempfile.mkdtemp()
+        path = Path(tmp_dir) / "p\u0430ypal.py"
+        path.write_text("safe = 1\n")
+        try:
+            findings = scan_file(path)
+            mixed_path = [f for f in findings if f["type"] == "mixed_script_path"]
+            assert len(mixed_path) == 1
+            assert mixed_path[0]["line"] == 1
+            assert "path" in mixed_path[0]["message"]
+        finally:
+            path.unlink()
+            os.rmdir(tmp_dir)
+
+    def test_cyrillic_in_package_directory(self):
+        tmp_dir = tempfile.mkdtemp()
+        package_dir = Path(tmp_dir) / "p\u0430ypal"
+        package_dir.mkdir()
+        path = package_dir / "client.py"
+        path.write_text("safe = 1\n")
+        try:
+            findings = scan_directory(tmp_dir)
+            mixed_path = [f for f in findings if f["type"] == "mixed_script_path"]
+            assert len(mixed_path) == 1
+            assert mixed_path[0]["basename"] == "client.py"
+            assert "client.py" in mixed_path[0]["message"]
+            assert tmp_dir not in mixed_path[0]["message"]
+        finally:
+            path.unlink()
+            package_dir.rmdir()
+            os.rmdir(tmp_dir)
+
+    def test_pure_cyrillic_comment_does_not_trigger_mixed_script(self):
+        path = _write_temp("# \u041f\u0440\u0438\u0432\u0435\u0442\nsafe = 1\n")
+        try:
+            findings = scan_file(path)
+            mixed = [f for f in findings if f["type"].startswith("mixed_script")]
+            assert mixed == []
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Summary
  - flag mixed-script/confusable Unicode in scannable file paths
  - pass repo-relative scan paths into the prompt-injection scanner
  - add coverage for source identifiers, import names, filenames, package directories, and pure Cyrillic comments

## Why
  Skylos already detected Cyrillic/Greek lookalike characters inside file contents, but it did not catch path-only spoofing.

  ## Fix
  - `scan_file()` now checks the provided scan path before scanning source contents
  - `scan_directory()` passes relative paths into `scan_file()`
  - analyzer scans pass repo-relative paths into the injection scanner
  - path findings are reported as `mixed_script_path`

  ## Tests
  - `pytest test/test_injection_scanner.py`
  - `pytest test/test_analyzer.py -k prompt_injection_scan_includes_scannable_docs`