### PR TITLE
fix(analyzer): keep scanner caches at project root

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2350,13 +2350,8 @@ class Skylos:
                     f for f in files if str(f).endswith((".py", ".pyi", ".pyw"))
                 ]
                 if py_files:
-                    dep_root = Path(
-                        os.path.commonpath([str(p.resolve()) for p in py_files])
-                    )
-                    if dep_root.is_file():
-                        dep_root = dep_root.parent
                     dep_findings = scan_python_dependency_hallucinations(
-                        dep_root, py_files
+                        project_root, py_files
                     )
                     if dep_findings:
                         dep_findings = [
@@ -2513,13 +2508,7 @@ class Skylos:
             try:
                 from skylos.rules.sca.vulnerability_scanner import scan_dependencies
 
-                scan_root = (
-                    Path(os.path.commonpath([str(p.resolve()) for p in files]))
-                    if files
-                    else Path(path[0] if isinstance(path, (list, tuple)) else path)
-                )
-                if scan_root.is_file():
-                    scan_root = scan_root.parent
+                scan_root = project_root
                 sca_findings = scan_dependencies(scan_root)
                 if sca_findings:
                     all_sca.extend(sca_findings)

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -2452,6 +2452,85 @@ def handler(request):
         assert result["analysis_summary"]["sca_count"] == 1
         assert result["dependency_vulnerabilities"][0]["rule_id"] == "CVE-TEST"
 
+    def test_danger_dependency_scan_uses_project_root_for_src_layout(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        pkg = tmp_path / "src" / "my_package"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "module.py").write_text("import requests\n", encoding="utf-8")
+
+        from skylos.rules.danger.danger_hallucination import dependency_hallucination
+
+        seen = {}
+
+        def fake_scan(repo_root, py_files):
+            seen["repo_root"] = Path(repo_root)
+            seen["py_files"] = list(py_files)
+            cache_path = Path(repo_root) / ".skylos" / "cache" / "pypi_exists.json"
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text("{}", encoding="utf-8")
+            return []
+
+        monkeypatch.setattr(
+            dependency_hallucination,
+            "scan_python_dependency_hallucinations",
+            fake_scan,
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path / "src"),
+                conf=0,
+                enable_danger=True,
+                grep_verify=False,
+            )
+        )
+
+        assert "error" not in result
+        assert seen["repo_root"] == tmp_path.resolve()
+        assert (tmp_path / ".skylos" / "cache" / "pypi_exists.json").exists()
+        assert not (pkg / ".skylos").exists()
+
+    def test_sca_scan_uses_project_root_for_src_layout(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        pkg = tmp_path / "src" / "my_package"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "module.py").write_text("def handler():\n    return 1\n")
+
+        from skylos.rules.sca import vulnerability_scanner
+
+        seen = {}
+
+        def fake_scan(root):
+            seen["root"] = Path(root)
+            cache_path = Path(root) / ".skylos" / "cache" / "osv_cache.json"
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text("{}", encoding="utf-8")
+            return []
+
+        monkeypatch.setattr(
+            vulnerability_scanner,
+            "scan_dependencies",
+            fake_scan,
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path / "src"),
+                conf=0,
+                enable_sca=True,
+                grep_verify=False,
+            )
+        )
+
+        assert "error" not in result
+        assert seen["root"] == tmp_path.resolve()
+        assert (tmp_path / ".skylos" / "cache" / "osv_cache.json").exists()
+        assert not (pkg / ".skylos").exists()
+
     def test_prompt_injection_scan_includes_scannable_docs(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
         app = tmp_path / "app.py"


### PR DESCRIPTION
Fixes #321

## Summary

Skylos was putting scanner cache files in the package folder `src/my_package/.skylos/cache/`.  Cache should be at the project root `.skylos/cache/`

## Fix

Use the analyzer's project root for both scanners.

Keeps:
```
  - pypi_exists.json
  - osv_cache.json
```
under the root .skylos/cache/ directory.

## Tests

`pytest -q test/test_analyzer.py`
