### PR TITLE
fix(gate): make file-level IAD architecture findings advisory

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -144,6 +144,15 @@ def _entrypoint_module_name(qname: str) -> str | None:
     return module_name or None
 
 
+def _architecture_iad_strict(architecture_cfg) -> bool:
+    if not isinstance(architecture_cfg, dict):
+        return False
+    for key in ("enforce_iad", "strict_iad"):
+        if key in architecture_cfg:
+            return bool(architecture_cfg.get(key))
+    return False
+
+
 def _expand_reexported_entrypoint_modules(
     entrypoint_qnames: set[str],
     entrypoint_modules: set[str],
@@ -1683,6 +1692,9 @@ class Skylos:
                             entrypoint_modules=entrypoint_modules,
                             package_boundary_modules=package_boundary_modules,
                             layer_policy=project_cfg.get("architecture"),
+                            iad_findings_advisory=not _architecture_iad_strict(
+                                project_cfg.get("architecture")
+                            ),
                         )
                         ignored_rules = set(project_cfg.get("ignore", []))
                         if arch_findings:

--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -194,6 +194,7 @@ def analyze_architecture(
     module_trees: dict[str, ast.AST] | None = None,
     module_abstractness: dict[str, dict[str, Any]] | None = None,
     module_loc: dict[str, int] | None = None,
+    iad_findings_advisory: bool = True,
 ) -> ArchitectureResult:
     result = ArchitectureResult()
 
@@ -407,12 +408,50 @@ def analyze_architecture(
             "zone_distribution": {},
         }
 
-    _generate_findings(result)
+    _generate_findings(result, iad_findings_advisory=iad_findings_advisory)
 
     return result
 
 
-def _generate_findings(result: ArchitectureResult):
+def _iad_scope_fields(advisory: bool) -> dict[str, Any]:
+    fields = {
+        "advisory": advisory,
+        "scope": "file",
+        "metric_granularity": "file-level heuristic",
+        "metric_origin": "Martin I/A/D release-unit metric",
+    }
+    if advisory:
+        fields["advisory_reason"] = (
+            "Martin's instability/abstractness/distance metric was defined for "
+            "release units. Skylos reports it at Python file granularity as an "
+            "architecture signal; it is not gate-blocking unless I/A/D enforcement "
+            "is enabled."
+        )
+    else:
+        fields["enforcement_reason"] = (
+            "I/A/D enforcement is enabled, so this file-level architecture signal "
+            "can block strict gates."
+        )
+    return fields
+
+
+def _iad_gate_note(advisory: bool) -> str:
+    if advisory:
+        return (
+            "Advisory: this file-level I/A/D signal does not block gates unless "
+            "I/A/D enforcement is enabled."
+        )
+    return (
+        "I/A/D enforcement is enabled, so this file-level architecture signal can "
+        "block strict gates."
+    )
+
+
+def _generate_findings(
+    result: ArchitectureResult,
+    *,
+    iad_findings_advisory: bool = True,
+):
     for name, m in result.modules.items():
         # SKY-Q802: High distance from main sequence
         if m.distance > 0.5 and m.total_coupling > 0:
@@ -436,11 +475,13 @@ def _generate_findings(result: ArchitectureResult):
                     "message": (
                         f"Module '{name}' is far from the Main Sequence "
                         f"(D={m.distance:.2f}, I={m.instability:.2f}, A={m.abstractness:.2f}). "
-                        f"Zone: {m.zone.replace('_', ' ')}."
+                        f"Zone: {m.zone.replace('_', ' ')}. "
+                        f"{_iad_gate_note(iad_findings_advisory)}"
                     ),
                     "file": m.file_path,
                     "basename": Path(m.file_path).name if m.file_path else name,
                     "line": 1,
+                    **_iad_scope_fields(iad_findings_advisory),
                 }
             )
 
@@ -450,13 +491,15 @@ def _generate_findings(result: ArchitectureResult):
                 zone_msg = (
                     f"Module '{name}' is in the Zone of Pain "
                     f"(concrete A={m.abstractness:.2f}, stable I={m.instability:.2f}). "
-                    f"Changes here can ripple widely. Consider introducing stable abstractions or reducing fan-in."
+                    "Changes here can ripple widely at file granularity. "
+                    f"{_iad_gate_note(iad_findings_advisory)}"
                 )
             else:
                 zone_msg = (
                     f"Module '{name}' is in the Zone of Uselessness "
                     f"(abstract A={m.abstractness:.2f}, unstable I={m.instability:.2f}). "
-                    f"Few stable consumers depend on it. Consider moving abstractions toward stable packages or removing unused abstractions."
+                    "Few stable consumers depend on it. "
+                    f"{_iad_gate_note(iad_findings_advisory)}"
                 )
 
             result.findings.append(
@@ -475,6 +518,7 @@ def _generate_findings(result: ArchitectureResult):
                     "file": m.file_path,
                     "basename": Path(m.file_path).name if m.file_path else name,
                     "line": 1,
+                    **_iad_scope_fields(iad_findings_advisory),
                 }
             )
 
