### PR TITLE
feat(vscode): add review queue provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ snugbug
 .ruff_cache
 dist
 node_modules
+*.vsix
 .pytest_cache
 .venv
 .coverage

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,4 +1,5 @@
 node_modules/**
 src/**
+test/**
 .vscode/**
 **/*.map

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,11 +1,27 @@
 ## Changelog
 
+## [0.6.0] - 2026-05-06
+
+### Added
+- **Review Queue source provenance**: findings now show Static, Automation, AI Assist, or Confirmed source labels
+- **Confirmed findings**: matching Static + Automation findings are merged into one Review Queue item and ranked higher
+- **Decision-focused finding details**: detail view now shows source, CI impact, evidence, priority reasons, and fix path
+- **Optional Automation Activity**: repo-level automation is clearly separated from the primary static Review Queue
+- **Optional real-time AI Assist**: automatic AI Assist is off by default and labeled separately from static analysis
+
+### Changed
+- Review Queue sections now use Blockers, Needs Review, Fixable, and Review Later
+- Severity remains the primary editor color; Confirmed appears as a badge/suffix instead of a separate primary color
+- Source filters now cover Static scan, Automation, AI Assist, and Confirmed findings
+- AI Assist and Automation failure copy now states static scan results are unaffected
+- Auto-fix commands now identify AI Assist explicitly in user-facing labels
+
 ## [0.5.0] - 2026-03-10
 
 ### Added
 - **Local AI support**: new `"local"` provider option with dedicated `skylos.localBaseUrl` and `skylos.localModel` settings. Works with Ollama, LM Studio, LocalAI, vLLM, Kimi, or any OpenAI-compatible server. No API key required
 - **SARIF export**: `Skylos: Export Report` now offers SARIF v2.1.0 output for CI/code-scanning integrations (GitHub Code Scanning, GitLab SAST, Azure DevOps). Includes rule metadata with CWE, OWASP, and PCI-DSS tags
-- **Sidebar filters**: filter findings by severity, category, source (CLI vs AI), or file name via the funnel icon in the sidebar title bar. Filters stack and can be cleared with the X button
+- **Sidebar filters**: filter findings by severity, category, source, or file name via the funnel icon in the sidebar title bar. Filters stack and can be cleared with the X button
 - **Configurable delta base branch**: `skylos.diffBase` setting (default `origin/main`) replaces the hardcoded base ref for delta mode. Supports any git ref
 - **Safer AI fix workflow**: `skylos.fixPreviewFirst` (default `true`) enforces diff preview before applying fixes. `skylos.postFixCommand` runs tests/linter after each fix with one-click undo on failure
 - Clear warning when `"local"` provider is selected but no server URL is configured, with "Open Settings" action

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -6,21 +6,23 @@
 
 ## Features
 
-* **Streaming Inline Analysis**: Ghost text appears character-by-character as the AI streams findings — see issues the instant they're detected
-* **Active Command Center**: A ranked repo-level queue highlights what matters now, fed by Skylos agent state instead of dumping every finding
+* **Skylos Review Queue**: A ranked sidebar queue puts CI-blocking, new, high-risk, evidence-backed, and fixable issues first
+* **Source provenance and confirmation**: Findings are labeled as Static, Automation, AI Assist, or Confirmed by multiple sources
+* **Decision-grade finding details**: Each finding explains why it was prioritized, what evidence Skylos has, likely CI impact, and the safest fix path
+* **Optional Automation Activity**: Repo-level background triage fed by Skylos automation state when you explicitly use it
 * **AI Security Copilot Chat**: Sidebar chat panel to ask questions about findings, get explanations, and apply fixes from code blocks
 * **Auto-Remediation**: One-click "Fix All" with severity picker, progress tracking, and dry-run preview mode
-* **AI-Powered Analysis**: Real-time bug detection as you type using GPT-4, Claude, or any local model — no save required
+* **Optional Real-Time AI Assist**: Opt-in bug detection as you type using GPT, Claude, or a local model
 * **Multi-Provider Support**: OpenAI, Anthropic, or any OpenAI-compatible local server (Ollama, LM Studio, LocalAI, vLLM)
-* **CodeLens Buttons**: "Fix with AI" and "Dismiss" buttons appear inline on error lines
+* **CodeLens Buttons**: Contextual "Fix with AI Assist", "Preview Engine Fix", "Ignore", and "Dismiss" actions appear on relevant lines
 * **Smart Caching**: Only re-analyzes functions that actually changed
 * **Multi-Language**: Python, TypeScript, JavaScript, TSX, JSX, Go
-* **CST-safe removals**: Uses LibCST to remove selected imports or functions (handles multiline imports, aliases, decorators, async etc..)
+* **Engine-backed cleanup previews**: Safe cleanup actions are previewed from Skylos engine output when an engine patch is available
 * **Framework-Aware Detection**: Handles Flask, Django, FastAPI routes and decorators
 * **Secrets Scanning**: Detects API keys & secrets (GitHub, GitLab, Slack, Stripe, AWS, Google, SendGrid, Twilio, private key blocks)
 * **Dangerous Patterns**: Flags risky code such as `eval/exec`, `os.system`, `subprocess(shell=True)`, `pickle.load/loads`, `yaml.load` without SafeLoader, hashlib.md5/sha1. Refer to `DANGEROUS_CODE.md` for the whole list.
 
-All analysis runs locally on your machine. AI features require an API key.
+Static analysis runs locally on your machine. AI Assist features are optional; they only send code to a configured provider when you explicitly use AI Assist commands or enable real-time AI Assist.
 
 ## How it works
 
@@ -30,8 +32,8 @@ On save, the extension scans the current file by default. Full workspace scans a
 skylos <workspace-folder> --json -c <confidence> [--secrets] [--danger] [--quality]
 ```
 
-**AI Analysis**
-As you type, the extension waits for idle (default 1s), extracts changed functions, and sends them to the configured AI provider for bug detection.
+**Optional AI Assist**
+Manual AI Assist commands and chat use your configured provider. Real-time AI Assist is off by default; when enabled, the extension waits for idle, extracts changed functions, and sends them to the configured AI provider.
 
 ## Requirements
 
@@ -57,36 +59,45 @@ Open your project in VS Code and save a file — diagnostics appear.
 
 ## Usage
 
+### First Run
+
+Open the VS Code walkthrough **Get Started with Skylos** or run:
+
+1. `Skylos: Doctor` to verify the CLI path and version
+2. `Skylos: Scan Workspace` to populate the Review Queue
+3. `Skylos: Toggle New Issues Only` on legacy repos or PR branches
+
 ### Basic
 
 - **Save any file** → Skylos CLI refreshes findings for that file
-- **Type and pause** → AI analyzes changed functions
-- **Click "Fix with AI"** on any error line to auto-fix
+- **Type and pause** → nothing leaves your machine unless `skylos.enableRealtimeAI` is enabled
+- **Click "Fix with AI Assist"** on any error line to auto-fix
 - **Command Palette** → `Skylos: Scan Workspace` for a full project scan
 
-### Streaming Inline Analysis
+### Optional Real-Time AI Assist
 
-When you have an API key set, streaming analysis activates automatically:
+Real-time AI is off by default so normal static scans do not make network calls. To enable it:
 
-1. Type in any supported file (Python, TS, JS, Go)
-2. After the idle delay (default 1s), `analyzing...` ghost text appears on function lines
-3. As the AI streams its response, issues appear character-by-character as blue italic text
-4. When the stream completes, normal decorations and diagnostics take over
+1. Set `skylos.enableRealtimeAI` to `true`
+2. Configure an AI Assist provider or local OpenAI-compatible server
+3. Optionally set `skylos.streamingInline` to `true` for ghost-text streaming
+
+When enabled, typing in a supported file starts analysis after the idle delay. If streaming inline is also enabled, `analyzing...` ghost text appears on function lines and streamed findings are rendered inline until normal diagnostics take over.
 
 If you start typing again during analysis, the previous stream is cancelled and a new one starts.
 
-To disable: set `skylos.streamingInline` to `false` in settings.
+To disable all automatic AI Assist, keep `skylos.enableRealtimeAI` set to `false`.
 
 ### AI Security Copilot Chat
 
 The chat panel lives in the Skylos sidebar:
 
 1. Open the **Skylos** sidebar (shield icon in the activity bar)
-2. The **Security Copilot** panel is below Findings
+2. The **Security Copilot** panel is below the Review Queue
 3. Type a question about any security topic and get a streamed response
 
 **Ask about a specific finding:**
-- In the Findings tree, **right-click any finding** → **"Ask AI About Finding"**
+- In the Review Queue, **right-click any finding** → **"Ask AI About Finding"**
 - The chat panel opens with that finding's context (file, severity, surrounding code)
 - Ask follow-up questions — the AI knows which finding you're looking at
 
@@ -100,7 +111,7 @@ The chat panel lives in the Skylos sidebar:
 
 Fix multiple findings at once:
 
-1. **`Cmd+Alt+F`** (Mac) / **`Ctrl+Alt+F`** (Windows/Linux), or Command Palette → `Skylos: Auto-Fix All`
+1. **`Cmd+Alt+F`** (Mac) / **`Ctrl+Alt+F`** (Windows/Linux), or Command Palette → `Skylos: Auto-Fix All with AI Assist`
 2. Pick a severity level:
    - **Fix Errors Only** — CRITICAL + HIGH
    - **Fix Errors + Warnings** — + MEDIUM
@@ -111,13 +122,13 @@ Fix multiple findings at once:
 6. After completion, Skylos re-scans to verify
 
 **Dry Run** — preview fixes without editing:
-1. Command Palette → `Skylos: Auto-Fix Dry Run`
+1. Command Palette → `Skylos: Auto-Fix AI Assist Dry Run`
 2. Pick severity level
 3. A markdown report opens with before/after code for each finding
 4. No files are modified
 
 **Safety:**
-- Dead code findings are skipped (use Remove Import/Function instead)
+- Dead code findings are skipped unless Skylos provides an engine-backed cleanup patch
 - Capped at 50 findings per run (change with `skylos.autoFixMaxFindings`)
 - 200ms delay between API calls to avoid rate limits
 - Cancellable via the progress notification
@@ -156,31 +167,35 @@ You can use any OpenAI-compatible local server instead of a cloud API. No API ke
 
 That's it — 3 lines. All AI features (inline analysis, chat, auto-fix) work with local models. No API key, no cloud, everything stays on your machine.
 
-### Sidebar Filters
+### Review Queue Filters
 
-The Findings sidebar has a filter button (funnel icon) in the title bar:
+The Review Queue has a filter button (funnel icon) in the title bar:
 
 1. Click the **filter icon** or Command Palette → `Skylos: Filter Findings`
 2. Choose a filter dimension:
    - **By Severity** — show only CRITICAL, HIGH, MEDIUM, etc.
-   - **By Category** — security, secrets, dead code, quality, or AI
-   - **By Source** — CLI (static analysis) vs AI (real-time)
+   - **By Category** — security, secrets, dead code, quality, or AI Assist
+   - **By Source** — Static scan, Automation, AI Assist, or Confirmed findings
    - **By File Name** — substring match (e.g. `auth.py`, `src/utils`)
 3. Filters stack — filter by severity, then by category to narrow further
 4. An **X** button appears in the title bar when a filter is active — click to clear
 
-### Command Center
+Click any Review Queue item to jump to the code, or open **Show Finding Detail** for the decision view. The detail panel keeps the editor quiet while still showing why a finding matters: priority reasons, evidence or trace metadata when the CLI emits it, CI-blocking risk, and whether the safest next step is an engine patch, safe-fix guidance, AI assistance, or manual review.
 
-The **Command Center** view in the Skylos sidebar shows a ranked repo-level action queue:
+If static analysis and Automation report the same rule at the same location, Skylos merges them into one confirmed finding labeled **Confirmed by Static + Automation**. Confirmed findings keep their severity color and rank higher because two analysis paths agree. Static-only findings remain first-class results; missing Automation or AI Assist state is not an error unless you explicitly invoke those optional modes.
 
-1. Click **Refresh Command Center** in the Command Center title bar, or run `Skylos: Refresh Command Center`
+### Automation Activity
+
+The **Automation Activity** view is optional. It is separate from the primary Review Queue and uses Skylos automation state for repo-level background triage:
+
+1. Click **Refresh Automation** in the Automation Activity title bar, or run `Skylos: Refresh Automation`
 2. Skylos reads `.skylos/agent_state.json` and shows the top ranked actions first
 3. Click an action to open the file at the flagged line
 4. Right-click an action to:
    - open a richer detail panel
-   - apply a safe cleanup fix when available
+   - preview an engine-backed cleanup patch when available
    - snooze or dismiss the action
-5. Use **Restore Triaged Actions** from the Command Center title bar to bring snoozed or dismissed items back
+5. Use **Restore Triaged Actions** from the Automation Activity title bar to bring snoozed or dismissed items back
 
 For continuous repo-level updates, run this in a terminal from your project root:
 
@@ -188,18 +203,18 @@ For continuous repo-level updates, run this in a terminal from your project root
 skylos agent watch .
 ```
 
-When the agent state file changes, the Command Center view refreshes automatically. You can also enable:
+When the automation state file changes, the Automation Activity view refreshes automatically. You can also enable:
 
 - `skylos.commandCenterRefreshOnOpen`
 - `skylos.commandCenterRefreshOnSave`
 - `skylos.commandCenterLimit`
 - `skylos.commandCenterStateFile`
 
-### Delta Mode
+### New Issues Mode
 
-Delta mode shows only **new issues since a base branch**, useful for PRs and legacy repos:
+New Issues mode shows only **new issues since a base branch**, useful for PRs and legacy repos:
 
-1. Click the **git-compare icon** in the sidebar title bar, or Command Palette → `Skylos: Toggle Delta Mode`
+1. Click the **git-compare icon** in the sidebar title bar, or Command Palette → `Skylos: Toggle New Issues Only`
 2. Configure the base branch via `skylos.diffBase` (default: `origin/main`)
 3. Supports any git ref: `origin/develop`, `HEAD~5`, a commit SHA, etc.
 
@@ -221,14 +236,17 @@ Open Settings → Extensions → Skylos (or settings.json):
 | `skylos.confidence` | number | `80` | Confidence threshold (0-100) |
 | `skylos.excludeFolders` | string[] | `["venv",".venv","build","dist",".git","__pycache__"]` | Exclude these folders |
 | `skylos.runOnSave` | boolean | `true` | Run Skylos on save |
-| `skylos.scanOnOpen` | boolean | `true` | Auto scan workspace on open |
+| `skylos.scanOnOpen` | boolean | `true` | Auto scan the first supported file opened in the session |
 | `skylos.enableSecrets` | boolean | `true` | Include secrets scanning |
 | `skylos.enableDanger` | boolean | `true` | Include dangerous-pattern checks |
 | `skylos.enableDeadCode` | boolean | `true` | Show dead code findings (functions, imports, classes, variables) |
 | `skylos.showDeadParams` | boolean | `false` | Show unused parameter findings (noisy with callbacks/interfaces) |
 | `skylos.enableQuality` | boolean | `true` | Include code quality checks |
 | `skylos.showPopup` | boolean | `true` | Show toast notification after scans |
-| `skylos.aiProvider` | string | `"openai"` | AI provider: `"openai"`, `"anthropic"`, or `"local"` |
+| `skylos.editorSignalLevel` | string | `"quiet"` | Editor visual noise: `quiet`, `balanced`, or `verbose` |
+| `skylos.codeLensMode` | string | `"highValue"` | CodeLens frequency: `off`, `activeLine`, `highValue`, or `all` |
+| `skylos.enableRealtimeAI` | boolean | `false` | Automatically run AI Assist as you edit |
+| `skylos.aiProvider` | string | `"openai"` | AI Assist provider: `"openai"`, `"anthropic"`, or `"local"` |
 | `skylos.openaiBaseUrl` | string | `"https://api.openai.com"` | Base URL for OpenAI API |
 | `skylos.openaiApiKey` | string | `""` | OpenAI API key |
 | `skylos.openaiModel` | string | `"gpt-4o"` | OpenAI model |
@@ -236,29 +254,31 @@ Open Settings → Extensions → Skylos (or settings.json):
 | `skylos.localModel` | string | `""` | Model name on your local server (e.g. `llama3.1`) |
 | `skylos.anthropicApiKey` | string | `""` | Anthropic API key |
 | `skylos.anthropicModel` | string | `"claude-sonnet-4-20250514"` | Anthropic model for analysis |
-| `skylos.idleMs` | number | `1000` | Milliseconds to wait before AI analysis |
+| `skylos.idleMs` | number | `1000` | Milliseconds to wait before optional real-time AI Assist |
 | `skylos.popupCooldownMs` | number | `8000` | Cooldown between AI popups (ms) |
-| `skylos.streamingInline` | boolean | `true` | Show streaming ghost text during AI analysis |
+| `skylos.streamingInline` | boolean | `false` | Show streaming ghost text when real-time AI Assist is enabled |
 | `skylos.autoFixMaxFindings` | number | `50` | Max findings to auto-fix per run (1-200) |
 | `skylos.diffBase` | string | `"origin/main"` | Git ref for delta mode base |
-| `skylos.fixPreviewFirst` | boolean | `true` | Always show diff preview before applying AI fixes |
-| `skylos.postFixCommand` | string | `""` | Shell command to run after AI fix (e.g. `npm test`, `pytest -x`) |
+| `skylos.fixPreviewFirst` | boolean | `true` | Always show diff preview before applying AI Assist fixes |
+| `skylos.postFixCommand` | string | `""` | Shell command to run after AI Assist fix (e.g. `npm test`, `pytest -x`) |
 
 ## Keyboard Shortcuts
 
 | Shortcut | Command |
 |----------|---------|
 | `Cmd+Alt+S` / `Ctrl+Alt+S` | Scan Workspace |
-| `Cmd+Alt+F` / `Ctrl+Alt+F` | Auto-Fix All |
+| `Cmd+Alt+F` / `Ctrl+Alt+F` | Auto-Fix All with AI Assist |
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | `Skylos: Scan Workspace` | Run skylos over the entire workspace |
-| `Skylos: Fix Issue with AI` | Fix the issue at cursor with AI |
-| `Skylos: Auto-Fix All` | Fix all findings with severity picker |
-| `Skylos: Auto-Fix Dry Run` | Preview fixes without editing files |
+| `Skylos: Doctor` | Check the configured Skylos CLI path and print setup details |
+| `Skylos: Fix Issue with AI Assist` | Fix the issue at cursor with AI Assist |
+| `Skylos: Preview Engine Fix` | Preview an engine-backed patch when one is available |
+| `Skylos: Auto-Fix All with AI Assist` | Fix all findings with severity picker |
+| `Skylos: Auto-Fix AI Assist Dry Run` | Preview fixes without editing files |
 | `Skylos: Ask AI About Finding` | Open chat with finding context (right-click in sidebar) |
 | `Skylos: Clear Chat` | Clear chat history and context |
 | `Skylos: Refresh` | Re-run scan |
@@ -266,14 +286,14 @@ Open Settings → Extensions → Skylos (or settings.json):
 | `Skylos: Filter Findings` | Filter sidebar by severity, category, source, or file |
 | `Skylos: Clear Filter` | Remove active sidebar filter |
 | `Skylos: Export Report` | Export findings as Markdown, JSON, or SARIF |
-| `Skylos: Toggle Delta Mode` | Toggle delta mode (new issues only vs all) |
+| `Skylos: Toggle New Issues Only` | Toggle new issues only vs all findings |
 
 ## Privacy
 
 - Static analysis runs entirely on your machine
 - AI features send only changed function code to your configured provider (OpenAI/Anthropic/local server)
 - Chat messages are sent to your configured provider — no third parties
-- With a local AI server, all AI analysis stays entirely on your machine
+- With a local AI server, all AI Assist analysis stays entirely on your machine
 - No telemetry, no data collection
 
 ## Contributing

--- a/editors/vscode/out/ai.js
+++ b/editors/vscode/out/ai.js
@@ -26,6 +26,8 @@ class AIAnalyzer {
         this.statusBar = sb;
     }
     async maybeAnalyze(document) {
+        if (!(0, config_1.isRealtimeAIEnabled)())
+            return;
         const apiKey = (0, config_1.getAIApiKey)();
         if (!apiKey)
             return;
@@ -125,7 +127,7 @@ class AIAnalyzer {
                 this.streamingManager?.clearAll();
                 return;
             }
-            scanner_1.out.appendLine(`AI Error: ${err}`);
+            scanner_1.out.appendLine(`AI Assist failed. Static scan results are unaffected: ${formatAIError(err)}`);
             if (this.statusBar)
                 this.statusBar.text = prevText;
         }
@@ -166,6 +168,11 @@ class AIAnalyzer {
     }
 }
 exports.AIAnalyzer = AIAnalyzer;
+function formatAIError(err) {
+    if (err instanceof Error)
+        return `${err.name}: ${err.message}`;
+    return String(err);
+}
 function extractFunctions(code, langId) {
     if (langId === "python")
         return extractPythonFunctions(code);
@@ -472,13 +479,13 @@ async function fixWithAI(filePath, range, errorMsg, previewOnly) {
     if (!apiKey) {
         let msg;
         if (provider === "anthropic") {
-            msg = "Set skylos.anthropicApiKey first.";
+            msg = "AI Fix needs a provider. Set skylos.anthropicApiKey or use engine fixes when available.";
         }
         else if (provider === "local") {
-            msg = "Set skylos.localBaseUrl to your local AI server (e.g. http://localhost:11434 for Ollama) and skylos.localModel to the model name.";
+            msg = "AI Fix needs a provider. Set skylos.localBaseUrl and skylos.localModel, or use engine fixes when available.";
         }
         else {
-            msg = 'Set skylos.openaiApiKey, or switch aiProvider to "local" and configure skylos.localBaseUrl.';
+            msg = 'AI Fix needs a provider. Set skylos.openaiApiKey, configure local AI Assist, or use engine fixes when available.';
         }
         vscode.window.showErrorMessage(msg);
         return;

--- a/editors/vscode/out/automationCore.js
+++ b/editors/vscode/out/automationCore.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.normalizeAutomationLine = normalizeAutomationLine;
+function normalizeAutomationLine(value) {
+    const line = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(line) || line < 1)
+        return 1;
+    return Math.floor(line);
+}

--- a/editors/vscode/out/codelens.js
+++ b/editors/vscode/out/codelens.js
@@ -4,54 +4,65 @@ exports.SkylosCodeLensProvider = void 0;
 const vscode = require("vscode");
 const types_1 = require("./types");
 const config_1 = require("./config");
+const findingCore_1 = require("./findingCore");
 class SkylosCodeLensProvider {
     constructor(store) {
         this.store = store;
         this._onDidChangeCodeLenses = new vscode.EventEmitter();
         this.onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
         this.disposables = [];
-        this.disposables.push(store.onDidChange(() => this._onDidChangeCodeLenses.fire()), store.onDidChangeAI(() => this._onDidChangeCodeLenses.fire()));
+        this.disposables.push(store.onDidChange(() => this._onDidChangeCodeLenses.fire()), store.onDidChangeAI(() => this._onDidChangeCodeLenses.fire()), vscode.window.onDidChangeTextEditorSelection(() => {
+            if ((0, config_1.getCodeLensMode)() === "activeLine") {
+                this._onDidChangeCodeLenses.fire();
+            }
+        }));
     }
     refresh() {
         this._onDidChangeCodeLenses.fire();
     }
     provideCodeLenses(document) {
         const lenses = [];
+        const mode = (0, config_1.getCodeLensMode)();
+        if (mode === "off")
+            return lenses;
         const findings = this.store.getFindingsForFile(document.uri.fsPath, { max: (0, config_1.getMaxDecorationsPerFile)() });
+        const activeEditor = vscode.window.activeTextEditor;
+        const activeLine = activeEditor?.document.uri.fsPath === document.uri.fsPath
+            ? activeEditor.selection.active.line
+            : undefined;
         for (const f of findings) {
             const line = Math.max(0, f.line - 1);
             if (line >= document.lineCount)
                 continue;
+            const isActiveLine = activeLine === line;
+            if (mode === "activeLine" && !isActiveLine) {
+                continue;
+            }
             const range = new vscode.Range(line, 0, line, 0);
-            if (f.category === "security" || f.category === "ai") {
+            const showAllActions = mode === "all" || mode === "activeLine";
+            const showHighValueActions = showAllActions || mode === "highValue";
+            if (showHighValueActions && (f.category === "security" || f.category === "ai")) {
                 lenses.push(new vscode.CodeLens(range, {
-                    title: "Fix with AI",
+                    title: "Fix with AI Assist",
                     command: "skylos.fix",
                     arguments: [document.uri.fsPath, range, f.message, false],
                 }));
             }
-            if (f.ruleId === "DEAD-IMPORT") {
+            if (showHighValueActions && f.fixPatch) {
                 lenses.push(new vscode.CodeLens(range, {
-                    title: "Remove Import",
-                    command: "skylos.removeImport",
-                    arguments: [document.uri, line],
+                    title: "Preview Engine Fix",
+                    command: "skylos.previewSafeFix",
+                    arguments: [f],
                 }));
             }
-            if (f.ruleId === "DEAD-FUNC") {
-                lenses.push(new vscode.CodeLens(range, {
-                    title: "Remove Function",
-                    command: "skylos.removeFunction",
-                    arguments: [document.uri, line],
-                }));
-            }
-            if (f.ruleId.startsWith("DEAD-")) {
+            if (showAllActions && (0, findingCore_1.isDeadCodeRule)(f.ruleId)) {
                 lenses.push(new vscode.CodeLens(range, {
                     title: "Ignore",
                     command: "skylos.addToWhitelist",
                     arguments: [f.message],
                 }));
             }
-            if (f.source === "ai") {
+            if (showHighValueActions && f.source === "ai") {
                 lenses.push(new vscode.CodeLens(range, {
                     title: "\u2715 Dismiss",
                     command: "skylos.dismissIssue",

--- a/editors/vscode/out/commandcenter.js
+++ b/editors/vscode/out/commandcenter.js
@@ -7,6 +7,7 @@ const child_process_1 = require("child_process");
 const vscode = require("vscode");
 const config_1 = require("./config");
 const scanner_1 = require("./scanner");
+const automationCore_1 = require("./automationCore");
 class SummaryNode {
     constructor(state) {
         this.state = state;
@@ -76,7 +77,7 @@ class SkylosCommandCenterProvider {
     async refresh() {
         const root = this.getWorkspaceRoot();
         if (!root) {
-            vscode.window.showWarningMessage("Skylos: open a folder to use Command Center.");
+            vscode.window.showWarningMessage("Skylos: open a folder to use Automation Activity.");
             return;
         }
         if (this.refreshing) {
@@ -85,14 +86,14 @@ class SkylosCommandCenterProvider {
         }
         this.refreshing = true;
         this._onDidChangeTreeData.fire();
-        vscode.window.setStatusBarMessage("Skylos: refreshing Command Center...", 3000);
+        vscode.window.setStatusBarMessage("Skylos: refreshing Automation Activity...", 3000);
         try {
             await this.runCommandCenterRefresh(root);
             await this.loadState();
         }
         catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            vscode.window.showErrorMessage(`Skylos Command Center refresh failed: ${msg}`);
+            vscode.window.showErrorMessage(`Automation refresh failed. Static scan results are unaffected. ${msg}`);
         }
         finally {
             this.refreshing = false;
@@ -113,6 +114,11 @@ class SkylosCommandCenterProvider {
     getFindingById(actionId) {
         return (this.state?.findings ?? []).find((finding) => finding.fingerprint === actionId);
     }
+    getQueueFindings() {
+        return this.getActions()
+            .map((action) => this.toSkylosFinding(action))
+            .filter((finding) => Boolean(finding));
+    }
     toSkylosFinding(action) {
         const finding = this.getFindingForAction(action);
         const absoluteFile = action.absolute_file || finding?.absolute_file || resolveActionPath(action.file);
@@ -125,25 +131,30 @@ class SkylosCommandCenterProvider {
             severity: normalizeSeverity(action.severity || finding?.severity),
             message: action.message || finding?.message || action.title,
             file: absoluteFile,
-            line: Number(action.line || finding?.line || 1),
+            line: (0, automationCore_1.normalizeAutomationLine)(action.line || finding?.line),
             col: 1,
+            fingerprint: finding?.fingerprint || action.id,
             confidence: finding?.confidence,
-            source: "cli",
+            source: "agent",
+            safeFix: action.safe_fix,
+            fixPatch: action.fix_patch || action.fixPatch || action.patch,
+            baselineStatus: action.baseline_status || finding?.baseline_status,
+            reviewReason: action.reason,
         };
     }
     async dismissAction(action) {
-        await this.runTriagingCommand(["dismiss", this.requireWorkspaceRoot(), action.id]);
+        await this.runTriagingCommand(["triage", "dismiss", this.requireWorkspaceRoot(), action.id]);
     }
     async snoozeAction(action, hours) {
-        await this.runTriagingCommand(["snooze", this.requireWorkspaceRoot(), action.id, "--hours", String(hours)]);
+        await this.runTriagingCommand(["triage", "snooze", this.requireWorkspaceRoot(), action.id, "--hours", String(hours)]);
     }
     async restoreAction(actionId) {
-        await this.runTriagingCommand(["restore", this.requireWorkspaceRoot(), actionId]);
+        await this.runTriagingCommand(["triage", "restore", this.requireWorkspaceRoot(), actionId]);
     }
     getTreeItem(element) {
         if (element instanceof SummaryNode) {
             const summary = element.state.summary;
-            const item = new vscode.TreeItem(summary?.headline ?? "Command Center", vscode.TreeItemCollapsibleState.None);
+            const item = new vscode.TreeItem(summary?.headline ?? "Automation Activity", vscode.TreeItemCollapsibleState.None);
             item.iconPath = new vscode.ThemeIcon("pulse");
             item.description = summary?.subtitle ?? describeState(element.state);
             item.tooltip = buildSummaryTooltip(element.state);
@@ -163,7 +174,7 @@ class SkylosCommandCenterProvider {
             item.iconPath = new vscode.ThemeIcon(this.refreshing ? "sync~spin" : "circle-slash");
             item.description = element.description;
             if (!this.refreshing) {
-                item.command = { title: "Refresh Command Center", command: "skylos.refreshCommandCenter" };
+                item.command = { title: "Refresh Automation", command: "skylos.refreshCommandCenter" };
             }
             return item;
         }
@@ -174,7 +185,8 @@ class SkylosCommandCenterProvider {
         item.description = `${action.file}:${action.line}`;
         item.tooltip = buildActionTooltip(action);
         item.iconPath = getActionIcon(action.severity);
-        item.contextValue = action.safe_fix ? "skylosCommandCenterActionSafeFix" : "skylosCommandCenterAction";
+        const hasEnginePatch = Boolean(action.fix_patch || action.fixPatch || action.patch);
+        item.contextValue = hasEnginePatch ? "skylosCommandCenterActionSafeFix" : "skylosCommandCenterAction";
         if (absoluteFile) {
             item.command = {
                 title: "Open action target",
@@ -192,14 +204,14 @@ class SkylosCommandCenterProvider {
             return [];
         }
         if (this.refreshing && !this.state) {
-            return [new EmptyNode("Refreshing Command Center...", "Running repo-level agent analysis")];
+            return [new EmptyNode("Refreshing Automation Activity...", "Running optional repo-level automation")];
         }
         if (!this.getWorkspaceRoot()) {
-            return [new EmptyNode("Open a workspace folder to use Command Center")];
+            return [new EmptyNode("Open a workspace folder to use Automation Activity")];
         }
         if (!this.state) {
             return [
-                new EmptyNode("No Command Center state yet", "Run Refresh Command Center or `skylos agent watch .`"),
+                new EmptyNode("No Automation Activity yet", "Optional: refresh once or run `skylos agent watch .`"),
             ];
         }
         const nodes = [new SummaryNode(this.state)];
@@ -270,7 +282,7 @@ class SkylosCommandCenterProvider {
     requireWorkspaceRoot() {
         const root = this.getWorkspaceRoot();
         if (!root) {
-            throw new Error("Open a workspace folder to use Command Center.");
+            throw new Error("Open a workspace folder to use Automation Activity.");
         }
         return root;
     }
@@ -308,7 +320,15 @@ class SkylosCommandCenterProvider {
         }));
     }
     runCommandCenterRefresh(root) {
-        const args = ["command-center", root, "--refresh", "--limit", String((0, config_1.getCommandCenterLimit)())];
+        const args = [
+            "status",
+            root,
+            "--refresh",
+            "--format",
+            "json",
+            "--limit",
+            String((0, config_1.getCommandCenterLimit)()),
+        ];
         const stateFile = (0, config_1.getCommandCenterStateFile)();
         if (stateFile) {
             args.push("--state-file", stateFile);
@@ -332,7 +352,7 @@ class SkylosCommandCenterProvider {
         if (stateFile && !fullArgs.includes("--state-file")) {
             fullArgs.push("--state-file", stateFile);
         }
-        scanner_1.out.appendLine(`Running Command Center command: ${bin} ${fullArgs.join(" ")}`);
+        scanner_1.out.appendLine(`Running Automation command: ${bin} ${fullArgs.join(" ")}`);
         return new Promise((resolve, reject) => {
             const proc = (0, child_process_1.spawn)(bin, fullArgs, { cwd: root });
             let stderr = "";
@@ -344,13 +364,13 @@ class SkylosCommandCenterProvider {
             });
             proc.on("close", (code) => {
                 if (stderr.trim()) {
-                    scanner_1.out.appendLine(`Command Center stderr: ${stderr.trim()}`);
+                    scanner_1.out.appendLine(`Automation stderr: ${stderr.trim()}`);
                 }
                 if (code === 0) {
                     resolve();
                     return;
                 }
-                reject(new Error(stderr.trim() || `Command Center exited with code ${code}`));
+                reject(new Error(stderr.trim() || `Automation exited with code ${code}`));
             });
             proc.on("error", (err) => reject(err));
         });

--- a/editors/vscode/out/config.js
+++ b/editors/vscode/out/config.js
@@ -6,6 +6,7 @@ exports.getExcludeFolders = getExcludeFolders;
 exports.isFeatureEnabled = isFeatureEnabled;
 exports.isRunOnSave = isRunOnSave;
 exports.isScanOnOpen = isScanOnOpen;
+exports.isRealtimeAIEnabled = isRealtimeAIEnabled;
 exports.getIdleMs = getIdleMs;
 exports.getPopupCooldownMs = getPopupCooldownMs;
 exports.isShowPopup = isShowPopup;
@@ -14,6 +15,8 @@ exports.getMaxProblemsPerFile = getMaxProblemsPerFile;
 exports.getMaxTreeFindings = getMaxTreeFindings;
 exports.getMaxTreeFindingsPerFile = getMaxTreeFindingsPerFile;
 exports.getMaxDecorationsPerFile = getMaxDecorationsPerFile;
+exports.getEditorSignalLevel = getEditorSignalLevel;
+exports.getCodeLensMode = getCodeLensMode;
 exports.isShowDeadCodeInProblems = isShowDeadCodeInProblems;
 exports.getCommandCenterLimit = getCommandCenterLimit;
 exports.isCommandCenterRefreshOnOpen = isCommandCenterRefreshOnOpen;
@@ -21,6 +24,7 @@ exports.isCommandCenterRefreshOnSave = isCommandCenterRefreshOnSave;
 exports.getCommandCenterStateFile = getCommandCenterStateFile;
 exports.getAIProvider = getAIProvider;
 exports.getOpenAIBaseUrl = getOpenAIBaseUrl;
+exports.getLocalBaseUrl = getLocalBaseUrl;
 exports.isLocalProvider = isLocalProvider;
 exports.getAIApiKey = getAIApiKey;
 exports.getAIModel = getAIModel;
@@ -58,6 +62,9 @@ function isRunOnSave() {
 function isScanOnOpen() {
     return cfg().get("scanOnOpen", true);
 }
+function isRealtimeAIEnabled() {
+    return cfg().get("enableRealtimeAI", false);
+}
 function getIdleMs() {
     return cfg().get("idleMs", 1000);
 }
@@ -82,6 +89,12 @@ function getMaxTreeFindingsPerFile() {
 function getMaxDecorationsPerFile() {
     return cfg().get("maxDecorationsPerFile", 25);
 }
+function getEditorSignalLevel() {
+    return cfg().get("editorSignalLevel", "quiet");
+}
+function getCodeLensMode() {
+    return cfg().get("codeLensMode", "highValue");
+}
 function isShowDeadCodeInProblems() {
     return cfg().get("showDeadCodeInProblems", false);
 }
@@ -103,9 +116,12 @@ function getAIProvider() {
 function getOpenAIBaseUrl() {
     const provider = getAIProvider();
     if (provider === "local") {
-        return (cfg().get("localBaseUrl", "") || "").replace(/\/+$/, "");
+        return getLocalBaseUrl();
     }
     return cfg().get("openaiBaseUrl", "https://api.openai.com").replace(/\/+$/, "");
+}
+function getLocalBaseUrl() {
+    return (cfg().get("localBaseUrl", "") || "").replace(/\/+$/, "");
 }
 function isLocalProvider() {
     return getAIProvider() === "local";
@@ -134,7 +150,7 @@ function isLanguageSupported(langId) {
     return types_1.SUPPORTED_LANGUAGES.includes(langId);
 }
 function isStreamingEnabled() {
-    return cfg().get("streamingInline", true);
+    return isRealtimeAIEnabled() && cfg().get("streamingInline", false);
 }
 function getAutoFixMaxFindings() {
     return cfg().get("autoFixMaxFindings", 50);

--- a/editors/vscode/out/configCore.js
+++ b/editors/vscode/out/configCore.js
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.shouldWarnMissingLocalAI = shouldWarnMissingLocalAI;
+function shouldWarnMissingLocalAI(options) {
+    return options.realtimeAIEnabled
+        && options.provider === "local"
+        && !String(options.localBaseUrl ?? "").trim();
+}

--- a/editors/vscode/out/decorations.js
+++ b/editors/vscode/out/decorations.js
@@ -3,11 +3,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.DecorationsManager = void 0;
 const vscode = require("vscode");
 const config_1 = require("./config");
+const provenanceCore_1 = require("./provenanceCore");
 const deadCodeType = () => ({
-    isWholeLine: true,
-    opacity: "0.45",
-    textDecoration: "line-through rgba(120, 160, 220, 0.5)",
-    overviewRulerColor: "rgba(80, 160, 255, 0.4)",
+    isWholeLine: false,
+    opacity: "0.72",
+    textDecoration: "underline dotted rgba(120, 160, 220, 0.35)",
+    overviewRulerColor: "rgba(80, 160, 255, 0.25)",
     overviewRulerLane: vscode.OverviewRulerLane.Right,
     after: {
         margin: "0 0 0 4ch",
@@ -44,7 +45,7 @@ const highType = () => ({
     },
 });
 const mediumType = () => ({
-    isWholeLine: true,
+    isWholeLine: false,
     borderWidth: "0 0 1px 0",
     borderStyle: "dotted",
     borderColor: "rgba(250, 204, 21, 0.4)",
@@ -57,8 +58,8 @@ const mediumType = () => ({
     },
 });
 const lowType = () => ({
-    isWholeLine: true,
-    overviewRulerColor: "rgba(80, 160, 255, 0.4)",
+    isWholeLine: false,
+    overviewRulerColor: "rgba(80, 160, 255, 0.25)",
     overviewRulerLane: vscode.OverviewRulerLane.Right,
     after: {
         margin: "0 0 0 4ch",
@@ -103,7 +104,7 @@ function classifyFinding(f) {
     return "low";
 }
 function formatInlineMessage(f, cat) {
-    const maxLen = 70;
+    const maxLen = 44;
     const ruleTag = f.ruleId !== "SKYLOS" ? `${f.ruleId} ` : "";
     if (cat === "dead") {
         const name = f.itemName ?? f.message.replace(/^Unused \w+:\s*/, "");
@@ -116,11 +117,14 @@ function formatInlineMessage(f, cat) {
     }
     if (cat === "critical" || cat === "high") {
         const sevLabel = f.severity.toUpperCase();
-        const msg = f.message.length > (maxLen - 15) ? f.message.slice(0, maxLen - 18) + "..." : f.message;
-        return `  ${sevLabel} ${ruleTag}— ${msg}`;
+        const shortMessage = simplifySecurityMessage(f.message);
+        const msg = shortMessage.length > (maxLen - 15) ? shortMessage.slice(0, maxLen - 18) + "..." : shortMessage;
+        const confirmed = (0, provenanceCore_1.isCorroborated)(f) ? " · Confirmed" : "";
+        return `  ${sevLabel} ${ruleTag}${msg}${confirmed}`;
     }
     const msg = f.message.length > maxLen ? f.message.slice(0, maxLen - 3) + "..." : f.message;
-    return `  ${ruleTag}${msg}`;
+    const confirmed = (0, provenanceCore_1.isCorroborated)(f) ? " · Confirmed" : "";
+    return `  ${ruleTag}${msg}${confirmed}`;
 }
 class DecorationsManager {
     constructor(store, context) {
@@ -160,6 +164,7 @@ class DecorationsManager {
     applyToEditor(editor) {
         const filePath = editor.document.uri.fsPath;
         const findings = this.store.getFindingsForFile(filePath, { max: (0, config_1.getMaxDecorationsPerFile)() });
+        const signalLevel = (0, config_1.getEditorSignalLevel)();
         const byCat = new Map();
         for (const key of this.decoTypes.keys()) {
             byCat.set(key, []);
@@ -174,17 +179,21 @@ class DecorationsManager {
                 continue;
             const range = new vscode.Range(line, 0, line, 0);
             const cat = classifyFinding(f);
-            const inlineMsg = formatInlineMessage(f, cat);
+            const showInline = shouldShowInlineMessage(f, cat, signalLevel);
+            const showLineDecoration = shouldShowLineDecoration(cat, signalLevel);
+            const inlineMsg = showInline ? formatInlineMessage(f, cat) : "";
             const sevKey = f.severity.toUpperCase();
-            const list = byCat.get(cat);
-            list.push({
-                range,
-                hoverMessage: f.message,
-                renderOptions: {
-                    after: { contentText: inlineMsg },
-                },
-            });
-            if (cat !== "dead") {
+            if (showInline || showLineDecoration) {
+                const list = byCat.get(cat);
+                list.push({
+                    range,
+                    hoverMessage: `${(0, provenanceCore_1.sourceSummary)(f)}: ${f.message}`,
+                    renderOptions: {
+                        after: { contentText: inlineMsg },
+                    },
+                });
+            }
+            if (showLineDecoration && cat !== "dead") {
                 const gutterColor = GUTTER_SEVERITY[sevKey] ?? "blue";
                 byGutter.get(gutterColor).push({ range });
             }
@@ -205,3 +214,24 @@ class DecorationsManager {
     }
 }
 exports.DecorationsManager = DecorationsManager;
+function shouldShowInlineMessage(finding, cat, signalLevel) {
+    if (signalLevel === "verbose")
+        return true;
+    if (signalLevel === "balanced") {
+        return cat === "critical" || cat === "high" || cat === "medium" || finding.source === "ai";
+    }
+    return cat === "critical" || cat === "high" || (0, provenanceCore_1.isCorroborated)(finding);
+}
+function shouldShowLineDecoration(cat, signalLevel) {
+    if (signalLevel === "verbose")
+        return true;
+    if (signalLevel === "balanced")
+        return cat !== "dead" && cat !== "low";
+    return cat === "critical" || cat === "high";
+}
+function simplifySecurityMessage(message) {
+    return message
+        .replace(/^Possible\s+/i, "")
+        .replace(/\s+vulnerability$/i, "")
+        .trim();
+}

--- a/editors/vscode/out/detail.js
+++ b/editors/vscode/out/detail.js
@@ -3,6 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.FindingDetailPanel = void 0;
 const vscode = require("vscode");
 const rules_1 = require("./rules");
+const reviewCore_1 = require("./reviewCore");
+const provenanceCore_1 = require("./provenanceCore");
 class FindingDetailPanel {
     show(finding) {
         if (this.panel) {
@@ -17,11 +19,14 @@ class FindingDetailPanel {
         this.panel.webview.onDidReceiveMessage((msg) => {
             switch (msg.command) {
                 case "fix":
-                    vscode.commands.executeCommand("skylos.fix", finding.file, finding.line, finding.message, finding.ruleId);
+                    vscode.commands.executeCommand("skylos.fix", finding.file, new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0), finding.message, false);
                     break;
                 case "dismiss":
                     vscode.commands.executeCommand("skylos.dismissIssue", finding.file, finding.line);
                     this.panel?.dispose();
+                    break;
+                case "previewFix":
+                    vscode.commands.executeCommand("skylos.previewSafeFix", finding);
                     break;
                 case "openFile":
                     vscode.commands.executeCommand("vscode.open", vscode.Uri.file(finding.file), {
@@ -35,13 +40,35 @@ class FindingDetailPanel {
         const meta = (0, rules_1.getRuleMeta)(f.ruleId);
         const shortFile = f.file.split("/").slice(-2).join("/");
         const sevColor = getSevColor(f.severity);
+        const reviewContext = {
+            currentFile: vscode.window.activeTextEditor?.document.uri.fsPath,
+        };
+        const reasons = (0, reviewCore_1.priorityReasons)(f, reviewContext);
+        const evidence = (0, reviewCore_1.evidenceLines)(f);
+        const plan = (0, reviewCore_1.fixPlan)(f);
+        const provenance = (0, provenanceCore_1.provenanceLabel)(f);
+        const summary = getFindingSummary(f, provenance);
+        const ciCopy = f.ciBlocking === true
+            ? "Skylos marked this finding as CI-blocking."
+            : (0, reviewCore_1.isLikelyCiBlocker)(f)
+                ? "This is likely to block a strict Skylos quality gate."
+                : "This is not a likely blocker by default, but it can still matter for review quality.";
+        const decisionRows = [
+            ["Rule", f.ruleId],
+            ["Category", f.category],
+            ["Source", provenance],
+            ["Location", `${f.relativePath ?? shortFile}:${f.line}`],
+            ...(f.confidence !== undefined ? [["Confidence", `${f.confidence}%`]] : []),
+            ...(f.baselineStatus || f.isNew ? [["Baseline", f.baselineStatus ?? "new"]] : []),
+            ["Engine fix", f.fixPatch ? "Preview available" : "No deterministic patch available"],
+        ];
         const tags = [];
         if (meta?.owasp)
-            tags.push(`<span class="tag owasp">OWASP ${meta.owasp}</span>`);
+            tags.push(`<span class="tag owasp">OWASP ${escapeHtml(meta.owasp)}</span>`);
         if (meta?.cwe)
-            tags.push(`<span class="tag cwe">${meta.cwe}</span>`);
+            tags.push(`<span class="tag cwe">${escapeHtml(meta.cwe)}</span>`);
         if (meta?.pciDss)
-            tags.push(`<span class="tag pci">PCI-DSS ${meta.pciDss}</span>`);
+            tags.push(`<span class="tag pci">PCI-DSS ${escapeHtml(meta.pciDss)}</span>`);
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -70,35 +97,70 @@ h2{font-size:13px;text-transform:uppercase;letter-spacing:.8px;opacity:.6;margin
 .btn-secondary{background:var(--vscode-button-secondaryBackground);color:var(--vscode-button-secondaryForeground)}
 .section{margin-top:16px;padding:14px;border-radius:8px;background:var(--vscode-input-background)}
 .section p{font-size:13px;opacity:.85}
+.list{margin:0;padding-left:18px;font-size:13px}
+.list li{margin:4px 0}
+.snippet{margin-top:10px;padding:10px;border-radius:6px;overflow:auto;background:var(--vscode-textCodeBlock-background,var(--vscode-editor-background));font-family:var(--vscode-editor-font-family);font-size:12px;line-height:1.45;white-space:pre-wrap}
+.impact{border-left:3px solid ${(0, reviewCore_1.isLikelyCiBlocker)(f) ? "#ef4444" : "#60a5fa"}}
+.decision{display:grid;grid-template-columns:max-content 1fr;gap:6px 14px;margin-top:14px;padding:12px;border:1px solid var(--vscode-widget-border,rgba(255,255,255,.12));border-radius:8px}
+.decision .k{font-size:12px;opacity:.6}
+.decision .v{font-size:12px;font-family:var(--vscode-editor-font-family)}
 hr{border:none;border-top:1px solid var(--vscode-widget-border,rgba(255,255,255,.1));margin:16px 0}
 </style>
 </head>
 <body>
 <span class="severity">${f.severity}</span>
-<h1>${meta?.name ?? f.ruleId}</h1>
-<div class="location" onclick="post('openFile')">${shortFile}:${f.line}</div>
+<h1>${escapeHtml(meta?.name ?? f.ruleId)}</h1>
+<div class="location" onclick="post('openFile')">${escapeHtml(shortFile)}:${f.line}</div>
 
-<p class="desc">${f.message}</p>
+<p class="desc"><strong>${escapeHtml(summary)}</strong></p>
+<p class="desc">${escapeHtml(f.message)}</p>
 
 ${tags.length > 0 ? `<div class="tags">${tags.join("")}</div>` : ""}
 
+<div class="decision">
+  ${decisionRows.map(([key, value]) => `<div class="k">${escapeHtml(key)}</div><div class="v">${escapeHtml(String(value))}</div>`).join("")}
+</div>
+
+<h2>Why This Is Here</h2>
+<div class="section">
+  <ul class="list">${reasons.map((reason) => `<li>${escapeHtml(reason)}</li>`).join("")}</ul>
+</div>
+
+<h2>Evidence</h2>
+<div class="section">
+  ${evidence.length > 0
+            ? `<ul class="list">${evidence.map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul>`
+            : f.snippet
+                ? `<p>Code snippet attached; no separate trace metadata was provided.</p>`
+                : `<p>No evidence trace was provided by this finding.</p>`}
+  ${f.snippet ? `<pre class="snippet">${escapeHtml(f.snippet)}</pre>` : ""}
+</div>
+
+<h2>CI Impact</h2>
+<div class="section impact"><p>${escapeHtml(ciCopy)}</p></div>
+
+<h2>Fix Plan</h2>
+<div class="fix-box">
+  <h3>${escapeHtml(plan.title)}</h3>
+  <ul class="list">${plan.steps.map((step) => `<li>${escapeHtml(step)}</li>`).join("")}</ul>
+</div>
+
 ${meta?.description ? `
 <h2>Description</h2>
-<div class="section"><p>${meta.description}</p></div>
+<div class="section"><p>${escapeHtml(meta.description)}</p></div>
 ` : ""}
 
 ${meta?.fix ? `
 <div class="fix-box">
-  <h3>Recommended Fix</h3>
-  <p>${meta.fix}</p>
+  <h3>Rule Guidance</h3>
+  <p>${escapeHtml(meta.fix)}</p>
 </div>
 ` : ""}
 
-${f.confidence !== undefined ? `<p style="font-size:12px;opacity:.5;margin-top:8px">Confidence: ${f.confidence}%</p>` : ""}
-
 <hr/>
 <div class="actions">
-  <button class="btn btn-primary" onclick="post('fix')">&#9889; Fix with AI</button>
+  ${f.fixPatch ? `<button class="btn btn-primary" onclick="post('previewFix')">Preview Engine Fix</button>` : ""}
+  <button class="btn btn-primary" onclick="post('fix')">Fix with AI Assist</button>
   <button class="btn btn-secondary" onclick="post('dismiss')">Dismiss</button>
   <button class="btn btn-secondary" onclick="post('openFile')">Go to File</button>
 </div>
@@ -115,6 +177,14 @@ function post(cmd){vscode.postMessage({command:cmd})}
     }
 }
 exports.FindingDetailPanel = FindingDetailPanel;
+function escapeHtml(value) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
 function getSevColor(sev) {
     switch (sev.toUpperCase()) {
         case "CRITICAL":
@@ -130,4 +200,13 @@ function getSevColor(sev) {
         default:
             return "#888";
     }
+}
+function getFindingSummary(finding, provenance) {
+    if (finding.source === "ai" && !finding.sources?.some((source) => source !== "ai")) {
+        return "AI Assist suggestion";
+    }
+    if (provenance.startsWith("Confirmed")) {
+        return `${provenance} finding`;
+    }
+    return `${provenance} finding`;
 }

--- a/editors/vscode/out/diagnosticCore.js
+++ b/editors/vscode/out/diagnosticCore.js
@@ -1,0 +1,36 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getDiagnosticRange = getDiagnosticRange;
+exports.severityRank = severityRank;
+function getDiagnosticRange(input) {
+    const startLine = Math.max(0, Math.floor((input.line || 1) - 1));
+    const startCol = Math.max(0, Math.floor(input.col ?? 0));
+    const hasExplicitEnd = input.endLine !== undefined || input.endCol !== undefined;
+    if (hasExplicitEnd) {
+        const endLine = Math.max(startLine, Math.floor((input.endLine ?? input.line ?? 1) - 1));
+        const endCol = Math.max(endLine === startLine ? startCol + 1 : 0, Math.floor(input.endCol ?? startCol + 1));
+        return { startLine, startCol, endLine, endCol };
+    }
+    return {
+        startLine,
+        startCol,
+        endLine: startLine,
+        endCol: startCol + 1,
+    };
+}
+function severityRank(severity) {
+    switch (severity) {
+        case "CRITICAL":
+            return 5;
+        case "HIGH":
+            return 4;
+        case "MEDIUM":
+        case "WARN":
+            return 3;
+        case "LOW":
+            return 2;
+        case "INFO":
+        default:
+            return 1;
+    }
+}

--- a/editors/vscode/out/diagnostics.js
+++ b/editors/vscode/out/diagnostics.js
@@ -3,30 +3,22 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.DiagnosticsManager = void 0;
 const vscode = require("vscode");
 const config_1 = require("./config");
+const diagnosticCore_1 = require("./diagnosticCore");
+const provenanceCore_1 = require("./provenanceCore");
 class DiagnosticsManager {
     constructor(store) {
         this.store = store;
         this.disposables = [];
-        this.cliCollection = vscode.languages.createDiagnosticCollection("skylos");
-        this.aiCollection = vscode.languages.createDiagnosticCollection("skylos-ai");
-        this.disposables.push(this.cliCollection, this.aiCollection, store.onDidChange(() => this.refreshCLI()), store.onDidChangeAI(() => this.refreshAI()));
+        this.collection = vscode.languages.createDiagnosticCollection("skylos");
+        this.disposables.push(this.collection, store.onDidChange(() => this.refresh()), store.onDidChangeAI(() => this.refresh()));
     }
-    refreshCLI() {
-        this.cliCollection.clear();
+    refresh() {
+        this.collection.clear();
         const findings = this.store.getVisibleFindings((0, config_1.getMaxProblems)(), {
-            source: "cli",
             includeDeadCode: (0, config_1.isShowDeadCodeInProblems)(),
             maxPerFile: (0, config_1.getMaxProblemsPerFile)(),
         });
-        this.publish(this.cliCollection, findings);
-    }
-    refreshAI() {
-        this.aiCollection.clear();
-        const findings = this.store.getVisibleFindings((0, config_1.getMaxProblems)(), {
-            source: "ai",
-            maxPerFile: (0, config_1.getMaxProblemsPerFile)(),
-        });
-        this.publish(this.aiCollection, findings);
+        this.publish(this.collection, findings);
     }
     dispose() {
         this.disposables.forEach((d) => d.dispose());
@@ -46,16 +38,28 @@ class DiagnosticsManager {
 }
 exports.DiagnosticsManager = DiagnosticsManager;
 function toDiagnostic(f) {
-    const line = Math.max(0, f.line - 1);
-    const col = Math.max(0, f.col);
-    const start = new vscode.Position(line, col);
-    const range = new vscode.Range(start, start);
+    const rangeFields = (0, diagnosticCore_1.getDiagnosticRange)(f);
+    const range = new vscode.Range(rangeFields.startLine, rangeFields.startCol, rangeFields.endLine, rangeFields.endCol);
     const severity = mapSeverity(f.severity);
-    const prefix = f.source === "ai" ? "[AI] " : f.ruleId !== "SKYLOS" ? `[${f.ruleId}] ` : "";
+    const provenance = (0, provenanceCore_1.provenanceLabel)(f);
+    const prefix = f.ruleId !== "SKYLOS" ? `[${provenance}] [${f.ruleId}] ` : `[${provenance}] `;
     const diag = new vscode.Diagnostic(range, `${prefix}${f.message}`, severity);
-    diag.source = f.source === "ai" ? "skylos-ai" : "skylos";
-    diag.code = f.ruleId;
+    diag.source = (0, provenanceCore_1.diagnosticSource)(f);
+    diag.code = f.ruleUrl
+        ? { value: f.ruleId, target: vscode.Uri.parse(f.ruleUrl) }
+        : f.ruleId;
+    diag.relatedInformation = relatedInformation(f);
     return diag;
+}
+function relatedInformation(f) {
+    const related = [];
+    for (const step of f.trace ?? []) {
+        if (!step.file)
+            continue;
+        const line = Math.max(0, (step.line ?? 1) - 1);
+        related.push(new vscode.DiagnosticRelatedInformation(new vscode.Location(vscode.Uri.file(step.file), new vscode.Position(line, 0)), step.message ?? step.label ?? step.symbol ?? "Related Skylos evidence"));
+    }
+    return related.length > 0 ? related : undefined;
 }
 function mapSeverity(s) {
     switch (s) {

--- a/editors/vscode/out/extension.js
+++ b/editors/vscode/out/extension.js
@@ -23,6 +23,7 @@ const filedecorations_1 = require("./filedecorations");
 const export_1 = require("./export");
 const commandcenter_1 = require("./commandcenter");
 const config_1 = require("./config");
+const configCore_1 = require("./configCore");
 function activate(context) {
     scanner_1.out.appendLine("Skylos extension activated");
     const store = new store_1.FindingsStore();
@@ -81,16 +82,40 @@ function activate(context) {
             }
             : undefined;
     };
-    commandCenterProvider.onDidUpdateState(updateCommandCenterBadge);
+    commandCenterProvider.onDidUpdateState(() => {
+        store.setAgentFindings(commandCenterProvider.getQueueFindings());
+        updateCommandCenterBadge();
+    });
     updateCommandCenterBadge();
     context.subscriptions.push(store, diagnostics, decorations, statusBar, treeProvider, codeLensProvider, treeView, commandCenterProvider, commandCenterView, hoverProvider.register(), codeLensProvider.register(), quickFixProvider.register(), streamingManager, dashboard, navigator, detailPanel, fileDecoProvider, fileDecoProvider.register(), scanner_1.out);
     context.subscriptions.push(vscode.window.registerWebviewViewProvider(chatview_1.SkylosChatViewProvider.viewType, chatProvider));
     void commandCenterProvider.initialize();
+    function recordScanFailure(err) {
+        const message = (0, scanner_1.buildScanErrorMessage)(err);
+        if (err instanceof scanner_1.SkylosScanError) {
+            store.setLastError({
+                kind: err.kind,
+                message,
+                command: err.details.command,
+                exitCode: err.details.exitCode,
+                stderr: err.details.stderr,
+            });
+        }
+        else {
+            store.setLastError({
+                kind: "unknown",
+                message,
+            });
+        }
+        return message;
+    }
     async function doWorkspaceScan(diffBase) {
         statusBar.setScanning(true);
         try {
             const result = await (0, scanner_1.scanWorkspace)(undefined, diffBase);
             store.setEngineMetadata(result.grade, result.summary, result.circularDeps, result.depVulns);
+            if (result.metadata)
+                store.setLastScan(result.metadata);
             store.setWorkspaceCLIFindings(result.findings);
             const total = result.findings.length;
             const criticalOrHigh = result.findings.filter((finding) => finding.severity === "CRITICAL" || finding.severity === "HIGH").length;
@@ -112,7 +137,7 @@ function activate(context) {
             }
         }
         catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
+            const msg = recordScanFailure(err);
             if (msg !== "Scan cancelled") {
                 vscode.window.showErrorMessage(`Skylos scan failed: ${msg}`);
             }
@@ -125,6 +150,8 @@ function activate(context) {
         statusBar.setScanning(true);
         try {
             const result = await (0, scanner_1.scanFile)(filePath);
+            if (result.metadata)
+                store.setLastScan(result.metadata);
             const fileFindings = result.findings.filter((finding) => finding.file === filePath);
             store.setFocusedCLIFindings(filePath, fileFindings);
             if (announce) {
@@ -134,7 +161,7 @@ function activate(context) {
             }
         }
         catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
+            const msg = recordScanFailure(err);
             if (msg !== "Scan cancelled") {
                 vscode.window.showErrorMessage(`Skylos scan failed: ${msg}`);
             }
@@ -151,32 +178,37 @@ function activate(context) {
     async function openCommandCenterDetail(node) {
         const finding = commandCenterProvider.toSkylosFinding(node.action);
         if (!finding) {
-            vscode.window.showWarningMessage("Skylos: this command-center action has no file target.");
+            vscode.window.showWarningMessage("Skylos: this Automation action has no file target.");
             return;
         }
         detailPanel.show(finding);
     }
     async function applyCommandCenterSafeFix(node) {
         const finding = commandCenterProvider.toSkylosFinding(node.action);
-        const safeFix = node.action.safe_fix;
-        if (!finding || !safeFix) {
+        if (!finding) {
             vscode.window.showInformationMessage("Skylos: no safe fix is available for this action.");
             return;
         }
-        const uri = vscode.Uri.file(finding.file);
-        const line = Math.max(0, finding.line - 1);
-        if (safeFix === "remove_import") {
-            await vscode.commands.executeCommand("skylos.removeImport", uri, line);
-        }
-        else if (safeFix === "remove_function") {
-            await vscode.commands.executeCommand("skylos.removeFunction", uri, line);
-        }
-        else {
-            vscode.window.showInformationMessage("Skylos: no safe fix is available for this action.");
+        await previewSafeFix(finding);
+    }
+    function resolveFinding(candidate) {
+        if (!candidate)
+            return undefined;
+        if (candidate instanceof sidebar_1.FindingNode)
+            return candidate.finding;
+        return candidate;
+    }
+    async function previewSafeFix(candidate) {
+        const finding = resolveFinding(candidate);
+        if (!finding?.fixPatch) {
+            vscode.window.showInformationMessage("Skylos: no engine-backed patch is available for this finding yet.");
             return;
         }
-        await scanSingleFile(finding.file, false);
-        commandCenterProvider.scheduleRefresh(250);
+        const patchDoc = await vscode.workspace.openTextDocument({
+            language: "diff",
+            content: finding.fixPatch,
+        });
+        await vscode.window.showTextDocument(patchDoc, { preview: true });
     }
     async function snoozeCommandCenterAction(node) {
         const pick = await vscode.window.showQuickPick([
@@ -193,7 +225,7 @@ function activate(context) {
     async function restoreTriagedCommandCenterAction() {
         const triaged = commandCenterProvider.getTriagedEntries();
         if (triaged.length === 0) {
-            vscode.window.showInformationMessage("Skylos: there are no snoozed or dismissed command-center actions.");
+            vscode.window.showInformationMessage("Skylos: there are no snoozed or dismissed Automation actions.");
             return;
         }
         const pick = await vscode.window.showQuickPick(triaged.map(({ id, entry }) => {
@@ -211,11 +243,20 @@ function activate(context) {
             return;
         await commandCenterProvider.restoreAction(pick.id);
         updateCommandCenterBadge();
-        vscode.window.setStatusBarMessage("Skylos: restored command-center action", 3000);
+        vscode.window.setStatusBarMessage("Skylos: restored Automation action", 3000);
     }
     context.subscriptions.push(vscode.commands.registerCommand("skylos.scan", () => {
         const diffBase = store.deltaMode ? (0, config_1.getDiffBase)() : undefined;
         doWorkspaceScan(diffBase);
+    }), vscode.commands.registerCommand("skylos.doctor", async () => {
+        const result = await (0, scanner_1.doctorSkylos)();
+        scanner_1.out.show(true);
+        if (result.ok) {
+            vscode.window.showInformationMessage("Skylos Doctor: CLI is reachable.");
+        }
+        else {
+            vscode.window.showWarningMessage(`Skylos Doctor: ${result.error ?? "CLI check failed."}`);
+        }
     }), vscode.commands.registerCommand("skylos.scanFile", async (uri) => {
         const targetUri = uri ?? vscode.window.activeTextEditor?.document.uri;
         if (!targetUri) {
@@ -228,56 +269,14 @@ function activate(context) {
         const label = store.deltaMode ? "Delta mode ON — showing new issues only" : "Delta mode OFF — showing all issues";
         vscode.window.setStatusBarMessage(`Skylos: ${label}`, 4000);
         void vscode.commands.executeCommand("skylos.scan");
-    }), vscode.commands.registerCommand("skylos.fix", ai_1.fixWithAI), vscode.commands.registerCommand("skylos.dismissIssue", (filePath, line) => {
+    }), vscode.commands.registerCommand("skylos.fix", ai_1.fixWithAI), vscode.commands.registerCommand("skylos.previewSafeFix", async (finding) => {
+        await previewSafeFix(finding);
+    }), vscode.commands.registerCommand("skylos.dismissIssue", (filePath, line) => {
         store.dismissAIFinding(filePath, line);
-    }), vscode.commands.registerCommand("skylos.removeImport", async (uri, line) => {
-        const doc = await vscode.workspace.openTextDocument(uri);
-        const editor = await vscode.window.showTextDocument(doc);
-        await editor.edit((eb) => {
-            eb.delete(new vscode.Range(line, 0, line + 1, 0));
-        });
-        store.removeFindingAtLine(uri.fsPath, line + 1);
-    }), vscode.commands.registerCommand("skylos.removeFunction", async (uri, line) => {
-        const doc = await vscode.workspace.openTextDocument(uri);
-        const editor = await vscode.window.showTextDocument(doc);
-        const langId = doc.languageId;
-        let endLine = line;
-        if (langId === "python") {
-            const startText = doc.lineAt(line).text;
-            const indent = startText.match(/^(\s*)/)?.[1].length ?? 0;
-            for (let j = line + 1; j < doc.lineCount; j++) {
-                const nextLine = doc.lineAt(j).text;
-                if (nextLine.trim() === "") {
-                    endLine = j;
-                    continue;
-                }
-                const nextIndent = nextLine.match(/^(\s*)/)?.[1].length ?? 0;
-                if (nextIndent <= indent && nextLine.trim() !== "")
-                    break;
-                endLine = j;
-            }
-        }
-        else {
-            let braceCount = 0;
-            let foundBrace = false;
-            for (let j = line; j < doc.lineCount; j++) {
-                for (const ch of doc.lineAt(j).text) {
-                    if (ch === "{") {
-                        braceCount++;
-                        foundBrace = true;
-                    }
-                    if (ch === "}")
-                        braceCount--;
-                }
-                endLine = j;
-                if (foundBrace && braceCount <= 0)
-                    break;
-            }
-        }
-        await editor.edit((eb) => {
-            eb.delete(new vscode.Range(line, 0, endLine + 1, 0));
-        });
-        store.removeFindingAtLine(uri.fsPath, line + 1);
+    }), vscode.commands.registerCommand("skylos.removeImport", async () => {
+        vscode.window.showInformationMessage("Skylos: direct line-delete cleanup is disabled. Use an engine-backed fix preview when available.");
+    }), vscode.commands.registerCommand("skylos.removeFunction", async () => {
+        vscode.window.showInformationMessage("Skylos: direct line-delete cleanup is disabled. Use an engine-backed fix preview when available.");
     }), vscode.commands.registerCommand("skylos.addToWhitelist", async (message) => {
         const match = message.match(/Unused \w+:\s*(.+)/);
         const name = match?.[1]?.trim();
@@ -330,7 +329,7 @@ function activate(context) {
     }), vscode.commands.registerCommand("skylos.commandCenterDismiss", async (node) => {
         await commandCenterProvider.dismissAction(node.action);
         updateCommandCenterBadge();
-        vscode.window.setStatusBarMessage("Skylos: dismissed command-center action", 3000);
+        vscode.window.setStatusBarMessage("Skylos: dismissed Automation action", 3000);
     }), vscode.commands.registerCommand("skylos.commandCenterSnooze", async (node) => {
         await snoozeCommandCenterAction(node);
     }), vscode.commands.registerCommand("skylos.commandCenterRestoreTriaged", async () => {
@@ -382,7 +381,7 @@ function activate(context) {
         const filterType = await vscode.window.showQuickPick([
             { label: "$(warning) By Severity", value: "severity" },
             { label: "$(symbol-class) By Category", value: "category" },
-            { label: "$(source-control) By Source (CLI vs AI)", value: "source" },
+            { label: "$(source-control) By Source", value: "source" },
             { label: "$(file) By File Name", value: "file" },
         ], { placeHolder: "Filter findings by..." });
         if (!filterType)
@@ -399,15 +398,17 @@ function activate(context) {
                 { label: "Technical Debt", value: "debt" },
                 { label: "Dead Code", value: "dead_code" },
                 { label: "Quality", value: "quality" },
-                { label: "AI Analysis", value: "ai" },
+                { label: "AI Assist", value: "ai" },
             ].map((c) => ({ ...c, description: c.value })), { placeHolder: "Show only this category" });
             if (cat)
                 store.filter = { ...store.filter, category: cat.value };
         }
         else if (filterType.value === "source") {
             const src = await vscode.window.showQuickPick([
-                { label: "CLI (static analysis)", value: "cli" },
-                { label: "AI (real-time analysis)", value: "ai" },
+                { label: "Static scan", value: "cli" },
+                { label: "Automation", value: "agent" },
+                { label: "AI Assist (optional real-time)", value: "ai" },
+                { label: "Confirmed findings", value: "confirmed" },
             ], { placeHolder: "Show only this source" });
             if (src)
                 store.filter = { ...store.filter, source: src.value };
@@ -489,12 +490,14 @@ function activate(context) {
             return;
         if (event.contentChanges.length === 0)
             return;
+        if (!(0, config_1.isRealtimeAIEnabled)())
+            return;
         if (aiDebounceTimer)
             clearTimeout(aiDebounceTimer);
         aiDebounceTimer = setTimeout(() => aiAnalyzer.maybeAnalyze(event.document), (0, config_1.getIdleMs)());
     }));
     context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((editor) => {
-        if (editor && (0, config_1.isLanguageSupported)(editor.document.languageId)) {
+        if (editor && (0, config_1.isRealtimeAIEnabled)() && (0, config_1.isLanguageSupported)(editor.document.languageId)) {
             if (aiDebounceTimer)
                 clearTimeout(aiDebounceTimer);
             aiDebounceTimer = setTimeout(() => aiAnalyzer.maybeAnalyze(editor.document), 1000);
@@ -506,8 +509,12 @@ function activate(context) {
             void commandCenterProvider.handleConfigurationChanged();
         }
     }));
-    if ((0, config_1.getAIProvider)() === "local" && !(0, config_1.getOpenAIBaseUrl)()) {
-        vscode.window.showWarningMessage('Skylos: AI provider is "local" but no server URL set. Configure skylos.localBaseUrl (e.g. http://localhost:11434 for Ollama).', "Open Settings").then((action) => {
+    if ((0, configCore_1.shouldWarnMissingLocalAI)({
+        realtimeAIEnabled: (0, config_1.isRealtimeAIEnabled)(),
+        provider: (0, config_1.getAIProvider)(),
+        localBaseUrl: (0, config_1.getLocalBaseUrl)(),
+    })) {
+        vscode.window.showWarningMessage('Skylos: AI Assist is enabled but not configured. Static scanning is still running locally. Configure skylos.localBaseUrl.', "Open Settings").then((action) => {
             if (action === "Open Settings") {
                 vscode.commands.executeCommand("workbench.action.openSettings", "skylos.localBaseUrl");
             }

--- a/editors/vscode/out/findingCore.js
+++ b/editors/vscode/out/findingCore.js
@@ -1,0 +1,264 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.normalizeReportCore = normalizeReportCore;
+exports.canonicalRuleId = canonicalRuleId;
+exports.isDeadCodeRule = isDeadCodeRule;
+exports.isUnusedImportRule = isUnusedImportRule;
+exports.isUnusedFunctionRule = isUnusedFunctionRule;
+exports.normalizeSeverity = normalizeSeverity;
+exports.makeFingerprint = makeFingerprint;
+const crypto = require("crypto");
+const path = require("path");
+const DEAD_CODE_RULES = {
+    unused_functions: { ruleId: "SKY-U001", legacyRuleId: "DEAD-FUNC", itemType: "function", label: "function" },
+    unused_imports: { ruleId: "SKY-U002", legacyRuleId: "DEAD-IMPORT", itemType: "import", label: "import" },
+    unused_variables: { ruleId: "SKY-U003", legacyRuleId: "DEAD-VAR", itemType: "variable", label: "variable" },
+    unused_classes: { ruleId: "SKY-U004", legacyRuleId: "DEAD-CLASS", itemType: "class", label: "class" },
+    unused_parameters: { ruleId: "SKY-U005", legacyRuleId: "DEAD-PARAM", itemType: "parameter", label: "parameter" },
+};
+const LEGACY_RULE_ALIASES = {
+    "DEAD-FUNC": "SKY-U001",
+    "DEAD-IMPORT": "SKY-U002",
+    "DEAD-VAR": "SKY-U003",
+    "DEAD-CLASS": "SKY-U004",
+    "DEAD-PARAM": "SKY-U005",
+    "SKY-DC001": "SKY-U001",
+    "SKY-DC002": "SKY-U002",
+};
+let findingCounter = 0;
+function normalizeReportCore(report, options) {
+    const findings = [];
+    mapUnused(findings, report.unused_functions, "unused_functions", options);
+    mapUnused(findings, report.unused_imports, "unused_imports", options);
+    mapUnused(findings, report.unused_classes, "unused_classes", options);
+    mapUnused(findings, report.unused_variables, "unused_variables", options);
+    mapUnused(findings, report.unused_parameters, "unused_parameters", options);
+    for (const secret of report.secrets ?? []) {
+        const finding = rawFindingToCore(secret, "secrets", options);
+        if (finding)
+            findings.push(finding);
+    }
+    for (const danger of report.danger ?? []) {
+        const finding = rawFindingToCore(danger, "security", options);
+        if (finding)
+            findings.push(finding);
+    }
+    for (const quality of report.quality ?? []) {
+        const finding = rawQualityFindingToCore(quality, options);
+        if (finding)
+            findings.push(finding);
+    }
+    return findings.filter((finding) => {
+        if (finding.category !== "dead_code")
+            return true;
+        if (!options.deadCodeEnabled)
+            return false;
+        if (finding.ruleId === "SKY-U005" && !options.showDeadParams)
+            return false;
+        if (finding.confidence !== undefined && finding.confidence < options.confidenceThreshold)
+            return false;
+        return true;
+    });
+}
+function canonicalRuleId(ruleId) {
+    return LEGACY_RULE_ALIASES[ruleId] ?? ruleId;
+}
+function isDeadCodeRule(ruleId) {
+    return canonicalRuleId(ruleId).startsWith("SKY-U");
+}
+function isUnusedImportRule(ruleId) {
+    return canonicalRuleId(ruleId) === "SKY-U002";
+}
+function isUnusedFunctionRule(ruleId) {
+    return canonicalRuleId(ruleId) === "SKY-U001";
+}
+function normalizeSeverity(value) {
+    const normalized = String(value ?? "").toUpperCase();
+    if (normalized === "CRITICAL")
+        return "CRITICAL";
+    if (normalized === "HIGH")
+        return "HIGH";
+    if (normalized === "MEDIUM")
+        return "MEDIUM";
+    if (normalized === "LOW")
+        return "LOW";
+    if (normalized === "WARN" || normalized === "WARNING")
+        return "WARN";
+    return "INFO";
+}
+function makeFingerprint(input) {
+    const material = [
+        canonicalRuleId(input.ruleId),
+        input.relativePath.replace(/\\/g, "/"),
+        String(input.line),
+        input.subject ?? "",
+        input.message,
+    ].join("\0");
+    const hash = crypto.createHash("sha1").update(material).digest("hex").slice(0, 20);
+    return `vsce:${hash}`;
+}
+function mapUnused(findings, items, key, options) {
+    const meta = DEAD_CODE_RULES[key];
+    for (const item of items ?? []) {
+        if (!item.file)
+            continue;
+        const paths = normalizePaths(item.file, options.wsRoot);
+        const name = item.name ?? item.simple_name ?? "";
+        const line = positiveLine(item.line ?? item.lineno);
+        const message = `Unused ${meta.label}: ${name}`;
+        const ruleId = canonicalRuleId(item.rule_id ?? meta.ruleId);
+        const fingerprint = item.fingerprint ?? makeFingerprint({
+            ruleId,
+            relativePath: paths.relativePath,
+            line,
+            message,
+            subject: name,
+        });
+        findings.push({
+            id: nextId(),
+            fingerprint,
+            ruleId,
+            legacyRuleId: meta.legacyRuleId,
+            category: "dead_code",
+            severity: "INFO",
+            message,
+            file: paths.absolutePath,
+            relativePath: paths.relativePath,
+            workspaceRoot: options.wsRoot,
+            line,
+            col: 0,
+            confidence: item.confidence,
+            itemType: meta.itemType,
+            itemName: name,
+            source: "cli",
+            baselineStatus: item.baseline_status,
+            isNew: item.is_new,
+        });
+    }
+}
+function rawFindingToCore(raw, category, options) {
+    if (!raw.file)
+        return undefined;
+    const paths = normalizePaths(raw.file, options.wsRoot);
+    const line = positiveLine(raw.line);
+    const ruleId = canonicalRuleId(raw.rule_id ?? "SKYLOS");
+    const message = raw.message ?? `Skylos ${category} finding`;
+    const fingerprint = raw.fingerprint ?? makeFingerprint({
+        ruleId,
+        relativePath: paths.relativePath,
+        line,
+        message,
+    });
+    const metadata = objectValue(raw.metadata);
+    return {
+        id: nextId(),
+        fingerprint,
+        ruleId,
+        category,
+        severity: normalizeSeverity(raw.severity),
+        message,
+        file: paths.absolutePath,
+        relativePath: paths.relativePath,
+        workspaceRoot: options.wsRoot,
+        line,
+        col: zeroBasedCol(raw.col),
+        endLine: positiveOptional(raw.end_line ?? raw.endLine),
+        endCol: zeroBasedOptional(raw.end_col ?? raw.endCol ?? raw.end_column ?? raw.endColumn),
+        confidence: raw.confidence,
+        source: "cli",
+        ruleUrl: raw.rule_url ?? raw.ruleUrl,
+        safeFix: raw.safe_fix ?? raw.safeFix,
+        fixPatch: raw.fix_patch ?? raw.fixPatch ?? raw.patch,
+        baselineStatus: raw.baseline_status ?? raw.baselineStatus,
+        isNew: raw.is_new ?? raw.isNew,
+        snippet: stringValue(raw.snippet ?? raw.code_snippet ?? raw.codeSnippet ?? raw.vulnerable_code),
+        explanation: stringValue(raw.explanation),
+        suggestion: stringValue(raw.suggestion),
+        evidence: evidenceList(raw.evidence ?? metadata?.evidence),
+        trace: traceSteps(raw.trace ?? raw.dataflow ?? metadata?.trace ?? metadata?.dataflow),
+        sourceSymbol: stringValue(raw.source_symbol ?? raw.sourceSymbol ?? metadata?.source_symbol ?? metadata?.sourceSymbol),
+        sinkSymbol: stringValue(raw.sink_symbol ?? raw.sinkSymbol ?? metadata?.sink_symbol ?? metadata?.sinkSymbol),
+        securityEvidence: objectValue(raw._security_evidence
+            ?? raw.security_evidence
+            ?? metadata?.security_evidence
+            ?? metadata?._security_evidence),
+        reviewReason: stringValue(raw._review_reason ?? raw.review_reason ?? metadata?.review_reason ?? metadata?._review_reason),
+        ciBlocking: booleanValue(raw._ci_blocking ?? raw.ci_blocking ?? metadata?.ci_blocking ?? metadata?._ci_blocking),
+    };
+}
+function rawQualityFindingToCore(raw, options) {
+    const message = raw.message ?? `Quality issue (${raw.kind ?? raw.metric ?? "quality"})`;
+    return rawFindingToCore({ ...raw, message, rule_id: raw.rule_id ?? "SKY-Q000" }, "quality", options);
+}
+function normalizePaths(filePath, wsRoot) {
+    const absolutePath = path.normalize(path.isAbsolute(filePath) ? filePath : path.join(wsRoot, filePath));
+    const relativePath = path.relative(wsRoot, absolutePath).replace(/\\/g, "/") || path.basename(absolutePath);
+    return { absolutePath, relativePath };
+}
+function positiveLine(value) {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 1)
+        return 1;
+    return Math.floor(value);
+}
+function positiveOptional(value) {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 1)
+        return undefined;
+    return Math.floor(value);
+}
+function zeroBasedCol(value) {
+    if (typeof value !== "number" || !Number.isFinite(value))
+        return 0;
+    return Math.max(0, Math.floor(value));
+}
+function zeroBasedOptional(value) {
+    if (typeof value !== "number" || !Number.isFinite(value))
+        return undefined;
+    return Math.max(0, Math.floor(value));
+}
+function stringValue(value) {
+    return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+function booleanValue(value) {
+    return typeof value === "boolean" ? value : undefined;
+}
+function objectValue(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value))
+        return undefined;
+    return value;
+}
+function evidenceList(value) {
+    if (!Array.isArray(value)) {
+        const single = stringValue(value);
+        return single ? [single] : undefined;
+    }
+    const items = value.filter((item) => typeof item === "string" && item.trim().length > 0);
+    return items.length > 0 ? items : undefined;
+}
+function traceSteps(value) {
+    if (!Array.isArray(value))
+        return undefined;
+    const steps = [];
+    for (const item of value) {
+        if (typeof item === "string" && item.trim().length > 0) {
+            steps.push({ message: item });
+            continue;
+        }
+        const obj = objectValue(item);
+        if (!obj)
+            continue;
+        const step = {
+            file: stringValue(obj.file ?? obj.path ?? obj.filename),
+            line: typeof obj.line === "number" && Number.isFinite(obj.line) ? Math.max(1, Math.floor(obj.line)) : undefined,
+            label: stringValue(obj.label ?? obj.kind),
+            message: stringValue(obj.message ?? obj.detail),
+            symbol: stringValue(obj.symbol ?? obj.name),
+        };
+        if (step.file || step.line || step.label || step.message || step.symbol)
+            steps.push(step);
+    }
+    return steps.length > 0 ? steps : undefined;
+}
+function nextId() {
+    findingCounter += 1;
+    return `f-${findingCounter}`;
+}

--- a/editors/vscode/out/hover.js
+++ b/editors/vscode/out/hover.js
@@ -5,6 +5,7 @@ const vscode = require("vscode");
 const rules_1 = require("./rules");
 const types_1 = require("./types");
 const config_1 = require("./config");
+const provenanceCore_1 = require("./provenanceCore");
 class SkylosHoverProvider {
     constructor(store) {
         this.store = store;
@@ -24,6 +25,7 @@ class SkylosHoverProvider {
             const ruleName = meta?.name ?? f.ruleId;
             md.appendMarkdown(`### ${sevEmoji} ${f.ruleId} — ${ruleName}\n\n`);
             md.appendMarkdown(`**Severity:** \`${f.severity}\`\n\n`);
+            md.appendMarkdown(`**Source:** \`${(0, provenanceCore_1.provenanceLabel)(f)}\`\n\n`);
             md.appendMarkdown(`${f.message}\n\n`);
             if (meta?.description) {
                 md.appendMarkdown(`*${meta.description}*\n\n`);

--- a/editors/vscode/out/provenanceCore.js
+++ b/editors/vscode/out/provenanceCore.js
@@ -1,0 +1,135 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeCorrelatedFindings = mergeCorrelatedFindings;
+exports.correlationKey = correlationKey;
+exports.sourceSummary = sourceSummary;
+exports.provenanceLabel = provenanceLabel;
+exports.sourceLabel = sourceLabel;
+exports.diagnosticSource = diagnosticSource;
+exports.isCorroborated = isCorroborated;
+exports.matchesSourceFilter = matchesSourceFilter;
+exports.getSources = getSources;
+const SOURCE_ORDER = ["cli", "agent", "ai"];
+function mergeCorrelatedFindings(findings) {
+    const byKey = new Map();
+    for (const finding of findings) {
+        const key = correlationKey(finding);
+        const existing = byKey.get(key);
+        byKey.set(key, existing ? mergePair(existing, finding) : withNormalizedSources(finding));
+    }
+    return [...byKey.values()];
+}
+function correlationKey(finding) {
+    const file = finding.file.replace(/\\/g, "/");
+    const line = Math.max(1, Math.floor(finding.line || 1));
+    const rule = finding.ruleId.trim().toUpperCase();
+    const subject = correlationSubject(finding);
+    if (rule && rule !== "AI" && rule !== "SKYLOS" && rule !== "SKY-ACTIVE") {
+        return `${file}:${line}:rule:${rule}:${subject}`;
+    }
+    return `${file}:${line}:${finding.category}:${subject}`;
+}
+function sourceSummary(finding) {
+    return getSources(finding).map(sourceLabel).join(" + ");
+}
+function provenanceLabel(finding) {
+    return isCorroborated(finding) ? `Confirmed by ${sourceSummary(finding)}` : sourceSummary(finding);
+}
+function sourceLabel(source) {
+    if (source === "cli")
+        return "Static";
+    if (source === "agent")
+        return "Automation";
+    return "AI Assist";
+}
+function diagnosticSource(finding) {
+    return `skylos ${sourceSummary(finding).toLowerCase().replace(/\s+/g, "-").replace(/-\+-/g, "+")}`;
+}
+function isCorroborated(finding) {
+    return getSources(finding).length > 1;
+}
+function matchesSourceFilter(finding, source) {
+    if (source === "confirmed")
+        return isCorroborated(finding);
+    return getSources(finding).includes(source);
+}
+function getSources(finding) {
+    const sources = finding.sources && finding.sources.length > 0 ? finding.sources : [finding.source];
+    return uniqueSources(sources).sort((a, b) => SOURCE_ORDER.indexOf(a) - SOURCE_ORDER.indexOf(b));
+}
+function correlationSubject(finding) {
+    const explicit = finding.sinkSymbol ?? finding.sourceSymbol ?? finding.itemName;
+    if (explicit && explicit.trim())
+        return normalizeSubject(explicit);
+    return normalizeSubject(finding.message).slice(0, 80);
+}
+function normalizeSubject(value) {
+    return value.toLowerCase().replace(/[^a-z0-9.]+/g, " ").trim();
+}
+function mergePair(a, b) {
+    const primary = choosePrimary(a, b);
+    const secondary = primary === a ? b : a;
+    const merged = {
+        ...primary,
+        severity: higherSeverity(a.severity, b.severity),
+        confidence: maxNumber(a.confidence, b.confidence),
+        safeFix: primary.safeFix ?? secondary.safeFix,
+        fixPatch: primary.fixPatch ?? secondary.fixPatch,
+        evidence: mergeStrings(a.evidence, b.evidence),
+        trace: mergeTrace(a.trace, b.trace),
+        reviewReason: primary.reviewReason ?? secondary.reviewReason,
+        ciBlocking: a.ciBlocking === true || b.ciBlocking === true ? true : primary.ciBlocking ?? secondary.ciBlocking,
+        baselineStatus: primary.baselineStatus ?? secondary.baselineStatus,
+        isNew: a.isNew === true || b.isNew === true ? true : primary.isNew ?? secondary.isNew,
+        sources: uniqueSources([...getSources(a), ...getSources(b)]),
+    };
+    return merged;
+}
+function withNormalizedSources(finding) {
+    return {
+        ...finding,
+        sources: getSources(finding),
+    };
+}
+function choosePrimary(a, b) {
+    const sourceDelta = SOURCE_ORDER.indexOf(a.source) - SOURCE_ORDER.indexOf(b.source);
+    if (sourceDelta !== 0)
+        return sourceDelta < 0 ? a : b;
+    return severityRank(a.severity) >= severityRank(b.severity) ? a : b;
+}
+function higherSeverity(a, b) {
+    return severityRank(a) >= severityRank(b) ? a : b;
+}
+function severityRank(severity) {
+    switch (severity.toUpperCase()) {
+        case "CRITICAL":
+            return 5;
+        case "HIGH":
+            return 4;
+        case "MEDIUM":
+        case "WARN":
+            return 3;
+        case "LOW":
+            return 2;
+        default:
+            return 1;
+    }
+}
+function maxNumber(a, b) {
+    if (a === undefined)
+        return b;
+    if (b === undefined)
+        return a;
+    return Math.max(a, b);
+}
+function mergeStrings(a, b) {
+    const values = [...(a ?? []), ...(b ?? [])].filter((value) => value.trim().length > 0);
+    return values.length > 0 ? [...new Set(values)] : undefined;
+}
+function mergeTrace(a, b) {
+    const values = [...(a ?? []), ...(b ?? [])];
+    return values.length > 0 ? values : undefined;
+}
+function uniqueSources(sources) {
+    return [...new Set(sources)];
+}

--- a/editors/vscode/out/quickfix.js
+++ b/editors/vscode/out/quickfix.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosQuickFixProvider = void 0;
 const vscode = require("vscode");
 const types_1 = require("./types");
+const findingCore_1 = require("./findingCore");
 class SkylosQuickFixProvider {
     constructor(store) {
         this.store = store;
@@ -10,12 +11,15 @@ class SkylosQuickFixProvider {
     provideCodeActions(document, _range, context) {
         const actions = [];
         for (const diag of context.diagnostics) {
-            if (diag.source !== "skylos" && diag.source !== "skylos-ai")
+            if (!diag.source?.startsWith("skylos"))
                 continue;
             const line = diag.range.start.line;
             const lineText = document.lineAt(line).text;
-            const ruleId = typeof diag.code === "string" ? diag.code : String(diag.code ?? "");
+            const ruleId = getRuleId(diag.code);
             const langId = document.languageId;
+            const finding = this.store.getFindingsForFile(document.uri.fsPath)
+                .find((candidate) => candidate.line === line + 1
+                && (candidate.ruleId === ruleId || candidate.legacyRuleId === ruleId));
             const ignoreComment = getIgnoreComment(langId);
             if (!lineText.includes(ignoreComment)) {
                 const ignoreAction = new vscode.CodeAction(`Skylos: Ignore on this line`, vscode.CodeActionKind.QuickFix);
@@ -30,26 +34,17 @@ class SkylosQuickFixProvider {
             fileIgnore.edit.insert(document.uri, new vscode.Position(0, 0), fileComment + "\n");
             fileIgnore.diagnostics = [diag];
             actions.push(fileIgnore);
-            if (ruleId === "DEAD-IMPORT") {
-                const removeAction = new vscode.CodeAction(`Remove unused import`, vscode.CodeActionKind.QuickFix);
-                removeAction.isPreferred = true;
-                removeAction.edit = new vscode.WorkspaceEdit();
-                const fullLine = new vscode.Range(line, 0, line + 1, 0);
-                removeAction.edit.delete(document.uri, fullLine);
-                removeAction.diagnostics = [diag];
-                actions.push(removeAction);
-            }
-            if (ruleId === "DEAD-FUNC") {
-                const removeFunc = new vscode.CodeAction(`Remove unused function`, vscode.CodeActionKind.QuickFix);
-                removeFunc.command = {
-                    title: "Remove function",
-                    command: "skylos.removeFunction",
-                    arguments: [document.uri, line],
+            if (finding?.fixPatch) {
+                const previewFix = new vscode.CodeAction("Skylos: Preview engine fix", vscode.CodeActionKind.QuickFix);
+                previewFix.command = {
+                    title: "Preview engine fix",
+                    command: "skylos.previewSafeFix",
+                    arguments: [finding],
                 };
-                removeFunc.diagnostics = [diag];
-                actions.push(removeFunc);
+                previewFix.diagnostics = [diag];
+                actions.push(previewFix);
             }
-            if (ruleId.startsWith("DEAD-")) {
+            if ((0, findingCore_1.isDeadCodeRule)(ruleId)) {
                 const whitelist = new vscode.CodeAction(`Add to whitelist`, vscode.CodeActionKind.QuickFix);
                 whitelist.command = {
                     title: "Add to whitelist",
@@ -59,15 +54,15 @@ class SkylosQuickFixProvider {
                 whitelist.diagnostics = [diag];
                 actions.push(whitelist);
             }
-            if (diag.source === "skylos-ai" || ruleId.startsWith("SKY-D") || ruleId.startsWith("SKY-S")) {
-                const fixAI = new vscode.CodeAction(`Fix with AI`, vscode.CodeActionKind.QuickFix);
+            if (diag.source.includes("ai-assist") || ruleId.startsWith("SKY-D") || ruleId.startsWith("SKY-S")) {
+                const fixAI = new vscode.CodeAction(`Fix with AI Assist`, vscode.CodeActionKind.QuickFix);
                 fixAI.command = {
-                    title: "Fix with AI",
+                    title: "Fix with AI Assist",
                     command: "skylos.fix",
                     arguments: [
                         document.uri.fsPath,
                         diag.range,
-                        diag.message.replace("[AI] ", ""),
+                        diag.message,
                         false,
                     ],
                 };
@@ -85,6 +80,15 @@ class SkylosQuickFixProvider {
 }
 exports.SkylosQuickFixProvider = SkylosQuickFixProvider;
 SkylosQuickFixProvider.providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+function getRuleId(code) {
+    if (typeof code === "string" || typeof code === "number") {
+        return String(code);
+    }
+    if (code && typeof code === "object" && "value" in code) {
+        return String(code.value);
+    }
+    return "";
+}
 function getIgnoreComment(langId) {
     if (langId === "python")
         return "# pragma: no skylos";

--- a/editors/vscode/out/reviewCore.js
+++ b/editors/vscode/out/reviewCore.js
@@ -1,0 +1,291 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.sortReviewQueue = sortReviewQueue;
+exports.reviewScore = reviewScore;
+exports.priorityReasons = priorityReasons;
+exports.ciImpact = ciImpact;
+exports.fixPlan = fixPlan;
+exports.evidenceLines = evidenceLines;
+exports.hasEvidence = hasEvidence;
+exports.isLikelyCiBlocker = isLikelyCiBlocker;
+exports.severityRank = severityRank;
+const provenanceCore_1 = require("./provenanceCore");
+function sortReviewQueue(findings, context = {}) {
+    return [...findings].sort((a, b) => reviewScore(b, context) - reviewScore(a, context)
+        || a.file.localeCompare(b.file)
+        || a.line - b.line
+        || a.message.localeCompare(b.message));
+}
+function reviewScore(finding, context = {}) {
+    let score = severityRank(finding.severity) * 10000;
+    if (finding.file === context.currentFile)
+        score += 100000;
+    else if (context.visibleFiles && new Set(context.visibleFiles).has(finding.file))
+        score += 50000;
+    if (finding.ciBlocking === true)
+        score += 70000;
+    if ((0, provenanceCore_1.isCorroborated)(finding))
+        score += 65000;
+    if (finding.isNew || finding.baselineStatus === "new")
+        score += 45000;
+    if (finding.category === "secrets")
+        score += 9000;
+    if (finding.category === "security")
+        score += 7000;
+    if (finding.fixPatch)
+        score += 3000;
+    if (hasEvidence(finding))
+        score += 750;
+    if (finding.source === "cli")
+        score += 500;
+    if (finding.confidence !== undefined)
+        score += Math.min(100, Math.max(0, finding.confidence));
+    return score;
+}
+function priorityReasons(finding, context = {}) {
+    const reasons = [];
+    if (finding.file === context.currentFile)
+        reasons.push("In the active editor");
+    else if (context.visibleFiles && new Set(context.visibleFiles).has(finding.file))
+        reasons.push("In an open editor");
+    if ((0, provenanceCore_1.isCorroborated)(finding))
+        reasons.push(`Confirmed by ${(0, provenanceCore_1.sourceSummary)(finding)}`);
+    if (finding.ciBlocking === true)
+        reasons.push("Marked as CI-blocking by Skylos");
+    if (finding.isNew || finding.baselineStatus === "new") {
+        reasons.push(context.diffBase ? `New against ${context.diffBase}` : "New against the configured baseline");
+    }
+    if (finding.severity === "CRITICAL" || finding.severity === "HIGH") {
+        reasons.push(`${finding.severity.toLowerCase()} severity`);
+    }
+    if (finding.category === "secrets")
+        reasons.push("Secret exposure risk");
+    else if (finding.category === "security")
+        reasons.push("Security finding");
+    if (finding.fixPatch)
+        reasons.push("Deterministic patch is available");
+    if (hasEvidence(finding))
+        reasons.push("Evidence is attached");
+    if (finding.reviewReason)
+        reasons.push(finding.reviewReason);
+    if (finding.confidence !== undefined)
+        reasons.push(`${finding.confidence}% confidence`);
+    if (reasons.length === 0)
+        reasons.push("Ranked by severity, category, and location");
+    return unique(reasons).slice(0, 6);
+}
+function ciImpact(findings, context = {}) {
+    const blockers = findings.filter(isLikelyCiBlocker);
+    const attention = findings.filter((finding) => !isLikelyCiBlocker(finding) && needsAttention(finding));
+    const scope = context.diffBase ? `new issues against ${context.diffBase}` : "the current review queue";
+    if (blockers.length > 0) {
+        const reasons = summarizeCounts(blockers);
+        return {
+            status: "blocking",
+            headline: `Likely CI block: ${blockers.length} blocker(s) in ${scope}`,
+            blockerCount: blockers.length,
+            attentionCount: attention.length,
+            reasons,
+        };
+    }
+    if (attention.length > 0) {
+        return {
+            status: "attention",
+            headline: `CI risk: ${attention.length} issue(s) need review in ${scope}`,
+            blockerCount: 0,
+            attentionCount: attention.length,
+            reasons: summarizeCounts(attention),
+        };
+    }
+    return {
+        status: "clean",
+        headline: findings.length === 0 ? "No Skylos issues in scope" : "No likely CI blockers in scope",
+        blockerCount: 0,
+        attentionCount: 0,
+        reasons: [],
+    };
+}
+function fixPlan(finding) {
+    if (finding.fixPatch) {
+        return {
+            mode: "engine",
+            title: "Preview the deterministic engine patch first",
+            steps: [
+                "Open the generated diff and verify the exact lines being changed.",
+                "Apply the patch only if the diff matches the finding and preserves behavior.",
+                "Rerun Skylos and the nearest tests after applying it.",
+            ],
+        };
+    }
+    if (finding.safeFix) {
+        return {
+            mode: "safe-fix",
+            title: "Use the safe-fix guidance",
+            steps: [
+                finding.safeFix,
+                "Review the local code path before editing.",
+                "Rerun Skylos after the change.",
+            ],
+        };
+    }
+    if (finding.suggestion) {
+        return {
+            mode: "ai",
+            title: "Use the suggested remediation as a starting point",
+            steps: [
+                finding.suggestion,
+                "Ask AI for a patch only after checking the affected code path.",
+                "Verify with the project test or lint command.",
+            ],
+        };
+    }
+    if (finding.category === "secrets") {
+        return {
+            mode: "manual",
+            title: "Rotate and remove the exposed secret",
+            steps: [
+                "Remove the secret from source control and replace it with a runtime secret source.",
+                "Rotate the leaked credential if it may have been committed or shared.",
+                "Rerun Skylos secrets scanning.",
+            ],
+        };
+    }
+    if (finding.category === "security") {
+        return {
+            mode: "manual",
+            title: "Fix the vulnerable data path",
+            steps: [
+                "Open the finding and inspect the source, sink, and validation path.",
+                "Add validation, sanitization, authorization, or safer APIs according to the rule.",
+                "Add or update a regression test for the dangerous path.",
+            ],
+        };
+    }
+    if (finding.category === "dead_code") {
+        return {
+            mode: "manual",
+            title: "Confirm reachability before removing code",
+            steps: [
+                "Check dynamic references, exports, framework hooks, and tests before deleting.",
+                "Remove the unused item or mark it intentionally retained.",
+                "Rerun Skylos dead-code analysis.",
+            ],
+        };
+    }
+    return {
+        mode: "manual",
+        title: "Review and fix locally",
+        steps: [
+            "Open the code at the reported line.",
+            "Apply the smallest behavior-preserving change that satisfies the rule.",
+            "Rerun Skylos and the closest relevant tests.",
+        ],
+    };
+}
+function evidenceLines(finding) {
+    const lines = [];
+    if (finding.explanation)
+        lines.push(finding.explanation);
+    if (finding.reviewReason)
+        lines.push(finding.reviewReason);
+    for (const item of finding.evidence ?? [])
+        lines.push(item);
+    if (finding.sourceSymbol || finding.sinkSymbol) {
+        const source = finding.sourceSymbol ? `source ${finding.sourceSymbol}` : "source unknown";
+        const sink = finding.sinkSymbol ? `sink ${finding.sinkSymbol}` : "sink unknown";
+        lines.push(`Data path: ${source} -> ${sink}`);
+    }
+    for (const step of finding.trace ?? []) {
+        const location = step.file ? `${step.file}${step.line ? `:${step.line}` : ""}` : undefined;
+        const message = step.message ?? step.label ?? step.symbol;
+        if (location && message)
+            lines.push(`${location} - ${message}`);
+        else if (location)
+            lines.push(location);
+        else if (message)
+            lines.push(message);
+    }
+    const security = summarizeSecurityEvidence(finding.securityEvidence);
+    lines.push(...security);
+    return unique(lines.filter((line) => line.trim().length > 0)).slice(0, 8);
+}
+function hasEvidence(finding) {
+    return Boolean(finding.snippet
+        || finding.explanation
+        || finding.reviewReason
+        || finding.sourceSymbol
+        || finding.sinkSymbol
+        || (finding.evidence && finding.evidence.length > 0)
+        || (finding.trace && finding.trace.length > 0)
+        || (finding.securityEvidence && Object.keys(finding.securityEvidence).length > 0));
+}
+function isLikelyCiBlocker(finding) {
+    if (finding.ciBlocking === true)
+        return true;
+    if (finding.severity === "CRITICAL")
+        return true;
+    if (finding.category === "secrets")
+        return finding.severity !== "INFO" && finding.severity !== "LOW";
+    return finding.category === "security" && finding.severity === "HIGH";
+}
+function severityRank(severity) {
+    switch (severity.toUpperCase()) {
+        case "CRITICAL":
+            return 5;
+        case "HIGH":
+            return 4;
+        case "MEDIUM":
+        case "WARN":
+            return 3;
+        case "LOW":
+            return 2;
+        case "INFO":
+        default:
+            return 1;
+    }
+}
+function needsAttention(finding) {
+    return finding.severity === "HIGH"
+        || finding.severity === "MEDIUM"
+        || finding.severity === "WARN"
+        || finding.isNew === true
+        || finding.baselineStatus === "new";
+}
+function summarizeCounts(findings) {
+    const counts = new Map();
+    for (const finding of findings) {
+        const key = `${finding.severity} ${finding.category}`;
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([key, count]) => `${count} ${key}`);
+}
+function summarizeSecurityEvidence(value) {
+    if (!value)
+        return [];
+    const lines = [];
+    const contractId = stringValue(value.contract_id);
+    const handler = stringValue(value.handler);
+    const missingGuards = stringArrayValue(value.missing_guards);
+    if (contractId)
+        lines.push(`Security contract: ${contractId}`);
+    if (handler)
+        lines.push(`Handler: ${handler}`);
+    if (missingGuards.length > 0)
+        lines.push(`Missing guards: ${missingGuards.join(", ")}`);
+    if (lines.length === 0)
+        lines.push(`Security evidence fields: ${Object.keys(value).slice(0, 6).join(", ")}`);
+    return lines;
+}
+function stringValue(value) {
+    return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+function stringArrayValue(value) {
+    if (!Array.isArray(value))
+        return [];
+    return value.filter((item) => typeof item === "string" && item.trim().length > 0);
+}
+function unique(values) {
+    return [...new Set(values)];
+}

--- a/editors/vscode/out/rules.js
+++ b/editors/vscode/out/rules.js
@@ -4,6 +4,11 @@ exports.getRuleMeta = getRuleMeta;
 exports.getSeverityForRule = getSeverityForRule;
 exports.getAllRules = getAllRules;
 const RULES = {
+    "SKY-U001": { name: "Unused function", severity: "INFO", category: "dead_code", description: "Function is defined but never called anywhere in the project.", fix: "Remove the function or add it to the whitelist." },
+    "SKY-U002": { name: "Unused import", severity: "INFO", category: "dead_code", description: "Import is never referenced in the module.", fix: "Remove the import statement." },
+    "SKY-U003": { name: "Unused variable", severity: "INFO", category: "dead_code", description: "Variable is assigned but never read.", fix: "Remove the variable or prefix with underscore." },
+    "SKY-U004": { name: "Unused class", severity: "INFO", category: "dead_code", description: "Class is defined but never instantiated or referenced.", fix: "Remove the class or add it to the whitelist." },
+    "SKY-U005": { name: "Unused parameter", severity: "INFO", category: "dead_code", description: "Parameter is declared but never used in the function body.", fix: "Remove the parameter or prefix with underscore." },
     "DEAD-FUNC": { name: "Unused function", severity: "INFO", category: "dead_code", description: "Function is defined but never called anywhere in the project.", fix: "Remove the function or add it to the whitelist." },
     "DEAD-IMPORT": { name: "Unused import", severity: "INFO", category: "dead_code", description: "Import is never referenced in the module.", fix: "Remove the import statement." },
     "DEAD-CLASS": { name: "Unused class", severity: "INFO", category: "dead_code", description: "Class is defined but never instantiated or referenced.", fix: "Remove the class or add it to the whitelist." },

--- a/editors/vscode/out/scanCore.js
+++ b/editors/vscode/out/scanCore.js
@@ -1,0 +1,68 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SkylosScanError = void 0;
+exports.buildScanArgs = buildScanArgs;
+exports.buildScanCommand = buildScanCommand;
+exports.formatCommand = formatCommand;
+exports.shellQuote = shellQuote;
+exports.buildScanErrorMessage = buildScanErrorMessage;
+class SkylosScanError extends Error {
+    constructor(kind, message, details = {}) {
+        super(message);
+        this.kind = kind;
+        this.details = details;
+        this.name = "SkylosScanError";
+    }
+}
+exports.SkylosScanError = SkylosScanError;
+function buildScanArgs(spec) {
+    const args = [spec.target, "--json", "-c", String(spec.confidence)];
+    for (const folder of spec.excludeFolders) {
+        args.push("--exclude-folder", folder);
+    }
+    if (spec.enableSecrets)
+        args.push("--secrets");
+    if (spec.enableDanger)
+        args.push("--danger");
+    if (spec.enableQuality)
+        args.push("--quality");
+    if (spec.diffBase)
+        args.push("--diff-base", spec.diffBase);
+    return args;
+}
+function buildScanCommand(bin, spec) {
+    const args = buildScanArgs(spec);
+    return {
+        args,
+        display: formatCommand(bin, args),
+    };
+}
+function formatCommand(bin, args) {
+    return [bin, ...args].map(shellQuote).join(" ");
+}
+function shellQuote(value) {
+    if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
+        return value;
+    }
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}
+function buildScanErrorMessage(error) {
+    if (!(error instanceof SkylosScanError)) {
+        return error instanceof Error ? error.message : String(error);
+    }
+    switch (error.kind) {
+        case "missing_binary":
+            return "Skylos executable was not found. Set `skylos.path` or install the Skylos CLI.";
+        case "invalid_json":
+            return "Skylos returned invalid JSON. Open the Skylos output channel for the raw command output.";
+        case "nonzero_exit": {
+            const code = error.details.exitCode ?? "?";
+            return `Skylos exited with code ${code}. Open the Skylos output channel for details.`;
+        }
+        case "cancelled":
+            return "Scan cancelled";
+        case "unknown":
+        default:
+            return error.message;
+    }
+}

--- a/editors/vscode/out/scanner.js
+++ b/editors/vscode/out/scanner.js
@@ -1,15 +1,21 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.out = void 0;
+exports.SkylosScanError = exports.buildScanErrorMessage = exports.out = void 0;
 exports.cancelScan = cancelScan;
 exports.scanWorkspace = scanWorkspace;
 exports.scanFile = scanFile;
+exports.doctorSkylos = doctorSkylos;
 exports.normalizeReport = normalizeReport;
 const vscode = require("vscode");
 const child_process_1 = require("child_process");
 const path = require("path");
 const config_1 = require("./config");
+const scanCore_1 = require("./scanCore");
+const findingCore_1 = require("./findingCore");
 exports.out = vscode.window.createOutputChannel("Skylos");
+var scanCore_2 = require("./scanCore");
+Object.defineProperty(exports, "buildScanErrorMessage", { enumerable: true, get: function () { return scanCore_2.buildScanErrorMessage; } });
+Object.defineProperty(exports, "SkylosScanError", { enumerable: true, get: function () { return scanCore_2.SkylosScanError; } });
 let activeProcess = null;
 function cancelScan() {
     if (activeProcess) {
@@ -30,26 +36,18 @@ async function scanFile(filePath, token) {
     const wsRoot = ws?.uri.fsPath ?? path.dirname(filePath);
     return runScan(filePath, wsRoot, token);
 }
-async function runScan(target, wsRoot, token, diffBase) {
-    cancelScan();
+async function doctorSkylos() {
     const bin = (0, config_1.getSkylosBin)();
-    const conf = (0, config_1.getConfidenceThreshold)();
-    const excludes = (0, config_1.getExcludeFolders)();
-    const args = [target, "--json", "-c", String(conf)];
-    excludes.forEach((f) => args.push("--exclude-folder", f));
-    if ((0, config_1.isFeatureEnabled)("secrets"))
-        args.push("--secrets");
-    if ((0, config_1.isFeatureEnabled)("danger"))
-        args.push("--danger");
-    if ((0, config_1.isFeatureEnabled)("quality"))
-        args.push("--quality");
-    if (diffBase)
-        args.push("--diff-base", diffBase);
+    const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const args = ["--version"];
+    const command = (0, scanCore_1.formatCommand)(bin, args);
     exports.out.appendLine("=".repeat(60));
-    exports.out.appendLine(`Running: ${bin} ${args.join(" ")}`);
-    return new Promise((resolve, reject) => {
+    exports.out.appendLine("Skylos Doctor");
+    exports.out.appendLine(`Workspace: ${wsRoot ?? "(none)"}`);
+    exports.out.appendLine(`Configured binary: ${bin}`);
+    exports.out.appendLine(`Version command: ${command}`);
+    return new Promise((resolve) => {
         const proc = (0, child_process_1.spawn)(bin, args, { cwd: wsRoot });
-        activeProcess = proc;
         let stdout = "";
         let stderr = "";
         proc.stdout.on("data", (data) => {
@@ -58,12 +56,90 @@ async function runScan(target, wsRoot, token, diffBase) {
         proc.stderr.on("data", (data) => {
             stderr += data.toString();
         });
-        token?.onCancellationRequested(() => {
-            proc.kill();
-            reject(new Error("Scan cancelled"));
+        proc.on("close", (code) => {
+            const ok = code === 0;
+            if (stdout.trim())
+                exports.out.appendLine(`stdout: ${stdout.trim()}`);
+            if (stderr.trim())
+                exports.out.appendLine(`stderr: ${stderr.trim()}`);
+            exports.out.appendLine(ok ? "Doctor result: OK" : `Doctor result: failed with exit code ${code}`);
+            resolve({
+                ok,
+                command,
+                bin,
+                workspaceRoot: wsRoot,
+                stdout,
+                stderr,
+                error: ok ? undefined : `Version command exited with code ${code}`,
+            });
         });
-        proc.on("close", () => {
+        proc.on("error", (err) => {
+            const errno = err.code;
+            const error = errno === "ENOENT"
+                ? "Skylos executable was not found. Set `skylos.path` or install the Skylos CLI."
+                : err.message;
+            exports.out.appendLine(`Doctor result: ${error}`);
+            resolve({
+                ok: false,
+                command,
+                bin,
+                workspaceRoot: wsRoot,
+                stdout,
+                stderr,
+                error,
+            });
+        });
+    });
+}
+async function runScan(target, wsRoot, token, diffBase) {
+    cancelScan();
+    const bin = (0, config_1.getSkylosBin)();
+    const command = (0, scanCore_1.buildScanCommand)(bin, {
+        target,
+        confidence: (0, config_1.getConfidenceThreshold)(),
+        excludeFolders: (0, config_1.getExcludeFolders)(),
+        enableSecrets: (0, config_1.isFeatureEnabled)("secrets"),
+        enableDanger: (0, config_1.isFeatureEnabled)("danger"),
+        enableQuality: (0, config_1.isFeatureEnabled)("quality"),
+        diffBase,
+    });
+    exports.out.appendLine("=".repeat(60));
+    exports.out.appendLine(`Running: ${command.display}`);
+    const startedAt = Date.now();
+    return new Promise((resolve, reject) => {
+        const proc = (0, child_process_1.spawn)(bin, command.args, { cwd: wsRoot });
+        activeProcess = proc;
+        let stdout = "";
+        let stderr = "";
+        let cancelled = false;
+        let settled = false;
+        const fail = (error) => {
+            if (settled)
+                return;
+            settled = true;
+            reject(error);
+        };
+        const succeed = (result) => {
+            if (settled)
+                return;
+            settled = true;
+            resolve(result);
+        };
+        proc.stdout.on("data", (data) => {
+            stdout += data.toString();
+        });
+        proc.stderr.on("data", (data) => {
+            stderr += data.toString();
+        });
+        token?.onCancellationRequested(() => {
+            cancelled = true;
+            proc.kill();
+            fail(new scanCore_1.SkylosScanError("cancelled", "Scan cancelled", { command: command.display }));
+        });
+        proc.on("close", (code) => {
             activeProcess = null;
+            if (cancelled)
+                return;
             if (stderr) {
                 exports.out.appendLine(`stderr: ${stderr}`);
             }
@@ -73,133 +149,46 @@ async function runScan(target, wsRoot, token, diffBase) {
             }
             catch {
                 exports.out.appendLine("Invalid JSON from CLI");
-                reject(new Error("Skylos returned invalid JSON."));
+                fail(new scanCore_1.SkylosScanError(code === 0 ? "invalid_json" : "nonzero_exit", code === 0 ? "Skylos returned invalid JSON." : `Skylos exited with code ${code}.`, { command: command.display, exitCode: code, stderr, stdout }));
                 return;
+            }
+            if (code !== 0) {
+                exports.out.appendLine(`Skylos exited with code ${code} but returned parseable JSON; showing parsed findings.`);
             }
             const findings = normalizeReport(report, wsRoot);
             printReport(findings, wsRoot);
-            resolve({
+            succeed({
                 findings,
                 grade: report.grade,
                 summary: report.analysis_summary,
                 circularDeps: report.circular_dependencies,
                 depVulns: report.dependency_vulnerabilities,
+                metadata: {
+                    command: command.display,
+                    target,
+                    workspaceRoot: wsRoot,
+                    diffBase,
+                    durationMs: Date.now() - startedAt,
+                    exitCode: code,
+                    stderr,
+                },
             });
         });
         proc.on("error", (err) => {
             activeProcess = null;
-            reject(err);
+            const errno = err.code;
+            const kind = errno === "ENOENT" ? "missing_binary" : "unknown";
+            fail(new scanCore_1.SkylosScanError(kind, err.message, { command: command.display, stderr }));
         });
     });
-}
-function resolvePath(filePath, wsRoot) {
-    if (path.isAbsolute(filePath))
-        return filePath;
-    return path.join(wsRoot, filePath);
-}
-let findingCounter = 0;
-function nextId() {
-    return `f-${++findingCounter}`;
 }
 function normalizeReport(report, wsRoot) {
-    const findings = [];
-    const mapUnused = (items, itemType, ruleId) => {
-        for (const u of items ?? []) {
-            if (!u.file)
-                continue;
-            const name = u.name ?? u.simple_name ?? "";
-            findings.push({
-                id: nextId(),
-                ruleId,
-                category: "dead_code",
-                severity: "INFO",
-                message: `Unused ${itemType}: ${name}`,
-                file: resolvePath(u.file, wsRoot),
-                line: u.line ?? u.lineno ?? 1,
-                col: 0,
-                confidence: u.confidence,
-                itemType,
-                itemName: name,
-                source: "cli",
-            });
-        }
-    };
-    mapUnused(report.unused_functions, "function", "DEAD-FUNC");
-    mapUnused(report.unused_imports, "import", "DEAD-IMPORT");
-    mapUnused(report.unused_classes, "class", "DEAD-CLASS");
-    mapUnused(report.unused_variables, "variable", "DEAD-VAR");
-    mapUnused(report.unused_parameters, "parameter", "DEAD-PARAM");
-    for (const s of report.secrets ?? []) {
-        if (!s.file)
-            continue;
-        findings.push(cliFindingToSkylos(s, "secrets", wsRoot));
-    }
-    for (const d of report.danger ?? []) {
-        if (!d.file)
-            continue;
-        findings.push(cliFindingToSkylos(d, "security", wsRoot));
-    }
-    for (const q of report.quality ?? []) {
-        if (!q.file)
-            continue;
-        const sev = normalizeSeverity(q.severity);
-        const ruleId = q.rule_id ?? "SKY-Q000";
-        const msg = q.message ?? `Quality issue (${q.kind ?? q.metric ?? "quality"})`;
-        findings.push({
-            id: nextId(),
-            ruleId,
-            category: "quality",
-            severity: sev,
-            message: msg,
-            file: resolvePath(q.file, wsRoot),
-            line: q.line ?? 1,
-            col: 0,
-            source: "cli",
-        });
-    }
-    const deadCodeOn = (0, config_1.isDeadCodeEnabled)();
-    const deadParamsOn = (0, config_1.isShowDeadParams)();
-    const confThreshold = (0, config_1.getConfidenceThreshold)();
-    return findings.filter((f) => {
-        if (f.category === "dead_code") {
-            if (!deadCodeOn)
-                return false;
-            if (f.ruleId === "DEAD-PARAM" && !deadParamsOn)
-                return false;
-            if (f.confidence !== undefined && f.confidence < confThreshold)
-                return false;
-        }
-        return true;
+    return (0, findingCore_1.normalizeReportCore)(report, {
+        wsRoot,
+        deadCodeEnabled: (0, config_1.isDeadCodeEnabled)(),
+        showDeadParams: (0, config_1.isShowDeadParams)(),
+        confidenceThreshold: (0, config_1.getConfidenceThreshold)(),
     });
-}
-function cliFindingToSkylos(f, category, wsRoot) {
-    const sev = normalizeSeverity(f.severity);
-    const ruleId = f.rule_id ?? "SKYLOS";
-    return {
-        id: nextId(),
-        ruleId,
-        category,
-        severity: sev,
-        message: f.message,
-        file: resolvePath(f.file, wsRoot),
-        line: f.line ?? 1,
-        col: f.col ?? 0,
-        source: "cli",
-    };
-}
-function normalizeSeverity(s) {
-    const t = (s ?? "").toUpperCase();
-    if (t === "CRITICAL")
-        return "CRITICAL";
-    if (t === "HIGH")
-        return "HIGH";
-    if (t === "MEDIUM")
-        return "MEDIUM";
-    if (t === "LOW")
-        return "LOW";
-    if (t === "WARN" || t === "WARNING")
-        return "WARN";
-    return "INFO";
 }
 function printReport(findings, wsRoot) {
     if (findings.length === 0) {

--- a/editors/vscode/out/sidebar.js
+++ b/editors/vscode/out/sidebar.js
@@ -4,25 +4,32 @@ exports.SkylosTreeProvider = exports.FindingNode = void 0;
 const vscode = require("vscode");
 const path = require("path");
 const config_1 = require("./config");
+const reviewCore_1 = require("./reviewCore");
+const provenanceCore_1 = require("./provenanceCore");
 class SummaryNode {
-    constructor(workingTotal, visibleTotal, rawTotal, filterActive) {
+    constructor(workingTotal, visibleTotal, rawTotal, filterActive, lastScan, lastError, impact) {
         this.workingTotal = workingTotal;
         this.visibleTotal = visibleTotal;
         this.rawTotal = rawTotal;
         this.filterActive = filterActive;
+        this.lastScan = lastScan;
+        this.lastError = lastError;
+        this.impact = impact;
     }
 }
-class CategoryNode {
-    constructor(category, label, findings) {
-        this.category = category;
+class SectionNode {
+    constructor(findings, label, description, icon = "list-ordered") {
+        this.findings = findings;
         this.label = label;
-        this.findings = findings;
+        this.description = description;
+        this.icon = icon;
     }
 }
-class FileNode {
-    constructor(filePath, findings) {
-        this.filePath = filePath;
-        this.findings = findings;
+class InfoNode {
+    constructor(label, description, command) {
+        this.label = label;
+        this.description = description;
+        this.command = command;
     }
 }
 class FindingNode {
@@ -37,15 +44,7 @@ const CATEGORY_LABELS = {
     secrets: "Secrets",
     quality: "Quality",
     debt: "Technical Debt",
-    ai: "AI Analysis",
-};
-const CATEGORY_ICONS = {
-    dead_code: "trash",
-    security: "shield",
-    secrets: "key",
-    quality: "beaker",
-    debt: "wrench",
-    ai: "sparkle",
+    ai: "AI Assist",
 };
 class SkylosTreeProvider {
     constructor(store) {
@@ -58,42 +57,64 @@ class SkylosTreeProvider {
     getTreeItem(element) {
         if (element instanceof SummaryNode) {
             const item = new vscode.TreeItem(element.workingTotal === 0
-                ? (element.filterActive ? "No findings match the current filter" : "No findings in scope")
-                : `Showing ${element.visibleTotal} of ${element.workingTotal} findings`, vscode.TreeItemCollapsibleState.None);
-            item.iconPath = new vscode.ThemeIcon("filter");
-            if (element.rawTotal !== element.workingTotal) {
+                ? (element.filterActive ? "No matching Skylos issues" : "No Skylos issues in scope")
+                : `${element.workingTotal} issue(s) to review`, vscode.TreeItemCollapsibleState.None);
+            item.iconPath = element.lastError
+                ? new vscode.ThemeIcon("warning", new vscode.ThemeColor("editorWarning.foreground"))
+                : new vscode.ThemeIcon("shield");
+            if (element.lastError) {
+                item.description = "Last scan failed";
+            }
+            else if (element.impact?.status === "blocking") {
+                item.description = `${element.impact.blockerCount} likely CI blocker(s)`;
+            }
+            else if (element.impact?.status === "attention") {
+                item.description = `${element.impact.attentionCount} need review`;
+            }
+            else if (element.lastScan?.diffBase) {
+                item.description = `New issues vs ${element.lastScan.diffBase}`;
+            }
+            else if (element.rawTotal !== element.workingTotal) {
                 item.description = `${element.rawTotal} total in repo`;
             }
+            else if (element.lastScan?.durationMs !== undefined) {
+                item.description = `Last scan ${Math.round(element.lastScan.durationMs / 100) / 10}s`;
+            }
             else if (element.workingTotal > element.visibleTotal) {
-                item.description = "Refine with filters or open Dashboard";
+                item.description = `Top ${element.visibleTotal} shown`;
             }
             else if (element.filterActive) {
                 item.description = "Filter active";
             }
+            item.tooltip = buildSummaryTooltip(element);
             item.command = {
                 title: "Filter findings",
                 command: element.filterActive ? "skylos.clearFilter" : "skylos.filterFindings",
             };
             return item;
         }
-        if (element instanceof CategoryNode) {
-            const item = new vscode.TreeItem(`${element.label} (${element.findings.length})`, vscode.TreeItemCollapsibleState.Collapsed);
-            item.iconPath = new vscode.ThemeIcon(CATEGORY_ICONS[element.category]);
+        if (element instanceof SectionNode) {
+            const item = new vscode.TreeItem(`${element.label} (${element.findings.length})`, vscode.TreeItemCollapsibleState.Expanded);
+            item.iconPath = new vscode.ThemeIcon(element.icon);
+            item.description = element.description;
             return item;
         }
-        if (element instanceof FileNode) {
-            const fileName = path.basename(element.filePath);
-            const item = new vscode.TreeItem(`${fileName} (${element.findings.length})`, vscode.TreeItemCollapsibleState.Collapsed);
-            item.iconPath = vscode.ThemeIcon.File;
-            item.description = path.dirname(element.filePath);
-            item.resourceUri = vscode.Uri.file(element.filePath);
+        if (element instanceof InfoNode) {
+            const item = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.None);
+            item.iconPath = new vscode.ThemeIcon(element.command ? "play" : "info");
+            item.description = element.description;
+            if (element.command) {
+                item.command = { title: element.label, command: element.command };
+            }
             return item;
         }
         const f = element.finding;
-        const item = new vscode.TreeItem(`L${f.line}: ${f.message}`, vscode.TreeItemCollapsibleState.None);
+        const item = new vscode.TreeItem(buildFindingLabel(f), vscode.TreeItemCollapsibleState.None);
         item.iconPath = getSeverityIcon(f.severity);
-        item.tooltip = `[${f.ruleId}] ${f.message}`;
-        item.contextValue = "skylosFinding";
+        item.description = buildFindingDescription(f, getReviewContext(this.store.lastScan));
+        item.tooltip = buildFindingTooltip(f, getReviewContext(this.store.lastScan));
+        item.contextValue = f.fixPatch ? "skylosFindingSafeFix" : "skylosFinding";
+        item.resourceUri = vscode.Uri.file(f.file);
         item.command = {
             title: "Go to finding",
             command: "vscode.open",
@@ -109,43 +130,33 @@ class SkylosTreeProvider {
             const summary = this.store.getVisibleSummary((0, config_1.getMaxTreeFindings)(), {
                 maxPerFile: (0, config_1.getMaxTreeFindingsPerFile)(),
             });
-            const all = this.store.getVisibleFindings((0, config_1.getMaxTreeFindings)(), {
+            const context = getReviewContext(this.store.lastScan);
+            const findings = (0, reviewCore_1.sortReviewQueue)(this.store.getVisibleFindings((0, config_1.getMaxTreeFindings)(), {
                 maxPerFile: (0, config_1.getMaxTreeFindingsPerFile)(),
-            });
-            const byCategory = new Map();
-            for (const f of all) {
-                const list = byCategory.get(f.category) ?? [];
-                list.push(f);
-                byCategory.set(f.category, list);
-            }
-            const nodes = [];
-            const order = ["security", "secrets", "debt", "dead_code", "quality", "ai"];
-            for (const cat of order) {
-                const findings = byCategory.get(cat);
-                if (findings && findings.length > 0) {
-                    nodes.push(new CategoryNode(cat, CATEGORY_LABELS[cat], findings));
+            }), context);
+            const allFindings = this.store.getAllFindings();
+            const impact = (0, reviewCore_1.ciImpact)(allFindings, context);
+            const nodes = [
+                new SummaryNode(summary.workingTotal, summary.visibleTotal, summary.rawTotal, this.store.hasActiveFilter, this.store.lastScan, this.store.lastError, impact),
+            ];
+            nodes.push(buildStatusNode(this.store.lastScan, this.store.lastError, allFindings));
+            if (findings.length === 0) {
+                if (this.store.lastError) {
+                    nodes.push(new InfoNode("Run Doctor", "Check the Skylos CLI setup", "skylos.doctor"));
                 }
+                else {
+                    nodes.push(new InfoNode("Scan Workspace", "Populate the Skylos review queue", "skylos.scan"));
+                }
+                return nodes;
             }
-            return [new SummaryNode(summary.workingTotal, summary.visibleTotal, summary.rawTotal, this.store.hasActiveFilter), ...nodes];
+            nodes.push(...buildReviewSections(findings, context));
+            return nodes;
         }
-        if (element instanceof SummaryNode) {
+        if (element instanceof SummaryNode || element instanceof InfoNode) {
             return [];
         }
-        if (element instanceof CategoryNode) {
-            const byFile = new Map();
-            for (const f of element.findings) {
-                const list = byFile.get(f.file) ?? [];
-                list.push(f);
-                byFile.set(f.file, list);
-            }
-            return [...byFile.entries()]
-                .sort((a, b) => compareFileBuckets(a[1], b[1]))
-                .map(([filePath, findings]) => new FileNode(filePath, findings));
-        }
-        if (element instanceof FileNode) {
-            return element.findings
-                .sort(compareFindingsInTree)
-                .map((f) => new FindingNode(f));
+        if (element instanceof SectionNode) {
+            return element.findings.map((f) => new FindingNode(f));
         }
         return [];
     }
@@ -155,6 +166,135 @@ class SkylosTreeProvider {
     }
 }
 exports.SkylosTreeProvider = SkylosTreeProvider;
+function buildStatusNode(lastScan, lastError, findings) {
+    const staticLabel = lastError ? "Static scan failed" : lastScan ? "Static scan complete" : "Static scan pending";
+    const automationOn = findings.some((finding) => (finding.sources ?? [finding.source]).includes("agent"));
+    const aiOn = (0, config_1.isRealtimeAIEnabled)();
+    return new InfoNode(staticLabel, `Automation: ${automationOn ? "On" : "Off"} · AI Assist: ${aiOn ? "On" : "Off"}`, lastError ? "skylos.doctor" : undefined);
+}
+function buildReviewSections(findings, context) {
+    const blockers = findings.filter((finding) => isBlockerFinding(finding, context));
+    const blockerKeys = new Set(blockers.map(findingKey));
+    const needsReview = findings.filter((finding) => !blockerKeys.has(findingKey(finding)) && isNeedsReviewFinding(finding, context));
+    const reviewKeys = new Set(needsReview.map(findingKey));
+    const safeFixes = findings.filter((finding) => finding.fixPatch && !blockerKeys.has(findingKey(finding)) && !reviewKeys.has(findingKey(finding)));
+    const used = new Set([...blockers, ...needsReview, ...safeFixes].map(findingKey));
+    const later = findings.filter((finding) => !used.has(findingKey(finding)));
+    const sections = [];
+    if (blockers.length > 0) {
+        sections.push(new SectionNode(blockers, "Blockers", "Likely to fail CI or expose security risk", "flame"));
+    }
+    if (needsReview.length > 0) {
+        sections.push(new SectionNode(needsReview, "Needs Review", "Important findings without a safe automatic fix", "eye"));
+    }
+    if (safeFixes.length > 0) {
+        sections.push(new SectionNode(safeFixes, "Fixable", "Engine-backed patch available", "diff"));
+    }
+    if (later.length > 0) {
+        sections.push(new SectionNode(later, sections.length === 0 ? "Review Queue" : "Review Later", "Lower-risk quality and dead-code findings", "list-ordered"));
+    }
+    return sections;
+}
+function isBlockerFinding(finding, context) {
+    const severity = finding.severity.toUpperCase();
+    return (0, reviewCore_1.isLikelyCiBlocker)(finding)
+        || severity === "CRITICAL"
+        || finding.category === "secrets"
+        || (finding.category === "security" && severity === "HIGH")
+        || ((0, provenanceCore_1.isCorroborated)(finding) && (severity === "HIGH" || severity === "CRITICAL"));
+}
+function isNeedsReviewFinding(finding, context) {
+    const severity = finding.severity.toUpperCase();
+    return finding.file === context.currentFile
+        || finding.isNew === true
+        || finding.baselineStatus === "new"
+        || (0, provenanceCore_1.isCorroborated)(finding)
+        || severity === "HIGH"
+        || finding.category === "security"
+        || severity === "MEDIUM"
+        || severity === "WARN";
+}
+function findingKey(finding) {
+    return finding.fingerprint ?? `${finding.ruleId}:${finding.file}:${finding.line}:${finding.message}`;
+}
+function buildFindingLabel(finding) {
+    return `${finding.severity} ${finding.ruleId}: ${shorten(finding.message, 72)}`;
+}
+function buildFindingDescription(finding, context) {
+    const file = `${path.basename(finding.file)}:${finding.line}`;
+    const badges = buildFindingBadges(finding, context);
+    return badges.length > 0 ? `${file}  ${badges.join(" ")}` : file;
+}
+function buildFindingBadges(finding, context) {
+    const badges = [];
+    if (finding.file === context.currentFile)
+        badges.push("current");
+    if ((0, provenanceCore_1.isCorroborated)(finding))
+        badges.push("Confirmed");
+    if ((0, reviewCore_1.isLikelyCiBlocker)(finding))
+        badges.push("ci");
+    if (finding.isNew || finding.baselineStatus === "new")
+        badges.push("new");
+    if (finding.fixPatch)
+        badges.push("fix");
+    if ((0, reviewCore_1.hasEvidence)(finding))
+        badges.push("evidence");
+    if (finding.confidence !== undefined)
+        badges.push(`${finding.confidence}%`);
+    badges.push((0, provenanceCore_1.sourceSummary)(finding));
+    badges.push(CATEGORY_LABELS[finding.category] ?? finding.category);
+    return badges;
+}
+function buildFindingTooltip(finding, context) {
+    const lines = [
+        `[${finding.ruleId}] ${finding.message}`,
+        `Severity: ${finding.severity}`,
+        `Category: ${CATEGORY_LABELS[finding.category] ?? finding.category}`,
+        `Source: ${(0, provenanceCore_1.isCorroborated)(finding) ? `Confirmed by ${(0, provenanceCore_1.sourceSummary)(finding)}` : (0, provenanceCore_1.sourceSummary)(finding)}`,
+        `Location: ${finding.relativePath ?? finding.file}:${finding.line}`,
+        "",
+        "Why ranked here:",
+        ...(0, reviewCore_1.priorityReasons)(finding, context).map((reason) => `- ${reason}`),
+    ];
+    if (finding.confidence !== undefined)
+        lines.push(`Confidence: ${finding.confidence}%`);
+    if (finding.isNew || finding.baselineStatus)
+        lines.push(`Baseline: ${finding.baselineStatus ?? "new"}`);
+    if (finding.fixPatch)
+        lines.push("Engine fix: preview available");
+    if ((0, reviewCore_1.hasEvidence)(finding))
+        lines.push("Evidence: attached");
+    return lines.join("\n");
+}
+function buildSummaryTooltip(node) {
+    const lines = [
+        `Visible: ${node.visibleTotal}`,
+        `In current scope: ${node.workingTotal}`,
+        `Raw total: ${node.rawTotal}`,
+    ];
+    if (node.impact) {
+        lines.push("", node.impact.headline);
+        for (const reason of node.impact.reasons)
+            lines.push(`- ${reason}`);
+    }
+    if (node.lastScan) {
+        lines.push(`Last command: ${node.lastScan.command}`);
+        if (node.lastScan.durationMs !== undefined) {
+            lines.push(`Duration: ${Math.round(node.lastScan.durationMs / 100) / 10}s`);
+        }
+    }
+    if (node.lastError) {
+        lines.push(`Last error: ${node.lastError.message}`);
+    }
+    return lines.join("\n");
+}
+function getReviewContext(lastScan) {
+    return {
+        currentFile: vscode.window.activeTextEditor?.document.uri.fsPath,
+        visibleFiles: vscode.window.visibleTextEditors.map((editor) => editor.document.uri.fsPath),
+        diffBase: lastScan?.diffBase,
+    };
+}
 function getSeverityIcon(severity) {
     const s = severity.toUpperCase();
     if (s === "CRITICAL" || s === "HIGH") {
@@ -165,34 +305,8 @@ function getSeverityIcon(severity) {
     }
     return new vscode.ThemeIcon("info", new vscode.ThemeColor("editorInfo.foreground"));
 }
-function compareFileBuckets(a, b) {
-    const severityDelta = maxSeverityRank(b) - maxSeverityRank(a);
-    if (severityDelta !== 0)
-        return severityDelta;
-    return b.length - a.length || a[0].file.localeCompare(b[0].file);
-}
-function compareFindingsInTree(a, b) {
-    const severityDelta = severityRank(b.severity) - severityRank(a.severity);
-    if (severityDelta !== 0)
-        return severityDelta;
-    return a.line - b.line || a.message.localeCompare(b.message);
-}
-function maxSeverityRank(findings) {
-    return findings.reduce((max, finding) => Math.max(max, severityRank(finding.severity)), 0);
-}
-function severityRank(severity) {
-    switch (severity.toUpperCase()) {
-        case "CRITICAL":
-            return 5;
-        case "HIGH":
-            return 4;
-        case "MEDIUM":
-        case "WARN":
-            return 3;
-        case "LOW":
-            return 2;
-        case "INFO":
-        default:
-            return 1;
-    }
+function shorten(value, max) {
+    if (value.length <= max)
+        return value;
+    return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}...`;
 }

--- a/editors/vscode/out/statusbar.js
+++ b/editors/vscode/out/statusbar.js
@@ -32,6 +32,14 @@ class SkylosStatusBar {
         const counts = this.store.countBySeverity();
         const total = Object.values(counts).reduce((s, n) => s + n, 0);
         const summary = this.store.getVisibleSummary((0, config_1.getMaxProblems)());
+        const lastError = this.store.lastError;
+        if (lastError) {
+            this.item.text = "$(warning) Skylos";
+            this.item.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
+            this.item.color = undefined;
+            this.item.tooltip = `Last Skylos scan failed: ${lastError.message}\nClick to open Security Dashboard`;
+            return;
+        }
         if (total === 0) {
             this.item.text = "$(shield) Skylos";
             this.item.backgroundColor = undefined;
@@ -58,7 +66,10 @@ class SkylosStatusBar {
         const scopeLine = summary.visibleTotal < summary.workingTotal
             ? `Showing top ${summary.visibleTotal} of ${summary.workingTotal} findings in editor surfaces\n`
             : "";
-        this.item.tooltip = `${scopeLine}Critical: ${critical} | High: ${high} | Medium: ${medium} | Low: ${low}\nClick to open Security Dashboard`;
+        const scanLine = this.store.lastScan?.diffBase
+            ? `Mode: new issues vs ${this.store.lastScan.diffBase}\n`
+            : "";
+        this.item.tooltip = `${scanLine}${scopeLine}Critical: ${critical} | High: ${high} | Medium: ${medium} | Low: ${low}\nClick to open Security Dashboard`;
     }
     dispose() {
         this.disposables.forEach((d) => d.dispose());

--- a/editors/vscode/out/store.js
+++ b/editors/vscode/out/store.js
@@ -2,10 +2,13 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FindingsStore = void 0;
 const vscode = require("vscode");
+const provenanceCore_1 = require("./provenanceCore");
+const reviewCore_1 = require("./reviewCore");
 class FindingsStore {
     constructor() {
         this.workspaceCliFindingsByFile = new Map();
         this.focusedCliFindingsByFile = new Map();
+        this.agentFindingsByFile = new Map();
         this.aiFindingsByFile = new Map();
         this._circularDeps = [];
         this._depVulns = [];
@@ -30,16 +33,37 @@ class FindingsStore {
         this.focusedCliFindingsByFile.set(filePath, findings);
         this._onDidChange.fire();
     }
+    setAgentFindings(findings) {
+        this.agentFindingsByFile.clear();
+        for (const f of findings) {
+            const list = this.agentFindingsByFile.get(f.file) ?? [];
+            list.push(f);
+            this.agentFindingsByFile.set(f.file, list);
+        }
+        this._onDidChange.fire();
+    }
     setEngineMetadata(grade, summary, circularDeps, depVulns) {
         this._grade = grade;
         this._summary = summary;
         this._circularDeps = circularDeps ?? [];
         this._depVulns = depVulns ?? [];
+        this._onDidChange.fire();
+    }
+    setLastScan(metadata) {
+        this._lastScan = metadata;
+        this._lastError = undefined;
+        this._onDidChange.fire();
+    }
+    setLastError(error) {
+        this._lastError = error;
+        this._onDidChange.fire();
     }
     get grade() { return this._grade; }
     get summary() { return this._summary; }
     get circularDeps() { return this._circularDeps; }
     get depVulns() { return this._depVulns; }
+    get lastScan() { return this._lastScan; }
+    get lastError() { return this._lastError; }
     get deltaMode() { return this._deltaMode; }
     set deltaMode(v) { this._deltaMode = v; }
     get filter() { return this._filter; }
@@ -58,6 +82,7 @@ class FindingsStore {
         else {
             this.aiFindingsByFile.set(filePath, findings);
         }
+        this._onDidChange.fire();
         this._onDidChangeAI.fire();
     }
     getFindingsForFile(filePath, options) {
@@ -69,7 +94,11 @@ class FindingsStore {
         return findings;
     }
     getAllRawFindings() {
-        return [...this.getCurrentCLIFindings(), ...this.getAIFindings()];
+        return (0, provenanceCore_1.mergeCorrelatedFindings)([
+            ...this.getCurrentCLIFindings(),
+            ...this.getAgentFindings(),
+            ...this.getAIFindings(),
+        ]);
     }
     getAllFindings() {
         return this.getFindingsByScope("working");
@@ -147,11 +176,14 @@ class FindingsStore {
     clear() {
         this.workspaceCliFindingsByFile.clear();
         this.focusedCliFindingsByFile.clear();
+        this.agentFindingsByFile.clear();
         this.aiFindingsByFile.clear();
         this._grade = undefined;
         this._summary = undefined;
         this._circularDeps = [];
         this._depVulns = [];
+        this._lastScan = undefined;
+        this._lastError = undefined;
         this._onDidChange.fire();
         this._onDidChangeAI.fire();
     }
@@ -171,8 +203,12 @@ class FindingsStore {
     }
     getQueriedFindings(options) {
         let findings = this.getAllRawFindings();
-        if (options?.source) {
-            findings = findings.filter((f) => f.source === options.source);
+        if (options?.source === "confirmed") {
+            findings = findings.filter(provenanceCore_1.isCorroborated);
+        }
+        else if (options?.source) {
+            const source = options.source;
+            findings = findings.filter((f) => (f.sources ?? [f.source]).includes(source));
         }
         if (options?.includeDeadCode === false) {
             findings = findings.filter((f) => f.category !== "dead_code");
@@ -185,7 +221,7 @@ class FindingsStore {
             return false;
         if (f.category && finding.category !== f.category)
             return false;
-        if (f.source && finding.source !== f.source)
+        if (f.source && !(0, provenanceCore_1.matchesSourceFilter)(finding, f.source))
             return false;
         if (f.filePattern && !finding.file.toLowerCase().includes(f.filePattern.toLowerCase()))
             return false;
@@ -215,6 +251,12 @@ class FindingsStore {
             all.push(...list);
         return all;
     }
+    getAgentFindings() {
+        const all = [];
+        for (const list of this.agentFindingsByFile.values())
+            all.push(...list);
+        return all;
+    }
 }
 exports.FindingsStore = FindingsStore;
 function sortFindingsForDisplay(findings) {
@@ -229,46 +271,14 @@ function sortFindingsForDisplay(findings) {
 }
 function sortFindingsInFile(findings) {
     return [...findings].sort((a, b) => {
-        const sevDelta = severityRank(b.severity) - severityRank(a.severity);
+        const sevDelta = (0, reviewCore_1.severityRank)(b.severity) - (0, reviewCore_1.severityRank)(a.severity);
         if (sevDelta !== 0)
             return sevDelta;
         return a.line - b.line || a.message.localeCompare(b.message);
     });
 }
 function getDisplayScore(finding, activeFile, visibleFiles) {
-    let score = severityRank(finding.severity) * 100;
-    if (finding.file === activeFile) {
-        score += 100000;
-    }
-    else if (visibleFiles.has(finding.file)) {
-        score += 50000;
-    }
-    if (finding.category === "security" || finding.category === "secrets") {
-        score += 500;
-    }
-    if (finding.source === "cli") {
-        score += 50;
-    }
-    if (finding.confidence !== undefined) {
-        score += Math.min(99, finding.confidence);
-    }
-    return score;
-}
-function severityRank(severity) {
-    switch (severity.toUpperCase()) {
-        case "CRITICAL":
-            return 5;
-        case "HIGH":
-            return 4;
-        case "MEDIUM":
-        case "WARN":
-            return 3;
-        case "LOW":
-            return 2;
-        case "INFO":
-        default:
-            return 1;
-    }
+    return (0, reviewCore_1.reviewScore)(finding, { currentFile: activeFile, visibleFiles });
 }
 function limitFindings(findings, maxTotal, maxPerFile) {
     if (!Number.isFinite(maxTotal) || maxTotal <= 0) {

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,20 +1,550 @@
 {
   "name": "skylos-vscode-extension",
-  "version": "0.2.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skylos-vscode-extension",
-      "version": "0.2.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.87.0",
+        "@vscode/vsce": "^3.9.1",
         "typescript": "^5.0.0"
       },
       "engines": {
         "vscode": "^1.87.0"
+      }
+    },
+    "node_modules/@azu/format-text": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+      "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@azu/style-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+      "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "@azu/format-text": "^1.0.1"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.9.0.tgz",
+      "integrity": "sha512-CzE+4PefDSJWj26zU7G1bKchlGRRHMBFreG4tAlGuzyI8hAPiYGobaJvZBgZBf6L63iphX7VH+ityL8VgEQz9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.5.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.5.2",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@secretlint/config-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+      "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/config-loader": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+      "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "ajv": "^8.17.1",
+        "debug": "^4.4.1",
+        "rc-config-loader": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "structured-source": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/formatter": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+      "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "@textlint/linter-formatter": "^15.2.0",
+        "@textlint/module-interop": "^15.2.0",
+        "@textlint/types": "^15.2.0",
+        "chalk": "^5.4.1",
+        "debug": "^4.4.1",
+        "pluralize": "^8.0.0",
+        "strip-ansi": "^7.1.0",
+        "table": "^6.9.0",
+        "terminal-link": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/formatter/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@secretlint/node": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+      "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-loader": "^10.2.2",
+        "@secretlint/core": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/source-creator": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "p-map": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/profiler": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+      "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/resolver": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+      "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/secretlint-formatter-sarif": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+      "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-sarif-builder": "^3.2.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-no-dotenv": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+      "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-preset-recommend": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+      "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/source-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+      "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2",
+        "istextorbinary": "^9.5.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/types": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+      "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@textlint/ast-node-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.6.0.tgz",
+      "integrity": "sha512-CxZHFbYAU7J0A4izz31wV2ZZfySR6aVj2OSR6/3tppZm7VV6hM7nA7sutsLwIiBL/v4lsB1RM79l4Dc/VrH4qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.6.0.tgz",
+      "integrity": "sha512-IwHRhjwxs0a5t1eNAoKAdV224CDca38LyopPofXpwO/d0J75wBvzf/cBHXNl4TMsLKhYGtR83UprcLEKj/gZsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azu/format-text": "^1.0.2",
+        "@azu/style-format": "^1.0.1",
+        "@textlint/module-interop": "15.6.0",
+        "@textlint/resolver": "15.6.0",
+        "@textlint/types": "15.6.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "lodash": "^4.18.1",
+        "pluralize": "^2.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "table": "^6.9.0",
+        "text-table": "^0.2.0"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+      "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/module-interop": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.6.0.tgz",
+      "integrity": "sha512-MHY6pJx9i5kOlrvUSK51887tYZjHAV2qnr6unBm7LtBLGDFo93utdYqHyWep8r9QLsilQdeijWtufJI46z4v4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/resolver": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.6.0.tgz",
+      "integrity": "sha512-T1l2Gd3455pwtm0cTewhX/LLy3bL9z6/Fu/am+jj+jjGfXVoknYkjfkZEKrjHlA7xzay0EfUKnu//teYemLeZw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.6.0.tgz",
+      "integrity": "sha512-CvgYb1PiqF4BGyoZebGWzAJCZ4ChJAZ9gtWjpQIMKE4Xe2KlSwDA8m8MsiZIV321f5Ibx38BMjC1Z/2ZYP2GQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "15.6.0"
       }
     },
     "node_modules/@types/node": {
@@ -26,11 +556,3218 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/vscode": {
       "version": "1.104.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz",
       "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
       "dev": true
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vscode/vsce": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
+      "integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@secretlint/node": "^10.1.2",
+        "@secretlint/secretlint-formatter-sarif": "^10.1.2",
+        "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+        "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^4.1.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^12.1.0",
+        "form-data": "^4.0.0",
+        "glob": "^11.0.0",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^14.1.0",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "secretlint": "^10.1.2",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.3",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^3.2.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/binaryextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+      "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/editions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+      "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "version-range": "^4.15.0"
+      },
+      "engines": {
+        "ecmascript": ">= es5",
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istextorbinary": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+      "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "binaryextensions": "^6.11.0",
+        "editions": "^6.21.0",
+        "textextensions": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.91.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.91.0.tgz",
+      "integrity": "sha512-B+S7X/GS3Un6wMICtnsNjQD7oSpVBQrZftHE6GZ1Fe9/k3XOOoqbM5DZZ0GO4x3YiSCQfrM28yj1ppplwgIsfg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-sarif-builder": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sarif": "^2.1.7",
+        "fs-extra": "^11.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc-config-loader": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+      "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/secretlint": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+      "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-creator": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/node": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "debug": "^4.4.1",
+        "globby": "^14.1.0",
+        "read-pkg": "^9.0.1"
+      },
+      "bin": {
+        "secretlint": "bin/secretlint.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/structured-source": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+      "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boundary": "^2.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+      "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "supports-hyperlinks": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/textextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+      "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.2",
@@ -45,11 +3782,216 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/version-range": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+      "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
     }
   }
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "skylos-vscode-extension",
   "displayName": "Skylos",
   "description": "VS Code extension for dead code detection, Python SAST, security scanning, and AI code review for Python, TypeScript, JavaScript, and Go.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "oha",
   "icon": "icon.png",
   "repository": { "type": "git", "url": "https://github.com/duriantaco/skylos" },
@@ -32,21 +32,22 @@
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:go",
-    "onCommand:skylos.scan"
+    "onCommand:skylos.scan",
+    "onCommand:skylos.doctor"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       { "command": "skylos.scan", "title": "Skylos: Scan Workspace", "icon": "$(refresh)" },
-      { "command": "skylos.fix", "title": "Skylos: Fix Issue with AI" },
+      { "command": "skylos.doctor", "title": "Skylos: Doctor", "icon": "$(tools)" },
+      { "command": "skylos.fix", "title": "Skylos: Fix Issue with AI Assist" },
+      { "command": "skylos.previewSafeFix", "title": "Skylos: Preview Engine Fix", "icon": "$(diff)" },
       { "command": "skylos.refresh", "title": "Skylos: Refresh", "icon": "$(refresh)" },
       { "command": "skylos.clear", "title": "Skylos: Clear All Findings", "icon": "$(clear-all)" },
       { "command": "skylos.dismissIssue", "title": "Skylos: Dismiss AI Finding" },
-      { "command": "skylos.removeImport", "title": "Skylos: Remove Unused Import" },
-      { "command": "skylos.removeFunction", "title": "Skylos: Remove Unused Function" },
       { "command": "skylos.addToWhitelist", "title": "Skylos: Add to Whitelist" },
-      { "command": "skylos.fixAll", "title": "Skylos: Auto-Fix All", "icon": "$(wand)" },
-      { "command": "skylos.fixAllDryRun", "title": "Skylos: Auto-Fix Dry Run", "icon": "$(preview)" },
+      { "command": "skylos.fixAll", "title": "Skylos: Auto-Fix All with AI Assist", "icon": "$(wand)" },
+      { "command": "skylos.fixAllDryRun", "title": "Skylos: Auto-Fix AI Assist Dry Run", "icon": "$(preview)" },
       { "command": "skylos.chatAboutFinding", "title": "Skylos: Ask AI About Finding", "icon": "$(comment-discussion)" },
       { "command": "skylos.clearChat", "title": "Skylos: Clear Chat", "icon": "$(clear-all)" },
       { "command": "skylos.dashboard", "title": "Skylos: Security Dashboard", "icon": "$(graph)" },
@@ -54,16 +55,16 @@
       { "command": "skylos.prevFinding", "title": "Skylos: Previous Finding", "icon": "$(arrow-up)" },
       { "command": "skylos.exportReport", "title": "Skylos: Export Report", "icon": "$(export)" },
       { "command": "skylos.scanFile", "title": "Skylos: Scan This File", "icon": "$(file-code)" },
-      { "command": "skylos.toggleDelta", "title": "Skylos: Toggle Delta Mode", "icon": "$(git-compare)" },
+      { "command": "skylos.toggleDelta", "title": "Skylos: Toggle New Issues Only", "icon": "$(git-compare)" },
       { "command": "skylos.showFindingDetail", "title": "Skylos: Show Finding Detail", "icon": "$(info)" },
       { "command": "skylos.filterFindings", "title": "Skylos: Filter Findings", "icon": "$(filter)" },
       { "command": "skylos.clearFilter", "title": "Skylos: Clear Filter", "icon": "$(close)" },
-      { "command": "skylos.refreshCommandCenter", "title": "Skylos: Refresh Command Center", "icon": "$(pulse)" },
-      { "command": "skylos.commandCenterOpenDetail", "title": "Skylos: Open Command Center Detail", "icon": "$(info)" },
-      { "command": "skylos.commandCenterApplySafeFix", "title": "Skylos: Apply Command Center Safe Fix", "icon": "$(wrench)" },
-      { "command": "skylos.commandCenterDismiss", "title": "Skylos: Dismiss Command Center Action", "icon": "$(close)" },
-      { "command": "skylos.commandCenterSnooze", "title": "Skylos: Snooze Command Center Action", "icon": "$(clock)" },
-      { "command": "skylos.commandCenterRestoreTriaged", "title": "Skylos: Restore Triaged Command Center Action", "icon": "$(history)" },
+      { "command": "skylos.refreshCommandCenter", "title": "Skylos: Refresh Automation", "icon": "$(pulse)" },
+      { "command": "skylos.commandCenterOpenDetail", "title": "Skylos: Open Automation Detail", "icon": "$(info)" },
+      { "command": "skylos.commandCenterApplySafeFix", "title": "Skylos: Preview Automation Fix", "icon": "$(diff)" },
+      { "command": "skylos.commandCenterDismiss", "title": "Skylos: Dismiss Automation Action", "icon": "$(close)" },
+      { "command": "skylos.commandCenterSnooze", "title": "Skylos: Snooze Automation Action", "icon": "$(clock)" },
+      { "command": "skylos.commandCenterRestoreTriaged", "title": "Skylos: Restore Automation Action", "icon": "$(history)" },
       { "command": "skylos.fixDeadCode", "title": "Skylos: Preview Dead Code Removal", "icon": "$(trash)" }
     ],
     "viewsContainers": {
@@ -79,12 +80,12 @@
       "skylos": [
         {
           "id": "skylosFindings",
-          "name": "Findings",
-          "icon": "$(shield)"
+          "name": "Review Queue",
+          "icon": "$(list-ordered)"
         },
         {
           "id": "skylosCommandCenter",
-          "name": "Command Center",
+          "name": "Automation Activity",
           "icon": "$(pulse)"
         },
         {
@@ -97,9 +98,7 @@
     "menus": {
       "view/title": [
         { "command": "skylos.refresh", "when": "view == skylosFindings", "group": "navigation" },
-        { "command": "skylos.clear", "when": "view == skylosFindings", "group": "navigation" },
-        { "command": "skylos.fixAll", "when": "view == skylosFindings", "group": "navigation" },
-        { "command": "skylos.dashboard", "when": "view == skylosFindings", "group": "navigation" },
+        { "command": "skylos.doctor", "when": "view == skylosFindings", "group": "navigation" },
         { "command": "skylos.toggleDelta", "when": "view == skylosFindings", "group": "navigation" },
         { "command": "skylos.filterFindings", "when": "view == skylosFindings", "group": "navigation" },
         { "command": "skylos.clearFilter", "when": "view == skylosFindings && skylos.filterActive", "group": "navigation" },
@@ -109,7 +108,10 @@
       ],
       "view/item/context": [
         { "command": "skylos.showFindingDetail", "when": "viewItem == skylosFinding", "group": "inline" },
+        { "command": "skylos.showFindingDetail", "when": "viewItem == skylosFindingSafeFix", "group": "inline" },
+        { "command": "skylos.previewSafeFix", "when": "viewItem == skylosFindingSafeFix", "group": "inline" },
         { "command": "skylos.chatAboutFinding", "when": "viewItem == skylosFinding", "group": "inline" },
+        { "command": "skylos.chatAboutFinding", "when": "viewItem == skylosFindingSafeFix", "group": "inline" },
         { "command": "skylos.commandCenterOpenDetail", "when": "view == skylosCommandCenter && viewItem == skylosCommandCenterAction", "group": "inline" },
         { "command": "skylos.commandCenterOpenDetail", "when": "view == skylosCommandCenter && viewItem == skylosCommandCenterActionSafeFix", "group": "inline" },
         { "command": "skylos.commandCenterApplySafeFix", "when": "view == skylosCommandCenter && viewItem == skylosCommandCenterActionSafeFix", "group": "inline" },
@@ -152,11 +154,52 @@
     "viewsWelcome": [
       {
         "view": "skylosFindings",
-        "contents": "No security findings yet.\n[Run Scan](command:skylos.scan)\n[Open Settings](command:workbench.action.openSettings?%5B%22skylos%22%5D)"
+        "contents": "No Skylos issues in the review queue yet.\n[Run Scan](command:skylos.scan)\n[Run Doctor](command:skylos.doctor)\n[Open Settings](command:workbench.action.openSettings?%5B%22skylos%22%5D)"
       },
       {
         "view": "skylosCommandCenter",
-        "contents": "No active command center state yet.\n[Refresh Command Center](command:skylos.refreshCommandCenter)\nRun `skylos agent watch .` in a terminal for continuous updates.\n[Restore Triaged Actions](command:skylos.commandCenterRestoreTriaged)"
+        "contents": "Optional repo-level automation. Static scans work without this.\n[Refresh Automation](command:skylos.refreshCommandCenter)\nFor continuous triage, run `skylos agent watch .` in a terminal.\n[Restore Triaged Actions](command:skylos.commandCenterRestoreTriaged)"
+      }
+    ],
+    "walkthroughs": [
+      {
+        "id": "skylos.setup",
+        "title": "Get Started with Skylos",
+        "description": "Validate the Skylos CLI, run a scan, and review the highest-value issues first.",
+        "steps": [
+          {
+            "id": "skylos.setup.doctor",
+            "title": "Check the Skylos CLI",
+            "description": "Run Doctor to verify the configured Skylos executable, workspace, and version output before relying on scan results.\n[Run Doctor](command:skylos.doctor)",
+            "completionEvents": [
+              "onCommand:skylos.doctor"
+            ]
+          },
+          {
+            "id": "skylos.setup.scan",
+            "title": "Run your first scan",
+            "description": "Scan the workspace and populate the Skylos Review Queue with security, quality, secrets, and dead-code findings.\n[Scan Workspace](command:skylos.scan)",
+            "completionEvents": [
+              "onCommand:skylos.scan"
+            ]
+          },
+          {
+            "id": "skylos.setup.newIssues",
+            "title": "Focus on new issues",
+            "description": "For legacy repos, switch to New Issues mode so Skylos prioritizes findings introduced since your configured base branch.\n[Toggle New Issues Only](command:skylos.toggleDelta)",
+            "completionEvents": [
+              "onCommand:skylos.toggleDelta"
+            ]
+          },
+          {
+            "id": "skylos.setup.privacy",
+            "title": "Choose AI privacy settings",
+            "description": "Static analysis runs locally and does not need AI. Optional AI features only run when you explicitly use AI commands or enable `skylos.enableRealtimeAI`.\n[Open Skylos AI Settings](command:workbench.action.openSettings?%5B%22skylos.enableRealtimeAI%22%5D)",
+            "completionEvents": [
+              "onSettingChanged:skylos.enableRealtimeAI"
+            ]
+          }
+        ]
       }
     ],
     "configuration": {
@@ -245,6 +288,38 @@
           "maximum": 250,
           "description": "Maximum findings per file to decorate inline with hover/code lenses"
         },
+        "skylos.editorSignalLevel": {
+          "type": "string",
+          "enum": [
+            "quiet",
+            "balanced",
+            "verbose"
+          ],
+          "default": "quiet",
+          "enumDescriptions": [
+            "Minimal editor noise. Inline messages only for critical/high issues; other findings stay in Problems, hover, and Review Queue.",
+            "Show concise inline messages for security and quality issues; keep dead code quiet.",
+            "Show all inline messages, including dead code and low-severity findings."
+          ],
+          "description": "Controls how much Skylos renders directly in the editor"
+        },
+        "skylos.codeLensMode": {
+          "type": "string",
+          "enum": [
+            "off",
+            "activeLine",
+            "highValue",
+            "all"
+          ],
+          "default": "highValue",
+          "enumDescriptions": [
+            "Disable Skylos CodeLens actions.",
+            "Show Skylos CodeLens actions only for findings on the active line.",
+            "Show CodeLens actions only for high-risk, AI, or engine-fixable findings.",
+            "Show all Skylos CodeLens actions."
+          ],
+          "description": "Controls how often Skylos action CodeLens entries appear above code"
+        },
         "skylos.showDeadCodeInProblems": {
           "type": "boolean",
           "default": false,
@@ -255,17 +330,17 @@
           "default": 10,
           "minimum": 3,
           "maximum": 50,
-          "description": "Maximum ranked actions to show in the Command Center view"
+          "description": "Maximum ranked actions to show in the optional Automation Activity view"
         },
         "skylos.commandCenterRefreshOnOpen": {
           "type": "boolean",
           "default": false,
-          "description": "Refresh the repo-level Command Center when the extension loads"
+          "description": "Refresh the optional repo-level Automation Activity when the extension loads"
         },
         "skylos.commandCenterRefreshOnSave": {
           "type": "boolean",
           "default": false,
-          "description": "Refresh the repo-level Command Center after saving a supported file"
+          "description": "Refresh the optional repo-level Automation Activity after saving a supported file"
         },
         "skylos.commandCenterStateFile": {
           "type": "string",
@@ -276,7 +351,7 @@
           "type": "number",
           "default": 1000,
           "minimum": 200,
-          "description": "Milliseconds of idle time before AI auto-analysis"
+          "description": "Milliseconds of idle time before optional real-time AI Assist starts"
         },
         "skylos.popupCooldownMs": {
           "type": "number",
@@ -293,7 +368,12 @@
             "Anthropic (cloud)",
             "Local AI server (Ollama, LM Studio, LocalAI, vLLM — any OpenAI-compatible endpoint)"
           ],
-          "description": "AI provider for code analysis and fixes"
+          "description": "AI Assist provider for optional analysis and fixes"
+        },
+        "skylos.enableRealtimeAI": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run AI Assist automatically as you edit. Static scans, Review Queue, and engine-backed findings work with this off."
         },
         "skylos.openaiBaseUrl": {
           "type": "string",
@@ -332,8 +412,8 @@
         },
         "skylos.streamingInline": {
           "type": "boolean",
-          "default": true,
-          "description": "Show streaming inline ghost text during AI analysis"
+          "default": false,
+          "description": "Show streaming inline ghost text when optional real-time AI Assist is enabled"
         },
         "skylos.enableDeadCode": {
           "type": "boolean",
@@ -360,12 +440,12 @@
         "skylos.fixPreviewFirst": {
           "type": "boolean",
           "default": true,
-          "description": "Always show a diff preview before applying AI fixes"
+          "description": "Always show a diff preview before applying AI Assist fixes"
         },
         "skylos.postFixCommand": {
           "type": "string",
           "default": "",
-          "description": "Shell command to run after applying an AI fix (e.g. 'npm test', 'pytest -x'). Leave empty to skip."
+          "description": "Shell command to run after applying an AI Assist fix (e.g. 'npm test', 'pytest -x'). Leave empty to skip."
         }
       }
     }
@@ -373,11 +453,13 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
+    "test": "npm run compile && node --test test/*.test.js",
     "package": "vsce package"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.87.0",
+    "@vscode/vsce": "^3.9.1",
     "typescript": "^5.0.0"
   }
 }

--- a/editors/vscode/src/ai.ts
+++ b/editors/vscode/src/ai.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as crypto from "crypto";
 import type { FindingsStore } from "./store";
 import type { SkylosFinding, AIIssue, FunctionBlock, AIProvider } from "./types";
-import { getAIProvider, getAIApiKey, getAIModel, getOpenAIBaseUrl, getPopupCooldownMs, isStreamingEnabled, isFixPreviewFirst, getPostFixCommand } from "./config";
+import { getAIProvider, getAIApiKey, getAIModel, getOpenAIBaseUrl, getPopupCooldownMs, isStreamingEnabled, isFixPreviewFirst, getPostFixCommand, isRealtimeAIEnabled } from "./config";
 import { out } from "./scanner";
 
 
@@ -28,6 +28,9 @@ export class AIAnalyzer {
   }
 
   async maybeAnalyze(document: vscode.TextDocument): Promise<void> {
+    if (!isRealtimeAIEnabled())
+      return;
+
     const apiKey = getAIApiKey();
     if (!apiKey) 
       return;
@@ -150,7 +153,7 @@ export class AIAnalyzer {
         this.streamingManager?.clearAll();
         return;
       }
-      out.appendLine(`AI Error: ${err}`);
+      out.appendLine(`AI Assist failed. Static scan results are unaffected: ${formatAIError(err)}`);
       if (this.statusBar) this.statusBar.text = prevText;
     } finally {
       this.inFlight = false;
@@ -199,6 +202,10 @@ export class AIAnalyzer {
   }
 }
 
+function formatAIError(err: unknown): string {
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}
 
 export function extractFunctions(code: string, langId: string): FunctionBlock[] {
   if (langId === "python") 
@@ -548,11 +555,11 @@ export async function fixWithAI(
   if (!apiKey) {
     let msg: string;
     if (provider === "anthropic") {
-      msg = "Set skylos.anthropicApiKey first.";
+      msg = "AI Fix needs a provider. Set skylos.anthropicApiKey or use engine fixes when available.";
     } else if (provider === "local") {
-      msg = "Set skylos.localBaseUrl to your local AI server (e.g. http://localhost:11434 for Ollama) and skylos.localModel to the model name.";
+      msg = "AI Fix needs a provider. Set skylos.localBaseUrl and skylos.localModel, or use engine fixes when available.";
     } else {
-      msg = 'Set skylos.openaiApiKey, or switch aiProvider to "local" and configure skylos.localBaseUrl.';
+      msg = 'AI Fix needs a provider. Set skylos.openaiApiKey, configure local AI Assist, or use engine fixes when available.';
     }
     vscode.window.showErrorMessage(msg);
     return;

--- a/editors/vscode/src/automationCore.ts
+++ b/editors/vscode/src/automationCore.ts
@@ -1,0 +1,5 @@
+export function normalizeAutomationLine(value: unknown): number {
+  const line = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(line) || line < 1) return 1;
+  return Math.floor(line);
+}

--- a/editors/vscode/src/codelens.ts
+++ b/editors/vscode/src/codelens.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 import type { FindingsStore } from "./store";
 import { getDocumentFilters } from "./types";
-import { getMaxDecorationsPerFile } from "./config";
+import { getCodeLensMode, getMaxDecorationsPerFile } from "./config";
+import { isDeadCodeRule } from "./findingCore";
 
 export class SkylosCodeLensProvider implements vscode.CodeLensProvider {
   private _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
@@ -12,6 +13,11 @@ export class SkylosCodeLensProvider implements vscode.CodeLensProvider {
     this.disposables.push(
       store.onDidChange(() => this._onDidChangeCodeLenses.fire()),
       store.onDidChangeAI(() => this._onDidChangeCodeLenses.fire()),
+      vscode.window.onDidChangeTextEditorSelection(() => {
+        if (getCodeLensMode() === "activeLine") {
+          this._onDidChangeCodeLenses.fire();
+        }
+      }),
     );
   }
 
@@ -21,45 +27,49 @@ export class SkylosCodeLensProvider implements vscode.CodeLensProvider {
 
   provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
     const lenses: vscode.CodeLens[] = [];
+    const mode = getCodeLensMode();
+    if (mode === "off") return lenses;
+
     const findings = this.store.getFindingsForFile(document.uri.fsPath, { max: getMaxDecorationsPerFile() });
+    const activeEditor = vscode.window.activeTextEditor;
+    const activeLine = activeEditor?.document.uri.fsPath === document.uri.fsPath
+      ? activeEditor.selection.active.line
+      : undefined;
 
     for (const f of findings) {
       const line = Math.max(0, f.line - 1);
       if (line >= document.lineCount) 
         continue;
-      const range = new vscode.Range(line, 0, line, 0);
+      const isActiveLine = activeLine === line;
+      if (mode === "activeLine" && !isActiveLine) {
+        continue;
+      }
 
-      if (f.category === "security" || f.category === "ai") {
+      const range = new vscode.Range(line, 0, line, 0);
+      const showAllActions = mode === "all" || mode === "activeLine";
+      const showHighValueActions = showAllActions || mode === "highValue";
+
+      if (showHighValueActions && (f.category === "security" || f.category === "ai")) {
         lenses.push(
           new vscode.CodeLens(range, {
-            title: "Fix with AI",
+            title: "Fix with AI Assist",
             command: "skylos.fix",
             arguments: [document.uri.fsPath, range, f.message, false],
           }),
         );
       }
 
-      if (f.ruleId === "DEAD-IMPORT") {
+      if (showHighValueActions && f.fixPatch) {
         lenses.push(
           new vscode.CodeLens(range, {
-            title: "Remove Import",
-            command: "skylos.removeImport",
-            arguments: [document.uri, line],
+            title: "Preview Engine Fix",
+            command: "skylos.previewSafeFix",
+            arguments: [f],
           }),
         );
       }
 
-      if (f.ruleId === "DEAD-FUNC") {
-        lenses.push(
-          new vscode.CodeLens(range, {
-            title: "Remove Function",
-            command: "skylos.removeFunction",
-            arguments: [document.uri, line],
-          }),
-        );
-      }
-
-      if (f.ruleId.startsWith("DEAD-")) {
+      if (showAllActions && isDeadCodeRule(f.ruleId)) {
         lenses.push(
           new vscode.CodeLens(range, {
             title: "Ignore",
@@ -69,7 +79,7 @@ export class SkylosCodeLensProvider implements vscode.CodeLensProvider {
         );
       }
 
-      if (f.source === "ai") {
+      if (showHighValueActions && f.source === "ai") {
         lenses.push(
           new vscode.CodeLens(range, {
             title: "\u2715 Dismiss",

--- a/editors/vscode/src/commandcenter.ts
+++ b/editors/vscode/src/commandcenter.ts
@@ -9,6 +9,7 @@ import {
   isCommandCenterRefreshOnOpen,
 } from "./config";
 import { out } from "./scanner";
+import { normalizeAutomationLine } from "./automationCore";
 import type {
   AgentCenterFinding,
   AgentCommandCenterItem,
@@ -96,7 +97,7 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
   async refresh(): Promise<void> {
     const root = this.getWorkspaceRoot();
     if (!root) {
-      vscode.window.showWarningMessage("Skylos: open a folder to use Command Center.");
+      vscode.window.showWarningMessage("Skylos: open a folder to use Automation Activity.");
       return;
     }
 
@@ -107,14 +108,14 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
 
     this.refreshing = true;
     this._onDidChangeTreeData.fire();
-    vscode.window.setStatusBarMessage("Skylos: refreshing Command Center...", 3000);
+    vscode.window.setStatusBarMessage("Skylos: refreshing Automation Activity...", 3000);
 
     try {
       await this.runCommandCenterRefresh(root);
       await this.loadState();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      vscode.window.showErrorMessage(`Skylos Command Center refresh failed: ${msg}`);
+      vscode.window.showErrorMessage(`Automation refresh failed. Static scan results are unaffected. ${msg}`);
     } finally {
       this.refreshing = false;
       this._onDidChangeTreeData.fire();
@@ -138,6 +139,12 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
     return (this.state?.findings ?? []).find((finding) => finding.fingerprint === actionId);
   }
 
+  getQueueFindings(): SkylosFinding[] {
+    return this.getActions()
+      .map((action) => this.toSkylosFinding(action))
+      .filter((finding): finding is SkylosFinding => Boolean(finding));
+  }
+
   toSkylosFinding(action: AgentCommandCenterItem): SkylosFinding | undefined {
     const finding = this.getFindingForAction(action);
     const absoluteFile = action.absolute_file || finding?.absolute_file || resolveActionPath(action.file);
@@ -150,30 +157,35 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
       severity: normalizeSeverity(action.severity || finding?.severity),
       message: action.message || finding?.message || action.title,
       file: absoluteFile,
-      line: Number(action.line || finding?.line || 1),
+      line: normalizeAutomationLine(action.line || finding?.line),
       col: 1,
+      fingerprint: finding?.fingerprint || action.id,
       confidence: finding?.confidence,
-      source: "cli",
+      source: "agent",
+      safeFix: action.safe_fix,
+      fixPatch: action.fix_patch || action.fixPatch || action.patch,
+      baselineStatus: action.baseline_status || finding?.baseline_status,
+      reviewReason: action.reason,
     };
   }
 
   async dismissAction(action: AgentCommandCenterItem): Promise<void> {
-    await this.runTriagingCommand(["dismiss", this.requireWorkspaceRoot(), action.id]);
+    await this.runTriagingCommand(["triage", "dismiss", this.requireWorkspaceRoot(), action.id]);
   }
 
   async snoozeAction(action: AgentCommandCenterItem, hours: number): Promise<void> {
-    await this.runTriagingCommand(["snooze", this.requireWorkspaceRoot(), action.id, "--hours", String(hours)]);
+    await this.runTriagingCommand(["triage", "snooze", this.requireWorkspaceRoot(), action.id, "--hours", String(hours)]);
   }
 
   async restoreAction(actionId: string): Promise<void> {
-    await this.runTriagingCommand(["restore", this.requireWorkspaceRoot(), actionId]);
+    await this.runTriagingCommand(["triage", "restore", this.requireWorkspaceRoot(), actionId]);
   }
 
   getTreeItem(element: CommandCenterNode): vscode.TreeItem {
     if (element instanceof SummaryNode) {
       const summary = element.state.summary;
       const item = new vscode.TreeItem(
-        summary?.headline ?? "Command Center",
+        summary?.headline ?? "Automation Activity",
         vscode.TreeItemCollapsibleState.None,
       );
       item.iconPath = new vscode.ThemeIcon("pulse");
@@ -197,7 +209,7 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
       item.iconPath = new vscode.ThemeIcon(this.refreshing ? "sync~spin" : "circle-slash");
       item.description = element.description;
       if (!this.refreshing) {
-        item.command = { title: "Refresh Command Center", command: "skylos.refreshCommandCenter" };
+        item.command = { title: "Refresh Automation", command: "skylos.refreshCommandCenter" };
       }
       return item;
     }
@@ -212,7 +224,8 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
     item.description = `${action.file}:${action.line}`;
     item.tooltip = buildActionTooltip(action);
     item.iconPath = getActionIcon(action.severity);
-    item.contextValue = action.safe_fix ? "skylosCommandCenterActionSafeFix" : "skylosCommandCenterAction";
+    const hasEnginePatch = Boolean(action.fix_patch || action.fixPatch || action.patch);
+    item.contextValue = hasEnginePatch ? "skylosCommandCenterActionSafeFix" : "skylosCommandCenterAction";
     if (absoluteFile) {
       item.command = {
         title: "Open action target",
@@ -232,18 +245,18 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
     }
 
     if (this.refreshing && !this.state) {
-      return [new EmptyNode("Refreshing Command Center...", "Running repo-level agent analysis")];
+      return [new EmptyNode("Refreshing Automation Activity...", "Running optional repo-level automation")];
     }
 
     if (!this.getWorkspaceRoot()) {
-      return [new EmptyNode("Open a workspace folder to use Command Center")];
+      return [new EmptyNode("Open a workspace folder to use Automation Activity")];
     }
 
     if (!this.state) {
       return [
         new EmptyNode(
-          "No Command Center state yet",
-          "Run Refresh Command Center or `skylos agent watch .`",
+          "No Automation Activity yet",
+          "Optional: refresh once or run `skylos agent watch .`",
         ),
       ];
     }
@@ -324,7 +337,7 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
   private requireWorkspaceRoot(): string {
     const root = this.getWorkspaceRoot();
     if (!root) {
-      throw new Error("Open a workspace folder to use Command Center.");
+      throw new Error("Open a workspace folder to use Automation Activity.");
     }
     return root;
   }
@@ -371,7 +384,15 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
   }
 
   private runCommandCenterRefresh(root: string): Promise<void> {
-    const args = ["command-center", root, "--refresh", "--limit", String(getCommandCenterLimit())];
+    const args = [
+      "status",
+      root,
+      "--refresh",
+      "--format",
+      "json",
+      "--limit",
+      String(getCommandCenterLimit()),
+    ];
     const stateFile = getCommandCenterStateFile();
     if (stateFile) {
       args.push("--state-file", stateFile);
@@ -399,7 +420,7 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
       fullArgs.push("--state-file", stateFile);
     }
 
-    out.appendLine(`Running Command Center command: ${bin} ${fullArgs.join(" ")}`);
+    out.appendLine(`Running Automation command: ${bin} ${fullArgs.join(" ")}`);
 
     return new Promise<void>((resolve, reject) => {
       const proc = spawn(bin, fullArgs, { cwd: root });
@@ -414,13 +435,13 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
 
       proc.on("close", (code) => {
         if (stderr.trim()) {
-          out.appendLine(`Command Center stderr: ${stderr.trim()}`);
+          out.appendLine(`Automation stderr: ${stderr.trim()}`);
         }
         if (code === 0) {
           resolve();
           return;
         }
-        reject(new Error(stderr.trim() || `Command Center exited with code ${code}`));
+        reject(new Error(stderr.trim() || `Automation exited with code ${code}`));
       });
 
       proc.on("error", (err) => reject(err));

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -35,6 +35,10 @@ export function isScanOnOpen(): boolean {
   return cfg().get<boolean>("scanOnOpen", true);
 }
 
+export function isRealtimeAIEnabled(): boolean {
+  return cfg().get<boolean>("enableRealtimeAI", false);
+}
+
 export function getIdleMs(): number {
   return cfg().get<number>("idleMs", 1000);
 }
@@ -67,6 +71,14 @@ export function getMaxDecorationsPerFile(): number {
   return cfg().get<number>("maxDecorationsPerFile", 25);
 }
 
+export function getEditorSignalLevel(): "quiet" | "balanced" | "verbose" {
+  return cfg().get<"quiet" | "balanced" | "verbose">("editorSignalLevel", "quiet");
+}
+
+export function getCodeLensMode(): "off" | "activeLine" | "highValue" | "all" {
+  return cfg().get<"off" | "activeLine" | "highValue" | "all">("codeLensMode", "highValue");
+}
+
 export function isShowDeadCodeInProblems(): boolean {
   return cfg().get<boolean>("showDeadCodeInProblems", false);
 }
@@ -94,9 +106,13 @@ export function getAIProvider(): AIProvider {
 export function getOpenAIBaseUrl(): string {
   const provider = getAIProvider();
   if (provider === "local") {
-    return (cfg().get<string>("localBaseUrl", "") || "").replace(/\/+$/, "");
+    return getLocalBaseUrl();
   }
   return cfg().get<string>("openaiBaseUrl", "https://api.openai.com").replace(/\/+$/, "");
+}
+
+export function getLocalBaseUrl(): string {
+  return (cfg().get<string>("localBaseUrl", "") || "").replace(/\/+$/, "");
 }
 
 export function isLocalProvider(): boolean {
@@ -126,7 +142,7 @@ export function isLanguageSupported(langId: string): boolean {
 }
 
 export function isStreamingEnabled(): boolean {
-  return cfg().get<boolean>("streamingInline", true);
+  return isRealtimeAIEnabled() && cfg().get<boolean>("streamingInline", false);
 }
 
 export function getAutoFixMaxFindings(): number {

--- a/editors/vscode/src/configCore.ts
+++ b/editors/vscode/src/configCore.ts
@@ -1,0 +1,9 @@
+export function shouldWarnMissingLocalAI(options: {
+  realtimeAIEnabled: boolean;
+  provider: string;
+  localBaseUrl?: string;
+}): boolean {
+  return options.realtimeAIEnabled
+    && options.provider === "local"
+    && !String(options.localBaseUrl ?? "").trim();
+}

--- a/editors/vscode/src/decorations.ts
+++ b/editors/vscode/src/decorations.ts
@@ -1,13 +1,14 @@
 import * as vscode from "vscode";
 import type { FindingsStore } from "./store";
 import type { SkylosFinding } from "./types";
-import { getMaxDecorationsPerFile } from "./config";
+import { getEditorSignalLevel, getMaxDecorationsPerFile } from "./config";
+import { isCorroborated, sourceSummary } from "./provenanceCore";
 
 const deadCodeType = (): vscode.DecorationRenderOptions => ({
-  isWholeLine: true,
-  opacity: "0.45",
-  textDecoration: "line-through rgba(120, 160, 220, 0.5)",
-  overviewRulerColor: "rgba(80, 160, 255, 0.4)",
+  isWholeLine: false,
+  opacity: "0.72",
+  textDecoration: "underline dotted rgba(120, 160, 220, 0.35)",
+  overviewRulerColor: "rgba(80, 160, 255, 0.25)",
   overviewRulerLane: vscode.OverviewRulerLane.Right,
   after: {
     margin: "0 0 0 4ch",
@@ -48,7 +49,7 @@ const highType = (): vscode.DecorationRenderOptions => ({
 });
 
 const mediumType = (): vscode.DecorationRenderOptions => ({
-  isWholeLine: true,
+  isWholeLine: false,
   borderWidth: "0 0 1px 0",
   borderStyle: "dotted",
   borderColor: "rgba(250, 204, 21, 0.4)",
@@ -62,8 +63,8 @@ const mediumType = (): vscode.DecorationRenderOptions => ({
 });
 
 const lowType = (): vscode.DecorationRenderOptions => ({
-  isWholeLine: true,
-  overviewRulerColor: "rgba(80, 160, 255, 0.4)",
+  isWholeLine: false,
+  overviewRulerColor: "rgba(80, 160, 255, 0.25)",
   overviewRulerLane: vscode.OverviewRulerLane.Right,
   after: {
     margin: "0 0 0 4ch",
@@ -115,7 +116,7 @@ function classifyFinding(f: SkylosFinding): DecoCategory {
 }
 
 function formatInlineMessage(f: SkylosFinding, cat: DecoCategory): string {
-  const maxLen = 70;
+  const maxLen = 44;
   const ruleTag = f.ruleId !== "SKYLOS" ? `${f.ruleId} ` : "";
 
   if (cat === "dead") {
@@ -131,12 +132,15 @@ function formatInlineMessage(f: SkylosFinding, cat: DecoCategory): string {
 
   if (cat === "critical" || cat === "high") {
     const sevLabel = f.severity.toUpperCase();
-    const msg = f.message.length > (maxLen - 15) ? f.message.slice(0, maxLen - 18) + "..." : f.message;
-    return `  ${sevLabel} ${ruleTag}— ${msg}`;
+    const shortMessage = simplifySecurityMessage(f.message);
+    const msg = shortMessage.length > (maxLen - 15) ? shortMessage.slice(0, maxLen - 18) + "..." : shortMessage;
+    const confirmed = isCorroborated(f) ? " · Confirmed" : "";
+    return `  ${sevLabel} ${ruleTag}${msg}${confirmed}`;
   }
 
   const msg = f.message.length > maxLen ? f.message.slice(0, maxLen - 3) + "..." : f.message;
-  return `  ${ruleTag}${msg}`;
+  const confirmed = isCorroborated(f) ? " · Confirmed" : "";
+  return `  ${ruleTag}${msg}${confirmed}`;
 }
 
 
@@ -187,6 +191,7 @@ export class DecorationsManager {
   private applyToEditor(editor: vscode.TextEditor): void {
     const filePath = editor.document.uri.fsPath;
     const findings = this.store.getFindingsForFile(filePath, { max: getMaxDecorationsPerFile() });
+    const signalLevel = getEditorSignalLevel();
 
     const byCat = new Map<DecoCategory, vscode.DecorationOptions[]>();
     for (const key of this.decoTypes.keys()) {
@@ -205,19 +210,23 @@ export class DecorationsManager {
 
       const range = new vscode.Range(line, 0, line, 0);
       const cat = classifyFinding(f);
-      const inlineMsg = formatInlineMessage(f, cat);
+      const showInline = shouldShowInlineMessage(f, cat, signalLevel);
+      const showLineDecoration = shouldShowLineDecoration(cat, signalLevel);
+      const inlineMsg = showInline ? formatInlineMessage(f, cat) : "";
       const sevKey = f.severity.toUpperCase();
 
-      const list = byCat.get(cat)!;
-      list.push({
-        range,
-        hoverMessage: f.message,
-        renderOptions: {
-          after: { contentText: inlineMsg },
-        },
-      });
+      if (showInline || showLineDecoration) {
+        const list = byCat.get(cat)!;
+        list.push({
+          range,
+          hoverMessage: `${sourceSummary(f)}: ${f.message}`,
+          renderOptions: {
+            after: { contentText: inlineMsg },
+          },
+        });
+      }
 
-      if (cat !== "dead") {
+      if (showLineDecoration && cat !== "dead") {
         const gutterColor = GUTTER_SEVERITY[sevKey] ?? "blue";
         byGutter.get(gutterColor)!.push({ range });
       }
@@ -237,4 +246,29 @@ export class DecorationsManager {
   dispose(): void {
     this.disposables.forEach((d) => d.dispose());
   }
+}
+
+function shouldShowInlineMessage(
+  finding: SkylosFinding,
+  cat: DecoCategory,
+  signalLevel: "quiet" | "balanced" | "verbose",
+): boolean {
+  if (signalLevel === "verbose") return true;
+  if (signalLevel === "balanced") {
+    return cat === "critical" || cat === "high" || cat === "medium" || finding.source === "ai";
+  }
+  return cat === "critical" || cat === "high" || isCorroborated(finding);
+}
+
+function shouldShowLineDecoration(cat: DecoCategory, signalLevel: "quiet" | "balanced" | "verbose"): boolean {
+  if (signalLevel === "verbose") return true;
+  if (signalLevel === "balanced") return cat !== "dead" && cat !== "low";
+  return cat === "critical" || cat === "high";
+}
+
+function simplifySecurityMessage(message: string): string {
+  return message
+    .replace(/^Possible\s+/i, "")
+    .replace(/\s+vulnerability$/i, "")
+    .trim();
 }

--- a/editors/vscode/src/detail.ts
+++ b/editors/vscode/src/detail.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 import type { SkylosFinding } from "./types";
 import { getRuleMeta } from "./rules";
+import { evidenceLines, fixPlan, isLikelyCiBlocker, priorityReasons } from "./reviewCore";
+import { provenanceLabel } from "./provenanceCore";
 
 export class FindingDetailPanel {
   private panel: vscode.WebviewPanel | undefined;
@@ -24,11 +26,20 @@ export class FindingDetailPanel {
     this.panel.webview.onDidReceiveMessage((msg) => {
       switch (msg.command) {
         case "fix":
-          vscode.commands.executeCommand("skylos.fix", finding.file, finding.line, finding.message, finding.ruleId);
+          vscode.commands.executeCommand(
+            "skylos.fix",
+            finding.file,
+            new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0),
+            finding.message,
+            false,
+          );
           break;
         case "dismiss":
           vscode.commands.executeCommand("skylos.dismissIssue", finding.file, finding.line);
           this.panel?.dispose();
+          break;
+        case "previewFix":
+          vscode.commands.executeCommand("skylos.previewSafeFix", finding);
           break;
         case "openFile":
           vscode.commands.executeCommand("vscode.open", vscode.Uri.file(finding.file), {
@@ -43,11 +54,33 @@ export class FindingDetailPanel {
     const meta = getRuleMeta(f.ruleId);
     const shortFile = f.file.split("/").slice(-2).join("/");
     const sevColor = getSevColor(f.severity);
+    const reviewContext = {
+      currentFile: vscode.window.activeTextEditor?.document.uri.fsPath,
+    };
+    const reasons = priorityReasons(f, reviewContext);
+    const evidence = evidenceLines(f);
+    const plan = fixPlan(f);
+    const provenance = provenanceLabel(f);
+    const summary = getFindingSummary(f, provenance);
+    const ciCopy = f.ciBlocking === true
+      ? "Skylos marked this finding as CI-blocking."
+      : isLikelyCiBlocker(f)
+        ? "This is likely to block a strict Skylos quality gate."
+        : "This is not a likely blocker by default, but it can still matter for review quality.";
+    const decisionRows = [
+      ["Rule", f.ruleId],
+      ["Category", f.category],
+      ["Source", provenance],
+      ["Location", `${f.relativePath ?? shortFile}:${f.line}`],
+      ...(f.confidence !== undefined ? [["Confidence", `${f.confidence}%`]] : []),
+      ...(f.baselineStatus || f.isNew ? [["Baseline", f.baselineStatus ?? "new"]] : []),
+      ["Engine fix", f.fixPatch ? "Preview available" : "No deterministic patch available"],
+    ];
 
     const tags: string[] = [];
-    if (meta?.owasp) tags.push(`<span class="tag owasp">OWASP ${meta.owasp}</span>`);
-    if (meta?.cwe) tags.push(`<span class="tag cwe">${meta.cwe}</span>`);
-    if (meta?.pciDss) tags.push(`<span class="tag pci">PCI-DSS ${meta.pciDss}</span>`);
+    if (meta?.owasp) tags.push(`<span class="tag owasp">OWASP ${escapeHtml(meta.owasp)}</span>`);
+    if (meta?.cwe) tags.push(`<span class="tag cwe">${escapeHtml(meta.cwe)}</span>`);
+    if (meta?.pciDss) tags.push(`<span class="tag pci">PCI-DSS ${escapeHtml(meta.pciDss)}</span>`);
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -77,35 +110,70 @@ h2{font-size:13px;text-transform:uppercase;letter-spacing:.8px;opacity:.6;margin
 .btn-secondary{background:var(--vscode-button-secondaryBackground);color:var(--vscode-button-secondaryForeground)}
 .section{margin-top:16px;padding:14px;border-radius:8px;background:var(--vscode-input-background)}
 .section p{font-size:13px;opacity:.85}
+.list{margin:0;padding-left:18px;font-size:13px}
+.list li{margin:4px 0}
+.snippet{margin-top:10px;padding:10px;border-radius:6px;overflow:auto;background:var(--vscode-textCodeBlock-background,var(--vscode-editor-background));font-family:var(--vscode-editor-font-family);font-size:12px;line-height:1.45;white-space:pre-wrap}
+.impact{border-left:3px solid ${isLikelyCiBlocker(f) ? "#ef4444" : "#60a5fa"}}
+.decision{display:grid;grid-template-columns:max-content 1fr;gap:6px 14px;margin-top:14px;padding:12px;border:1px solid var(--vscode-widget-border,rgba(255,255,255,.12));border-radius:8px}
+.decision .k{font-size:12px;opacity:.6}
+.decision .v{font-size:12px;font-family:var(--vscode-editor-font-family)}
 hr{border:none;border-top:1px solid var(--vscode-widget-border,rgba(255,255,255,.1));margin:16px 0}
 </style>
 </head>
 <body>
 <span class="severity">${f.severity}</span>
-<h1>${meta?.name ?? f.ruleId}</h1>
-<div class="location" onclick="post('openFile')">${shortFile}:${f.line}</div>
+<h1>${escapeHtml(meta?.name ?? f.ruleId)}</h1>
+<div class="location" onclick="post('openFile')">${escapeHtml(shortFile)}:${f.line}</div>
 
-<p class="desc">${f.message}</p>
+<p class="desc"><strong>${escapeHtml(summary)}</strong></p>
+<p class="desc">${escapeHtml(f.message)}</p>
 
 ${tags.length > 0 ? `<div class="tags">${tags.join("")}</div>` : ""}
 
+<div class="decision">
+  ${decisionRows.map(([key, value]) => `<div class="k">${escapeHtml(key)}</div><div class="v">${escapeHtml(String(value))}</div>`).join("")}
+</div>
+
+<h2>Why This Is Here</h2>
+<div class="section">
+  <ul class="list">${reasons.map((reason) => `<li>${escapeHtml(reason)}</li>`).join("")}</ul>
+</div>
+
+<h2>Evidence</h2>
+<div class="section">
+  ${evidence.length > 0
+    ? `<ul class="list">${evidence.map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul>`
+    : f.snippet
+      ? `<p>Code snippet attached; no separate trace metadata was provided.</p>`
+      : `<p>No evidence trace was provided by this finding.</p>`}
+  ${f.snippet ? `<pre class="snippet">${escapeHtml(f.snippet)}</pre>` : ""}
+</div>
+
+<h2>CI Impact</h2>
+<div class="section impact"><p>${escapeHtml(ciCopy)}</p></div>
+
+<h2>Fix Plan</h2>
+<div class="fix-box">
+  <h3>${escapeHtml(plan.title)}</h3>
+  <ul class="list">${plan.steps.map((step) => `<li>${escapeHtml(step)}</li>`).join("")}</ul>
+</div>
+
 ${meta?.description ? `
 <h2>Description</h2>
-<div class="section"><p>${meta.description}</p></div>
+<div class="section"><p>${escapeHtml(meta.description)}</p></div>
 ` : ""}
 
 ${meta?.fix ? `
 <div class="fix-box">
-  <h3>Recommended Fix</h3>
-  <p>${meta.fix}</p>
+  <h3>Rule Guidance</h3>
+  <p>${escapeHtml(meta.fix)}</p>
 </div>
 ` : ""}
 
-${f.confidence !== undefined ? `<p style="font-size:12px;opacity:.5;margin-top:8px">Confidence: ${f.confidence}%</p>` : ""}
-
 <hr/>
 <div class="actions">
-  <button class="btn btn-primary" onclick="post('fix')">&#9889; Fix with AI</button>
+  ${f.fixPatch ? `<button class="btn btn-primary" onclick="post('previewFix')">Preview Engine Fix</button>` : ""}
+  <button class="btn btn-primary" onclick="post('fix')">Fix with AI Assist</button>
   <button class="btn btn-secondary" onclick="post('dismiss')">Dismiss</button>
   <button class="btn btn-secondary" onclick="post('openFile')">Go to File</button>
 </div>
@@ -123,6 +191,15 @@ function post(cmd){vscode.postMessage({command:cmd})}
   }
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function getSevColor(sev: string): string {
   switch (sev.toUpperCase()) {
     case "CRITICAL": 
@@ -138,4 +215,14 @@ function getSevColor(sev: string): string {
     default: 
       return "#888";
   }
+}
+
+function getFindingSummary(finding: SkylosFinding, provenance: string): string {
+  if (finding.source === "ai" && !finding.sources?.some((source) => source !== "ai")) {
+    return "AI Assist suggestion";
+  }
+  if (provenance.startsWith("Confirmed")) {
+    return `${provenance} finding`;
+  }
+  return `${provenance} finding`;
 }

--- a/editors/vscode/src/diagnosticCore.ts
+++ b/editors/vscode/src/diagnosticCore.ts
@@ -1,0 +1,52 @@
+import type { CoreSeverity } from "./findingCore";
+
+export interface DiagnosticRangeInput {
+  line: number;
+  col?: number;
+  endLine?: number;
+  endCol?: number;
+}
+
+export interface CoreDiagnosticRange {
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+}
+
+export function getDiagnosticRange(input: DiagnosticRangeInput): CoreDiagnosticRange {
+  const startLine = Math.max(0, Math.floor((input.line || 1) - 1));
+  const startCol = Math.max(0, Math.floor(input.col ?? 0));
+
+  const hasExplicitEnd = input.endLine !== undefined || input.endCol !== undefined;
+  if (hasExplicitEnd) {
+    const endLine = Math.max(startLine, Math.floor((input.endLine ?? input.line ?? 1) - 1));
+    const endCol = Math.max(endLine === startLine ? startCol + 1 : 0, Math.floor(input.endCol ?? startCol + 1));
+    return { startLine, startCol, endLine, endCol };
+  }
+
+  return {
+    startLine,
+    startCol,
+    endLine: startLine,
+    endCol: startCol + 1,
+  };
+}
+
+export function severityRank(severity: CoreSeverity): number {
+  switch (severity) {
+    case "CRITICAL":
+      return 5;
+    case "HIGH":
+      return 4;
+    case "MEDIUM":
+    case "WARN":
+      return 3;
+    case "LOW":
+      return 2;
+    case "INFO":
+    default:
+      return 1;
+  }
+}
+

--- a/editors/vscode/src/diagnostics.ts
+++ b/editors/vscode/src/diagnostics.ts
@@ -2,41 +2,30 @@ import * as vscode from "vscode";
 import type { FindingsStore } from "./store";
 import type { SkylosFinding, Severity } from "./types";
 import { getMaxProblems, getMaxProblemsPerFile, isShowDeadCodeInProblems } from "./config";
+import { getDiagnosticRange } from "./diagnosticCore";
+import { diagnosticSource, provenanceLabel } from "./provenanceCore";
 
 export class DiagnosticsManager {
-  private cliCollection: vscode.DiagnosticCollection;
-  private aiCollection: vscode.DiagnosticCollection;
+  private collection: vscode.DiagnosticCollection;
   private disposables: vscode.Disposable[] = [];
 
   constructor(private store: FindingsStore) {
-    this.cliCollection = vscode.languages.createDiagnosticCollection("skylos");
-    this.aiCollection = vscode.languages.createDiagnosticCollection("skylos-ai");
+    this.collection = vscode.languages.createDiagnosticCollection("skylos");
 
     this.disposables.push(
-      this.cliCollection,
-      this.aiCollection,
-      store.onDidChange(() => this.refreshCLI()),
-      store.onDidChangeAI(() => this.refreshAI()),
+      this.collection,
+      store.onDidChange(() => this.refresh()),
+      store.onDidChangeAI(() => this.refresh()),
     );
   }
 
-  private refreshCLI(): void {
-    this.cliCollection.clear();
+  private refresh(): void {
+    this.collection.clear();
     const findings = this.store.getVisibleFindings(getMaxProblems(), {
-      source: "cli",
       includeDeadCode: isShowDeadCodeInProblems(),
       maxPerFile: getMaxProblemsPerFile(),
     });
-    this.publish(this.cliCollection, findings);
-  }
-
-  private refreshAI(): void {
-    this.aiCollection.clear();
-    const findings = this.store.getVisibleFindings(getMaxProblems(), {
-      source: "ai",
-      maxPerFile: getMaxProblemsPerFile(),
-    });
-    this.publish(this.aiCollection, findings);
+    this.publish(this.collection, findings);
   }
 
   dispose(): void {
@@ -59,16 +48,36 @@ export class DiagnosticsManager {
 }
 
 function toDiagnostic(f: SkylosFinding): vscode.Diagnostic {
-  const line = Math.max(0, f.line - 1);
-  const col = Math.max(0, f.col);
-  const start = new vscode.Position(line, col);
-  const range = new vscode.Range(start, start);
+  const rangeFields = getDiagnosticRange(f);
+  const range = new vscode.Range(
+    rangeFields.startLine,
+    rangeFields.startCol,
+    rangeFields.endLine,
+    rangeFields.endCol,
+  );
   const severity = mapSeverity(f.severity);
-  const prefix = f.source === "ai" ? "[AI] " : f.ruleId !== "SKYLOS" ? `[${f.ruleId}] ` : "";
+  const provenance = provenanceLabel(f);
+  const prefix = f.ruleId !== "SKYLOS" ? `[${provenance}] [${f.ruleId}] ` : `[${provenance}] `;
   const diag = new vscode.Diagnostic(range, `${prefix}${f.message}`, severity);
-  diag.source = f.source === "ai" ? "skylos-ai" : "skylos";
-  diag.code = f.ruleId;
+  diag.source = diagnosticSource(f);
+  diag.code = f.ruleUrl
+    ? { value: f.ruleId, target: vscode.Uri.parse(f.ruleUrl) }
+    : f.ruleId;
+  diag.relatedInformation = relatedInformation(f);
   return diag;
+}
+
+function relatedInformation(f: SkylosFinding): vscode.DiagnosticRelatedInformation[] | undefined {
+  const related: vscode.DiagnosticRelatedInformation[] = [];
+  for (const step of f.trace ?? []) {
+    if (!step.file) continue;
+    const line = Math.max(0, (step.line ?? 1) - 1);
+    related.push(new vscode.DiagnosticRelatedInformation(
+      new vscode.Location(vscode.Uri.file(step.file), new vscode.Position(line, 0)),
+      step.message ?? step.label ?? step.symbol ?? "Related Skylos evidence",
+    ));
+  }
+  return related.length > 0 ? related : undefined;
 }
 
 function mapSeverity(s: Severity): vscode.DiagnosticSeverity {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { FindingsStore } from "./store";
-import { scanWorkspace, scanFile, cancelScan, out } from "./scanner";
+import { scanWorkspace, scanFile, cancelScan, out, doctorSkylos, buildScanErrorMessage, SkylosScanError } from "./scanner";
 import { DiagnosticsManager } from "./diagnostics";
 import { DecorationsManager } from "./decorations";
 import { SkylosTreeProvider, FindingNode } from "./sidebar";
@@ -26,13 +26,15 @@ import {
   isShowPopup,
   getDiffBase,
   getAIProvider,
-  getOpenAIBaseUrl,
+  getLocalBaseUrl,
   getSkylosBin,
   getMaxTreeFindings,
   getMaxTreeFindingsPerFile,
   isCommandCenterRefreshOnSave,
+  isRealtimeAIEnabled,
 } from "./config";
-import type { AutoFixOptions, Category, Severity } from "./types";
+import { shouldWarnMissingLocalAI } from "./configCore";
+import type { AutoFixOptions, Category, Severity, SkylosFinding } from "./types";
 
 export function activate(context: vscode.ExtensionContext) {
   out.appendLine("Skylos extension activated");
@@ -100,7 +102,10 @@ export function activate(context: vscode.ExtensionContext) {
         }
       : undefined;
   };
-  commandCenterProvider.onDidUpdateState(updateCommandCenterBadge);
+  commandCenterProvider.onDidUpdateState(() => {
+    store.setAgentFindings(commandCenterProvider.getQueueFindings());
+    updateCommandCenterBadge();
+  });
   updateCommandCenterBadge();
 
   context.subscriptions.push(
@@ -124,11 +129,31 @@ export function activate(context: vscode.ExtensionContext) {
   );
   void commandCenterProvider.initialize();
 
+  function recordScanFailure(err: unknown): string {
+    const message = buildScanErrorMessage(err);
+    if (err instanceof SkylosScanError) {
+      store.setLastError({
+        kind: err.kind,
+        message,
+        command: err.details.command,
+        exitCode: err.details.exitCode,
+        stderr: err.details.stderr,
+      });
+    } else {
+      store.setLastError({
+        kind: "unknown",
+        message,
+      });
+    }
+    return message;
+  }
+
   async function doWorkspaceScan(diffBase?: string): Promise<void> {
     statusBar.setScanning(true);
     try {
       const result = await scanWorkspace(undefined, diffBase);
       store.setEngineMetadata(result.grade, result.summary, result.circularDeps, result.depVulns);
+      if (result.metadata) store.setLastScan(result.metadata);
       store.setWorkspaceCLIFindings(result.findings);
       const total = result.findings.length;
       const criticalOrHigh = result.findings.filter((finding) =>
@@ -153,7 +178,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.setStatusBarMessage("Skylos: no issues", 5000);
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = recordScanFailure(err);
       if (msg !== "Scan cancelled") {
         vscode.window.showErrorMessage(`Skylos scan failed: ${msg}`);
       }
@@ -166,6 +191,7 @@ export function activate(context: vscode.ExtensionContext) {
     statusBar.setScanning(true);
     try {
       const result = await scanFile(filePath);
+      if (result.metadata) store.setLastScan(result.metadata);
       const fileFindings = result.findings.filter((finding) => finding.file === filePath);
       store.setFocusedCLIFindings(filePath, fileFindings);
       if (announce) {
@@ -177,7 +203,7 @@ export function activate(context: vscode.ExtensionContext) {
         );
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = recordScanFailure(err);
       if (msg !== "Scan cancelled") {
         vscode.window.showErrorMessage(`Skylos scan failed: ${msg}`);
       }
@@ -194,7 +220,7 @@ export function activate(context: vscode.ExtensionContext) {
   async function openCommandCenterDetail(node: ActionNode): Promise<void> {
     const finding = commandCenterProvider.toSkylosFinding(node.action);
     if (!finding) {
-      vscode.window.showWarningMessage("Skylos: this command-center action has no file target.");
+      vscode.window.showWarningMessage("Skylos: this Automation action has no file target.");
       return;
     }
     detailPanel.show(finding);
@@ -202,26 +228,34 @@ export function activate(context: vscode.ExtensionContext) {
 
   async function applyCommandCenterSafeFix(node: ActionNode): Promise<void> {
     const finding = commandCenterProvider.toSkylosFinding(node.action);
-    const safeFix = node.action.safe_fix;
-    if (!finding || !safeFix) {
+    if (!finding) {
       vscode.window.showInformationMessage("Skylos: no safe fix is available for this action.");
       return;
     }
 
-    const uri = vscode.Uri.file(finding.file);
-    const line = Math.max(0, finding.line - 1);
+    await previewSafeFix(finding);
+  }
 
-    if (safeFix === "remove_import") {
-      await vscode.commands.executeCommand("skylos.removeImport", uri, line);
-    } else if (safeFix === "remove_function") {
-      await vscode.commands.executeCommand("skylos.removeFunction", uri, line);
-    } else {
-      vscode.window.showInformationMessage("Skylos: no safe fix is available for this action.");
+  function resolveFinding(candidate?: SkylosFinding | FindingNode): SkylosFinding | undefined {
+    if (!candidate) return undefined;
+    if (candidate instanceof FindingNode) return candidate.finding;
+    return candidate;
+  }
+
+  async function previewSafeFix(candidate?: SkylosFinding | FindingNode): Promise<void> {
+    const finding = resolveFinding(candidate);
+    if (!finding?.fixPatch) {
+      vscode.window.showInformationMessage(
+        "Skylos: no engine-backed patch is available for this finding yet.",
+      );
       return;
     }
 
-    await scanSingleFile(finding.file, false);
-    commandCenterProvider.scheduleRefresh(250);
+    const patchDoc = await vscode.workspace.openTextDocument({
+      language: "diff",
+      content: finding.fixPatch,
+    });
+    await vscode.window.showTextDocument(patchDoc, { preview: true });
   }
 
   async function snoozeCommandCenterAction(node: ActionNode): Promise<void> {
@@ -243,7 +277,7 @@ export function activate(context: vscode.ExtensionContext) {
   async function restoreTriagedCommandCenterAction(): Promise<void> {
     const triaged = commandCenterProvider.getTriagedEntries();
     if (triaged.length === 0) {
-      vscode.window.showInformationMessage("Skylos: there are no snoozed or dismissed command-center actions.");
+      vscode.window.showInformationMessage("Skylos: there are no snoozed or dismissed Automation actions.");
       return;
     }
 
@@ -265,13 +299,23 @@ export function activate(context: vscode.ExtensionContext) {
 
     await commandCenterProvider.restoreAction(pick.id);
     updateCommandCenterBadge();
-    vscode.window.setStatusBarMessage("Skylos: restored command-center action", 3000);
+    vscode.window.setStatusBarMessage("Skylos: restored Automation action", 3000);
   }
 
   context.subscriptions.push(
     vscode.commands.registerCommand("skylos.scan", () => {
       const diffBase = store.deltaMode ? getDiffBase() : undefined;
       doWorkspaceScan(diffBase);
+    }),
+
+    vscode.commands.registerCommand("skylos.doctor", async () => {
+      const result = await doctorSkylos();
+      out.show(true);
+      if (result.ok) {
+        vscode.window.showInformationMessage("Skylos Doctor: CLI is reachable.");
+      } else {
+        vscode.window.showWarningMessage(`Skylos Doctor: ${result.error ?? "CLI check failed."}`);
+      }
     }),
 
     vscode.commands.registerCommand("skylos.scanFile", async (uri?: vscode.Uri) => {
@@ -292,55 +336,24 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand("skylos.fix", fixWithAI),
 
+    vscode.commands.registerCommand("skylos.previewSafeFix", async (finding?: SkylosFinding | FindingNode) => {
+      await previewSafeFix(finding);
+    }),
+
     vscode.commands.registerCommand("skylos.dismissIssue", (filePath: string, line: number) => {
       store.dismissAIFinding(filePath, line);
     }),
 
-    vscode.commands.registerCommand("skylos.removeImport", async (uri: vscode.Uri, line: number) => {
-      const doc = await vscode.workspace.openTextDocument(uri);
-      const editor = await vscode.window.showTextDocument(doc);
-      await editor.edit((eb) => {
-        eb.delete(new vscode.Range(line, 0, line + 1, 0));
-      });
-      store.removeFindingAtLine(uri.fsPath, line + 1);
+    vscode.commands.registerCommand("skylos.removeImport", async () => {
+      vscode.window.showInformationMessage(
+        "Skylos: direct line-delete cleanup is disabled. Use an engine-backed fix preview when available.",
+      );
     }),
 
-    vscode.commands.registerCommand("skylos.removeFunction", async (uri: vscode.Uri, line: number) => {
-      const doc = await vscode.workspace.openTextDocument(uri);
-      const editor = await vscode.window.showTextDocument(doc);
-      const langId = doc.languageId;
-
-      let endLine = line;
-      if (langId === "python") {
-        const startText = doc.lineAt(line).text;
-        const indent = startText.match(/^(\s*)/)?.[1].length ?? 0;
-        for (let j = line + 1; j < doc.lineCount; j++) {
-          const nextLine = doc.lineAt(j).text;
-          if (nextLine.trim() === "") { endLine = j;
-            continue; }
-          const nextIndent = nextLine.match(/^(\s*)/)?.[1].length ?? 0;
-          if (nextIndent <= indent && nextLine.trim() !== "")
-            break;
-          endLine = j;
-        }
-      } else {
-        let braceCount = 0;
-        let foundBrace = false;
-        for (let j = line; j < doc.lineCount; j++) {
-          for (const ch of doc.lineAt(j).text) {
-            if (ch === "{") { braceCount++; foundBrace = true; }
-            if (ch === "}") braceCount--;
-          }
-          endLine = j;
-          if (foundBrace && braceCount <= 0)
-            break;
-        }
-      }
-
-      await editor.edit((eb) => {
-        eb.delete(new vscode.Range(line, 0, endLine + 1, 0));
-      });
-      store.removeFindingAtLine(uri.fsPath, line + 1);
+    vscode.commands.registerCommand("skylos.removeFunction", async () => {
+      vscode.window.showInformationMessage(
+        "Skylos: direct line-delete cleanup is disabled. Use an engine-backed fix preview when available.",
+      );
     }),
 
     vscode.commands.registerCommand("skylos.addToWhitelist", async (message: string) => {
@@ -418,7 +431,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("skylos.commandCenterDismiss", async (node: ActionNode) => {
       await commandCenterProvider.dismissAction(node.action);
       updateCommandCenterBadge();
-      vscode.window.setStatusBarMessage("Skylos: dismissed command-center action", 3000);
+      vscode.window.setStatusBarMessage("Skylos: dismissed Automation action", 3000);
     }),
 
     vscode.commands.registerCommand("skylos.commandCenterSnooze", async (node: ActionNode) => {
@@ -488,11 +501,11 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand("skylos.filterFindings", async () => {
       const filterType = await vscode.window.showQuickPick(
-        [
-          { label: "$(warning) By Severity", value: "severity" },
-          { label: "$(symbol-class) By Category", value: "category" },
-          { label: "$(source-control) By Source (CLI vs AI)", value: "source" },
-          { label: "$(file) By File Name", value: "file" },
+          [
+            { label: "$(warning) By Severity", value: "severity" },
+            { label: "$(symbol-class) By Category", value: "category" },
+            { label: "$(source-control) By Source", value: "source" },
+            { label: "$(file) By File Name", value: "file" },
         ],
         { placeHolder: "Filter findings by..." },
       );
@@ -512,7 +525,7 @@ export function activate(context: vscode.ExtensionContext) {
             { label: "Technical Debt", value: "debt" },
             { label: "Dead Code", value: "dead_code" },
             { label: "Quality", value: "quality" },
-            { label: "AI Analysis", value: "ai" },
+            { label: "AI Assist", value: "ai" },
           ].map((c) => ({ ...c, description: c.value })),
           { placeHolder: "Show only this category" },
         );
@@ -520,8 +533,10 @@ export function activate(context: vscode.ExtensionContext) {
       } else if (filterType.value === "source") {
         const src = await vscode.window.showQuickPick(
           [
-            { label: "CLI (static analysis)", value: "cli" as const },
-            { label: "AI (real-time analysis)", value: "ai" as const },
+            { label: "Static scan", value: "cli" as const },
+            { label: "Automation", value: "agent" as const },
+            { label: "AI Assist (optional real-time)", value: "ai" as const },
+            { label: "Confirmed findings", value: "confirmed" as const },
           ],
           { placeHolder: "Show only this source" },
         );
@@ -618,6 +633,8 @@ export function activate(context: vscode.ExtensionContext) {
         return;
       if (event.contentChanges.length === 0)
         return;
+      if (!isRealtimeAIEnabled())
+        return;
 
       if (aiDebounceTimer) clearTimeout(aiDebounceTimer);
       aiDebounceTimer = setTimeout(() => aiAnalyzer.maybeAnalyze(event.document), getIdleMs());
@@ -626,7 +643,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
-      if (editor && isLanguageSupported(editor.document.languageId)) {
+      if (editor && isRealtimeAIEnabled() && isLanguageSupported(editor.document.languageId)) {
         if (aiDebounceTimer) clearTimeout(aiDebounceTimer);
         aiDebounceTimer = setTimeout(() => aiAnalyzer.maybeAnalyze(editor.document), 1000);
       }
@@ -642,9 +659,13 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   );
 
-  if (getAIProvider() === "local" && !getOpenAIBaseUrl()) {
+  if (shouldWarnMissingLocalAI({
+    realtimeAIEnabled: isRealtimeAIEnabled(),
+    provider: getAIProvider(),
+    localBaseUrl: getLocalBaseUrl(),
+  })) {
     vscode.window.showWarningMessage(
-      'Skylos: AI provider is "local" but no server URL set. Configure skylos.localBaseUrl (e.g. http://localhost:11434 for Ollama).',
+      'Skylos: AI Assist is enabled but not configured. Static scanning is still running locally. Configure skylos.localBaseUrl.',
       "Open Settings",
     ).then((action) => {
       if (action === "Open Settings") {

--- a/editors/vscode/src/findingCore.ts
+++ b/editors/vscode/src/findingCore.ts
@@ -1,0 +1,416 @@
+import * as crypto from "crypto";
+import * as path from "path";
+
+export type CoreSeverity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "INFO" | "WARN";
+export type CoreCategory = "dead_code" | "security" | "secrets" | "quality" | "debt" | "ai";
+
+interface RawUnusedItem {
+  name?: string;
+  simple_name?: string;
+  type?: string;
+  file?: string;
+  line?: number;
+  lineno?: number;
+  confidence?: number;
+  module?: string;
+  rule_id?: string;
+  fingerprint?: string;
+  baseline_status?: string;
+  is_new?: boolean;
+}
+
+interface RawFinding {
+  message?: string;
+  file?: string;
+  line?: number;
+  col?: number;
+  rule_id?: string;
+  severity?: string;
+  confidence?: number;
+  fingerprint?: string;
+  rule_url?: string;
+  ruleUrl?: string;
+  end_line?: number;
+  endLine?: number;
+  end_col?: number;
+  endCol?: number;
+  end_column?: number;
+  endColumn?: number;
+  safe_fix?: string;
+  safeFix?: string;
+  fix_patch?: string;
+  fixPatch?: string;
+  patch?: string;
+  baseline_status?: string;
+  baselineStatus?: string;
+  is_new?: boolean;
+  isNew?: boolean;
+  snippet?: string;
+  code_snippet?: string;
+  codeSnippet?: string;
+  vulnerable_code?: string;
+  explanation?: string;
+  suggestion?: string;
+  evidence?: unknown;
+  trace?: unknown;
+  dataflow?: unknown;
+  source_symbol?: string;
+  sourceSymbol?: string;
+  sink_symbol?: string;
+  sinkSymbol?: string;
+  _security_evidence?: Record<string, unknown>;
+  security_evidence?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  _review_reason?: string;
+  review_reason?: string;
+  _ci_blocking?: boolean;
+  ci_blocking?: boolean;
+}
+
+interface RawQualityFinding extends RawFinding {
+  kind?: string;
+  metric?: string;
+  value?: number;
+  threshold?: number;
+}
+
+export interface RawCLIReport {
+  unused_functions?: RawUnusedItem[];
+  unused_imports?: RawUnusedItem[];
+  unused_classes?: RawUnusedItem[];
+  unused_variables?: RawUnusedItem[];
+  unused_parameters?: RawUnusedItem[];
+  secrets?: RawFinding[];
+  danger?: RawFinding[];
+  quality?: RawQualityFinding[];
+}
+
+export interface NormalizeReportOptions {
+  wsRoot: string;
+  deadCodeEnabled: boolean;
+  showDeadParams: boolean;
+  confidenceThreshold: number;
+}
+
+export interface CoreFinding {
+  id: string;
+  fingerprint: string;
+  ruleId: string;
+  legacyRuleId?: string;
+  category: CoreCategory;
+  severity: CoreSeverity;
+  message: string;
+  file: string;
+  relativePath: string;
+  workspaceRoot: string;
+  line: number;
+  col: number;
+  endLine?: number;
+  endCol?: number;
+  confidence?: number;
+  itemType?: string;
+  itemName?: string;
+  source: "cli" | "ai";
+  ruleUrl?: string;
+  safeFix?: string;
+  fixPatch?: string;
+  baselineStatus?: string;
+  isNew?: boolean;
+  snippet?: string;
+  explanation?: string;
+  suggestion?: string;
+  evidence?: string[];
+  trace?: CoreTraceStep[];
+  sourceSymbol?: string;
+  sinkSymbol?: string;
+  securityEvidence?: Record<string, unknown>;
+  reviewReason?: string;
+  ciBlocking?: boolean;
+}
+
+export interface CoreTraceStep {
+  file?: string;
+  line?: number;
+  label?: string;
+  message?: string;
+  symbol?: string;
+}
+
+const DEAD_CODE_RULES: Record<string, { ruleId: string; legacyRuleId: string; itemType: string; label: string }> = {
+  unused_functions: { ruleId: "SKY-U001", legacyRuleId: "DEAD-FUNC", itemType: "function", label: "function" },
+  unused_imports: { ruleId: "SKY-U002", legacyRuleId: "DEAD-IMPORT", itemType: "import", label: "import" },
+  unused_variables: { ruleId: "SKY-U003", legacyRuleId: "DEAD-VAR", itemType: "variable", label: "variable" },
+  unused_classes: { ruleId: "SKY-U004", legacyRuleId: "DEAD-CLASS", itemType: "class", label: "class" },
+  unused_parameters: { ruleId: "SKY-U005", legacyRuleId: "DEAD-PARAM", itemType: "parameter", label: "parameter" },
+};
+
+const LEGACY_RULE_ALIASES: Record<string, string> = {
+  "DEAD-FUNC": "SKY-U001",
+  "DEAD-IMPORT": "SKY-U002",
+  "DEAD-VAR": "SKY-U003",
+  "DEAD-CLASS": "SKY-U004",
+  "DEAD-PARAM": "SKY-U005",
+  "SKY-DC001": "SKY-U001",
+  "SKY-DC002": "SKY-U002",
+};
+
+let findingCounter = 0;
+
+export function normalizeReportCore(report: RawCLIReport, options: NormalizeReportOptions): CoreFinding[] {
+  const findings: CoreFinding[] = [];
+
+  mapUnused(findings, report.unused_functions, "unused_functions", options);
+  mapUnused(findings, report.unused_imports, "unused_imports", options);
+  mapUnused(findings, report.unused_classes, "unused_classes", options);
+  mapUnused(findings, report.unused_variables, "unused_variables", options);
+  mapUnused(findings, report.unused_parameters, "unused_parameters", options);
+
+  for (const secret of report.secrets ?? []) {
+    const finding = rawFindingToCore(secret, "secrets", options);
+    if (finding) findings.push(finding);
+  }
+
+  for (const danger of report.danger ?? []) {
+    const finding = rawFindingToCore(danger, "security", options);
+    if (finding) findings.push(finding);
+  }
+
+  for (const quality of report.quality ?? []) {
+    const finding = rawQualityFindingToCore(quality, options);
+    if (finding) findings.push(finding);
+  }
+
+  return findings.filter((finding) => {
+    if (finding.category !== "dead_code") return true;
+    if (!options.deadCodeEnabled) return false;
+    if (finding.ruleId === "SKY-U005" && !options.showDeadParams) return false;
+    if (finding.confidence !== undefined && finding.confidence < options.confidenceThreshold) return false;
+    return true;
+  });
+}
+
+export function canonicalRuleId(ruleId: string): string {
+  return LEGACY_RULE_ALIASES[ruleId] ?? ruleId;
+}
+
+export function isDeadCodeRule(ruleId: string): boolean {
+  return canonicalRuleId(ruleId).startsWith("SKY-U");
+}
+
+export function isUnusedImportRule(ruleId: string): boolean {
+  return canonicalRuleId(ruleId) === "SKY-U002";
+}
+
+export function isUnusedFunctionRule(ruleId: string): boolean {
+  return canonicalRuleId(ruleId) === "SKY-U001";
+}
+
+export function normalizeSeverity(value?: string): CoreSeverity {
+  const normalized = String(value ?? "").toUpperCase();
+  if (normalized === "CRITICAL") return "CRITICAL";
+  if (normalized === "HIGH") return "HIGH";
+  if (normalized === "MEDIUM") return "MEDIUM";
+  if (normalized === "LOW") return "LOW";
+  if (normalized === "WARN" || normalized === "WARNING") return "WARN";
+  return "INFO";
+}
+
+export function makeFingerprint(input: {
+  ruleId: string;
+  relativePath: string;
+  line: number;
+  message: string;
+  subject?: string;
+}): string {
+  const material = [
+    canonicalRuleId(input.ruleId),
+    input.relativePath.replace(/\\/g, "/"),
+    String(input.line),
+    input.subject ?? "",
+    input.message,
+  ].join("\0");
+  const hash = crypto.createHash("sha1").update(material).digest("hex").slice(0, 20);
+  return `vsce:${hash}`;
+}
+
+function mapUnused(
+  findings: CoreFinding[],
+  items: RawUnusedItem[] | undefined,
+  key: keyof typeof DEAD_CODE_RULES,
+  options: NormalizeReportOptions,
+): void {
+  const meta = DEAD_CODE_RULES[key];
+  for (const item of items ?? []) {
+    if (!item.file) continue;
+    const paths = normalizePaths(item.file, options.wsRoot);
+    const name = item.name ?? item.simple_name ?? "";
+    const line = positiveLine(item.line ?? item.lineno);
+    const message = `Unused ${meta.label}: ${name}`;
+    const ruleId = canonicalRuleId(item.rule_id ?? meta.ruleId);
+    const fingerprint = item.fingerprint ?? makeFingerprint({
+      ruleId,
+      relativePath: paths.relativePath,
+      line,
+      message,
+      subject: name,
+    });
+
+    findings.push({
+      id: nextId(),
+      fingerprint,
+      ruleId,
+      legacyRuleId: meta.legacyRuleId,
+      category: "dead_code",
+      severity: "INFO",
+      message,
+      file: paths.absolutePath,
+      relativePath: paths.relativePath,
+      workspaceRoot: options.wsRoot,
+      line,
+      col: 0,
+      confidence: item.confidence,
+      itemType: meta.itemType,
+      itemName: name,
+      source: "cli",
+      baselineStatus: item.baseline_status,
+      isNew: item.is_new,
+    });
+  }
+}
+
+function rawFindingToCore(
+  raw: RawFinding,
+  category: CoreCategory,
+  options: NormalizeReportOptions,
+): CoreFinding | undefined {
+  if (!raw.file) return undefined;
+  const paths = normalizePaths(raw.file, options.wsRoot);
+  const line = positiveLine(raw.line);
+  const ruleId = canonicalRuleId(raw.rule_id ?? "SKYLOS");
+  const message = raw.message ?? `Skylos ${category} finding`;
+  const fingerprint = raw.fingerprint ?? makeFingerprint({
+    ruleId,
+    relativePath: paths.relativePath,
+    line,
+    message,
+  });
+  const metadata = objectValue(raw.metadata);
+
+  return {
+    id: nextId(),
+    fingerprint,
+    ruleId,
+    category,
+    severity: normalizeSeverity(raw.severity),
+    message,
+    file: paths.absolutePath,
+    relativePath: paths.relativePath,
+    workspaceRoot: options.wsRoot,
+    line,
+    col: zeroBasedCol(raw.col),
+    endLine: positiveOptional(raw.end_line ?? raw.endLine),
+    endCol: zeroBasedOptional(raw.end_col ?? raw.endCol ?? raw.end_column ?? raw.endColumn),
+    confidence: raw.confidence,
+    source: "cli",
+    ruleUrl: raw.rule_url ?? raw.ruleUrl,
+    safeFix: raw.safe_fix ?? raw.safeFix,
+    fixPatch: raw.fix_patch ?? raw.fixPatch ?? raw.patch,
+    baselineStatus: raw.baseline_status ?? raw.baselineStatus,
+    isNew: raw.is_new ?? raw.isNew,
+    snippet: stringValue(raw.snippet ?? raw.code_snippet ?? raw.codeSnippet ?? raw.vulnerable_code),
+    explanation: stringValue(raw.explanation),
+    suggestion: stringValue(raw.suggestion),
+    evidence: evidenceList(raw.evidence ?? metadata?.evidence),
+    trace: traceSteps(raw.trace ?? raw.dataflow ?? metadata?.trace ?? metadata?.dataflow),
+    sourceSymbol: stringValue(raw.source_symbol ?? raw.sourceSymbol ?? metadata?.source_symbol ?? metadata?.sourceSymbol),
+    sinkSymbol: stringValue(raw.sink_symbol ?? raw.sinkSymbol ?? metadata?.sink_symbol ?? metadata?.sinkSymbol),
+    securityEvidence: objectValue(
+      raw._security_evidence
+      ?? raw.security_evidence
+      ?? metadata?.security_evidence
+      ?? metadata?._security_evidence,
+    ),
+    reviewReason: stringValue(raw._review_reason ?? raw.review_reason ?? metadata?.review_reason ?? metadata?._review_reason),
+    ciBlocking: booleanValue(raw._ci_blocking ?? raw.ci_blocking ?? metadata?.ci_blocking ?? metadata?._ci_blocking),
+  };
+}
+
+function rawQualityFindingToCore(raw: RawQualityFinding, options: NormalizeReportOptions): CoreFinding | undefined {
+  const message = raw.message ?? `Quality issue (${raw.kind ?? raw.metric ?? "quality"})`;
+  return rawFindingToCore({ ...raw, message, rule_id: raw.rule_id ?? "SKY-Q000" }, "quality", options);
+}
+
+function normalizePaths(filePath: string, wsRoot: string): { absolutePath: string; relativePath: string } {
+  const absolutePath = path.normalize(path.isAbsolute(filePath) ? filePath : path.join(wsRoot, filePath));
+  const relativePath = path.relative(wsRoot, absolutePath).replace(/\\/g, "/") || path.basename(absolutePath);
+  return { absolutePath, relativePath };
+}
+
+function positiveLine(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return 1;
+  return Math.floor(value);
+}
+
+function positiveOptional(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return undefined;
+  return Math.floor(value);
+}
+
+function zeroBasedCol(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function zeroBasedOptional(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.floor(value));
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function evidenceList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    const single = stringValue(value);
+    return single ? [single] : undefined;
+  }
+  const items = value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+  return items.length > 0 ? items : undefined;
+}
+
+function traceSteps(value: unknown): CoreTraceStep[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const steps: CoreTraceStep[] = [];
+  for (const item of value) {
+    if (typeof item === "string" && item.trim().length > 0) {
+      steps.push({ message: item });
+      continue;
+    }
+    const obj = objectValue(item);
+    if (!obj) continue;
+    const step: CoreTraceStep = {
+      file: stringValue(obj.file ?? obj.path ?? obj.filename),
+      line: typeof obj.line === "number" && Number.isFinite(obj.line) ? Math.max(1, Math.floor(obj.line)) : undefined,
+      label: stringValue(obj.label ?? obj.kind),
+      message: stringValue(obj.message ?? obj.detail),
+      symbol: stringValue(obj.symbol ?? obj.name),
+    };
+    if (step.file || step.line || step.label || step.message || step.symbol) steps.push(step);
+  }
+  return steps.length > 0 ? steps : undefined;
+}
+
+function nextId(): string {
+  findingCounter += 1;
+  return `f-${findingCounter}`;
+}

--- a/editors/vscode/src/hover.ts
+++ b/editors/vscode/src/hover.ts
@@ -3,6 +3,7 @@ import type { FindingsStore } from "./store";
 import { getRuleMeta } from "./rules";
 import { getDocumentFilters } from "./types";
 import { getMaxDecorationsPerFile } from "./config";
+import { provenanceLabel } from "./provenanceCore";
 
 
 export class SkylosHoverProvider implements vscode.HoverProvider {
@@ -28,6 +29,7 @@ export class SkylosHoverProvider implements vscode.HoverProvider {
 
       md.appendMarkdown(`### ${sevEmoji} ${f.ruleId} — ${ruleName}\n\n`);
       md.appendMarkdown(`**Severity:** \`${f.severity}\`\n\n`);
+      md.appendMarkdown(`**Source:** \`${provenanceLabel(f)}\`\n\n`);
       md.appendMarkdown(`${f.message}\n\n`);
 
       if (meta?.description) {

--- a/editors/vscode/src/provenanceCore.ts
+++ b/editors/vscode/src/provenanceCore.ts
@@ -1,0 +1,169 @@
+export type FindingSource = "cli" | "agent" | "ai";
+
+export interface ProvenanceFinding {
+  id: string;
+  fingerprint?: string;
+  ruleId: string;
+  category: string;
+  severity: string;
+  message: string;
+  file: string;
+  line: number;
+  source: FindingSource;
+  sources?: FindingSource[];
+  confidence?: number;
+  safeFix?: string;
+  fixPatch?: string;
+  evidence?: string[];
+  trace?: Array<{ file?: string; line?: number; label?: string; message?: string; symbol?: string }>;
+  reviewReason?: string;
+  ciBlocking?: boolean;
+  baselineStatus?: string;
+  isNew?: boolean;
+  sourceSymbol?: string;
+  sinkSymbol?: string;
+  itemName?: string;
+}
+
+const SOURCE_ORDER: FindingSource[] = ["cli", "agent", "ai"];
+
+export function mergeCorrelatedFindings<T extends ProvenanceFinding>(findings: T[]): T[] {
+  const byKey = new Map<string, T>();
+
+  for (const finding of findings) {
+    const key = correlationKey(finding);
+    const existing = byKey.get(key);
+    byKey.set(key, existing ? mergePair(existing, finding) : withNormalizedSources(finding));
+  }
+
+  return [...byKey.values()];
+}
+
+export function correlationKey(finding: ProvenanceFinding): string {
+  const file = finding.file.replace(/\\/g, "/");
+  const line = Math.max(1, Math.floor(finding.line || 1));
+  const rule = finding.ruleId.trim().toUpperCase();
+  const subject = correlationSubject(finding);
+  if (rule && rule !== "AI" && rule !== "SKYLOS" && rule !== "SKY-ACTIVE") {
+    return `${file}:${line}:rule:${rule}:${subject}`;
+  }
+  return `${file}:${line}:${finding.category}:${subject}`;
+}
+
+export function sourceSummary(finding: Pick<ProvenanceFinding, "source" | "sources">): string {
+  return getSources(finding).map(sourceLabel).join(" + ");
+}
+
+export function provenanceLabel(finding: Pick<ProvenanceFinding, "source" | "sources">): string {
+  return isCorroborated(finding) ? `Confirmed by ${sourceSummary(finding)}` : sourceSummary(finding);
+}
+
+export function sourceLabel(source: FindingSource): string {
+  if (source === "cli") return "Static";
+  if (source === "agent") return "Automation";
+  return "AI Assist";
+}
+
+export function diagnosticSource(finding: Pick<ProvenanceFinding, "source" | "sources">): string {
+  return `skylos ${sourceSummary(finding).toLowerCase().replace(/\s+/g, "-").replace(/-\+-/g, "+")}`;
+}
+
+export function isCorroborated(finding: Pick<ProvenanceFinding, "source" | "sources">): boolean {
+  return getSources(finding).length > 1;
+}
+
+export function matchesSourceFilter(
+  finding: Pick<ProvenanceFinding, "source" | "sources">,
+  source: FindingSource | "confirmed",
+): boolean {
+  if (source === "confirmed") return isCorroborated(finding);
+  return getSources(finding).includes(source);
+}
+
+export function getSources(finding: Pick<ProvenanceFinding, "source" | "sources">): FindingSource[] {
+  const sources = finding.sources && finding.sources.length > 0 ? finding.sources : [finding.source];
+  return uniqueSources(sources).sort((a, b) => SOURCE_ORDER.indexOf(a) - SOURCE_ORDER.indexOf(b));
+}
+
+function correlationSubject(finding: ProvenanceFinding): string {
+  const explicit = finding.sinkSymbol ?? finding.sourceSymbol ?? finding.itemName;
+  if (explicit && explicit.trim()) return normalizeSubject(explicit);
+  return normalizeSubject(finding.message).slice(0, 80);
+}
+
+function normalizeSubject(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9.]+/g, " ").trim();
+}
+
+function mergePair<T extends ProvenanceFinding>(a: T, b: T): T {
+  const primary = choosePrimary(a, b);
+  const secondary = primary === a ? b : a;
+  const merged: T = {
+    ...primary,
+    severity: higherSeverity(a.severity, b.severity) as T["severity"],
+    confidence: maxNumber(a.confidence, b.confidence),
+    safeFix: primary.safeFix ?? secondary.safeFix,
+    fixPatch: primary.fixPatch ?? secondary.fixPatch,
+    evidence: mergeStrings(a.evidence, b.evidence),
+    trace: mergeTrace(a.trace, b.trace),
+    reviewReason: primary.reviewReason ?? secondary.reviewReason,
+    ciBlocking: a.ciBlocking === true || b.ciBlocking === true ? true : primary.ciBlocking ?? secondary.ciBlocking,
+    baselineStatus: primary.baselineStatus ?? secondary.baselineStatus,
+    isNew: a.isNew === true || b.isNew === true ? true : primary.isNew ?? secondary.isNew,
+    sources: uniqueSources([...getSources(a), ...getSources(b)]),
+  };
+  return merged;
+}
+
+function withNormalizedSources<T extends ProvenanceFinding>(finding: T): T {
+  return {
+    ...finding,
+    sources: getSources(finding),
+  };
+}
+
+function choosePrimary<T extends ProvenanceFinding>(a: T, b: T): T {
+  const sourceDelta = SOURCE_ORDER.indexOf(a.source) - SOURCE_ORDER.indexOf(b.source);
+  if (sourceDelta !== 0) return sourceDelta < 0 ? a : b;
+  return severityRank(a.severity) >= severityRank(b.severity) ? a : b;
+}
+
+function higherSeverity(a: string, b: string): string {
+  return severityRank(a) >= severityRank(b) ? a : b;
+}
+
+function severityRank(severity: string): number {
+  switch (severity.toUpperCase()) {
+    case "CRITICAL":
+      return 5;
+    case "HIGH":
+      return 4;
+    case "MEDIUM":
+    case "WARN":
+      return 3;
+    case "LOW":
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+function maxNumber(a: number | undefined, b: number | undefined): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+}
+
+function mergeStrings(a: string[] | undefined, b: string[] | undefined): string[] | undefined {
+  const values = [...(a ?? []), ...(b ?? [])].filter((value) => value.trim().length > 0);
+  return values.length > 0 ? [...new Set(values)] : undefined;
+}
+
+function mergeTrace<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
+  const values = [...(a ?? []), ...(b ?? [])];
+  return values.length > 0 ? values : undefined;
+}
+
+function uniqueSources(sources: FindingSource[]): FindingSource[] {
+  return [...new Set(sources)];
+}

--- a/editors/vscode/src/quickfix.ts
+++ b/editors/vscode/src/quickfix.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { FindingsStore } from "./store";
 import { getDocumentFilters } from "./types";
+import { isDeadCodeRule } from "./findingCore";
 
 
 export class SkylosQuickFixProvider implements vscode.CodeActionProvider {
@@ -16,13 +17,18 @@ export class SkylosQuickFixProvider implements vscode.CodeActionProvider {
     const actions: vscode.CodeAction[] = [];
 
     for (const diag of context.diagnostics) {
-      if (diag.source !== "skylos" && diag.source !== "skylos-ai") 
+      if (!diag.source?.startsWith("skylos"))
         continue;
 
       const line = diag.range.start.line;
       const lineText = document.lineAt(line).text;
-      const ruleId = typeof diag.code === "string" ? diag.code : String(diag.code ?? "");
+      const ruleId = getRuleId(diag.code);
       const langId = document.languageId;
+      const finding = this.store.getFindingsForFile(document.uri.fsPath)
+        .find((candidate) =>
+          candidate.line === line + 1
+          && (candidate.ruleId === ruleId || candidate.legacyRuleId === ruleId),
+        );
 
       const ignoreComment = getIgnoreComment(langId);
 
@@ -51,34 +57,21 @@ export class SkylosQuickFixProvider implements vscode.CodeActionProvider {
       fileIgnore.diagnostics = [diag];
       actions.push(fileIgnore);
 
-      if (ruleId === "DEAD-IMPORT") {
-        const removeAction = new vscode.CodeAction(
-          `Remove unused import`,
+      if (finding?.fixPatch) {
+        const previewFix = new vscode.CodeAction(
+          "Skylos: Preview engine fix",
           vscode.CodeActionKind.QuickFix,
         );
-        removeAction.isPreferred = true;
-        removeAction.edit = new vscode.WorkspaceEdit();
-        const fullLine = new vscode.Range(line, 0, line + 1, 0);
-        removeAction.edit.delete(document.uri, fullLine);
-        removeAction.diagnostics = [diag];
-        actions.push(removeAction);
-      }
-
-      if (ruleId === "DEAD-FUNC") {
-        const removeFunc = new vscode.CodeAction(
-          `Remove unused function`,
-          vscode.CodeActionKind.QuickFix,
-        );
-        removeFunc.command = {
-          title: "Remove function",
-          command: "skylos.removeFunction",
-          arguments: [document.uri, line],
+        previewFix.command = {
+          title: "Preview engine fix",
+          command: "skylos.previewSafeFix",
+          arguments: [finding],
         };
-        removeFunc.diagnostics = [diag];
-        actions.push(removeFunc);
+        previewFix.diagnostics = [diag];
+        actions.push(previewFix);
       }
 
-      if (ruleId.startsWith("DEAD-")) {
+      if (isDeadCodeRule(ruleId)) {
         const whitelist = new vscode.CodeAction(
           `Add to whitelist`,
           vscode.CodeActionKind.QuickFix,
@@ -92,18 +85,18 @@ export class SkylosQuickFixProvider implements vscode.CodeActionProvider {
         actions.push(whitelist);
       }
 
-      if (diag.source === "skylos-ai" || ruleId.startsWith("SKY-D") || ruleId.startsWith("SKY-S")) {
+      if (diag.source.includes("ai-assist") || ruleId.startsWith("SKY-D") || ruleId.startsWith("SKY-S")) {
         const fixAI = new vscode.CodeAction(
-          `Fix with AI`,
+          `Fix with AI Assist`,
           vscode.CodeActionKind.QuickFix,
         );
         fixAI.command = {
-          title: "Fix with AI",
+          title: "Fix with AI Assist",
           command: "skylos.fix",
           arguments: [
             document.uri.fsPath,
             diag.range,
-            diag.message.replace("[AI] ", ""),
+            diag.message,
             false,
           ],
         };
@@ -120,6 +113,16 @@ export class SkylosQuickFixProvider implements vscode.CodeActionProvider {
       providedCodeActionKinds: SkylosQuickFixProvider.providedCodeActionKinds,
     });
   }
+}
+
+function getRuleId(code: vscode.Diagnostic["code"]): string {
+  if (typeof code === "string" || typeof code === "number") {
+    return String(code);
+  }
+  if (code && typeof code === "object" && "value" in code) {
+    return String(code.value);
+  }
+  return "";
 }
 
 function getIgnoreComment(langId: string): string {

--- a/editors/vscode/src/reviewCore.ts
+++ b/editors/vscode/src/reviewCore.ts
@@ -1,0 +1,296 @@
+import type { SkylosFinding } from "./types";
+import { isCorroborated, sourceSummary } from "./provenanceCore";
+
+export interface ReviewContext {
+  currentFile?: string;
+  visibleFiles?: Iterable<string>;
+  diffBase?: string;
+}
+
+export interface CiImpact {
+  status: "blocking" | "attention" | "clean";
+  headline: string;
+  blockerCount: number;
+  attentionCount: number;
+  reasons: string[];
+}
+
+export interface FixPlan {
+  mode: "engine" | "safe-fix" | "ai" | "manual";
+  title: string;
+  steps: string[];
+}
+
+export function sortReviewQueue(findings: SkylosFinding[], context: ReviewContext = {}): SkylosFinding[] {
+  return [...findings].sort((a, b) =>
+    reviewScore(b, context) - reviewScore(a, context)
+    || a.file.localeCompare(b.file)
+    || a.line - b.line
+    || a.message.localeCompare(b.message),
+  );
+}
+
+export function reviewScore(finding: SkylosFinding, context: ReviewContext = {}): number {
+  let score = severityRank(finding.severity) * 10000;
+  if (finding.file === context.currentFile) score += 100000;
+  else if (context.visibleFiles && new Set(context.visibleFiles).has(finding.file)) score += 50000;
+
+  if (finding.ciBlocking === true) score += 70000;
+  if (isCorroborated(finding)) score += 65000;
+  if (finding.isNew || finding.baselineStatus === "new") score += 45000;
+  if (finding.category === "secrets") score += 9000;
+  if (finding.category === "security") score += 7000;
+  if (finding.fixPatch) score += 3000;
+  if (hasEvidence(finding)) score += 750;
+  if (finding.source === "cli") score += 500;
+  if (finding.confidence !== undefined) score += Math.min(100, Math.max(0, finding.confidence));
+  return score;
+}
+
+export function priorityReasons(finding: SkylosFinding, context: ReviewContext = {}): string[] {
+  const reasons: string[] = [];
+  if (finding.file === context.currentFile) reasons.push("In the active editor");
+  else if (context.visibleFiles && new Set(context.visibleFiles).has(finding.file)) reasons.push("In an open editor");
+  if (isCorroborated(finding)) reasons.push(`Confirmed by ${sourceSummary(finding)}`);
+  if (finding.ciBlocking === true) reasons.push("Marked as CI-blocking by Skylos");
+  if (finding.isNew || finding.baselineStatus === "new") {
+    reasons.push(context.diffBase ? `New against ${context.diffBase}` : "New against the configured baseline");
+  }
+  if (finding.severity === "CRITICAL" || finding.severity === "HIGH") {
+    reasons.push(`${finding.severity.toLowerCase()} severity`);
+  }
+  if (finding.category === "secrets") reasons.push("Secret exposure risk");
+  else if (finding.category === "security") reasons.push("Security finding");
+  if (finding.fixPatch) reasons.push("Deterministic patch is available");
+  if (hasEvidence(finding)) reasons.push("Evidence is attached");
+  if (finding.reviewReason) reasons.push(finding.reviewReason);
+  if (finding.confidence !== undefined) reasons.push(`${finding.confidence}% confidence`);
+  if (reasons.length === 0) reasons.push("Ranked by severity, category, and location");
+  return unique(reasons).slice(0, 6);
+}
+
+export function ciImpact(findings: SkylosFinding[], context: ReviewContext = {}): CiImpact {
+  const blockers = findings.filter(isLikelyCiBlocker);
+  const attention = findings.filter((finding) => !isLikelyCiBlocker(finding) && needsAttention(finding));
+  const scope = context.diffBase ? `new issues against ${context.diffBase}` : "the current review queue";
+
+  if (blockers.length > 0) {
+    const reasons = summarizeCounts(blockers);
+    return {
+      status: "blocking",
+      headline: `Likely CI block: ${blockers.length} blocker(s) in ${scope}`,
+      blockerCount: blockers.length,
+      attentionCount: attention.length,
+      reasons,
+    };
+  }
+
+  if (attention.length > 0) {
+    return {
+      status: "attention",
+      headline: `CI risk: ${attention.length} issue(s) need review in ${scope}`,
+      blockerCount: 0,
+      attentionCount: attention.length,
+      reasons: summarizeCounts(attention),
+    };
+  }
+
+  return {
+    status: "clean",
+    headline: findings.length === 0 ? "No Skylos issues in scope" : "No likely CI blockers in scope",
+    blockerCount: 0,
+    attentionCount: 0,
+    reasons: [],
+  };
+}
+
+export function fixPlan(finding: SkylosFinding): FixPlan {
+  if (finding.fixPatch) {
+    return {
+      mode: "engine",
+      title: "Preview the deterministic engine patch first",
+      steps: [
+        "Open the generated diff and verify the exact lines being changed.",
+        "Apply the patch only if the diff matches the finding and preserves behavior.",
+        "Rerun Skylos and the nearest tests after applying it.",
+      ],
+    };
+  }
+
+  if (finding.safeFix) {
+    return {
+      mode: "safe-fix",
+      title: "Use the safe-fix guidance",
+      steps: [
+        finding.safeFix,
+        "Review the local code path before editing.",
+        "Rerun Skylos after the change.",
+      ],
+    };
+  }
+
+  if (finding.suggestion) {
+    return {
+      mode: "ai",
+      title: "Use the suggested remediation as a starting point",
+      steps: [
+        finding.suggestion,
+        "Ask AI for a patch only after checking the affected code path.",
+        "Verify with the project test or lint command.",
+      ],
+    };
+  }
+
+  if (finding.category === "secrets") {
+    return {
+      mode: "manual",
+      title: "Rotate and remove the exposed secret",
+      steps: [
+        "Remove the secret from source control and replace it with a runtime secret source.",
+        "Rotate the leaked credential if it may have been committed or shared.",
+        "Rerun Skylos secrets scanning.",
+      ],
+    };
+  }
+
+  if (finding.category === "security") {
+    return {
+      mode: "manual",
+      title: "Fix the vulnerable data path",
+      steps: [
+        "Open the finding and inspect the source, sink, and validation path.",
+        "Add validation, sanitization, authorization, or safer APIs according to the rule.",
+        "Add or update a regression test for the dangerous path.",
+      ],
+    };
+  }
+
+  if (finding.category === "dead_code") {
+    return {
+      mode: "manual",
+      title: "Confirm reachability before removing code",
+      steps: [
+        "Check dynamic references, exports, framework hooks, and tests before deleting.",
+        "Remove the unused item or mark it intentionally retained.",
+        "Rerun Skylos dead-code analysis.",
+      ],
+    };
+  }
+
+  return {
+    mode: "manual",
+    title: "Review and fix locally",
+    steps: [
+      "Open the code at the reported line.",
+      "Apply the smallest behavior-preserving change that satisfies the rule.",
+      "Rerun Skylos and the closest relevant tests.",
+    ],
+  };
+}
+
+export function evidenceLines(finding: SkylosFinding): string[] {
+  const lines: string[] = [];
+  if (finding.explanation) lines.push(finding.explanation);
+  if (finding.reviewReason) lines.push(finding.reviewReason);
+  for (const item of finding.evidence ?? []) lines.push(item);
+
+  if (finding.sourceSymbol || finding.sinkSymbol) {
+    const source = finding.sourceSymbol ? `source ${finding.sourceSymbol}` : "source unknown";
+    const sink = finding.sinkSymbol ? `sink ${finding.sinkSymbol}` : "sink unknown";
+    lines.push(`Data path: ${source} -> ${sink}`);
+  }
+
+  for (const step of finding.trace ?? []) {
+    const location = step.file ? `${step.file}${step.line ? `:${step.line}` : ""}` : undefined;
+    const message = step.message ?? step.label ?? step.symbol;
+    if (location && message) lines.push(`${location} - ${message}`);
+    else if (location) lines.push(location);
+    else if (message) lines.push(message);
+  }
+
+  const security = summarizeSecurityEvidence(finding.securityEvidence);
+  lines.push(...security);
+  return unique(lines.filter((line) => line.trim().length > 0)).slice(0, 8);
+}
+
+export function hasEvidence(finding: SkylosFinding): boolean {
+  return Boolean(
+    finding.snippet
+    || finding.explanation
+    || finding.reviewReason
+    || finding.sourceSymbol
+    || finding.sinkSymbol
+    || (finding.evidence && finding.evidence.length > 0)
+    || (finding.trace && finding.trace.length > 0)
+    || (finding.securityEvidence && Object.keys(finding.securityEvidence).length > 0),
+  );
+}
+
+export function isLikelyCiBlocker(finding: SkylosFinding): boolean {
+  if (finding.ciBlocking === true) return true;
+  if (finding.severity === "CRITICAL") return true;
+  if (finding.category === "secrets") return finding.severity !== "INFO" && finding.severity !== "LOW";
+  return finding.category === "security" && finding.severity === "HIGH";
+}
+
+export function severityRank(severity: string): number {
+  switch (severity.toUpperCase()) {
+    case "CRITICAL":
+      return 5;
+    case "HIGH":
+      return 4;
+    case "MEDIUM":
+    case "WARN":
+      return 3;
+    case "LOW":
+      return 2;
+    case "INFO":
+    default:
+      return 1;
+  }
+}
+
+function needsAttention(finding: SkylosFinding): boolean {
+  return finding.severity === "HIGH"
+    || finding.severity === "MEDIUM"
+    || finding.severity === "WARN"
+    || finding.isNew === true
+    || finding.baselineStatus === "new";
+}
+
+function summarizeCounts(findings: SkylosFinding[]): string[] {
+  const counts = new Map<string, number>();
+  for (const finding of findings) {
+    const key = `${finding.severity} ${finding.category}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([key, count]) => `${count} ${key}`);
+}
+
+function summarizeSecurityEvidence(value: Record<string, unknown> | undefined): string[] {
+  if (!value) return [];
+  const lines: string[] = [];
+  const contractId = stringValue(value.contract_id);
+  const handler = stringValue(value.handler);
+  const missingGuards = stringArrayValue(value.missing_guards);
+  if (contractId) lines.push(`Security contract: ${contractId}`);
+  if (handler) lines.push(`Handler: ${handler}`);
+  if (missingGuards.length > 0) lines.push(`Missing guards: ${missingGuards.join(", ")}`);
+  if (lines.length === 0) lines.push(`Security evidence fields: ${Object.keys(value).slice(0, 6).join(", ")}`);
+  return lines;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function stringArrayValue(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}

--- a/editors/vscode/src/rules.ts
+++ b/editors/vscode/src/rules.ts
@@ -13,6 +13,12 @@ export interface RuleMeta {
 }
 
 const RULES: Record<string, RuleMeta> = {
+  "SKY-U001": { name: "Unused function", severity: "INFO", category: "dead_code", description: "Function is defined but never called anywhere in the project.", fix: "Remove the function or add it to the whitelist." },
+  "SKY-U002": { name: "Unused import", severity: "INFO", category: "dead_code", description: "Import is never referenced in the module.", fix: "Remove the import statement." },
+  "SKY-U003": { name: "Unused variable", severity: "INFO", category: "dead_code", description: "Variable is assigned but never read.", fix: "Remove the variable or prefix with underscore." },
+  "SKY-U004": { name: "Unused class", severity: "INFO", category: "dead_code", description: "Class is defined but never instantiated or referenced.", fix: "Remove the class or add it to the whitelist." },
+  "SKY-U005": { name: "Unused parameter", severity: "INFO", category: "dead_code", description: "Parameter is declared but never used in the function body.", fix: "Remove the parameter or prefix with underscore." },
+
   "DEAD-FUNC": { name: "Unused function", severity: "INFO", category: "dead_code", description: "Function is defined but never called anywhere in the project.", fix: "Remove the function or add it to the whitelist." },
   "DEAD-IMPORT": { name: "Unused import", severity: "INFO", category: "dead_code", description: "Import is never referenced in the module.", fix: "Remove the import statement." },
   "DEAD-CLASS": { name: "Unused class", severity: "INFO", category: "dead_code", description: "Class is defined but never instantiated or referenced.", fix: "Remove the class or add it to the whitelist." },

--- a/editors/vscode/src/scanCore.ts
+++ b/editors/vscode/src/scanCore.ts
@@ -1,0 +1,93 @@
+export interface ScanCommandSpec {
+  target: string;
+  confidence: number;
+  excludeFolders: string[];
+  enableSecrets: boolean;
+  enableDanger: boolean;
+  enableQuality: boolean;
+  diffBase?: string;
+}
+
+export interface ScanCommand {
+  args: string[];
+  display: string;
+}
+
+export type ScanFailureKind =
+  | "missing_binary"
+  | "invalid_json"
+  | "nonzero_exit"
+  | "cancelled"
+  | "unknown";
+
+export class SkylosScanError extends Error {
+  constructor(
+    public readonly kind: ScanFailureKind,
+    message: string,
+    public readonly details: {
+      command?: string;
+      exitCode?: number | null;
+      stderr?: string;
+      stdout?: string;
+    } = {},
+  ) {
+    super(message);
+    this.name = "SkylosScanError";
+  }
+}
+
+export function buildScanArgs(spec: ScanCommandSpec): string[] {
+  const args = [spec.target, "--json", "-c", String(spec.confidence)];
+
+  for (const folder of spec.excludeFolders) {
+    args.push("--exclude-folder", folder);
+  }
+  if (spec.enableSecrets) args.push("--secrets");
+  if (spec.enableDanger) args.push("--danger");
+  if (spec.enableQuality) args.push("--quality");
+  if (spec.diffBase) args.push("--diff-base", spec.diffBase);
+
+  return args;
+}
+
+export function buildScanCommand(bin: string, spec: ScanCommandSpec): ScanCommand {
+  const args = buildScanArgs(spec);
+  return {
+    args,
+    display: formatCommand(bin, args),
+  };
+}
+
+export function formatCommand(bin: string, args: string[]): string {
+  return [bin, ...args].map(shellQuote).join(" ");
+}
+
+export function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildScanErrorMessage(error: unknown): string {
+  if (!(error instanceof SkylosScanError)) {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  switch (error.kind) {
+    case "missing_binary":
+      return "Skylos executable was not found. Set `skylos.path` or install the Skylos CLI.";
+    case "invalid_json":
+      return "Skylos returned invalid JSON. Open the Skylos output channel for the raw command output.";
+    case "nonzero_exit": {
+      const code = error.details.exitCode ?? "?";
+      return `Skylos exited with code ${code}. Open the Skylos output channel for details.`;
+    }
+    case "cancelled":
+      return "Scan cancelled";
+    case "unknown":
+    default:
+      return error.message;
+  }
+}
+

--- a/editors/vscode/src/scanner.ts
+++ b/editors/vscode/src/scanner.ts
@@ -1,10 +1,13 @@
 import * as vscode from "vscode";
 import { spawn, type ChildProcess } from "child_process";
 import * as path from "path";
-import type { SkylosFinding, CLIReport, UnusedItem, CLIFinding, QualityFinding, Severity, Category, CLIGrade, AnalysisSummary, CircularDependency, DependencyVulnerability } from "./types";
+import type { SkylosFinding, CLIReport, CLIGrade, AnalysisSummary, CircularDependency, DependencyVulnerability, ScanMetadata } from "./types";
 import { getSkylosBin, getConfidenceThreshold, getExcludeFolders, isFeatureEnabled, isDeadCodeEnabled, isShowDeadParams } from "./config";
+import { buildScanCommand, formatCommand, SkylosScanError } from "./scanCore";
+import { normalizeReportCore } from "./findingCore";
 
 export const out = vscode.window.createOutputChannel("Skylos");
+export { buildScanErrorMessage, SkylosScanError } from "./scanCore";
 
 let activeProcess: ChildProcess | null = null;
 
@@ -21,6 +24,17 @@ export interface ScanResult {
   summary?: AnalysisSummary;
   circularDeps?: CircularDependency[];
   depVulns?: DependencyVulnerability[];
+  metadata?: ScanMetadata;
+}
+
+export interface DoctorResult {
+  ok: boolean;
+  command: string;
+  bin: string;
+  workspaceRoot?: string;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
 }
 
 export async function scanWorkspace(token?: vscode.CancellationToken, diffBase?: string): Promise<ScanResult> {
@@ -39,31 +53,20 @@ export async function scanFile(filePath: string, token?: vscode.CancellationToke
   return runScan(filePath, wsRoot, token);
 }
 
-async function runScan(target: string, wsRoot: string, token?: vscode.CancellationToken, diffBase?: string): Promise<ScanResult> {
-  cancelScan();
-
+export async function doctorSkylos(): Promise<DoctorResult> {
   const bin = getSkylosBin();
-  const conf = getConfidenceThreshold();
-  const excludes = getExcludeFolders();
-
-  const args = [target, "--json", "-c", String(conf)];
-  excludes.forEach((f) => args.push("--exclude-folder", f));
-  if (isFeatureEnabled("secrets"))
-    args.push("--secrets");
-  if (isFeatureEnabled("danger"))
-    args.push("--danger");
-  if (isFeatureEnabled("quality"))
-    args.push("--quality");
-  if (diffBase)
-    args.push("--diff-base", diffBase);
+  const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const args = ["--version"];
+  const command = formatCommand(bin, args);
 
   out.appendLine("=".repeat(60));
-  out.appendLine(`Running: ${bin} ${args.join(" ")}`);
+  out.appendLine("Skylos Doctor");
+  out.appendLine(`Workspace: ${wsRoot ?? "(none)"}`);
+  out.appendLine(`Configured binary: ${bin}`);
+  out.appendLine(`Version command: ${command}`);
 
-  return new Promise<ScanResult>((resolve, reject) => {
+  return new Promise<DoctorResult>((resolve) => {
     const proc = spawn(bin, args, { cwd: wsRoot });
-    activeProcess = proc;
-
     let stdout = "";
     let stderr = "";
 
@@ -74,13 +77,96 @@ async function runScan(target: string, wsRoot: string, token?: vscode.Cancellati
       stderr += data.toString();
     });
 
-    token?.onCancellationRequested(() => {
-      proc.kill();
-      reject(new Error("Scan cancelled"));
+    proc.on("close", (code) => {
+      const ok = code === 0;
+      if (stdout.trim()) out.appendLine(`stdout: ${stdout.trim()}`);
+      if (stderr.trim()) out.appendLine(`stderr: ${stderr.trim()}`);
+      out.appendLine(ok ? "Doctor result: OK" : `Doctor result: failed with exit code ${code}`);
+      resolve({
+        ok,
+        command,
+        bin,
+        workspaceRoot: wsRoot,
+        stdout,
+        stderr,
+        error: ok ? undefined : `Version command exited with code ${code}`,
+      });
     });
 
-    proc.on("close", () => {
+    proc.on("error", (err) => {
+      const errno = (err as NodeJS.ErrnoException).code;
+      const error = errno === "ENOENT"
+        ? "Skylos executable was not found. Set `skylos.path` or install the Skylos CLI."
+        : err.message;
+      out.appendLine(`Doctor result: ${error}`);
+      resolve({
+        ok: false,
+        command,
+        bin,
+        workspaceRoot: wsRoot,
+        stdout,
+        stderr,
+        error,
+      });
+    });
+  });
+}
+
+async function runScan(target: string, wsRoot: string, token?: vscode.CancellationToken, diffBase?: string): Promise<ScanResult> {
+  cancelScan();
+
+  const bin = getSkylosBin();
+  const command = buildScanCommand(bin, {
+    target,
+    confidence: getConfidenceThreshold(),
+    excludeFolders: getExcludeFolders(),
+    enableSecrets: isFeatureEnabled("secrets"),
+    enableDanger: isFeatureEnabled("danger"),
+    enableQuality: isFeatureEnabled("quality"),
+    diffBase,
+  });
+
+  out.appendLine("=".repeat(60));
+  out.appendLine(`Running: ${command.display}`);
+  const startedAt = Date.now();
+
+  return new Promise<ScanResult>((resolve, reject) => {
+    const proc = spawn(bin, command.args, { cwd: wsRoot });
+    activeProcess = proc;
+
+    let stdout = "";
+    let stderr = "";
+    let cancelled = false;
+    let settled = false;
+
+    const fail = (error: SkylosScanError) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    const succeed = (result: ScanResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    proc.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    token?.onCancellationRequested(() => {
+      cancelled = true;
+      proc.kill();
+      fail(new SkylosScanError("cancelled", "Scan cancelled", { command: command.display }));
+    });
+
+    proc.on("close", (code) => {
       activeProcess = null;
+      if (cancelled) return;
 
       if (stderr) {
         out.appendLine(`stderr: ${stderr}`);
@@ -91,149 +177,55 @@ async function runScan(target: string, wsRoot: string, token?: vscode.Cancellati
         report = JSON.parse(stdout || "{}");
       } catch {
         out.appendLine("Invalid JSON from CLI");
-        reject(new Error("Skylos returned invalid JSON."));
+        fail(new SkylosScanError(
+          code === 0 ? "invalid_json" : "nonzero_exit",
+          code === 0 ? "Skylos returned invalid JSON." : `Skylos exited with code ${code}.`,
+          { command: command.display, exitCode: code, stderr, stdout },
+        ));
         return;
+      }
+
+      if (code !== 0) {
+        out.appendLine(`Skylos exited with code ${code} but returned parseable JSON; showing parsed findings.`);
       }
 
       const findings = normalizeReport(report, wsRoot);
       printReport(findings, wsRoot);
 
-      resolve({
+      succeed({
         findings,
         grade: report.grade,
         summary: report.analysis_summary,
         circularDeps: report.circular_dependencies,
         depVulns: report.dependency_vulnerabilities,
+        metadata: {
+          command: command.display,
+          target,
+          workspaceRoot: wsRoot,
+          diffBase,
+          durationMs: Date.now() - startedAt,
+          exitCode: code,
+          stderr,
+        },
       });
     });
 
     proc.on("error", (err) => {
       activeProcess = null;
-      reject(err);
+      const errno = (err as NodeJS.ErrnoException).code;
+      const kind = errno === "ENOENT" ? "missing_binary" : "unknown";
+      fail(new SkylosScanError(kind, err.message, { command: command.display, stderr }));
     });
   });
-}
-
-function resolvePath(filePath: string, wsRoot: string): string {
-  if (path.isAbsolute(filePath))
-    return filePath;
-  return path.join(wsRoot, filePath);
-}
-
-let findingCounter = 0;
-function nextId(): string {
-  return `f-${++findingCounter}`;
 }
 
 export function normalizeReport(report: CLIReport, wsRoot: string): SkylosFinding[] {
-  const findings: SkylosFinding[] = [];
-
-  const mapUnused = (items: UnusedItem[] | undefined, itemType: string, ruleId: string) => {
-    for (const u of items ?? []) {
-      if (!u.file)
-        continue;
-      const name = u.name ?? u.simple_name ?? "";
-      findings.push({
-        id: nextId(),
-        ruleId,
-        category: "dead_code",
-        severity: "INFO",
-        message: `Unused ${itemType}: ${name}`,
-        file: resolvePath(u.file, wsRoot),
-        line: u.line ?? u.lineno ?? 1,
-        col: 0,
-        confidence: u.confidence,
-        itemType,
-        itemName: name,
-        source: "cli",
-      });
-    }
-  };
-
-  mapUnused(report.unused_functions, "function", "DEAD-FUNC");
-  mapUnused(report.unused_imports, "import", "DEAD-IMPORT");
-  mapUnused(report.unused_classes, "class", "DEAD-CLASS");
-  mapUnused(report.unused_variables, "variable", "DEAD-VAR");
-  mapUnused(report.unused_parameters, "parameter", "DEAD-PARAM");
-
-  for (const s of report.secrets ?? []) {
-    if (!s.file)
-      continue;
-    findings.push(cliFindingToSkylos(s, "secrets", wsRoot));
-  }
-
-  for (const d of report.danger ?? []) {
-    if (!d.file)
-      continue;
-    findings.push(cliFindingToSkylos(d, "security", wsRoot));
-  }
-
-  for (const q of report.quality ?? []) {
-    if (!q.file)
-      continue;
-    const sev = normalizeSeverity(q.severity);
-    const ruleId = q.rule_id ?? "SKY-Q000";
-    const msg = q.message ?? `Quality issue (${q.kind ?? q.metric ?? "quality"})`;
-    findings.push({
-      id: nextId(),
-      ruleId,
-      category: "quality",
-      severity: sev,
-      message: msg,
-      file: resolvePath(q.file, wsRoot),
-      line: q.line ?? 1,
-      col: 0,
-      source: "cli",
-    });
-  }
-
-  const deadCodeOn = isDeadCodeEnabled();
-  const deadParamsOn = isShowDeadParams();
-  const confThreshold = getConfidenceThreshold();
-
-  return findings.filter((f) => {
-    if (f.category === "dead_code") {
-      if (!deadCodeOn) return false;
-      if (f.ruleId === "DEAD-PARAM" && !deadParamsOn) return false;
-      if (f.confidence !== undefined && f.confidence < confThreshold) return false;
-    }
-    return true;
-  });
-}
-
-function cliFindingToSkylos(f: CLIFinding, category: Category, wsRoot: string): SkylosFinding {
-  const sev = normalizeSeverity(f.severity);
-  const ruleId = f.rule_id ?? "SKYLOS";
-  return {
-    id: nextId(),
-    ruleId,
-    category,
-    severity: sev,
-    message: f.message,
-    file: resolvePath(f.file, wsRoot),
-    line: f.line ?? 1,
-    col: f.col ?? 0,
-    source: "cli",
-  };
-}
-
-function normalizeSeverity(s?: string): Severity {
-  const t = (s ?? "").toUpperCase();
-  if (t === "CRITICAL")
-    return "CRITICAL";
-
-  if (t === "HIGH")
-    return "HIGH";
-
-  if (t === "MEDIUM")
-    return "MEDIUM";
-
-  if (t === "LOW")
-    return "LOW";
-
-  if (t === "WARN" || t === "WARNING")
-    return "WARN";
-  return "INFO";
+  return normalizeReportCore(report, {
+    wsRoot,
+    deadCodeEnabled: isDeadCodeEnabled(),
+    showDeadParams: isShowDeadParams(),
+    confidenceThreshold: getConfidenceThreshold(),
+  }) as SkylosFinding[];
 }
 
 function printReport(findings: SkylosFinding[], wsRoot: string): void {

--- a/editors/vscode/src/sidebar.ts
+++ b/editors/vscode/src/sidebar.ts
@@ -1,10 +1,20 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import type { FindingsStore } from "./store";
-import type { SkylosFinding, Category } from "./types";
-import { getMaxTreeFindings, getMaxTreeFindingsPerFile } from "./config";
+import type { SkylosFinding, Category, ScanFailureMetadata, ScanMetadata } from "./types";
+import { getMaxTreeFindings, getMaxTreeFindingsPerFile, isRealtimeAIEnabled } from "./config";
+import {
+  ciImpact,
+  hasEvidence,
+  isLikelyCiBlocker,
+  priorityReasons,
+  sortReviewQueue,
+  type CiImpact,
+  type ReviewContext,
+} from "./reviewCore";
+import { isCorroborated, sourceSummary } from "./provenanceCore";
 
-type TreeNode = SummaryNode | CategoryNode | FileNode | FindingNode;
+type TreeNode = SummaryNode | SectionNode | FindingNode | InfoNode;
 
 class SummaryNode {
   constructor(
@@ -12,22 +22,23 @@ class SummaryNode {
     public readonly visibleTotal: number,
     public readonly rawTotal: number,
     public readonly filterActive: boolean,
+    public readonly lastScan?: ScanMetadata,
+    public readonly lastError?: ScanFailureMetadata,
+    public readonly impact?: CiImpact,
   ) {}
 }
 
-class CategoryNode {
+class SectionNode {
   constructor(
-    public readonly category: Category,
+    public readonly findings: SkylosFinding[],
     public readonly label: string,
-    public readonly findings: SkylosFinding[],
+    public readonly description?: string,
+    public readonly icon = "list-ordered",
   ) {}
 }
 
-class FileNode {
-  constructor(
-    public readonly filePath: string,
-    public readonly findings: SkylosFinding[],
-  ) {}
+class InfoNode {
+  constructor(public readonly label: string, public readonly description?: string, public readonly command?: string) {}
 }
 
 export class FindingNode {
@@ -40,16 +51,7 @@ const CATEGORY_LABELS: Record<Category, string> = {
   secrets: "Secrets",
   quality: "Quality",
   debt: "Technical Debt",
-  ai: "AI Analysis",
-};
-
-const CATEGORY_ICONS: Record<Category, string> = {
-  dead_code: "trash",
-  security: "shield",
-  secrets: "key",
-  quality: "beaker",
-  debt: "wrench",
-  ai: "sparkle",
+  ai: "AI Assist",
 };
 
 export class SkylosTreeProvider implements vscode.TreeDataProvider<TreeNode> {
@@ -68,18 +70,31 @@ export class SkylosTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     if (element instanceof SummaryNode) {
       const item = new vscode.TreeItem(
         element.workingTotal === 0
-          ? (element.filterActive ? "No findings match the current filter" : "No findings in scope")
-          : `Showing ${element.visibleTotal} of ${element.workingTotal} findings`,
+          ? (element.filterActive ? "No matching Skylos issues" : "No Skylos issues in scope")
+          : `${element.workingTotal} issue(s) to review`,
         vscode.TreeItemCollapsibleState.None,
       );
-      item.iconPath = new vscode.ThemeIcon("filter");
-      if (element.rawTotal !== element.workingTotal) {
+      item.iconPath = element.lastError
+        ? new vscode.ThemeIcon("warning", new vscode.ThemeColor("editorWarning.foreground"))
+        : new vscode.ThemeIcon("shield");
+      if (element.lastError) {
+        item.description = "Last scan failed";
+      } else if (element.impact?.status === "blocking") {
+        item.description = `${element.impact.blockerCount} likely CI blocker(s)`;
+      } else if (element.impact?.status === "attention") {
+        item.description = `${element.impact.attentionCount} need review`;
+      } else if (element.lastScan?.diffBase) {
+        item.description = `New issues vs ${element.lastScan.diffBase}`;
+      } else if (element.rawTotal !== element.workingTotal) {
         item.description = `${element.rawTotal} total in repo`;
+      } else if (element.lastScan?.durationMs !== undefined) {
+        item.description = `Last scan ${Math.round(element.lastScan.durationMs / 100) / 10}s`;
       } else if (element.workingTotal > element.visibleTotal) {
-        item.description = "Refine with filters or open Dashboard";
+        item.description = `Top ${element.visibleTotal} shown`;
       } else if (element.filterActive) {
         item.description = "Filter active";
       }
+      item.tooltip = buildSummaryTooltip(element);
       item.command = {
         title: "Filter findings",
         command: element.filterActive ? "skylos.clearFilter" : "skylos.filterFindings",
@@ -87,32 +102,33 @@ export class SkylosTreeProvider implements vscode.TreeDataProvider<TreeNode> {
       return item;
     }
 
-    if (element instanceof CategoryNode) {
+    if (element instanceof SectionNode) {
       const item = new vscode.TreeItem(
         `${element.label} (${element.findings.length})`,
-        vscode.TreeItemCollapsibleState.Collapsed,
+        vscode.TreeItemCollapsibleState.Expanded,
       );
-      item.iconPath = new vscode.ThemeIcon(CATEGORY_ICONS[element.category]);
+      item.iconPath = new vscode.ThemeIcon(element.icon);
+      item.description = element.description;
       return item;
     }
 
-    if (element instanceof FileNode) {
-      const fileName = path.basename(element.filePath);
-      const item = new vscode.TreeItem(
-        `${fileName} (${element.findings.length})`,
-        vscode.TreeItemCollapsibleState.Collapsed,
-      );
-      item.iconPath = vscode.ThemeIcon.File;
-      item.description = path.dirname(element.filePath);
-      item.resourceUri = vscode.Uri.file(element.filePath);
+    if (element instanceof InfoNode) {
+      const item = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.None);
+      item.iconPath = new vscode.ThemeIcon(element.command ? "play" : "info");
+      item.description = element.description;
+      if (element.command) {
+        item.command = { title: element.label, command: element.command };
+      }
       return item;
     }
 
     const f = element.finding;
-    const item = new vscode.TreeItem(`L${f.line}: ${f.message}`, vscode.TreeItemCollapsibleState.None);
+    const item = new vscode.TreeItem(buildFindingLabel(f), vscode.TreeItemCollapsibleState.None);
     item.iconPath = getSeverityIcon(f.severity);
-    item.tooltip = `[${f.ruleId}] ${f.message}`;
-    item.contextValue = "skylosFinding";
+    item.description = buildFindingDescription(f, getReviewContext(this.store.lastScan));
+    item.tooltip = buildFindingTooltip(f, getReviewContext(this.store.lastScan));
+    item.contextValue = f.fixPatch ? "skylosFindingSafeFix" : "skylosFinding";
+    item.resourceUri = vscode.Uri.file(f.file);
     item.command = {
       title: "Go to finding",
       command: "vscode.open",
@@ -129,47 +145,44 @@ export class SkylosTreeProvider implements vscode.TreeDataProvider<TreeNode> {
       const summary = this.store.getVisibleSummary(getMaxTreeFindings(), {
         maxPerFile: getMaxTreeFindingsPerFile(),
       });
-      const all = this.store.getVisibleFindings(getMaxTreeFindings(), {
+      const context = getReviewContext(this.store.lastScan);
+      const findings = sortReviewQueue(this.store.getVisibleFindings(getMaxTreeFindings(), {
         maxPerFile: getMaxTreeFindingsPerFile(),
-      });
-      const byCategory = new Map<Category, SkylosFinding[]>();
-      for (const f of all) {
-        const list = byCategory.get(f.category) ?? [];
-        list.push(f);
-        byCategory.set(f.category, list);
+      }), context);
+      const allFindings = this.store.getAllFindings();
+      const impact = ciImpact(allFindings, context);
+      const nodes: TreeNode[] = [
+        new SummaryNode(
+          summary.workingTotal,
+          summary.visibleTotal,
+          summary.rawTotal,
+          this.store.hasActiveFilter,
+          this.store.lastScan,
+          this.store.lastError,
+          impact,
+        ),
+      ];
+      nodes.push(buildStatusNode(this.store.lastScan, this.store.lastError, allFindings));
+
+      if (findings.length === 0) {
+        if (this.store.lastError) {
+          nodes.push(new InfoNode("Run Doctor", "Check the Skylos CLI setup", "skylos.doctor"));
+        } else {
+          nodes.push(new InfoNode("Scan Workspace", "Populate the Skylos review queue", "skylos.scan"));
+        }
+        return nodes;
       }
 
-      const nodes: CategoryNode[] = [];
-      const order: Category[] = ["security", "secrets", "debt", "dead_code", "quality", "ai"];
-      for (const cat of order) {
-        const findings = byCategory.get(cat);
-        if (findings && findings.length > 0) {
-          nodes.push(new CategoryNode(cat, CATEGORY_LABELS[cat], findings));
-        }
-      }
-      return [new SummaryNode(summary.workingTotal, summary.visibleTotal, summary.rawTotal, this.store.hasActiveFilter), ...nodes];
+      nodes.push(...buildReviewSections(findings, context));
+      return nodes;
     }
 
-    if (element instanceof SummaryNode) {
+    if (element instanceof SummaryNode || element instanceof InfoNode) {
       return [];
     }
 
-    if (element instanceof CategoryNode) {
-      const byFile = new Map<string, SkylosFinding[]>();
-      for (const f of element.findings) {
-        const list = byFile.get(f.file) ?? [];
-        list.push(f);
-        byFile.set(f.file, list);
-      }
-      return [...byFile.entries()]
-        .sort((a, b) => compareFileBuckets(a[1], b[1]))
-        .map(([filePath, findings]) => new FileNode(filePath, findings));
-    }
-
-    if (element instanceof FileNode) {
-      return element.findings
-        .sort(compareFindingsInTree)
-        .map((f) => new FindingNode(f));
+    if (element instanceof SectionNode) {
+      return element.findings.map((f) => new FindingNode(f));
     }
 
     return [];
@@ -179,6 +192,167 @@ export class SkylosTreeProvider implements vscode.TreeDataProvider<TreeNode> {
     this._onDidChangeTreeData.dispose();
     this.disposables.forEach((d) => d.dispose());
   }
+}
+
+function buildStatusNode(
+  lastScan: ScanMetadata | undefined,
+  lastError: ScanFailureMetadata | undefined,
+  findings: SkylosFinding[],
+): InfoNode {
+  const staticLabel = lastError ? "Static scan failed" : lastScan ? "Static scan complete" : "Static scan pending";
+  const automationOn = findings.some((finding) => (finding.sources ?? [finding.source]).includes("agent"));
+  const aiOn = isRealtimeAIEnabled();
+  return new InfoNode(
+    staticLabel,
+    `Automation: ${automationOn ? "On" : "Off"} · AI Assist: ${aiOn ? "On" : "Off"}`,
+    lastError ? "skylos.doctor" : undefined,
+  );
+}
+
+function buildReviewSections(findings: SkylosFinding[], context: ReviewContext): SectionNode[] {
+  const blockers = findings.filter((finding) => isBlockerFinding(finding, context));
+  const blockerKeys = new Set(blockers.map(findingKey));
+  const needsReview = findings.filter((finding) =>
+    !blockerKeys.has(findingKey(finding)) && isNeedsReviewFinding(finding, context),
+  );
+  const reviewKeys = new Set(needsReview.map(findingKey));
+  const safeFixes = findings.filter((finding) =>
+    finding.fixPatch && !blockerKeys.has(findingKey(finding)) && !reviewKeys.has(findingKey(finding)),
+  );
+  const used = new Set([...blockers, ...needsReview, ...safeFixes].map(findingKey));
+  const later = findings.filter((finding) => !used.has(findingKey(finding)));
+
+  const sections: SectionNode[] = [];
+  if (blockers.length > 0) {
+    sections.push(new SectionNode(
+      blockers,
+      "Blockers",
+      "Likely to fail CI or expose security risk",
+      "flame",
+    ));
+  }
+  if (needsReview.length > 0) {
+    sections.push(new SectionNode(
+      needsReview,
+      "Needs Review",
+      "Important findings without a safe automatic fix",
+      "eye",
+    ));
+  }
+  if (safeFixes.length > 0) {
+    sections.push(new SectionNode(
+      safeFixes,
+      "Fixable",
+      "Engine-backed patch available",
+      "diff",
+    ));
+  }
+  if (later.length > 0) {
+    sections.push(new SectionNode(
+      later,
+      sections.length === 0 ? "Review Queue" : "Review Later",
+      "Lower-risk quality and dead-code findings",
+      "list-ordered",
+    ));
+  }
+  return sections;
+}
+
+function isBlockerFinding(finding: SkylosFinding, context: ReviewContext): boolean {
+  const severity = finding.severity.toUpperCase();
+  return isLikelyCiBlocker(finding)
+    || severity === "CRITICAL"
+    || finding.category === "secrets"
+    || (finding.category === "security" && severity === "HIGH")
+    || (isCorroborated(finding) && (severity === "HIGH" || severity === "CRITICAL"));
+}
+
+function isNeedsReviewFinding(finding: SkylosFinding, context: ReviewContext): boolean {
+  const severity = finding.severity.toUpperCase();
+  return finding.file === context.currentFile
+    || finding.isNew === true
+    || finding.baselineStatus === "new"
+    || isCorroborated(finding)
+    || severity === "HIGH"
+    || finding.category === "security"
+    || severity === "MEDIUM"
+    || severity === "WARN";
+}
+
+function findingKey(finding: SkylosFinding): string {
+  return finding.fingerprint ?? `${finding.ruleId}:${finding.file}:${finding.line}:${finding.message}`;
+}
+
+function buildFindingLabel(finding: SkylosFinding): string {
+  return `${finding.severity} ${finding.ruleId}: ${shorten(finding.message, 72)}`;
+}
+
+function buildFindingDescription(finding: SkylosFinding, context: ReviewContext): string {
+  const file = `${path.basename(finding.file)}:${finding.line}`;
+  const badges = buildFindingBadges(finding, context);
+  return badges.length > 0 ? `${file}  ${badges.join(" ")}` : file;
+}
+
+function buildFindingBadges(finding: SkylosFinding, context: ReviewContext): string[] {
+  const badges: string[] = [];
+  if (finding.file === context.currentFile) badges.push("current");
+  if (isCorroborated(finding)) badges.push("Confirmed");
+  if (isLikelyCiBlocker(finding)) badges.push("ci");
+  if (finding.isNew || finding.baselineStatus === "new") badges.push("new");
+  if (finding.fixPatch) badges.push("fix");
+  if (hasEvidence(finding)) badges.push("evidence");
+  if (finding.confidence !== undefined) badges.push(`${finding.confidence}%`);
+  badges.push(sourceSummary(finding));
+  badges.push(CATEGORY_LABELS[finding.category] ?? finding.category);
+  return badges;
+}
+
+function buildFindingTooltip(finding: SkylosFinding, context: ReviewContext): string {
+  const lines = [
+    `[${finding.ruleId}] ${finding.message}`,
+    `Severity: ${finding.severity}`,
+    `Category: ${CATEGORY_LABELS[finding.category] ?? finding.category}`,
+    `Source: ${isCorroborated(finding) ? `Confirmed by ${sourceSummary(finding)}` : sourceSummary(finding)}`,
+    `Location: ${finding.relativePath ?? finding.file}:${finding.line}`,
+    "",
+    "Why ranked here:",
+    ...priorityReasons(finding, context).map((reason) => `- ${reason}`),
+  ];
+  if (finding.confidence !== undefined) lines.push(`Confidence: ${finding.confidence}%`);
+  if (finding.isNew || finding.baselineStatus) lines.push(`Baseline: ${finding.baselineStatus ?? "new"}`);
+  if (finding.fixPatch) lines.push("Engine fix: preview available");
+  if (hasEvidence(finding)) lines.push("Evidence: attached");
+  return lines.join("\n");
+}
+
+function buildSummaryTooltip(node: SummaryNode): string {
+  const lines = [
+    `Visible: ${node.visibleTotal}`,
+    `In current scope: ${node.workingTotal}`,
+    `Raw total: ${node.rawTotal}`,
+  ];
+  if (node.impact) {
+    lines.push("", node.impact.headline);
+    for (const reason of node.impact.reasons) lines.push(`- ${reason}`);
+  }
+  if (node.lastScan) {
+    lines.push(`Last command: ${node.lastScan.command}`);
+    if (node.lastScan.durationMs !== undefined) {
+      lines.push(`Duration: ${Math.round(node.lastScan.durationMs / 100) / 10}s`);
+    }
+  }
+  if (node.lastError) {
+    lines.push(`Last error: ${node.lastError.message}`);
+  }
+  return lines.join("\n");
+}
+
+function getReviewContext(lastScan?: ScanMetadata): ReviewContext {
+  return {
+    currentFile: vscode.window.activeTextEditor?.document.uri.fsPath,
+    visibleFiles: vscode.window.visibleTextEditors.map((editor) => editor.document.uri.fsPath),
+    diffBase: lastScan?.diffBase,
+  };
 }
 
 function getSeverityIcon(severity: string): vscode.ThemeIcon {
@@ -192,35 +366,7 @@ function getSeverityIcon(severity: string): vscode.ThemeIcon {
   return new vscode.ThemeIcon("info", new vscode.ThemeColor("editorInfo.foreground"));
 }
 
-function compareFileBuckets(a: SkylosFinding[], b: SkylosFinding[]): number {
-  const severityDelta = maxSeverityRank(b) - maxSeverityRank(a);
-  if (severityDelta !== 0) return severityDelta;
-  return b.length - a.length || a[0].file.localeCompare(b[0].file);
-}
-
-function compareFindingsInTree(a: SkylosFinding, b: SkylosFinding): number {
-  const severityDelta = severityRank(b.severity) - severityRank(a.severity);
-  if (severityDelta !== 0) return severityDelta;
-  return a.line - b.line || a.message.localeCompare(b.message);
-}
-
-function maxSeverityRank(findings: SkylosFinding[]): number {
-  return findings.reduce((max, finding) => Math.max(max, severityRank(finding.severity)), 0);
-}
-
-function severityRank(severity: string): number {
-  switch (severity.toUpperCase()) {
-    case "CRITICAL":
-      return 5;
-    case "HIGH":
-      return 4;
-    case "MEDIUM":
-    case "WARN":
-      return 3;
-    case "LOW":
-      return 2;
-    case "INFO":
-    default:
-      return 1;
-  }
+function shorten(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}...`;
 }

--- a/editors/vscode/src/statusbar.ts
+++ b/editors/vscode/src/statusbar.ts
@@ -40,6 +40,15 @@ export class SkylosStatusBar {
     const counts = this.store.countBySeverity();
     const total = Object.values(counts).reduce((s, n) => s + n, 0);
     const summary = this.store.getVisibleSummary(getMaxProblems());
+    const lastError = this.store.lastError;
+
+    if (lastError) {
+      this.item.text = "$(warning) Skylos";
+      this.item.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
+      this.item.color = undefined;
+      this.item.tooltip = `Last Skylos scan failed: ${lastError.message}\nClick to open Security Dashboard`;
+      return;
+    }
 
     if (total === 0) {
       this.item.text = "$(shield) Skylos";
@@ -69,7 +78,10 @@ export class SkylosStatusBar {
     const scopeLine = summary.visibleTotal < summary.workingTotal
       ? `Showing top ${summary.visibleTotal} of ${summary.workingTotal} findings in editor surfaces\n`
       : "";
-    this.item.tooltip = `${scopeLine}Critical: ${critical} | High: ${high} | Medium: ${medium} | Low: ${low}\nClick to open Security Dashboard`;
+    const scanLine = this.store.lastScan?.diffBase
+      ? `Mode: new issues vs ${this.store.lastScan.diffBase}\n`
+      : "";
+    this.item.tooltip = `${scanLine}${scopeLine}Critical: ${critical} | High: ${high} | Medium: ${medium} | Low: ${low}\nClick to open Security Dashboard`;
   }
 
   dispose(): void {

--- a/editors/vscode/src/store.ts
+++ b/editors/vscode/src/store.ts
@@ -6,19 +6,27 @@ import type {
   CircularDependency,
   DependencyVulnerability,
   FindingsFilter,
+  ScanFailureMetadata,
+  ScanMetadata,
 } from "./types";
+import type { FindingSource } from "./provenanceCore";
+import { isCorroborated, matchesSourceFilter, mergeCorrelatedFindings } from "./provenanceCore";
+import { reviewScore, severityRank } from "./reviewCore";
 
 type FindingsScope = "raw" | "working";
 
 export class FindingsStore {
   private workspaceCliFindingsByFile = new Map<string, SkylosFinding[]>();
   private focusedCliFindingsByFile = new Map<string, SkylosFinding[]>();
+  private agentFindingsByFile = new Map<string, SkylosFinding[]>();
   private aiFindingsByFile = new Map<string, SkylosFinding[]>();
 
   private _grade: CLIGrade | undefined;
   private _summary: AnalysisSummary | undefined;
   private _circularDeps: CircularDependency[] = [];
   private _depVulns: DependencyVulnerability[] = [];
+  private _lastScan: ScanMetadata | undefined;
+  private _lastError: ScanFailureMetadata | undefined;
   private _deltaMode = false;
   private _filter: FindingsFilter = {};
 
@@ -44,6 +52,16 @@ export class FindingsStore {
     this._onDidChange.fire();
   }
 
+  setAgentFindings(findings: SkylosFinding[]): void {
+    this.agentFindingsByFile.clear();
+    for (const f of findings) {
+      const list = this.agentFindingsByFile.get(f.file) ?? [];
+      list.push(f);
+      this.agentFindingsByFile.set(f.file, list);
+    }
+    this._onDidChange.fire();
+  }
+
   setEngineMetadata(
     grade?: CLIGrade,
     summary?: AnalysisSummary,
@@ -54,12 +72,26 @@ export class FindingsStore {
     this._summary = summary;
     this._circularDeps = circularDeps ?? [];
     this._depVulns = depVulns ?? [];
+    this._onDidChange.fire();
+  }
+
+  setLastScan(metadata: ScanMetadata): void {
+    this._lastScan = metadata;
+    this._lastError = undefined;
+    this._onDidChange.fire();
+  }
+
+  setLastError(error: ScanFailureMetadata): void {
+    this._lastError = error;
+    this._onDidChange.fire();
   }
 
   get grade(): CLIGrade | undefined { return this._grade; }
   get summary(): AnalysisSummary | undefined { return this._summary; }
   get circularDeps(): CircularDependency[] { return this._circularDeps; }
   get depVulns(): DependencyVulnerability[] { return this._depVulns; }
+  get lastScan(): ScanMetadata | undefined { return this._lastScan; }
+  get lastError(): ScanFailureMetadata | undefined { return this._lastError; }
 
   get deltaMode(): boolean { return this._deltaMode; }
   set deltaMode(v: boolean) { this._deltaMode = v; }
@@ -81,13 +113,14 @@ export class FindingsStore {
     } else {
       this.aiFindingsByFile.set(filePath, findings);
     }
+    this._onDidChange.fire();
     this._onDidChangeAI.fire();
   }
 
   getFindingsForFile(
     filePath: string,
     options?: {
-      source?: "cli" | "ai";
+      source?: FindingSource | "confirmed";
       includeDeadCode?: boolean;
       max?: number;
     },
@@ -101,7 +134,11 @@ export class FindingsStore {
   }
 
   getAllRawFindings(): SkylosFinding[] {
-    return [...this.getCurrentCLIFindings(), ...this.getAIFindings()];
+    return mergeCorrelatedFindings([
+      ...this.getCurrentCLIFindings(),
+      ...this.getAgentFindings(),
+      ...this.getAIFindings(),
+    ]);
   }
 
   getAllFindings(): SkylosFinding[] {
@@ -111,7 +148,7 @@ export class FindingsStore {
   getVisibleFindings(
     maxTotal: number,
     options?: {
-      source?: "cli" | "ai";
+      source?: FindingSource | "confirmed";
       includeDeadCode?: boolean;
       maxPerFile?: number;
     },
@@ -123,7 +160,7 @@ export class FindingsStore {
   getVisibleSummary(
     maxTotal: number,
     options?: {
-      source?: "cli" | "ai";
+      source?: FindingSource | "confirmed";
       includeDeadCode?: boolean;
       maxPerFile?: number;
     },
@@ -196,11 +233,14 @@ export class FindingsStore {
   clear(): void {
     this.workspaceCliFindingsByFile.clear();
     this.focusedCliFindingsByFile.clear();
+    this.agentFindingsByFile.clear();
     this.aiFindingsByFile.clear();
     this._grade = undefined;
     this._summary = undefined;
     this._circularDeps = [];
     this._depVulns = [];
+    this._lastScan = undefined;
+    this._lastError = undefined;
     this._onDidChange.fire();
     this._onDidChangeAI.fire();
   }
@@ -223,12 +263,15 @@ export class FindingsStore {
   }
 
   private getQueriedFindings(options?: {
-    source?: "cli" | "ai";
+    source?: FindingSource | "confirmed";
     includeDeadCode?: boolean;
   }): SkylosFinding[] {
     let findings = this.getAllRawFindings();
-    if (options?.source) {
-      findings = findings.filter((f) => f.source === options.source);
+    if (options?.source === "confirmed") {
+      findings = findings.filter(isCorroborated);
+    } else if (options?.source) {
+      const source = options.source;
+      findings = findings.filter((f) => (f.sources ?? [f.source]).includes(source));
     }
     if (options?.includeDeadCode === false) {
       findings = findings.filter((f) => f.category !== "dead_code");
@@ -240,7 +283,7 @@ export class FindingsStore {
     const f = this._filter;
     if (f.severity && finding.severity !== f.severity) return false;
     if (f.category && finding.category !== f.category) return false;
-    if (f.source && finding.source !== f.source) return false;
+    if (f.source && !matchesSourceFilter(finding, f.source)) return false;
     if (f.filePattern && !finding.file.toLowerCase().includes(f.filePattern.toLowerCase())) return false;
     return true;
   }
@@ -269,6 +312,12 @@ export class FindingsStore {
     for (const list of this.aiFindingsByFile.values()) all.push(...list);
     return all;
   }
+
+  private getAgentFindings(): SkylosFinding[] {
+    const all: SkylosFinding[] = [];
+    for (const list of this.agentFindingsByFile.values()) all.push(...list);
+    return all;
+  }
 }
 
 function sortFindingsForDisplay(findings: SkylosFinding[]): SkylosFinding[] {
@@ -295,42 +344,7 @@ function getDisplayScore(
   activeFile: string | undefined,
   visibleFiles: Set<string>,
 ): number {
-  let score = severityRank(finding.severity) * 100;
-
-  if (finding.file === activeFile) {
-    score += 100000;
-  } else if (visibleFiles.has(finding.file)) {
-    score += 50000;
-  }
-
-  if (finding.category === "security" || finding.category === "secrets") {
-    score += 500;
-  }
-  if (finding.source === "cli") {
-    score += 50;
-  }
-  if (finding.confidence !== undefined) {
-    score += Math.min(99, finding.confidence);
-  }
-
-  return score;
-}
-
-function severityRank(severity: string): number {
-  switch (severity.toUpperCase()) {
-    case "CRITICAL":
-      return 5;
-    case "HIGH":
-      return 4;
-    case "MEDIUM":
-    case "WARN":
-      return 3;
-    case "LOW":
-      return 2;
-    case "INFO":
-    default:
-      return 1;
-  }
+  return reviewScore(finding, { currentFile: activeFile, visibleFiles });
 }
 
 function limitFindings(findings: SkylosFinding[], maxTotal: number, maxPerFile?: number): SkylosFinding[] {

--- a/editors/vscode/src/types.ts
+++ b/editors/vscode/src/types.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import type { FindingSource } from "./provenanceCore";
 
 export const SUPPORTED_LANGUAGES = [
   "python",
@@ -13,19 +14,49 @@ export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "INFO" | "WARN";
 export type Category = "dead_code" | "security" | "secrets" | "quality" | "debt" | "ai";
 
+export interface FindingTraceStep {
+  file?: string;
+  line?: number;
+  label?: string;
+  message?: string;
+  symbol?: string;
+}
+
 export interface SkylosFinding {
   id: string;
+  fingerprint?: string;
   ruleId: string;
+  legacyRuleId?: string;
   category: Category;
   severity: Severity;
   message: string;
   file: string;
+  relativePath?: string;
+  workspaceRoot?: string;
   line: number;
   col: number;
+  endLine?: number;
+  endCol?: number;
   confidence?: number;
   itemType?: string;
   itemName?: string;
-  source: "cli" | "ai";
+  source: FindingSource;
+  sources?: FindingSource[];
+  ruleUrl?: string;
+  safeFix?: string;
+  fixPatch?: string;
+  baselineStatus?: string;
+  isNew?: boolean;
+  snippet?: string;
+  explanation?: string;
+  suggestion?: string;
+  evidence?: string[];
+  trace?: FindingTraceStep[];
+  sourceSymbol?: string;
+  sinkSymbol?: string;
+  securityEvidence?: Record<string, unknown>;
+  reviewReason?: string;
+  ciBlocking?: boolean;
 }
 
 export interface UnusedItem {
@@ -37,6 +68,10 @@ export interface UnusedItem {
   lineno?: number;
   confidence?: number;
   module?: string;
+  rule_id?: string;
+  fingerprint?: string;
+  baseline_status?: string;
+  is_new?: boolean;
 }
 
 export interface CLIFinding {
@@ -47,6 +82,45 @@ export interface CLIFinding {
   rule_id?: string;
   severity?: string;
   compliance_tags?: string[];
+  confidence?: number;
+  fingerprint?: string;
+  rule_url?: string;
+  ruleUrl?: string;
+  end_line?: number;
+  endLine?: number;
+  end_col?: number;
+  endCol?: number;
+  end_column?: number;
+  endColumn?: number;
+  safe_fix?: string;
+  safeFix?: string;
+  fix_patch?: string;
+  fixPatch?: string;
+  patch?: string;
+  baseline_status?: string;
+  baselineStatus?: string;
+  is_new?: boolean;
+  isNew?: boolean;
+  snippet?: string;
+  code_snippet?: string;
+  codeSnippet?: string;
+  vulnerable_code?: string;
+  explanation?: string;
+  suggestion?: string;
+  evidence?: unknown;
+  trace?: unknown;
+  dataflow?: unknown;
+  source_symbol?: string;
+  sourceSymbol?: string;
+  sink_symbol?: string;
+  sinkSymbol?: string;
+  _security_evidence?: Record<string, unknown>;
+  security_evidence?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  _review_reason?: string;
+  review_reason?: string;
+  _ci_blocking?: boolean;
+  ci_blocking?: boolean;
 }
 
 export interface QualityFinding {
@@ -59,6 +133,64 @@ export interface QualityFinding {
   message?: string;
   file: string;
   line?: number;
+  col?: number;
+  confidence?: number;
+  fingerprint?: string;
+  rule_url?: string;
+  ruleUrl?: string;
+  end_line?: number;
+  endLine?: number;
+  end_col?: number;
+  endCol?: number;
+  end_column?: number;
+  endColumn?: number;
+  safe_fix?: string;
+  safeFix?: string;
+  fix_patch?: string;
+  fixPatch?: string;
+  patch?: string;
+  baseline_status?: string;
+  baselineStatus?: string;
+  is_new?: boolean;
+  isNew?: boolean;
+  snippet?: string;
+  code_snippet?: string;
+  codeSnippet?: string;
+  vulnerable_code?: string;
+  explanation?: string;
+  suggestion?: string;
+  evidence?: unknown;
+  trace?: unknown;
+  dataflow?: unknown;
+  source_symbol?: string;
+  sourceSymbol?: string;
+  sink_symbol?: string;
+  sinkSymbol?: string;
+  _security_evidence?: Record<string, unknown>;
+  security_evidence?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  _review_reason?: string;
+  review_reason?: string;
+  _ci_blocking?: boolean;
+  ci_blocking?: boolean;
+}
+
+export interface ScanMetadata {
+  command: string;
+  target: string;
+  workspaceRoot: string;
+  diffBase?: string;
+  durationMs?: number;
+  exitCode?: number | null;
+  stderr?: string;
+}
+
+export interface ScanFailureMetadata {
+  kind: string;
+  message: string;
+  command?: string;
+  exitCode?: number | null;
+  stderr?: string;
 }
 
 export interface CLIGrade {
@@ -147,7 +279,7 @@ export interface AutoFixOptions {
 export interface FindingsFilter {
   severity?: Severity;
   category?: Category;
-  source?: "cli" | "ai";
+  source?: FindingSource | "confirmed";
   filePattern?: string;
 }
 
@@ -167,6 +299,9 @@ export interface AgentCommandCenterItem {
   rule_id?: string;
   message?: string;
   safe_fix?: string;
+  fix_patch?: string;
+  fixPatch?: string;
+  patch?: string;
   hotspot_score?: number;
   priority_score?: number;
   signal_count?: number;

--- a/editors/vscode/test/automationCore.test.js
+++ b/editors/vscode/test/automationCore.test.js
@@ -1,0 +1,17 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { normalizeAutomationLine } = require("../out/automationCore");
+
+test("normalizeAutomationLine accepts numeric and string line values", () => {
+  assert.equal(normalizeAutomationLine(7), 7);
+  assert.equal(normalizeAutomationLine("8"), 8);
+  assert.equal(normalizeAutomationLine(3.8), 3);
+});
+
+test("normalizeAutomationLine falls back to line 1 for malformed values", () => {
+  assert.equal(normalizeAutomationLine(undefined), 1);
+  assert.equal(normalizeAutomationLine("not-a-line"), 1);
+  assert.equal(normalizeAutomationLine(0), 1);
+  assert.equal(normalizeAutomationLine(-4), 1);
+});

--- a/editors/vscode/test/configCore.test.js
+++ b/editors/vscode/test/configCore.test.js
@@ -1,0 +1,27 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { shouldWarnMissingLocalAI } = require("../out/configCore");
+
+test("shouldWarnMissingLocalAI only warns for enabled local AI without base URL", () => {
+  assert.equal(shouldWarnMissingLocalAI({
+    realtimeAIEnabled: true,
+    provider: "local",
+    localBaseUrl: "",
+  }), true);
+  assert.equal(shouldWarnMissingLocalAI({
+    realtimeAIEnabled: true,
+    provider: "local",
+    localBaseUrl: "http://localhost:11434",
+  }), false);
+  assert.equal(shouldWarnMissingLocalAI({
+    realtimeAIEnabled: false,
+    provider: "local",
+    localBaseUrl: "",
+  }), false);
+  assert.equal(shouldWarnMissingLocalAI({
+    realtimeAIEnabled: true,
+    provider: "openai",
+    localBaseUrl: "",
+  }), false);
+});

--- a/editors/vscode/test/diagnosticCore.test.js
+++ b/editors/vscode/test/diagnosticCore.test.js
@@ -1,0 +1,28 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { getDiagnosticRange, severityRank } = require("../out/diagnosticCore");
+
+test("getDiagnosticRange converts one-based line to non-zero VS Code range", () => {
+  assert.deepEqual(getDiagnosticRange({ line: 7, col: 0 }), {
+    startLine: 6,
+    startCol: 0,
+    endLine: 6,
+    endCol: 1,
+  });
+});
+
+test("getDiagnosticRange respects explicit end locations", () => {
+  assert.deepEqual(getDiagnosticRange({ line: 3, col: 2, endLine: 5, endCol: 8 }), {
+    startLine: 2,
+    startCol: 2,
+    endLine: 4,
+    endCol: 8,
+  });
+});
+
+test("severityRank orders critical above informational findings", () => {
+  assert.equal(severityRank("CRITICAL") > severityRank("INFO"), true);
+  assert.equal(severityRank("WARN"), severityRank("MEDIUM"));
+});
+

--- a/editors/vscode/test/findingCore.test.js
+++ b/editors/vscode/test/findingCore.test.js
@@ -1,0 +1,133 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const path = require("node:path");
+
+const {
+  canonicalRuleId,
+  isDeadCodeRule,
+  makeFingerprint,
+  normalizeReportCore,
+} = require("../out/findingCore");
+
+const wsRoot = path.join(path.sep, "repo");
+
+test("normalizeReportCore maps dead code to canonical SKY-U rule ids with stable fingerprints", () => {
+  const findings = normalizeReportCore({
+    unused_imports: [
+      { file: "src/app.py", line: 4, name: "os", confidence: 92 },
+    ],
+  }, {
+    wsRoot,
+    deadCodeEnabled: true,
+    showDeadParams: false,
+    confidenceThreshold: 80,
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].ruleId, "SKY-U002");
+  assert.equal(findings[0].legacyRuleId, "DEAD-IMPORT");
+  assert.equal(findings[0].file, path.join(wsRoot, "src/app.py"));
+  assert.equal(findings[0].relativePath, "src/app.py");
+  assert.match(findings[0].fingerprint, /^vsce:[a-f0-9]{20}$/);
+});
+
+test("normalizeReportCore filters hidden dead params and low-confidence dead code", () => {
+  const findings = normalizeReportCore({
+    unused_parameters: [
+      { file: "src/app.py", line: 10, name: "request", confidence: 99 },
+    ],
+    unused_functions: [
+      { file: "src/app.py", line: 20, name: "helper", confidence: 20 },
+    ],
+  }, {
+    wsRoot,
+    deadCodeEnabled: true,
+    showDeadParams: false,
+    confidenceThreshold: 80,
+  });
+
+  assert.equal(findings.length, 0);
+});
+
+test("normalizeReportCore maps security, secrets, and quality findings", () => {
+  const findings = normalizeReportCore({
+    danger: [
+      { file: "src/app.py", line: 2, rule_id: "SKY-D203", severity: "critical", message: "os.system" },
+    ],
+    secrets: [
+      { file: "src/keys.py", line: 1, rule_id: "SKY-S101", severity: "HIGH", message: "secret" },
+    ],
+    quality: [
+      { file: "src/q.py", line: 5, rule_id: "SKY-Q301", severity: "warn", message: "complex" },
+    ],
+  }, {
+    wsRoot,
+    deadCodeEnabled: true,
+    showDeadParams: false,
+    confidenceThreshold: 80,
+  });
+
+  assert.deepEqual(findings.map((finding) => finding.category), ["secrets", "security", "quality"]);
+  assert.deepEqual(findings.map((finding) => finding.severity), ["HIGH", "CRITICAL", "WARN"]);
+});
+
+test("normalizeReportCore preserves evidence metadata for review details", () => {
+  const findings = normalizeReportCore({
+    danger: [
+      {
+        file: "src/app.py",
+        line: 12,
+        rule_id: "SKY-D216",
+        severity: "critical",
+        message: "Possible SSRF",
+        snippet: "requests.get(url)",
+        explanation: "User-controlled URL reaches outbound request.",
+        suggestion: "Validate URL scheme and host before fetching.",
+        evidence: ["url parameter flows into requests.get"],
+        trace: [{ file: "src/app.py", line: 10, message: "url from request" }],
+        source_symbol: "url",
+        sink_symbol: "requests.get",
+        metadata: {
+          ci_blocking: true,
+          review_reason: "Network sink with tainted input",
+          security_evidence: { contract_id: "route-auth", missing_guards: ["auth"] },
+        },
+      },
+    ],
+  }, {
+    wsRoot,
+    deadCodeEnabled: true,
+    showDeadParams: false,
+    confidenceThreshold: 80,
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].snippet, "requests.get(url)");
+  assert.equal(findings[0].suggestion, "Validate URL scheme and host before fetching.");
+  assert.deepEqual(findings[0].evidence, ["url parameter flows into requests.get"]);
+  assert.equal(findings[0].trace.length, 1);
+  assert.equal(findings[0].trace[0].file, "src/app.py");
+  assert.equal(findings[0].trace[0].line, 10);
+  assert.equal(findings[0].trace[0].message, "url from request");
+  assert.equal(findings[0].sourceSymbol, "url");
+  assert.equal(findings[0].sinkSymbol, "requests.get");
+  assert.equal(findings[0].ciBlocking, true);
+  assert.equal(findings[0].reviewReason, "Network sink with tainted input");
+  assert.equal(findings[0].securityEvidence.contract_id, "route-auth");
+});
+
+test("canonicalRuleId preserves current ids and aliases legacy dead-code ids", () => {
+  assert.equal(canonicalRuleId("DEAD-FUNC"), "SKY-U001");
+  assert.equal(canonicalRuleId("SKY-D203"), "SKY-D203");
+  assert.equal(isDeadCodeRule("DEAD-IMPORT"), true);
+});
+
+test("makeFingerprint is deterministic", () => {
+  const input = {
+    ruleId: "SKY-D203",
+    relativePath: "src/app.py",
+    line: 10,
+    message: "danger",
+  };
+  assert.equal(makeFingerprint(input), makeFingerprint(input));
+});

--- a/editors/vscode/test/provenanceCore.test.js
+++ b/editors/vscode/test/provenanceCore.test.js
@@ -1,0 +1,80 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  diagnosticSource,
+  isCorroborated,
+  matchesSourceFilter,
+  mergeCorrelatedFindings,
+  sourceSummary,
+} = require("../out/provenanceCore");
+
+function finding(overrides = {}) {
+  return {
+    id: overrides.id ?? "f",
+    ruleId: "SKY-D216",
+    category: "security",
+    severity: "HIGH",
+    message: "Possible SSRF",
+    file: "/repo/app.py",
+    line: 10,
+    source: "cli",
+    ...overrides,
+  };
+}
+
+test("mergeCorrelatedFindings merges static and agent findings on the same rule location", () => {
+  const merged = mergeCorrelatedFindings([
+    finding({ id: "static", source: "cli", confidence: 80 }),
+    finding({ id: "agent", source: "agent", severity: "CRITICAL", confidence: 95, reviewReason: "Hot path" }),
+  ]);
+
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].id, "static");
+  assert.equal(merged[0].source, "cli");
+  assert.deepEqual(merged[0].sources, ["cli", "agent"]);
+  assert.equal(merged[0].severity, "CRITICAL");
+  assert.equal(merged[0].confidence, 95);
+  assert.equal(merged[0].reviewReason, "Hot path");
+  assert.equal(sourceSummary(merged[0]), "Static + Automation");
+  assert.equal(diagnosticSource(merged[0]), "skylos static+automation");
+  assert.equal(isCorroborated(merged[0]), true);
+});
+
+test("mergeCorrelatedFindings keeps unrelated sources as separate findings", () => {
+  const merged = mergeCorrelatedFindings([
+    finding({ id: "static", line: 10, source: "cli" }),
+    finding({ id: "agent", line: 11, source: "agent" }),
+  ]);
+
+  assert.equal(merged.length, 2);
+  assert.deepEqual(merged.map((item) => sourceSummary(item)).sort(), ["Automation", "Static"]);
+});
+
+test("mergeCorrelatedFindings does not confirm different findings on the same rule line", () => {
+  const merged = mergeCorrelatedFindings([
+    finding({ id: "static", source: "cli", message: "Possible SSRF in requests.get" }),
+    finding({ id: "agent", source: "agent", message: "Possible SSRF in httpx.get" }),
+  ]);
+
+  assert.equal(merged.length, 2);
+  assert.equal(merged.some(isCorroborated), false);
+});
+
+test("mergeCorrelatedFindings confirms same subject even when messages differ", () => {
+  const merged = mergeCorrelatedFindings([
+    finding({ id: "static", source: "cli", message: "Possible SSRF", sinkSymbol: "requests.get" }),
+    finding({ id: "agent", source: "agent", message: "Network sink with tainted input", sinkSymbol: "requests.get" }),
+  ]);
+
+  assert.equal(merged.length, 1);
+  assert.equal(sourceSummary(merged[0]), "Static + Automation");
+});
+
+test("matchesSourceFilter handles confirmed and secondary sources", () => {
+  const confirmed = finding({ source: "cli", sources: ["cli", "agent"] });
+  assert.equal(matchesSourceFilter(confirmed, "confirmed"), true);
+  assert.equal(matchesSourceFilter(confirmed, "cli"), true);
+  assert.equal(matchesSourceFilter(confirmed, "agent"), true);
+  assert.equal(matchesSourceFilter(confirmed, "ai"), false);
+});

--- a/editors/vscode/test/reviewCore.test.js
+++ b/editors/vscode/test/reviewCore.test.js
@@ -1,0 +1,89 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  ciImpact,
+  evidenceLines,
+  fixPlan,
+  priorityReasons,
+  sortReviewQueue,
+} = require("../out/reviewCore");
+
+function finding(overrides = {}) {
+  return {
+    id: "f",
+    fingerprint: "fp",
+    ruleId: "SKY-Q001",
+    category: "quality",
+    severity: "INFO",
+    message: "Issue",
+    file: "/repo/src/app.py",
+    relativePath: "src/app.py",
+    workspaceRoot: "/repo",
+    line: 1,
+    col: 0,
+    source: "cli",
+    ...overrides,
+  };
+}
+
+test("sortReviewQueue prioritizes active-file, new, CI-blocking security findings", () => {
+  const lowCurrent = finding({ id: "current", file: "/repo/src/current.py", severity: "LOW" });
+  const blocker = finding({
+    id: "blocker",
+    category: "security",
+    severity: "CRITICAL",
+    file: "/repo/src/api.py",
+    isNew: true,
+    ciBlocking: true,
+  });
+  const ordered = sortReviewQueue([lowCurrent, blocker], { currentFile: "/repo/src/current.py", diffBase: "origin/main" });
+
+  assert.equal(ordered[0].id, "blocker");
+  assert.equal(ordered[1].id, "current");
+
+  const reasons = priorityReasons(blocker, { diffBase: "origin/main" });
+  assert.ok(reasons.includes("Marked as CI-blocking by Skylos"));
+  assert.ok(reasons.includes("New against origin/main"));
+  assert.ok(reasons.includes("critical severity"));
+});
+
+test("ciImpact reports likely blockers and attention-only queues separately", () => {
+  const impact = ciImpact([
+    finding({ category: "secrets", severity: "HIGH" }),
+    finding({ category: "quality", severity: "MEDIUM" }),
+  ], { diffBase: "origin/main" });
+
+  assert.equal(impact.status, "blocking");
+  assert.equal(impact.blockerCount, 1);
+  assert.match(impact.headline, /Likely CI block/);
+
+  const attention = ciImpact([
+    finding({ category: "quality", severity: "MEDIUM" }),
+  ]);
+  assert.equal(attention.status, "attention");
+  assert.equal(attention.blockerCount, 0);
+  assert.equal(attention.attentionCount, 1);
+});
+
+test("evidenceLines summarizes trace and security contract metadata", () => {
+  const lines = evidenceLines(finding({
+    explanation: "User input reaches a network sink.",
+    trace: [{ file: "src/app.py", line: 42, message: "requests.get(url)" }],
+    sourceSymbol: "url",
+    sinkSymbol: "requests.get",
+    securityEvidence: { contract_id: "route-auth", handler: "fetch", missing_guards: ["auth", "scope"] },
+  }));
+
+  assert.ok(lines.includes("User input reaches a network sink."));
+  assert.ok(lines.includes("Data path: source url -> sink requests.get"));
+  assert.ok(lines.includes("src/app.py:42 - requests.get(url)"));
+  assert.ok(lines.includes("Security contract: route-auth"));
+  assert.ok(lines.includes("Missing guards: auth, scope"));
+});
+
+test("fixPlan prefers deterministic patches before AI or manual guidance", () => {
+  assert.equal(fixPlan(finding({ fixPatch: "--- a\n+++ b" })).mode, "engine");
+  assert.equal(fixPlan(finding({ suggestion: "Use a parameterized query." })).mode, "ai");
+  assert.equal(fixPlan(finding({ category: "security", severity: "HIGH" })).mode, "manual");
+});

--- a/editors/vscode/test/scanCore.test.js
+++ b/editors/vscode/test/scanCore.test.js
@@ -1,0 +1,56 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  buildScanArgs,
+  buildScanCommand,
+  buildScanErrorMessage,
+  SkylosScanError,
+} = require("../out/scanCore");
+
+test("buildScanArgs includes enabled features, excludes, confidence, and diff base", () => {
+  const args = buildScanArgs({
+    target: "/repo",
+    confidence: 80,
+    excludeFolders: [".venv", "node_modules"],
+    enableSecrets: true,
+    enableDanger: false,
+    enableQuality: true,
+    diffBase: "origin/main",
+  });
+
+  assert.deepEqual(args, [
+    "/repo",
+    "--json",
+    "-c",
+    "80",
+    "--exclude-folder",
+    ".venv",
+    "--exclude-folder",
+    "node_modules",
+    "--secrets",
+    "--quality",
+    "--diff-base",
+    "origin/main",
+  ]);
+});
+
+test("buildScanCommand shell-quotes display command without changing args", () => {
+  const command = buildScanCommand("/path with spaces/skylos", {
+    target: "/repo with spaces",
+    confidence: 75,
+    excludeFolders: [],
+    enableSecrets: false,
+    enableDanger: true,
+    enableQuality: false,
+  });
+
+  assert.equal(command.args[0], "/repo with spaces");
+  assert.match(command.display, /^'\/path with spaces\/skylos' '\/repo with spaces'/);
+});
+
+test("buildScanErrorMessage gives actionable missing binary message", () => {
+  const message = buildScanErrorMessage(new SkylosScanError("missing_binary", "spawn ENOENT"));
+  assert.match(message, /executable was not found/);
+});
+


### PR DESCRIPTION
## Summary

  Improve the VSCE review experience so users can easily distinguish static scan findings

## Changes

  - Rename the main findings view to **Review Queue**
  - Separate optional repo level automation into **Automation Activity**
  - Add source provenance labels such as static, automation, AI Assist, confirmed
  - Merge matching Static + Automation findings into confirmed findings
  - Keep severity as the primary editor signal color, with confirmation shown as a badge
  - Make editor signals quieter by default
  - Turn optional real-time AI Assist off by default
  - Improve failure copy so Automation/AI errors do not look like static scan failures
  - Add `Doctor` command and onboarding walkthrough
  - Bump VS Code extension version to `0.6.0`

## Testing

  - `npm test`
  - `git diff --check`