### PR TITLE
fix(architecture): suppress cli entrypoint false positives

### DIFF
--- a/scripts/regression_delta.py
+++ b/scripts/regression_delta.py
@@ -8,17 +8,24 @@ from typing import Any
 
 
 def _load_json(path: str | Path) -> dict[str, Any]:
-    safe_path = _safe_workspace_json(path)
+    workspace = Path.cwd().resolve()
+    safe_path = _safe_workspace_json(path, workspace)
+    if not safe_path.is_relative_to(workspace):
+        raise ValueError(f"JSON path escapes workspace: {path}")
     return json.loads(safe_path.read_text(encoding="utf-8"))
 
 
-def _safe_workspace_json(path: str | Path) -> Path:
+def _safe_workspace_json(path: str | Path, workspace: Path) -> Path:
     candidate = Path(path)
-    if str(candidate) != candidate.name:
+    if candidate.is_absolute() or str(candidate) != candidate.name:
         raise ValueError(f"expected a workspace-local JSON filename, got: {path}")
-    if candidate.suffix != ".json":
+    if candidate.suffix.lower() != ".json":
         raise ValueError(f"expected a .json file, got: {path}")
-    return Path.cwd() / candidate.name
+
+    safe_path = (workspace / candidate.name).resolve()
+    if not safe_path.is_relative_to(workspace):
+        raise ValueError(f"JSON path escapes workspace: {path}")
+    return safe_path
 
 
 def _case_failures(summary: dict[str, Any]) -> dict[str, set[tuple[str, ...]]]:

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -135,6 +135,44 @@ _RUST_SOURCE_EXTS = (".rs",)
 
 _TRY_NODE_TYPES = (ast.Try, getattr(ast, "TryStar", ast.Try))
 
+
+def _entrypoint_module_name(qname: str) -> str | None:
+    if not isinstance(qname, str) or "." not in qname:
+        return None
+    module_name, _symbol = qname.rsplit(".", 1)
+    return module_name or None
+
+
+def _expand_reexported_entrypoint_modules(
+    entrypoint_qnames: set[str],
+    entrypoint_modules: set[str],
+    raw_imports_by_file: dict[Path, list],
+    modmap: dict[Path, str],
+    module_files: dict[str, str],
+) -> set[str]:
+    modules = set(entrypoint_modules)
+    known_modules = set(module_files)
+
+    for qname in entrypoint_qnames:
+        if "." not in qname:
+            continue
+
+        entry_module, entry_symbol = qname.rsplit(".", 1)
+        for file_path, raw_imports in raw_imports_by_file.items():
+            if modmap.get(file_path) != entry_module:
+                continue
+
+            for import_module, _line, import_type, imported_names in raw_imports:
+                if import_type != "from_import":
+                    continue
+                if entry_symbol not in imported_names:
+                    continue
+                if import_module in known_modules:
+                    modules.add(import_module)
+
+    return modules
+
+
 _LINTER_RULE_NODE_TYPES = {
     ComplexityRule: (ast.FunctionDef, ast.AsyncFunctionDef),
     CognitiveComplexityRule: (ast.FunctionDef, ast.AsyncFunctionDef),
@@ -1354,8 +1392,14 @@ class Skylos:
         workspace_inventory=None,
         architecture_abstractness=None,
         architecture_loc=None,
+        architecture_main_guard_modules=None,
+        pyproject_entrypoint_qnames=None,
+        pyproject_entrypoint_modules=None,
     ):
         """Assemble the final result dict from analysis outputs."""
+        architecture_main_guard_modules = set(architecture_main_guard_modules or ())
+        pyproject_entrypoint_qnames = set(pyproject_entrypoint_qnames or ())
+        pyproject_entrypoint_modules = set(pyproject_entrypoint_modules or ())
         unused = []
         dead_class_keys = {
             key
@@ -1567,6 +1611,17 @@ class Skylos:
                             circular_rule._analyzer.architecture_dependencies
                         )
                         mod_files = dict(circular_rule._analyzer.modules)
+                        entrypoint_modules = (
+                            pyproject_entrypoint_modules
+                            | architecture_main_guard_modules
+                        )
+                        entrypoint_modules = _expand_reexported_entrypoint_modules(
+                            pyproject_entrypoint_qnames,
+                            entrypoint_modules,
+                            all_raw_imports,
+                            modmap,
+                            mod_files,
+                        )
 
                         mod_trees = {}
                         if not architecture_abstractness:
@@ -1588,6 +1643,7 @@ class Skylos:
                             module_trees=mod_trees,
                             module_abstractness=architecture_abstractness,
                             module_loc=architecture_loc,
