### PR TITLE
feat(cicd): add AI PR risk passport

### DIFF
--- a/skylos/cicd/review.py
+++ b/skylos/cicd/review.py
@@ -15,6 +15,10 @@ from skylos.cicd.evidence import (
     evidence_label_title,
     redact_sensitive_text,
 )
+from skylos.cicd.risk_passport import (
+    build_risk_passport,
+    format_risk_passport_markdown,
+)
 from skylos.rules.quality.regression import detect_security_regressions
 
 console = Console()
@@ -31,6 +35,7 @@ def run_pr_review(
     grade: dict | None = None,
     previous_grade: dict | None = None,
     llm_findings: list[dict] | None = None,
+    defense_report: dict | None = None,
     evidence_cards: bool = False,
 ) -> None:
     pr_number = pr_number or _detect_pr_number()
@@ -71,6 +76,13 @@ def run_pr_review(
         findings = all_findings + regression_findings
 
     all_findings.extend(regression_findings)
+    provenance = _resolve_review_provenance(results, diff_base=diff_base)
+    risk_passport = build_risk_passport(
+        all_findings=all_findings,
+        diff_findings=findings,
+        provenance=provenance,
+        defense_report=defense_report,
+    )
 
     if findings and not summary_only:
         _post_pr_review(
@@ -88,12 +100,27 @@ def run_pr_review(
         grade=grade,
         previous_grade=previous_grade,
         evidence_cards=evidence_cards,
+        risk_passport=risk_passport,
     )
 
     console.print(
         f"[green]Posted review on PR #{pr_number} "
         f"({len(findings)} inline, {len(all_findings)} total)[/green]"
     )
+
+
+def _resolve_review_provenance(results: dict, *, diff_base: str) -> dict | None:
+    provenance = results.get("provenance")
+    if isinstance(provenance, dict):
+        return provenance
+
+    project_root = results.get("project_root") or "."
+    try:
+        from skylos.provenance import analyze_provenance
+
+        return analyze_provenance(project_root, base_ref=diff_base).to_dict()
+    except Exception:
+        return None
 
 
 def get_changed_line_ranges(base_ref: str = "origin/main") -> list[dict]:
@@ -264,6 +291,14 @@ def _copy_safe_finding_metadata(source: dict, target: dict) -> None:
     confidence = source.get("confidence")
     if isinstance(confidence, int):
         target["confidence"] = confidence
+
+    ai_authored = source.get("ai_authored")
+    if isinstance(ai_authored, bool):
+        target["ai_authored"] = ai_authored
+
+    ai_agent = source.get("ai_agent")
+    if isinstance(ai_agent, str):
+        target["ai_agent"] = ai_agent
 
     verification = source.get("verification")
     if isinstance(verification, dict):
@@ -555,6 +590,7 @@ def _post_summary_comment(
     grade: dict | None = None,
     previous_grade: dict | None = None,
     evidence_cards: bool = False,
+    risk_passport: dict | None = None,
 ) -> None:
     by_severity = {}
     for f in all_findings:
@@ -571,10 +607,15 @@ def _post_summary_comment(
         "",
         f"**{len(diff_findings)}** issue(s) on changed lines | "
         f"**{len(all_findings)}** total",
-        "",
-        "| Severity | Count |",
-        "|----------|-------|",
     ]
+    lines.extend(format_risk_passport_markdown(risk_passport))
+    lines.extend(
+        [
+            "",
+            "| Severity | Count |",
+            "|----------|-------|",
+        ]
+    )
 
     for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW"):
         count = by_severity.get(sev, 0)

--- a/skylos/cicd/risk_passport.py
+++ b/skylos/cicd/risk_passport.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from typing import Any
+
+from skylos.cicd.evidence import (
+    build_evidence_cards,
+    evidence_counts,
+    redact_sensitive_text,
+)
+
+_SEVERITY_SCORE = {
+    "CRITICAL": 4,
+    "HIGH": 3,
+    "MEDIUM": 2,
+    "LOW": 1,
+}
+
+
+def build_risk_passport(
+    *,
+    all_findings: list[dict[str, Any]],
+    diff_findings: list[dict[str, Any]],
+    provenance: dict[str, Any] | None = None,
+    defense_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    provenance_data = provenance if isinstance(provenance, dict) else {}
+    ai_files = _agent_files(provenance_data)
+    reasons: list[str] = []
+    warning_reasons: list[str] = []
+    high_risk_ai_files: set[str] = set()
+    weakened_controls: set[str] = set()
+
+    cards = build_evidence_cards(diff_findings)
+    counts = evidence_counts(cards)
+
+    for finding, card in zip(diff_findings, cards):
+        severity_score = _severity_score(finding.get("severity"))
+        is_ai = _is_ai_authored_finding(finding, provenance_data, ai_files)
+        file_label = _display_file(finding.get("file"))
+
+        if card.kind == "security_regression":
+            control = str(finding.get("control_type") or "unknown")
+            weakened_controls.add(control)
+            reasons.append(f"Changed-line security regression: {control}")
+            continue
+
+        if card.kind == "secret":
+            reasons.append(
+                f"Changed-line secret exposure in {file_label or 'unknown file'}"
+            )
+            continue
+
+        if (
+            is_ai
+            and card.kind == "security"
+            and severity_score >= _SEVERITY_SCORE["HIGH"]
+            and card.label in {"proven", "likely"}
+        ):
+            if file_label:
+                high_risk_ai_files.add(file_label)
+            severity = str(finding.get("severity") or "HIGH").upper()
+            reasons.append(
+                f"AI-authored {card.label} {severity} security finding"
+            )
+            continue
+
+        if severity_score >= _SEVERITY_SCORE["HIGH"] and card.label == "speculative":
+            warning_reasons.append(
+                f"High-severity speculative finding in {file_label or 'unknown file'}"
+            )
+            continue
+
+        if is_ai and severity_score > 0:
+            warning_reasons.append(
+                f"AI-authored changed-line finding in {file_label or 'unknown file'}"
+            )
+
+    missing_guardrails, defense_block_files, defense_warnings = _defense_risk(
+        defense_report, ai_files
+    )
+    high_risk_ai_files.update(defense_block_files)
+    reasons.extend(
+        f"AI-authored LLM integration failed high-risk guardrail: {plugin_id}"
+        for plugin_id in missing_guardrails["blocking"]
+    )
+    warning_reasons.extend(defense_warnings)
+
+    if provenance_data.get("confidence") == "low" and ai_files:
+        warning_reasons.append("AI provenance detected with low confidence")
+
+    recommendation: str
+    if reasons:
+        recommendation = "BLOCK"
+    elif warning_reasons:
+        recommendation = "WARN"
+    else:
+        recommendation = "PASS"
+
+    summary = provenance_data.get("summary") or {}
+    agents = summary.get("agents_seen") or []
+
+    return {
+        "recommendation": recommendation,
+        "ai_authored_files": len(ai_files),
+        "ai_agents": sorted(str(agent) for agent in agents if str(agent).strip()),
+        "provenance_confidence": provenance_data.get("confidence") or "unavailable",
+        "changed_line_evidence": counts,
+        "high_risk_ai_files": sorted(high_risk_ai_files),
+        "security_controls_weakened": sorted(weakened_controls),
+        "missing_llm_guardrails": sorted(
+            set(missing_guardrails["blocking"] + missing_guardrails["warning"])
+        ),
+        "reasons": reasons,
+        "warnings": warning_reasons,
+    }
+
+
+def format_risk_passport_markdown(passport: dict[str, Any] | None) -> list[str]:
+    if not passport:
+        return []
+
+    counts = passport.get("changed_line_evidence") or {}
+    evidence_text = (
+        f"Proven {int(counts.get('proven') or 0)} / "
+        f"Likely {int(counts.get('likely') or 0)} / "
+        f"Speculative {int(counts.get('speculative') or 0)}"
+    )
+
+    lines = [
+        "",
+        "### AI PR Risk Passport",
+        "",
+        f"**Merge recommendation: {passport.get('recommendation', 'PASS')}**",
+        "",
+        "| Signal | Value |",
+        "|--------|-------|",
+        f"| AI-authored files | {int(passport.get('ai_authored_files') or 0)} |",
+        f"| Agents | {_join_values(passport.get('ai_agents'))} |",
+        "| Provenance confidence | "
+        f"{passport.get('provenance_confidence') or 'unavailable'} |",
+        f"| Changed-line evidence | {evidence_text} |",
+        f"| High-risk AI files | {_join_values(passport.get('high_risk_ai_files'))} |",
+        "| Security controls weakened | "
+        f"{_join_values(passport.get('security_controls_weakened'))} |",
+        "| Missing LLM guardrails | "
+        f"{_join_values(passport.get('missing_llm_guardrails'))} |",
+    ]
+
+    reasons = list(passport.get("reasons") or [])
+    warnings = list(passport.get("warnings") or [])
+    if reasons or warnings:
+        lines.extend(["", "**Reasons:**"])
+        for reason in reasons[:5]:
+            lines.append(f"- BLOCK: {redact_sensitive_text(reason)}")
+        for warning in warnings[:5]:
+            lines.append(f"- WARN: {redact_sensitive_text(warning)}")
+
+    return lines
+
+
+def _defense_risk(
+    defense_report: dict[str, Any] | None, ai_files: set[str]
+) -> tuple[dict[str, list[str]], set[str], list[str]]:
+    missing = {"blocking": [], "warning": []}
+    block_files: set[str] = set()
+    warnings: list[str] = []
+
+    if not isinstance(defense_report, dict):
+        return missing, block_files, warnings
+
+    for finding in defense_report.get("findings") or []:
+        if not isinstance(finding, dict):
+            continue
+        if finding.get("passed") is not False:
+            continue
+        if str(finding.get("category") or "defense") != "defense":
+            continue
+
+        plugin_id = str(finding.get("plugin_id") or "unknown_guardrail")
+        severity_score = _severity_score(finding.get("severity"))
+        location = _location_file(
+            finding.get("location") or finding.get("integration_location")
+        )
+        matched_ai_file = _matched_ai_file(location, ai_files)
+
+        if severity_score >= _SEVERITY_SCORE["HIGH"] and matched_ai_file:
+            missing["blocking"].append(plugin_id)
+            block_files.add(matched_ai_file)
+        else:
+            missing["warning"].append(plugin_id)
+            warnings.append(f"LLM defense guardrail failed: {plugin_id}")
+
+    missing["blocking"] = sorted(set(missing["blocking"]))
+    missing["warning"] = sorted(set(missing["warning"]))
+    return missing, block_files, warnings
+
+
+def _is_ai_authored_finding(
+    finding: dict[str, Any], provenance: dict[str, Any], ai_files: set[str]
+) -> bool:
+    if finding.get("ai_authored") is True:
+        return True
+    if finding.get("ai_authored") is False and not provenance:
+        return False
+
+    file_path = _location_file(finding.get("file") or finding.get("file_path"))
+    if not file_path:
+        return False
+
+    file_prov = _file_provenance(file_path, provenance)
+    if file_prov is not None:
+        if not file_prov.get("agent_authored"):
+            return False
+        ranges = file_prov.get("agent_lines") or []
+        line = _int_or_none(finding.get("line") or finding.get("line_number"))
+        if ranges and line is not None:
+            return _line_in_ranges(line, ranges)
+        return True
+
+    return _matched_ai_file(file_path, ai_files) is not None
+
+
+def _file_provenance(
+    file_path: str, provenance: dict[str, Any]
+) -> dict[str, Any] | None:
+    files = provenance.get("files") or {}
+    if not isinstance(files, dict):
+        return None
+    if isinstance(files.get(file_path), dict):
+        return files[file_path]
+    for prov_path, data in files.items():
+        if _paths_match(file_path, str(prov_path)) and isinstance(data, dict):
+            return data
+    return None
+
+
+def _line_in_ranges(line: int, ranges: list[Any]) -> bool:
+    for raw_range in ranges:
+        if not isinstance(raw_range, (list, tuple)) or len(raw_range) < 2:
+            continue
+        start = _int_or_none(raw_range[0])
+        end = _int_or_none(raw_range[1])
+        if start is not None and end is not None and start <= line <= end:
+            return True
+    return False
+
+
+def _agent_files(provenance: dict[str, Any]) -> set[str]:
+    return {
+        str(path).replace("\\", "/")
+        for path in (provenance.get("agent_files") or [])
+        if str(path).strip()
+    }
+
+
+def _matched_ai_file(location: str | None, ai_files: set[str]) -> str | None:
+    if not location:
+        return None
+    for ai_file in ai_files:
+        if _paths_match(location, ai_file):
+            return ai_file
+    return None
+
+
+def _paths_match(left: str, right: str) -> bool:
+    left_norm = left.replace("\\", "/").strip("/")
+    right_norm = right.replace("\\", "/").strip("/")
+    if not left_norm or not right_norm:
+        return False
+    return (
+        left_norm == right_norm
+        or left_norm.endswith("/" + right_norm)
+        or right_norm.endswith("/" + left_norm)
+    )
+
+
+def _location_file(raw: Any) -> str:
+    text = str(raw or "").strip().replace("\\", "/")
+    if not text:
+        return ""
+    if ":" in text:
+        path_part, maybe_line = text.rsplit(":", 1)
+        if maybe_line.isdigit():
+            return path_part
+    return text
+
+
+def _display_file(raw: Any) -> str:
+    path = _location_file(raw)
+    return path.rsplit("/", 1)[-1] if path else ""
+
+
+def _severity_score(raw: Any) -> int:
+    return _SEVERITY_SCORE.get(str(raw or "").upper(), 0)
+
+
+def _int_or_none(raw: Any) -> int | None:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _join_values(raw: Any) -> str:
+    values = [redact_sensitive_text(item) for item in raw or [] if str(item).strip()]
+    return ", ".join(values[:5]) if values else "-"

--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -127,6 +127,14 @@ def generate_workflow(
             defend_parts.append(_upload_env_block())
         defend_step = "\n".join(defend_parts)
 
+    review_args = ["--input skylos-results.json"]
+    if use_llm:
+        review_args.append("--llm-input skylos-llm-results.json")
+    if use_defend:
+        review_args.append("--defense-input defense-results.json")
+    review_args.extend([f"--diff-base {pr_base_ref}", "--evidence-cards"])
+    review_command = "skylos cicd review " + " ".join(review_args)
+
     permissions_block = """permissions:
   contents: read
   pull-requests: write
@@ -180,9 +188,7 @@ jobs:
 
       - name: PR Review Comments
         if: github.event_name == 'pull_request' && always()
-        run: skylos cicd review --input skylos-results.json{
-        " --llm-input skylos-llm-results.json" if use_llm else ""
-    } --diff-base {pr_base_ref}
+        run: {review_command}
         env:
           GH_TOKEN: ${{{{ github.token }}}}
 {

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -53,6 +53,13 @@ def _default_workflow_output() -> str:
     return str(base / ".github" / "workflows" / "skylos.yml")
 
 
+def _read_review_sidecar_json(raw_path: str, *, label: str) -> dict | list:
+    safe_name = Path(raw_path).name
+    if not safe_name or safe_name != str(raw_path):
+        raise ValueError(f"{label} must be a filename in the current directory")
+    return json.loads(Path(safe_name).read_text(encoding="utf-8"))
+
+
 def run_cicd_command(
     argv: list[str],
     *,
@@ -159,6 +166,13 @@ def run_cicd_command(
     p_ci_rev.add_argument("--diff-base", default="origin/main")
     p_ci_rev.add_argument("--llm-input", help="LLM agent review results JSON file")
     p_ci_rev.add_argument(
+        "--defense-input",
+        help=(
+            "AI defense sidecar JSON filename from `skylos defend` "
+            "(for example: defense-results.json)"
+        ),
+    )
+    p_ci_rev.add_argument(
         "--evidence-cards",
         action="store_true",
         help="Format PR comments with Proven, Likely, or Speculative evidence labels.",
@@ -250,6 +264,18 @@ def run_cicd_command(
             except Exception as e:
                 console.print(f"[yellow]Could not read LLM results: {e}[/yellow]")
 
+        defense_report = None
+        if getattr(cicd_args, "defense_input", None):
+            try:
+                defense_report = _read_review_sidecar_json(
+                    cicd_args.defense_input,
+                    label="--defense-input",
+                )
+            except Exception as e:
+                console.print(
+                    f"[yellow]Could not read defense results: {e}[/yellow]"
+                )
+
         run_pr_review(
             results,
             pr_number=cicd_args.pr,
@@ -258,6 +284,7 @@ def run_cicd_command(
             max_comments=cicd_args.max_comments,
             diff_base=cicd_args.diff_base,
             llm_findings=llm_findings,
+            defense_report=defense_report,
             evidence_cards=cicd_args.evidence_cards,
         )
         return 0

--- a/test/test_cicd_review.py
+++ b/test/test_cicd_review.py
@@ -139,6 +139,26 @@ def test_flatten_findings_preserves_safe_evidence_metadata():
     assert "raw_context" not in finding["verification"]
 
 
+def test_flatten_findings_preserves_ai_provenance_flags():
+    findings = _flatten_findings(
+        {
+            "danger": [
+                {
+                    "rule_id": "SKY-D201",
+                    "file": "app.py",
+                    "line": 3,
+                    "message": "eval",
+                    "ai_authored": True,
+                    "ai_agent": "codex",
+                }
+            ]
+        }
+    )
+
+    assert findings[0]["ai_authored"] is True
+    assert findings[0]["ai_agent"] == "codex"
+
+
 def test_merge_llm_hypothesis_does_not_downgrade_static_finding_source():
     static_findings = [
         {
@@ -307,6 +327,48 @@ def test_summary_comment_includes_evidence_counts_when_enabled():
     assert "### Evidence" in body
     assert "| Proven | 1 |" in body
     assert "| Speculative | 1 |" in body
+
+
+def test_summary_comment_includes_risk_passport_when_supplied():
+    captured = {}
+
+    def mock_run(cmd, **kwargs):
+        if "pr" in cmd and "comment" in cmd:
+            captured["body"] = cmd[cmd.index("--body") + 1]
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return FakeResult()
+
+    risk_passport = {
+        "recommendation": "BLOCK",
+        "ai_authored_files": 2,
+        "ai_agents": ["codex"],
+        "provenance_confidence": "high",
+        "changed_line_evidence": {"proven": 1, "likely": 0, "speculative": 0},
+        "high_risk_ai_files": ["app.py"],
+        "security_controls_weakened": ["auth"],
+        "missing_llm_guardrails": [],
+        "reasons": ["Changed-line security regression: auth"],
+        "warnings": [],
+    }
+
+    with patch("skylos.cicd.review.subprocess.run", side_effect=mock_run):
+        _post_summary_comment(
+            [],
+            [],
+            42,
+            "owner/repo",
+            risk_passport=risk_passport,
+        )
+
+    body = captured["body"]
+    assert "### AI PR Risk Passport" in body
+    assert "**Merge recommendation: BLOCK**" in body
+    assert "| Security controls weakened | auth |" in body
 
 
 def test_detect_pr_number(monkeypatch):

--- a/test/test_cicd_risk_passport.py
+++ b/test/test_cicd_risk_passport.py
@@ -1,0 +1,180 @@
+from skylos.cicd.risk_passport import (
+    build_risk_passport,
+    format_risk_passport_markdown,
+)
+
+
+def test_risk_passport_passes_without_findings_or_ai_provenance():
+    passport = build_risk_passport(
+        all_findings=[],
+        diff_findings=[],
+        provenance=None,
+        defense_report=None,
+    )
+
+    assert passport["recommendation"] == "PASS"
+    assert passport["provenance_confidence"] == "unavailable"
+
+
+def test_risk_passport_blocks_ai_authored_high_security_finding():
+    finding = {
+        "category": "danger",
+        "rule_id": "SKY-D201",
+        "severity": "HIGH",
+        "file": "app.py",
+        "line": 10,
+        "message": "eval() usage",
+        "ai_authored": True,
+    }
+
+    passport = build_risk_passport(
+        all_findings=[finding],
+        diff_findings=[finding],
+        provenance=None,
+        defense_report=None,
+    )
+
+    assert passport["recommendation"] == "BLOCK"
+    assert passport["high_risk_ai_files"] == ["app.py"]
+    assert passport["changed_line_evidence"]["proven"] == 1
+
+
+def test_risk_passport_blocks_security_regression():
+    finding = {
+        "kind": "security_regression",
+        "category": "security_regression",
+        "control_type": "auth",
+        "severity": "HIGH",
+        "file": "views.py",
+        "line": 4,
+        "message": "Auth removed",
+    }
+
+    passport = build_risk_passport(
+        all_findings=[finding],
+        diff_findings=[finding],
+        provenance=None,
+        defense_report=None,
+    )
+
+    assert passport["recommendation"] == "BLOCK"
+    assert passport["security_controls_weakened"] == ["auth"]
+
+
+def test_risk_passport_warns_for_high_speculative_finding():
+    finding = {
+        "category": "security",
+        "severity": "HIGH",
+        "_source": "llm",
+        "_security_evidence": "hypothesis",
+        "file": "views.py",
+        "line": 8,
+        "message": "Possible auth issue",
+    }
+
+    passport = build_risk_passport(
+        all_findings=[finding],
+        diff_findings=[finding],
+        provenance=None,
+        defense_report=None,
+    )
+
+    assert passport["recommendation"] == "WARN"
+    assert passport["changed_line_evidence"]["speculative"] == 1
+
+
+def test_risk_passport_warns_for_medium_ai_quality_finding():
+    finding = {
+        "category": "quality",
+        "severity": "MEDIUM",
+        "file": "app.py",
+        "line": 7,
+        "message": "Complexity",
+    }
+    provenance = {
+        "agent_files": ["app.py"],
+        "files": {
+            "app.py": {
+                "agent_authored": True,
+                "agent_lines": [[1, 20]],
+                "agent_name": "codex",
+            }
+        },
+        "summary": {"agents_seen": ["codex"]},
+        "confidence": "medium",
+    }
+
+    passport = build_risk_passport(
+        all_findings=[finding],
+        diff_findings=[finding],
+        provenance=provenance,
+        defense_report=None,
+    )
+
+    assert passport["recommendation"] == "WARN"
+    assert passport["ai_authored_files"] == 1
+    assert passport["ai_agents"] == ["codex"]
+
+
+def test_risk_passport_blocks_failed_high_defense_on_ai_file():
+    provenance = {
+        "agent_files": ["app.py"],
+        "files": {"app.py": {"agent_authored": True, "agent_lines": [[1, 20]]}},
+        "summary": {},
+        "confidence": "high",
+    }
+    defense_report = {
+        "findings": [
+            {
+                "plugin_id": "output_validation",
+                "passed": False,
+                "location": "app.py:12",
+                "severity": "high",
+                "category": "defense",
+            }
+        ]
+    }
+
+    passport = build_risk_passport(
+        all_findings=[],
+        diff_findings=[],
+        provenance=provenance,
+        defense_report=defense_report,
+    )
+
+    assert passport["recommendation"] == "BLOCK"
+    assert passport["high_risk_ai_files"] == ["app.py"]
+    assert passport["missing_llm_guardrails"] == ["output_validation"]
+
+
+def test_risk_passport_ignores_malformed_defense_report():
+    passport = build_risk_passport(
+        all_findings=[],
+        diff_findings=[],
+        provenance=None,
+        defense_report={"findings": ["bad"]},
+    )
+
+    assert passport["recommendation"] == "PASS"
+
+
+def test_format_risk_passport_markdown_renders_summary():
+    passport = {
+        "recommendation": "WARN",
+        "ai_authored_files": 1,
+        "ai_agents": ["codex"],
+        "provenance_confidence": "medium",
+        "changed_line_evidence": {"proven": 1, "likely": 0, "speculative": 1},
+        "high_risk_ai_files": [],
+        "security_controls_weakened": [],
+        "missing_llm_guardrails": ["output_validation"],
+        "reasons": [],
+        "warnings": ["LLM defense guardrail failed: output_validation"],
+    }
+
+    body = "\n".join(format_risk_passport_markdown(passport))
+
+    assert "### AI PR Risk Passport" in body
+    assert "**Merge recommendation: WARN**" in body
+    assert "Proven 1 / Likely 0 / Speculative 1" in body
+    assert "output_validation" in body

--- a/test/test_cicd_workflow.py
+++ b/test/test_cicd_workflow.py
@@ -26,6 +26,8 @@ def test_workflow_has_all_steps():
     assert "PR Review Comments" in step_names
     quality_gate = next(s for s in steps if s.get("name") == "Quality Gate")
     assert "--advisory" in quality_gate["run"]
+    pr_review = next(s for s in steps if s.get("name") == "PR Review Comments")
+    assert "--evidence-cards" in pr_review["run"]
 
 
 def test_workflow_triggers():
@@ -141,6 +143,7 @@ def test_workflow_scan_path_is_monorepo_aware():
     content = generate_workflow(scan_path="apps/api", use_upload=True, use_defend=True)
     assert "skylos apps/api" in content
     assert "skylos defend apps/api" in content
+    assert "--defense-input defense-results.json" in content
 
 
 def test_workflow_prefixes_leading_dash_scan_path():

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -739,9 +739,12 @@ def test_cicd_gate_command_reads_input_and_returns_gate_exit(tmp_path):
     assert mock_gate.call_args.kwargs["result"]["project_root"] == str(tmp_path)
 
 
-def test_cicd_review_command_passes_evidence_cards_flag(tmp_path):
+def test_cicd_review_command_passes_evidence_cards_flag(tmp_path, monkeypatch):
     results_path = tmp_path / "results.json"
     results_path.write_text(json.dumps({"project_root": str(tmp_path), "danger": []}))
+    defense_path = tmp_path / "defense.json"
+    defense_path.write_text(json.dumps({"findings": []}))
+    monkeypatch.chdir(tmp_path)
     from skylos.commands.cicd_cmd import run_cicd_command
 
     with patch("skylos.cicd.review.run_pr_review") as mock_review:
@@ -755,6 +758,8 @@ def test_cicd_review_command_passes_evidence_cards_flag(tmp_path):
                 "--repo",
                 "owner/repo",
                 "--evidence-cards",
+                "--defense-input",
+                defense_path.name,
             ],
             console_factory=lambda: Mock(),
             load_config_func=lambda path: {},
@@ -764,6 +769,7 @@ def test_cicd_review_command_passes_evidence_cards_flag(tmp_path):
 
     assert exit_code == 0
     assert mock_review.call_args.kwargs["evidence_cards"] is True
+    assert mock_review.call_args.kwargs["defense_report"] == {"findings": []}
     assert mock_review.call_args.kwargs["pr_number"] == 12
 
 


### PR DESCRIPTION
## Summary

The passport gives an advisory merge recommendation: `PASS`, `WARN`, or `BLOCK`, based on changed-line findings, evidence labels, AI provenance, security regressions, secrets, and optional AI defense results.

## Added

  - Added CICD risk passport aggregation for PR summaries.
  - Add `skylos cicd review --defense-input defense-results.json`.
  - Enable `--evidence-cards` by default in generated Skylos workflows.
  - Pass defense results into PR review summaries when generated workflows use `--defend`.
  - Add tests for passport behavior, PR summary rendering, workflow generation, and CLI wiring.

## Verification

  - pytest test/ test_cli_refactor_guardrails.py::test_cicd_review_command_passes_evidence_cards_flag test/test_cicd_*.py

  ## Notes

  The passport PR is advisory only. We did not change CI exit behavior or make the existing quality gate stricter.
