### PR TITLE
fix(architecture): rename misleading healthy zone fallback

### DIFF
--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -24,7 +24,7 @@ class ModuleMetrics:
     instability: float = 0.0
     abstractness: float = 0.0
     distance: float = 0.0
-    zone: str = "healthy"
+    zone: str = "off_main_sequence"
     total_classes: int = 0
     abstract_classes: int = 0
     total_functions: int = 0
@@ -163,7 +163,7 @@ def _classify_zone(abstractness: float, instability: float) -> str:
     if abstractness > 0.7 and instability > 0.7:
         return "zone_of_uselessness"
 
-    return "healthy"
+    return "off_main_sequence"
 
 
 def _has_main_guard(tree: ast.AST) -> bool:
@@ -376,7 +376,9 @@ def analyze_architecture(
                 "main_sequence": sum(
                     1 for m in all_metrics if m.zone == "main_sequence"
                 ),
-                "healthy": sum(1 for m in all_metrics if m.zone == "healthy"),
+                "off_main_sequence": sum(
+                    1 for m in all_metrics if m.zone == "off_main_sequence"
+                ),
                 "zone_of_pain": sum(1 for m in all_metrics if m.zone == "zone_of_pain"),
                 "zone_of_uselessness": sum(
                     1 for m in all_metrics if m.zone == "zone_of_uselessness"

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -705,7 +705,7 @@ class TestAnalyze:
         result = json.loads(result_json)
         metrics = result["architecture_metrics"]["module_metrics"]
         assert metrics["mypkg"]["zone"] == "main_sequence"
-        assert metrics["mypkg.cli"]["zone"] == "healthy"
+        assert metrics["mypkg.cli"]["zone"] == "off_main_sequence"
         assert metrics["mypkg._helpers"]["distance"] == 1.0
 
         architecture_rules = {

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -72,6 +72,19 @@ class Baz:
 
 
 class TestClassifyZone:
+    def test_canonical_truth_table(self):
+        cases = [
+            (0.0, 0.0, "zone_of_pain"),
+            (1.0, 1.0, "zone_of_uselessness"),
+            (0.0, 1.0, "main_sequence"),
+            (1.0, 0.0, "main_sequence"),
+            (0.0, 0.5, "off_main_sequence"),
+            (0.5, 0.0, "off_main_sequence"),
+        ]
+
+        for abstractness, instability, expected in cases:
+            assert _classify_zone(abstractness, instability) == expected
+
     def test_main_sequence(self):
         assert _classify_zone(0.5, 0.5) == "main_sequence"
         assert _classify_zone(0.4, 0.6) == "main_sequence"
@@ -84,8 +97,9 @@ class TestClassifyZone:
     def test_zone_of_uselessness(self):
         assert _classify_zone(0.9, 0.9) == "zone_of_uselessness"
 
-    def test_healthy(self):
-        assert _classify_zone(0.5, 0.2) == "healthy"
+    def test_off_main_sequence(self):
+        assert _classify_zone(0.5, 0.2) == "off_main_sequence"
+        assert _classify_zone(0.0, 0.4) == "off_main_sequence"
 
 
 class TestArchitectureContext:
@@ -352,6 +366,8 @@ class TestAnalyzeArchitecture:
         assert "architecture_fitness" in sm
         assert "coupling_health" in sm
         assert "zone_distribution" in sm
+        assert "off_main_sequence" in sm["zone_distribution"]
+        assert "healthy" not in sm["zone_distribution"]
 
     def test_abstractness_from_trees(self):
         tree_a = ast.parse("""
@@ -402,3 +418,37 @@ class Base2(ABC):
             module_trees={"a": tree_a},
         )
         assert isinstance(findings, list)
+
+    def test_high_distance_message_does_not_call_fallback_healthy(self):
+        result = analyze_architecture(
+            dependency_graph={
+                "stableish": set(),
+                "consumer_a": {"stableish"},
+                "consumer_b": {"stableish"},
+            },
+            module_files={
+                "stableish": "/p/stableish.py",
+                "consumer_a": "/p/consumer_a.py",
+                "consumer_b": "/p/consumer_b.py",
+            },
+            module_abstractness={
+                "stableish": {
+                    "abstractness": 0.4,
+                    "total_classes": 1,
+                    "abstract_classes": 0,
+                    "total_functions": 0,
+                    "abstract_methods": 0,
+                    "type_vars": 0,
+                    "protocols": 0,
+                },
+            },
+        )
+
+        q802 = next(
+            f
+            for f in result.findings
+            if f["rule_id"] == "SKY-Q802" and f["name"] == "stableish"
+        )
+        assert result.modules["stableish"].zone == "off_main_sequence"
+        assert "Zone: off main sequence." in q802["message"]
+        assert "Zone: healthy." not in q802["message"]


### PR DESCRIPTION
## Summary

Fixes #305.

Skylos was reporting confusing and contradictory findings. A module cannot be both "far" and "healthy" in the same result

## What Changed

  - Renamed the fallback zone from healthy to off_main_sequence.
  - Updated architecture summary counts to use off_main_sequence.
  - Added a regression test for Q802

## Test

```
- pytest test/test_architecture.py test/test_analyzer.py test/test_circular_deps.py
```