### PR TITLE
feat(languages): add Dart support and harden PHP scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,17 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 WORKDIR /src
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc libc6-dev && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY pyproject.toml README.md LICENSE ./
 COPY skylos ./skylos
 COPY --from=go-build /out/skylos-go ./skylos/engines/go/skylos-go
 
 RUN python -m pip install --upgrade pip build && \
-    python -m build --wheel --outdir /dist
+    python -m build --wheel --outdir /dist && \
+    python -m pip wheel --wheel-dir /wheelhouse /dist/*.whl
 
 FROM python:3.12-slim
 
@@ -32,10 +37,10 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 WORKDIR /work
 
-COPY --from=build /dist/*.whl /tmp/dist/
+COPY --from=build /wheelhouse /tmp/wheelhouse
 
-RUN python -m pip install /tmp/dist/*.whl && \
-    rm -rf /tmp/dist
+RUN python -m pip install --no-index --find-links=/tmp/wheelhouse skylos && \
+    rm -rf /tmp/wheelhouse
 
 ENTRYPOINT ["skylos"]
 CMD ["--help"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "skylos"
 version = "4.12.1"
 requires-python = ">=3.10"
-description = "Open-source AI code security and static analysis for Python, TypeScript/JavaScript, Go, Java, PHP, and Rust. Finds dead code, secrets, vulnerabilities, and diff-aware regressions."
+description = "Open-source AI code security and static analysis for Python, TypeScript/JavaScript, Go, Java, PHP, Rust, and Dart. Finds dead code, secrets, vulnerabilities, and diff-aware regressions."
 authors = [{name = "Aaron Oh", email = "aaronoh2015@gmail.com"}]
 readme = "README.md"
 license = "Apache-2.0"
@@ -77,6 +77,7 @@ dependencies = [
     "tree-sitter-java>=0.23.0",
     "tree-sitter-php>=0.24.1",
     "tree-sitter-rust>=0.24.2",
+    "tree-sitter-dart-orchard>=0.3.2",
     "tomli>=2.0.1; python_version < '3.11'",
     "pyyaml",
     "networkx",

--- a/skylos/agent_center.py
+++ b/skylos/agent_center.py
@@ -34,7 +34,17 @@ from skylos.agent_payload import (
 
 STATE_DIR = ".skylos"
 STATE_FILE = "agent_state.json"
-SUPPORTED_EXTENSIONS = {".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".php", ".rs"}
+SUPPORTED_EXTENSIONS = {
+    ".py",
+    ".go",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".php",
+    ".rs",
+    ".dart",
+}
 
 
 def run_analyze(*args, **kwargs):

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -22,6 +22,7 @@ from skylos.constants import AUTO_CALLED, MARKREFS_TICK_DEFAULT
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.languages.php import scan_php_file
+from skylos.visitors.languages.dart import scan_dart_file
 from skylos.visitors.languages.typescript import scan_typescript_file
 from skylos.visitors.languages.typescript.analysis import (
     build_ts_import_graph,
@@ -133,6 +134,7 @@ _TS_JS_SOURCE_EXTS = (
 )
 _PHP_SOURCE_EXTS = (".php",)
 _RUST_SOURCE_EXTS = (".rs",)
+_DART_SOURCE_EXTS = (".dart",)
 
 _TRY_NODE_TYPES = (ast.Try, getattr(ast, "TryStar", ast.Try))
 
@@ -412,6 +414,7 @@ class Skylos:
         ".java": "Java",
         ".php": "PHP",
         ".rs": "Rust",
+        ".dart": "Dart",
     }
 
     def _count_languages(self, files) -> dict[str, int]:
@@ -439,6 +442,7 @@ class Skylos:
             ".java",
             *(_PHP_SOURCE_EXTS),
             *(_RUST_SOURCE_EXTS),
+            *(_DART_SOURCE_EXTS),
         }
         ext_list = [
             "py",
@@ -454,6 +458,7 @@ class Skylos:
             "java",
             "php",
             "rs",
+            "dart",
         ]
 
         # use rust file discovery when avail
@@ -2703,6 +2708,16 @@ def proc_file(
 
     if str(file).endswith(".rs"):
         out = scan_rust_file(
+            file,
+            cfg,
+            enable_danger_rules=enable_danger_rules,
+        )
+        if isinstance(out, tuple) and len(out) < 13:
+            return (*out, *([None] * (13 - len(out))))
+        return out[:13]
+
+    if str(file).endswith(".dart"):
+        out = scan_dart_file(
             file,
             cfg,
             enable_danger_rules=enable_danger_rules,

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -3604,6 +3604,7 @@ def main() -> None:
                     ".java",
                     ".php",
                     ".rs",
+                    ".dart",
                 }
                 config_exts = {
                     ".yaml",

--- a/skylos/cli_shared.py
+++ b/skylos/cli_shared.py
@@ -18,6 +18,7 @@ def get_git_changed_files(root_path):
         ".java",
         ".php",
         ".rs",
+        ".dart",
     }
 
     def _collect_supported(output, repo_root):

--- a/skylos/dead_code_benchmark.py
+++ b/skylos/dead_code_benchmark.py
@@ -65,7 +65,15 @@ DEFAULT_SCAN = {
 }
 
 SUPPORTED_SCANNERS = {"skylos", "vulture", "ruff"}
-SUPPORTED_LANGUAGES = {"python", "go", "java", "javascript", "typescript", "rust"}
+SUPPORTED_LANGUAGES = {
+    "python",
+    "go",
+    "java",
+    "javascript",
+    "typescript",
+    "rust",
+    "dart",
+}
 SCANNER_LANGUAGE_SUPPORT = {
     "skylos": SUPPORTED_LANGUAGES,
     "vulture": {"python"},

--- a/skylos/fixgen.py
+++ b/skylos/fixgen.py
@@ -43,6 +43,7 @@ _BRACE_LANG_EXTS = {
     ".go": "go",
     ".rs": "rust",
     ".java": "java",
+    ".dart": "dart",
 }
 
 
@@ -160,7 +161,7 @@ def _validate_file(file_path: str, content: str) -> list[str]:
         return _validate_go_syntax(file_path, content)
     if ext == ".rs":
         return _validate_rust_syntax(file_path, content)
-    if ext == ".java":
+    if ext in {".java", ".dart"}:
         return _check_brace_balance(file_path, content)
     return []
 

--- a/skylos/grader.py
+++ b/skylos/grader.py
@@ -62,6 +62,7 @@ _COMMENT_PREFIXES: dict[str, str] = {
     ".jsx": "//",
     ".php": "//",
     ".rs": "//",
+    ".dart": "//",
 }
 
 

--- a/skylos/grep_verify.py
+++ b/skylos/grep_verify.py
@@ -47,6 +47,7 @@ _GO_EXTS = {".go"}
 _JAVA_EXTS = {".java"}
 _PHP_EXTS = {".php"}
 _RUST_EXTS = {".rs"}
+_DART_EXTS = {".dart"}
 
 _ALL_SOURCE_GLOBS = [
     "*.py",
@@ -61,6 +62,7 @@ _ALL_SOURCE_GLOBS = [
     "*.java",
     "*.php",
     "*.rs",
+    "*.dart",
     "*.rst",
     "*.md",
     "*.yaml",
@@ -78,6 +80,7 @@ _LANG_GLOBS: dict[str, list[str]] = {
     "java": ["*.java"],
     "php": ["*.php"],
     "rust": ["*.rs"],
+    "dart": ["*.dart"],
 }
 
 _IGNORED_GREP_PATH_PARTS = (
@@ -121,6 +124,8 @@ def detect_language(file_path: str) -> str:
         return "php"
     if ext in _RUST_EXTS:
         return "rust"
+    if ext in _DART_EXTS:
+        return "dart"
     return "python"
 
 
@@ -639,7 +644,6 @@ def _run_ts_strategies(
         if usages:
             results["ts_imports"] = usages[:max_per_strategy]
 
-    # require("...") references
     require_pattern = rf'require\s*\(["\x27].*{re.escape(simple_name)}["\x27]\)'
     require_refs = _run_grep(
         require_pattern,
@@ -653,7 +657,6 @@ def _run_ts_strategies(
         if usages:
             results["ts_require"] = usages[:max_per_strategy]
 
-    # JSX usage: <Component /> or <Component>
     if kind in ("class", "function", "variable") and simple_name[0].isupper():
         jsx_pattern = rf"<{re.escape(simple_name)}[\s/>]"
         jsx_refs = _run_grep(
@@ -697,7 +700,6 @@ def _run_ts_strategies(
             if usages:
                 results["ts_decorator"] = usages[:max_per_strategy]
 
-    # implements Interface
     if kind in ("class", "interface"):
         impl_pattern = rf"implements\s+.*\b{re.escape(simple_name)}\b"
         impl_refs = _run_grep(

--- a/skylos/llm/cleanup_orchestrator.py
+++ b/skylos/llm/cleanup_orchestrator.py
@@ -32,7 +32,18 @@ SKIP_DIRS = {
     ".coverage",
 }
 
-CODE_EXTENSIONS = {".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rs", ".java", ".php"}
+CODE_EXTENSIONS = {
+    ".py",
+    ".js",
+    ".ts",
+    ".jsx",
+    ".tsx",
+    ".go",
+    ".rs",
+    ".java",
+    ".php",
+    ".dart",
+}
 
 MAX_FILE_SIZE = 100_000  # bytes
 MAX_FILE_LINES = 2000

--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -43,6 +43,7 @@ ALLOWED_FILE_SUFFIXES = (
     ".go",
     ".php",
     ".rs",
+    ".dart",
 )
 
 PROVIDER_PATTERNS = [

--- a/skylos/security_benchmark.py
+++ b/skylos/security_benchmark.py
@@ -45,7 +45,15 @@ DEFAULT_SCAN = {
 }
 
 SUPPORTED_SCANNERS = {"skylos", "bandit"}
-SUPPORTED_LANGUAGES = {"python", "go", "java", "javascript", "typescript", "rust"}
+SUPPORTED_LANGUAGES = {
+    "python",
+    "go",
+    "java",
+    "javascript",
+    "typescript",
+    "rust",
+    "dart",
+}
 SCANNER_LANGUAGE_SUPPORT = {
     "skylos": SUPPORTED_LANGUAGES,
     "bandit": {"python"},

--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -172,11 +172,6 @@ def _write_link(
         "linked_at": payload["linked_at"],
     }
     payload["projects"] = projects
-    # if folder_id:
-    #     payload["folder_id"] = str(folder_id)
-    # if folder_name:
-    #     payload["folder_name"] = str(folder_name)
-
     link_path.write_text(json.dumps(payload, indent=2))
     return str(link_path)
 
@@ -615,6 +610,7 @@ PRECOMMIT_HOOK_DEPENDENCIES = [
     "tree-sitter-java>=0.23.0",
     "tree-sitter-php>=0.24.1",
     "tree-sitter-rust>=0.24.2",
+    "tree-sitter-dart-orchard>=0.3.2",
     "tomli>=2.0.1; python_version < '3.11'",
     "pyyaml",
     "networkx",
@@ -663,9 +659,10 @@ repos:
 def _write_sync_config(skylos_dir: Path, config_data):
     config_payload = config_data.get("config")
     if not isinstance(config_payload, dict):
-        # Backward-compat: older/newer cloud deployments may return the
-        # sync config directly at the top level instead of wrapping it.
-        config_payload = config_data if isinstance(config_data, dict) else {}
+        if isinstance(config_data, dict):
+            config_payload = config_data
+        else:
+            config_payload = {}
 
     config_path = skylos_dir / CONFIG_FILE
     with config_path.open("w") as f:

--- a/skylos/visitors/languages/dart/__init__.py
+++ b/skylos/visitors/languages/dart/__init__.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .core import DartCore
+from .danger import scan_danger
+
+
+class DummyVisitor:
+    def __init__(
+        self,
+        *,
+        is_test_file: bool = False,
+        test_decorated_lines: set[int] | None = None,
+    ) -> None:
+        self.is_test_file = is_test_file
+        self.test_decorated_lines = test_decorated_lines or set()
+        self.dataclass_fields: set[str] = set()
+        self.pydantic_models: set[str] = set()
+        self.class_defs: dict = {}
+        self.first_read_lineno: dict = {}
+        self.framework_decorated_lines: set[int] = set()
+        self.detected_frameworks: set[str] = set()
+
+
+def _empty_result(config: dict) -> tuple:
+    return (
+        [],
+        [],
+        set(),
+        set(),
+        DummyVisitor(),
+        DummyVisitor(),
+        [],
+        [],
+        [],
+        None,
+        None,
+        config,
+        [],
+    )
+
+
+def scan_dart_file(
+    file_path: str,
+    config: dict | None = None,
+    *,
+    enable_danger_rules: bool = True,
+) -> tuple:
+    if config is None:
+        config = {}
+
+    try:
+        path = Path(file_path)
+        if path.suffix.lower() != ".dart":
+            raise ValueError("unsupported Dart path")
+        source = path.read_bytes()  # skylos: ignore[SKY-D215]
+    except Exception:
+        return _empty_result(config)
+
+    core = DartCore(str(path), source)
+    core.scan()
+
+    visitor = DummyVisitor(
+        is_test_file=core.is_test_file,
+        test_decorated_lines=core.test_decorated_lines,
+    )
+    findings = (
+        scan_danger(core.root_node, str(path), source) if enable_danger_rules else []
+    )
+
+    return (
+        core.defs,
+        core.refs,
+        set(),
+        set(),
+        visitor,
+        DummyVisitor(),
+        [],
+        findings,
+        [],
+        None,
+        None,
+        config,
+        core.raw_imports,
+    )
+
+
+__all__ = ["scan_dart_file"]

--- a/skylos/visitors/languages/dart/core.py
+++ b/skylos/visitors/languages/dart/core.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tree_sitter import Language, Parser
+
+try:
+    import tree_sitter_dart_orchard as tsdart
+except ImportError:
+    tsdart = None
+
+from skylos.visitor import Definition
+
+try:
+    DART_LANG: Language | None = (
+        Language(tsdart.language()) if tsdart is not None else None
+    )
+except Exception:
+    DART_LANG = None
+
+_PARSER_CACHE: dict[int, Parser] = {}
+
+_FLUTTER_BASES = {
+    "StatelessWidget",
+    "StatefulWidget",
+    "State",
+    "Widget",
+}
+
+_FLUTTER_LIFECYCLE_METHODS = {
+    "build",
+    "createState",
+    "initState",
+    "dispose",
+    "didChangeDependencies",
+    "didUpdateWidget",
+    "reassemble",
+    "deactivate",
+    "activate",
+}
+
+_TEST_ENTRYPOINTS = {
+    "main",
+    "setUp",
+    "setUpAll",
+    "tearDown",
+    "tearDownAll",
+}
+
+
+def _get_parser(lang: Language) -> Parser:
+    lang_id = id(lang)
+    if lang_id not in _PARSER_CACHE:
+        _PARSER_CACHE[lang_id] = Parser(lang)
+    return _PARSER_CACHE[lang_id]
+
+
+def _is_test_path(file_path: str | Path) -> bool:
+    lower = str(file_path).lower().replace("\\", "/")
+    return "/test/" in lower or lower.endswith("_test.dart")
+
+
+def _is_private_name(name: str) -> bool:
+    return name.startswith("_")
+
+
+class DartCore:
+    def __init__(self, file_path: str, source_bytes: bytes) -> None:
+        self.file_path: str = file_path
+        self.source: bytes = source_bytes
+        self.defs: list[Definition] = []
+        self.refs: list[tuple[str, str]] = []
+        self.raw_imports: list[dict[str, object]] = []
+        self.call_pairs: list[tuple[str, str]] = []
+        self.test_decorated_lines: set[int] = set()
+        self.lang: Language | None = DART_LANG
+        self.is_test_file = _is_test_path(file_path)
+        self._seen_refs: set[tuple[str, int]] = set()
+
+        if self.lang:
+            self.parser = _get_parser(self.lang)
+            self.tree = self.parser.parse(source_bytes)
+            self.root_node = self.tree.root_node
+        else:
+            self.tree = None
+            self.root_node = None
+
+    def _get_text(self, node) -> str:
+        return self.source[node.start_byte : node.end_byte].decode("utf-8", "ignore")
+
+    def _child_by_type(self, node, type_name: str):
+        for child in node.children:
+            if child.type == type_name:
+                return child
+        return None
+
+    def _children_of_type(self, node, type_name: str) -> list:
+        return [child for child in node.children if child.type == type_name]
+
+    def _node_name_text(self, node) -> str:
+        if node is None:
+            return ""
+        return self._get_text(node).strip()
+
+    def _name_node(self, node):
+        by_field = node.child_by_field_name("name")
+        if by_field is not None:
+            return by_field
+        for child in node.children:
+            if child.type in {"identifier", "type_identifier"}:
+                return child
+        return None
+
+    def _first_descendant_of_type(self, node, type_name: str):
+        if node.type == type_name:
+            return node
+        for child in node.children:
+            found = self._first_descendant_of_type(child, type_name)
+            if found is not None:
+                return found
+        return None
+
+    def _descendants_of_type(self, node, type_name: str):
+        if node.type == type_name:
+            yield node
+        for child in node.children:
+            yield from self._descendants_of_type(child, type_name)
+
+    def _function_signature_name_node(self, signature):
+        name_node = signature.child_by_field_name("name")
+        if name_node is not None:
+            return name_node
+        params = self._child_by_type(signature, "formal_parameter_list")
+        candidates = []
+        for child in signature.children:
+            if child is params:
+                break
+            if child.type == "identifier":
+                candidates.append(child)
+        return candidates[-1] if candidates else None
+
+    def _next_body(self, siblings: list, index: int):
+        if index + 1 < len(siblings) and siblings[index + 1].type == "function_body":
+            return siblings[index + 1]
+        return None
+
+    def _add_ref(
+        self, name: str, start_byte: int, *, current_callable: str | None
+    ) -> None:
+        if not name:
+            return
+        simple = name.split(".")[-1].strip()
+        if not simple or simple in {"this", "super", "true", "false", "null"}:
+            return
+        if current_callable and simple == current_callable.split(".")[-1]:
+            return
+        key = (simple, start_byte)
+        if key in self._seen_refs:
+            return
+        self._seen_refs.add(key)
+        self.refs.append((simple, self.file_path))
+        if current_callable:
+            self.call_pairs.append((current_callable, simple))
+
+    def scan(self) -> None:
+        if not self.root_node:
+            return
+        self._scan_block(self.root_node, current_class=None, current_callable=None)
+        self._build_call_graph()
+
+    def _scan_block(
+        self,
+        node,
+        *,
+        current_class: str | None,
+        current_callable: str | None,
+    ) -> None:
+        children = list(node.children)
+        index = 0
+        while index < len(children):
+            child = children[index]
+
+            if child.type == "import_or_export":
+                self._scan_import_or_export(child)
+                index += 1
+                continue
+
+            if child.type == "class_definition":
+                self._scan_class(child)
+                index += 1
+                continue
+
+            if child.type == "enum_declaration":
+                self._scan_enum(child)
+                index += 1
+                continue
+
+            if child.type == "function_signature":
+                body = self._next_body(children, index)
+                self._scan_function(child, body)
+                index += 2 if body is not None else 1
+                continue
+
+            if child.type == "static_final_declaration_list":
+                self._scan_static_final_declarations(
+                    child, current_class=current_class, is_exported=False
+                )
+                self._scan_refs_in_node(child, current_callable=current_callable)
+                index += 1
+                continue
+
+            self._scan_refs_in_node(child, current_callable=current_callable)
+            self._scan_block(
+                child,
+                current_class=current_class,
+                current_callable=current_callable,
+            )
+            index += 1
+
+    def _scan_import_or_export(self, node) -> None:
+        text = self._get_text(node).strip()
+        uri_node = self._first_descendant_of_type(node, "string_literal")
+        source = self._get_text(uri_node).strip("\"'") if uri_node is not None else ""
+        names: list[str] = []
+
+        for combinator in self._descendants_of_type(node, "combinator"):
+            comb_text = self._get_text(combinator).strip()
+            if not comb_text.startswith("show "):
+                continue
+            for ident in self._descendants_of_type(combinator, "identifier"):
+                name = self._node_name_text(ident)
+                if not name or name in {"show", "hide"}:
+                    continue
+                names.append(name)
+                d = Definition(name, "import", self.file_path, ident.start_point[0] + 1)
+                self.defs.append(d)
+
+        if not names and text.startswith("import "):
+            prefix_node = None
+            match = re.search(r"\bas\s+([A-Za-z_]\w*)", text)
+            if match:
+                source_name = match.group(1)
+                prefix_node = node
+            elif source.startswith("package:"):
+                source_name = source.split("/")[-1].removesuffix(".dart")
+            else:
+                source_name = Path(source).stem
+            if source_name and source_name not in {".", ""}:
+                names.append(source_name)
+                line = prefix_node.start_point[0] + 1 if prefix_node else node.start_point[0] + 1
+                d = Definition(source_name, "import", self.file_path, line)
+                self.defs.append(d)
+
+        self.raw_imports.append(
+            {"source": source, "names": names, "line": node.start_point[0] + 1}
+        )
+
+    def _scan_class(self, node) -> None:
+        name_node = self._name_node(node)
+        class_name = self._node_name_text(name_node)
+        if not class_name:
+            return
+
+        bases: list[str] = []
+        for base_node in self._descendants_of_type(node, "type_identifier"):
+            if base_node is name_node:
+                continue
+            parent = base_node.parent
+            if parent is not None and parent.type in {"superclass", "interfaces", "mixins"}:
+                base_name = self._node_name_text(base_node)
+                bases.append(base_name)
+                self._add_ref(base_name, base_node.start_byte, current_callable=None)
+
+        d = Definition(class_name, "class", self.file_path, name_node.start_point[0] + 1)
+        d.base_classes = bases
+        d.is_exported = (
+            not _is_private_name(class_name)
+            and any(base in _FLUTTER_BASES for base in bases)
+        )
+        self.defs.append(d)
+
+        body = self._child_by_type(node, "class_body")
+        if body is None:
+            return
+
+        children = list(body.children)
+        index = 0
+        while index < len(children):
+            child = children[index]
+
+            if child.type == "declaration":
+                self._scan_class_declaration(child, current_class=class_name)
+                index += 1
+                continue
+
+            if child.type == "method_signature":
+                body_node = self._next_body(children, index)
+                self._scan_method(
+                    child,
+                    body_node,
+                    current_class=class_name,
+                    class_bases=bases,
+                )
+                if body_node is not None:
+                    index += 2
+                else:
+                    index += 1
+                continue
+
+            index += 1
+
+    def _scan_class_declaration(self, node, *, current_class: str) -> None:
+        constructor = self._first_descendant_of_type(node, "constructor_signature")
+        if constructor is None:
+            constructor = self._first_descendant_of_type(
+                node, "constant_constructor_signature"
+            )
+        if constructor is not None:
+            name_node = self._name_node(constructor)
+            constructor_name = self._node_name_text(name_node) or current_class
+            qualified = f"{current_class}.{constructor_name}"
+            d = Definition(
+                qualified,
+                "method",
+                self.file_path,
+                constructor.start_point[0] + 1,
+            )
+            d.is_exported = not _is_private_name(constructor_name)
+            self.defs.append(d)
+
+            params = self._first_descendant_of_type(constructor, "formal_parameter_list")
+            if params is not None:
+                for param in self._descendants_of_type(params, "super_formal_parameter"):
+                    ident = self._child_by_type(param, "identifier")
+                    if ident is not None:
+                        self._add_ref(
+                            self._node_name_text(ident),
+                            ident.start_byte,
+                            current_callable=qualified,
+                        )
+                for param in self._descendants_of_type(params, "constructor_param"):
+                    ident = self._child_by_type(param, "identifier")
+                    if ident is not None:
+                        self._add_ref(
+                            self._node_name_text(ident),
+                            ident.start_byte,
+                            current_callable=qualified,
+                        )
+            return
+
+        field_list = self._first_descendant_of_type(node, "initialized_identifier_list")
+        if field_list is not None:
+            for ident in self._descendants_of_type(field_list, "identifier"):
+                field_name = self._node_name_text(ident)
+                if not field_name:
+                    continue
+                d = Definition(
+                    f"{current_class}.{field_name}",
+                    "variable",
+                    self.file_path,
+                    ident.start_point[0] + 1,
+                )
+                d.is_exported = not _is_private_name(field_name)
+                self.defs.append(d)
+
+        static_final = self._first_descendant_of_type(
+            node, "static_final_declaration_list"
+        )
+        if static_final is not None:
+            self._scan_static_final_declarations(
+                static_final,
+                current_class=current_class,
+                is_exported=True,
+            )
+
+    def _scan_method(
+        self,
+        node,
+        body,
+        *,
+        current_class: str,
+        class_bases: list[str],
+    ) -> None:
+        signature = self._first_descendant_of_type(node, "function_signature")
+        if signature is None:
+            return
+        name_node = self._function_signature_name_node(signature)
+        method_name = self._node_name_text(name_node)
+        if not method_name:
+            return
+
+        qualified = f"{current_class}.{method_name}"
+        d = Definition(qualified, "method", self.file_path, name_node.start_point[0] + 1)
+        implicit = self._is_implicit_method(method_name, class_bases, node)
+        d.is_exported = implicit or not _is_private_name(method_name)
+        if implicit:
+            self.test_decorated_lines.add(name_node.start_point[0] + 1)
+        self.defs.append(d)
+
+        if body is not None:
+            self._scan_refs_in_node(body, current_callable=qualified)
+            self._scan_block(
+                body,
+                current_class=current_class,
+                current_callable=qualified,
+            )
+
+    def _is_implicit_method(self, name: str, bases: list[str], node) -> bool:
+        if name in _FLUTTER_LIFECYCLE_METHODS and any(
+            base in _FLUTTER_BASES for base in bases
+        ):
+            return True
+        return False
+
+    def _scan_function(self, signature, body) -> None:
+        name_node = self._function_signature_name_node(signature)
+        func_name = self._node_name_text(name_node)
+        if not func_name:
+            return
+        d = Definition(func_name, "function", self.file_path, name_node.start_point[0] + 1)
+        d.is_exported = (
+            func_name == "main"
+            or (self.is_test_file and func_name in _TEST_ENTRYPOINTS)
+            or (self.is_test_file and func_name.startswith("test"))
+        )
+        if d.is_exported:
+            self.test_decorated_lines.add(name_node.start_point[0] + 1)
+        self.defs.append(d)
+
+        if body is not None:
+            self._scan_refs_in_node(body, current_callable=func_name)
+            self._scan_block(body, current_class=None, current_callable=func_name)
+
+    def _scan_enum(self, node) -> None:
+        name_node = self._name_node(node)
+        enum_name = self._node_name_text(name_node)
+        if not enum_name:
+            return
+        d = Definition(enum_name, "class", self.file_path, name_node.start_point[0] + 1)
+        d.is_exported = not _is_private_name(enum_name)
+        self.defs.append(d)
+
+        body = self._child_by_type(node, "enum_body")
+        if body is None:
+            return
+        for const_node in self._descendants_of_type(body, "enum_constant"):
+            ident = self._child_by_type(const_node, "identifier")
+            name = self._node_name_text(ident)
+            if not name:
+                continue
+            const_def = Definition(
+                f"{enum_name}.{name}",
+                "variable",
+                self.file_path,
+                ident.start_point[0] + 1,
+            )
+            const_def.is_exported = not _is_private_name(enum_name)
+            self.defs.append(const_def)
+
+    def _scan_static_final_declarations(
+        self,
+        node,
+        *,
+        current_class: str | None,
+        is_exported: bool,
+    ) -> None:
+        for declaration in self._descendants_of_type(node, "static_final_declaration"):
+            ident = self._child_by_type(declaration, "identifier")
+            name = self._node_name_text(ident)
+            if not name:
+                continue
+            qualified = f"{current_class}.{name}" if current_class else name
+            d = Definition(
+                qualified,
+                "variable",
+                self.file_path,
+                ident.start_point[0] + 1,
+            )
+            d.is_exported = is_exported and not _is_private_name(name)
+            self.defs.append(d)
+
+    def _scan_refs_in_node(self, node, *, current_callable: str | None) -> None:
+        children = list(node.children)
+        for idx, child in enumerate(children):
+            next_child = children[idx + 1] if idx + 1 < len(children) else None
+            next_next = children[idx + 2] if idx + 2 < len(children) else None
+
+            if child.type == "identifier" and self._selector_is_call(next_child):
+                self._add_ref(
+                    self._node_name_text(child),
+                    child.start_byte,
+                    current_callable=current_callable,
+                )
+
+            if (
+                child.type == "selector"
+                and self._selector_name(child)
+                and self._selector_is_call(next_child)
+            ):
+                self._add_ref(
+                    self._selector_name(child),
+                    child.start_byte,
+                    current_callable=current_callable,
+                )
+
+            if (
+                child.type == "unconditional_assignable_selector"
+                and self._selector_is_call(next_child or next_next)
+            ):
+                ident = self._child_by_type(child, "identifier")
+                self._add_ref(
+                    self._node_name_text(ident),
+                    child.start_byte,
+                    current_callable=current_callable,
+                )
+
+            self._scan_refs_in_node(child, current_callable=current_callable)
+
+    def _selector_is_call(self, node) -> bool:
+        if node is None or node.type != "selector":
+            return False
+        return self._first_descendant_of_type(node, "argument_part") is not None
+
+    def _selector_name(self, node) -> str:
+        if node is None or node.type != "selector":
+            return ""
+        ident = self._child_by_type(node, "identifier")
+        if ident is not None:
+            return self._node_name_text(ident)
+        text = self._get_text(node).strip()
+        if text.startswith("."):
+            return text[1:]
+        return ""
+
+    def _build_call_graph(self) -> None:
+        name_to_def: dict[str, Definition] = {}
+        for d in self.defs:
+            name_to_def[d.name] = d
+            name_to_def.setdefault(d.simple_name, d)
+
+        for caller, callee in self.call_pairs:
+            caller_def = name_to_def.get(caller)
+            callee_def = name_to_def.get(callee)
+            if caller_def and callee_def and caller_def is not callee_def:
+                caller_def.calls.add(callee_def.name)
+                callee_def.called_by.add(caller_def.name)

--- a/skylos/visitors/languages/dart/danger.py
+++ b/skylos/visitors/languages/dart/danger.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_TAINT_NAME_RE = re.compile(
+    r"(arg|cmd|command|file|filename|input|name|path|payload|request|url|uri)",
+    re.I,
+)
+
+_SOURCE_HINTS = {
+    "Platform.environment",
+    "stdin.readLineSync",
+    "Uri.base",
+    "window.location",
+}
+
+_SANITIZER_HINTS = {
+    "canonicalize",
+    "basename(",
+    "path.basename",
+    "Uri.https(",
+}
+
+_PROCESS_RE = re.compile(r"\bProcess\.(run|runSync|start|startDetached)\s*\(")
+_HTTP_RE = re.compile(
+    r"(\bhttp\.(get|post|put|patch|delete|head)\s*\(|\bDio\(\)\.(get|post|put|patch|delete|head)\s*\(|\bHttpClient\(\)\.(getUrl|openUrl)\s*\()"
+)
+_FILE_RE = re.compile(
+    r"(\bFile\s*\(|\bDirectory\s*\(|\brootBundle\.loadString\s*\(|\bFileImage\s*\()"
+)
+
+
+def scan_danger(root_node, file_path: str, source: bytes) -> list[dict]:
+    if root_node is None:
+        return []
+
+    findings: list[dict] = []
+
+    def node_text(node) -> str:
+        return source[node.start_byte : node.end_byte].decode("utf-8", "ignore")
+
+    def child_by_type(node, type_name: str):
+        for child in node.children:
+            if child.type == type_name:
+                return child
+        return None
+
+    def first_descendant(node, type_name: str):
+        if node.type == type_name:
+            return node
+        for child in node.children:
+            found = first_descendant(child, type_name)
+            if found is not None:
+                return found
+        return None
+
+    def descendants(node, type_name: str):
+        if node.type == type_name:
+            yield node
+        for child in node.children:
+            yield from descendants(child, type_name)
+
+    def function_name(signature) -> str:
+        by_field = signature.child_by_field_name("name")
+        if by_field is not None:
+            return node_text(by_field).strip()
+        params = child_by_type(signature, "formal_parameter_list")
+        candidates = []
+        for child in signature.children:
+            if child is params:
+                break
+            if child.type == "identifier":
+                candidates.append(child)
+        return node_text(candidates[-1]).strip() if candidates else ""
+
+    def collect_tainted_params(signature) -> set[str]:
+        params = child_by_type(signature, "formal_parameter_list")
+        if params is None:
+            return set()
+        names: set[str] = set()
+        for param in descendants(params, "formal_parameter"):
+            identifiers = [node_text(i).strip() for i in descendants(param, "identifier")]
+            if not identifiers:
+                continue
+            name = identifiers[-1]
+            if _TAINT_NAME_RE.search(name):
+                names.add(name)
+        return names
+
+    def is_sanitized_expr_text(expr: str) -> bool:
+        compact = re.sub(r"\s+", "", expr)
+        return any(hint in expr or hint in compact for hint in _SANITIZER_HINTS)
+
+    def is_tainted_text(expr: str, tainted_vars: set[str]) -> bool:
+        if not expr or is_sanitized_expr_text(expr):
+            return False
+        if any(hint in expr for hint in _SOURCE_HINTS):
+            return True
+        return any(re.search(rf"\b{re.escape(name)}\b", expr) for name in tainted_vars)
+
+    def add_finding(rule_id: str, message: str, node) -> None:
+        findings.append(
+            {
+                "rule_id": rule_id,
+                "severity": "HIGH",
+                "message": message,
+                "file": str(Path(file_path)),
+                "line": node.start_point[0] + 1,
+                "col": node.start_point[1],
+                "category": "danger",
+            }
+        )
+
+    def assignment_lhs_rhs(node):
+        if node.type == "local_variable_declaration":
+            definition = first_descendant(node, "initialized_variable_definition")
+            if definition is None:
+                return None, None
+            lhs = child_by_type(definition, "identifier")
+            rhs_parts = []
+            seen_eq = False
+            for child in definition.children:
+                if child.type == "=":
+                    seen_eq = True
+                    continue
+                if seen_eq:
+                    rhs_parts.append(node_text(child))
+            return lhs, " ".join(rhs_parts).strip()
+
+        if node.type == "assignment_expression":
+            lhs = node.child_by_field_name("left")
+            rhs = node.child_by_field_name("right")
+            if lhs is not None and rhs is not None:
+                return lhs, node_text(rhs)
+            parts = [child for child in node.children if child.type != "="]
+            if len(parts) >= 2:
+                return parts[0], node_text(parts[1])
+
+        return None, None
+
+    def handle_assignment(node, tainted_vars: set[str]) -> None:
+        lhs, rhs_text = assignment_lhs_rhs(node)
+        if lhs is None or not rhs_text:
+            return
+        name = node_text(lhs).strip()
+        if not name:
+            return
+        if is_tainted_text(rhs_text, tainted_vars):
+            tainted_vars.add(name)
+        else:
+            tainted_vars.discard(name)
+
+    def handle_expression(node, tainted_vars: set[str]) -> None:
+        expr = node_text(node)
+        if not is_tainted_text(expr, tainted_vars):
+            return
+
+        if _PROCESS_RE.search(expr):
+            add_finding(
+                "SKY-D212",
+                "Process execution receives tainted input; validate or allowlist the command.",
+                node,
+            )
+            return
+
+        if _HTTP_RE.search(expr):
+            add_finding(
+                "SKY-D216",
+                "User-controlled URL reaches an outbound request sink.",
+                node,
+            )
+            return
+
+        if _FILE_RE.search(expr):
+            add_finding(
+                "SKY-D215",
+                "User-controlled path reaches a filesystem sink without path validation.",
+                node,
+            )
+
+    def walk_scope(node, tainted_vars: set[str]) -> None:
+        for child in node.children:
+            if child.type in {"function_signature", "method_signature"}:
+                continue
+
+            handle_assignment(child, tainted_vars)
+
+            if child.type in {
+                "expression_statement",
+                "return_statement",
+                "local_variable_declaration",
+            }:
+                handle_expression(child, tainted_vars)
+
+            walk_scope(child, tainted_vars)
+
+    def scan_functions(node) -> None:
+        children = list(node.children)
+        index = 0
+        while index < len(children):
+            child = children[index]
+            if child.type == "function_signature":
+                body = (
+                    children[index + 1]
+                    if index + 1 < len(children)
+                    and children[index + 1].type == "function_body"
+                    else None
+                )
+                if body is not None:
+                    _ = function_name(child)
+                    walk_scope(body, collect_tainted_params(child))
+                    index += 2
+                    continue
+
+            if child.type == "method_signature":
+                signature = first_descendant(child, "function_signature")
+                body = (
+                    children[index + 1]
+                    if index + 1 < len(children)
+                    and children[index + 1].type == "function_body"
+                    else None
+                )
+                if signature is not None and body is not None:
+                    _ = function_name(signature)
+                    walk_scope(body, collect_tainted_params(signature))
+                    index += 2
+                    continue
+
+            scan_functions(child)
+            index += 1
+
+    scan_functions(root_node)
+    return _dedupe_findings(findings)
+
+
+def _dedupe_findings(findings: list[dict]) -> list[dict]:
+    seen: set[tuple[str, str, int]] = set()
+    deduped: list[dict] = []
+    for finding in findings:
+        key = (finding["rule_id"], finding["file"], finding["line"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(finding)
+    return deduped

--- a/skylos/visitors/languages/php/core.py
+++ b/skylos/visitors/languages/php/core.py
@@ -215,6 +215,19 @@ class PhpCore:
                 self._scan_class_like(child, namespace=active_namespace)
                 continue
 
+            if child.type == "enum_declaration":
+                self._scan_enum(child, namespace=active_namespace)
+                continue
+
+            if child.type == "const_declaration":
+                self._scan_constant_declaration(
+                    child,
+                    current_class=None,
+                    namespace=active_namespace,
+                    is_exported=False,
+                )
+                continue
+
             if child.type == "function_definition":
                 self._scan_function(child, namespace=active_namespace)
                 continue
@@ -280,11 +293,78 @@ class PhpCore:
                 self._scan_property_declaration(child, current_class=qualified)
                 continue
 
+            if child.type == "const_declaration":
+                self._scan_constant_declaration(
+                    child,
+                    current_class=qualified,
+                    namespace=namespace,
+                    is_exported=self._is_publicish(child, default_public=False),
+                )
+                continue
+
             if child.type == "method_declaration":
                 self._scan_method(child, current_class=qualified, class_bases=bases)
                 continue
 
             self._scan_refs_in_node(child, current_callable=None)
+
+    def _scan_enum(self, node, *, namespace: str) -> None:
+        name_node = self._child_by_type(node, "name")
+        enum_name = self._node_name_text(name_node)
+        if not enum_name:
+            return
+        qualified = self._qualified_symbol(enum_name, namespace)
+        enum_def = Definition(
+            qualified,
+            "class",
+            self.file_path,
+            name_node.start_point[0] + 1,
+        )
+        enum_def.is_exported = True
+        self.defs.append(enum_def)
+
+        declaration_list = self._child_by_type(node, "enum_declaration_list")
+        if declaration_list is None:
+            return
+        for case in self._children_of_type(declaration_list, "enum_case"):
+            case_node = self._child_by_type(case, "name")
+            case_name = self._node_name_text(case_node)
+            if not case_name:
+                continue
+            d = Definition(
+                f"{qualified}.{case_name}",
+                "variable",
+                self.file_path,
+                case_node.start_point[0] + 1,
+            )
+            d.is_exported = True
+            self.defs.append(d)
+
+    def _scan_constant_declaration(
+        self,
+        node,
+        *,
+        current_class: str | None,
+        namespace: str,
+        is_exported: bool,
+    ) -> None:
+        for const in self._children_of_type(node, "const_element"):
+            name_node = self._child_by_type(const, "name")
+            const_name = self._node_name_text(name_node)
+            if not const_name:
+                continue
+            if current_class:
+                qualified = f"{current_class}.{const_name}"
+            else:
+                qualified = self._qualified_symbol(const_name, namespace)
+            d = Definition(
+                qualified,
+                "variable",
+                self.file_path,
+                name_node.start_point[0] + 1,
+            )
+            d.is_exported = is_exported
+            self.defs.append(d)
 
     def _scan_property_declaration(self, node, *, current_class: str) -> None:
         is_exported = self._is_publicish(node, default_public=False)
@@ -312,7 +392,7 @@ class PhpCore:
         qualified = f"{current_class}.{method_name}"
         implicit_entrypoint = self._is_magic_or_test_entrypoint(
             method_name, class_bases, line
-        )
+        ) or self._has_test_attribute(node, line)
 
         d = Definition(qualified, "method", self.file_path, line)
         d.is_exported = self._is_publicish(node) or implicit_entrypoint
@@ -346,6 +426,17 @@ class PhpCore:
                 class_bases=class_bases,
             )
 
+    def _has_test_attribute(self, node, line: int) -> bool:
+        for attr_list in self._children_of_type(node, "attribute_list"):
+            for attr in self._descendants_of_type(attr_list, "attribute"):
+                name_node = self._child_by_type(attr, "name")
+                attr_name = self._node_name_text(name_node)
+                if attr_name != "Test" and not attr_name.endswith("\\Test"):
+                    continue
+                self.test_decorated_lines.add(line)
+                return True
+        return False
+
     def _scan_function(self, node, *, namespace: str) -> None:
         name_node = self._child_by_type(node, "name")
         func_name = self._node_name_text(name_node)
@@ -370,9 +461,13 @@ class PhpCore:
     def _scan_use_imports(self, node) -> None:
         names: list[str] = []
         line = node.start_point[0] + 1
-        for clause in self._children_of_type(node, "namespace_use_clause"):
-            target_node = self._child_by_type(clause, "qualified_name")
-            alias_node = self._child_by_type(clause, "name")
+        for clause in self._descendants_of_type(node, "namespace_use_clause"):
+            target_node = (
+                clause.child_by_field_name("name")
+                or self._child_by_type(clause, "qualified_name")
+                or self._child_by_type(clause, "name")
+            )
+            alias_node = clause.child_by_field_name("alias")
             target = self._node_name_text(target_node)
             alias = self._node_name_text(alias_node) or target.split("\\")[-1]
             if not alias:
@@ -385,6 +480,12 @@ class PhpCore:
             names.append(alias)
         if names:
             self.raw_imports.append({"source": "use", "names": names, "line": line})
+
+    def _descendants_of_type(self, node, type_name: str):
+        if node.type == type_name:
+            yield node
+        for child in node.children:
+            yield from self._descendants_of_type(child, type_name)
 
     def _scan_include_import(self, node) -> None:
         expr = None

--- a/skylos/visitors/languages/php/danger.py
+++ b/skylos/visitors/languages/php/danger.py
@@ -10,8 +10,27 @@ _SUPERGLOBALS = {
     "$_FILES",
 }
 
-_FILE_SINKS = {"file_get_contents", "fopen", "readfile", "unlink", "file"}
+_FILE_SINKS = {
+    "file_get_contents",
+    "file_put_contents",
+    "fopen",
+    "readfile",
+    "unlink",
+    "file",
+    "copy",
+    "rename",
+    "mkdir",
+    "rmdir",
+    "chmod",
+}
 _SANITIZERS = {"basename"}
+_FILTER_INPUT_SOURCES = {
+    "INPUT_GET",
+    "INPUT_POST",
+    "INPUT_REQUEST",
+    "INPUT_COOKIE",
+    "INPUT_SERVER",
+}
 
 
 def scan_danger(root_node, file_path: str, source: bytes) -> list[dict]:
@@ -32,9 +51,23 @@ def scan_danger(root_node, file_path: str, source: bytes) -> list[dict]:
     def is_superglobal_var(node) -> bool:
         return node is not None and node.type == "variable_name" and text(node).strip() in _SUPERGLOBALS
 
+    def is_filter_input_source(node) -> bool:
+        if node is None or node.type != "function_call_expression":
+            return False
+        name_node = child_by_type(node, "name")
+        call_name = text(name_node).strip().lstrip("\\") if name_node else ""  # skylos: ignore[SKY-D211]
+        if call_name != "filter_input":
+            return False
+        args = child_by_type(node, "arguments")
+        return args is not None and any(
+            text(child).strip() in _FILTER_INPUT_SOURCES for child in args.children
+        )
+
     def is_tainted_expr(node, tainted_vars: set[str]) -> bool:
         if node is None:
             return False
+        if is_filter_input_source(node):
+            return True
         if is_superglobal_var(node):
             return True
         if node.type == "variable_name":

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -212,6 +212,7 @@ class TestSkylos:
                 ".java",
                 ".php",
                 ".rs",
+                ".dart",
             },
             exclude_folders=None,
         )

--- a/test/test_dart.py
+++ b/test/test_dart.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skylos.analyzer import analyze, proc_file
+from skylos.visitors.languages.dart import scan_dart_file
+
+
+def _scan_dart(tmp_path: Path, code: str, filename: str = "lib/main.dart") -> tuple:
+    file_path = tmp_path / filename
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(code, encoding="utf-8")
+    return scan_dart_file(str(file_path), {})
+
+
+def test_dart_scanner_collects_defs_refs_and_raw_imports(tmp_path):
+    defs, refs, _, _, visitor, _, quality, danger, _, _, _, _, raw_imports = _scan_dart(
+        tmp_path,
+        """
+import 'package:flutter/material.dart';
+import 'src/user.dart' show User;
+export 'src/api.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  @override
+  void initState() { super.initState(); }
+
+  @override
+  Widget build(BuildContext context) { return Text('hi'); }
+
+  void _unusedHelper() {}
+}
+
+enum Role { admin, user }
+
+void main() { runApp(HomePage()); }
+void used() { _helper(); }
+void _helper() {}
+""",
+    )
+
+    def_names = {d.name for d in defs}
+    ref_names = {r[0] for r in refs}
+    exported = {d.name for d in defs if d.is_exported}
+
+    assert "material" in def_names
+    assert "User" in def_names
+    assert "HomePage" in def_names
+    assert "HomePage.HomePage" in def_names
+    assert "HomePage.createState" in def_names
+    assert "_HomePageState" in def_names
+    assert "_HomePageState.initState" in def_names
+    assert "_HomePageState.build" in def_names
+    assert "_HomePageState._unusedHelper" in def_names
+    assert "Role" in def_names
+    assert "Role.admin" in def_names
+    assert "main" in def_names
+    assert "_helper" in def_names
+
+    assert "runApp" in ref_names
+    assert "HomePage" in ref_names
+    assert "_HomePageState" in ref_names
+    assert "_helper" in ref_names
+
+    assert "HomePage" in exported
+    assert "HomePage.createState" in exported
+    assert "_HomePageState.initState" in exported
+    assert "_HomePageState.build" in exported
+    assert "_HomePageState._unusedHelper" not in exported
+    assert "main" in exported
+
+    assert visitor.is_test_file is False
+    assert quality == []
+    assert danger == []
+    assert raw_imports == [
+        {
+            "source": "package:flutter/material.dart",
+            "names": ["material"],
+            "line": 2,
+        },
+        {"source": "src/user.dart", "names": ["User"], "line": 3},
+        {"source": "src/api.dart", "names": [], "line": 4},
+    ]
+
+
+def test_dart_test_file_marks_main_as_test_related(tmp_path):
+    defs, _, _, _, visitor, _, _, _, _, _, _, _, _ = _scan_dart(
+        tmp_path,
+        """
+import 'package:test/test.dart';
+
+void main() {
+  test('works', () {});
+}
+""",
+        filename="test/user_test.dart",
+    )
+
+    main_def = next(d for d in defs if d.name == "main")
+
+    assert main_def.is_exported is True
+    assert visitor.is_test_file is True
+    assert visitor.test_decorated_lines
+
+
+def test_proc_file_dispatches_dart_to_dart_scanner(tmp_path):
+    file_path = tmp_path / "main.dart"
+    file_path.write_text("void main() {}\n", encoding="utf-8")
+
+    out = proc_file(str(file_path))
+    defs = out[0]
+
+    assert any(defn.name == "main" for defn in defs)
+
+
+def test_analyze_dart_reports_language_summary_and_dead_code(tmp_path):
+    file_path = tmp_path / "main.dart"
+    file_path.write_text(
+        """
+void main() { used(); }
+void used() {}
+void _unusedPrivate() {}
+""",
+        encoding="utf-8",
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=60, grep_verify=False))
+    unused = {item["full_name"] for item in result["unused_functions"]}
+
+    assert result["analysis_summary"]["languages"] == {"Dart": 1}
+    assert "_unusedPrivate" in unused
+    assert "used" not in unused

--- a/test/test_dart_security.py
+++ b/test/test_dart_security.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.visitors.languages.dart import scan_dart_file
+
+
+def _scan_dart_findings(tmp_path: Path, code: str) -> list[dict]:
+    file_path = tmp_path / "main.dart"
+    file_path.write_text(code, encoding="utf-8")
+    return scan_dart_file(str(file_path), {})[7]
+
+
+def _rule_ids(findings: list[dict]) -> set[str]:
+    return {finding["rule_id"] for finding in findings}
+
+
+def test_process_run_with_tainted_command_flags(tmp_path):
+    findings = _scan_dart_findings(
+        tmp_path,
+        """
+import 'dart:io';
+
+Future<void> runCommand(String command) async {
+  await Process.run(command, ['--version']);
+}
+""",
+    )
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_http_get_with_tainted_url_flags(tmp_path):
+    findings = _scan_dart_findings(
+        tmp_path,
+        """
+import 'package:http/http.dart' as http;
+
+Future<void> fetch(String url) async {
+  await http.get(Uri.parse(url));
+}
+""",
+    )
+    assert "SKY-D216" in _rule_ids(findings)
+
+
+def test_http_get_literal_url_is_safe(tmp_path):
+    findings = _scan_dart_findings(
+        tmp_path,
+        """
+import 'package:http/http.dart' as http;
+
+Future<void> fetch() async {
+  await http.get(Uri.parse('https://example.com/health'));
+}
+""",
+    )
+    assert "SKY-D216" not in _rule_ids(findings)
+
+
+def test_file_read_with_tainted_path_flags(tmp_path):
+    findings = _scan_dart_findings(
+        tmp_path,
+        """
+import 'dart:io';
+
+Future<String> readFile(String path) async {
+  final requested = path;
+  return File(requested).readAsString();
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_basename_sanitized_file_path_is_safe(tmp_path):
+    findings = _scan_dart_findings(
+        tmp_path,
+        """
+import 'dart:io';
+import 'package:path/path.dart' as path;
+
+Future<String> readFile(String fileName) async {
+  final safe = path.basename(fileName);
+  return File('/srv/data/$safe').readAsString();
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_taint_does_not_leak_across_functions(tmp_path):
+    findings = _scan_dart_findings(
+        tmp_path,
+        """
+import 'dart:io';
+
+Future<void> unsafe(String command) async {
+  await Process.run(command, []);
+}
+
+Future<String> safe() async {
+  final path = '/srv/data/report.txt';
+  return File(path).readAsString();
+}
+""",
+    )
+    assert _rule_ids(findings) == {"SKY-D212"}

--- a/test/test_php.py
+++ b/test/test_php.py
@@ -111,3 +111,80 @@ class UserTest extends TestCase {
     assert "UserTest.test_it_works" in exported
     assert visitor.is_test_file is True
     assert visitor.test_decorated_lines
+
+
+def test_php_scanner_collects_grouped_imports_enums_and_constants(tmp_path):
+    defs, _, _, _, _, _, _, _, _, _, _, _, raw_imports = _scan_php(
+        tmp_path,
+        """<?php
+namespace App;
+
+use Foo\\{Bar, Baz as Quux};
+
+const GLOBAL_FLAG = true;
+
+class Demo {
+    public const VERSION = '1';
+}
+
+enum Role {
+    case Admin;
+    case User;
+}
+""",
+    )
+
+    def_names = {d.name for d in defs}
+    exported = {d.name for d in defs if d.is_exported}
+
+    assert "Bar" in def_names
+    assert "Quux" in def_names
+    assert "App.GLOBAL_FLAG" in def_names
+    assert "App.Demo.VERSION" in def_names
+    assert "App.Role" in def_names
+    assert "App.Role.Admin" in def_names
+    assert "App.Role.User" in def_names
+
+    assert "App.GLOBAL_FLAG" not in exported
+    assert "App.Demo.VERSION" in exported
+    assert "App.Role" in exported
+    assert "App.Role.Admin" in exported
+
+    assert raw_imports == [{"source": "use", "names": ["Bar", "Quux"], "line": 4}]
+
+
+def test_phpunit_test_attribute_marks_method_as_entrypoint(tmp_path):
+    defs, _, _, _, visitor, _, _, _, _, _, _, _, _ = _scan_php(
+        tmp_path,
+        """<?php
+use PHPUnit\\Framework\\Attributes\\Test;
+
+class DemoTest extends TestCase {
+    #[Test]
+    public function it_works(): void {}
+}
+""",
+        filename="tests/DemoTest.php",
+    )
+
+    method = next(d for d in defs if d.name == "DemoTest.it_works")
+
+    assert method.is_exported is True
+    assert visitor.test_decorated_lines
+
+
+def test_non_phpunit_attribute_does_not_mark_method_as_entrypoint(tmp_path):
+    defs, _, _, _, visitor, _, _, _, _, _, _, _, _ = _scan_php(
+        tmp_path,
+        """<?php
+class Demo {
+    #[Latest]
+    private function helper(): void {}
+}
+""",
+    )
+
+    method = next(d for d in defs if d.name == "Demo.helper")
+
+    assert method.is_exported is False
+    assert not visitor.test_decorated_lines

--- a/test/test_php_security.py
+++ b/test/test_php_security.py
@@ -57,6 +57,28 @@ file_get_contents($path);
     assert "SKY-D215" in _rule_ids(findings)
 
 
+def test_filter_input_to_file_put_contents_flags(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+$path = filter_input(INPUT_GET, 'path');
+file_put_contents($path, 'data');
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_filter_input_to_rename_flags(tmp_path):
+    findings = _scan_php_findings(
+        tmp_path,
+        """<?php
+$from = filter_input(INPUT_POST, 'from');
+rename($from, '/srv/data/archive.txt');
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
 def test_fixed_path_file_sink_is_safe(tmp_path):
     findings = _scan_php_findings(
         tmp_path,

--- a/test/test_secrets_nonpy.py
+++ b/test/test_secrets_nonpy.py
@@ -28,6 +28,9 @@ class TestAllowedSuffixes:
     def test_rust_suffix_allowed(self):
         assert ".rs" in ALLOWED_FILE_SUFFIXES
 
+    def test_dart_suffix_allowed(self):
+        assert ".dart" in ALLOWED_FILE_SUFFIXES
+
 
 class TestEnvFileScanning:
     def test_detects_aws_key_in_env(self):

--- a/uv.lock
+++ b/uv.lock
@@ -2399,7 +2399,7 @@ wheels = [
 
 [[package]]
 name = "skylos"
-version = "4.12.0"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "ca9" },
@@ -2416,6 +2416,7 @@ dependencies = [
     { name = "textual" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-dart-orchard" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-php" },
@@ -2464,6 +2465,7 @@ requires-dist = [
     { name = "textual", specifier = ">=1.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
+    { name = "tree-sitter-dart-orchard", specifier = ">=0.3.2" },
     { name = "tree-sitter-go", specifier = ">=0.23.0" },
     { name = "tree-sitter-java", specifier = ">=0.23.0" },
     { name = "tree-sitter-php", specifier = ">=0.24.1" },
@@ -2723,6 +2725,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
 ]
+
+[[package]]
+name = "tree-sitter-dart-orchard"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/43/cc963608a3a62d4cbc99647f6cec4e49944612b6673ef208d8a1e252cf51/tree_sitter_dart_orchard-0.3.2.tar.gz", hash = "sha256:99b6e7ce0e41b3dec95c6985dded2a967e2c9ccd7085cff4d4b743c75b50db40", size = 253313, upload-time = "2025-11-17T15:53:26.69Z" }
 
 [[package]]
 name = "tree-sitter-go"


### PR DESCRIPTION
## Summary

  - Add Dart/Flutter scanner support with tree-sitter parsing.
  - Collect Dart defs, refs, imports/exports, `main` entrypoints, test entrypoints, and Flutter lifecycle methods.
  - Add Dart security coverage for tainted process execution, outbound URL sinks, and filesystem/path sinks.
  - Registers `.dart` across analyzer dispatch, language summaries, CLI/pre-commit, secrets scanning, grep verification, agent tooling, cleanup tooling, benchmarks, fixgen, and grading.
  - Hardens PHP scanning

  ## Tests

  -  pytest test/test_dart.py test/test_dart_security.py test/test_php.py test/test_php_security.py test/test_secrets_nonpy.py test/test_grep_verify.py test/test_analyzer.py test/test_fixgen_multilang.py test/test_security_benchmark.py test/test_dead_code_benchmark.py test/test_cli_refactor_guardrails.py`
  - pytest .`
