### PR TITLE
ci(regression): compare benchmark results against base

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -31,7 +33,66 @@ jobs:
           uv venv
           uv pip install -e .
 
-      - name: Run curated corpus guard
+      - name: Run curated corpus guard (head)
+        id: head
+        shell: bash
         run: |
-          uv run python scripts/corpus_ci.py --manifest corpus/manifest.json | tee /tmp/corpus-summary.txt
+          set +e
+          uv run python scripts/corpus_ci.py --manifest corpus/manifest.json --json > corpus-guard-head.json
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          uv run python - <<'PY' | tee /tmp/corpus-summary.txt
+          import json
+          from skylos.corpus_ci import format_summary
+
+          with open("corpus-guard-head.json", encoding="utf-8") as fh:
+              print(format_summary(json.load(fh)))
+          PY
           cat /tmp/corpus-summary.txt >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      - name: Run curated corpus guard (base)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git worktree add /tmp/skylos-corpus-base "${{ github.event.pull_request.base.sha }}"
+          cd /tmp/skylos-corpus-base
+          mkdir -p /tmp/skylos-go-build-base /tmp/skylos-go-gopath-base
+          cd skylos/engines/go
+          GOCACHE=/tmp/skylos-go-build-base GOPATH=/tmp/skylos-go-gopath-base go build -o skylos-go ./cmd/skylos-go
+          cd /tmp/skylos-corpus-base
+          uv venv
+          uv pip install -e .
+          set +e
+          uv run python scripts/corpus_ci.py --manifest corpus/manifest.json --json > "$GITHUB_WORKSPACE/corpus-guard-base.json"
+          exit 0
+
+      - name: Compare corpus guard regression delta
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set +e
+          uv run python scripts/regression_delta.py \
+            --kind corpus \
+            --base corpus-guard-base.json \
+            --head corpus-guard-head.json \
+            | tee corpus-guard-delta.txt
+          status=${PIPESTATUS[0]}
+          cat corpus-guard-delta.txt >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Require corpus guard success on push
+        if: github.event_name != 'pull_request' && steps.head.outputs.status != '0'
+        run: exit 1
+
+      - name: Upload corpus guard results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: corpus-guard-results
+          path: |
+            corpus-guard-head.json
+            corpus-guard-base.json
+            corpus-guard-delta.txt
+          if-no-files-found: ignore

--- a/.github/workflows/quality-benchmark.yml
+++ b/.github/workflows/quality-benchmark.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v4
 
@@ -21,7 +23,62 @@ jobs:
           uv venv
           uv pip install -e .
 
-      - name: Run quality benchmark
+      - name: Run quality benchmark (head)
+        id: head
+        shell: bash
         run: |
-          uv run python scripts/quality_benchmark.py --manifest benchmarks/quality/manifest.json | tee /tmp/quality-benchmark-summary.txt
+          set +e
+          uv run python scripts/quality_benchmark.py --manifest benchmarks/quality/manifest.json --json > quality-benchmark-head.json
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          uv run python - <<'PY' | tee /tmp/quality-benchmark-summary.txt
+          import json
+          from skylos.quality_benchmark import format_summary
+
+          with open("quality-benchmark-head.json", encoding="utf-8") as fh:
+              print(format_summary(json.load(fh)))
+          PY
           cat /tmp/quality-benchmark-summary.txt >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      - name: Run quality benchmark (base)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git worktree add /tmp/skylos-quality-base "${{ github.event.pull_request.base.sha }}"
+          cd /tmp/skylos-quality-base
+          uv venv
+          uv pip install -e .
+          set +e
+          uv run python scripts/quality_benchmark.py --manifest benchmarks/quality/manifest.json --json > "$GITHUB_WORKSPACE/quality-benchmark-base.json"
+          exit 0
+
+      - name: Compare quality benchmark regression delta
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set +e
+          uv run python scripts/regression_delta.py \
+            --kind quality \
+            --base quality-benchmark-base.json \
+            --head quality-benchmark-head.json \
+            | tee quality-benchmark-delta.txt
+          status=${PIPESTATUS[0]}
+          cat quality-benchmark-delta.txt >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Require quality benchmark success on push
+        if: github.event_name != 'pull_request' && steps.head.outputs.status != '0'
+        run: exit 1
+
+      - name: Upload quality benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-benchmark-results
+          path: |
+            quality-benchmark-head.json
+            quality-benchmark-base.json
+            quality-benchmark-delta.txt
+          if-no-files-found: ignore

