### PR TITLE
fix(architecture): repair Q802/Q803 audit defects

### DIFF
--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -240,7 +240,10 @@ def analyze_architecture(
                 metrics.protocols = abs_data["protocols"]
 
         metrics.distance = abs(metrics.abstractness + metrics.instability - 1.0)
-        metrics.zone = _classify_zone(metrics.abstractness, metrics.instability)
+        if metrics.total_coupling == 0:
+            metrics.zone = "disconnected"
+        else:
+            metrics.zone = _classify_zone(metrics.abstractness, metrics.instability)
 
         if module_loc and module_name in module_loc:
             metrics.loc = module_loc[module_name]
@@ -383,6 +386,9 @@ def analyze_architecture(
                 "zone_of_uselessness": sum(
                     1 for m in all_metrics if m.zone == "zone_of_uselessness"
                 ),
+                "disconnected": sum(
+                    1 for m in all_metrics if m.zone == "disconnected"
+                ),
             },
         }
     else:
@@ -506,7 +512,7 @@ def get_architecture_findings(
     entrypoint_modules: set[str] | None = None,
     package_boundary_modules: set[str] | None = None,
     private_helper_ce_limit: int = 2,
-    private_helper_ca_limit: int = 2,
+    private_helper_ca_limit: int = 3,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     result = analyze_architecture(
         dependency_graph=dependency_graph,
@@ -615,7 +621,7 @@ def _filter_contextual_findings(
                 rule_id == "SKY-Q803"
                 and simple_name.startswith("_")
                 and metrics is not None
-                and metrics.zone == "zone_of_pain"
+                and metrics.zone in {"zone_of_pain", "zone_of_uselessness"}
                 and metrics.ca <= private_helper_ca_limit
             ):
                 continue

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -758,6 +758,40 @@ class TestAnalyze:
         }
         assert ("SKY-Q803", "mypkg._banner") not in architecture_rules
 
+    def test_analyze_architecture_labels_empty_package_disconnected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pkg = root / "mypkg"
+            pkg.mkdir()
+            (root / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "disconnected-package-repro"\n'
+                'version = "0.1.0"\n',
+                encoding="utf-8",
+            )
+            (pkg / "__init__.py").write_text("", encoding="utf-8")
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        metrics = result["architecture_metrics"]["module_metrics"]
+        distribution = result["architecture_metrics"]["system_metrics"][
+            "zone_distribution"
+        ]
+        assert metrics["mypkg"]["ca"] == 0
+        assert metrics["mypkg"]["ce"] == 0
+        assert metrics["mypkg"]["zone"] == "disconnected"
+        assert distribution["disconnected"] == 1
+        assert distribution["zone_of_pain"] == 0
+
+        architecture_rules = {
+            (f.get("rule_id"), f.get("name"))
+            for f in result.get("quality", [])
+            if f.get("rule_id") in {"SKY-Q802", "SKY-Q803"}
+        }
+        assert ("SKY-Q802", "mypkg") not in architecture_rules
+        assert ("SKY-Q803", "mypkg") not in architecture_rules
+
     def test_analyze_architecture_filters_library_reexport_and_test_leaf_noise(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -101,6 +101,17 @@ class TestClassifyZone:
         assert _classify_zone(0.5, 0.2) == "off_main_sequence"
         assert _classify_zone(0.0, 0.4) == "off_main_sequence"
 
+    def test_disconnected_module_is_not_labeled_pain(self):
+        result = analyze_architecture(
+            dependency_graph={"mypkg": set()},
+            module_files={"mypkg": "/p/mypkg/__init__.py"},
+        )
+
+        assert result.modules["mypkg"].total_coupling == 0
+        assert result.modules["mypkg"].zone == "disconnected"
+        assert result.system_metrics["zone_distribution"]["zone_of_pain"] == 0
+        assert result.system_metrics["zone_distribution"]["disconnected"] == 1
+
 
 class TestArchitectureContext:
     def test_main_guard_detected(self):
@@ -198,7 +209,7 @@ class Command(Protocol):
         assert summary["module_metrics"]["mypkg._banner"]["zone"] == "zone_of_pain"
         assert ("SKY-Q803", "mypkg._banner") not in rules
 
-    def test_private_helper_high_fan_in_keeps_q803_zone_of_pain(self):
+    def test_private_helper_three_importers_filters_q803_zone_of_pain(self):
         graph = {
             "consumer_a": {"mypkg._shared"},
             "consumer_b": {"mypkg._shared"},
@@ -218,7 +229,65 @@ class Command(Protocol):
         )
 
         assert summary["module_metrics"]["mypkg._shared"]["ca"] == 3
+        assert ("SKY-Q803", "mypkg._shared") not in {
+            (f["rule_id"], f["name"]) for f in findings
+        }
+
+    def test_private_helper_high_fan_in_keeps_q803_zone_of_pain(self):
+        graph = {
+            "consumer_a": {"mypkg._shared"},
+            "consumer_b": {"mypkg._shared"},
+            "consumer_c": {"mypkg._shared"},
+            "consumer_d": {"mypkg._shared"},
+            "mypkg._shared": set(),
+        }
+        module_files = {
+            "consumer_a": "/p/consumer_a.py",
+            "consumer_b": "/p/consumer_b.py",
+            "consumer_c": "/p/consumer_c.py",
+            "consumer_d": "/p/consumer_d.py",
+            "mypkg._shared": "/p/mypkg/_shared.py",
+        }
+
+        findings, summary = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+        )
+
+        assert summary["module_metrics"]["mypkg._shared"]["ca"] == 4
         assert ("SKY-Q803", "mypkg._shared") in {
+            (f["rule_id"], f["name"]) for f in findings
+        }
+
+    def test_private_helper_filters_q803_zone_of_uselessness(self):
+        graph = {
+            "mypkg._contracts": {"mypkg.impl"},
+            "mypkg.impl": set(),
+        }
+        module_files = {
+            "mypkg._contracts": "/p/mypkg/_contracts.py",
+            "mypkg.impl": "/p/mypkg/impl.py",
+        }
+        module_trees = {
+            "mypkg._contracts": ast.parse("""
+from typing import Protocol
+from .impl import build
+
+class Builder(Protocol):
+    ...
+""")
+        }
+
+        findings, summary = get_architecture_findings(
+            dependency_graph=graph,
+            module_files=module_files,
+            module_trees=module_trees,
+        )
+
+        assert summary["module_metrics"]["mypkg._contracts"]["zone"] == (
+            "zone_of_uselessness"
+        )
+        assert ("SKY-Q803", "mypkg._contracts") not in {
             (f["rule_id"], f["name"]) for f in findings
         }
 


### PR DESCRIPTION
Fixes #312.

## Summary 

  1. Empty package marker files like `__init__.py` had no imports and no importers, but were still labeled as `zone_of_pain`.
  2. Small private helper modules like `_helper.py` could still get `SKY-Q803` warnings, even when their shape was low-risk 

  ## Changes

  - Label fully disconnected modules as `disconnected` instead of `zone_of_pain`.
  - In `zone_distribution` count disconnected modules separately.
  - Extend private-helper Q803 filtering to `zone_of_pain` and `zone_of_uselessness`.
  - Allow low fan-in private helpers up to `Ca <= 3`, while keeping broader private helpers flagged.

  ## Tests

  - `pytest -q test/test_analyzer.py test/test_architecture.py test/test_quality_rules.py test/test_quality_new_rules.py test/test_circular_deps.py`