### PR TITLE
fix(python): detect unreachable loop code

### DIFF
--- a/skylos/rules/quality/unreachable.py
+++ b/skylos/rules/quality/unreachable.py
@@ -19,6 +19,22 @@ _BODY_NODE_TYPES = (
 )
 
 
+def _static_bool(value):
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _iter_is_statically_empty(node):
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return len(node.elts) == 0
+    if isinstance(node, ast.Dict):
+        return len(node.keys) == 0
+    if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)):
+        return len(node.value) == 0
+    return False
+
+
 class UnreachableCodeRule(SkylosRule):
     rule_id = "SKY-UC001"
     name = "Unreachable Code"
@@ -69,7 +85,7 @@ class UnreachableCodeRule(SkylosRule):
                 return findings
 
         if isinstance(node, ast.While):
-            cond = evaluate_static_condition(node.test, file_path=filename)
+            cond = _static_bool(evaluate_static_condition(node.test, file_path=filename))
 
             if cond is False and node.body:
                 first = node.body[0]
@@ -81,6 +97,25 @@ class UnreachableCodeRule(SkylosRule):
                         col=getattr(first, "col_offset", node.col_offset),
                         msg="Dead code: loop body never runs because condition is always False",
                         value="while_false",
+                        kind="dead_branch",
+                    )
+                )
+                return findings
+
+        if isinstance(node, ast.For):
+            if _iter_is_statically_empty(node.iter) and node.body:
+                first = node.body[0]
+                findings.append(
+                    self._mk(
+                        filename,
+                        basename,
+                        line=getattr(first, "lineno", node.lineno),
+                        col=getattr(first, "col_offset", node.col_offset),
+                        msg=(
+                            "Dead code: loop body never runs because iterable is "
+                            "statically empty"
+                        ),
+                        value="for_empty_iterable",
                         kind="dead_branch",
                     )
                 )
@@ -142,6 +177,10 @@ class UnreachableCodeRule(SkylosRule):
                 stmt.orelse
             )
 
+        if isinstance(stmt, ast.While):
+            cond = _static_bool(evaluate_static_condition(stmt.test))
+            return cond is True and not self._has_current_loop_break(stmt.body)
+
         return False
 
     def _block_terminates(self, stmts):
@@ -161,4 +200,28 @@ class UnreachableCodeRule(SkylosRule):
             return "continue"
         if isinstance(stmt, ast.If):
             return "return"
+        if isinstance(stmt, ast.While):
+            return "loop that cannot fall through"
         return "return"
+
+    def _has_current_loop_break(self, stmts):
+        stack = list(reversed(stmts))
+        boundary_nodes = (
+            ast.For,
+            ast.AsyncFor,
+            ast.While,
+            ast.FunctionDef,
+            ast.AsyncFunctionDef,
+            ast.ClassDef,
+            ast.Lambda,
+        )
+
+        while stack:
+            node = stack.pop()
+            if isinstance(node, ast.Break):
+                return True
+            if isinstance(node, boundary_nodes):
+                continue
+            stack.extend(reversed(list(ast.iter_child_nodes(node))))
+
+        return False

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -2107,6 +2107,34 @@ def make_id():
         assert findings[0]["name"] == "uuid.uuid4"
         assert findings[0]["value"] == "discarded_result"
 
+    def test_analyze_flags_unreachable_loop_code(self, tmp_path):
+        src = tmp_path / "app.py"
+        src.write_text(
+            """
+def poll():
+    return None
+
+def run():
+    while True:
+        poll()
+    return "unreachable"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
+        )
+        findings = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-UC001"
+        ]
+
+        assert any(
+            f["value"] == "loop that cannot fall through" and f["line"] == 7
+            for f in findings
+        )
+
     def test_analyze_repo_rules_use_root_project_ignore_config(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
             """

--- a/test/test_unreachable.py
+++ b/test/test_unreachable.py
@@ -135,6 +135,74 @@ def loop_func():
         self.assertEqual(findings[0]["line"], 4)
         self.assertIn("always False", findings[0]["message"])
 
+    def test_for_empty_iterable_dead_branch(self):
+        code = """
+def loop_func():
+    for item in []:
+        print(item)
+    return 1
+"""
+        tree = ast.parse(code)
+        for_node = tree.body[0].body[0]
+        findings = self.rule.visit_node(for_node, self.context)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["line"], 4)
+        self.assertEqual(findings[0]["value"], "for_empty_iterable")
+        self.assertIn("statically empty", findings[0]["message"])
+
+    def test_while_true_without_break_makes_following_code_unreachable(self):
+        code = """
+def loop_func():
+    while True:
+        poll()
+    print("unreachable")
+"""
+        findings = self._analyze(code)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["line"], 5)
+        self.assertEqual(findings[0]["value"], "loop that cannot fall through")
+
+    def test_while_one_without_break_makes_following_code_unreachable(self):
+        code = """
+def loop_func():
+    while 1:
+        poll()
+    print("unreachable")
+"""
+        findings = self._analyze(code)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["line"], 5)
+
+    def test_while_true_with_current_loop_break_allows_following_code(self):
+        code = """
+def loop_func(ready):
+    while True:
+        if ready():
+            break
+        poll()
+    return 1
+"""
+        findings = self._analyze(code)
+
+        self.assertEqual(findings, [])
+
+    def test_nested_break_does_not_make_outer_while_fall_through(self):
+        code = """
+def loop_func(rows):
+    while True:
+        for row in rows:
+            break
+        poll()
+    print("unreachable")
+"""
+        findings = self._analyze(code)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["line"], 7)
+
     def test_nested_if_else_termination(self):
         code = """
 def complex_logic(x, y):


### PR DESCRIPTION
 ## Summary
  - Extend Python unreachable-code detection for loop cases.
  - Flag loop bodies that cannot run for statically empty literal iterables.
  - Flag statements after `while True` / `while 1` loops when the current loop has no reachable `break`.
  - Avoid counting nested-loop `break` statements as breaking the outer loop.

  ## Tests
  - pytest test/test_unreachable.py test/test_quality_rules.py test/test_analyzer.py`