--- a/scripts/regression_delta.py
+++ b/scripts/regression_delta.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: str | Path) -> dict[str, Any]:
+    safe_path = _safe_workspace_json(path)
+    return json.loads(safe_path.read_text(encoding="utf-8"))
+
+
+def _safe_workspace_json(path: str | Path) -> Path:
+    candidate = Path(path)
+    if str(candidate) != candidate.name:
+        raise ValueError(f"expected a workspace-local JSON filename, got: {path}")
+    if candidate.suffix != ".json":
+        raise ValueError(f"expected a .json file, got: {path}")
+    return Path.cwd() / candidate.name
+
+
+def _case_failures(summary: dict[str, Any]) -> dict[str, set[tuple[str, ...]]]:
+    failures_by_case: dict[str, set[tuple[str, ...]]] = {}
+    for case in summary.get("cases", []) or []:
+        case_id = str(case.get("id") or "")
+        failures = case.get("failures", []) or []
+        if not case_id or not failures:
+            continue
+
+        keys = failures_by_case.setdefault(case_id, set())
+        for failure in failures:
+            keys.add(
+                (
+                    str(failure.get("failure_type") or "expectation"),
+                    str(failure.get("category") or ""),
+                    str(failure.get("mode") or ""),
+                    str(failure.get("expected") or ""),
+                )
+            )
+    return failures_by_case
+
+
+def _new_failures(
+    base: dict[str, Any], head: dict[str, Any]
+) -> dict[str, set[tuple[str, ...]]]:
+    base_failures = _case_failures(base)
+    head_failures = _case_failures(head)
+
+    new: dict[str, set[tuple[str, ...]]] = {}
+    for case_id, failures in head_failures.items():
+        added = failures - base_failures.get(case_id, set())
+        if added:
+            new[case_id] = added
+    return new
+
+
+def _failure_count(summary: dict[str, Any]) -> int:
+    return int(summary.get("failure_count") or 0)
+
+
+def _score(summary: dict[str, Any], key: str) -> float:
+    scores = summary.get("scores", {}) or {}
+    return float(scores.get(key) or 0.0)
+
+
+def _taxonomy_scores(summary: dict[str, Any]) -> dict[str, float]:
+    taxonomy = summary.get("taxonomy", {}) or {}
+    return {
+        str(name): float((bucket or {}).get("weighted_score") or 0.0)
+        for name, bucket in taxonomy.items()
+    }
+
+
+def compare_corpus(base: dict[str, Any], head: dict[str, Any]) -> tuple[bool, list[str]]:
+    lines = [
+        "# Corpus Guard Regression Delta",
+        "",
+        f"Base failures: {_failure_count(base)}",
+        f"Head failures: {_failure_count(head)}",
+    ]
+    failed = False
+
+    if _failure_count(head) > _failure_count(base):
+        failed = True
+        lines.append(
+            f"Regression: failure count increased "
+            f"{_failure_count(base)} -> {_failure_count(head)}."
+        )
+
+    added = _new_failures(base, head)
+    if added:
+        failed = True
+        lines.append("Regression: new failing corpus expectations:")
+        for case_id, failures in sorted(added.items()):
+            for failure in sorted(failures):
+                _, category, mode, expected = failure
+                lines.append(f"- {case_id}: {mode} {category} -> {expected}")
+
+    if not failed:
+        lines.append("No corpus regression detected.")
+
+    return not failed, lines
+
+
+def compare_quality(base: dict[str, Any], head: dict[str, Any]) -> tuple[bool, list[str]]:
+    base_score = _score(base, "overall_score")
+    head_score = _score(head, "overall_score")
+    lines = [
+        "# Quality Benchmark Regression Delta",
+        "",
+        f"Base failures: {_failure_count(base)}",
+        f"Head failures: {_failure_count(head)}",
+        f"Base overall score: {base_score}",
+        f"Head overall score: {head_score}",
+    ]
+    failed = False
+
+    if _failure_count(head) > _failure_count(base):
+        failed = True
+        lines.append(
+            f"Regression: failure count increased "
+            f"{_failure_count(base)} -> {_failure_count(head)}."
+        )
+
+    if head_score < base_score:
+        failed = True
+        lines.append(f"Regression: overall score dropped {base_score} -> {head_score}.")
+
+    base_taxonomy = _taxonomy_scores(base)
+    head_taxonomy = _taxonomy_scores(head)
+    for label, base_value in sorted(base_taxonomy.items()):
+        if label not in head_taxonomy:
+            continue
+        head_value = head_taxonomy[label]
+        if head_value < base_value:
+            failed = True
+            lines.append(
+                f"Regression: taxonomy '{label}' score dropped "
+                f"{base_value} -> {head_value}."
+            )
+
+    added = _new_failures(base, head)
+    if added:
+        failed = True
+        lines.append("Regression: new failing quality benchmark expectations:")
+        for case_id, failures in sorted(added.items()):
+            for failure in sorted(failures):
+                failure_type, category, mode, expected = failure
+                lines.append(
+                    f"- {case_id}: {failure_type} {mode} {category} -> {expected}"
+                )
+
+    if not failed:
+        lines.append("No quality benchmark regression detected.")
+
+    return not failed, lines
+
+
+def compare(
+    kind: str, base: dict[str, Any], head: dict[str, Any]
+) -> tuple[bool, list[str]]:
+    if kind == "corpus":
+        return compare_corpus(base, head)
+    if kind == "quality":
+        return compare_quality(base, head)
+    raise ValueError(f"unsupported regression delta kind: {kind}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare base and head benchmark JSON outputs for regressions."
+    )
+    parser.add_argument("--kind", choices=("corpus", "quality"), required=True)
+    parser.add_argument("--base", required=True, help="Base branch JSON summary.")
+    parser.add_argument("--head", required=True, help="Head branch JSON summary.")
+    args = parser.parse_args()
+
+    passed, lines = compare(args.kind, _load_json(args.base), _load_json(args.head))
+    print("\n".join(lines))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_regression_delta.py
+++ b/test/test_regression_delta.py
@@ -1,0 +1,154 @@
+import pytest
+
+from scripts.regression_delta import _safe_workspace_json, compare
+
+
+def _corpus_summary(failures=None):
+    failures = failures or {}
+    return {
+        "failure_count": sum(len(items) for items in failures.values()),
+        "cases": [
+            {
+                "id": case_id,
+                "failures": [
+                    {
+                        "category": category,
+                        "mode": mode,
+                        "expected": expected,
+                        "found": ["actual"],
+                    }
+                    for category, mode, expected in items
+                ],
+            }
+            for case_id, items in failures.items()
+        ],
+    }
+
+
+def _quality_summary(
+    *,
+    failure_count=0,
+    overall_score=100.0,
+    taxonomy=None,
+    failures=None,
+):
+    failures = failures or {}
+    taxonomy = taxonomy or {"precision_guard": 100.0, "maintainability": 100.0}
+    return {
+        "failure_count": failure_count or sum(len(items) for items in failures.values()),
+        "scores": {"overall_score": overall_score},
+        "taxonomy": {
+            label: {"weighted_score": score} for label, score in taxonomy.items()
+        },
+        "cases": [
+            {
+                "id": case_id,
+                "failures": [
+                    {
+                        "failure_type": failure_type,
+                        "category": category,
+                        "mode": mode,
+                        "expected": expected,
+                        "found": ["actual"],
+                    }
+                    for failure_type, category, mode, expected in items
+                ],
+            }
+            for case_id, items in failures.items()
+        ],
+    }
+
+
+def test_corpus_no_change_passes():
+    summary = _corpus_summary(
+        {"known-case": [("quality", "present", "SKY-Q301")]}
+    )
+
+    passed, lines = compare("corpus", summary, summary)
+
+    assert passed is True
+    assert "No corpus regression detected." in lines
+
+
+def test_corpus_new_failure_fails():
+    base = _corpus_summary()
+    head = _corpus_summary(
+        {"new-case": [("unused_functions", "absent", "handler")]}
+    )
+
+    passed, lines = compare("corpus", base, head)
+
+    assert passed is False
+    assert any("failure count increased" in line for line in lines)
+    assert any("new-case" in line for line in lines)
+
+
+def test_corpus_removed_failure_passes():
+    base = _corpus_summary(
+        {"known-case": [("unused_functions", "absent", "handler")]}
+    )
+    head = _corpus_summary()
+
+    passed, lines = compare("corpus", base, head)
+
+    assert passed is True
+    assert "No corpus regression detected." in lines
+
+
+def test_quality_failure_count_increase_fails():
+    base = _quality_summary(failure_count=0)
+    head = _quality_summary(
+        failures={
+            "quality-case": [("expectation", "quality", "present", "SKY-L006")]
+        }
+    )
+
+    passed, lines = compare("quality", base, head)
+
+    assert passed is False
+    assert any("failure count increased" in line for line in lines)
+    assert any("quality-case" in line for line in lines)
+
+
+def test_quality_overall_score_drop_fails():
+    base = _quality_summary(overall_score=100.0)
+    head = _quality_summary(overall_score=99.0)
+
+    passed, lines = compare("quality", base, head)
+
+    assert passed is False
+    assert any("overall score dropped" in line for line in lines)
+
+
+def test_quality_taxonomy_score_drop_fails():
+    base = _quality_summary(taxonomy={"precision_guard": 100.0})
+    head = _quality_summary(taxonomy={"precision_guard": 95.0})
+
+    passed, lines = compare("quality", base, head)
+
+    assert passed is False
+    assert any("taxonomy 'precision_guard' score dropped" in line for line in lines)
+
+
+def test_quality_score_improvement_passes():
+    base = _quality_summary(
+        overall_score=95.0, taxonomy={"precision_guard": 95.0}
+    )
+    head = _quality_summary(
+        overall_score=100.0, taxonomy={"precision_guard": 100.0}
+    )
+
+    passed, lines = compare("quality", base, head)
+
+    assert passed is True
+    assert "No quality benchmark regression detected." in lines
+
+
+def test_json_inputs_must_be_workspace_local_filenames():
+    assert _safe_workspace_json("head.json").name == "head.json"
+
+    with pytest.raises(ValueError, match="workspace-local"):
+        _safe_workspace_json("../head.json")
+
+    with pytest.raises(ValueError, match=".json"):
+        _safe_workspace_json("head.txt")


### PR DESCRIPTION
## Summary

 Makes corpus and quality benchmark CI compare PR results against the base branch. This turns the existing benchmark/corpus guards from "current result only" into a regression delta check for pull requests.

## Tests

```bash
- pytest test/test_regression_delta.py
```