### PR TITLE
fix(security): harden agent service and API surfaces

### DIFF
--- a/skylos/agent_service.py
+++ b/skylos/agent_service.py
@@ -5,7 +5,7 @@ import threading
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Callable
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlsplit, urlparse
 
 from skylos.agent_center import (
     clear_action_triage,
@@ -20,6 +20,64 @@ from skylos.agent_center import (
 
 def _error_payload(message: str) -> dict[str, str]:
     return {"error": message}
+
+
+def _format_origin_host(host: str) -> str:
+    host = str(host or "").strip()
+    if host.startswith("[") and host.endswith("]"):
+        return host
+    if ":" in host:
+        return f"[{host}]"
+    return host
+
+
+def _origin_for_host(host: str, port: int) -> str | None:
+    formatted = _format_origin_host(host)
+    if not formatted:
+        return None
+    return f"http://{formatted}:{port}"
+
+
+def _normalize_origin(origin: str) -> str | None:
+    origin = str(origin or "").strip()
+    if not origin:
+        return None
+
+    parsed = urlsplit(origin)
+    if not parsed.scheme or not parsed.netloc or parsed.username or parsed.password:
+        return None
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        return None
+
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+
+def _default_allowed_origins(host: str, port: int) -> frozenset[str]:
+    host = str(host or "").strip()
+    if host in {"", "0.0.0.0", "::", "::0"}:
+        origin_hosts = ("127.0.0.1", "localhost", "::1")
+    elif host in {"127.0.0.1", "localhost"}:
+        origin_hosts = ("127.0.0.1", "localhost")
+    elif host in {"::1", "[::1]"}:
+        origin_hosts = ("::1", "localhost")
+    else:
+        origin_hosts = (host,)
+
+    origins = {
+        normalized
+        for origin_host in origin_hosts
+        if (origin := _origin_for_host(origin_host, port))
+        if (normalized := _normalize_origin(origin))
+    }
+    return frozenset(origins)
+
+
+def _normalize_allowed_origins(origins: list[str]) -> frozenset[str]:
+    return frozenset(
+        normalized
+        for origin in origins
+        if (normalized := _normalize_origin(origin)) is not None
+    )
 
 
 class AgentServiceController:
@@ -240,13 +298,28 @@ class AgentServiceHandler(BaseHTTPRequestHandler):
     controller: AgentServiceController
     token: str | None = None
     default_limit: int = 10
+    allowed_origins: frozenset[str] = frozenset()
 
     def do_OPTIONS(self) -> None:
+        if not self._origin_is_allowed():
+            self._send_json(
+                HTTPStatus.FORBIDDEN,
+                _error_payload("Origin is not allowed"),
+            )
+            return
+
         self.send_response(HTTPStatus.NO_CONTENT)
         self._send_cors_headers()
         self.end_headers()
 
     def do_GET(self) -> None:
+        if not self._origin_is_allowed():
+            self._send_json(
+                HTTPStatus.FORBIDDEN,
+                _error_payload("Origin is not allowed"),
+            )
+            return
+
         if not self._is_authorized():
             return
 
@@ -260,6 +333,13 @@ class AgentServiceHandler(BaseHTTPRequestHandler):
         self._send_json(status, payload)
 
     def do_POST(self) -> None:
+        if not self._origin_is_allowed():
+            self._send_json(
+                HTTPStatus.FORBIDDEN,
+                _error_payload("Origin is not allowed"),
+            )
+            return
+
         if not self._is_authorized():
             return
 
@@ -284,6 +364,15 @@ class AgentServiceHandler(BaseHTTPRequestHandler):
             return True
         self._send_json(HTTPStatus.UNAUTHORIZED, _error_payload("Unauthorized"))
         return False
+
+    def _origin_is_allowed(self) -> bool:
+        raw_origin = self.headers.get("Origin", "")
+        if not raw_origin:
+            return True
+        origin = _normalize_origin(raw_origin)
+        if origin is None:
+            return False
+        return origin in self.allowed_origins
 
     def _read_json_body(self) -> dict[str, Any]:
         length = int(self.headers.get("Content-Length", "0") or "0")
@@ -321,11 +410,19 @@ class AgentServiceHandler(BaseHTTPRequestHandler):
         self.wfile.write(data)
 
     def _send_cors_headers(self) -> None:
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header(
-            "Access-Control-Allow-Headers", "Content-Type, X-Skylos-Agent-Token"
-        )
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        raw_origin = self.headers.get("Origin", "")
+        if not raw_origin:
+            return
+
+        self.send_header("Vary", "Origin")
+        origin = _normalize_origin(raw_origin)
+        if origin in self.allowed_origins:
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header(
+                "Access-Control-Allow-Headers",
+                "Content-Type, X-Skylos-Agent-Token",
+            )
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 
 
 class SafeAgentServiceHandler(AgentServiceHandler):
@@ -353,6 +450,7 @@ def _bind_agent_service_handler(
     *,
     token: str | None,
     default_limit: int,
+    allowed_origins: frozenset[str],
 ) -> type[SafeAgentServiceHandler]:
     return type(
         "BoundAgentServiceHandler",
@@ -361,6 +459,7 @@ def _bind_agent_service_handler(
             "controller": controller,
             "token": token,
             "default_limit": default_limit,
+            "allowed_origins": allowed_origins,
         },
     )
 
@@ -376,6 +475,7 @@ def create_agent_service(
     use_baseline: bool = True,
     default_limit: int = 10,
     refresh_on_start: bool = False,
+    allowed_origins: list[str] | None = None,
 ) -> ThreadingHTTPServer:
     controller = AgentServiceController(
         path,
@@ -385,12 +485,22 @@ def create_agent_service(
         default_limit=default_limit,
         refresh_on_start=refresh_on_start,
     )
+    server = ThreadingHTTPServer((host, port), SafeAgentServiceHandler)
+    actual_host = str(server.server_address[0])
+    actual_port = int(server.server_address[1])
+    if allowed_origins is not None:
+        normalized_allowed_origins = _normalize_allowed_origins(allowed_origins)
+    else:
+        default_origins = set(_default_allowed_origins(host, actual_port))
+        default_origins.update(_default_allowed_origins(actual_host, actual_port))
+        normalized_allowed_origins = frozenset(default_origins)
     handler_class = _bind_agent_service_handler(
         controller,
         token=token,
         default_limit=default_limit,
+        allowed_origins=normalized_allowed_origins,
     )
-    server = ThreadingHTTPServer((host, port), handler_class)
+    server.RequestHandlerClass = handler_class
     server.controller = controller  # type: ignore[attr-defined]
     return server
 
@@ -406,6 +516,7 @@ def serve_agent_service(
     use_baseline: bool = True,
     default_limit: int = 10,
     refresh_on_start: bool = False,
+    allowed_origins: list[str] | None = None,
 ) -> ThreadingHTTPServer:
     server = create_agent_service(
         path,
@@ -417,6 +528,7 @@ def serve_agent_service(
         use_baseline=use_baseline,
         default_limit=default_limit,
         refresh_on_start=refresh_on_start,
+        allowed_origins=allowed_origins,
     )
     server.serve_forever()
     return server

--- a/skylos/api.py
+++ b/skylos/api.py
@@ -1,4 +1,5 @@
 import os
+import ipaddress
 import logging
 import requests
 import subprocess
@@ -14,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 from skylos.constants import (
@@ -175,15 +177,115 @@ else:
 UPLOAD_PROTOCOL_VERSION = 1
 
 
+def _normalize_http_url(
+    url: Any,
+    *,
+    allowed_schemes: frozenset[str],
+    allow_fragment: bool = False,
+) -> str:
+    if not isinstance(url, str):
+        raise ValueError("URL must be a string")
+    stripped = url.strip()
+    parsed = urlsplit(stripped)
+    scheme = parsed.scheme.lower()
+    if scheme not in allowed_schemes:
+        raise ValueError("URL scheme is not allowed")
+    if not parsed.hostname:
+        raise ValueError("URL host is required")
+    if parsed.username or parsed.password:
+        raise ValueError("URL credentials are not allowed")
+    if parsed.fragment and not allow_fragment:
+        raise ValueError("URL fragment is not allowed")
+    return urlunsplit(
+        (
+            scheme,
+            parsed.netloc.lower(),
+            parsed.path,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def _host_is_private_or_metadata(hostname: str | None) -> bool:
+    if not hostname:
+        return True
+    host = hostname.strip("[]").rstrip(".").lower()
+    if host in {
+        "localhost",
+        "localhost.localdomain",
+        "metadata.google.internal",
+    }:
+        return True
+    if host.endswith(".localhost") or host.endswith(".local"):
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _validate_api_request_url(url: Any) -> str:
+    return _normalize_http_url(
+        url,
+        allowed_schemes=frozenset({"http", "https"}),
+    )
+
+
+def _validate_artifact_upload_url(url: Any) -> str:
+    safe_url = _normalize_http_url(url, allowed_schemes=frozenset({"https"}))
+    parsed = urlsplit(safe_url)
+    if _host_is_private_or_metadata(parsed.hostname):
+        raise ValueError("upload URL host is not allowed")
+    return safe_url
+
+
+def _validate_github_oidc_request_url(url: Any) -> str:
+    safe_url = _normalize_http_url(url, allowed_schemes=frozenset({"https"}))
+    host = (urlsplit(safe_url).hostname or "").rstrip(".").lower()
+    if host != "actions.githubusercontent.com" and not host.endswith(
+        ".actions.githubusercontent.com"
+    ):
+        raise ValueError("GitHub OIDC URL host is not allowed")
+    return safe_url
+
+
+def _append_query_param(url: str, key: str, value: str) -> str:
+    parsed = urlsplit(url)
+    query = parse_qsl(parsed.query, keep_blank_values=True)
+    query.append((key, value))
+    return urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            urlencode(query),
+            parsed.fragment,
+        )
+    )
+
+
 def _try_github_oidc_token():
     oidc_url = os.getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
     oidc_token = os.getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
     if not oidc_url or not oidc_token:
         return None
     try:
-        sep = "&" if "?" in oidc_url else "?"
+        oidc_url = _append_query_param(
+            _validate_github_oidc_request_url(oidc_url),
+            "audience",
+            "skylos",
+        )
         resp = requests.get(
-            f"{oidc_url}{sep}audience=skylos",
+            oidc_url,
             headers={"Authorization": f"Bearer {oidc_token}"},
             timeout=SUBPROCESS_TIMEOUT,
         )
@@ -293,16 +395,27 @@ def get_git_root() -> str | None:
         return None
 
 
+def _resolve_repo_link_path(git_root) -> Path | None:
+    if not git_root:
+        return None
+    root = Path(git_root).resolve()
+    candidate = (root / ".skylos" / "link.json").resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
 def _load_repo_link(git_root):
     try:
-        if not git_root:
+        p = _resolve_repo_link_path(git_root)
+        if p is None:
             return {}
-        p = os.path.join(git_root, ".skylos", "link.json")
-        if not os.path.exists(p):
+        if not p.exists():
             return {}
-        import json
 
-        return json.loads(open(p, "r", encoding="utf-8").read() or "{}")
+        return json.loads(p.read_text(encoding="utf-8") or "{}")
     except (OSError, json.JSONDecodeError, ValueError):
         return {}
 
@@ -408,15 +521,38 @@ def get_git_info() -> tuple[str, str, str, dict]:
     return commit, branch, actor, ci
 
 
-def extract_snippet(file_abs, line_number, context=SNIPPET_CONTEXT_LINES) -> str | None:
+def _resolve_snippet_path(file_abs, repo_root=None) -> Path | None:
     if not file_abs:
         return None
     try:
-        with open(file_abs, "r", encoding="utf-8", errors="ignore") as f:
-            lines = f.readlines()
+        candidate = Path(file_abs).resolve()
+        if repo_root:
+            root = Path(repo_root).resolve()
+            try:
+                candidate.relative_to(root)
+            except ValueError:
+                return None
+        if not candidate.is_file():
+            return None
+        return candidate
+    except OSError:
+        return None
+
+
+def extract_snippet(
+    file_abs,
+    line_number,
+    context=SNIPPET_CONTEXT_LINES,
+    repo_root=None,
+) -> str | None:
+    safe_path = _resolve_snippet_path(file_abs, repo_root)
+    if safe_path is None:
+        return None
+    try:
+        lines = safe_path.read_text(encoding="utf-8", errors="ignore").splitlines()
         start = max(0, line_number - 1 - context)
         end = min(len(lines), line_number + context)
-        return "\n".join([line.rstrip("\n") for line in lines[start:end]])
+        return "\n".join(lines[start:end])
     except (OSError, UnicodeDecodeError):
         return None
 
@@ -818,7 +954,9 @@ def _normalize_findings(
 
         if file_abs and line:
             finding["snippet"] = (
-                finding.get("snippet") or extract_snippet(file_abs, line) or None
+                finding.get("snippet")
+                or extract_snippet(file_abs, line, repo_root=git_root)
+                or None
             )
 
         if extract_metadata:
@@ -1366,6 +1504,11 @@ def _post_json_with_retries(
     initial_message=None,
     accepted_statuses=(200, 201, 401, 402),
 ):
+    try:
+        safe_url = _validate_api_request_url(url)
+    except ValueError as exc:
+        return None, f"Unsafe API URL: {exc}"
+
     last_err = None
     for attempt in range(3):
         try:
@@ -1375,7 +1518,7 @@ def _post_json_with_retries(
                 elif attempt > 0:
                     print(f" retrying ({attempt + 1}/3)...", end="", flush=True)
             response = requests.post(
-                url,
+                safe_url,
                 json=payload,
                 headers=headers,
                 timeout=NETWORK_TIMEOUT_LONG,
@@ -1429,6 +1572,13 @@ def upload_artifact(
     url = instruction.get("url")
     if not url:
         return {"success": False, "error": f"Missing upload URL for {artifact.name}."}
+    try:
+        safe_url = _validate_artifact_upload_url(url)
+    except ValueError as exc:
+        return {
+            "success": False,
+            "error": f"Unsafe upload URL for {artifact.name}: {exc}",
+        }
 
     headers = dict(instruction.get("headers") or {})
     accepted_statuses = tuple(instruction.get("accepted_statuses") or (200, 201, 204))
@@ -1445,7 +1595,7 @@ def upload_artifact(
                         **headers,
                     }
                     response = requests.put(
-                        url,
+                        safe_url,
                         data=handle,
                         headers=req_headers,
                         timeout=timeout,
@@ -1454,7 +1604,7 @@ def upload_artifact(
                     file_field = instruction.get("file_field") or "file"
                     fields = dict(instruction.get("fields") or {})
                     response = requests.post(
-                        url,
+                        safe_url,
                         data=fields,
                         files={
                             file_field: (

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -3492,6 +3492,13 @@ def _build_agent_parser():
     p_serve.add_argument("--no-baseline", action="store_true")
     p_serve.add_argument("--limit", type=int, default=10)
     p_serve.add_argument("--refresh-on-start", action="store_true")
+    p_serve.add_argument(
+        "--allowed-origin",
+        dest="allowed_origins",
+        action="append",
+        default=None,
+        help="Trusted browser origin for the agent API CORS allow-list. Repeatable.",
+    )
 
     return agent_parser
 
@@ -4073,6 +4080,7 @@ def main() -> None:
                     use_baseline=not agent_args.no_baseline,
                     default_limit=agent_args.limit,
                     refresh_on_start=agent_args.refresh_on_start,
+                    allowed_origins=agent_args.allowed_origins,
                 )
                 address = server.server_address
                 console.print(

--- a/skylos/login.py
+++ b/skylos/login.py
@@ -427,7 +427,20 @@ def _parse_callback_request(path: str, *, expected_state: str | None):
 
 
 def _whoami_url(base_url: str) -> str:
-    normalized = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    return _safe_whoami_url(base_url)
+
+
+def _safe_whoami_url(base_url: str) -> str:
+    normalized = (base_url or DEFAULT_BASE_URL).strip().rstrip("/")
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Login base URL must use HTTP or HTTPS")
+    if not parsed.netloc:
+        raise ValueError("Login base URL must include a host")
+    if parsed.username or parsed.password:
+        raise ValueError("Login base URL must not include credentials")
+    if parsed.fragment:
+        raise ValueError("Login base URL must not include a fragment")
     if normalized.endswith("/api"):
         return f"{normalized}/sync/whoami"
     return f"{normalized}/api/sync/whoami"
@@ -435,8 +448,13 @@ def _whoami_url(base_url: str) -> str:
 
 def _verify_login_result(token: str, *, base_url: str) -> LoginResult | None:
     try:
+        whoami_url = _safe_whoami_url(base_url)
+    except ValueError:
+        return None
+
+    try:
         resp = requests.get(
-            _whoami_url(base_url),
+            whoami_url,
             headers={"Authorization": f"Bearer {token}"},
             timeout=30,
         )

--- a/skylos/rules/danger/taint.py
+++ b/skylos/rules/danger/taint.py
@@ -18,11 +18,21 @@ CMD_SANITIZERS = {
 URL_SANITIZERS = {
     "urllib.parse.quote",
     "urllib.parse.quote_plus",
+    "_safe_sync_url",
+    "_safe_whoami_url",
+    "_validate_api_request_url",
+    "_validate_artifact_upload_url",
+    "_validate_github_oidc_request_url",
 }
 
 PATH_SANITIZERS = {
     "os.path.basename",
     "pathlib.PurePath.name",
+    "_resolve_analysis_target",
+    "_resolve_policy_path",
+    "_resolve_repo_link_path",
+    "_resolve_snippet_path",
+    "_result_path",
 }
 
 

--- a/skylos/sync.py
+++ b/skylos/sync.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from datetime import datetime, timezone
 import subprocess
+from urllib.parse import urlparse
 
 try:
     import requests
@@ -185,8 +186,39 @@ def _delete_link(repo_root: Path):
 
 
 def get_api_url():
-    return os.environ.get("SKYLOS_API_URL", DEFAULT_API_URL)
+    return _normalize_api_base_url(os.environ.get("SKYLOS_API_URL", DEFAULT_API_URL))
     # return os.environ.get("SKYLOS_API_URL", LOCAL_API_URL)
+
+
+def _normalize_api_base_url(base_url: str) -> str:
+    normalized = (base_url or DEFAULT_API_URL).strip().rstrip("/")
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"}:
+        raise AuthError("SKYLOS_API_URL must use HTTP or HTTPS")
+    if not parsed.netloc:
+        raise AuthError("SKYLOS_API_URL must include a host")
+    if parsed.username or parsed.password:
+        raise AuthError("SKYLOS_API_URL must not include credentials")
+    if parsed.fragment:
+        raise AuthError("SKYLOS_API_URL must not include a fragment")
+    return normalized
+
+
+def _normalize_api_endpoint(endpoint: str) -> str:
+    if not isinstance(endpoint, str):
+        raise AuthError("API endpoint must be a string")
+    parsed = urlparse(endpoint)
+    if parsed.scheme or parsed.netloc:
+        raise AuthError("API endpoint must be relative")
+    if not endpoint.startswith("/") or endpoint.startswith("//"):
+        raise AuthError("API endpoint must start with a single slash")
+    if "\\" in endpoint or any(part == ".." for part in parsed.path.split("/")):
+        raise AuthError("API endpoint contains an unsafe path segment")
+    return endpoint
+
+
+def _safe_sync_url(endpoint: str) -> str:
+    return f"{get_api_url()}{_normalize_api_endpoint(endpoint)}"
 
 
 def _try_ci_oidc_token():
@@ -287,7 +319,7 @@ def _auth_headers(token):
 
 
 def api_get(endpoint, token):
-    url = f"{get_api_url()}{endpoint}"
+    url = _safe_sync_url(endpoint)
 
     try:
         resp = requests.get(

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -33,15 +33,41 @@ logger = logging.getLogger("skylos-mcp")
 
 RESULTS_DIR = Path(
     os.getenv("SKYLOS_MCP_RESULTS_DIR", Path.home() / ".skylos" / "mcp_results")
-)
+).expanduser().resolve()
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
 _results_cache: dict[str, dict[str, Any]] = {}
+_RUN_ID_RE = re.compile(r"^[a-f0-9]{12}$")
+
+
+def _make_run_id(tool: str, path: str, ts: str) -> str:
+    return hashlib.sha256(f"{ts}-{tool}-{path}".encode()).hexdigest()[:12]
+
+
+def _validate_run_id(run_id: str) -> str | None:
+    candidate = str(run_id or "")
+    if candidate == "latest":
+        return candidate
+    if _RUN_ID_RE.fullmatch(candidate):
+        return candidate
+    return None
+
+
+def _result_path(run_id: str) -> Path | None:
+    safe_id = _validate_run_id(run_id)
+    if safe_id is None:
+        return None
+    candidate = (RESULTS_DIR / f"{safe_id}.json").resolve()
+    try:
+        candidate.relative_to(RESULTS_DIR)
+    except ValueError:
+        return None
+    return candidate
 
 
 def _store_result(result: dict, tool: str, path: str) -> str:
     ts = datetime.now(timezone.utc).isoformat()
-    run_id = hashlib.sha256(f"{ts}-{tool}-{path}".encode()).hexdigest()[:12]
+    run_id = _make_run_id(tool, path, ts)
 
     envelope = {
         "run_id": run_id,
@@ -55,8 +81,12 @@ def _store_result(result: dict, tool: str, path: str) -> str:
     _results_cache["latest"] = envelope
 
     try:
-        (RESULTS_DIR / f"{run_id}.json").write_text(json.dumps(envelope, indent=2))
-        (RESULTS_DIR / "latest.json").write_text(json.dumps(envelope, indent=2))
+        run_path = _result_path(run_id)
+        latest_path = _result_path("latest")
+        if run_path is not None:
+            run_path.write_text(json.dumps(envelope, indent=2))
+        if latest_path is not None:
+            latest_path.write_text(json.dumps(envelope, indent=2))
     except OSError as exc:
         logger.warning("Could not persist result to disk: %s", exc)
 
@@ -64,13 +94,18 @@ def _store_result(result: dict, tool: str, path: str) -> str:
 
 
 def _load_result(run_id: str) -> dict | None:
-    if run_id in _results_cache:
-        return _results_cache[run_id]
+    safe_id = _validate_run_id(run_id)
+    if safe_id is None:
+        return None
+    if safe_id in _results_cache:
+        return _results_cache[safe_id]
 
-    disk = RESULTS_DIR / f"{run_id}.json"
+    disk = _result_path(safe_id)
+    if disk is None:
+        return None
     if disk.exists():
         data = json.loads(disk.read_text())
-        _results_cache[run_id] = data
+        _results_cache[safe_id] = data
         return data
     return None
 
@@ -280,9 +315,22 @@ def _validate_code_change_impl(
     }
 
 
+def _resolve_analysis_target(path: str) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _resolve_policy_path(target: Path, policy_name: str) -> Path | None:
+    candidate = (target / policy_name).resolve()
+    try:
+        candidate.relative_to(target)
+    except ValueError:
+        return None
+    return candidate
+
+
 def _get_security_context_impl(path: str) -> dict:
     """Core logic for get_security_context, extracted for testability."""
-    target = Path(path).resolve()
+    target = _resolve_analysis_target(path)
     if not target.exists():
         return {"error": f"Path does not exist: {path}"}
 
@@ -428,7 +476,9 @@ def _get_security_context_impl(path: str) -> dict:
     context["input_validation"] = sorted(validation)
 
     for policy_name in (".skylos.yml", ".skylos.yaml", "skylos.yml", "skylos.yaml"):
-        policy_path = target / policy_name
+        policy_path = _resolve_policy_path(target, policy_name)
+        if policy_path is None:
+            continue
         if policy_path.exists():
             try:
                 import yaml

--- a/test/test_agent_service.py
+++ b/test/test_agent_service.py
@@ -6,12 +6,20 @@ import json
 import threading
 
 from skylos.agent_center import rebuild_agent_state_from_existing, save_agent_state
-from skylos.agent_service import AgentServiceController, create_agent_service
+from skylos.agent_service import (
+    AgentServiceController,
+    _default_allowed_origins,
+    create_agent_service,
+)
 
 
 @contextlib.contextmanager
 def running_agent_service(
-    project_root, *, token: str | None = None, default_limit: int = 10
+    project_root,
+    *,
+    token: str | None = None,
+    default_limit: int = 10,
+    allowed_origins: list[str] | None = None,
 ):
     server = create_agent_service(
         str(project_root),
@@ -19,6 +27,7 @@ def running_agent_service(
         port=0,
         token=token,
         default_limit=default_limit,
+        allowed_origins=allowed_origins,
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -30,6 +39,41 @@ def running_agent_service(
         thread.join(timeout=5)
 
 
+def request_http(
+    server,
+    method: str,
+    path: str,
+    *,
+    token: str | None = None,
+    body: dict | None = None,
+    raw_body: str | None = None,
+    origin: str | None = None,
+    headers: dict[str, str] | None = None,
+):
+    host, port = server.server_address
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    request_headers = {"Content-Type": "application/json"}
+    if origin is not None:
+        request_headers["Origin"] = origin
+    if token is not None:
+        request_headers["X-Skylos-Agent-Token"] = token
+    if headers:
+        request_headers.update(headers)
+    payload = (
+        raw_body
+        if raw_body is not None
+        else (None if body is None else json.dumps(body))
+    )
+    try:
+        conn.request(method, path, body=payload, headers=request_headers)
+        response = conn.getresponse()
+        response_headers = {k.lower(): v for k, v in response.getheaders()}
+        raw = response.read().decode("utf-8")
+        return response.status, response_headers, raw
+    finally:
+        conn.close()
+
+
 def request_json(
     server,
     method: str,
@@ -38,24 +82,24 @@ def request_json(
     token: str | None = None,
     body: dict | None = None,
     raw_body: str | None = None,
+    origin: str | None = None,
+    headers: dict[str, str] | None = None,
 ):
-    host, port = server.server_address
-    conn = http.client.HTTPConnection(host, port, timeout=5)
-    headers = {"Content-Type": "application/json"}
-    if token is not None:
-        headers["X-Skylos-Agent-Token"] = token
-    payload = (
-        raw_body
-        if raw_body is not None
-        else (None if body is None else json.dumps(body))
+    status, _headers, raw = request_http(
+        server,
+        method,
+        path,
+        token=token,
+        body=body,
+        raw_body=raw_body,
+        origin=origin,
+        headers=headers,
     )
-    try:
-        conn.request(method, path, body=payload, headers=headers)
-        response = conn.getresponse()
-        raw = response.read().decode("utf-8")
-        return response.status, json.loads(raw)
-    finally:
-        conn.close()
+    return status, json.loads(raw)
+
+
+def service_origin(server, host: str = "127.0.0.1") -> str:
+    return f"http://{host}:{server.server_address[1]}"
 
 
 def build_service_state(project_root, findings):
@@ -384,3 +428,181 @@ def test_create_agent_service_limit_fallback_and_clamp(tmp_path):
         )
         assert status == 200
         assert len(payload["items"]) == 10
+
+
+def test_agent_service_cors_rejects_disallowed_origin_before_mutation(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "security:1",
+                "rule_id": "SKY-D999",
+                "category": "security",
+                "severity": "HIGH",
+                "message": "Shell injection path",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 9,
+                "confidence": 91,
+                "is_new_vs_baseline": True,
+                "is_new_since_last_scan": True,
+                "is_in_changed_file": True,
+            },
+        ],
+    )
+
+    with running_agent_service(project_root) as server:
+        status, headers, raw = request_http(
+            server,
+            "POST",
+            "/triage/dismiss",
+            origin="https://evil.example.com",
+            body={"action_id": "security:1"},
+        )
+        assert status == 403
+        assert json.loads(raw) == {"error": "Origin is not allowed"}
+        assert "access-control-allow-origin" not in headers
+        assert headers["vary"] == "Origin"
+
+        status, headers, raw = request_http(
+            server,
+            "POST",
+            "/triage/dismiss",
+            origin="null",
+            body={"action_id": "security:1"},
+        )
+        assert status == 403
+        assert json.loads(raw) == {"error": "Origin is not allowed"}
+        assert "access-control-allow-origin" not in headers
+        assert headers["vary"] == "Origin"
+
+        status, payload = request_json(server, "GET", "/state")
+        assert status == 200
+        assert payload.get("triage", {}) == {}
+
+
+def test_agent_service_cors_allows_default_local_origin_to_mutate(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "security:1",
+                "rule_id": "SKY-D999",
+                "category": "security",
+                "severity": "HIGH",
+                "message": "Shell injection path",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 9,
+                "confidence": 91,
+                "is_new_vs_baseline": True,
+                "is_new_since_last_scan": True,
+                "is_in_changed_file": True,
+            },
+        ],
+    )
+
+    with running_agent_service(project_root) as server:
+        origin = service_origin(server)
+        status, headers, raw = request_http(
+            server,
+            "POST",
+            "/triage/dismiss",
+            origin=origin,
+            body={"action_id": "security:1"},
+        )
+        payload = json.loads(raw)
+
+        assert status == 200
+        assert headers["access-control-allow-origin"] == origin
+        assert headers["vary"] == "Origin"
+        assert payload["triage"]["security:1"]["status"] == "dismissed"
+
+
+def test_agent_service_cors_preflight_origin_policy(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(project_root, [])
+
+    with running_agent_service(project_root) as server:
+        status, headers, _raw = request_http(
+            server,
+            "OPTIONS",
+            "/triage/dismiss",
+            origin="https://evil.example.com",
+            headers={"Access-Control-Request-Method": "POST"},
+        )
+        assert status == 403
+        assert "access-control-allow-origin" not in headers
+
+        origin = service_origin(server)
+        status, headers, raw = request_http(
+            server,
+            "OPTIONS",
+            "/triage/dismiss",
+            origin=origin,
+            headers={"Access-Control-Request-Method": "POST"},
+        )
+        assert status == 204
+        assert raw == ""
+        assert headers["access-control-allow-origin"] == origin
+        assert "X-Skylos-Agent-Token" in headers["access-control-allow-headers"]
+        assert "POST" in headers["access-control-allow-methods"]
+
+
+def test_agent_service_cors_custom_allowed_origins_override_defaults(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(project_root, [])
+
+    with running_agent_service(
+        project_root,
+        allowed_origins=["https://dashboard.example.com/"],
+    ) as server:
+        status, headers, raw = request_http(
+            server,
+            "GET",
+            "/health",
+            origin="https://dashboard.example.com",
+        )
+        assert status == 200
+        assert json.loads(raw)["ok"] is True
+        assert (
+            headers["access-control-allow-origin"]
+            == "https://dashboard.example.com"
+        )
+
+        status, headers, _raw = request_http(
+            server,
+            "GET",
+            "/health",
+            origin=service_origin(server),
+        )
+        assert status == 403
+        assert "access-control-allow-origin" not in headers
+
+
+def test_agent_service_no_origin_header_still_works_without_cors_grant(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    build_service_state(project_root, [])
+
+    with running_agent_service(project_root) as server:
+        status, headers, raw = request_http(server, "GET", "/health")
+        assert status == 200
+        assert json.loads(raw)["ok"] is True
+        assert "access-control-allow-origin" not in headers
+
+
+def test_default_allowed_origins_include_ipv6_loopback():
+    wildcard_origins = _default_allowed_origins("0.0.0.0", 5089)
+    ipv6_origins = _default_allowed_origins("::1", 5089)
+
+    assert "http://127.0.0.1:5089" in wildcard_origins
+    assert "http://localhost:5089" in wildcard_origins
+    assert "http://[::1]:5089" in wildcard_origins
+    assert "http://[::1]:5089" in ipv6_origins

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,7 +5,7 @@ import subprocess
 import gzip
 import tempfile
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
 
 import skylos.api as api
 from skylos.api import (
@@ -232,20 +232,46 @@ class TestSkylosApi(unittest.TestCase):
 
     def test_extract_snippet_valid(self):
         content = "line1\nline2\nline3\nline4\nline5\n"
-        with patch("builtins.open", mock_open(read_data=content)):
-            snippet = extract_snippet("fake.py", 3, context=1)
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(content)
+            file_path = handle.name
+        try:
+            snippet = extract_snippet(file_path, 3, context=1)
             self.assertEqual(snippet, "line2\nline3\nline4")
+        finally:
+            os.unlink(file_path)
 
     def test_extract_snippet_context_zero(self):
         content = "a\nb\nc\nd\n"
-        with patch("builtins.open", mock_open(read_data=content)):
-            snippet = extract_snippet("fake.py", 3, context=0)
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(content)
+            file_path = handle.name
+        try:
+            snippet = extract_snippet(file_path, 3, context=0)
             self.assertEqual(snippet, "c")
+        finally:
+            os.unlink(file_path)
 
     def test_extract_snippet_missing_file_returns_none(self):
-        with patch("builtins.open", side_effect=FileNotFoundError):
-            snippet = extract_snippet("missing.py", 1, context=2)
-            self.assertIsNone(snippet)
+        snippet = extract_snippet("missing.py", 1, context=2)
+        self.assertIsNone(snippet)
+
+    def test_extract_snippet_rejects_file_outside_repo_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = api.Path(td) / "repo"
+            outside = api.Path(td) / "outside.txt"
+            inside = repo / "inside.txt"
+            repo.mkdir()
+            inside.write_text("inside\n", encoding="utf-8")
+            outside.write_text("outside\n", encoding="utf-8")
+
+            self.assertEqual(
+                extract_snippet(str(inside), 1, context=0, repo_root=str(repo)),
+                "inside",
+            )
+            self.assertIsNone(
+                extract_snippet(str(outside), 1, context=0, repo_root=str(repo))
+            )
 
     @patch("skylos.api.get_project_token")
     @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
@@ -1067,6 +1093,61 @@ class TestSkylosApi(unittest.TestCase):
         kwargs = mock_post.call_args.kwargs
         self.assertEqual(kwargs["data"]["key"], "artifact-key")
         self.assertEqual(kwargs["files"]["file"][0], "definitions.json.gz")
+
+    @patch("requests.put")
+    def test_upload_artifact_rejects_private_upload_url(self, mock_put):
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            handle.write(b"abc")
+            artifact_path = handle.name
+
+        artifact = api.UploadArtifact(
+            name="definitions",
+            file_path=api.Path(artifact_path),
+            filename="definitions.json.gz",
+            required=False,
+            content_type="application/json",
+            content_encoding="gzip",
+            size_bytes=3,
+            sha256="abc123",
+        )
+        try:
+            result = api.upload_artifact(
+                artifact,
+                {"method": "PUT", "url": "https://169.254.169.254/upload"},
+            )
+        finally:
+            artifact.cleanup()
+
+        self.assertFalse(result["success"])
+        self.assertIn("Unsafe upload URL", result["error"])
+        mock_put.assert_not_called()
+
+    @patch("requests.post")
+    def test_post_json_with_retries_rejects_non_http_url(self, mock_post):
+        response, error = api._post_json_with_retries(
+            "file:///tmp/report",
+            {},
+            {"ok": True},
+            quiet=True,
+        )
+
+        self.assertIsNone(response)
+        self.assertIn("Unsafe API URL", error)
+        mock_post.assert_not_called()
+
+    @patch("requests.get")
+    def test_github_oidc_token_rejects_non_github_url(self, mock_get):
+        with patch.dict(
+            os.environ,
+            {
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://169.254.169.254/token",
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "TOKEN",
+            },
+            clear=False,
+        ):
+            self.assertIsNone(api._try_github_oidc_token())
+
+        mock_get.assert_not_called()
 
 
 class TestDetectCI(unittest.TestCase):

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -64,6 +64,15 @@ def test_verify_login_result_rejects_missing_project_id(monkeypatch):
     assert loginmod._verify_login_result("TOK", base_url="https://skylos.dev") is None
 
 
+def test_verify_login_result_rejects_unsafe_base_url(monkeypatch):
+    def fail_get(*args, **kwargs):
+        raise AssertionError("unsafe login URL should not be requested")
+
+    monkeypatch.setattr(loginmod.requests, "get", fail_get)
+
+    assert loginmod._verify_login_result("TOK", base_url="file:///tmp/socket") is None
+
+
 def test_browser_login_rejects_unverified_callback(monkeypatch):
     class FakeServer:
         timeout = 5

--- a/test/test_mcp_summary.py
+++ b/test/test_mcp_summary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import skylos_mcp.server as mcp_server
 from skylos_mcp.server import (
     _architecture_payload,
     _health_score_payload,
@@ -93,3 +94,11 @@ def test_health_score_payload_summarizes_counts_and_grade():
     assert payload["top_issues"] == [
         {"category": "quality", "key_issue": "Architecture layer violation"}
     ]
+
+
+def test_load_result_rejects_path_traversal_run_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(mcp_server, "RESULTS_DIR", tmp_path)
+    mcp_server._results_cache.clear()
+
+    assert mcp_server._load_result("../latest") is None
+    assert mcp_server._load_result("latest/../../secret") is None

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -180,6 +180,25 @@ def test_api_get_success(monkeypatch):
     assert out == {"ok": True}
 
 
+def test_api_get_rejects_absolute_endpoint(monkeypatch):
+    def fail_get(*args, **kwargs):
+        raise AssertionError("unsafe endpoint should not be requested")
+
+    monkeypatch.setattr(syncmod.requests, "get", fail_get)
+
+    with pytest.raises(syncmod.AuthError) as e:
+        syncmod.api_get("https://evil.example/api/sync/whoami", "TOKEN")
+    assert "relative" in str(e.value)
+
+
+def test_api_get_rejects_unsafe_base_url(monkeypatch):
+    monkeypatch.setenv("SKYLOS_API_URL", "file:///tmp/socket")
+
+    with pytest.raises(syncmod.AuthError) as e:
+        syncmod.api_get("/api/sync/whoami", "TOKEN")
+    assert "HTTP or HTTPS" in str(e.value)
+
+
 def test_api_get_401_raises(monkeypatch):
     def fake_get(url, headers=None, timeout=None):
         return FakeResponse(401, {"ok": False})


### PR DESCRIPTION
## Summary

  - restrict agent service CORS to explicit trusted origins instead of wildcard responses
  - reject disallowed browser origins before agent state mutation
  - harden API-facing URL handling against SSRF-style inputs
  - constrain repo snippet/link reads and MCP result lookup paths

Credit to @sebastiondev for reporting the permissive agent service CORS behavior in #333. This PR reimplements the fix in-tree with stricter origin rejection and broader API hardening.

## Security

This avoids merging the public security fix PR directly and keeps the remediation aligned with `SECURITY.md`.

  ## Tests

  -  pytest test/test_api.py test/test_login.py test/test_sync.py test/ test_mcp_summary.py test/test_agent_service.py`
  -  pytest test/test_ssrf.py test/test_path_traversal.py test/test_api.py test/test_login.py test/test_sync.py test/test_mcp_summary.py test/test_agent_service.py`
  - pre-commit run skylos-gate`
  - pytest .`