### PR TITLE
fix(architecture): suppress library re-export false positives

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from skylos.visitor import Visitor
 
-from skylos.circular_deps import CircularDependencyRule
+from skylos.circular_deps import CircularDependencyRule, _resolve_from_import_targets
 
 from skylos.constants import AUTO_CALLED, MARKREFS_TICK_DEFAULT
 
@@ -169,6 +169,37 @@ def _expand_reexported_entrypoint_modules(
                     continue
                 if import_module in known_modules:
                     modules.add(import_module)
+
+    return modules
+
+
+def _find_package_boundary_modules(
+    raw_imports_by_file: dict[Path, list],
+    modmap: dict[Path, str],
+    module_files: dict[str, str],
+) -> set[str]:
+    modules: set[str] = set()
+    known_modules = set(module_files)
+
+    for file_path, raw_imports in raw_imports_by_file.items():
+        package_module = modmap.get(file_path)
+        if not package_module or Path(file_path).name != "__init__.py":
+            continue
+
+        for import_module, _line, import_type, imported_names in raw_imports:
+            if import_type != "from_import":
+                continue
+
+            targets = _resolve_from_import_targets(
+                import_module,
+                imported_names,
+                known_modules,
+            )
+            for target in targets:
+                if target != package_module and target.startswith(
+                    package_module + "."
+                ):
+                    modules.add(target)
 
     return modules
 
@@ -1622,6 +1653,11 @@ class Skylos:
                             modmap,
                             mod_files,
                         )
+                        package_boundary_modules = _find_package_boundary_modules(
+                            all_raw_imports,
+                            modmap,
+                            mod_files,
+                        )
 
                         mod_trees = {}
                         if not architecture_abstractness:
@@ -1644,6 +1680,7 @@ class Skylos:
                             module_abstractness=architecture_abstractness,
                             module_loc=architecture_loc,
                             entrypoint_modules=entrypoint_modules,
+                            package_boundary_modules=package_boundary_modules,
                         )
                         ignored_rules = set(project_cfg.get("ignore", []))
                         if arch_findings:

--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -153,15 +153,15 @@ def _compute_abstractness(tree: ast.AST) -> dict[str, Any]:
 
 
 def _classify_zone(abstractness: float, instability: float) -> str:
-    if abstractness > 0.7 and instability < 0.3:
-        return "zone_of_pain"
-
-    if abstractness < 0.3 and instability > 0.7:
-        return "zone_of_uselessness"
-
     distance = abs(abstractness + instability - 1.0)
     if distance <= 0.2:
         return "main_sequence"
+
+    if abstractness < 0.3 and instability < 0.3:
+        return "zone_of_pain"
+
+    if abstractness > 0.7 and instability > 0.7:
+        return "zone_of_uselessness"
 
     return "healthy"
 
