### PR TITLE
fix(architecture): suppress private helper Q803 false positives

### DIFF
--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -506,6 +506,7 @@ def get_architecture_findings(
     entrypoint_modules: set[str] | None = None,
     package_boundary_modules: set[str] | None = None,
     private_helper_ce_limit: int = 2,
+    private_helper_ca_limit: int = 2,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     result = analyze_architecture(
         dependency_graph=dependency_graph,
@@ -528,6 +529,7 @@ def get_architecture_findings(
         entrypoint_modules=contextual_entrypoints,
         package_boundary_modules=set(package_boundary_modules or ()),
         private_helper_ce_limit=private_helper_ce_limit,
+        private_helper_ca_limit=private_helper_ca_limit,
     )
 
     summary = {
@@ -566,6 +568,7 @@ def _filter_contextual_findings(
     entrypoint_modules: set[str],
     package_boundary_modules: set[str],
     private_helper_ce_limit: int,
+    private_helper_ca_limit: int,
 ) -> list[dict[str, Any]]:
     afferent: dict[str, set[str]] = defaultdict(set)
     for importer, deps in dependency_graph.items():
@@ -598,13 +601,22 @@ def _filter_contextual_findings(
         if rule_id == "SKY-Q803" and module_name in entrypoint_modules:
             continue
 
-        if rule_id == "SKY-Q802" and isinstance(module_name, str):
+        if rule_id in {"SKY-Q802", "SKY-Q803"} and isinstance(module_name, str):
             simple_name = module_name.rsplit(".", 1)[-1]
             metrics = modules.get(module_name)
             if (
-                simple_name.startswith("_")
+                rule_id == "SKY-Q802"
+                and simple_name.startswith("_")
                 and metrics is not None
                 and metrics.ce <= private_helper_ce_limit
+            ):
+                continue
+            if (
+                rule_id == "SKY-Q803"
+                and simple_name.startswith("_")
+                and metrics is not None
+                and metrics.zone == "zone_of_pain"
+                and metrics.ca <= private_helper_ca_limit
             ):
                 continue
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -717,6 +717,47 @@ class TestAnalyze:
         assert ("SKY-Q803", "mypkg.cli") not in architecture_rules
         assert ("SKY-Q802", "mypkg._helpers") not in architecture_rules
 
+    def test_analyze_architecture_filters_low_fan_in_private_helper_q803(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pkg = root / "mypkg"
+            pkg.mkdir()
+            (root / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "q803-private-helper-repro"\n'
+                'version = "0.1.0"\n\n'
+                "[project.scripts]\n"
+                'mypkg = "mypkg.cli:main"\n',
+                encoding="utf-8",
+            )
+            (pkg / "__init__.py").write_text("", encoding="utf-8")
+            (pkg / "cli.py").write_text(
+                "from ._banner import print_banner\n\n"
+                "def main():\n"
+                "    print_banner()\n",
+                encoding="utf-8",
+            )
+            (pkg / "_banner.py").write_text(
+                "def print_banner():\n"
+                '    print("hello")\n',
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        metrics = result["architecture_metrics"]["module_metrics"]
+        assert metrics["mypkg._banner"]["ca"] == 1
+        assert metrics["mypkg._banner"]["ce"] == 0
+        assert metrics["mypkg._banner"]["zone"] == "zone_of_pain"
+
+        architecture_rules = {
+            (f.get("rule_id"), f.get("name"))
+            for f in result.get("quality", [])
+            if f.get("rule_id") in {"SKY-Q802", "SKY-Q803"}
+        }
+        assert ("SKY-Q803", "mypkg._banner") not in architecture_rules
+
     def test_analyze_architecture_filters_library_reexport_and_test_leaf_noise(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -169,6 +169,59 @@ class Command(Protocol):
         assert summary["module_metrics"]["mypkg.cli"]["zone"] == "zone_of_uselessness"
         assert summary["module_metrics"]["mypkg._helpers"]["distance"] == 1.0
 
+    def test_private_helper_low_fan_in_filters_q803_zone_of_pain(self):
+        graph = {
+            "mypkg.cli": {"mypkg._banner"},
+            "mypkg._banner": set(),
+        }
+        module_files = {
+            "mypkg.cli": "/p/mypkg/cli.py",
+            "mypkg._banner": "/p/mypkg/_banner.py",
+        }
+
+        raw_findings, _ = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+            private_helper_ca_limit=0,
+        )
+        assert ("SKY-Q803", "mypkg._banner") in {
+            (f["rule_id"], f["name"]) for f in raw_findings
+        }
+
+        findings, summary = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+        )
+
+        rules = {(f["rule_id"], f["name"]) for f in findings}
+        assert summary["module_metrics"]["mypkg._banner"]["ca"] == 1
+        assert summary["module_metrics"]["mypkg._banner"]["zone"] == "zone_of_pain"
+        assert ("SKY-Q803", "mypkg._banner") not in rules
+
+    def test_private_helper_high_fan_in_keeps_q803_zone_of_pain(self):
+        graph = {
+            "consumer_a": {"mypkg._shared"},
+            "consumer_b": {"mypkg._shared"},
+            "consumer_c": {"mypkg._shared"},
+            "mypkg._shared": set(),
+        }
+        module_files = {
+            "consumer_a": "/p/consumer_a.py",
+            "consumer_b": "/p/consumer_b.py",
+            "consumer_c": "/p/consumer_c.py",
+            "mypkg._shared": "/p/mypkg/_shared.py",
+        }
+
+        findings, summary = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+        )
+
+        assert summary["module_metrics"]["mypkg._shared"]["ca"] == 3
+        assert ("SKY-Q803", "mypkg._shared") in {
+            (f["rule_id"], f["name"]) for f in findings
+        }
+
     def test_main_guard_module_filters_zone_warning(self):
         tree = ast.parse("""
 from typing import Protocol


### PR DESCRIPTION
Fixes #311.

## Summary

  - Suppress `SKY-Q803` for private `_*.py` helper modules when fan-in is low.
  - Keep `SKY-Q803` active when a private helper is imported by many modules.
  - Add regression tests for the reported `_banner.py` layout and for the high fan-in case.

## Bug

FP. Small private helper modules like `mypkg/_banner.py` were in the "zone of Pain" even when they were only imported by one local module

  ## Tests

  - `pytest test/test_analyzer.py test/test_architecture.py`
  - `pytest test/test_quality_rules.py test/test_quality_new_rules.py test/test_circular_deps.py`