+                            entrypoint_modules=entrypoint_modules,
                         )
                         ignored_rules = set(project_cfg.get("ignore", []))
                         if arch_findings:
@@ -1716,12 +1772,18 @@ class Skylos:
         project_cfg = load_config(project_root)
         project_ignore = set(project_cfg.get("ignore", []))
         requested_changed_files = changed_files
+        pyproject_entrypoint_qnames = set()
+        pyproject_entrypoint_modules = set()
 
         try:
             from skylos.pyproject_entrypoints import extract_entrypoints
 
             for qname in extract_entrypoints(project_root):
+                pyproject_entrypoint_qnames.add(qname)
                 global_pattern_tracker.known_qualified_refs.add(qname)
+                module_name = _entrypoint_module_name(qname)
+                if module_name:
+                    pyproject_entrypoint_modules.add(module_name)
         except Exception:
             logger.debug("Failed to extract pyproject entrypoints", exc_info=True)
 
@@ -1748,6 +1810,7 @@ class Skylos:
         all_clone_fragments = []
         architecture_abstractness = {}
         architecture_loc = {}
+        architecture_main_guard_modules = set()
 
         per_file_ignore_lines = {}
         pattern_trackers = {}
@@ -1876,10 +1939,13 @@ class Skylos:
                 if file_architecture_metrics:
                     abstractness = file_architecture_metrics.get("abstractness")
                     loc = file_architecture_metrics.get("loc")
+                    has_main_guard = file_architecture_metrics.get("has_main_guard")
                     if abstractness is not None:
                         architecture_abstractness[mod] = abstractness
                     if loc is not None:
                         architecture_loc[mod] = loc
+                    if has_main_guard:
+                        architecture_main_guard_modules.add(mod)
                 for callee, method_refs in file_param_method_refs.items():
                     all_param_method_refs[callee].extend(method_refs)
                 for callee, arg_refs in file_call_arg_types.items():
@@ -2513,6 +2579,9 @@ class Skylos:
             workspace_inventory=workspace_inventory,
             architecture_abstractness=architecture_abstractness,
             architecture_loc=architecture_loc,
+            architecture_main_guard_modules=architecture_main_guard_modules,
+            pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
+            pyproject_entrypoint_modules=pyproject_entrypoint_modules,
         )
 
         return json.dumps(result, indent=2)
