### PR TITLE
feat(defend): add versioned OWASP coverage

### DIFF
--- a/skylos/commands/defend_cmd.py
+++ b/skylos/commands/defend_cmd.py
@@ -4,11 +4,29 @@ from pathlib import Path
 
 from rich.progress import SpinnerColumn, TextColumn
 
+from skylos.defend.owasp import (
+    DEFAULT_OWASP_FRAMEWORK,
+    compute_owasp_coverage,
+    normalize_owasp_selection,
+    supported_owasp_frameworks,
+    validate_owasp_ids,
+)
 
-def _build_empty_defense_json() -> str:
+
+def _build_empty_defense_json(
+    *,
+    owasp_framework: str = DEFAULT_OWASP_FRAMEWORK,
+    owasp_version: str | int | None = None,
+) -> str:
+    owasp_framework, owasp_version = normalize_owasp_selection(
+        owasp_framework,
+        owasp_version,
+    )
     return json.dumps(
         {
             "version": "1.0",
+            "owasp_framework": owasp_framework,
+            "owasp_version": owasp_version,
             "summary": {
                 "integrations_found": 0,
                 "total_checks": 0,
@@ -18,6 +36,11 @@ def _build_empty_defense_json() -> str:
                 "risk_rating": "SECURE",
             },
             "findings": [],
+            "owasp_coverage": compute_owasp_coverage(
+                [],
+                framework=owasp_framework,
+                version=owasp_version,
+            ),
             "ops_score": {
                 "passed": 0,
                 "total": 0,
@@ -69,7 +92,18 @@ def run_defend_command(
     def_parser.add_argument(
         "--owasp",
         dest="owasp_filter",
-        help="Comma-separated OWASP LLM IDs to filter (e.g. LLM01,LLM04)",
+        help="Comma-separated OWASP IDs to filter (e.g. LLM01,LLM04 or ASI02)",
+    )
+    def_parser.add_argument(
+        "--owasp-framework",
+        choices=supported_owasp_frameworks(),
+        default=DEFAULT_OWASP_FRAMEWORK,
+        type=str.lower,
+        help="OWASP framework to report against",
+    )
+    def_parser.add_argument(
+        "--owasp-version",
+        help="OWASP framework version (llm: 2024/2025, agentic: 2026)",
     )
     def_parser.add_argument(
         "--exclude",
@@ -87,7 +121,7 @@ def run_defend_command(
     console = console_factory()
 
     from skylos.defend.engine import run_defense_checks
-    from skylos.defend.policy import compute_owasp_coverage, load_policy
+    from skylos.defend.policy import load_policy
     from skylos.defend.report import format_defense_json, format_defense_table
     from skylos.discover.detector import _collect_ai_files, detect_integrations
 
@@ -103,6 +137,15 @@ def run_defend_command(
         console.print(
             f"[red]Error: --min-score must be 0-100, got {def_args.min_score}[/red]"
         )
+        return 1
+
+    try:
+        owasp_framework, owasp_version = normalize_owasp_selection(
+            def_args.owasp_framework,
+            def_args.owasp_version,
+        )
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
         return 1
 
     exclude = {
@@ -133,16 +176,15 @@ def run_defend_command(
 
     owasp_filter = None
     if def_args.owasp_filter:
-        from skylos.defend.policy import OWASP_LLM_MAPPING
-
-        owasp_filter = [s.strip().upper() for s in def_args.owasp_filter.split(",")]
-        for oid in owasp_filter:
-            if oid not in OWASP_LLM_MAPPING:
-                console.print(
-                    f"[red]Error: unknown OWASP ID '{oid}'. "
-                    f"Valid: {', '.join(sorted(OWASP_LLM_MAPPING))}[/red]"
-                )
-                return 1
+        try:
+            owasp_filter = validate_owasp_ids(
+                def_args.owasp_filter.split(","),
+                framework=owasp_framework,
+                version=owasp_version,
+            )
+        except ValueError as e:
+            console.print(f"[red]Error: {e}[/red]")
+            return 1
 
     with progress_factory(
         SpinnerColumn(),
@@ -156,7 +198,10 @@ def run_defend_command(
 
     if not integrations:
         if def_args.output_json:
-            empty = _build_empty_defense_json()
+            empty = _build_empty_defense_json(
+                owasp_framework=owasp_framework,
+                owasp_version=owasp_version,
+            )
             if def_args.output_file:
                 Path(def_args.output_file).write_text(empty, encoding="utf-8")
             else:
@@ -173,9 +218,15 @@ def run_defend_command(
         policy=policy,
         min_severity=def_args.min_severity,
         owasp_filter=owasp_filter,
+        owasp_framework=owasp_framework,
+        owasp_version=owasp_version,
     )
 
-    owasp_coverage = compute_owasp_coverage(results)
+    owasp_coverage = compute_owasp_coverage(
+        results,
+        framework=owasp_framework,
+        version=owasp_version,
+    )
 
     json_output = None
     if def_args.output_json or def_args.upload:
@@ -188,6 +239,8 @@ def run_defend_command(
             owasp_coverage,
             ops_score,
             integrations=integrations,
+            owasp_framework=owasp_framework,
+            owasp_version=owasp_version,
         )
 
     if def_args.output_json:
@@ -200,6 +253,8 @@ def run_defend_command(
             len(files),
             owasp_coverage,
             ops_score,
+            owasp_framework=owasp_framework,
+            owasp_version=owasp_version,
         )
 
     if def_args.output_file:

--- a/skylos/defend/engine.py
+++ b/skylos/defend/engine.py
@@ -9,6 +9,11 @@ from skylos.defend.scoring import compute_defense_score, compute_ops_score
 from skylos.defend.plugins import ALL_PLUGINS
 from skylos.defend.plugin import DefensePlugin
 from skylos.defend.policy import DefensePolicy
+from skylos.defend.owasp import (
+    DEFAULT_OWASP_FRAMEWORK,
+    normalize_owasp_selection,
+    plugin_ids_for_owasp_filter,
+)
 
 
 def run_defense_checks(
@@ -18,9 +23,20 @@ def run_defense_checks(
     policy: DefensePolicy | None = None,
     min_severity: str | None = None,
     owasp_filter: list[str] | None = None,
+    owasp_framework: str | None = DEFAULT_OWASP_FRAMEWORK,
+    owasp_version: str | int | None = None,
 ) -> tuple[list[DefenseResult], DefenseScore, OpsScore]:
     severity_order = {"critical": 4, "high": 3, "medium": 2, "low": 1}
     min_sev_val = severity_order.get(min_severity, 0) if min_severity else 0
+    owasp_framework, owasp_version = normalize_owasp_selection(
+        owasp_framework,
+        owasp_version,
+    )
+    owasp_plugin_ids = plugin_ids_for_owasp_filter(
+        owasp_filter,
+        framework=owasp_framework,
+        version=owasp_version,
+    )
 
     plugins = _resolve_plugins(policy)
     results: list[DefenseResult] = []
@@ -30,11 +46,7 @@ def run_defense_checks(
             if not plugin.applies_to(integration):
                 continue
 
-            if (
-                owasp_filter
-                and plugin.owasp_llm is not None
-                and plugin.owasp_llm not in owasp_filter
-            ):
+            if owasp_plugin_ids is not None and plugin.id not in owasp_plugin_ids:
                 continue
 
             if severity_order.get(plugin.severity, 0) < min_sev_val:

--- a/skylos/defend/owasp.py
+++ b/skylos/defend/owasp.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+DEFAULT_OWASP_FRAMEWORK = "llm"
+DEFAULT_OWASP_VERSION_BY_FRAMEWORK = {
+    "llm": "2025",
+    "agentic": "2026",
+}
+
+OWASP_FRAMEWORK_ALIASES = {
+    "llm": "llm",
+    "llms": "llm",
+    "agent": "agentic",
+    "agents": "agentic",
+    "agentic": "agentic",
+    "asi": "agentic",
+}
+
+OWASP_VERSION_ALIASES = {
+    ("llm", "1.1"): "2024",
+    ("llm", "v1.1"): "2024",
+    ("llm", "2023/24"): "2024",
+    ("llm", "2024"): "2024",
+    ("llm", "2.0"): "2025",
+    ("llm", "v2.0"): "2025",
+    ("llm", "2025"): "2025",
+    ("agentic", "2026"): "2026",
+}
+
+OWASP_REGISTRY: dict[tuple[str, str], dict[str, dict[str, Any]]] = {
+    ("llm", "2024"): {
+        "LLM01": {
+            "name": "Prompt Injection",
+            "plugins": [
+                "prompt-delimiter",
+                "input-length-limit",
+                "untrusted-input-to-prompt",
+                "rag-context-isolation",
+            ],
+        },
+        "LLM02": {
+            "name": "Insecure Output Handling",
+            "plugins": ["no-dangerous-sink", "output-validation"],
+        },
+        "LLM03": {
+            "name": "Training Data Poisoning",
+            "plugins": [],
+        },
+        "LLM04": {
+            "name": "Model Denial of Service",
+            "plugins": ["input-length-limit", "cost-controls", "rate-limiting"],
+        },
+        "LLM05": {
+            "name": "Supply Chain Vulnerabilities",
+            "plugins": ["model-pinned"],
+        },
+        "LLM06": {
+            "name": "Sensitive Information Disclosure",
+            "plugins": ["output-pii-filter"],
+        },
+        "LLM07": {
+            "name": "Insecure Plugin Design",
+            "plugins": ["tool-schema-present", "tool-scope"],
+        },
+        "LLM08": {
+            "name": "Excessive Agency",
+            "plugins": ["tool-schema-present", "tool-scope"],
+        },
+        "LLM09": {
+            "name": "Overreliance",
+            "plugins": ["output-validation"],
+        },
+        "LLM10": {
+            "name": "Model Theft",
+            "plugins": ["rate-limiting", "cost-controls"],
+        },
+    },
+    ("llm", "2025"): {
+        "LLM01": {
+            "name": "Prompt Injection",
+            "plugins": [
+                "prompt-delimiter",
+                "input-length-limit",
+                "untrusted-input-to-prompt",
+                "rag-context-isolation",
+            ],
+        },
+        "LLM02": {
+            "name": "Sensitive Information Disclosure",
+            "plugins": ["output-pii-filter"],
+        },
+        "LLM03": {
+            "name": "Supply Chain",
+            "plugins": ["model-pinned"],
+        },
+        "LLM04": {
+            "name": "Data and Model Poisoning",
+            "plugins": [],
+        },
+        "LLM05": {
+            "name": "Improper Output Handling",
+            "plugins": ["no-dangerous-sink", "output-validation"],
+        },
+        "LLM06": {
+            "name": "Excessive Agency",
+            "plugins": ["tool-schema-present", "tool-scope"],
+        },
+        "LLM07": {
+            "name": "System Prompt Leakage",
+            "plugins": [],
+        },
+        "LLM08": {
+            "name": "Vector and Embedding Weaknesses",
+            "plugins": ["rag-context-isolation"],
+        },
+        "LLM09": {
+            "name": "Misinformation",
+            "plugins": ["output-validation"],
+        },
+        "LLM10": {
+            "name": "Unbounded Consumption",
+            "plugins": ["input-length-limit", "cost-controls", "rate-limiting"],
+        },
+    },
+    ("agentic", "2026"): {
+        "ASI01": {
+            "name": "Agent Goal Hijack",
+            "plugins": [
+                "prompt-delimiter",
+                "input-length-limit",
+                "untrusted-input-to-prompt",
+                "rag-context-isolation",
+            ],
+        },
+        "ASI02": {
+            "name": "Tool Misuse and Exploitation",
+            "plugins": ["tool-schema-present", "tool-scope", "no-dangerous-sink"],
+        },
+        "ASI03": {
+            "name": "Identity and Privilege Abuse",
+            "plugins": ["tool-scope"],
+        },
+        "ASI04": {
+            "name": "Agentic Supply Chain Vulnerabilities",
+            "plugins": ["model-pinned", "tool-schema-present"],
+        },
+        "ASI05": {
+            "name": "Unexpected Code Execution (RCE)",
+            "plugins": ["no-dangerous-sink", "output-validation", "tool-scope"],
+        },
+        "ASI06": {
+            "name": "Memory & Context Poisoning",
+            "plugins": [
+                "prompt-delimiter",
+                "untrusted-input-to-prompt",
+                "rag-context-isolation",
+            ],
+        },
+        "ASI07": {
+            "name": "Insecure Inter-Agent Communication",
+            "plugins": [],
+        },
+        "ASI08": {
+            "name": "Cascading Failures",
+            "plugins": ["logging-present", "cost-controls", "rate-limiting"],
+        },
+        "ASI09": {
+            "name": "Human-Agent Trust Exploitation",
+            "plugins": ["output-validation"],
+        },
+        "ASI10": {
+            "name": "Rogue Agents",
+            "plugins": ["tool-scope", "logging-present"],
+        },
+    },
+}
+
+OWASP_REPORT_LABELS = {
+    ("llm", "2024"): "OWASP LLM Top 10 2024",
+    ("llm", "2025"): "OWASP LLM Top 10 2025",
+    ("agentic", "2026"): "OWASP Agentic Top 10 2026",
+}
+
+OWASP_LLM_MAPPING = OWASP_REGISTRY[("llm", "2025")]
+
+
+def supported_owasp_frameworks() -> list[str]:
+    return sorted({framework for framework, _version in OWASP_REGISTRY})
+
+
+def supported_owasp_versions(framework: str) -> list[str]:
+    framework = normalize_owasp_framework(framework)
+    return sorted(version for candidate, version in OWASP_REGISTRY if candidate == framework)
+
+
+def normalize_owasp_framework(framework: str | None = None) -> str:
+    raw = framework or DEFAULT_OWASP_FRAMEWORK
+    normalized = OWASP_FRAMEWORK_ALIASES.get(raw.strip().lower())
+    if normalized is None:
+        valid = ", ".join(supported_owasp_frameworks())
+        raise ValueError(f"Unsupported OWASP framework '{raw}'. Valid: {valid}")
+    return normalized
+
+
+def normalize_owasp_selection(
+    framework: str | None = None,
+    version: str | int | None = None,
+) -> tuple[str, str]:
+    normalized_framework = normalize_owasp_framework(framework)
+    raw_version = (
+        DEFAULT_OWASP_VERSION_BY_FRAMEWORK[normalized_framework]
+        if version is None
+        else str(version).strip().lower()
+    )
+    normalized_version = OWASP_VERSION_ALIASES.get(
+        (normalized_framework, raw_version),
+        raw_version,
+    )
+    if (normalized_framework, normalized_version) not in OWASP_REGISTRY:
+        valid = ", ".join(supported_owasp_versions(normalized_framework))
+        raise ValueError(
+            f"Unsupported OWASP version '{version}' for framework "
+            f"'{normalized_framework}'. Valid: {valid}"
+        )
+    return normalized_framework, normalized_version
+
+
+def get_owasp_mapping(
+    framework: str | None = None,
+    version: str | int | None = None,
+) -> dict[str, dict[str, Any]]:
+    framework, version = normalize_owasp_selection(framework, version)
+    return OWASP_REGISTRY[(framework, version)]
+
+
+def owasp_report_label(
+    framework: str | None = None,
+    version: str | int | None = None,
+) -> str:
+    framework, version = normalize_owasp_selection(framework, version)
+    return OWASP_REPORT_LABELS[(framework, version)]
+
+
+def validate_owasp_ids(
+    ids: list[str],
+    *,
+    framework: str | None = None,
+    version: str | int | None = None,
+) -> list[str]:
+    mapping = get_owasp_mapping(framework, version)
+    normalized_ids = [owasp_id.strip().upper() for owasp_id in ids if owasp_id.strip()]
+    invalid = [owasp_id for owasp_id in normalized_ids if owasp_id not in mapping]
+    if invalid:
+        valid = ", ".join(sorted(mapping))
+        raise ValueError(
+            f"Unknown OWASP ID '{invalid[0]}'. Valid for "
+            f"{owasp_report_label(framework, version)}: {valid}"
+        )
+    return normalized_ids
+
+
+def plugin_ids_for_owasp_filter(
+    ids: list[str] | None,
+    *,
+    framework: str | None = None,
+    version: str | int | None = None,
+) -> set[str] | None:
+    if ids is None:
+        return None
+
+    mapping = get_owasp_mapping(framework, version)
+    plugin_ids: set[str] = set()
+    for owasp_id in validate_owasp_ids(ids, framework=framework, version=version):
+        plugin_ids.update(mapping[owasp_id]["plugins"])
+    return plugin_ids
+
+
+def compute_owasp_coverage(
+    results: list,
+    *,
+    framework: str | None = None,
+    version: str | int | None = None,
+) -> dict[str, dict[str, Any]]:
+    mapping = get_owasp_mapping(framework, version)
+    coverage = {}
+
+    for owasp_id, info in mapping.items():
+        plugin_ids = set(info["plugins"])
+        relevant = [result for result in results if result.plugin_id in plugin_ids]
+        passed = sum(1 for result in relevant if result.passed)
+        total = len(relevant)
+
+        if total == 0:
+            status = "not_applicable"
+            pct = None
+        else:
+            pct = round(passed / total * 100)
+            if pct == 100:
+                status = "covered"
+            elif pct > 0:
+                status = "partial"
+            else:
+                status = "uncovered"
+
+        coverage[owasp_id] = {
+            "name": info["name"],
+            "plugins": info["plugins"],
+            "status": status,
+            "passed": passed,
+            "total": total,
+            "coverage_pct": pct,
+        }
+
+    return coverage

--- a/skylos/defend/policy.py
+++ b/skylos/defend/policy.py
@@ -4,6 +4,41 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from skylos.defend.owasp import (
+    DEFAULT_OWASP_FRAMEWORK,
+    DEFAULT_OWASP_VERSION_BY_FRAMEWORK,
+    OWASP_LLM_MAPPING,
+    OWASP_REGISTRY,
+    compute_owasp_coverage,
+    get_owasp_mapping,
+    normalize_owasp_framework,
+    normalize_owasp_selection,
+    owasp_report_label,
+    plugin_ids_for_owasp_filter,
+    supported_owasp_frameworks,
+    supported_owasp_versions,
+    validate_owasp_ids,
+)
+
+__all__ = [
+    "DefensePolicy",
+    "DEFAULT_OWASP_FRAMEWORK",
+    "DEFAULT_OWASP_VERSION_BY_FRAMEWORK",
+    "OWASP_LLM_MAPPING",
+    "OWASP_REGISTRY",
+    "compute_owasp_coverage",
+    "get_owasp_mapping",
+    "load_policy",
+    "normalize_owasp_framework",
+    "normalize_owasp_selection",
+    "owasp_report_label",
+    "plugin_ids_for_owasp_filter",
+    "supported_owasp_frameworks",
+    "supported_owasp_versions",
+    "validate_owasp_ids",
+    "_parse_policy",
+]
+
 try:
     import yaml
 
@@ -26,55 +61,6 @@ class DefensePolicy:
                 "fail_on": self.gate_fail_on,
             },
         }
-
-
-OWASP_LLM_MAPPING: dict[str, dict[str, Any]] = {
-    "LLM01": {
-        "name": "Prompt Injection",
-        "plugins": [
-            "prompt-delimiter",
-            "input-length-limit",
-            "untrusted-input-to-prompt",
-            "rag-context-isolation",
-        ],
-    },
-    "LLM02": {
-        "name": "Insecure Output Handling",
-        "plugins": ["no-dangerous-sink", "output-validation"],
-    },
-    "LLM03": {
-        "name": "Training Data Poisoning / Supply Chain",
-        "plugins": ["model-pinned"],
-    },
-    "LLM04": {
-        "name": "Excessive Agency",
-        "plugins": ["tool-schema-present", "tool-scope"],
-    },
-    "LLM05": {
-        "name": "Improper Error Handling",
-        "plugins": [],
-    },
-    "LLM06": {
-        "name": "PII Disclosure",
-        "plugins": ["output-pii-filter"],
-    },
-    "LLM07": {
-        "name": "Insecure Plugin Design",
-        "plugins": ["tool-schema-present", "tool-scope"],
-    },
-    "LLM08": {
-        "name": "Excessive Autonomy",
-        "plugins": ["tool-scope"],
-    },
-    "LLM09": {
-        "name": "Overreliance",
-        "plugins": ["output-validation"],
-    },
-    "LLM10": {
-        "name": "Unbounded Consumption",
-        "plugins": ["input-length-limit", "cost-controls", "rate-limiting"],
-    },
-}
 
 
 def load_policy(path: str | Path | None = None) -> Optional[DefensePolicy]:
@@ -174,36 +160,3 @@ def _parse_policy(raw: dict) -> DefensePolicy:
         gate_min_score=gate_min_score,
         gate_fail_on=gate_fail_on,
     )
-
-
-def compute_owasp_coverage(
-    results: list,
-) -> dict[str, dict[str, Any]]:
-    coverage = {}
-    for owasp_id, info in OWASP_LLM_MAPPING.items():
-        relevant = [r for r in results if r.owasp_llm == owasp_id]
-        passed = sum(1 for r in relevant if r.passed)
-        total = len(relevant)
-
-        if total == 0:
-            status = "not_applicable"
-            pct = None
-        else:
-            pct = round(passed / total * 100)
-            if pct == 100:
-                status = "covered"
-            elif pct > 0:
-                status = "partial"
-            else:
-                status = "uncovered"
-
-        coverage[owasp_id] = {
-            "name": info["name"],
-            "plugins": info["plugins"],
-            "status": status,
-            "passed": passed,
-            "total": total,
-            "coverage_pct": pct,
-        }
-
-    return coverage

--- a/skylos/defend/report.py
+++ b/skylos/defend/report.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from skylos.defend.result import DefenseResult, DefenseScore, OpsScore
 from skylos.defend.scoring import compute_defense_score, SEVERITY_WEIGHTS
-from skylos.defend.policy import compute_owasp_coverage
+from skylos.defend.owasp import (
+    DEFAULT_OWASP_FRAMEWORK,
+    normalize_owasp_selection,
+    owasp_report_label,
+)
 
 
 def format_defense_table(
@@ -17,6 +21,8 @@ def format_defense_table(
     files_scanned: int = 0,
     owasp_coverage: dict | None = None,
     ops_score: OpsScore | None = None,
+    owasp_framework: str | None = DEFAULT_OWASP_FRAMEWORK,
+    owasp_version: str | int | None = None,
 ) -> str:
     lines = []
 
@@ -71,7 +77,7 @@ def format_defense_table(
 
     if owasp_coverage:
         lines.append("")
-        lines.append("OWASP LLM Top 10 Coverage:")
+        lines.append(f"{owasp_report_label(owasp_framework, owasp_version)} Coverage:")
         for owasp_id, info in owasp_coverage.items():
             if info["status"] == "not_applicable":
                 continue
@@ -102,7 +108,13 @@ def format_defense_json(
     owasp_coverage: dict | None = None,
     ops_score: OpsScore | None = None,
     integrations: list | None = None,
+    owasp_framework: str | None = DEFAULT_OWASP_FRAMEWORK,
+    owasp_version: str | int | None = None,
 ) -> str:
+    owasp_framework, owasp_version = normalize_owasp_selection(
+        owasp_framework,
+        owasp_version,
+    )
     by_severity: dict[str, dict[str, int]] = {}
     for sev in ("critical", "high", "medium", "low"):
         sev_results: list[DefenseResult] = []
@@ -158,6 +170,8 @@ def format_defense_json(
         "version": "1.0",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "project": project_path,
+        "owasp_framework": owasp_framework,
+        "owasp_version": owasp_version,
         "summary": {
             "integrations_found": integrations_count,
             "files_scanned": files_scanned,
@@ -174,7 +188,7 @@ def format_defense_json(
         "findings": findings,
     }
 
-    if owasp_coverage:
+    if owasp_coverage is not None:
         data["owasp_coverage"] = owasp_coverage
 
     if ops_score:

--- a/skylos/suite.py
+++ b/skylos/suite.py
@@ -20,9 +20,14 @@ _DEFENSE_NOTE = "AI defense currently scans Python and TypeScript direct SDK int
 
 
 def _empty_defense_payload(project_path: str) -> dict[str, Any]:
+    from skylos.defend.owasp import compute_owasp_coverage, normalize_owasp_selection
+
+    owasp_framework, owasp_version = normalize_owasp_selection()
     return {
         "version": "1.0",
         "project": project_path,
+        "owasp_framework": owasp_framework,
+        "owasp_version": owasp_version,
         "summary": {
             "integrations_found": 0,
             "files_scanned": 0,
@@ -45,6 +50,11 @@ def _empty_defense_payload(project_path: str) -> dict[str, Any]:
         },
         "integrations": [],
         "findings": [],
+        "owasp_coverage": compute_owasp_coverage(
+            [],
+            framework=owasp_framework,
+            version=owasp_version,
+        ),
         "ops_score": {
             "passed": 0,
             "total": 0,
@@ -327,6 +337,8 @@ def run_suite(
                 owasp_coverage,
                 ops_score,
                 integrations=integrations,
+                owasp_framework="llm",
+                owasp_version="2025",
             )
         )
         defense_report["note"] = _DEFENSE_NOTE

--- a/skylos/tour.py
+++ b/skylos/tour.py
@@ -55,7 +55,7 @@ STEPS = [
             "[bold]Map LLM integrations[/bold] in your codebase:\n"
             "  [bold cyan]skylos discover .[/bold cyan]\n"
             "\n"
-            "[bold]Check for missing defenses[/bold] (OWASP LLM Top 10):\n"
+            "[bold]Check for missing defenses[/bold] (OWASP LLM/Agentic Top 10):\n"
             "  [bold cyan]skylos defend .[/bold cyan]\n"
             "\n"
             "Detects prompt injection risks, missing PII filters,\n"

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -585,6 +585,9 @@ def test_defend_command_json_output_prints_empty_report(tmp_path):
     payload = json.loads(mock_print.call_args.args[0])
     assert payload["summary"]["integrations_found"] == 0
     assert payload["summary"]["score_pct"] == 100
+    assert payload["owasp_framework"] == "llm"
+    assert payload["owasp_version"] == "2025"
+    assert "LLM01" in payload["owasp_coverage"]
     assert payload["ops_score"]["rating"] == "EXCELLENT"
 
 
@@ -617,7 +620,27 @@ def test_defend_command_json_output_writes_empty_report_file(tmp_path):
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     assert payload["summary"]["integrations_found"] == 0
     assert payload["summary"]["score_pct"] == 100
+    assert payload["owasp_framework"] == "llm"
+    assert payload["owasp_version"] == "2025"
+    assert "LLM01" in payload["owasp_coverage"]
     assert payload["ops_score"]["rating"] == "EXCELLENT"
+
+
+def test_defend_command_rejects_invalid_owasp_version(tmp_path):
+    target = tmp_path / "repo"
+    target.mkdir()
+    console = Mock()
+
+    from skylos.commands.defend_cmd import run_defend_command
+
+    exit_code = run_defend_command(
+        [str(target), "--owasp-version", "2026"],
+        console_factory=lambda: console,
+        progress_factory=lambda *args, **kwargs: _progress_ctx(),
+    )
+
+    assert exit_code == 1
+    assert "Unsupported OWASP version" in console.print.call_args.args[0]
 
 
 def test_defend_command_json_upload_formats_once(tmp_path):

--- a/test/test_defend.py
+++ b/test/test_defend.py
@@ -23,6 +23,7 @@ from skylos.defend.policy import (
     compute_owasp_coverage,
     _parse_policy,
     OWASP_LLM_MAPPING,
+    get_owasp_mapping,
 )
 from skylos.defend.plugins import ALL_PLUGINS
 from skylos.defend.plugins.no_dangerous_sink import NoDangerousSinkPlugin
@@ -330,9 +331,34 @@ class TestEngine:
         results, score, _ops = run_defense_checks(
             [integ], _empty_graph(), owasp_filter=["LLM01"]
         )
-        for r in results:
-            # Plugins with owasp_llm=None pass through the filter (ops plugins)
-            assert r.owasp_llm == "LLM01" or r.owasp_llm is None
+        allowed = set(OWASP_LLM_MAPPING["LLM01"]["plugins"])
+        assert {r.plugin_id for r in results} <= allowed
+        assert "logging-present" not in {r.plugin_id for r in results}
+
+    def test_agentic_owasp_filter(self):
+        tool = ToolDef(
+            name="shell",
+            location="t.py:1",
+            dangerous_calls=["subprocess.run (L5)"],
+            has_typed_schema=False,
+        )
+        integ = _make_integration(
+            integration_type="agent",
+            tools=[tool],
+            output_sinks=["eval (L45)"],
+        )
+        results, score, _ops = run_defense_checks(
+            [integ],
+            _empty_graph(),
+            owasp_filter=["ASI02"],
+            owasp_framework="agentic",
+            owasp_version="2026",
+        )
+        allowed = set(get_owasp_mapping("agentic", "2026")["ASI02"]["plugins"])
+        plugin_ids = {r.plugin_id for r in results}
+        assert plugin_ids <= allowed
+        assert "tool-scope" in plugin_ids
+        assert "no-dangerous-sink" in plugin_ids
 
     def test_policy_disables_plugin(self):
         integ = _make_integration(model_value="gpt-4o", model_pinned=False)
@@ -409,9 +435,42 @@ class TestReport:
         output = format_defense_json(results, score, 1, 10)
         data = json.loads(output)
         assert data["version"] == "1.0"
+        assert data["owasp_framework"] == "llm"
+        assert data["owasp_version"] == "2025"
         assert data["summary"]["total_checks"] == 1
         assert data["summary"]["passed"] == 1
         assert len(data["findings"]) == 1
+
+    def test_table_uses_selected_owasp_label(self):
+        results = [
+            DefenseResult(
+                "tool-scope",
+                False,
+                "t.py:10",
+                "t.py:10",
+                "tool too broad",
+                "high",
+                5,
+                "defense",
+            ),
+        ]
+        score = compute_defense_score(results)
+        coverage = compute_owasp_coverage(
+            results,
+            framework="agentic",
+            version="2026",
+        )
+        output = format_defense_table(
+            results,
+            score,
+            1,
+            10,
+            coverage,
+            owasp_framework="agentic",
+            owasp_version="2026",
+        )
+        assert "OWASP Agentic Top 10 2026 Coverage" in output
+        assert "ASI02" in output
 
 
 # ---------------------------------------------------------------------------
@@ -509,15 +568,15 @@ class TestOWASPCoverage:
                 owasp_llm="LLM01",
             ),
             DefenseResult(
-                "no-dangerous-sink",
+                "output-pii-filter",
                 True,
                 "t:1",
                 "t:1",
                 "ok",
-                "critical",
-                8,
+                "high",
+                5,
                 "defense",
-                owasp_llm="LLM02",
+                owasp_llm="LLM06",
             ),
         ]
         coverage = compute_owasp_coverage(results)
@@ -556,13 +615,52 @@ class TestOWASPCoverage:
     def test_coverage_not_applicable(self):
         results = []
         coverage = compute_owasp_coverage(results)
-        assert coverage["LLM06"]["status"] == "not_applicable"
+        assert coverage["LLM07"]["status"] == "not_applicable"
 
     def test_all_owasp_ids_present(self):
         coverage = compute_owasp_coverage([])
         for i in range(1, 11):
             key = f"LLM{i:02d}"
             assert key in coverage
+
+    def test_coverage_supports_llm_2024(self):
+        results = [
+            DefenseResult(
+                "no-dangerous-sink",
+                False,
+                "t:1",
+                "t:1",
+                "bad",
+                "critical",
+                8,
+                "defense",
+                owasp_llm="LLM02",
+            ),
+        ]
+        coverage = compute_owasp_coverage(results, framework="llm", version="2024")
+        assert coverage["LLM02"]["name"] == "Insecure Output Handling"
+        assert coverage["LLM02"]["status"] == "uncovered"
+
+    def test_coverage_supports_agentic_2026(self):
+        results = [
+            DefenseResult(
+                "tool-scope",
+                True,
+                "t:1",
+                "t:1",
+                "ok",
+                "high",
+                5,
+                "defense",
+            ),
+        ]
+        coverage = compute_owasp_coverage(
+            results,
+            framework="agentic",
+            version="2026",
+        )
+        assert "ASI10" in coverage
+        assert coverage["ASI02"]["status"] == "covered"
 
 
 # ---------------------------------------------------------------------------
@@ -1403,11 +1501,23 @@ def chat(msg):
         assert "rate-limiting" in ids
 
     def test_owasp_mapping_updated(self):
-        """OWASP mapping should include Phase 3 plugins."""
+        """Default OWASP LLM 2025 mapping should include Phase 3 plugins."""
         assert "untrusted-input-to-prompt" in OWASP_LLM_MAPPING["LLM01"]["plugins"]
         assert "rag-context-isolation" in OWASP_LLM_MAPPING["LLM01"]["plugins"]
-        assert "output-pii-filter" in OWASP_LLM_MAPPING["LLM06"]["plugins"]
+        assert "output-pii-filter" in OWASP_LLM_MAPPING["LLM02"]["plugins"]
+        assert "tool-scope" in OWASP_LLM_MAPPING["LLM06"]["plugins"]
         assert "cost-controls" in OWASP_LLM_MAPPING["LLM10"]["plugins"]
+
+    def test_owasp_registry_has_supported_versions(self):
+        assert get_owasp_mapping("llm", "2024")["LLM10"]["name"] == "Model Theft"
+        assert (
+            get_owasp_mapping("llm", "2025")["LLM10"]["name"]
+            == "Unbounded Consumption"
+        )
+        assert (
+            get_owasp_mapping("agentic", "2026")["ASI01"]["name"]
+            == "Agent Goal Hijack"
+        )
 
     def test_policy_accepts_phase3_plugins(self):
         """Policy parser should accept Phase 3 plugin IDs."""


### PR DESCRIPTION
## Summary
- Add a versioned OWASP registry for `llm:2024`, `llm:2025`, and `agentic:2026`.
- Add `skylos defend --owasp-framework` and `--owasp-version`, with `--owasp` ID validation scoped to the selected framework/version.
- Include OWASP framework/version metadata in JSON reports and dynamic table labels.
- Keep the suite and empty defense reports defaulted to OWASP LLM 2025.

## Notes
- This reports OWASP coverage/alignment, not compliance certification.
- `OWASP_LLM_MAPPING` remains available as the LLM 2025 compatibility alias.

## Sources
- OWASP LLM Top 10 2024 v1.1: https://owasp.org/www-project-top-10-for-large-language-model-applications/
- OWASP LLM Top 10 2025: https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/
- OWASP Agentic Top 10 2026: https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/

## Tests
- pytest test/test_defend.py`
- pytest test/test_cli_refactor_guardrails.py`
- pytest test/test_suite.py`
- pytest test/test_defend_typescript.py`