### PR TITLE
fix(python): detect no-effect statements

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -79,6 +79,7 @@ from skylos.rules.quality.logic import (
     BooleanTrapRule,
     BroadExceptionRule,
     MissingNetworkTimeoutRule,
+    NoEffectStatementRule,
 )
 from skylos.rules.quality.practices import (
     FrameworkPracticeRule,
@@ -261,6 +262,7 @@ _LINTER_RULE_NODE_TYPES = {
     BooleanTrapRule: (ast.FunctionDef, ast.AsyncFunctionDef),
     BroadExceptionRule: (ast.ExceptHandler,),
     MissingNetworkTimeoutRule: (ast.Call,),
+    NoEffectStatementRule: (ast.Expr,),
     GodClassRule: (ast.ClassDef,),
     CBORule: (ast.ClassDef,),
     LCOMRule: (ast.ClassDef,),
@@ -2884,6 +2886,8 @@ def proc_file(
                 q_rules.append(
                     MissingNetworkTimeoutRule(vibe_dictionary=vibe_dictionary)
                 )
+            if "SKY-L033" not in cfg["ignore"]:
+                q_rules.append(NoEffectStatementRule())
             # SKY-D260 (prompt injection) is now handled by injection_scanner..
             if "SKY-Q501" not in cfg["ignore"]:
                 q_rules.append(GodClassRule())

--- a/skylos/rules/quality/logic.py
+++ b/skylos/rules/quality/logic.py
@@ -3017,3 +3017,89 @@ class BroadExceptionRule(SkylosRule):
                 "col": node.col_offset,
             }
         ]
+
+
+_NO_EFFECT_EXPR_TYPES = (
+    ast.BinOp,
+    ast.BoolOp,
+    ast.Compare,
+    ast.Dict,
+    ast.IfExp,
+    ast.List,
+    ast.Name,
+    ast.Set,
+    ast.Tuple,
+    ast.UnaryOp,
+)
+
+_PURE_DISCARDED_CALLS = {
+    "uuid.uuid1",
+    "uuid.uuid3",
+    "uuid.uuid4",
+    "uuid.uuid5",
+}
+
+
+def _contains_possible_effect(node):
+    return any(
+        isinstance(child, (ast.Call, ast.Await, ast.Yield, ast.YieldFrom, ast.NamedExpr))
+        for child in ast.walk(node)
+    )
+
+
+class NoEffectStatementRule(SkylosRule):
+    rule_id = "SKY-L033"
+    name = "No-Effect Statement"
+
+    def visit_node(self, node, context):
+        if not isinstance(node, ast.Expr):
+            return None
+
+        value = node.value
+        issue_name = "expression"
+        issue_value = "no_effect"
+        message = (
+            "Expression statement has no effect because its result is discarded. "
+            "Assign/use the result or remove the statement."
+        )
+
+        if isinstance(value, ast.Constant):
+            if isinstance(value.value, str) or value.value is ...:
+                return None
+            if value.value is None:
+                return None
+        elif isinstance(value, (ast.Await, ast.Yield, ast.YieldFrom)):
+            return None
+        elif isinstance(value, ast.Call):
+            call_name = _qualified_call_name(value.func)
+            if call_name not in _PURE_DISCARDED_CALLS:
+                return None
+            issue_name = call_name
+            issue_value = "discarded_result"
+            message = (
+                f"Return value from '{call_name}()' is discarded. "
+                "Assign/use the result or remove the call."
+            )
+        elif not isinstance(value, _NO_EFFECT_EXPR_TYPES):
+            return None
+        elif _contains_possible_effect(value):
+            return None
+
+        filename = context.get("filename", "")
+        return [
+            {
+                "rule_id": self.rule_id,
+                "kind": "logic",
+                "severity": "LOW",
+                "type": "statement",
+                "name": issue_name,
+                "simple_name": issue_name,
+                "value": issue_value,
+                "threshold": 0,
+                "message": message,
+                "file": filename,
+                "basename": Path(filename).name,
+                "line": node.lineno,
+                "col": node.col_offset,
+            }
+        ]

--- a/skylos/rules/quality/standards.py
+++ b/skylos/rules/quality/standards.py
@@ -79,6 +79,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     ],
     "SKY-L031": [{"id": "CWE-400", "name": "Uncontrolled Resource Consumption"}],
     "SKY-L032": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
