### PR TITLE
fix(architecture): preserve submodule coupling targets

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1563,7 +1563,9 @@ class Skylos:
                     try:
                         from skylos.architecture import get_architecture_findings
 
-                        dep_graph = dict(circular_rule._analyzer.dependencies)
+                        dep_graph = dict(
+                            circular_rule._analyzer.architecture_dependencies
+                        )
                         mod_files = dict(circular_rule._analyzer.modules)
 
                         mod_trees = {}

--- a/skylos/circular_deps.py
+++ b/skylos/circular_deps.py
@@ -10,6 +10,47 @@ except ImportError:
     _fast_find_cycles = None
 
 
+def _module_root(module_name: str) -> str:
+    return module_name.split(".")[0] if module_name else ""
+
+
+def _known_module_names(module_name: str) -> Set[str]:
+    if not module_name:
+        return set()
+    return {module_name, _module_root(module_name)}
+
+
+def _resolve_known_module(module_name: str, known_modules: Set[str]) -> str | None:
+    parts = module_name.split(".")
+    for end in range(len(parts), 0, -1):
+        candidate = ".".join(parts[:end])
+        if candidate in known_modules:
+            return candidate
+    return None
+
+
+def _resolve_from_import_targets(
+    import_module: str, imported_names: List[str], known_modules: Set[str]
+) -> Dict[str, List[str]]:
+    base_target = _resolve_known_module(import_module, known_modules)
+    targets: Dict[str, List[str]] = defaultdict(list)
+
+    if not imported_names:
+        if base_target:
+            targets[base_target] = []
+        return dict(targets)
+
+    for imported_name in imported_names:
+        member_target = _resolve_known_module(
+            f"{import_module}.{imported_name}", known_modules
+        )
+        target = member_target or base_target
+        if target:
+            targets[target].append(imported_name)
+
+    return dict(targets)
+
+
 @dataclass
 class ModuleDependency:
     from_module: str
@@ -44,6 +85,7 @@ class DependencyGraphBuilder(ast.NodeVisitor):
         self.file_path = file_path
         self.known_modules = known_modules
         self.dependencies: List[ModuleDependency] = []
+        self.architecture_dependencies: List[ModuleDependency] = []
 
     def generic_visit(self, node):
         for child in ast.iter_child_nodes(node):
@@ -51,12 +93,21 @@ class DependencyGraphBuilder(ast.NodeVisitor):
 
     def visit_Import(self, node: ast.Import):
         for alias in node.names:
