### PR TITLE
fix(architecture): add Q802 Q803 remediation hints

### DIFF
--- a/skylos/architecture.py
+++ b/skylos/architecture.py
@@ -439,12 +439,75 @@ def _iad_gate_note(advisory: bool) -> str:
     if advisory:
         return (
             "Advisory: this file-level I/A/D signal does not block gates unless "
-            "I/A/D enforcement is enabled."
+            "I/A/D enforcement is enabled. See remediations for safe options."
         )
     return (
         "I/A/D enforcement is enabled, so this file-level architecture signal can "
-        "block strict gates."
+        "block strict gates. See remediations for safe options."
     )
+
+
+def _iad_docs_url(rule_id: str) -> str:
+    return f"https://docs.skylos.dev/rules/{rule_id}"
+
+
+def _iad_remediations(module_name: str, zone: str) -> list[dict[str, str]]:
+    simple_name = module_name.rsplit(".", 1)[-1]
+    if simple_name.startswith("_"):
+        helper_hint = (
+            "This module is already marked private. If it belongs to one release-unit, "
+            "keep the finding as an advisory signal unless the fan-in reflects a real "
+            "maintenance problem. Do not add fake imports or one-off abstractions just "
+            "to move the metric."
+        )
+        helper_title = "Keep private-helper intent explicit"
+    else:
+        private_name = f"_{simple_name}"
+        helper_hint = (
+            f"If '{module_name}' is an internal helper rather than public API, rename "
+            f"the module to '{private_name}' and update imports. Do not add fake "
+            "imports or one-off abstractions just to move the metric."
+        )
+        helper_title = "Mark internal helpers as private"
+
+    remediations = [
+        {
+            "title": helper_title,
+            "hint": helper_hint,
+            "applies_when": "The module is an implementation detail inside one release-unit.",
+        },
+        {
+            "title": "Introduce a real abstraction boundary",
+            "hint": (
+                "Add a Protocol or ABC only when consumers genuinely need an interface "
+                "with multiple implementations or an extension boundary. Avoid header "
+                "interfaces created only to satisfy the score."
+            ),
+            "applies_when": "The module is public API or has real interchangeable implementations.",
+        },
+        {
+            "title": "Split responsibilities when fan-in is meaningful",
+            "hint": (
+                "If many consumers depend on unrelated behavior in this module, split "
+                "cohesive responsibilities so changes do not ripple through all callers."
+            ),
+            "applies_when": "High fan-in reflects mixed responsibilities, not just shared helpers.",
+        },
+    ]
+
+    if zone == "zone_of_uselessness":
+        remediations.append(
+            {
+                "title": "Remove or move unused abstractions",
+                "hint": (
+                    "If abstractions have few stable consumers, move them near their "
+                    "callers or remove abstractions that are not carrying a real boundary."
+                ),
+                "applies_when": "The module is abstract but not depended on by stable code.",
+            }
+        )
+
+    return remediations
 
 
 def _generate_findings(
@@ -481,6 +544,8 @@ def _generate_findings(
                     "file": m.file_path,
                     "basename": Path(m.file_path).name if m.file_path else name,
                     "line": 1,
+                    "docs_url": _iad_docs_url("SKY-Q802"),
+                    "remediations": _iad_remediations(name, m.zone),
                     **_iad_scope_fields(iad_findings_advisory),
                 }
             )
@@ -518,6 +583,8 @@ def _generate_findings(
                     "file": m.file_path,
                     "basename": Path(m.file_path).name if m.file_path else name,
                     "line": 1,
+                    "docs_url": _iad_docs_url("SKY-Q803"),
+                    "remediations": _iad_remediations(name, m.zone),
                     **_iad_scope_fields(iad_findings_advisory),
                 }
             )

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -650,6 +650,16 @@ class Base2(ABC):
         )
         assert all("Martin I/A/D" in f["metric_origin"] for f in iad_findings)
         assert all("Advisory:" in f["message"] for f in iad_findings)
+        assert all(f["docs_url"].endswith(f["rule_id"]) for f in iad_findings)
+        assert all(f.get("remediations") for f in iad_findings)
+        remediation_titles = {
+            item["title"]
+            for finding in iad_findings
+            for item in finding["remediations"]
+        }
+        assert "Mark internal helpers as private" in remediation_titles
+        assert "Introduce a real abstraction boundary" in remediation_titles
+        assert "Split responsibilities when fan-in is meaningful" in remediation_titles
 
     def test_iad_findings_can_be_marked_enforced(self):
         findings, _ = get_architecture_findings(
@@ -674,3 +684,31 @@ class Base2(ABC):
         assert all(f["advisory"] is False for f in iad_findings)
         assert all("enforcement_reason" in f for f in iad_findings)
         assert all("Advisory:" not in f["message"] for f in iad_findings)
+        assert all(f.get("remediations") for f in iad_findings)
+
+    def test_private_helper_remediation_does_not_suggest_fake_metric_workarounds(self):
+        findings, _ = get_architecture_findings(
+            dependency_graph={
+                "pkg._helpers": set(),
+                "pkg.consumer_a": {"pkg._helpers"},
+                "pkg.consumer_b": {"pkg._helpers"},
+                "pkg.consumer_c": {"pkg._helpers"},
+                "pkg.consumer_d": {"pkg._helpers"},
+            },
+            module_files={
+                "pkg._helpers": "/p/pkg/_helpers.py",
+                "pkg.consumer_a": "/p/pkg/consumer_a.py",
+                "pkg.consumer_b": "/p/pkg/consumer_b.py",
+                "pkg.consumer_c": "/p/pkg/consumer_c.py",
+                "pkg.consumer_d": "/p/pkg/consumer_d.py",
+            },
+        )
+
+        q803 = next(f for f in findings if f["rule_id"] == "SKY-Q803")
+        titles = {item["title"] for item in q803["remediations"]}
+        hints = " ".join(item["hint"] for item in q803["remediations"])
+
+        assert q803["name"] == "pkg._helpers"
+        assert "Keep private-helper intent explicit" in titles
+        assert "fake" in hints
+        assert "one-off abstractions" in hints


### PR DESCRIPTION
Fixes #320

## Problem

Q802/Q803 findings already have contextual exemptions, but the emitted findings did not explain the remediation paths clearly. That made the advice too easy to misread. 

## Fix

Each finding now includes:

  - docs_url
  - remediations

## Verification

```
pytest -q test/test_architecture.py test/test_analyzer.py test/test_gatekeeper.py test/test_gate_kwargs.py test/test_cli.py test/test_cli_precommit.py
```