@@ -2911,10 +2980,11 @@ def proc_file(
                 else:
                     architecture_tree = tree
 
-                from skylos.architecture import _compute_abstractness
+                from skylos.architecture import _compute_abstractness, _has_main_guard
 
                 architecture_metrics = {
                     "abstractness": _compute_abstractness(architecture_tree),
+                    "has_main_guard": _has_main_guard(architecture_tree),
                     "loc": sum(
                         1
                         for line in source.splitlines()

--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -166,6 +166,26 @@ def _classify_zone(abstractness: float, instability: float) -> str:
     return "healthy"
 
 
+def _has_main_guard(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+
+        test = node.test
+        if isinstance(test, ast.Compare) and len(test.ops) == 1 and len(test.comparators) == 1:
+            left = test.left
+            right = test.comparators[0]
+            if isinstance(test.ops[0], ast.Eq):
+                left_is_name = isinstance(left, ast.Name) and left.id == "__name__"
+                right_is_main = isinstance(right, ast.Constant) and right.value == "__main__"
+                right_is_name = isinstance(right, ast.Name) and right.id == "__name__"
+                left_is_main = isinstance(left, ast.Constant) and left.value == "__main__"
+                if (left_is_name and right_is_main) or (right_is_name and left_is_main):
+                    return True
+
+    return False
+
+
 def analyze_architecture(
     dependency_graph: dict[str, set[str]],
     module_files: dict[str, str],
@@ -481,6 +501,8 @@ def get_architecture_findings(
     module_trees: dict[str, ast.AST] | None = None,
     module_abstractness: dict[str, dict[str, Any]] | None = None,
     module_loc: dict[str, int] | None = None,
+    entrypoint_modules: set[str] | None = None,
+    private_helper_ce_limit: int = 2,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     result = analyze_architecture(
         dependency_graph=dependency_graph,
@@ -488,6 +510,19 @@ def get_architecture_findings(
         module_trees=module_trees,
         module_abstractness=module_abstractness,
         module_loc=module_loc,
+    )
+
+    contextual_entrypoints = set(entrypoint_modules or ())
+    if module_trees:
+        for module_name, tree in module_trees.items():
+            if tree is not None and _has_main_guard(tree):
+                contextual_entrypoints.add(module_name)
+
+    findings = _filter_contextual_findings(
+        result.findings,
+        result.modules,
+        entrypoint_modules=contextual_entrypoints,
+        private_helper_ce_limit=private_helper_ce_limit,
     )
 
     summary = {
@@ -515,4 +550,34 @@ def get_architecture_findings(
         },
     }
 
-    return result.findings, summary
+    return findings, summary
+
+
+def _filter_contextual_findings(
+    findings: list[dict[str, Any]],
+    modules: dict[str, ModuleMetrics],
+    *,
+    entrypoint_modules: set[str],
+    private_helper_ce_limit: int,
+) -> list[dict[str, Any]]:
+    filtered = []
+    for finding in findings:
+        rule_id = finding.get("rule_id")
+        module_name = finding.get("name")
+
+        if rule_id == "SKY-Q803" and module_name in entrypoint_modules:
+            continue
+
+        if rule_id == "SKY-Q802" and isinstance(module_name, str):
+            simple_name = module_name.rsplit(".", 1)[-1]
+            metrics = modules.get(module_name)
+            if (
+                simple_name.startswith("_")
+                and metrics is not None
+                and metrics.ce <= private_helper_ce_limit
+            ):
+                continue
+
+        filtered.append(finding)
+
+    return filtered

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -657,6 +657,66 @@ class TestAnalyze:
         assert metrics["app.package_a.cli"]["ca"] == 1
         assert metrics["app.package_a.cli"]["zone"] != "zone_of_uselessness"
 
+    def test_analyze_architecture_filters_cli_entrypoint_and_private_helper_noise(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pkg = root / "mypkg"
+            pkg.mkdir()
+            (root / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "issue300-repro"\n'
+                'version = "0.1.0"\n\n'
+                "[project.scripts]\n"
+                'mypkg = "mypkg:main"\n',
+                encoding="utf-8",
+            )
+            (pkg / "__init__.py").write_text(
+                "from .cli import main\n"
+                '__all__ = ["main"]\n',
+                encoding="utf-8",
+            )
+            (pkg / "cli.py").write_text(
+                "from .flow_a import run_a\n"
+                "from .flow_b import run_b\n"
+                "from .flow_c import run_c\n\n"
+                "def main():\n"
+                "    run_a()\n"
+                "    run_b()\n"
+                "    run_c()\n",
+                encoding="utf-8",
+            )
+            (pkg / "_helpers.py").write_text(
+                "def normalize(value):\n"
+                "    return value.strip().lower()\n\n"
+                "def emit(value):\n"
+                "    print(normalize(value))\n",
+                encoding="utf-8",
+            )
+            for suffix in ("a", "b", "c"):
+                (pkg / f"flow_{suffix}.py").write_text(
+                    "from ._helpers import emit\n\n"
+                    f"def run_{suffix}():\n"
+                    f'    emit("{suffix}")\n',
+                    encoding="utf-8",
+                )
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        metrics = result["architecture_metrics"]["module_metrics"]
+        assert metrics["mypkg"]["zone"] == "zone_of_uselessness"
+        assert metrics["mypkg.cli"]["zone"] == "zone_of_uselessness"
+        assert metrics["mypkg._helpers"]["distance"] == 1.0
+
+        architecture_rules = {
+            (f.get("rule_id"), f.get("name"))
+            for f in result.get("quality", [])
+            if f.get("rule_id") in {"SKY-Q802", "SKY-Q803"}
+        }
+        assert ("SKY-Q803", "mypkg") not in architecture_rules
+        assert ("SKY-Q803", "mypkg.cli") not in architecture_rules
+        assert ("SKY-Q802", "mypkg._helpers") not in architecture_rules
+
     @patch("skylos.analyzer.scan_typescript_file")
     def test_proc_file_dispatches_mjs_to_typescript_scanner(self, mock_scan):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -4,6 +4,7 @@ from skylos.architecture import (
     get_architecture_findings,
     _compute_abstractness,
     _classify_zone,
+    _has_main_guard,
 )
 
 
@@ -84,6 +85,79 @@ class TestClassifyZone:
 
     def test_healthy(self):
         assert _classify_zone(0.5, 0.2) == "healthy"
+
+
+class TestArchitectureContext:
+    def test_main_guard_detected(self):
+        tree = ast.parse("""
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()
+""")
+        assert _has_main_guard(tree)
+
+    def test_entrypoint_and_private_helpers_filter_contextual_findings(self):
+        graph = {
+            "mypkg.cli": {"mypkg.flow_a", "mypkg.flow_b", "mypkg.flow_c"},
+            "mypkg.flow_a": {"mypkg._helpers"},
+            "mypkg.flow_b": {"mypkg._helpers"},
+            "mypkg.flow_c": {"mypkg._helpers"},
+            "mypkg._helpers": set(),
+        }
+        module_files = {
+            "mypkg.cli": "/p/mypkg/cli.py",
+            "mypkg.flow_a": "/p/mypkg/flow_a.py",
+            "mypkg.flow_b": "/p/mypkg/flow_b.py",
+            "mypkg.flow_c": "/p/mypkg/flow_c.py",
+            "mypkg._helpers": "/p/mypkg/_helpers.py",
+        }
+
+        raw_findings, _ = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+            private_helper_ce_limit=-1,
+        )
+        assert ("SKY-Q803", "mypkg.cli") in {
+            (f["rule_id"], f["name"]) for f in raw_findings
+        }
+        assert ("SKY-Q802", "mypkg._helpers") in {
+            (f["rule_id"], f["name"]) for f in raw_findings
+        }
+
+        findings, summary = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+            entrypoint_modules={"mypkg.cli"},
+        )
+
+        rules = {(f["rule_id"], f["name"]) for f in findings}
+        assert ("SKY-Q803", "mypkg.cli") not in rules
+        assert ("SKY-Q802", "mypkg._helpers") not in rules
+        assert summary["module_metrics"]["mypkg.cli"]["zone"] == "zone_of_uselessness"
+        assert summary["module_metrics"]["mypkg._helpers"]["distance"] == 1.0
+
+    def test_main_guard_module_filters_zone_warning(self):
+        tree = ast.parse("""
+from worker import run
+
+def main():
+    run()
+
+if __name__ == "__main__":
+    main()
+""")
+
+        findings, summary = get_architecture_findings(
+            dependency_graph={"cli": {"worker"}, "worker": set()},
+            module_files={"cli": "/p/cli.py", "worker": "/p/worker.py"},
+            module_trees={"cli": tree},
+        )
+
+        rules = {(f["rule_id"], f["name"]) for f in findings}
+        assert summary["module_metrics"]["cli"]["zone"] == "zone_of_uselessness"
+        assert ("SKY-Q803", "cli") not in rules
 
 
 class TestAnalyzeArchitecture:

--- a/test/test_regression_delta.py
+++ b/test/test_regression_delta.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 
 from scripts.regression_delta import _safe_workspace_json, compare
 
@@ -145,10 +146,12 @@ def test_quality_score_improvement_passes():
 
 
 def test_json_inputs_must_be_workspace_local_filenames():
-    assert _safe_workspace_json("head.json").name == "head.json"
+    workspace = Path.cwd().resolve()
+
+    assert _safe_workspace_json("head.json", workspace).name == "head.json"
 
     with pytest.raises(ValueError, match="workspace-local"):
-        _safe_workspace_json("../head.json")
+        _safe_workspace_json("../head.json", workspace)
 
     with pytest.raises(ValueError, match=".json"):
-        _safe_workspace_json("head.txt")
+        _safe_workspace_json("head.txt", workspace)


### PR DESCRIPTION
## Summary
  - Suppress `SKY-Q803` for Python CLI entrypoint modules discovered from `pyproject.toml`,`__main__` guards, and package re-export entrypoints.
  - Suppress `SKY-Q802` for private helper modules with low outgoing coupling.

## Why

Bug was a FP. Skylos was treating CLI dispatcher modules like normal library modules. CLI usualy imports many flow modules and has few or no internal dependents, so the architecture heuristic classified it as highly unstable and reported `SKY-Q803`.

As for `SKY-Q802`. Private helper modules had the opposite shape. Many modules import them, but they usually do not import much themselves.

## Verification
```
  - pytest test/test_architecture.py test/test_analyzer.py::TestAnalyze::test_analyze_architecture_filters_cli_entrypoint_and_private_helper_noise`
  -  pytest test/test_analyzer.py::TestAnalyze::test_analyze_quality_includes_architecture_findings test/test_analyzer.py::TestAnalyze::test_analyze_architecture_metrics_preserve_dotted_submodule_imports test/test_analyzer.py::TestAnalyze::test_analyze_architecture_metrics_preserve_resolved_relative_imports test/test_analyzer.py::TestAnalyze::test_analyze_architecture_filters_cli_entrypoint_and_private_helper_noise`
```

Fixes #300