-            module = alias.name.split(".")[0]
-            if self._is_internal_module(alias.name):
+            module = _resolve_known_module(alias.name, self.known_modules)
+            if module:
                 self.dependencies.append(
                     ModuleDependency(
                         from_module=self.module_name,
-                        to_module=alias.name.split(".")[0],
+                        to_module=_module_root(alias.name),
+                        import_line=node.lineno,
+                        import_type="import",
+                        imported_names=[alias.asname or alias.name],
+                    )
+                )
+                self.architecture_dependencies.append(
+                    ModuleDependency(
+                        from_module=self.module_name,
+                        to_module=module,
                         import_line=node.lineno,
                         import_type="import",
                         imported_names=[alias.asname or alias.name],
@@ -65,47 +116,57 @@ class DependencyGraphBuilder(ast.NodeVisitor):
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
         if node.module and node.level == 0:
-            module = node.module.split(".")[0]
-            if self._is_internal_module(node.module):
-                names = [a.name for a in node.names if a.name != "*"]
+            names = [a.name for a in node.names if a.name != "*"]
+            targets = _resolve_from_import_targets(
+                node.module, names, self.known_modules
+            )
+            if targets:
                 self.dependencies.append(
                     ModuleDependency(
                         from_module=self.module_name,
-                        to_module=module,
+                        to_module=_module_root(node.module),
                         import_line=node.lineno,
                         import_type="from_import",
                         imported_names=names,
                     )
                 )
+                for target, target_names in targets.items():
+                    self.architecture_dependencies.append(
+                        ModuleDependency(
+                            from_module=self.module_name,
+                            to_module=target,
+                            import_line=node.lineno,
+                            import_type="from_import",
+                            imported_names=target_names,
+                        )
+                    )
         elif node.level > 0:
             pass
 
     def _is_internal_module(self, module: str) -> bool:
-        root = module.split(".")[0]
-        return root in self.known_modules
+        return _resolve_known_module(module, self.known_modules) is not None
 
 
 class CircularDependencyAnalyzer:
     def __init__(self):
         self.modules: Dict[str, str] = {}
         self.dependencies: Dict[str, Set[str]] = defaultdict(set)
+        self.architecture_dependencies: Dict[str, Set[str]] = defaultdict(set)
         self.all_deps: List[ModuleDependency] = []
         self.known_modules: Set[str] = set()
 
     def add_file(self, tree: ast.AST, file_path: str, module_name: str):
         self.modules[module_name] = file_path
-        root_module = module_name.split(".")[0]
-        self.known_modules.add(root_module)
+        self.known_modules.update(_known_module_names(module_name))
 
     def build_graph_from_raw_imports(self, raw_imports_by_module: Dict[str, list]):
         for module_name in self.modules:
-            root = module_name.split(".")[0]
-            self.known_modules.add(root)
+            self.known_modules.update(_known_module_names(module_name))
 
         for module_name, raw_imports in raw_imports_by_module.items():
             file_path = self.modules.get(module_name, "")
             for import_module, line, import_type, names in raw_imports:
-                root = import_module.split(".")[0]
+                root = _module_root(import_module)
                 if root in self.known_modules:
                     dep = ModuleDependency(
                         from_module=module_name,
@@ -117,10 +178,24 @@ class CircularDependencyAnalyzer:
                     self.dependencies[dep.from_module].add(dep.to_module)
                     self.all_deps.append(dep)
 
+                if import_type == "from_import":
+                    architecture_targets = _resolve_from_import_targets(
+                        import_module, names, self.known_modules
+                    )
+                else:
+                    architecture_target = _resolve_known_module(
+                        import_module, self.known_modules
+                    )
+                    architecture_targets = (
+                        {architecture_target: names} if architecture_target else {}
+                    )
+
+                for target in architecture_targets:
+                    self.architecture_dependencies[module_name].add(target)
+
     def build_graph(self, trees: Dict[str, ast.AST]):
         for module_name in self.modules:
-            root = module_name.split(".")[0]
-            self.known_modules.add(root)
+            self.known_modules.update(_known_module_names(module_name))
 
         for module_name, file_path in self.modules.items():
             if module_name in trees:
@@ -132,6 +207,8 @@ class CircularDependencyAnalyzer:
                 for dep in builder.dependencies:
                     self.dependencies[dep.from_module].add(dep.to_module)
                     self.all_deps.append(dep)
+                for dep in builder.architecture_dependencies:
+                    self.architecture_dependencies[dep.from_module].add(dep.to_module)
 
     def find_simple_cycles(self) -> List[List[str]]:
         if _fast_find_cycles is not None:

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -595,6 +595,68 @@ class TestAnalyze:
             result.get("quality", [])
         )
 
+    def test_analyze_architecture_metrics_preserve_dotted_submodule_imports(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "package_a").mkdir()
+            (root / "package_b").mkdir()
+            (root / "package_a" / "__init__.py").write_text("", encoding="utf-8")
+            (root / "package_a" / "cli.py").write_text(
+                "import sync_common\n"
+                "def main():\n"
+                "    return sync_common.VALUE\n",
+                encoding="utf-8",
+            )
+            (root / "package_b" / "__init__.py").write_text("", encoding="utf-8")
+            (root / "package_b" / "cli.py").write_text(
+                "from package_a.cli import main as run_a\n"
+                "import sync_common\n"
+                "def main():\n"
+                "    return run_a() + sync_common.VALUE\n",
+                encoding="utf-8",
+            )
+            (root / "sync_common.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        metrics = result["architecture_metrics"]["module_metrics"]
+        assert metrics["package_a"]["ca"] == 0
+        assert metrics["package_a.cli"]["ca"] == 1
+        assert metrics["package_a.cli"]["zone"] != "zone_of_uselessness"
+
+    def test_analyze_architecture_metrics_preserve_resolved_relative_imports(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "app" / "package_a").mkdir(parents=True)
+            (root / "app" / "package_b").mkdir()
+            (root / "app" / "__init__.py").write_text("", encoding="utf-8")
+            (root / "app" / "package_a" / "__init__.py").write_text(
+                "", encoding="utf-8"
+            )
+            (root / "app" / "package_a" / "cli.py").write_text(
+                "def main():\n"
+                "    return 1\n",
+                encoding="utf-8",
+            )
+            (root / "app" / "package_b" / "__init__.py").write_text(
+                "", encoding="utf-8"
+            )
+            (root / "app" / "package_b" / "cli.py").write_text(
+                "from ..package_a.cli import main as run_a\n"
+                "def main():\n"
+                "    return run_a()\n",
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        metrics = result["architecture_metrics"]["module_metrics"]
+        assert metrics["app.package_a"]["ca"] == 0
+        assert metrics["app.package_a.cli"]["ca"] == 1
+        assert metrics["app.package_a.cli"]["zone"] != "zone_of_uselessness"
+
     @patch("skylos.analyzer.scan_typescript_file")
     def test_proc_file_dispatches_mjs_to_typescript_scanner(self, mock_scan):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:

--- a/test/test_circular_deps.py
+++ b/test/test_circular_deps.py
@@ -1,5 +1,6 @@
 import ast
 import pytest
+from skylos.architecture import get_architecture_findings
 from skylos.circular_deps import (
     CircularDependencyAnalyzer,
     CircularDependencyRule,
@@ -22,6 +23,21 @@ class TestDependencyGraphBuilder:
         assert len(builder.dependencies) == 1
         assert builder.dependencies[0].to_module == "foo"
         assert builder.dependencies[0].import_type == "import"
+        assert len(builder.architecture_dependencies) == 1
+        assert builder.architecture_dependencies[0].to_module == "foo"
+
+    def test_from_package_import_known_submodule(self):
+        code = "from myproject import submodule"
+        tree = ast.parse(code)
+        known = {"myproject", "myproject.submodule"}
+
+        builder = DependencyGraphBuilder("main", "main.py", known)
+        builder.visit(tree)
+
+        assert len(builder.dependencies) == 1
+        assert builder.dependencies[0].to_module == "myproject"
+        assert len(builder.architecture_dependencies) == 1
+        assert builder.architecture_dependencies[0].to_module == "myproject.submodule"
 
     def test_from_import(self):
         code = "from foo import bar, baz"
@@ -52,6 +68,8 @@ import myproject
 
         assert len(builder.dependencies) == 1
         assert builder.dependencies[0].to_module == "myproject"
+        assert len(builder.architecture_dependencies) == 1
+        assert builder.architecture_dependencies[0].to_module == "myproject"
 
     def test_dotted_import(self):
         code = "from myproject.submodule import thing"
@@ -62,6 +80,9 @@ import myproject
         builder.visit(tree)
 
         assert len(builder.dependencies) == 1
+        assert builder.dependencies[0].to_module == "myproject"
+        assert len(builder.architecture_dependencies) == 1
+        assert builder.architecture_dependencies[0].to_module == "myproject.submodule"
 
     def test_tracks_line_number(self):
         code = """# comment
@@ -227,6 +248,107 @@ def main():
         passed, message = rule.check()
 
         assert passed is True
+
+    @pytest.mark.parametrize(
+        "package_b_import",
+        [
+            ("package_a.cli", 1, "from_import", ["main"]),
+            ("package_a.cli", 1, "import", ["package_a.cli"]),
+            ("package_a.cli", 1, "import", ["_mod"]),
+        ],
+    )
+    def test_raw_imports_preserve_precise_architecture_edges_for_dotted_imports(
+        self, package_b_import
+    ):
+        rule = CircularDependencyRule()
+        modules = {
+            "package_a": ("/project/package_a/__init__.py", []),
+            "package_a.cli": (
+                "/project/package_a/cli.py",
+                [("sync_common", 1, "import", ["sync_common"])],
+            ),
+            "package_b": ("/project/package_b/__init__.py", []),
+            "package_b.cli": (
+                "/project/package_b/cli.py",
+                [package_b_import, ("sync_common", 2, "import", ["sync_common"])],
+            ),
+            "sync_common": ("/project/sync_common.py", []),
+        }
+
+        for module_name, (file_path, raw_imports) in modules.items():
+            rule.add_file_imports(file_path, module_name, raw_imports)
+
+        rule.analyze()
+
+        circular_graph = dict(rule._analyzer.dependencies)
+        architecture_graph = dict(rule._analyzer.architecture_dependencies)
+        assert circular_graph["package_b.cli"] == {"package_a", "sync_common"}
+        assert architecture_graph["package_b.cli"] == {
+            "package_a.cli",
+            "sync_common",
+        }
+
+        _, summary = get_architecture_findings(
+            dependency_graph=architecture_graph,
+            module_files=dict(rule._analyzer.modules),
+        )
+
+        assert summary["module_metrics"]["package_a"]["ca"] == 0
+        assert summary["module_metrics"]["package_a.cli"]["ca"] == 1
+        assert summary["module_metrics"]["package_a.cli"]["zone"] != (
+            "zone_of_uselessness"
+        )
+
+    def test_raw_imports_do_not_trace_init_reexports(self):
+        rule = CircularDependencyRule()
+        modules = {
+            "package_a": (
+                "/project/package_a/__init__.py",
+                [("package_a.cli", 1, "from_import", ["main"])],
+            ),
+            "package_a.cli": ("/project/package_a/cli.py", []),
+            "package_b.cli": (
+                "/project/package_b/cli.py",
+                [("package_a", 1, "from_import", ["main"])],
+            ),
+        }
+
+        for module_name, (file_path, raw_imports) in modules.items():
+            rule.add_file_imports(file_path, module_name, raw_imports)
+
+        rule.analyze()
+
+        architecture_graph = dict(rule._analyzer.architecture_dependencies)
+        assert architecture_graph["package_b.cli"] == {"package_a"}
+
+    def test_raw_imports_keep_circular_cycle_detection_root_collapsed(self):
+        rule = CircularDependencyRule()
+        modules = {
+            "package_a": (
+                "/project/package_a/__init__.py",
+                [("package_b.cli", 1, "from_import", ["main"])],
+            ),
+            "package_a.cli": ("/project/package_a/cli.py", []),
+            "package_b": (
+                "/project/package_b/__init__.py",
+                [("package_a.cli", 1, "from_import", ["main"])],
+            ),
+            "package_b.cli": ("/project/package_b/cli.py", []),
+        }
+
+        for module_name, (file_path, raw_imports) in modules.items():
+            rule.add_file_imports(file_path, module_name, raw_imports)
+
+        findings = rule.analyze()
+
+        circular_graph = dict(rule._analyzer.dependencies)
+        architecture_graph = dict(rule._analyzer.architecture_dependencies)
+        assert circular_graph["package_a"] == {"package_b"}
+        assert circular_graph["package_b"] == {"package_a"}
+        assert architecture_graph["package_a"] == {"package_b.cli"}
+        assert architecture_graph["package_b"] == {"package_a.cli"}
+        assert len(findings) == 1
+        assert set(findings[0]["cycle"]) == {"package_a", "package_b"}
 
 
 class TestConvenienceFunction:


### PR DESCRIPTION
 ## Summary

Fixes architecture metrics for explicit dotted imports to submodules. Keep the existing root collapsed graph for circular dependency detection, and add architecture graph for `Ca/Ce` metrics.

## Changes

  - Kept existing circular dependency behavior with root collapsed edges.
  - Add architecture dependencies for known dotted modules.
  - Use precise graph when computing architecture metrics

## Verification

```
pytest test/test_circular_deps.py test/test_architecture.py
```

Fixes #293.