@@ -722,6 +766,7 @@ def get_architecture_findings(
     private_helper_ce_limit: int = 2,
     private_helper_ca_limit: int = 3,
     layer_policy: dict[str, Any] | None = None,
+    iad_findings_advisory: bool = True,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     result = analyze_architecture(
         dependency_graph=dependency_graph,
@@ -729,6 +774,7 @@ def get_architecture_findings(
         module_trees=module_trees,
         module_abstractness=module_abstractness,
         module_loc=module_loc,
+        iad_findings_advisory=iad_findings_advisory,
     )
 
     contextual_entrypoints = set(entrypoint_modules or ())

--- a/skylos/commands/init_cmd.py
+++ b/skylos/commands/init_cmd.py
@@ -38,6 +38,9 @@ extra_network_timeout_calls = []
 
 [tool.skylos.architecture]
 strict = false
+# Q802/Q803 are file-level I/A/D architecture signals by default. Set this to
+# true only if those signals should block strict gates in this project.
+enforce_iad = false
 
 # [[tool.skylos.architecture.layers]]
 # name = "api"

--- a/skylos/config.py
+++ b/skylos/config.py
@@ -22,6 +22,7 @@ DEFAULTS = {
     "max_circular_deps": -1,
     "architecture": {
         "strict": False,
+        "enforce_iad": False,
         "layers": [],
         "rules": [],
     },

--- a/skylos/gatekeeper.py
+++ b/skylos/gatekeeper.py
@@ -21,6 +21,7 @@ DEAD_CODE_RESULT_KEYS = (
     "unused_parameters",
 )
 AGENT_GATE_PREFIX = "Agent gate: "
+ADVISORY_QUALITY_RULE_IDS = {"SKY-Q802", "SKY-Q803"}
 
 
 def run_cmd(cmd_list, error_msg="Git command failed"):
@@ -138,6 +139,18 @@ def _split_danger_by_severity(danger):
         elif sev == "high":
             high_issues.append(issue)
     return critical_issues, high_issues
+
+
+def _is_advisory_quality_finding(finding):
+    return (
+        isinstance(finding, dict)
+        and bool(finding.get("advisory"))
+        and str(finding.get("rule_id", "")) in ADVISORY_QUALITY_RULE_IDS
+    )
+
+
+def _gate_quality_findings(quality):
+    return [finding for finding in quality if not _is_advisory_quality_finding(finding)]
 
 
 def _append_threshold_reason(reasons, *, count, limit, message_template):
@@ -286,7 +299,8 @@ def _check_agent_gate(findings_lists, agent_file_set, agent_cfg, reasons):
 
 
 def _check_strict_gate(*, total_findings, danger, quality, secrets):
-    total_issues = total_findings + len(danger) + len(quality) + len(secrets)
+    gate_quality = _gate_quality_findings(quality)
+    total_issues = total_findings + len(danger) + len(gate_quality) + len(secrets)
     if total_issues > 0:
         return False, [f"Strict mode: {total_issues} issue(s) found"]
     return True, []
@@ -382,6 +396,7 @@ def check_gate(results, config, strict=False, provenance=None):
     total_findings = _count_dead_code_findings(results)
     danger = results.get("danger", []) or []
     quality = results.get("quality", []) or []
+    gate_quality = _gate_quality_findings(quality)
     secrets = results.get("secrets", []) or []
     gate_config = config.get("gate", {}) if config else {}
 
@@ -389,7 +404,7 @@ def check_gate(results, config, strict=False, provenance=None):
         return _check_strict_gate(
             total_findings=total_findings,
             danger=danger,
-            quality=quality,
+            quality=gate_quality,
             secrets=secrets,
         )
 
@@ -403,7 +418,7 @@ def check_gate(results, config, strict=False, provenance=None):
         max_high=gate_config.get("max_high", 5),
         security_count=len(danger),
         max_security=gate_config.get("max_security", 10),
-        quality_count=len(quality),
+        quality_count=len(gate_quality),
         max_quality=gate_config.get("max_quality", 10),
         secrets_count=len(secrets),
         max_secrets=gate_config.get("max_secrets", None),
@@ -416,7 +431,7 @@ def check_gate(results, config, strict=False, provenance=None):
     if provenance and agent_cfg and provenance.agent_files:
         agent_file_set = set(provenance.agent_files)
         agent_passed = _check_agent_gate(
-            _build_findings_lists(results, danger, quality, secrets),
+            _build_findings_lists(results, danger, gate_quality, secrets),
             agent_file_set,
             agent_cfg,
             reasons,

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -10,7 +10,13 @@ from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.penalties import apply_penalties
 
-from skylos.analyzer import Skylos, proc_file, analyze, _resolve_analysis_root
+from skylos.analyzer import (
+    Skylos,
+    proc_file,
+    analyze,
+    _architecture_iad_strict,
+    _resolve_analysis_root,
+)
 
 
 @pytest.fixture
@@ -373,6 +379,11 @@ class TestHeuristics:
 
 
 class TestAnalyze:
+    def test_architecture_iad_strict_requires_explicit_iad_opt_in(self):
+        assert _architecture_iad_strict({"strict": True}) is False
+        assert _architecture_iad_strict({"enforce_iad": True}) is True
+        assert _architecture_iad_strict({"strict_iad": True}) is True
+
     @patch("skylos.analyzer.proc_file")
     def test_analyze_basic(self, mock_proc_file, temp_python_project):
         mock_def = Mock()

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -624,3 +624,53 @@ class Base2(ABC):
         assert result.modules["stableish"].zone == "off_main_sequence"
         assert "Zone: off main sequence." in q802["message"]
         assert "Zone: healthy." not in q802["message"]
+
+    def test_iad_findings_are_advisory_by_default(self):
+        findings, _ = get_architecture_findings(
+            dependency_graph={
+                "stableish": set(),
+                "consumer_a": {"stableish"},
+                "consumer_b": {"stableish"},
+            },
+            module_files={
+                "stableish": "/p/stableish.py",
+                "consumer_a": "/p/consumer_a.py",
+                "consumer_b": "/p/consumer_b.py",
+            },
+        )
+
+        iad_findings = [
+            f for f in findings if f["rule_id"] in {"SKY-Q802", "SKY-Q803"}
+        ]
+
+        assert {f["rule_id"] for f in iad_findings} == {"SKY-Q802", "SKY-Q803"}
+        assert all(f["advisory"] is True for f in iad_findings)
+        assert all(
+            f["metric_granularity"] == "file-level heuristic" for f in iad_findings
+        )
+        assert all("Martin I/A/D" in f["metric_origin"] for f in iad_findings)
+        assert all("Advisory:" in f["message"] for f in iad_findings)
+
+    def test_iad_findings_can_be_marked_enforced(self):
+        findings, _ = get_architecture_findings(
+            dependency_graph={
+                "stableish": set(),
+                "consumer_a": {"stableish"},
+                "consumer_b": {"stableish"},
+            },
+            module_files={
+                "stableish": "/p/stableish.py",
+                "consumer_a": "/p/consumer_a.py",
+                "consumer_b": "/p/consumer_b.py",
+            },
+            iad_findings_advisory=False,
+        )
+
+        iad_findings = [
+            f for f in findings if f["rule_id"] in {"SKY-Q802", "SKY-Q803"}
+        ]
+
+        assert {f["rule_id"] for f in iad_findings} == {"SKY-Q802", "SKY-Q803"}
+        assert all(f["advisory"] is False for f in iad_findings)
+        assert all("enforcement_reason" in f for f in iad_findings)
+        assert all("Advisory:" not in f["message"] for f in iad_findings)

--- a/test/test_gatekeeper.py
+++ b/test/test_gatekeeper.py
@@ -165,6 +165,73 @@ def test_check_gate_provenance_none_ignores_agent():
     assert passed is True
 
 
+def test_check_gate_strict_ignores_advisory_iad_quality():
+    results = {
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-Q802",
+                "advisory": True,
+                "file": "pkg/helpers.py",
+                "line": 1,
+            },
+            {
+                "rule_id": "SKY-Q803",
+                "advisory": True,
+                "file": "pkg/helpers.py",
+                "line": 1,
+            },
+        ],
+        "secrets": [],
+    }
+
+    passed, reasons = gk.check_gate(results, {}, strict=True)
+
+    assert passed is True
+    assert reasons == []
+
+
+def test_check_gate_strict_blocks_enforced_iad_quality():
+    results = {
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-Q802",
+                "advisory": False,
+                "file": "pkg/helpers.py",
+                "line": 1,
+            }
+        ],
+        "secrets": [],
+    }
+
+    passed, reasons = gk.check_gate(results, {}, strict=True)
+
+    assert passed is False
+    assert "Strict mode" in reasons[0]
+
+
+def test_check_gate_quality_threshold_ignores_advisory_iad_quality():
+    results = {
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-Q803",
+                "advisory": True,
+                "file": "pkg/helpers.py",
+                "line": 1,
+            }
+        ],
+        "secrets": [],
+    }
+    config = {"gate": {"max_quality": 0}}
+
+    passed, reasons = gk.check_gate(results, config)
+
+    assert passed is True
+    assert reasons == []
+
+
 def test_check_gate_agent_stricter_threshold():
     results = {
         "danger": [{"severity": "high", "file": "ai_file.py"}],


### PR DESCRIPTION
Fixes #322

## Problem

`SKY-Q802` and `SKY-Q803` use Martin’s instability/abstractness/distance metric which was meant for release units, Skylos applies it at Python file level, which can be too strong as a strict gate failure.

## Fix

Make file-level Q802/Q803 findings advisory by default. Gatekeeper now excludes advisory Q802/Q803 findings from strict-gate and quality threshold failure counts.

Projects that want the old blocking behavior can opt in:

  ```toml
  [tool.skylos.architecture]
  enforce_iad = true
```

## Verification

```
 pytest -q test/test_architecture.py test/test_gatekeeper.py test/test_gate_kwargs.py test/test_analyzer.py test/test_cli.py test/test_cli_precommit.py
```