@@ -439,14 +439,14 @@ def _generate_findings(result: ArchitectureResult):
             if m.zone == "zone_of_pain":
                 zone_msg = (
                     f"Module '{name}' is in the Zone of Pain "
-                    f"(highly abstract A={m.abstractness:.2f}, highly stable I={m.instability:.2f}). "
-                    f"Changes here ripple widely. Consider reducing abstractness or allowing more instability."
+                    f"(concrete A={m.abstractness:.2f}, stable I={m.instability:.2f}). "
+                    f"Changes here can ripple widely. Consider introducing stable abstractions or reducing fan-in."
                 )
             else:
                 zone_msg = (
                     f"Module '{name}' is in the Zone of Uselessness "
-                    f"(concrete A={m.abstractness:.2f}, unstable I={m.instability:.2f}). "
-                    f"Nobody depends on it. Consider abstracting its interface or removing if unused."
+                    f"(abstract A={m.abstractness:.2f}, unstable I={m.instability:.2f}). "
+                    f"Few stable consumers depend on it. Consider moving abstractions toward stable packages or removing unused abstractions."
                 )
 
             result.findings.append(
@@ -502,6 +502,7 @@ def get_architecture_findings(
     module_abstractness: dict[str, dict[str, Any]] | None = None,
     module_loc: dict[str, int] | None = None,
     entrypoint_modules: set[str] | None = None,
+    package_boundary_modules: set[str] | None = None,
     private_helper_ce_limit: int = 2,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     result = analyze_architecture(
@@ -521,7 +522,9 @@ def get_architecture_findings(
     findings = _filter_contextual_findings(
         result.findings,
         result.modules,
+        dependency_graph=dependency_graph,
         entrypoint_modules=contextual_entrypoints,
+        package_boundary_modules=set(package_boundary_modules or ()),
         private_helper_ce_limit=private_helper_ce_limit,
     )
 
@@ -557,13 +560,38 @@ def _filter_contextual_findings(
     findings: list[dict[str, Any]],
     modules: dict[str, ModuleMetrics],
     *,
+    dependency_graph: dict[str, set[str]],
     entrypoint_modules: set[str],
+    package_boundary_modules: set[str],
     private_helper_ce_limit: int,
 ) -> list[dict[str, Any]]:
+    afferent: dict[str, set[str]] = defaultdict(set)
+    for importer, deps in dependency_graph.items():
+        for dep in deps:
+            afferent[dep].add(importer)
+
     filtered = []
     for finding in findings:
         rule_id = finding.get("rule_id")
         module_name = finding.get("name")
+
+        if (
+            rule_id in {"SKY-Q802", "SKY-Q803"}
+            and isinstance(module_name, str)
+            and _is_reexported_package_boundary_module(
+                module_name,
+                package_boundary_modules,
+                afferent,
+            )
+        ):
+            continue
+
+        if (
+            rule_id == "SKY-Q803"
+            and isinstance(module_name, str)
+            and _is_test_module(module_name, finding.get("file", ""))
+        ):
+            continue
 
         if rule_id == "SKY-Q803" and module_name in entrypoint_modules:
             continue
@@ -581,3 +609,30 @@ def _filter_contextual_findings(
         filtered.append(finding)
 
     return filtered
+
+
+def _is_reexported_package_boundary_module(
+    module_name: str,
+    package_boundary_modules: set[str],
+    afferent: dict[str, set[str]],
+) -> bool:
+    if module_name not in package_boundary_modules or "." not in module_name:
+        return False
+
+    parent_package = module_name.rsplit(".", 1)[0]
+    return afferent.get(module_name, set()) == {parent_package}
+
+
+def _is_test_module(module_name: str, file_path: Any) -> bool:
+    path = Path(str(file_path)).as_posix() if file_path else ""
+    basename = Path(path).name if path else ""
+    parts = set(module_name.split("."))
+
+    return (
+        "tests" in parts
+        or module_name.startswith("test_")
+        or ".test_" in module_name
+        or basename.startswith("test_")
+        or basename.endswith("_test.py")
+        or "/tests/" in path
+    )

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -704,8 +704,8 @@ class TestAnalyze:
 
         result = json.loads(result_json)
         metrics = result["architecture_metrics"]["module_metrics"]
-        assert metrics["mypkg"]["zone"] == "zone_of_uselessness"
-        assert metrics["mypkg.cli"]["zone"] == "zone_of_uselessness"
+        assert metrics["mypkg"]["zone"] == "main_sequence"
+        assert metrics["mypkg.cli"]["zone"] == "healthy"
         assert metrics["mypkg._helpers"]["distance"] == 1.0
 
         architecture_rules = {
@@ -716,6 +716,68 @@ class TestAnalyze:
         assert ("SKY-Q803", "mypkg") not in architecture_rules
         assert ("SKY-Q803", "mypkg.cli") not in architecture_rules
         assert ("SKY-Q802", "mypkg._helpers") not in architecture_rules
+
+    def test_analyze_architecture_filters_library_reexport_and_test_leaf_noise(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pkg = root / "src" / "mini_pkg"
+            tests = root / "tests"
+            pkg.mkdir(parents=True)
+            tests.mkdir()
+            (root / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "mini-pkg"\n'
+                'version = "0.1.0"\n'
+                'requires-python = ">=3.10"\n\n'
+                "[build-system]\n"
+                'requires = ["setuptools>=68"]\n'
+                'build-backend = "setuptools.build_meta"\n\n'
+                "[tool.setuptools]\n"
+                'package-dir = {"" = "src"}\n',
+                encoding="utf-8",
+            )
+            (pkg / "__init__.py").write_text(
+                '"""Minimal library entry point that re-exports core symbols."""\n'
+                "from .core import Greeter, greet\n\n"
+                '__all__ = ["Greeter", "greet"]\n',
+                encoding="utf-8",
+            )
+            (pkg / "core.py").write_text(
+                '"""Concrete library implementation."""\n'
+                "from dataclasses import dataclass\n\n\n"
+                "@dataclass(frozen=True)\n"
+                "class Greeter:\n"
+                "    name: str\n\n"
+                "    def hello(self) -> str:\n"
+                '        return f"Hello, {self.name}!"\n\n\n'
+                "def greet(name: str) -> str:\n"
+                "    return Greeter(name=name).hello()\n",
+                encoding="utf-8",
+            )
+            (tests / "__init__.py").write_text("", encoding="utf-8")
+            (tests / "test_core.py").write_text(
+                "from mini_pkg import greet\n\n\n"
+                "def test_greet():\n"
+                '    assert greet("world") == "Hello, world!"\n',
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        metrics = result["architecture_metrics"]["module_metrics"]
+        assert metrics["mini_pkg.core"]["distance"] == 1.0
+        assert metrics["mini_pkg.core"]["zone"] == "zone_of_pain"
+        assert metrics["tests.test_core"]["zone"] == "main_sequence"
+
+        architecture_rules = {
+            (f.get("rule_id"), f.get("name"))
+            for f in result.get("quality", [])
+            if f.get("rule_id") in {"SKY-Q802", "SKY-Q803"}
+        }
+        assert ("SKY-Q802", "mini_pkg.core") not in architecture_rules
+        assert ("SKY-Q803", "mini_pkg.core") not in architecture_rules
+        assert ("SKY-Q803", "tests.test_core") not in architecture_rules
 
     @patch("skylos.analyzer.scan_typescript_file")
     def test_proc_file_dispatches_mjs_to_typescript_scanner(self, mock_scan):

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -76,12 +76,13 @@ class TestClassifyZone:
         assert _classify_zone(0.5, 0.5) == "main_sequence"
         assert _classify_zone(0.4, 0.6) == "main_sequence"
         assert _classify_zone(0.6, 0.4) == "main_sequence"
+        assert _classify_zone(0.0, 0.9) == "main_sequence"
 
     def test_zone_of_pain(self):
-        assert _classify_zone(0.9, 0.0) == "zone_of_pain"
+        assert _classify_zone(0.0, 0.0) == "zone_of_pain"
 
     def test_zone_of_uselessness(self):
-        assert _classify_zone(0.0, 0.9) == "zone_of_uselessness"
+        assert _classify_zone(0.9, 0.9) == "zone_of_uselessness"
 
     def test_healthy(self):
         assert _classify_zone(0.5, 0.2) == "healthy"
@@ -117,6 +118,14 @@ if __name__ == "__main__":
         raw_findings, _ = get_architecture_findings(
             dependency_graph=graph,
             module_files=module_files,
+            module_trees={
+                "mypkg.cli": ast.parse("""
+from typing import Protocol
+
+class Command(Protocol):
+    ...
+""")
+            },
             private_helper_ce_limit=-1,
         )
         assert ("SKY-Q803", "mypkg.cli") in {
@@ -129,6 +138,14 @@ if __name__ == "__main__":
         findings, summary = get_architecture_findings(
             dependency_graph=graph,
             module_files=module_files,
+            module_trees={
+                "mypkg.cli": ast.parse("""
+from typing import Protocol
+
+class Command(Protocol):
+    ...
+""")
+            },
             entrypoint_modules={"mypkg.cli"},
         )
 
@@ -140,7 +157,20 @@ if __name__ == "__main__":
 
     def test_main_guard_module_filters_zone_warning(self):
         tree = ast.parse("""
+from typing import Protocol
 from worker import run
+
+class CommandA(Protocol):
+    ...
+
+class CommandB(Protocol):
+    ...
+
+class CommandC(Protocol):
+    ...
+
+class CommandD(Protocol):
+    ...
 
 def main():
     run()
@@ -158,6 +188,74 @@ if __name__ == "__main__":
         rules = {(f["rule_id"], f["name"]) for f in findings}
         assert summary["module_metrics"]["cli"]["zone"] == "zone_of_uselessness"
         assert ("SKY-Q803", "cli") not in rules
+
+    def test_reexported_package_boundary_filters_structural_findings(self):
+        graph = {
+            "mini_pkg": {"mini_pkg.core"},
+            "mini_pkg.core": set(),
+        }
+        module_files = {
+            "mini_pkg": "/p/mini_pkg/__init__.py",
+            "mini_pkg.core": "/p/mini_pkg/core.py",
+        }
+
+        raw_findings, _ = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+        )
+        assert ("SKY-Q802", "mini_pkg.core") in {
+            (f["rule_id"], f["name"]) for f in raw_findings
+        }
+        assert ("SKY-Q803", "mini_pkg.core") in {
+            (f["rule_id"], f["name"]) for f in raw_findings
+        }
+
+        findings, summary = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+            package_boundary_modules={"mini_pkg.core"},
+        )
+
+        rules = {(f["rule_id"], f["name"]) for f in findings}
+        assert ("SKY-Q802", "mini_pkg.core") not in rules
+        assert ("SKY-Q803", "mini_pkg.core") not in rules
+        assert summary["module_metrics"]["mini_pkg.core"]["zone"] == "zone_of_pain"
+
+    def test_q803_skips_test_modules(self):
+        test_tree = ast.parse("""
+from typing import Protocol
+
+class CommandA(Protocol):
+    ...
+
+class CommandB(Protocol):
+    ...
+
+class CommandC(Protocol):
+    ...
+
+class CommandD(Protocol):
+    ...
+
+def test_contract():
+    assert True
+""")
+
+        findings, summary = get_architecture_findings(
+            dependency_graph={"tests.test_contract": {"app"}, "app": set()},
+            module_files={
+                "tests.test_contract": "/p/tests/test_contract.py",
+                "app": "/p/app.py",
+            },
+            module_trees={"tests.test_contract": test_tree},
+        )
+
+        assert summary["module_metrics"]["tests.test_contract"]["zone"] == (
+            "zone_of_uselessness"
+        )
+        assert ("SKY-Q803", "tests.test_contract") not in {
+            (f["rule_id"], f["name"]) for f in findings
+        }
 
 
 class TestAnalyzeArchitecture:


### PR DESCRIPTION
Fixes #306
Refs #305

## Summary

  - Fixed architecture zone classification so Pain/Uselessness match the canonical A/I model.
  - Stop reporting SKY-Q802/Q803 on normal Python library modules re-exported from package `__init__.py`, when that package is the only module importing them.
  - Stop reporting SKY-Q803 on test files, since test files are normally imported by the test runner instead of by application code.

## Bug

Skylos was warning on a normal Python library layout e.g.:
```
pkg/__init__.py
pkg/core.py
```

This happened because `__init__.py` imports from `core.py` so users can do:

`from pkg import greet`

Skylos treated that normal package setup as an architecture problem and reported SKY-Q802/Q803. This pr will resolve that pattern. 

## Tests

  - `pytest test/test_architecture.py test/test_analyzer.py`
