### PR TITLE
feat(quality): add architecture policy and placeholder checks

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -66,6 +66,7 @@ from skylos.rules.quality.logic import (
     PhantomCallRule,
     InsecureRandomRule,
     HardcodedCredentialRule,
+    MockPlaceholderDataRule,
     ErrorDisclosureRule,
     BroadFilePermissionsRule,
     PhantomDecoratorRule,
@@ -1681,6 +1682,7 @@ class Skylos:
                             module_loc=architecture_loc,
                             entrypoint_modules=entrypoint_modules,
                             package_boundary_modules=package_boundary_modules,
+                            layer_policy=project_cfg.get("architecture"),
                         )
                         ignored_rules = set(project_cfg.get("ignore", []))
                         if arch_findings:
@@ -2836,6 +2838,10 @@ def proc_file(
                 q_rules.append(InsecureRandomRule(vibe_dictionary=vibe_dictionary))
             if "SKY-L014" not in cfg["ignore"]:
                 q_rules.append(HardcodedCredentialRule(vibe_dictionary=vibe_dictionary))
+            if "SKY-L032" not in cfg["ignore"]:
+                q_rules.append(
+                    MockPlaceholderDataRule(vibe_dictionary=vibe_dictionary)
+                )
             if "SKY-L017" not in cfg["ignore"]:
                 q_rules.append(ErrorDisclosureRule())
             if "SKY-L020" not in cfg["ignore"]:

--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -4,11 +4,13 @@ Rule IDs:
 - SKY-Q802: High distance from main sequence
 - SKY-Q803: Zone of Pain / Zone of Uselessness warning
 - SKY-Q804: Dependency Inversion Principle violation
+- SKY-Q805: Architecture layer policy violation
 """
 
 from __future__ import annotations
 
 import ast
+import fnmatch
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -503,6 +505,212 @@ def _generate_findings(result: ArchitectureResult):
         )
 
 
+def _normalize_layer_policy(policy: Any) -> dict[str, Any] | None:
+    if not isinstance(policy, dict):
+        return None
+
+    raw_layers = policy.get("layers") or []
+    raw_rules = policy.get("rules") or []
+    if not isinstance(raw_layers, list) or not isinstance(raw_rules, list):
+        return None
+    if not raw_layers or not raw_rules:
+        return None
+
+    layers: list[dict[str, Any]] = []
+    for raw_layer in raw_layers:
+        if not isinstance(raw_layer, dict):
+            continue
+        name = str(raw_layer.get("name") or "").strip()
+        if not name:
+            continue
+        patterns = raw_layer.get("patterns")
+        if patterns is None:
+            patterns = raw_layer.get("packages")
+        if isinstance(patterns, str):
+            patterns = [patterns]
+        if not isinstance(patterns, list):
+            patterns = []
+        clean_patterns = [str(p).strip() for p in patterns if str(p).strip()]
+        if clean_patterns:
+            layers.append({"name": name, "patterns": clean_patterns})
+
+    rules: list[dict[str, Any]] = []
+    for raw_rule in raw_rules:
+        if not isinstance(raw_rule, dict):
+            continue
+        from_layer = str(raw_rule.get("from") or "").strip()
+        if not from_layer:
+            continue
+
+        allow = raw_rule.get("allow") or []
+        deny = raw_rule.get("deny") or []
+        if isinstance(allow, str):
+            allow = [allow]
+        if isinstance(deny, str):
+            deny = [deny]
+        if not isinstance(allow, list):
+            allow = []
+        if not isinstance(deny, list):
+            deny = []
+
+        clean_allow = [str(v).strip() for v in allow if str(v).strip()]
+        clean_deny = [str(v).strip() for v in deny if str(v).strip()]
+        if clean_allow or clean_deny:
+            rules.append(
+                {
+                    "from": from_layer,
+                    "allow": clean_allow,
+                    "deny": clean_deny,
+                    "severity": str(raw_rule.get("severity") or "HIGH").upper(),
+                }
+            )
+
+    if not layers or not rules:
+        return None
+
+    return {
+        "strict": bool(policy.get("strict", False)),
+        "layers": layers,
+        "rules": rules,
+    }
+
+
+def _layer_pattern_matches(module_name: str, file_path: str, pattern: str) -> bool:
+    normalized = pattern.strip().replace("/", ".").strip(".")
+    if not normalized:
+        return False
+
+    file_module = Path(file_path).with_suffix("").as_posix().replace("/", ".")
+    candidates = {module_name, file_module}
+    for candidate in candidates:
+        if candidate == normalized or candidate.startswith(normalized + "."):
+            return True
+        if fnmatch.fnmatchcase(candidate, normalized):
+            return True
+        if fnmatch.fnmatchcase(candidate, normalized + ".*"):
+            return True
+        if normalized in candidate.split("."):
+            return True
+
+    return False
+
+
+def _map_modules_to_layers(
+    module_files: dict[str, str],
+    layers: list[dict[str, Any]],
+) -> dict[str, str]:
+    mapped: dict[str, str] = {}
+    for module_name, file_path in module_files.items():
+        matches: list[tuple[int, int, str]] = []
+        for layer in layers:
+            for pattern in layer["patterns"]:
+                if _layer_pattern_matches(module_name, file_path, pattern):
+                    specificity = pattern.count(".")
+                    matches.append((specificity, len(pattern), layer["name"]))
+        if matches:
+            matches.sort(key=lambda item: (-item[0], -item[1], item[2]))
+            mapped[module_name] = matches[0][2]
+        else:
+            mapped[module_name] = "unknown"
+    return mapped
+
+
+def get_layer_policy_findings(
+    dependency_graph: dict[str, set[str]],
+    module_files: dict[str, str],
+    policy: Any,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    normalized = _normalize_layer_policy(policy)
+    if not normalized:
+        return [], {}
+
+    layer_map = _map_modules_to_layers(module_files, normalized["layers"])
+    rules_by_from = {rule["from"]: rule for rule in normalized["rules"]}
+    findings: list[dict[str, Any]] = []
+
+    checked_edges = 0
+    for from_module, deps in sorted(dependency_graph.items()):
+        from_layer = layer_map.get(from_module, "unknown")
+        for to_module in sorted(deps):
+            if to_module not in module_files:
+                continue
+            to_layer = layer_map.get(to_module, "unknown")
+            if from_module == to_module:
+                continue
+            checked_edges += 1
+
+            rule = rules_by_from.get(from_layer)
+            violation_reason = ""
+            severity = "HIGH"
+
+            if normalized["strict"] and (
+                from_layer == "unknown" or to_layer == "unknown"
+            ):
+                violation_reason = (
+                    "Dependency involves module(s) outside configured architecture layers"
+                )
+                severity = "MEDIUM"
+            elif rule is None:
+                continue
+            elif to_layer in set(rule["deny"]):
+                violation_reason = (
+                    f"Layer '{from_layer}' is explicitly denied from depending on "
+                    f"'{to_layer}'"
+                )
+                severity = rule["severity"]
+            elif rule["allow"] and to_layer not in set(rule["allow"]):
+                allowed = ", ".join(rule["allow"])
+                violation_reason = (
+                    f"Layer '{from_layer}' may only depend on: {allowed}"
+                )
+                severity = rule["severity"]
+            else:
+                continue
+
+            source_file = module_files.get(from_module, "")
+            findings.append(
+                {
+                    "rule_id": "SKY-Q805",
+                    "kind": "architecture",
+                    "severity": severity
+                    if severity in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+                    else "HIGH",
+                    "type": "module_dependency",
+                    "name": from_module,
+                    "simple_name": from_module.split(".")[-1],
+                    "value": f"{from_layer}->{to_layer}",
+                    "from_module": from_module,
+                    "to_module": to_module,
+                    "from_layer": from_layer,
+                    "to_layer": to_layer,
+                    "message": (
+                        f"Architecture layer violation: '{from_module}' "
+                        f"({from_layer}) depends on '{to_module}' ({to_layer}). "
+                        f"{violation_reason}."
+                    ),
+                    "file": source_file,
+                    "basename": Path(source_file).name if source_file else from_module,
+                    "line": 1,
+                }
+            )
+
+    mapped_counts: dict[str, int] = defaultdict(int)
+    for layer in layer_map.values():
+        mapped_counts[layer] += 1
+
+    summary = {
+        "enabled": True,
+        "strict": normalized["strict"],
+        "layer_count": len(normalized["layers"]),
+        "rule_count": len(normalized["rules"]),
+        "checked_edges": checked_edges,
+        "violation_count": len(findings),
+        "module_layers": dict(sorted(layer_map.items())),
+        "layer_distribution": dict(sorted(mapped_counts.items())),
+    }
+    return findings, summary
+
+
 def get_architecture_findings(
     dependency_graph: dict[str, set[str]],
     module_files: dict[str, str],
@@ -513,6 +721,7 @@ def get_architecture_findings(
     package_boundary_modules: set[str] | None = None,
     private_helper_ce_limit: int = 2,
     private_helper_ca_limit: int = 3,
+    layer_policy: dict[str, Any] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     result = analyze_architecture(
         dependency_graph=dependency_graph,
@@ -538,6 +747,14 @@ def get_architecture_findings(
         private_helper_ca_limit=private_helper_ca_limit,
     )
 
+    policy_findings, policy_summary = get_layer_policy_findings(
+        dependency_graph=dependency_graph,
+        module_files=module_files,
+        policy=layer_policy,
+    )
+    if policy_findings:
+        findings.extend(policy_findings)
+
     summary = {
         "system_metrics": result.system_metrics,
         "module_count": len(result.modules),
@@ -562,6 +779,8 @@ def get_architecture_findings(
             for name, m in result.modules.items()
         },
     }
+    if policy_summary:
+        summary["layer_policy"] = policy_summary
 
     return findings, summary
 

--- a/skylos/commands/init_cmd.py
+++ b/skylos/commands/init_cmd.py
@@ -36,6 +36,21 @@ extra_credential_names = []
 extra_sensitive_file_keywords = []
 extra_network_timeout_calls = []
 
+[tool.skylos.architecture]
+strict = false
+
+# [[tool.skylos.architecture.layers]]
+# name = "api"
+# patterns = ["app.api", "app.routes"]
+#
+# [[tool.skylos.architecture.layers]]
+# name = "domain"
+# patterns = ["app.domain", "app.models"]
+#
+# [[tool.skylos.architecture.rules]]
+# from = "domain"
+# deny = ["api"]
+
 [tool.skylos.whitelist]
 names = []
 

--- a/skylos/config.py
+++ b/skylos/config.py
@@ -20,6 +20,11 @@ DEFAULTS = {
     "nudges": True,
     "check_circular": True,
     "max_circular_deps": -1,
+    "architecture": {
+        "strict": False,
+        "layers": [],
+        "rules": [],
+    },
     "masking": {
         "names": [],
         "decorators": [],
@@ -183,7 +188,9 @@ def _merge_user_config(base_cfg: dict, user_cfg: dict | None) -> dict:
             merged_masking.update(value or {})
             final_cfg["masking"] = merged_masking
             continue
-        if key in ("gate", "templates", "vibe") and isinstance(value, dict):
+        if key in ("gate", "templates", "vibe", "architecture") and isinstance(
+            value, dict
+        ):
             merged_section = {}
             merged_section.update(final_cfg.get(key, {}) or {})
             merged_section.update(value)

--- a/skylos/rules/quality/logic.py
+++ b/skylos/rules/quality/logic.py
@@ -1995,6 +1995,48 @@ _CREDENTIAL_DSN_RE = re.compile(
 )
 
 _PLACEHOLDER_VALUES = DEFAULT_VIBE_DICTIONARY.placeholder_values
+_MOCK_CONTEXT_WORDS = {
+    "mock",
+    "fake",
+    "dummy",
+    "placeholder",
+    "sample",
+    "example",
+    "fixture",
+    "stub",
+    "demo",
+}
+_PLACEHOLDER_EMAIL_RE = re.compile(
+    r"(?i)^[a-z0-9._%+-]+@"
+    r"("
+    r"example\.(?:com|org|net)|test\.(?:com|org|net)|localhost|invalid|"
+    r"foo\.com|bar\.com"
+    r")$"
+)
+_PLACEHOLDER_PHONE_RE = re.compile(
+    r"(?:^|[^0-9])"
+    r"(\(?(?:0{3}|1{3}|123)\)?[-.\s]?(?:0{3,4}|1{3,4}|456)[-.\s]?"
+    r"(?:0{4}|1{4}|7890))"
+    r"(?:[^0-9]|$)"
+)
+_UUID_RE = re.compile(
+    r"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+_TEST_CREDENTIAL_RE = re.compile(
+    r"(?i)^(?:password|secret|api[_-]?key|token|credential|auth)[0-9]*$"
+    r"|^(?:password|secret)123$"
+    r"|^test(?:password|secret|key)$"
+)
+_PLACEHOLDER_DOMAINS = (
+    "example.com",
+    "example.org",
+    "example.net",
+    "test.com",
+    "test.org",
+    "test.net",
+    "foo.com",
+    "bar.com",
+)
 
 
 def _is_credential_var(name, vibe_dictionary=None):
@@ -2006,6 +2048,104 @@ def _is_credential_var(name, vibe_dictionary=None):
         if lower.endswith(suffix):
             return True
     return False
+
+
+def _name_has_mock_context(name: str) -> bool:
+    parts = {p for p in re.split(r"[^a-zA-Z0-9]+", name.lower()) if p}
+    return bool(parts & _MOCK_CONTEXT_WORDS)
+
+
+def _target_names(node) -> list[str]:
+    names = []
+
+    def collect(target):
+        if isinstance(target, ast.Name):
+            names.append(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.append(target.attr)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for item in target.elts:
+                collect(item)
+
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            collect(target)
+    elif isinstance(node, ast.AnnAssign):
+        collect(node.target)
+
+    return names
+
+
+def _is_low_entropy_uuid(value: str) -> bool:
+    if not _UUID_RE.match(value):
+        return False
+    cleaned = value.replace("-", "").lower()
+    if not cleaned:
+        return False
+    if len(set(cleaned)) <= 2:
+        return True
+    return cleaned in {
+        "00000000000000000000000000000000",
+        "11111111111111111111111111111111",
+        "ffffffffffffffffffffffffffffffff",
+        "12345678123456781234567812345678",
+    }
+
+
+def _is_repetitive_placeholder(value: str) -> bool:
+    if len(value) < 4 or len(value) > 20:
+        return False
+    if len(set(value)) == 1:
+        return True
+    if len(value) % 2 == 0:
+        pair = value[:2]
+        return pair * (len(value) // 2) == value
+    return False
+
+
+def _classify_placeholder_value(
+    value: str,
+    target_names: list[str],
+    vibe_dictionary=None,
+):
+    vibe_dictionary = vibe_dictionary or DEFAULT_VIBE_DICTIONARY
+    stripped = value.strip()
+    lower = stripped.lower()
+    target_context = any(_name_has_mock_context(name) for name in target_names)
+    credential_context = any(
+        _is_credential_var(name, vibe_dictionary) for name in target_names
+    )
+
+    if _PLACEHOLDER_EMAIL_RE.match(stripped):
+        return "placeholder_email", "MEDIUM", "Email uses a test/example domain"
+
+    if _is_low_entropy_uuid(stripped):
+        return (
+            "low_entropy_uuid",
+            "MEDIUM",
+            "UUID has a low-entropy placeholder pattern",
+        )
+
+    if _PLACEHOLDER_PHONE_RE.search(stripped):
+        return "placeholder_phone", "MEDIUM", "Phone number uses a placeholder pattern"
+
+    if credential_context and _TEST_CREDENTIAL_RE.match(stripped):
+        return (
+            "test_credential",
+            "HIGH",
+            "Credential value is a common test placeholder",
+        )
+
+    if target_context and lower in vibe_dictionary.placeholder_values:
+        return "placeholder_value", "MEDIUM", "Value is a configured placeholder token"
+
+    if target_context and any(domain in lower for domain in _PLACEHOLDER_DOMAINS):
+        return "placeholder_domain", "LOW", "Value references a test/example domain"
+
+    if target_context and _is_repetitive_placeholder(stripped):
+        return "repetitive_placeholder", "LOW", "Value is a repetitive placeholder"
+
+    return None
 
 
 def _is_env_lookup(node):
@@ -2155,6 +2295,110 @@ class HardcodedCredentialRule(SkylosRule):
                             )
 
         return findings if findings else None
+
+
+class MockPlaceholderDataRule(SkylosRule):
+    rule_id = "SKY-L032"
+    name = "Mock Or Placeholder Data"
+
+    def __init__(self, vibe_dictionary=None):
+        self.vibe_dictionary = vibe_dictionary or DEFAULT_VIBE_DICTIONARY
+
+    def visit_node(self, node, context):
+        if not isinstance(
+            node,
+            (ast.Assign, ast.AnnAssign, ast.FunctionDef, ast.AsyncFunctionDef),
+        ):
+            return None
+
+        filename = context.get("filename", "")
+        if _is_test_file(filename):
+            return None
+
+        findings = []
+        basename = _basename(filename)
+
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            value = _string_literal_value(node.value)
+            if value is not None:
+                self._add_finding(
+                    findings,
+                    value=value,
+                    target_names=_target_names(node),
+                    filename=filename,
+                    basename=basename,
+                    line=getattr(node.value, "lineno", getattr(node, "lineno", 1)),
+                    col=getattr(
+                        node.value,
+                        "col_offset",
+                        getattr(node, "col_offset", 0),
+                    ),
+                )
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for arg, default in _iter_arg_defaults(node):
+                value = _string_literal_value(default)
+                if value is None:
+                    continue
+                arg_name = arg.arg if hasattr(arg, "arg") else str(arg)
+                self._add_finding(
+                    findings,
+                    value=value,
+                    target_names=[arg_name],
+                    filename=filename,
+                    basename=basename,
+                    line=getattr(default, "lineno", getattr(node, "lineno", 1)),
+                    col=getattr(
+                        default,
+                        "col_offset",
+                        getattr(node, "col_offset", 0),
+                    ),
+                )
+
+        return findings if findings else None
+
+    def _add_finding(
+        self,
+        findings,
+        *,
+        value,
+        target_names,
+        filename,
+        basename,
+        line,
+        col,
+    ):
+        classification = _classify_placeholder_value(
+            value,
+            target_names,
+            self.vibe_dictionary,
+        )
+        if not classification:
+            return
+
+        placeholder_type, severity, rationale = classification
+        name = target_names[0] if target_names else placeholder_type
+        findings.append(
+            {
+                "rule_id": self.rule_id,
+                "kind": "logic",
+                "severity": severity,
+                "type": "literal",
+                "name": name,
+                "simple_name": name,
+                "value": placeholder_type,
+                "threshold": 0,
+                "mock_data_type": placeholder_type,
+                "message": (
+                    f"Mock or placeholder data in '{name}' "
+                    f"({placeholder_type}). {rationale}."
+                ),
+                "file": filename,
+                "basename": basename,
+                "line": line,
+                "col": col,
+            }
+        )
 
 
 def _iter_arg_defaults(func_node):

--- a/skylos/rules/quality/standards.py
+++ b/skylos/rules/quality/standards.py
@@ -78,6 +78,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
         }
     ],
     "SKY-L031": [{"id": "CWE-400", "name": "Uncontrolled Resource Consumption"}],
+    "SKY-L032": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-T101": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-T102": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-F101": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
@@ -139,6 +140,8 @@ STANDARD_REFS: dict[str, list[str]] = {
     "SKY-C401": ["Clone detection: duplicated implementation fragments"],
     "SKY-Q701": ["CK Metrics: CBO (Coupling Between Objects)", "ISO/IEC 9126"],
     "SKY-Q702": ["CK Metrics: LCOM (Lack of Cohesion of Methods)", "ISO/IEC 9126"],
+    "SKY-Q805": ["Architecture layer dependency policy"],
+    "SKY-L032": ["Production data hygiene: mock and placeholder values"],
     "SKY-C303": ["ISO/IEC 5055:2021 §6.3.2"],
     "SKY-C304": ["ISO/IEC 5055:2021 §6.3.3"],
     "SKY-T101": ["PEP 484", "Typed public API parameters"],

--- a/skylos_mcp/auth.py
+++ b/skylos_mcp/auth.py
@@ -16,6 +16,8 @@ TOOL_CREDIT_MAP: dict[str, str] = {
     "analyze": "mcp_analyze",
     "security_scan": "mcp_security_scan",
     "quality_check": "mcp_quality_check",
+    "architecture_check": "mcp_quality_check",
+    "health_score": "mcp_quality_check",
     "secrets_scan": "mcp_secrets_scan",
     "remediate": "mcp_remediate",
     "provenance_scan": "mcp_provenance_scan",

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -466,6 +466,16 @@ def _run_analysis(
     return json.loads(result_json)
 
 
+_ARCHITECTURE_RULE_IDS = {"SKY-Q701", "SKY-Q802", "SKY-Q803", "SKY-Q804", "SKY-Q805"}
+
+
+def _is_architecture_finding(finding: dict) -> bool:
+    return (
+        finding.get("kind") == "architecture"
+        or finding.get("rule_id") in _ARCHITECTURE_RULE_IDS
+    )
+
+
 def _make_summary(result: dict, focus: str | None = None) -> dict:
     summary = result.get("analysis_summary", {})
     out: dict[str, Any] = {"analysis_summary": summary}
@@ -508,6 +518,79 @@ def _make_summary(result: dict, focus: str | None = None) -> dict:
             out["secrets"] = result["secrets"]
 
     return out
+
+
+def _architecture_payload(result: dict) -> dict:
+    findings = [
+        finding
+        for finding in result.get("quality", []) or []
+        if _is_architecture_finding(finding)
+    ]
+    payload: dict[str, Any] = {
+        "analysis_summary": result.get("analysis_summary", {}),
+        "architecture_metrics": result.get("architecture_metrics", {}),
+        "findings": findings,
+    }
+    if result.get("circular_dependencies"):
+        payload["circular_dependencies"] = result["circular_dependencies"]
+    return payload
+
+
+def _health_score_payload(result: dict) -> dict:
+    summary = result.get("analysis_summary", {})
+    grade = result.get("grade", {})
+    categories = grade.get("categories", {}) if isinstance(grade, dict) else {}
+    dead_code_count = sum(
+        len(result.get(key, []) or [])
+        for key in [
+            "unused_functions",
+            "unused_imports",
+            "unused_classes",
+            "unused_variables",
+            "unused_parameters",
+            "unused_files",
+        ]
+    )
+
+    architecture_metrics = result.get("architecture_metrics", {}) or {}
+    layer_policy = architecture_metrics.get("layer_policy", {}) or {}
+    system_metrics = architecture_metrics.get("system_metrics", {}) or {}
+    counts = {
+        "dead_code": dead_code_count,
+        "quality": summary.get("quality_count", 0),
+        "security": summary.get("danger_count", 0),
+        "secrets": summary.get("secrets_count", 0),
+        "dependencies": summary.get("sca_count", 0),
+        "architecture_policy_violations": layer_policy.get("violation_count", 0),
+        "circular_dependencies": len(result.get("circular_dependencies", []) or []),
+    }
+    category_scores = {
+        name: {
+            "score": data.get("score"),
+            "letter": data.get("letter"),
+            "key_issue": data.get("key_issue"),
+        }
+        for name, data in categories.items()
+        if isinstance(data, dict)
+    }
+    top_issues = [
+        {
+            "category": name,
+            "key_issue": data["key_issue"],
+        }
+        for name, data in category_scores.items()
+        if data.get("key_issue")
+        and not str(data["key_issue"]).lower().startswith("no ")
+    ]
+
+    return {
+        "grade": grade,
+        "category_scores": category_scores,
+        "counts": counts,
+        "architecture_fitness": system_metrics.get("architecture_fitness"),
+        "analysis_summary": summary,
+        "top_issues": top_issues,
+    }
 
 
 def _gate(tool_name: str) -> str | None:
@@ -589,6 +672,53 @@ def _register_tools(mcp):
         )
         summary = _make_summary(result, focus="quality")
         run_id = _store_result(result, "quality_check", path)
+        summary["_run_id"] = run_id
+        return json.dumps(summary, indent=2)
+
+    @mcp.tool()
+    def architecture_check(
+        path: str,
+        confidence: int = 60,
+        exclude_folders: list[str] | None = None,
+    ) -> str:
+        gate_err = _gate("architecture_check")
+        if gate_err:
+            return gate_err
+
+        result = _run_analysis(
+            path,
+            confidence=confidence,
+            exclude_folders=exclude_folders,
+            enable_quality=True,
+        )
+        summary = _architecture_payload(result)
+        run_id = _store_result(result, "architecture_check", path)
+        summary["_run_id"] = run_id
+        return json.dumps(summary, indent=2)
+
+    @mcp.tool()
+    def health_score(
+        path: str,
+        confidence: int = 60,
+        include_security: bool = True,
+        include_secrets: bool = True,
+        include_quality: bool = True,
+        exclude_folders: list[str] | None = None,
+    ) -> str:
+        gate_err = _gate("health_score")
+        if gate_err:
+            return gate_err
+
+        result = _run_analysis(
+            path,
+            confidence=confidence,
+            exclude_folders=exclude_folders,
+            enable_secrets=include_secrets,
+            enable_danger=include_security,
+            enable_quality=include_quality,
+        )
+        summary = _health_score_payload(result)
+        run_id = _store_result(result, "health_score", path)
         summary["_run_id"] = run_id
         return json.dumps(summary, indent=2)
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -657,6 +657,52 @@ class TestAnalyze:
         assert metrics["app.package_a.cli"]["ca"] == 1
         assert metrics["app.package_a.cli"]["zone"] != "zone_of_uselessness"
 
+    def test_analyze_applies_configured_architecture_layer_policy(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pyproject.toml").write_text(
+                "[tool.skylos.architecture]\n"
+                "strict = false\n\n"
+                "[[tool.skylos.architecture.layers]]\n"
+                'name = "api"\n'
+                'patterns = ["app.api"]\n\n'
+                "[[tool.skylos.architecture.layers]]\n"
+                'name = "domain"\n'
+                'patterns = ["app.domain"]\n\n'
+                "[[tool.skylos.architecture.rules]]\n"
+                'from = "domain"\n'
+                'deny = ["api"]\n',
+                encoding="utf-8",
+            )
+            (root / "app" / "api").mkdir(parents=True)
+            (root / "app" / "domain").mkdir(parents=True)
+            (root / "app" / "__init__.py").write_text("", encoding="utf-8")
+            (root / "app" / "api" / "__init__.py").write_text("", encoding="utf-8")
+            (root / "app" / "domain" / "__init__.py").write_text(
+                "", encoding="utf-8"
+            )
+            (root / "app" / "api" / "routes.py").write_text(
+                "API_VALUE = 1\n",
+                encoding="utf-8",
+            )
+            (root / "app" / "domain" / "model.py").write_text(
+                "from app.api.routes import API_VALUE\n"
+                "def model_value():\n"
+                "    return API_VALUE\n",
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), enable_quality=True, grep_verify=False)
+
+        result = json.loads(result_json)
+        policy_findings = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-Q805"
+        ]
+        assert len(policy_findings) == 1
+        assert policy_findings[0]["from_layer"] == "domain"
+        assert policy_findings[0]["to_layer"] == "api"
+        assert result["architecture_metrics"]["layer_policy"]["violation_count"] == 1
+
     def test_analyze_architecture_filters_cli_entrypoint_and_private_helper_noise(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1936,6 +1982,26 @@ def fake_call():
         dependency_findings = [f for f in quality if f.get("rule_id") == "SKY-U005"]
 
         assert dependency_findings == []
+
+    def test_analyze_flags_mock_placeholder_data_in_production_file(self, tmp_path):
+        src = tmp_path / "app.py"
+        src.write_text(
+            'SUPPORT_EMAIL = "test@example.com"\n'
+            'USER_ID = "00000000-0000-0000-0000-000000000000"\n',
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
+        )
+        findings = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L032"
+        ]
+
+        assert {f["mock_data_type"] for f in findings} == {
+            "placeholder_email",
+            "low_entropy_uuid",
+        }
 
     def test_analyze_repo_rules_use_root_project_ignore_config(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -2,6 +2,7 @@ import ast
 from skylos.architecture import (
     analyze_architecture,
     get_architecture_findings,
+    get_layer_policy_findings,
     _compute_abstractness,
     _classify_zone,
     _has_main_guard,
@@ -258,6 +259,55 @@ class Command(Protocol):
         assert ("SKY-Q803", "mypkg._shared") in {
             (f["rule_id"], f["name"]) for f in findings
         }
+
+
+class TestLayerPolicy:
+    def test_layer_policy_deny_rule_reports_violation(self):
+        graph = {
+            "app.domain.model": {"app.api.routes"},
+            "app.api.routes": set(),
+        }
+        module_files = {
+            "app.domain.model": "/p/app/domain/model.py",
+            "app.api.routes": "/p/app/api/routes.py",
+        }
+        policy = {
+            "layers": [
+                {"name": "domain", "patterns": ["app.domain"]},
+                {"name": "api", "patterns": ["app.api"]},
+            ],
+            "rules": [{"from": "domain", "deny": ["api"]}],
+        }
+
+        findings, summary = get_layer_policy_findings(graph, module_files, policy)
+
+        assert summary["violation_count"] == 1
+        assert findings[0]["rule_id"] == "SKY-Q805"
+        assert findings[0]["from_layer"] == "domain"
+        assert findings[0]["to_layer"] == "api"
+
+    def test_layer_policy_allow_rule_accepts_allowed_edges(self):
+        graph = {
+            "app.api.routes": {"app.domain.model"},
+            "app.domain.model": set(),
+        }
+        module_files = {
+            "app.api.routes": "/p/app/api/routes.py",
+            "app.domain.model": "/p/app/domain/model.py",
+        }
+        policy = {
+            "layers": [
+                {"name": "api", "patterns": ["app.api"]},
+                {"name": "domain", "patterns": ["app.domain"]},
+            ],
+            "rules": [{"from": "api", "allow": ["domain"]}],
+        }
+
+        findings, summary = get_layer_policy_findings(graph, module_files, policy)
+
+        assert findings == []
+        assert summary["checked_edges"] == 1
+        assert summary["module_layers"]["app.api.routes"] == "api"
 
     def test_private_helper_filters_q803_zone_of_uselessness(self):
         graph = {

--- a/test/test_mcp_auth.py
+++ b/test/test_mcp_auth.py
@@ -108,6 +108,13 @@ class TestCheckToolAccess:
         assert allowed is False
         assert "requires authentication" in err
 
+    def test_unauthenticated_focused_quality_tools_blocked(self):
+        self._set_session(authenticated=False)
+        for tool in ("architecture_check", "health_score"):
+            allowed, err = check_tool_access(tool)
+            assert allowed is False
+            assert "requires authentication" in err
+
     def test_unauthenticated_secrets_scan_blocked(self):
         self._set_session(authenticated=False)
         allowed, err = check_tool_access("secrets_scan")
@@ -281,6 +288,8 @@ class TestDeductCredits:
             "analyze": "mcp_analyze",
             "security_scan": "mcp_security_scan",
             "quality_check": "mcp_quality_check",
+            "architecture_check": "mcp_quality_check",
+            "health_score": "mcp_quality_check",
             "secrets_scan": "mcp_secrets_scan",
             "remediate": "mcp_remediate",
         }

--- a/test/test_mcp_summary.py
+++ b/test/test_mcp_summary.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from skylos_mcp.server import _make_summary
+from skylos_mcp.server import (
+    _architecture_payload,
+    _health_score_payload,
+    _make_summary,
+)
 
 
 def test_make_summary_includes_workspace_report_when_present():
@@ -32,3 +36,60 @@ def test_make_summary_omits_empty_workspace_report():
     summary = _make_summary(result)
 
     assert "workspaces" not in summary
+
+
+def test_architecture_payload_filters_architecture_findings():
+    result = {
+        "analysis_summary": {"quality_count": 2},
+        "architecture_metrics": {"layer_policy": {"violation_count": 1}},
+        "quality": [
+            {"rule_id": "SKY-Q805", "kind": "architecture", "name": "domain"},
+            {"rule_id": "SKY-L014", "kind": "logic", "name": "password"},
+        ],
+    }
+
+    payload = _architecture_payload(result)
+
+    assert payload["architecture_metrics"]["layer_policy"]["violation_count"] == 1
+    assert [finding["rule_id"] for finding in payload["findings"]] == ["SKY-Q805"]
+
+
+def test_health_score_payload_summarizes_counts_and_grade():
+    result = {
+        "analysis_summary": {
+            "quality_count": 3,
+            "danger_count": 1,
+            "secrets_count": 0,
+            "sca_count": 2,
+        },
+        "grade": {
+            "overall": {"score": 88, "letter": "B+"},
+            "categories": {
+                "quality": {
+                    "score": 82,
+                    "letter": "B-",
+                    "key_issue": "Architecture layer violation",
+                },
+                "secrets": {
+                    "score": 100,
+                    "letter": "A+",
+                    "key_issue": "No secrets found",
+                },
+            },
+        },
+        "unused_functions": [{"name": "old"}],
+        "architecture_metrics": {
+            "layer_policy": {"violation_count": 1},
+            "system_metrics": {"architecture_fitness": 0.91},
+        },
+    }
+
+    payload = _health_score_payload(result)
+
+    assert payload["grade"]["overall"]["letter"] == "B+"
+    assert payload["counts"]["dead_code"] == 1
+    assert payload["counts"]["architecture_policy_violations"] == 1
+    assert payload["architecture_fitness"] == 0.91
+    assert payload["top_issues"] == [
+        {"category": "quality", "key_issue": "Architecture layer violation"}
+    ]

--- a/test/test_quality_rules.py
+++ b/test/test_quality_rules.py
@@ -20,6 +20,7 @@ from skylos.rules.quality.logic import (
     PhantomCallRule,
     InsecureRandomRule,
     HardcodedCredentialRule,
+    MockPlaceholderDataRule,
     DuplicateStringLiteralRule,
     TooManyReturnsRule,
     BooleanTrapRule,
@@ -362,6 +363,47 @@ password = os.environ["PASSWORD"]
         rule = HardcodedCredentialRule()
         findings = check_code(rule, code)
         assert not any(f["rule_id"] == "SKY-L014" for f in findings)
+
+
+# --- SKY-L032: Mock Or Placeholder Data ---
+
+
+class TestMockPlaceholderData:
+    def test_obvious_production_placeholders(self):
+        code = """
+SUPPORT_EMAIL = "test@example.com"
+USER_ID = "00000000-0000-0000-0000-000000000000"
+PLACEHOLDER_PHONE = "123-456-7890"
+API_PASSWORD = "password123"
+"""
+        rule = MockPlaceholderDataRule()
+        findings = check_code(rule, code, filename="app.py")
+        types = {f["mock_data_type"] for f in findings}
+        assert {
+            "placeholder_email",
+            "low_entropy_uuid",
+            "placeholder_phone",
+            "test_credential",
+        } <= types
+
+    def test_skips_test_files(self):
+        code = """
+SUPPORT_EMAIL = "test@example.com"
+API_PASSWORD = "password123"
+"""
+        rule = MockPlaceholderDataRule()
+        findings = check_code(rule, code, filename="test_app.py")
+        assert not any(f["rule_id"] == "SKY-L032" for f in findings)
+
+    def test_domain_requires_mock_context(self):
+        code = """
+BASE_URL = "https://example.com"
+SAMPLE_URL = "https://example.com/users"
+"""
+        rule = MockPlaceholderDataRule()
+        findings = check_code(rule, code, filename="app.py")
+        assert [f["name"] for f in findings] == ["SAMPLE_URL"]
+        assert findings[0]["mock_data_type"] == "placeholder_domain"
 
 
 # --- SKY-UC001: Unreachable Code ---


### PR DESCRIPTION
## Summary

  - Adds configurable architecture layer checks in `pyproject.toml`.
  - Reports forbidden layer imports as `SKY-Q805`.
  - Add layer policy metrics under `architecture_metrics.layer_policy`.
  - Add production placeholder-data detection as `SKY-L032`.
  - Flag fake values like `test@example.com`, all-zero UUIDs, placeholder phone numbers, and test credentials.
  - Skips placeholder-data findings in test files.
  - Add `architecture_check` MCP tool for architecture-only output.
  - Add `health_score` MCP tool for grade, counts, category scores, architecture fitness, and top issues.

## Tests

  -  `pytest .`
