### PR TITLE
fix(python): keep pyproject GUI scripts live

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2266,10 +2266,6 @@ class Skylos:
 
         self.pattern_trackers = pattern_trackers
 
-        for tracker in pattern_trackers.values():
-            if hasattr(tracker, "known_qualified_refs"):
-                tracker.known_qualified_refs.clear()
-
         self._global_abc_classes = set()
         self._global_protocol_classes = set()
         self._global_abstract_methods = {}

--- a/skylos/implicit_refs.py
+++ b/skylos/implicit_refs.py
@@ -32,7 +32,7 @@ class ImplicitRefTracker:
 
     def should_mark_as_used(self, definition):
         if getattr(definition, "name", None) in self.known_qualified_refs:
-            return True, 100, "entrypoint (pyproject.scripts)"
+            return True, 100, "entrypoint (pyproject)"
 
         simple_name = definition.simple_name
 

--- a/skylos/pyproject_entrypoints.py
+++ b/skylos/pyproject_entrypoints.py
@@ -39,12 +39,14 @@ def extract_entrypoints(project_root):
     out: set[str] = set()
 
     # PEP 621
-    scripts = (data.get("project") or {}).get("scripts") or {}
-    if isinstance(scripts, dict):
-        for _, target in scripts.items():
-            q = _to_qname(target)
-            if q:
-                out.add(q)
+    project = data.get("project") or {}
+    for table_name in ("scripts", "gui-scripts"):
+        scripts = project.get(table_name) or {}
+        if isinstance(scripts, dict):
+            for _, target in scripts.items():
+                q = _to_qname(target)
+                if q:
+                    out.add(q)
 
     poetry_scripts = (
         ((data.get("tool") or {}).get("poetry") or {}).get("scripts")

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -775,6 +775,34 @@ class TestAnalyze:
         assert ("SKY-Q803", "mypkg.cli") not in architecture_rules
         assert ("SKY-Q802", "mypkg._helpers") not in architecture_rules
 
+    def test_pyproject_gui_script_entrypoint_is_not_reported_dead(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pkg = root / "mypkg"
+            pkg.mkdir()
+            (root / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "gui-entrypoint-repro"\n'
+                'version = "0.1.0"\n\n'
+                "[project.gui-scripts]\n"
+                'mypkg-gui = "mypkg.gui:launch"\n',
+                encoding="utf-8",
+            )
+            (pkg / "__init__.py").write_text("", encoding="utf-8")
+            (pkg / "gui.py").write_text(
+                "def launch():\n"
+                '    print("hello")\n',
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), conf=0, grep_verify=False)
+
+        result = json.loads(result_json)
+        unused_functions = {
+            item["full_name"] for item in result.get("unused_functions", [])
+        }
+        assert "mypkg.gui.launch" not in unused_functions
+
     def test_analyze_architecture_filters_low_fan_in_private_helper_q803(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary

  - Keep PEP 621 `[project.gui-scripts]` targets live during dead-code analysis.
  - Preserve pyproject-qualified entrypoint refs through analyzer liveness so GUI entrypoints are not reported as unused.

  ## Tests

  - pytest test/test_analyzer.py::TestAnalyze::test_pyproject_gui_script_entrypoint_is_not_reported_dead test/test_module_reachability.py test/test_implicit_refs.py`