### PR TITLE
feat(cicd): add PR evidence cards

### DIFF
--- a/skylos/cicd/evidence.py
+++ b/skylos/cicd/evidence.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Literal
+
+EvidenceLabel = Literal["proven", "likely", "speculative"]
+EvidenceKind = Literal[
+    "security",
+    "security_regression",
+    "secret",
+    "quality",
+    "dependency",
+    "custom",
+]
+
+
+@dataclass(frozen=True)
+class EvidenceCard:
+    label: EvidenceLabel
+    kind: EvidenceKind
+    confidence: int
+    title: str
+    rule_id: str
+    file: str
+    line: int
+    symbol: str | None = None
+    evidence: tuple[str, ...] = ()
+    impact: str = ""
+    suggested_fix: str | None = None
+    gate_blocking: bool = False
+
+
+_SECRET_PATTERNS = (
+    re.compile(r"\bsk_(?:live|test|proj)_[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}\b"),
+    re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
+    re.compile(r"\b[A-Za-z0-9_./+=-]{40,}\b"),
+)
+
+_RULE_SUGGESTIONS: dict[str, str] = {
+    "SKY-D201": "Replace dynamic evaluation with a safe parser for the expected input format.",
+    "SKY-D203": "Use subprocess with an argument list and shell disabled.",
+    "SKY-D211": "Use parameterized queries instead of building SQL with string interpolation.",
+    "SKY-D212": "Validate or escape command input, or pass arguments without a shell.",
+    "SKY-D215": "Resolve paths under an allowed directory before opening filesystem paths.",
+    "SKY-D216": "Validate outbound URLs against an allowlist and block internal network targets.",
+    "SKY-D223": "Declare the dependency in project metadata or remove the import.",
+    "SKY-D280": "Verify webhook signatures before trusting webhook request bodies.",
+    "SKY-D281": "Keep webhook signature verification before any request body parsing or side effects.",
+    "SKY-D282": "Use a webhook library or HMAC comparison that verifies the provider signature.",
+    "SKY-S101": "Move the secret to environment variables or a secrets manager, then rotate it.",
+    "SKY-S102": "Move the credential to a secrets manager, then rotate the exposed value.",
+}
+
+_REGRESSION_SUGGESTIONS: dict[str, str] = {
+    "auth": "Re-add the authentication check before the protected handler runs.",
+    "csrf": "Re-enable CSRF protection for the affected request path.",
+    "tls": "Keep TLS certificate verification enabled.",
+    "crypto": "Use a modern cryptographic primitive or hash algorithm.",
+    "rate_limit": "Re-add rate limiting around the affected endpoint or action.",
+    "validation": "Restore input validation before the value reaches the risky sink.",
+    "headers": "Restore the security header or middleware.",
+    "encryption": "Restore encryption before sensitive data is stored or transmitted.",
+    "logging": "Restore audit logging for the security-relevant action.",
+    "sanitization": "Restore output sanitization before rendering user-controlled content.",
+    "permission": "Re-add the permission check before the protected action runs.",
+}
+
+_SEVERITY_CONFIDENCE = {
+    "proven": {"CRITICAL": 96, "HIGH": 92, "MEDIUM": 84, "LOW": 76},
+    "likely": {"CRITICAL": 86, "HIGH": 80, "MEDIUM": 72, "LOW": 64},
+    "speculative": {"CRITICAL": 58, "HIGH": 55, "MEDIUM": 50, "LOW": 45},
+}
+
+
+def build_evidence_cards(findings: list[dict[str, Any]]) -> list[EvidenceCard]:
+    return [build_evidence_card(finding) for finding in findings]
+
+
+def build_evidence_card(finding: dict[str, Any]) -> EvidenceCard:
+    kind = _evidence_kind(finding)
+    label = _evidence_label(finding, kind)
+    rule_id = str(finding.get("rule_id") or "")
+    severity = str(finding.get("severity") or "MEDIUM").upper()
+    control_type = str(finding.get("control_type") or "")
+
+    return EvidenceCard(
+        label=label,
+        kind=kind,
+        confidence=_confidence(label, severity, finding),
+        title=_title(finding, kind),
+        rule_id=rule_id,
+        file=str(finding.get("file") or ""),
+        line=_line_number(finding.get("line")),
+        symbol=_optional_text(finding.get("symbol")),
+        evidence=_evidence_lines(finding, kind, label),
+        impact=_impact(kind, control_type),
+        suggested_fix=_suggested_fix(finding, kind, rule_id, control_type),
+        gate_blocking=severity in {"CRITICAL", "HIGH"},
+    )
+
+
+def evidence_counts(cards: list[EvidenceCard]) -> dict[EvidenceLabel, int]:
+    counts: dict[EvidenceLabel, int] = {
+        "proven": 0,
+        "likely": 0,
+        "speculative": 0,
+    }
+    for card in cards:
+        counts[card.label] += 1
+    return counts
+
+
+def evidence_label_title(label: EvidenceLabel) -> str:
+    return {
+        "proven": "Proven",
+        "likely": "Likely",
+        "speculative": "Speculative",
+    }[label]
+
+
+def redact_sensitive_text(value: Any) -> str:
+    text = "" if value is None else str(value)
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[redacted]", text)
+    return text
+
+
+def _evidence_kind(finding: dict[str, Any]) -> EvidenceKind:
+    category = str(finding.get("category") or "").lower()
+    kind = str(finding.get("kind") or "").lower()
+
+    if category == "security_regression" or kind == "security_regression":
+        return "security_regression"
+    if category in {"secrets", "secret"}:
+        return "secret"
+    if category in {"danger", "security"}:
+        return "security"
+    if category in {"dependency", "dependencies"}:
+        return "dependency"
+    if category == "custom_rules":
+        return "custom"
+    return "quality"
+
+
+def _evidence_label(finding: dict[str, Any], kind: EvidenceKind) -> EvidenceLabel:
+    if kind in {"security_regression", "secret"}:
+        return "proven"
+
+    if _verification_verdict(finding) == "VERIFIED":
+        return "proven"
+
+    source = str(finding.get("_source") or "").lower()
+    security_evidence = _security_evidence(finding)
+    if source == "llm" and security_evidence == "hypothesis":
+        return "speculative"
+    if source == "llm":
+        return "likely" if security_evidence == "review_supported" else "speculative"
+
+    rule_id = str(finding.get("rule_id") or "")
+    if kind == "security" and rule_id.startswith(("SKY-D", "SKY-S")):
+        return "proven"
+    if kind == "quality" and rule_id.startswith("SKY-UC"):
+        return "proven"
+
+    if security_evidence == "hypothesis":
+        return "speculative"
+
+    return "likely"
+
+
+def _confidence(label: EvidenceLabel, severity: str, finding: dict[str, Any]) -> int:
+    explicit = finding.get("confidence")
+    if isinstance(explicit, int):
+        return max(1, min(99, explicit))
+    return _SEVERITY_CONFIDENCE[label].get(
+        severity, _SEVERITY_CONFIDENCE[label]["MEDIUM"]
+    )
+
+
+def _title(finding: dict[str, Any], kind: EvidenceKind) -> str:
+    if kind == "secret":
+        return "Hardcoded secret detected"
+    if kind == "security_regression":
+        control_type = str(finding.get("control_type") or "")
+        if control_type:
+            control_label = control_type.replace("_", " ")
+            return f"Security control regression: {control_label}"
+        return "Security control regression"
+
+    message = redact_sensitive_text(finding.get("message") or "")
+    if not message:
+        message = str(finding.get("rule_id") or kind.replace("_", " "))
+    return _limit(message, 120)
+
+
+def _evidence_lines(
+    finding: dict[str, Any], kind: EvidenceKind, label: EvidenceLabel
+) -> tuple[str, ...]:
+    rule_id = str(finding.get("rule_id") or "")
+    control_type = str(finding.get("control_type") or "")
+    lines: list[str] = []
+
+    if kind == "secret":
+        return (
+            "Static secret detection matched a credential pattern.",
+            "The secret value is intentionally omitted from PR output.",
+        )
+
+    if kind == "security_regression":
+        return (f"PR diff removed or weakened {_control_phrase(control_type)}.",)
+
+    if _verification_verdict(finding) == "VERIFIED":
+        lines.append("Skylos verification marked this finding as verified.")
+    elif label == "speculative":
+        lines.append("The finding is not backed by verifier-confirmed evidence yet.")
+    elif str(finding.get("_source") or "").lower() == "llm":
+        lines.append("LLM review supplied supporting evidence, but no verifier proof.")
+    elif rule_id:
+        prefix = "Configured custom rule" if kind == "custom" else "Static Skylos rule"
+        lines.append(f"{prefix} {rule_id} matched this line.")
+    else:
+        lines.append("Static analysis matched this line.")
+
+    reason = _review_reason(finding)
+    if reason:
+        lines.append(_limit(redact_sensitive_text(reason), 180))
+
+    return tuple(lines)
+
+
+def _impact(kind: EvidenceKind, control_type: str) -> str:
+    if kind == "secret":
+        return "A committed credential can be copied from the repository or logs."
+    if kind == "security_regression":
+        return f"The affected change may reduce protection from {_control_phrase(control_type)}."
+    if kind == "security":
+        return "The affected code may expose a security weakness if reachable."
+    if kind == "dependency":
+        return "The dependency change may affect supply-chain or runtime safety."
+    if kind == "custom":
+        return "The change violates a configured project rule."
+    return "The issue can increase maintenance cost or review risk."
+
+
+def _suggested_fix(
+    finding: dict[str, Any],
+    kind: EvidenceKind,
+    rule_id: str,
+    control_type: str,
+) -> str | None:
+    if kind == "secret":
+        return "Rotate the exposed credential and move it to a secrets manager or environment variable."
+    if kind == "security_regression":
+        return _REGRESSION_SUGGESTIONS.get(
+            control_type,
+            "Restore or replace the removed security control before merging.",
+        )
+
+    suggestion = finding.get("suggestion")
+    if suggestion:
+        return _limit(redact_sensitive_text(suggestion), 220)
+    return _RULE_SUGGESTIONS.get(rule_id) or _fallback_suggested_fix(kind)
+
+
+def _fallback_suggested_fix(kind: EvidenceKind) -> str:
+    if kind == "security":
+        return "Review the risky data flow and add the narrowest validation, escaping, or guard needed."
+    if kind == "dependency":
+        return "Review the dependency change and pin, update, or remove the package as appropriate."
+    if kind == "custom":
+        return "Update the code to satisfy the configured project rule, or adjust the rule if this case is intentional."
+    return "Refactor the affected code to remove the reported maintainability issue."
+
+
+def _control_phrase(control_type: str) -> str:
+    control_label = control_type.replace("_", " ") if control_type else "security"
+    if control_label.endswith("control"):
+        return control_label
+    return f"{control_label} control"
+
+
+def _verification_verdict(finding: dict[str, Any]) -> str:
+    verification = finding.get("verification")
+    if isinstance(verification, dict):
+        verdict = verification.get("verdict")
+        if isinstance(verdict, str):
+            return verdict.upper()
+
+    verdict = finding.get("_review_verdict")
+    if isinstance(verdict, str):
+        return verdict.upper()
+    return ""
+
+
+def _security_evidence(finding: dict[str, Any]) -> str:
+    evidence = finding.get("_security_evidence")
+    if isinstance(evidence, str):
+        return evidence
+
+    metadata = finding.get("metadata")
+    if isinstance(metadata, dict):
+        evidence = metadata.get("security_evidence")
+        if isinstance(evidence, str):
+            return evidence
+    return ""
+
+
+def _review_reason(finding: dict[str, Any]) -> str:
+    reason = finding.get("_review_reason")
+    if isinstance(reason, str):
+        return reason
+
+    metadata = finding.get("metadata")
+    if isinstance(metadata, dict):
+        reason = metadata.get("review_reason")
+        if isinstance(reason, str):
+            return reason
+    return ""
+
+
+def _line_number(value: Any) -> int:
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 1
+
+
+def _optional_text(value: Any) -> str | None:
+    if not value:
+        return None
+    return _limit(redact_sensitive_text(value), 120)
+
+
+def _limit(text: str, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+    return f"{text[: max_length - 3].rstrip()}..."

--- a/skylos/cicd/review.py
+++ b/skylos/cicd/review.py
@@ -7,6 +7,14 @@ import subprocess
 
 from rich.console import Console
 
+from skylos.cicd.evidence import (
+    EvidenceCard,
+    build_evidence_card,
+    build_evidence_cards,
+    evidence_counts,
+    evidence_label_title,
+    redact_sensitive_text,
+)
 from skylos.rules.quality.regression import detect_security_regressions
 
 console = Console()
@@ -23,6 +31,7 @@ def run_pr_review(
     grade: dict | None = None,
     previous_grade: dict | None = None,
     llm_findings: list[dict] | None = None,
+    evidence_cards: bool = False,
 ) -> None:
     pr_number = pr_number or _detect_pr_number()
     repo = repo or os.environ.get("GITHUB_REPOSITORY")
@@ -64,7 +73,12 @@ def run_pr_review(
     all_findings.extend(regression_findings)
 
     if findings and not summary_only:
-        _post_pr_review(findings[:max_comments], pr_number, repo)
+        _post_pr_review(
+            findings[:max_comments],
+            pr_number,
+            repo,
+            evidence_cards=evidence_cards,
+        )
 
     _post_summary_comment(
         all_findings,
@@ -73,6 +87,7 @@ def run_pr_review(
         repo,
         grade=grade,
         previous_grade=previous_grade,
+        evidence_cards=evidence_cards,
     )
 
     console.print(
@@ -209,26 +224,75 @@ def filter_findings_to_diff(
     return filtered
 
 
+_SAFE_FINDING_METADATA_FIELDS = (
+    "security_evidence",
+    "review_verdict",
+    "review_reason",
+)
+_SAFE_VERIFICATION_FIELDS = ("verdict", "confidence", "reason")
+
+
 def _flatten_findings(results: dict) -> list[dict]:
     findings = []
 
     for category in ("danger", "quality", "secrets", "custom_rules"):
         for f in results.get(category, []) or []:
-            findings.append(
-                {
-                    "file": f.get("file") or f.get("file_path") or "",
-                    "line": f.get("line") or f.get("line_number") or 1,
-                    "message": f.get("message")
-                    or f.get("msg")
-                    or f.get("detail")
-                    or "",
-                    "rule_id": f.get("rule_id") or "",
-                    "severity": f.get("severity", "MEDIUM"),
-                    "category": category,
-                }
-            )
+            finding = {
+                "file": f.get("file") or f.get("file_path") or "",
+                "line": f.get("line") or f.get("line_number") or 1,
+                "message": f.get("message") or f.get("msg") or f.get("detail") or "",
+                "rule_id": f.get("rule_id") or "",
+                "severity": f.get("severity", "MEDIUM"),
+                "category": category,
+            }
+            _copy_safe_finding_metadata(f, finding)
+            findings.append(finding)
 
     return findings
+
+
+def _copy_safe_finding_metadata(source: dict, target: dict) -> None:
+    for key in ("_security_evidence", "_review_verdict", "_review_reason"):
+        value = source.get(key)
+        if isinstance(value, str):
+            target[key] = value
+
+    symbol = source.get("symbol")
+    if isinstance(symbol, str):
+        target["symbol"] = symbol
+
+    confidence = source.get("confidence")
+    if isinstance(confidence, int):
+        target["confidence"] = confidence
+
+    verification = source.get("verification")
+    if isinstance(verification, dict):
+        safe_verification = {
+            key: value
+            for key, value in verification.items()
+            if key in _SAFE_VERIFICATION_FIELDS
+            and isinstance(value, (str, int, float, bool))
+        }
+        if safe_verification:
+            target["verification"] = safe_verification
+
+    metadata = source.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+
+    safe_metadata = {
+        key: value
+        for key, value in metadata.items()
+        if key in _SAFE_FINDING_METADATA_FIELDS and isinstance(value, str)
+    }
+    if safe_metadata:
+        target["metadata"] = safe_metadata
+        if "security_evidence" in safe_metadata:
+            target["_security_evidence"] = safe_metadata["security_evidence"]
+        if "review_verdict" in safe_metadata:
+            target["_review_verdict"] = safe_metadata["review_verdict"]
+        if "review_reason" in safe_metadata:
+            target["_review_reason"] = safe_metadata["review_reason"]
 
 
 def _merge_llm_findings(
@@ -256,25 +320,26 @@ def _merge_llm_findings(
                 finding["vulnerable_code"] = llm["vulnerable_code"]
             if llm.get("fixed_code"):
                 finding["fixed_code"] = llm["fixed_code"]
+            _copy_safe_finding_metadata(llm, finding)
             matched_keys.add(key)
 
     for key, llm in llm_by_loc.items():
         if key not in matched_keys:
-            static_findings.append(
-                {
-                    "file": llm.get("file", ""),
-                    "line": llm.get("line", 0),
-                    "message": llm.get("message", ""),
-                    "rule_id": llm.get("rule_id", ""),
-                    "severity": llm.get("severity", "MEDIUM"),
-                    "category": llm.get("_category", "security"),
-                    "suggestion": llm.get("suggestion"),
-                    "explanation": llm.get("explanation"),
-                    "vulnerable_code": llm.get("vulnerable_code"),
-                    "fixed_code": llm.get("fixed_code"),
-                    "_source": "llm",
-                }
-            )
+            finding = {
+                "file": llm.get("file", ""),
+                "line": llm.get("line", 0),
+                "message": llm.get("message", ""),
+                "rule_id": llm.get("rule_id", ""),
+                "severity": llm.get("severity", "MEDIUM"),
+                "category": llm.get("_category", "security"),
+                "suggestion": llm.get("suggestion"),
+                "explanation": llm.get("explanation"),
+                "vulnerable_code": llm.get("vulnerable_code"),
+                "fixed_code": llm.get("fixed_code"),
+            }
+            _copy_safe_finding_metadata(llm, finding)
+            finding["_source"] = "llm"
+            static_findings.append(finding)
 
     return static_findings
 
@@ -309,7 +374,7 @@ def _format_review_comment(finding: dict) -> str:
     kind = finding.get("kind", "")
     severity = finding.get("severity", "MEDIUM")
     rule_id = finding.get("rule_id", "")
-    message = finding.get("message", "")
+    message = redact_sensitive_text(finding.get("message", ""))
     rule_str = f" `{rule_id}`" if rule_id else ""
 
     if kind == "security_regression":
@@ -324,7 +389,7 @@ def _format_review_comment(finding: dict) -> str:
         ]
         suggestion = _REGRESSION_SUGGESTIONS.get(control_type)
         if suggestion:
-            parts.extend(["", f"**Fix:** {suggestion}"])
+            parts.extend(["", f"**Fix:** {redact_sensitive_text(suggestion)}"])
     else:
         badge = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡", "LOW": "🔵"}.get(
             severity, "⚪"
@@ -333,7 +398,7 @@ def _format_review_comment(finding: dict) -> str:
 
         explanation = finding.get("explanation")
         if explanation:
-            parts.extend(["", f"**Why:** {explanation}"])
+            parts.extend(["", f"**Why:** {redact_sensitive_text(explanation)}"])
 
         vulnerable_code = finding.get("vulnerable_code")
         fixed_code = finding.get("fixed_code")
@@ -344,23 +409,66 @@ def _format_review_comment(finding: dict) -> str:
                     "",
                     "**Vulnerable code:**",
                     "```python",
-                    vulnerable_code,
+                    redact_sensitive_text(vulnerable_code),
                     "```",
                     "",
                     "**Fixed code:**",
                     "```python",
-                    fixed_code,
+                    redact_sensitive_text(fixed_code),
                     "```",
                 ]
             )
         else:
             suggestion = finding.get("suggestion") or _RULE_SUGGESTIONS.get(rule_id)
             if suggestion:
-                parts.extend(["", f"**Fix:** {suggestion}"])
+                parts.extend(["", f"**Fix:** {redact_sensitive_text(suggestion)}"])
 
     footer = "\n\n---\n_🤖 Analyzed by [Skylos](https://github.com/duriantaco/skylos) • [Add to your repo](https://github.com/duriantaco/skylos#cicd)_"
     parts.append(footer)
 
+    return "\n".join(parts)
+
+
+def _format_evidence_card_comment(
+    finding: dict, card: EvidenceCard | None = None
+) -> str:
+    card = card or build_evidence_card(finding)
+    rule_str = f" `{card.rule_id}`" if card.rule_id else ""
+    risk = {
+        "security": "security finding",
+        "security_regression": "security regression",
+        "secret": "secret exposure",
+        "quality": "quality issue",
+        "dependency": "dependency issue",
+        "custom": "custom rule match",
+    }[card.kind]
+    location = f"{card.file}:{card.line}" if card.file else str(card.line)
+
+    parts = [
+        f"**Risk: {evidence_label_title(card.label)} {risk}**{rule_str}",
+        "",
+        redact_sensitive_text(card.title),
+        "",
+        f"**Location:** `{location}`",
+        "",
+        "**Evidence:**",
+    ]
+
+    for item in card.evidence or ("No extra evidence attached.",):
+        parts.append(f"- {redact_sensitive_text(item)}")
+
+    if card.impact:
+        parts.extend(["", f"**Impact:** {redact_sensitive_text(card.impact)}"])
+
+    if card.suggested_fix:
+        parts.extend(
+            ["", f"**Suggested fix:** {redact_sensitive_text(card.suggested_fix)}"]
+        )
+
+    parts.extend(["", f"**Confidence:** {card.confidence}%"])
+
+    footer = "\n\n---\n_🤖 Analyzed by [Skylos](https://github.com/duriantaco/skylos) • [Add to your repo](https://github.com/duriantaco/skylos#cicd)_"
+    parts.append(footer)
     return "\n".join(parts)
 
 
@@ -380,16 +488,27 @@ def _to_relative_path(filepath: str) -> str:
     return filepath
 
 
-def _post_pr_review(findings: list[dict], pr_number: int, repo: str) -> None:
+def _post_pr_review(
+    findings: list[dict],
+    pr_number: int,
+    repo: str,
+    *,
+    evidence_cards: bool = False,
+) -> None:
     comments = []
     for f in findings:
         if not f.get("file") or not f.get("line"):
             continue
+        body = (
+            _format_evidence_card_comment(f)
+            if evidence_cards
+            else _format_review_comment(f)
+        )
         comments.append(
             {
                 "path": _to_relative_path(f["file"]),
                 "line": f["line"],
-                "body": _format_review_comment(f),
+                "body": body,
             }
         )
 
@@ -435,6 +554,7 @@ def _post_summary_comment(
     *,
     grade: dict | None = None,
     previous_grade: dict | None = None,
+    evidence_cards: bool = False,
 ) -> None:
     by_severity = {}
     for f in all_findings:
@@ -496,8 +616,26 @@ def _post_summary_comment(
         for f in regression_findings:
             control = f.get("control_type", "unknown")
             file = os.path.basename(f.get("file", ""))
-            msg = f.get("message", "")
+            msg = redact_sensitive_text(f.get("message", ""))
             lines.append(f"| {control} | {file} | {msg} |")
+
+    if evidence_cards:
+        cards = build_evidence_cards(all_findings)
+        counts = evidence_counts(cards)
+        if cards:
+            lines.extend(
+                [
+                    "",
+                    "### Evidence",
+                    "",
+                    "| Label | Count |",
+                    "|-------|-------|",
+                ]
+            )
+            for label in ("proven", "likely", "speculative"):
+                count = counts[label]
+                if count > 0:
+                    lines.append(f"| {evidence_label_title(label)} | {count} |")
 
     critical_findings = [
         f for f in diff_findings if f.get("severity") in ("CRITICAL", "HIGH")
@@ -511,7 +649,8 @@ def _post_summary_comment(
             file = os.path.basename(f.get("file", ""))
             line_no = f.get("line", "")
             loc = f" ({file}:{line_no})" if file else ""
-            lines.append(f"- {badge} **{sev}**{rule}{loc}: {f.get('message', '')}")
+            message = redact_sensitive_text(f.get("message", ""))
+            lines.append(f"- {badge} **{sev}**{rule}{loc}: {message}")
 
             vuln_code = f.get("vulnerable_code")
             fix_code = f.get("fixed_code")
@@ -521,12 +660,12 @@ def _post_summary_comment(
                 lines.append("")
                 lines.append("  **Vulnerable:**")
                 lines.append("  ```python")
-                for code_line in vuln_code.splitlines():
+                for code_line in redact_sensitive_text(vuln_code).splitlines():
                     lines.append(f"  {code_line}")
                 lines.append("  ```")
                 lines.append("  **Fixed:**")
                 lines.append("  ```python")
-                for code_line in fix_code.splitlines():
+                for code_line in redact_sensitive_text(fix_code).splitlines():
                     lines.append(f"  {code_line}")
                 lines.append("  ```")
                 lines.append("  </details>")
@@ -534,7 +673,7 @@ def _post_summary_comment(
             else:
                 fix = f.get("suggestion") or _RULE_SUGGESTIONS.get(f.get("rule_id", ""))
                 if fix:
-                    lines.append(f"  - **Fix:** {fix}")
+                    lines.append(f"  - **Fix:** {redact_sensitive_text(fix)}")
 
     if grade:
         overall = grade["overall"]
@@ -566,7 +705,7 @@ def _post_summary_comment(
         for cat_name in ("security", "quality", "dead_code", "dependencies", "secrets"):
             cat = cats[cat_name]
             display = cat_name.replace("_", " ").title()
-            issue = (cat.get("key_issue") or "-")[:50]
+            issue = redact_sensitive_text(cat.get("key_issue") or "-")[:50]
 
             delta_str = ""
             if previous_grade and cat_name in previous_grade.get("categories", {}):

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -158,6 +158,11 @@ def run_cicd_command(
     p_ci_rev.add_argument("--max-comments", type=int, default=25)
     p_ci_rev.add_argument("--diff-base", default="origin/main")
     p_ci_rev.add_argument("--llm-input", help="LLM agent review results JSON file")
+    p_ci_rev.add_argument(
+        "--evidence-cards",
+        action="store_true",
+        help="Format PR comments with Proven, Likely, or Speculative evidence labels.",
+    )
 
     if not argv:
         cicd_parser.print_help()
@@ -253,6 +258,7 @@ def run_cicd_command(
             max_comments=cicd_args.max_comments,
             diff_base=cicd_args.diff_base,
             llm_findings=llm_findings,
+            evidence_cards=cicd_args.evidence_cards,
         )
         return 0
 

--- a/test/test_cicd_evidence.py
+++ b/test/test_cicd_evidence.py
@@ -1,0 +1,194 @@
+from skylos.cicd.evidence import (
+    build_evidence_card,
+    build_evidence_cards,
+    evidence_counts,
+    redact_sensitive_text,
+)
+
+
+def _stripe_like_token() -> str:
+    return "sk" + "_live_" + "abcdefghijklmnopqrstuvwxyz1234567890"
+
+
+def _github_like_token() -> str:
+    return "gh" + "p_" + "abcdefghijklmnopqrstuvwxyz123456"
+
+
+def test_static_security_finding_is_proven():
+    card = build_evidence_card(
+        {
+            "category": "danger",
+            "rule_id": "SKY-D201",
+            "severity": "CRITICAL",
+            "file": "app.py",
+            "line": 12,
+            "message": "eval() on user input",
+        }
+    )
+
+    assert card.label == "proven"
+    assert card.kind == "security"
+    assert card.confidence == 96
+    assert "Static Skylos rule SKY-D201" in card.evidence[0]
+
+
+def test_llm_hypothesis_finding_is_speculative():
+    card = build_evidence_card(
+        {
+            "category": "security",
+            "rule_id": "SKY-L001",
+            "severity": "HIGH",
+            "file": "app.py",
+            "line": 8,
+            "message": "Potential auth bypass",
+            "_source": "llm",
+            "_security_evidence": "hypothesis",
+        }
+    )
+
+    assert card.label == "speculative"
+    assert card.confidence == 55
+    assert "not backed by verifier-confirmed evidence" in card.evidence[0]
+
+
+def test_verified_llm_finding_is_proven():
+    card = build_evidence_card(
+        {
+            "category": "security",
+            "rule_id": "SKY-L002",
+            "severity": "HIGH",
+            "file": "views.py",
+            "line": 3,
+            "message": "Authorization check missing",
+            "_source": "llm",
+            "verification": {"verdict": "VERIFIED"},
+        }
+    )
+
+    assert card.label == "proven"
+    assert "verified" in card.evidence[0]
+
+
+def test_review_supported_llm_finding_is_likely_not_proven():
+    card = build_evidence_card(
+        {
+            "category": "security",
+            "rule_id": "SKY-D201",
+            "severity": "HIGH",
+            "file": "app.py",
+            "line": 4,
+            "message": "eval() may be reachable",
+            "_source": "llm",
+            "_security_evidence": "review_supported",
+        }
+    )
+
+    assert card.label == "likely"
+    assert "LLM review supplied supporting evidence" in card.evidence[0]
+
+
+def test_security_regression_card_is_proven():
+    card = build_evidence_card(
+        {
+            "kind": "security_regression",
+            "category": "security_regression",
+            "control_type": "auth",
+            "severity": "HIGH",
+            "file": "views.py",
+            "line": 10,
+            "message": "Auth decorator was removed",
+            "rule_id": "SKY-L021",
+        }
+    )
+
+    assert card.label == "proven"
+    assert card.kind == "security_regression"
+    assert "auth control" in card.evidence[0]
+    assert "authentication check" in card.suggested_fix
+
+
+def test_unknown_security_regression_card_has_fallback_suggested_fix():
+    card = build_evidence_card(
+        {
+            "kind": "security_regression",
+            "category": "security_regression",
+            "control_type": "new_control",
+            "severity": "HIGH",
+            "file": "views.py",
+            "line": 10,
+            "message": "Security control was removed",
+            "rule_id": "SKY-L099",
+        }
+    )
+
+    assert card.label == "proven"
+    assert "new control control" not in card.evidence[0]
+    assert card.evidence[0] == "PR diff removed or weakened new control."
+    assert card.suggested_fix == (
+        "Restore or replace the removed security control before merging."
+    )
+
+
+def test_secret_card_does_not_expose_secret_value():
+    token = _stripe_like_token()
+    card = build_evidence_card(
+        {
+            "category": "secrets",
+            "rule_id": "SKY-S101",
+            "severity": "HIGH",
+            "file": "settings.py",
+            "line": 2,
+            "message": f"Found API key {token}",
+            "value": token,
+        }
+    )
+
+    rendered = "\n".join(
+        [
+            card.title,
+            *card.evidence,
+            card.impact,
+            card.suggested_fix or "",
+        ]
+    )
+    assert token not in rendered
+    assert "secret value is intentionally omitted".lower() in rendered.lower()
+
+
+def test_redact_sensitive_text_removes_token_like_values():
+    token = _github_like_token()
+    assert token not in redact_sensitive_text(f"token={token}")
+
+
+def test_evidence_counts_come_from_cards():
+    cards = build_evidence_cards(
+        [
+            {"category": "danger", "rule_id": "SKY-D201", "severity": "HIGH"},
+            {
+                "category": "security",
+                "_source": "llm",
+                "_security_evidence": "hypothesis",
+            },
+            {"category": "quality", "rule_id": "SKY-Q301"},
+        ]
+    )
+
+    assert evidence_counts(cards) == {"proven": 1, "likely": 1, "speculative": 1}
+
+
+def test_generic_quality_card_has_fallback_suggested_fix():
+    card = build_evidence_card(
+        {
+            "category": "quality",
+            "rule_id": "SKY-Q999",
+            "severity": "MEDIUM",
+            "file": "app.py",
+            "line": 5,
+            "message": "Generic maintainability issue",
+        }
+    )
+
+    assert card.label == "likely"
+    assert card.suggested_fix == (
+        "Refactor the affected code to remove the reported maintainability issue."
+    )

--- a/test/test_cicd_review.py
+++ b/test/test_cicd_review.py
@@ -1,12 +1,18 @@
+from unittest.mock import patch
+
 import pytest
 
 from skylos.cicd.review import (
     _parse_unified_diff,
     filter_findings_to_diff,
     _flatten_findings,
+    _merge_llm_findings,
     _format_review_comment,
+    _format_evidence_card_comment,
+    _post_summary_comment,
     _detect_pr_number,
 )
+from skylos.cicd.evidence import build_evidence_card
 
 
 SAMPLE_DIFF = """\
@@ -26,6 +32,10 @@ index 111..222 100644
 -    return old_value
 +    return new_value
 """
+
+
+def _stripe_like_token() -> str:
+    return "sk" + "_live_" + "abcdefghijklmnopqrstuvwxyz1234567890"
 
 
 @pytest.fixture
@@ -97,6 +107,67 @@ def test_flatten_findings(sample_results):
     assert findings[2]["category"] == "quality"
 
 
+def test_flatten_findings_preserves_safe_evidence_metadata():
+    token = _stripe_like_token()
+    findings = _flatten_findings(
+        {
+            "danger": [
+                {
+                    "rule_id": "SKY-L001",
+                    "file": "app.py",
+                    "line": 3,
+                    "message": "Potential issue",
+                    "metadata": {
+                        "security_evidence": "hypothesis",
+                        "review_reason": "needs runtime proof",
+                        "raw_secret": token,
+                    },
+                    "verification": {
+                        "verdict": "VERIFIED",
+                        "raw_context": "not copied",
+                    },
+                }
+            ]
+        }
+    )
+
+    finding = findings[0]
+    assert finding["_security_evidence"] == "hypothesis"
+    assert finding["_review_reason"] == "needs runtime proof"
+    assert finding["verification"] == {"verdict": "VERIFIED"}
+    assert "raw_secret" not in finding["metadata"]
+    assert "raw_context" not in finding["verification"]
+
+
+def test_merge_llm_hypothesis_does_not_downgrade_static_finding_source():
+    static_findings = [
+        {
+            "category": "danger",
+            "rule_id": "SKY-D201",
+            "severity": "HIGH",
+            "message": "eval() usage",
+            "file": "app.py",
+            "line": 3,
+        }
+    ]
+    llm_findings = [
+        {
+            "rule_id": "SKY-D201",
+            "file": "app.py",
+            "line": 3,
+            "_source": "llm",
+            "_security_evidence": "hypothesis",
+            "explanation": "possible issue",
+        }
+    ]
+
+    merged = _merge_llm_findings(static_findings, llm_findings)
+    card = build_evidence_card(merged[0])
+
+    assert merged[0].get("_source") != "llm"
+    assert card.label == "proven"
+
+
 def test_format_review_comment():
     finding = {
         "severity": "CRITICAL",
@@ -107,6 +178,135 @@ def test_format_review_comment():
     assert "CRITICAL" in comment
     assert "SKY-D201" in comment
     assert "SQL injection" in comment
+
+
+def test_format_review_comment_redacts_secret_like_values():
+    token = _stripe_like_token()
+    finding = {
+        "severity": "HIGH",
+        "rule_id": "SKY-S101",
+        "message": f"Secret value {token}",
+    }
+
+    comment = _format_review_comment(finding)
+
+    assert token not in comment
+    assert "[redacted]" in comment
+
+
+def test_format_evidence_card_comment():
+    finding = {
+        "category": "danger",
+        "severity": "HIGH",
+        "rule_id": "SKY-D211",
+        "message": "SQL built from user input",
+        "file": "app.py",
+        "line": 9,
+    }
+
+    comment = _format_evidence_card_comment(finding)
+
+    assert "Risk: Proven security finding" in comment
+    assert "SKY-D211" in comment
+    assert "Evidence:" in comment
+    assert "Impact:" in comment
+    assert "Suggested fix:" in comment
+    assert "Confidence:" in comment
+
+
+def test_format_evidence_card_comment_includes_fallback_suggested_fix():
+    finding = {
+        "category": "quality",
+        "severity": "MEDIUM",
+        "rule_id": "SKY-Q999",
+        "message": "Generic maintainability issue",
+        "file": "app.py",
+        "line": 5,
+    }
+
+    comment = _format_evidence_card_comment(finding)
+
+    assert "Risk: Likely quality issue" in comment
+    assert "Suggested fix:" in comment
+    assert "Refactor the affected code" in comment
+
+
+def test_summary_comment_omits_evidence_counts_by_default():
+    captured = {}
+
+    def mock_run(cmd, **kwargs):
+        if "pr" in cmd and "comment" in cmd:
+            captured["body"] = cmd[cmd.index("--body") + 1]
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return FakeResult()
+
+    finding = {
+        "category": "danger",
+        "severity": "HIGH",
+        "rule_id": "SKY-D201",
+        "message": "eval() usage",
+        "file": "app.py",
+        "line": 4,
+    }
+
+    with patch("skylos.cicd.review.subprocess.run", side_effect=mock_run):
+        _post_summary_comment([finding], [finding], 42, "owner/repo")
+
+    assert "### Evidence" not in captured["body"]
+
+
+def test_summary_comment_includes_evidence_counts_when_enabled():
+    captured = {}
+
+    def mock_run(cmd, **kwargs):
+        if "pr" in cmd and "comment" in cmd:
+            captured["body"] = cmd[cmd.index("--body") + 1]
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return FakeResult()
+
+    findings = [
+        {
+            "category": "danger",
+            "severity": "HIGH",
+            "rule_id": "SKY-D201",
+            "message": "eval() usage",
+            "file": "app.py",
+            "line": 4,
+        },
+        {
+            "category": "security",
+            "severity": "HIGH",
+            "_source": "llm",
+            "_security_evidence": "hypothesis",
+            "message": "Possible auth issue",
+            "file": "views.py",
+            "line": 8,
+        },
+    ]
+
+    with patch("skylos.cicd.review.subprocess.run", side_effect=mock_run):
+        _post_summary_comment(
+            findings,
+            findings,
+            42,
+            "owner/repo",
+            evidence_cards=True,
+        )
+
+    body = captured["body"]
+    assert "### Evidence" in body
+    assert "| Proven | 1 |" in body
+    assert "| Speculative | 1 |" in body
 
 
 def test_detect_pr_number(monkeypatch):

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -739,6 +739,34 @@ def test_cicd_gate_command_reads_input_and_returns_gate_exit(tmp_path):
     assert mock_gate.call_args.kwargs["result"]["project_root"] == str(tmp_path)
 
 
+def test_cicd_review_command_passes_evidence_cards_flag(tmp_path):
+    results_path = tmp_path / "results.json"
+    results_path.write_text(json.dumps({"project_root": str(tmp_path), "danger": []}))
+    from skylos.commands.cicd_cmd import run_cicd_command
+
+    with patch("skylos.cicd.review.run_pr_review") as mock_review:
+        exit_code = run_cicd_command(
+            [
+                "review",
+                "--input",
+                str(results_path),
+                "--pr",
+                "12",
+                "--repo",
+                "owner/repo",
+                "--evidence-cards",
+            ],
+            console_factory=lambda: Mock(),
+            load_config_func=lambda path: {},
+            run_gate_interaction_func=Mock(),
+            emit_github_annotations_func=Mock(),
+        )
+
+    assert exit_code == 0
+    assert mock_review.call_args.kwargs["evidence_cards"] is True
+    assert mock_review.call_args.kwargs["pr_number"] == 12
+
+
 def test_cli_guardrail_static_json_output_passthrough(monkeypatch):
     result = {
         "unused_functions": [{"name": "unused_func", "file": "test.py", "line": 10}],


### PR DESCRIPTION
## Summary

  - add optional PR evidence cards for `skylos cicd review`
  - label review findings as `Proven`, `Likely`, or `Speculative`
  - include evidence, impact, suggested fix, and confidence in evidence card comments
  - add summary counts for evidence labels when `--evidence-cards` is enabled

## Add/Fix

  - add an evidence card builder for PR review findings
  - add `--evidence-cards` to `skylos cicd review`
  - preserve safe evidence metadata while flattening findings
  - keep static `SKY-D` / `SKY-S` findings proven even when matched with LLM metadata
  - keep review-supported LLM-only findings likely unless verifier verdict is `VERIFIED`
  - redact secret-like values before rendering comments

## Tests

- `pytest test/test_cicd_evidence.py test/test_cicd_review.py test/test_cli_refactor_guardrails.py::test_cicd_review_command_passes_evidence_cards_flag`