### PR TITLE
feat(security): add SSRF evidence packets

### DIFF
--- a/skylos/api.py
+++ b/skylos/api.py
@@ -960,7 +960,12 @@ def _normalize_findings(
             )
 
         if extract_metadata:
-            metadata = {}
+            existing_metadata = finding.get("metadata")
+            metadata = (
+                dict(existing_metadata)
+                if isinstance(existing_metadata, dict)
+                else {}
+            )
             for meta_key in (
                 "_source",
                 "_confidence",

--- a/skylos/rules/danger/danger_net/ssrf_flow.py
+++ b/skylos/rules/danger/danger_net/ssrf_flow.py
@@ -209,6 +209,77 @@ def _is_interpolated_string(node):
     return False
 
 
+def _safe_expr_text(node: ast.AST | None, max_length: int = 160) -> str:
+    if node is None:
+        return "unknown"
+    try:
+        text = ast.unparse(node)
+    except Exception:
+        text = type(node).__name__
+    text = " ".join(str(text).split())
+    if len(text) > max_length:
+        return text[: max_length - 3] + "..."
+    return text or "unknown"
+
+
+def _request_base_name(node: ast.AST | None) -> str | None:
+    current = node
+    while isinstance(current, (ast.Attribute, ast.Subscript)):
+        current = current.value
+    if isinstance(current, ast.Name):
+        return current.id
+    return None
+
+
+def _source_label(node: ast.AST, *, interpolated: bool) -> str:
+    if _request_base_name(node) == "request":
+        return "request-derived URL value"
+    if isinstance(node, ast.Name):
+        return f"tainted variable `{node.id}`"
+    if isinstance(node, ast.JoinedStr) or interpolated:
+        return "interpolated URL expression"
+    return "tainted URL expression"
+
+
+def _ssrf_security_evidence(
+    *,
+    symbol: str,
+    sink: str,
+    url_arg: ast.AST,
+    interpolated: bool,
+) -> dict:
+    source = _source_label(url_arg, interpolated=interpolated)
+    expression = _safe_expr_text(url_arg)
+    entrypoint = symbol if symbol and symbol != "<module>" else None
+
+    evidence = {
+        "evidence_kind": "source_to_sink",
+        "source": source,
+        "sink": sink,
+        "path": [
+            source,
+            f"url expression `{expression}`",
+            f"HTTP sink `{sink}`",
+        ],
+        "guards_seen": [],
+        "guards_missing": [
+            "URL host or scheme allowlist",
+            "private, loopback, and metadata host rejection",
+        ],
+        "confidence_reason": (
+            "Untrusted URL data can influence the outbound HTTP request target."
+        ),
+        "test_hint": (
+            "Assert untrusted input cannot control the request host and private "
+            "or metadata URLs are rejected before the HTTP client call."
+        ),
+        "fix_shape": "validate and allowlist the URL before the HTTP request",
+    }
+    if entrypoint:
+        evidence["entrypoint"] = entrypoint
+    return evidence
+
+
 class _SSRFFlowChecker(TaintVisitor):
     HTTP_METHODS = {"get", "post", "put", "delete", "head", "options", "request"}
 
@@ -258,6 +329,29 @@ class _SSRFFlowChecker(TaintVisitor):
 
         return False
 
+    def _append_finding(self, node: ast.Call, url_arg: ast.AST, sink: str) -> None:
+        interpolated = _is_interpolated_string(url_arg)
+        symbol = self._current_symbol()
+        self.findings.append(
+            {
+                "rule_id": "SKY-D216",
+                "severity": "CRITICAL",
+                "message": "Possible SSRF: tainted URL passed to HTTP client.",
+                "file": str(self.file_path),
+                "line": node.lineno,
+                "col": node.col_offset,
+                "symbol": symbol,
+                "metadata": {
+                    "security_evidence": _ssrf_security_evidence(
+                        symbol=symbol,
+                        sink=sink,
+                        url_arg=url_arg,
+                        interpolated=interpolated,
+                    )
+                },
+            }
+        )
+
     def visit_Call(self, node):
         qn = _qualified_name_from_call(node)
 
@@ -270,34 +364,14 @@ class _SSRFFlowChecker(TaintVisitor):
                     if _is_interpolated_string(url_arg) or _tainted_url_is_ssrf_relevant(
                         self, url_arg
                     ):
-                        self.findings.append(
-                            {
-                                "rule_id": "SKY-D216",
-                                "severity": "CRITICAL",
-                                "message": "Possible SSRF: tainted URL passed to HTTP client.",
-                                "file": str(self.file_path),
-                                "line": node.lineno,
-                                "col": node.col_offset,
-                                "symbol": self._current_symbol(),
-                            }
-                        )
+                        self._append_finding(node, url_arg, qn)
 
         if qn and qn.endswith(".urlopen") and node.args:
             url_arg = node.args[0]
             if _is_interpolated_string(url_arg) or _tainted_url_is_ssrf_relevant(
                 self, url_arg
             ):
-                self.findings.append(
-                    {
-                        "rule_id": "SKY-D216",
-                        "severity": "CRITICAL",
-                        "message": "Possible SSRF: tainted URL passed to HTTP client.",
-                        "file": str(self.file_path),
-                        "line": node.lineno,
-                        "col": node.col_offset,
-                        "symbol": self._current_symbol(),
-                    }
-                )
+                self._append_finding(node, url_arg, qn)
 
         self.generic_visit(node)
 

--- a/test/test_sarif_exporter.py
+++ b/test/test_sarif_exporter.py
@@ -170,8 +170,11 @@ def test_results_include_skylos_metadata_when_present():
             "category": "SECURITY",
             "metadata": {
                 "security_evidence": {
+                    "evidence_kind": "source_to_sink",
+                    "entrypoint": "admin_handler",
                     "contract_id": "admin-route-auth",
                     "missing_guards": ["require_admin"],
+                    "path": ["request", "handler", "response"],
                 }
             },
         }
