### PR TITLE
fix(python): suppress override method parameters

### DIFF
--- a/skylos/visitor.py
+++ b/skylos/visitor.py
@@ -62,6 +62,12 @@ PYTHON_BUILTINS = {
 
 DYNAMIC_PATTERNS = {"getattr", "globals", "eval", "exec"}
 
+OVERRIDE_DECORATORS = {
+    "override",
+    "typing.override",
+    "typing_extensions.override",
+}
+
 IMPLICIT_DUNDERS = {
     "__init__",
     "__new__",
@@ -763,6 +769,10 @@ class Visitor(ast.NodeVisitor):
                 is_abstract_or_overload = True
                 break
 
+        is_explicit_override = bool(self.cls) and any(
+            deco_name in OVERRIDE_DECORATORS for deco_name in decorator_names
+        )
+
         if self.cls and self.cls in self.abc_classes and is_abstract_or_overload:
             if self.cls not in self.abstract_methods:
                 self.abstract_methods[self.cls] = set()
@@ -835,7 +845,7 @@ class Visitor(ast.NodeVisitor):
 
         skip_params = self._in_protocol_class or getattr(
             self, "_in_abstract_or_overload", False
-        )
+        ) or is_explicit_override
 
         for arg in all_args:
             param_name = f"{qualified_name}.{arg.arg}"

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1559,6 +1559,45 @@ def pytest_assertrepr_compare(config, op, left, right):
         assert "left" not in unused_parameters
         assert "right" not in unused_parameters
 
+    def test_analyze_suppresses_override_method_parameters(self, tmp_path):
+        src = tmp_path / "models.py"
+        src.write_text(
+            """
+from typing import override
+import typing_extensions
+
+class Base:
+    def render(self, value, context, unused_base):
+        return value + context + unused_base
+
+class TypedChild(Base):
+    @override
+    def render(self, value, context, compat):
+        return value + context
+
+class ExtensionChild(Base):
+    @typing_extensions.override()
+    def render(self, value, context, compat_ext):
+        return value + context
+
+class PlainChild(Base):
+    def render(self, value, context, plain_unused):
+        return value + context
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unused_parameters = {
+            item["full_name"] for item in result["unused_parameters"]
+        }
+
+        assert "models.TypedChild.render.compat" not in unused_parameters
+        assert "models.ExtensionChild.render.compat_ext" not in unused_parameters
+        assert "models.PlainChild.render.plain_unused" in unused_parameters
+
     def test_analyze_suppresses_sqlalchemy_listener_parameters(self, tmp_path):
         src = tmp_path / "listener.py"
         src.write_text(


### PR DESCRIPTION
 ## Summary

  - Suppresses unused parameter findings for methods decorated with `@override`.
  - Supports `typing.override`, `typing_extensions.override`, and called decorator forms like`@typing_extensions.override()`.
  - Keeps undecorated subclass methods unchanged

  ## Tests

  - pytest .`