### PR TITLE
docs(contributing): add contributor roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,188 @@
-# Contributing to Skylos
+# Contributing To Skylos
 
-## How Can I Contribute?
+Skylos is a local-first static analysis tool and PR gate. Good contributions
+make the scanner more correct, easier to run, or easier to trust in CI.
 
-### Reporting Bugs
-- If you find a bug, please open an issue on GitHub.
-- Include a clear title and description.
-- Describe the steps to reproduce the bug.
-- Include details about your environment (OS, Python version, Skylos version).
-- Provide any relevant error messages or logs.
+Start with the smallest change that proves the behavior. A narrow rule with a
+strong regression test is better than a broad heuristic that creates false
+positives. If you are unsure, please refer to `ROADMAP.md`
 
-### Suggesting Enhancements
-- Open an issue on GitHub to discuss your ideas.
-- Clearly describe the feature and why it would be useful.
+## Ways To Contribute
 
-### Pull Requests
+Useful contributions include:
 
-1.  **Fork the repo:** Click the "Fork" button at the top right of the [Skylos GitHub page](https://github.com/duriantaco/skylos).
-2.  **Clone your fork:** `git clone https://github.com/YOUR_USERNAME/skylos.git`
-3.  **Create a separate branch:** `git checkout -b feature/your-changes` or `bugfix/the-bug-you-fixed`
-4.  **Set Up Development Environment:**
-    * Please ensure that you have Python (>=3.9) installed.
+- Bug reports with a minimal reproduction and the exact `skylos` command used.
+- False-positive or false-negative reports with a small code sample.
+- New security, secrets, quality, or dead-code rules with focused tests.
+- Framework-awareness improvements for real entrypoints, callbacks, decorators,
+  and generated code patterns.
+- CI/CD and PR review improvements that make findings easier to understand.
+- Documentation that helps users configure Skylos or understand a rule.
+- Benchmark and corpus cases that protect a confirmed behavior.
 
-    * Install Python development dependencies (like `inquirer` for interactive mode testing, `pytest`): `pip install inquirer pytest`
-    * Build Skylos in development mode: `pip install -e .`
-5.  **Make Your Changes:**
-    * For Python CLI changes, primarily in `skylos/cli.py`.
-6.  **Add Tests:**
-    * For Python integration tests: `pytest test/` from the project root.
-    * For static-analysis precision changes: `python3 scripts/corpus_ci.py --manifest corpus/manifest.json`
-    * Ensure your changes are covered by new or existing tests.
-7.  **Update Documentation:** If your changes affect user-facing features or the API, please update `README.md` or other relevant documentation.
-8.  **Commit Your Changes:** `git commit -am 'your changes'`
-9.  **Push to Your Branch:** `git push origin feature/your-changes`
-10. **Open a Pull Request:** Go to the original Skylos repo and open a pull request from your forked branch.
-    * Provide clear description of your changes.
-    * Reference any related issues.
+Before starting large work, open an issue or draft PR so maintainers can confirm
+the scope.
 
-## Contribution Authorship And AI Use
+## Development Setup
 
-- Contributors are expected to write and own their submitted code, issue reports, PR descriptions, and review summaries. AI-generated content submitted as one's own work will not be accepted.
-- Contributors must be able to explain, test, and defend any substantive change. If a contributor cannot clearly explain what changed and why, the submission may be rejected regardless of how it was produced.
-- Maintainers evaluate submissions on correctness, clarity, test coverage, and the contributor's demonstrated understanding of the change.
-- Assistive use is permitted for spelling, grammar, minor cleanups, and supplemental research. If AI tools played a meaningful role in producing a contribution, please disclose that in the PR.
-- This policy governs what gets submitted to Skylos, **NOT** every private tool used in the background. We are taking a stricter posture for now because review capacity is limited and the project quality bar is high.
+Skylos supports Python 3.10 and newer.
 
-## Code Style
-- You can look at our code and just follow it accordingly. Try your best to follow best practices. 
+```bash
+git clone https://github.com/YOUR_USERNAME/skylos.git
+cd skylos
+python -m venv .venv
+. .venv/bin/activate
+pip install -e ".[test,llm]"
+```
+
+If you do not need LLM-related tests, `pip install -e ".[test]"` is enough for
+most static-analysis work.
+
+Run the CLI from the checkout:
+
+```bash
+skylos --help
+skylos . --no-provenance
+skylos . -a
+```
+
+## Choosing The Right Files
+
+Use this map to keep changes in the right part of the repo.
+
+| Contribution | Main Files | Common Tests |
+|:---|:---|:---|
+| CLI command parsing or dispatch | `skylos/cli.py`, `skylos/commands/*.py` | `test/test_cli*.py`, command-specific tests |
+| GitHub Actions workflow generation | `skylos/cicd/workflow.py`, `action.yml` | `test/test_cicd_workflow.py` |
+| PR review comments and summaries | `skylos/cicd/review.py` | `test/test_cicd_review.py`, `test/test_regression.py` |
+| CI gate behavior | `skylos/gatekeeper.py`, `skylos/cicd/*`, `scripts/skylos_gate.py` | `test/test_cicd_gate.py`, `test/test_gatekeeper.py` |
+| Python dead-code precision | `skylos/analyzer.py`, `skylos/dead_code.py`, `skylos/visitors/*.py`, `skylos/*reachability*.py` | `test/test_dead_code*.py`, `test/test_framework_aware.py`, corpus tests |
+| TypeScript/JavaScript support | `skylos/visitors/languages/typescript/*.py` | `test/test_typescript*.py`, relevant language tests |
+| Java support | `skylos/visitors/languages/java/*.py` | `test/test_java*.py` |
+| Go support | `skylos/visitors/languages/go/*.py`, `skylos/engines/go_*.py` | `test/test_go*.py` |
+| PHP support | `skylos/visitors/languages/php/*.py` | `test/test_php*.py` |
+| Rust support | `skylos/visitors/languages/rust/*.py` | `test/test_rust*.py` |
+| Python security rules | `skylos/rules/danger/**/*.py`, `skylos/security_contracts.py` | `test/test_*flow.py`, `test/test_security*.py` |
+| Secrets rules | `skylos/rules/secrets.py`, `skylos/credentials.py` | `test/test_credentials.py`, secrets tests |
+| Quality rules | `skylos/rules/quality/*.py`, `skylos/linter.py` | `test/test_complexity.py`, `test/test_*quality*.py` |
+| Technical debt reports | `skylos/debt/*.py`, `skylos/commands/debt_cmd.py` | `test/test_debt.py` |
+| AI defense checks | `skylos/defend/*.py`, `skylos/commands/defend_cmd.py` | `test/test_defend*.py` |
+| Agent and verifier workflows | `skylos/llm/*.py`, `skylos/agent_*.py` | `test/test_agent*.py`, `test/test_*verifier.py` |
+| VS Code extension | `editors/vscode/src/*.ts`, `editors/vscode/package.json` | extension build/lint commands |
+| MCP server | `skylos_mcp/*.py` | MCP-related tests |
+| Benchmarks | `benchmarks/**`, `scripts/*benchmark*.py` | benchmark scripts and focused unit tests |
+| Corpus precision fixtures | `corpus/fixtures/**`, `corpus/manifest.json` | `python scripts/corpus_ci.py --manifest corpus/manifest.json` |
+
+If you are unsure where a change belongs, open the issue first and describe the
+rule or behavior you want to change.
+
+## Rule Contributions
+
+For new rules, include:
+
+- A short rule name and stable rule ID if the rule emits user-facing findings.
+- A positive test that proves Skylos catches the risky pattern.
+- A negative test that proves Skylos does not flag the safe pattern.
+- A clear message and suggested fix when possible.
+- A narrow scope. Do not flag every similar-looking pattern unless the rule can
+  distinguish safe from unsafe usage.
+
+For security rules, prefer structured parsing, data-flow checks, or framework
+contracts over string-only matching. If a heuristic is unavoidable, keep severity
+and confidence conservative.
 
 ## Precision Policy
 
-- Treat the corpus as a required regression guard for dead-code precision.
-- If you fix a confirmed false positive or precision regression, add a minimal fixture under `corpus/fixtures/` that isolates the runtime contract or language pattern.
-- Register the case in `corpus/manifest.json` with narrow expectations and a source link to the upstream framework or library pattern that motivated it.
-- Keep fixtures small and pattern-focused. The corpus should protect specific contracts, not attempt to model an entire framework in one file.
-- Prefer explicit contracts over broad heuristic suppression. If a pattern is plausible but not proven, keep the rule narrow or lower confidence instead of hard-suppressing it.
-- Do not relax or remove an existing corpus expectation unless the original pattern was invalid or the contract changed.
+Treat false positives as serious regressions. A scanner that users cannot trust
+will be ignored.
+
+- If you fix a confirmed false positive, add a minimal fixture under
+  `corpus/fixtures/` when the case describes a reusable framework or language
+  contract.
+- Register corpus fixtures in `corpus/manifest.json` with narrow expectations.
+- Keep fixtures small and pattern-focused.
+- Prefer explicit contracts over broad suppression.
+- Do not relax or remove an existing corpus expectation unless the original
+  expectation was invalid or the upstream contract changed.
+
+Run the corpus gate when changing dead-code precision:
+
+```bash
+python scripts/corpus_ci.py --manifest corpus/manifest.json
+```
+
+## Tests And Checks
+
+Run the narrowest relevant test first, then a broader check before opening a PR.
+
+```bash
+pytest -q test/test_file_you_changed.py
+pytest -q
+python -m ruff check skylos test
+```
+
+For PR review, CI, or gate changes, also run the relevant command-level tests:
+
+```bash
+pytest -q test/test_cicd_review.py test/test_cicd_gate.py test/test_cicd_workflow.py
+```
+
+For benchmark-sensitive work:
+
+```bash
+python scripts/dead_code_benchmark.py
+python scripts/security_benchmark.py
+python scripts/quality_benchmark.py
+python scripts/agent_review_benchmark.py
+```
+
+Only run benchmark scripts that are relevant to your change. If a benchmark
+result changes, explain why in the PR.
+
+## Pull Request Checklist
+
+Before opening a PR:
+
+- Keep the PR focused on one behavior or one small feature.
+- Add tests for the behavior changed.
+- Update docs when commands, config, output, or rule behavior changes.
+- Include before/after output when fixing CLI behavior or PR comments.
+- Explain false-positive and false-negative risks for scanner changes.
+- Mention any benchmark or corpus result that changed.
+
+A useful PR description answers:
+
+- What problem does this solve?
+- What changed?
+- Why did the bug or gap exist?
+- What files or lines are important?
+- What was tested?
+- What risks remain?
+
+## AI Use
+
+Contributors are expected to understand and own their submitted work.
+
+- Do not submit code, tests, issue reports, or review summaries that you cannot
+  explain.
+- If AI tools materially helped produce the contribution, disclose that in the
+  PR.
+- Maintainers may ask for an explanation, reproduction, or test evidence before
+  reviewing generated-looking changes.
+
+Assistive use for spelling, formatting, or research is fine. The quality bar is
+correctness and demonstrated understanding.
+
+## Reporting Security Issues
+
+Do not open a public issue for a vulnerability in Skylos itself. Follow
+`SECURITY.md` for responsible disclosure.
+
+For scanner rule gaps, open a normal issue if the report does not expose a live
+secret, private exploit path, or sensitive user code.
 
 ## Getting Help
-If you have questions or need help, feel free to open an issue with the "question" label.
 
-Thank you for contributing!
+Use GitHub issues for bugs, questions, feature proposals, and rule requests.
+Include the command you ran, the expected behavior, the actual behavior, and a
+minimal reproduction whenever possible.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 [VS Code Extension](./editors/vscode/README.md) |
 [Real-World Results](./REAL_WORLD_RESULTS.md) |
 [Benchmarks](./BENCHMARK.md) |
+[Roadmap](./ROADMAP.md) |
 [Contributing](./CONTRIBUTING.md)
 
 **English** | [Chinese README](./README_CN.md)
@@ -273,6 +274,7 @@ metadata, and supports monorepo subprojects through `--scan-path`.
 | Benchmarks and methodology | [BENCHMARK.md](./BENCHMARK.md) |
 | Security policy | [SECURITY.md](./SECURITY.md) |
 | Release process | [RELEASE_WORKFLOW.md](./RELEASE_WORKFLOW.md) |
+| Contribution priorities | [ROADMAP.md](./ROADMAP.md) |
 | Contributing | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 
 ## Common Questions
@@ -303,6 +305,7 @@ Use baselines, whitelists, inline suppressions, or runtime tracing. See the
 
 - Report security issues through [SECURITY.md](./SECURITY.md).
 - Open bugs and false-positive reports with minimal repros.
+- Check [ROADMAP.md](./ROADMAP.md) for useful contribution areas.
 - Read [CONTRIBUTING.md](./CONTRIBUTING.md) before sending a pull request.
 - See [QUALITY.md](./QUALITY.md) for project quality and gate expectations.
 - Join the [Discord](https://discord.gg/Ftn9t9tErf) for community support.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,182 @@
+# Skylos Roadmap
+
+This roadmap lists areas where contributions are especially useful. It is not a
+release promise. Priorities can change when users report false positives,
+security gaps, or CI breakages.
+
+If you want to work on a larger item, open an issue or draft PR first so the
+scope can be confirmed.
+
+## Current Direction
+
+Skylos is focused on five product goals:
+
+- Make static findings trustworthy enough for CI and PR review.
+- Reduce dead-code false positives in dynamic frameworks.
+- Catch security and AI-generated-code mistakes before they reach main.
+- Keep the tool local-first and usable without mandatory LLM or cloud calls.
+- Make findings easy to explain, reproduce, and fix.
+
+## Good First Contributions
+
+These are small, low-risk areas for new contributors. You can do the following:
+
+- Add a minimal false-positive fixture to `corpus/fixtures/` and register it in `corpus/manifest.json`.
+- Improve an unclear finding message or suggested fix.
+- Add a missing negative test for an existing rule.
+- Add a small benchmark case for an already-supported pattern.
+
+## Near-Term Priorities
+
+### PR Review Evidence
+
+Goal: make PR comments explain why a finding is proven, likely, or speculative.
+
+Useful work:
+
+- Improve evidence-card wording for more rule families.
+- Keep evidence labels conservative when LLM or verifier data is incomplete.
+- Add better suggestions for high-signal security and quality rules.
+
+Main files:
+
+- `skylos/cicd/review.py`
+- `skylos/cicd/evidence.py`
+- `skylos/commands/cicd_cmd.py`
+- `test/test_cicd_review.py`
+- `test/test_cicd_evidence.py`
+
+### Dead-Code Precision
+
+Goal: reduce false positives without hiding real unused code.
+
+Useful work:
+
+- Add framework contracts for real entrypoints, decorators, callbacks, signals, serializers, and plugin hooks.
+- Improve TS/JS workspace and export reachability
+- Add/Improve cross-language test coverage for Java, Go, PHP, and Rust
+- Add a small corpus fixtures for confirmed framework patterns.
+
+Main files:
+
+- `skylos/analyzer.py`
+- `skylos/dead_code.py`
+- `skylos/dead_code_liveness.py`
+- `skylos/module_reachability.py`
+- `skylos/visitors/framework_aware.py`
+- `skylos/visitors/languages/**`
+- `corpus/fixtures/**`
+- `corpus/manifest.json`
+
+### Security And Vibe-Coding Rules
+
+Goal: catch common security mistakes from fast AI-assisted coding without turning the scanner into noise.
+
+Useful work:
+
+- Add narrow rules for missing verification, disabled controls, unsafe defaults prompt-injection exposure, tool-call misuse, and missing network timeouts.
+- Improve webhook, SSRF, path traversal, command injection, SQL injection, XSS, JWT, CORS, and MCP checks.
+- Add safe-pattern tests so rules do not punish correct code.
+- Improve secret redaction in any user-facing output path.
+
+Main files:
+
+- `skylos/rules/danger/**/*.py`
+- `skylos/rules/secrets.py`
+- `skylos/rules/vibe_dictionary.py`
+- `skylos/security_contracts.py`
+- `skylos/injection_scanner.py`
+- `test/test_*flow.py`
+- `test/test_security*.py`
+
+### Technical Debt Reports
+
+Goal: make `skylos debt` useful for conservative cleanup planning.
+
+Useful work:
+
+- Improve hotspot explanations without inventing evidence.
+- Add clearer changed-code and history views.
+- Add tests for report rendering and baseline comparisons.
+- Keep debt scoring stable and explainable.
+
+Main files:
+
+- `skylos/debt/*.py`
+- `skylos/commands/debt_cmd.py`
+- `test/test_debt.py`
+
+### CI/CD And Quality Gates
+
+Goal: make Skylos easy to adopt in GitHub Actions without surprising users.
+
+Useful work:
+
+- Improve generated workflow comments and defaults.
+- Keep gate behavior predictable between local and CI runs.
+- Add diff-aware tests for annotations and PR summaries.
+- Improve failure messages with exact next steps.
+
+Main files:
+
+- `skylos/cicd/workflow.py`
+- `skylos/cicd/review.py`
+- `skylos/gatekeeper.py`
+- `action.yml`
+- `scripts/skylos_gate.py`
+- `test/test_cicd_*.py`
+
+### Performance
+
+Goal: make scans faster without unsafe caching or stale results. (Cache is inherently tricky so got to approch this with a more conservative approach)
+
+Useful work:
+
+- Profile parser and visitor hot spots.
+- Reduce repeated filesystem or dependency graph work.
+- Add benchmark cases before changing scan strategy.
+- Avoid broad persistent caching unless invalidation is explicit, tested, and easy to disable.
+
+Main files:
+
+- `skylos/file_discovery.py`
+- `skylos/fast.py`
+- `skylos/grep_cache.py`
+- `skylos/pipeline.py`
+- `scripts/analyzer_speed_check.py`
+- benchmark scripts under `scripts/`
+
+### Editor And Agent Integrations
+
+Goal: make findings useful where users write and review code.
+
+Useful work:
+
+- Improve VS Code diagnostics, quick fixes, and rule metadata.
+- Keep extension rule IDs and severity colors in sync with core Skylos.
+- Improve MCP server responses for AI coding assistants.
+- Add tests around agent/verifier behavior when evidence is incomplete.
+
+Main files:
+
+- `editors/vscode/src/**`
+- `editors/vscode/package.json`
+- `skylos_mcp/*.py`
+- `skylos/llm/*.py`
+- `skylos/agent_*.py`
+- `test/test_agent*.py`
+- `test/test_*verifier.py`
+
+
+## How To Propose A Roadmap Item
+
+If you will like to propose a roadmap item, open an issue with:
+
+- The user problem.
+- A minimal example or target workflow.
+- The expected command/output behavior.
+- The likely files that need to change.
+- The tests or corpus cases that would prove the behavior.
+- Known false-positive or compatibility risks.
+
+For implementation guidance, see `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary

  - add `ROADMAP.md` with contribution priorities and cautious areas
  - rewrite `CONTRIBUTING.md` with setup, file ownership, tests, and PR guidance