### PR TITLE
ci(regression): compare benchmark results against base

### DIFF
--- a/scripts/regression_delta.py
+++ b/scripts/regression_delta.py
@@ -8,17 +8,24 @@ from typing import Any
 
 
 def _load_json(path: str | Path) -> dict[str, Any]:
-    safe_path = _safe_workspace_json(path)
+    workspace = Path.cwd().resolve()
+    safe_path = _safe_workspace_json(path, workspace)
+    if not safe_path.is_relative_to(workspace):
+        raise ValueError(f"JSON path escapes workspace: {path}")
     return json.loads(safe_path.read_text(encoding="utf-8"))
 
 
-def _safe_workspace_json(path: str | Path) -> Path:
+def _safe_workspace_json(path: str | Path, workspace: Path) -> Path:
     candidate = Path(path)
-    if str(candidate) != candidate.name:
+    if candidate.is_absolute() or str(candidate) != candidate.name:
         raise ValueError(f"expected a workspace-local JSON filename, got: {path}")
-    if candidate.suffix != ".json":
+    if candidate.suffix.lower() != ".json":
         raise ValueError(f"expected a .json file, got: {path}")
-    return Path.cwd() / candidate.name
+
+    safe_path = (workspace / candidate.name).resolve()
+    if not safe_path.is_relative_to(workspace):
+        raise ValueError(f"JSON path escapes workspace: {path}")
+    return safe_path
 
 
 def _case_failures(summary: dict[str, Any]) -> dict[str, set[tuple[str, ...]]]:

--- a/test/test_regression_delta.py
+++ b/test/test_regression_delta.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 
 from scripts.regression_delta import _safe_workspace_json, compare
 
@@ -145,10 +146,12 @@ def test_quality_score_improvement_passes():
 
 
 def test_json_inputs_must_be_workspace_local_filenames():
-    assert _safe_workspace_json("head.json").name == "head.json"
+    workspace = Path.cwd().resolve()
+
+    assert _safe_workspace_json("head.json", workspace).name == "head.json"
 
     with pytest.raises(ValueError, match="workspace-local"):
-        _safe_workspace_json("../head.json")
+        _safe_workspace_json("../head.json", workspace)
 
     with pytest.raises(ValueError, match=".json"):
-        _safe_workspace_json("head.txt")
+        _safe_workspace_json("head.txt", workspace)


### PR DESCRIPTION
## Summary

  Makes corpus and quality benchmark CI compare PR results against the base branch.

## Why

  Current CI catches only known expectation failures. It does not clearly detect when a PR makes corpus or benchmark results worse compared with `main`.

## Changes

  - Add `scripts/regression_delta.py` for comparing benchmark JSON outputs.
  - Update Corpus Guard CI to fail on new corpus failures.
  - Update Quality Benchmark CI

## How to test

```bash
 pytest test/test_regression_delta.py
```
