### PR TITLE
feat(security): flag unverified webhook handlers

### DIFF
--- a/skylos/rules/danger/danger.py
+++ b/skylos/rules/danger/danger.py
@@ -14,6 +14,7 @@ from .danger_cors.cors_flow import scan as scan_cors
 from .danger_jwt.jwt_flow import scan as scan_jwt
 from .danger_access.access_flow import scan as scan_access
 from .danger_mcp.mcp_flow import scan as scan_mcp
+from .danger_webhook.webhook_flow import scan as scan_webhook
 from .danger_hallucination.dependency_hallucination import (
     scan_python_dependency_hallucinations,
 )
@@ -239,6 +240,7 @@ _CORS_TOKENS = (
 )
 _JWT_TOKENS = ("jwt", "verify_signature", "algorithms")
 _MCP_TOKENS = ("mcp", "fastmcp")
+_WEBHOOK_TOKENS = ("webhook", "webhooks")
 
 
 def _has_any(source: str, tokens: tuple[str, ...]) -> bool:
@@ -259,6 +261,7 @@ def scan_file_with_tree(tree, file_path, findings, *, source: str | None = None)
         scan_jwt(tree, file_path, findings)
         scan_access(tree, file_path, findings)
         scan_mcp(tree, file_path, findings)
+        scan_webhook(tree, file_path, findings)
         return
 
     source_lower = source.lower()
@@ -284,6 +287,10 @@ def scan_file_with_tree(tree, file_path, findings, *, source: str | None = None)
         scan_access(tree, file_path, findings)
     if _has_any(source_lower, _MCP_TOKENS):
         scan_mcp(tree, file_path, findings)
+    if _has_any(source_lower, _WEBHOOK_TOKENS) or _has_any(
+        str(file_path).lower(), _WEBHOOK_TOKENS
+    ):
+        scan_webhook(tree, file_path, findings, source=source)
 
 
 def _scan_file(file_path: Path, findings):

--- a/skylos/rules/danger/danger_webhook/__init__.py
+++ b/skylos/rules/danger/danger_webhook/__init__.py
@@ -1,0 +1,1 @@
+"""Webhook signature verification rules."""