@@ -181,6 +184,9 @@ def test_results_include_skylos_metadata_when_present():
     result = sarif["runs"][0]["results"][0]
 
     assert result["properties"]["skylos_metadata"]["security_evidence"] == {
+        "evidence_kind": "source_to_sink",
+        "entrypoint": "admin_handler",
         "contract_id": "admin-route-auth",
         "missing_guards": ["require_admin"],
+        "path": ["request", "handler", "response"],
     }

--- a/test/test_security_verifier.py
+++ b/test/test_security_verifier.py
@@ -136,3 +136,37 @@ def test_normalize_findings_preserves_security_review_metadata():
     assert metadata["ci_blocking"] is False
     assert metadata["security_evidence"] == "review_supported"
     assert metadata["review_verdict"] == "SUPPORTED"
+
+
+def test_normalize_findings_preserves_existing_security_evidence_packet():
+    packet = {
+        "evidence_kind": "source_to_sink",
+        "entrypoint": "fetch_url",
+        "source": "tainted variable `url`",
+        "sink": "requests.get",
+        "path": ["tainted variable `url`", "HTTP sink `requests.get`"],
+        "guards_missing": ["URL host or scheme allowlist"],
+    }
+
+    normalized = api._normalize_findings(
+        [
+            {
+                "file": "app.py",
+                "line": 8,
+                "message": "Possible SSRF",
+                "rule_id": "SKY-D216",
+                "severity": "CRITICAL",
+                "metadata": {"security_evidence": packet},
+                "_source": "static",
+                "_confidence": "high",
+            }
+        ],
+        "SECURITY",
+        "/repo",
+        extract_metadata=True,
+    )
+
+    metadata = normalized[0]["metadata"]
+    assert metadata["source"] == "static"
+    assert metadata["confidence"] == "high"
+    assert metadata["security_evidence"] == packet

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -12,6 +12,10 @@ def _rule_ids(findings):
     return {f["rule_id"] for f in findings}
 
 
+def _ssrf_findings(findings):
+    return [f for f in findings if f["rule_id"] == "SKY-D216"]
+
+
 def _scan_one(tmp_path: Path, name, code):
     file_path = _write(tmp_path, name, code)
     return scan_ctx(tmp_path, [file_path])
@@ -21,6 +25,21 @@ def test_requests_tainted_url_flags(tmp_path):
     code = "import requests\ndef f():\n    u = input()\n    requests.get(u)\n"
     out = _scan_one(tmp_path, "ssrf_req.py", code)
     assert "SKY-D216" in _rule_ids(out)
+
+
+def test_requests_tainted_url_includes_security_evidence(tmp_path):
+    code = "import requests\ndef fetch_url(url):\n    return requests.get(url)\n"
+    out = _scan_one(tmp_path, "ssrf_evidence.py", code)
+    finding = _ssrf_findings(out)[0]
+
+    evidence = finding["metadata"]["security_evidence"]
+    assert evidence["evidence_kind"] == "source_to_sink"
+    assert evidence["entrypoint"] == "fetch_url"
+    assert evidence["source"] == "tainted variable `url`"
+    assert evidence["sink"] == "requests.get"
+    assert "URL host or scheme allowlist" in evidence["guards_missing"]
+    assert "test_hint" in evidence
+    assert "fix_shape" in evidence
 
 
 def test_httpx_tainted_url_flags(tmp_path):
@@ -33,6 +52,16 @@ def test_urllib_urlopen_tainted_url_flags(tmp_path):
     code = "import urllib.request as u\ndef f(x):\n    u.urlopen(f'http://{x}')\n"
     out = _scan_one(tmp_path, "ssrf_urlopen.py", code)
     assert "SKY-D216" in _rule_ids(out)
+
+
+def test_urllib_urlopen_security_evidence_names_sink(tmp_path):
+    code = "import urllib.request as u\ndef f(x):\n    u.urlopen(f'http://{x}')\n"
+    out = _scan_one(tmp_path, "ssrf_urlopen_evidence.py", code)
+    evidence = _ssrf_findings(out)[0]["metadata"]["security_evidence"]
+
+    assert evidence["sink"] == "u.urlopen"
+    assert evidence["source"] == "interpolated URL expression"
+    assert any("HTTP sink `u.urlopen`" == step for step in evidence["path"])
 
 
 def test_requests_constant_url_ok(tmp_path):


### PR DESCRIPTION
## Summary

  - attach structured `metadata.security_evidence` packets to Python SSRF findings
  - preserve existing finding metadata during report upload normalization

  ## Notes

SSRF findings now carry source, sink, path, missing guards, confidence reason, test hint

  ## Tests

  - pytest test/test_ssrf.py test/test_security_verifier.py test/test_sarif_exporter.py`
  - pytest test/test_api.py test/test_security_verifier.py test/test_sarif_exporter.py test/test_ssrf.py`
  - pytest test/test_ssrf.py test/test_security_verifier.py test/test_api.py test/test_dangerous.py test/test_path_traversal.py`