+    "SKY-L033": [{"id": "CWE-1164", "name": "Irrelevant Code"}],
     "SKY-T101": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-T102": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-F101": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
@@ -153,6 +154,7 @@ STANDARD_REFS: dict[str, list[str]] = {
     "SKY-R103": ["Repository policy: Skylos quality gate"],
     "SKY-R104": ["Repository policy: pre-commit"],
     "SKY-R105": ["Repository policy: TypeScript type checking"],
+    "SKY-L033": ["Python no-effect expression statements"],
 }
 
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -2082,6 +2082,31 @@ def fake_call():
             "low_entropy_uuid",
         }
 
+    def test_analyze_flags_no_effect_statement(self, tmp_path):
+        src = tmp_path / "app.py"
+        src.write_text(
+            """
+import uuid
+
+def make_id():
+    uuid.uuid4()
+    return "ok"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
+        )
+        findings = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L033"
+        ]
+
+        assert len(findings) == 1
+        assert findings[0]["name"] == "uuid.uuid4"
+        assert findings[0]["value"] == "discarded_result"
+
     def test_analyze_repo_rules_use_root_project_ignore_config(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
             """

--- a/test/test_quality_standards.py
+++ b/test/test_quality_standards.py
@@ -15,6 +15,7 @@ from skylos.rules.quality.logic import (
     DuplicateStringLiteralRule,
     TooManyReturnsRule,
     BooleanTrapRule,
+    NoEffectStatementRule,
 )
 from skylos.sarif_exporter import SarifExporter
 
@@ -321,6 +322,72 @@ def foo(self, flag=True):
 def foo(x, y=42, z="hello"):
     pass
 """
+        assert self._run(code) == []
+
+
+# ---------------------------------------------------------------------------
+# NoEffectStatementRule (SKY-L033)
+# ---------------------------------------------------------------------------
+
+
+class TestNoEffectStatementRule:
+    def _run(self, code):
+        rule = NoEffectStatementRule()
+        tree = ast.parse(textwrap.dedent(code))
+        ctx = {"filename": "app.py"}
+        results = []
+        for node in ast.walk(tree):
+            r = rule.visit_node(node, ctx)
+            if r:
+                results.extend(r)
+        return results
+
+    def test_detects_useless_expression_statement(self):
+        code = """
+def foo(value):
+    value + 1
+    return value
+"""
+        results = self._run(code)
+        assert len(results) == 1
+        assert results[0]["rule_id"] == "SKY-L033"
+        assert results[0]["value"] == "no_effect"
+        assert results[0]["line"] == 3
+
+    def test_detects_discarded_pure_uuid_call(self):
+        code = """
+import uuid
+
+def make_id():
+    uuid.uuid4()
+"""
+        results = self._run(code)
+        assert len(results) == 1
+        assert results[0]["name"] == "uuid.uuid4"
+        assert results[0]["value"] == "discarded_result"
+
+    def test_skips_side_effecting_calls(self):
+        code = """
+def foo(logger):
+    print("hello")
+    logger.info("hello")
+"""
+        assert self._run(code) == []
+
+    def test_skips_expressions_containing_side_effecting_calls(self):
+        code = """
+def foo(logger):
+    (logger.info("hello"), 1)
+"""
+        assert self._run(code) == []
+
+    def test_skips_docstrings_ellipsis_and_await(self):
+        code = '''
+async def foo(task):
+    """Docstring."""
+    ...
+    await task()
+'''
         assert self._run(code) == []
 
 


### PR DESCRIPTION
## Summary
  - Add `SKY-L033` to detect Python expression statements that have no effect.
  - Flag discarded known-pure UUID calls like `uuid.uuid4()` while avoiding arbitrary calls that may have side effects.
  - Register rule in the quality scanner

  ## Tests
```
  - pytest test/test_quality_standards.py test/test_analyzer.py`
  - pytest .`
```