--- a/skylos/rules/danger/danger_webhook/webhook_flow.py
+++ b/skylos/rules/danger/danger_webhook/webhook_flow.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+RULE_ID = "SKY-D282"
+
+_WEBHOOK_PROVIDER_HINTS = (
+    "stripe",
+    "github",
+    "clerk",
+    "svix",
+    "shopify",
+    "supabase",
+    "resend",
+    "twilio",
+    "slack",
+    "discord",
+    "linear",
+    "vercel",
+    "netlify",
+    "paddle",
+    "lemon_squeezy",
+    "lemonsqueezy",
+)
+
+_REQUEST_BODY_HINTS = (
+    "request.get_json",
+    "request.json",
+    "request.data",
+    "request.body",
+    "await request.body",
+    "await request.json",
+    "json.loads(request.body",
+)
+
+_VERIFY_PATTERNS = (
+    re.compile(r"\bconstruct_event\s*\(", re.I),
+    re.compile(r"\bconstructevent\s*\(", re.I),
+    re.compile(r"\bverify_signature\s*\(", re.I),
+    re.compile(r"\bverify_webhook\s*\(", re.I),
+    re.compile(r"\bverifywebhook\s*\(", re.I),
+    re.compile(r"\bverifysignature\s*\(", re.I),
+    re.compile(r"\bvalidate_signature\s*\(", re.I),
+    re.compile(r"\bvalidate_webhook\s*\(", re.I),
+    re.compile(r"\bvalidatesignature\s*\(", re.I),
+    re.compile(r"\bvalidatewebhook\s*\(", re.I),
+    re.compile(r"\bhmac\.compare_digest\s*\(", re.I),
+    re.compile(r"\bhmac\.new\s*\(", re.I),
+    re.compile(r"\bWebhook\s*\([^)]*\).*?\.verify\s*\(", re.I | re.S),
+    re.compile(r"\bWebhook\.verify\s*\(", re.I),
+)
+
+_TEST_PATH_PARTS = {"test", "tests", "fixtures", "fixture"}
+
+
+def _is_test_path(file_path: str | Path) -> bool:
+    normalized = str(file_path).replace("\\", "/").lower()
+    parts = set(normalized.split("/"))
+    base = Path(normalized).name
+    return (
+        bool(parts & _TEST_PATH_PARTS)
+        or base.startswith("test_")
+        or base.endswith("_test.py")
+    )
+
+
+def _dotted_name(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Call):
+        return _dotted_name(node.func)
+    return ""
+
+
+def _string_values(node: ast.AST | None) -> list[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        values: list[str] = []
+        for item in node.elts:
+            values.extend(_string_values(item))
+        return values
+    return []
+
+
+def _decorator_route_path(decorator: ast.AST) -> str:
+    call = decorator if isinstance(decorator, ast.Call) else None
+    if call is None or not call.args:
+        return ""
+    first_arg = call.args[0]
+    if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+        return first_arg.value
+    return ""
+
+
+def _decorator_has_post(decorator: ast.AST) -> bool:
+    call = decorator if isinstance(decorator, ast.Call) else None
+    name = _dotted_name(call.func if call else decorator).lower()
+    tail = name.rsplit(".", 1)[-1]
+    if tail == "post":
+        return True
+
+    if call is None or tail != "route":
+        return False
+
+    for keyword in call.keywords:
+        if keyword.arg == "methods":
+            methods = {value.upper() for value in _string_values(keyword.value)}
+            if "POST" in methods:
+                return True
+    return False
+
+
+def _function_source(source: str, node: ast.AST) -> str:
+    segment = ast.get_source_segment(source, node)
+    if segment is not None:
+        return segment
+    start = max(getattr(node, "lineno", 1) - 1, 0)
+    end = getattr(node, "end_lineno", start + 1)
+    return "\n".join(source.splitlines()[start:end])
+
+
+def _has_provider_hint(text: str) -> bool:
+    lower = text.lower()
+    return any(provider in lower for provider in _WEBHOOK_PROVIDER_HINTS)
+
+
+def _uses_request_body(text: str) -> bool:
+    lower = text.lower()
+    return any(hint in lower for hint in _REQUEST_BODY_HINTS)
+
+
+def _has_signature_verification(text: str) -> bool:
+    return any(pattern.search(text) for pattern in _VERIFY_PATTERNS)
+
+
+class _WebhookSignatureChecker(ast.NodeVisitor):
+    def __init__(self, file_path: str | Path, findings: list[dict], source: str):
+        self.file_path = file_path
+        self.findings = findings
+        self.source = source
+        self.path_text = str(file_path).replace("\\", "/")
+
+    def generic_visit(self, node: ast.AST) -> None:
+        for _field, value in ast.iter_fields(node):
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        self.visit(item)
+            elif isinstance(value, ast.AST):
+                self.visit(value)
+
+    def _report(self, node: ast.AST) -> None:
+        self.findings.append(
+            {
+                "rule_id": RULE_ID,
+                "severity": "HIGH",
+                "message": (
+                    "Webhook handler processes inbound events without obvious "
+                    "signature verification. Verify provider signatures before "
+                    "parsing or trusting the event body."
+                ),
+                "file": str(self.file_path),
+                "line": getattr(node, "lineno", 1),
+                "col": getattr(node, "col_offset", 0),
+            }
+        )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._check_function(node)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._check_function(node)
+        self.generic_visit(node)
+
+    def _check_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        function_text = _function_source(self.source, node)
+        route_paths = [_decorator_route_path(deco) for deco in node.decorator_list]
+        combined = "\n".join([self.path_text, node.name, *route_paths, function_text])
+        combined_lower = combined.lower()
+
+        if "webhook" not in combined_lower and "webhooks" not in combined_lower:
+            return
+        if not _has_provider_hint(combined):
+            return
+
+        has_post = any(_decorator_has_post(deco) for deco in node.decorator_list)
+        if not has_post and not re.search(
+            r"\brequest\.method\s*(?:==|===)\s*['\"]POST['\"]", function_text
+        ):
+            return
+
+        if not _uses_request_body(function_text):
+            return
+        if _has_signature_verification(function_text):
+            return
+
+        self._report(node)
+
+
+def scan(tree: ast.AST, file_path, findings, *, source: str | None = None) -> None:
+    try:
+        if _is_test_path(file_path):
+            return
+        if source is None:
+            source = Path(file_path).read_text(  # skylos: ignore[SKY-D215]
+                encoding="utf-8", errors="ignore"
+            )
+        checker = _WebhookSignatureChecker(file_path, findings, source)
+        checker.visit(tree)
+    except Exception as e:
+        print(f"Webhook signature analysis failed for {file_path}: {e}", file=sys.stderr)

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -183,6 +183,53 @@ _ERROR_DISCLOSURE_PROPS = {"stack", "sql", "sqlMessage", "sqlState"}
 
 _RESPONSE_METHODS = {"json", "send", "write", "end"}
 
+_WEBHOOK_PROVIDER_HINTS = (
+    "stripe",
+    "github",
+    "clerk",
+    "svix",
+    "shopify",
+    "supabase",
+    "resend",
+    "twilio",
+    "slack",
+    "discord",
+    "linear",
+    "vercel",
+    "netlify",
+    "paddle",
+    "lemon_squeezy",
+    "lemonsqueezy",
+)
+
+_WEBHOOK_BODY_HINTS = (
+    ".json(",
+    ".text(",
+    ".arraybuffer(",
+    ".formdata(",
+    ".body",
+    "rawbody",
+    "raw_body",
+)
+
+_WEBHOOK_VERIFY_PATTERNS = (
+    re.compile(r"\bconstructEvent\s*\("),
+    re.compile(r"\bconstruct_event\s*\(", re.I),
+    re.compile(r"\bverifySignature\s*\("),
+    re.compile(r"\bverifyWebhook\s*\("),
+    re.compile(r"\bvalidateSignature\s*\("),
+    re.compile(r"\bvalidateWebhook\s*\("),
+    re.compile(r"\bverify_signature\s*\(", re.I),
+    re.compile(r"\bverify_webhook\s*\(", re.I),
+    re.compile(r"\bvalidate_signature\s*\(", re.I),
+    re.compile(r"\bvalidate_webhook\s*\(", re.I),
+    re.compile(r"\bcrypto\.timingSafeEqual\s*\("),
+    re.compile(r"\btimingSafeEqual\s*\("),
+    re.compile(r"\bcreateHmac\s*\("),
+    re.compile(r"\bnew\s+Webhook\s*\([^)]*\).*?\.verify\s*\(", re.S),
+    re.compile(r"\bWebhook\.verify\s*\("),
+)
+
 
 def _shannon_entropy(s: str) -> float:
     if not s:
@@ -777,6 +824,7 @@ def scan_danger(
     _check_nextjs_missing_auth(source_bytes, file_path, findings)
     _check_nextjs_client_secrets(source_bytes, file_path, findings)
     _check_nextjs_server_action_sqli(source_bytes, file_path, findings)
+    _check_unverified_webhook_handler(source_bytes, file_path, findings)
     _check_archive_extraction_path_traversal(root_node, source_bytes, file_path, findings)
 
     return findings
@@ -854,6 +902,92 @@ _ARCHIVE_SCOPE_NODE_TYPES = frozenset(
 )
 
 _ARCHIVE_CONTROL_FLOW_HINTS = ("return", "continue", "throw", "break")
+
+
+def _is_test_file_path(file_path: str) -> bool:
+    normalized = str(file_path).replace(os.sep, "/").lower()
+    base = os.path.basename(normalized)
+    return (
+        get_non_library_dir_kind(file_path) == "test"
+        or "/test/" in normalized
+        or "/tests/" in normalized
+        or ".spec." in base
+        or ".test." in base
+    )
+
+
+def _has_webhook_provider_hint(text: str) -> bool:
+    lower = text.lower()
+    return any(provider in lower for provider in _WEBHOOK_PROVIDER_HINTS)
+
+
+def _has_webhook_body_use(source_text: str) -> bool:
+    lower = source_text.lower()
+    return any(hint in lower for hint in _WEBHOOK_BODY_HINTS)
+
+
+def _has_webhook_signature_verification(source_text: str) -> bool:
+    return any(pattern.search(source_text) for pattern in _WEBHOOK_VERIFY_PATTERNS)
+
+
+def _has_inbound_webhook_post(source_text: str) -> bool:
+    post_patterns = (
+        r"\bexport\s+(?:async\s+)?function\s+POST\b",
+        r"\bexport\s+const\s+POST\b",
+        r"\b(?:app|router|server|fastify|hono)\.post\s*\(",
+        r"\b(?:req|request)\.method\s*(?:={2,3})\s*['\"]POST['\"]",
+        r"\bcase\s+['\"]POST['\"]",
+    )
+    return any(re.search(pattern, source_text) for pattern in post_patterns)
+
+
+def _webhook_finding_line(source_text: str) -> int:
+    for index, line in enumerate(source_text.splitlines(), 1):
+        if (
+            "webhook" in line.lower()
+            or re.search(r"\bPOST\b", line)
+            or ".post(" in line
+        ):
+            return index
+    return 1
+
+
+def _check_unverified_webhook_handler(
+    source_bytes: bytes, file_path: str, findings: list[dict]
+) -> None:
+    if _is_test_file_path(file_path):
+        return
+
+    source_text = source_bytes.decode("utf-8", errors="replace")
+    normalized_path = str(file_path).replace(os.sep, "/")
+    combined = f"{normalized_path}\n{source_text}"
+    combined_lower = combined.lower()
+
+    if "webhook" not in combined_lower and "webhooks" not in combined_lower:
+        return
+    if not _has_webhook_provider_hint(combined):
+        return
+    if not _has_inbound_webhook_post(source_text):
+        return
+    if not _has_webhook_body_use(source_text):
+        return
+    if _has_webhook_signature_verification(source_text):
+        return
+
+    findings.append(
+        {
+            "rule_id": "SKY-D282",
+            "severity": "HIGH",
+            "message": (
+                "Webhook handler processes inbound events without obvious signature "
+                "verification. Verify provider signatures before parsing or trusting "
+                "the event body."
+            ),
+            "file": str(file_path),
+            "line": _webhook_finding_line(source_text),
+            "col": 0,
+        }
+    )
 
 
 def _has_mutating_exported_route_handler(source_text: str) -> bool:

--- a/test/test_webhook_signature.py
+++ b/test/test_webhook_signature.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import ast
+import textwrap
+
+from skylos.rules.danger.danger import scan_file_with_tree
+from skylos.visitors.languages.typescript import scan_typescript_file
+
+
+def _scan_python(code: str, filename: str = "app.py") -> list[dict]:
+    source = textwrap.dedent(code)
+    tree = ast.parse(source)
+    findings: list[dict] = []
+    scan_file_with_tree(tree, filename, findings, source=source)
+    return findings
+
+
+def _scan_ts(tmp_path, code: str, filename: str) -> list[dict]:
+    path = tmp_path / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(code), encoding="utf-8")
+    results = scan_typescript_file(str(path))
+    *_, danger = results[:8]
+    return danger
+
+
+def _rule_ids(findings: list[dict]) -> set[str]:
+    return {finding["rule_id"] for finding in findings}
+
+
+def test_fastapi_stripe_webhook_without_signature_flags():
+    findings = _scan_python(
+        """
+        app = make_app()
+
+        @app.post("/stripe/webhook")
+        async def stripe_webhook(request):
+            event = await request.json()
+            if event["type"] == "checkout.session.completed":
+                grant_credits(event["data"]["object"]["customer"])
+            return {"ok": True}
+        """
+    )
+
+    assert "SKY-D282" in _rule_ids(findings)
+
+
+def test_fastapi_stripe_webhook_with_construct_event_is_safe():
+    findings = _scan_python(
+        """
+        app = make_app()
+
+        @app.post("/stripe/webhook")
+        async def stripe_webhook(request):
+            body = await request.body()
+            sig = request.headers.get("stripe-signature")
+            event = stripe.Webhook.construct_event(body, sig, STRIPE_WEBHOOK_SECRET)
+            return {"ok": True}
+        """
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_flask_github_webhook_with_hmac_compare_is_safe():
+    findings = _scan_python(
+        """
+        app = make_app()
+
+        @app.route("/github/webhook", methods=["POST"])
+        def github_webhook():
+            body = request.data
+            sig = request.headers.get("x-hub-signature-256")
+            expected = sign(body)
+            if not hmac.compare_digest(sig, expected):
+                return "bad", 401
+            return "ok"
+        """
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_non_webhook_callback_route_is_not_flagged():
+    findings = _scan_python(
+        """
+        app = make_app()
+
+        @app.post("/oauth/callback")
+        async def oauth_callback(request):
+            payload = await request.json()
+            return payload
+        """
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_python_test_path_is_not_flagged():
+    findings = _scan_python(
+        """
+        app = make_app()
+
+        @app.post("/stripe/webhook")
+        async def stripe_webhook(request):
+            event = await request.json()
+            return event
+        """,
+        filename="tests/test_webhook.py",
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_nextjs_stripe_webhook_without_signature_flags(tmp_path):
+    findings = _scan_ts(
+        tmp_path,
+        """
+        export async function POST(req: Request) {
+          const event = await req.json();
+          if (event.type === "checkout.session.completed") {
+            await grantCredits(event.data.object.customer);
+          }
+          return Response.json({ received: true });
+        }
+        """,
+        "app/api/stripe/webhook/route.ts",
+    )
+
+    assert "SKY-D282" in _rule_ids(findings)
+
+
+def test_nextjs_stripe_webhook_with_construct_event_is_safe(tmp_path):
+    findings = _scan_ts(
+        tmp_path,
+        """
+        export async function POST(req: Request) {
+          const body = await req.text();
+          const sig = req.headers.get("stripe-signature");
+          const event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET!);
+          return Response.json({ received: true });
+        }
+        """,
+        "app/api/stripe/webhook/route.ts",
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_express_github_webhook_with_hmac_is_safe(tmp_path):
+    findings = _scan_ts(
+        tmp_path,
+        """
+        app.post("/github/webhook", async (req, res) => {
+          const signature = req.headers["x-hub-signature-256"];
+          const expected = createHmac("sha256", secret).update(req.body).digest("hex");
+          if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+            return res.status(401).send("bad");
+          }
+          return res.json({ ok: true });
+        });
+        """,
+        "src/server.ts",
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_non_webhook_post_route_is_not_flagged(tmp_path):
+    findings = _scan_ts(
+        tmp_path,
+        """
+        export async function POST(req: Request) {
+          const payload = await req.json();
+          return Response.json(payload);
+        }
+        """,
+        "app/api/users/route.ts",
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_typescript_test_file_is_not_flagged(tmp_path):
+    findings = _scan_ts(
+        tmp_path,
+        """
+        export async function POST(req: Request) {
+          const event = await req.json();
+          return Response.json(event);
+        }
+        """,
+        "tests/stripe-webhook.test.ts",
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)


### PR DESCRIPTION
## Summary

  - add `SKY-D282` for webhook handlers that process inbound events without obvious signature verification
  - cover Python webhook handlers and TypeScript / Next / Express-style webhook handlers
  - add tests for unsafe and verified Stripe / GitHub-style handlers

## What was added

  Skylos did not have a dedicated rule for unsigned webhook handlers. A vibe coded handler could read a Stripe, GitHub, Clerk, Shopify, or similar webhook body and update app state without proving the request came from the provider.

## Fix

  - wire the Python danger scanner into webhook-aware scanning
  - add Python and TypeScript webhook detectors
  - skip test files and require webhook/provider/body/POST evidence before reporting
  - suppress findings when strong verification evidence is present, such as `construct_event`, `constructEvent`, `hmac.compare_digest`, `createHmac`, or `crypto.timingSafeEqual`

## Tests

  - `pytest test/test_webhook_signature.py`
  - `pytest test/test_typescript_expanded.py test/test_ts_danger_nextjs.py test/test_good_practices_rules.py test/test_mass_assignment.py test/test_webhook_signature.py test/test_analyzer.py`