### PR TITLE
feat(security): add Deep Mode audit foundation

### DIFF
--- a/skylos/api.py
+++ b/skylos/api.py
@@ -960,7 +960,12 @@ def _normalize_findings(
             )
 
         if extract_metadata:
-            metadata = {}
+            existing_metadata = finding.get("metadata")
+            metadata = (
+                dict(existing_metadata)
+                if isinstance(existing_metadata, dict)
+                else {}
+            )
             for meta_key in (
                 "_source",
                 "_confidence",

--- a/skylos/audit_candidates.py
+++ b/skylos/audit_candidates.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from skylos.audit_redaction import sanitize_for_audit
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    DEFAULT_PROJECT_ID,
+    STATUS_ERROR,
+    STATUS_NOT_ANALYZED,
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    AuditCandidate,
+    AuditScanSummary,
+    code_region_hash,
+    language_for_path,
+    normalize_relative_path,
+    sha256_file,
+    sha256_text,
+    stable_json_hash,
+)
+from skylos.config import load_config
+from skylos.constants import parse_exclude_folders
+from skylos.file_discovery import discover_source_files, should_exclude_path
+from skylos.llm.repo_activation import build_repo_activation_index
+from skylos.pipeline import run_static_on_files
+from skylos.rules.secrets import scan_ctx as scan_secrets_ctx
+
+DEEP_AUDIT_EXTENSIONS = (
+    ".py",
+    ".pyi",
+    ".pyw",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".go",
+    ".java",
+    ".php",
+    ".rs",
+    ".dart",
+    ".env",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".conf",
+)
+
+SEVERITY_PRIORITY = {
+    "critical": 1000,
+    "high": 800,
+    "medium": 500,
+    "low": 200,
+    "info": 100,
+}
+
+SECURITY_PATH_TOKENS = (
+    "admin",
+    "auth",
+    "billing",
+    "crypto",
+    "login",
+    "oauth",
+    "password",
+    "payment",
+    "query",
+    "secret",
+    "session",
+    "sql",
+    "token",
+    "upload",
+)
+
+
+def scan_deep_audit_candidates(
+    path: str | Path,
+    *,
+    project_id: str = DEFAULT_PROJECT_ID,
+    changed_files: list[str | Path] | None = None,
+    exclude_folders: list[str] | None = None,
+    audit_root: str | Path | None = None,
+) -> tuple[AuditScanSummary, AuditStore]:
+    project_root = _project_root(path)
+    project_cfg = load_config(project_root)
+    parsed_excludes = list(
+        exclude_folders
+        or parse_exclude_folders(
+            use_defaults=True,
+            config_exclude_folders=project_cfg.get("exclude"),
+        )
+    )
+    if ".skylos" not in parsed_excludes:
+        parsed_excludes.append(".skylos")
+    config_hash = stable_json_hash(
+        {
+            "config": project_cfg,
+            "exclude": parsed_excludes,
+            "extensions": DEEP_AUDIT_EXTENSIONS,
+        }
+    )
+
+    files = _discover_audit_files(
+        path,
+        project_root=project_root,
+        changed_files=changed_files,
+        exclude_folders=parsed_excludes,
+    )
+    static_result = run_static_on_files(
+        files,
+        project_root=project_root,
+        conf=10,
+        enable_secrets=True,
+        enable_danger=True,
+        enable_quality=False,
+        exclude_folders=parsed_excludes,
+    )
+    _merge_direct_secret_findings(
+        static_result,
+        files,
+        project_root=project_root,
+    )
+    candidates_by_file = _build_static_candidates(
+        files,
+        project_root=project_root,
+        static_result=static_result,
+    )
+    _add_repo_activation_candidates(
+        candidates_by_file,
+        files,
+        project_root=project_root,
+        static_result=static_result,
+    )
+    _add_path_signal_candidates(candidates_by_file, files, project_root=project_root)
+
+    store = AuditStore(project_root, project_id=project_id, audit_root=audit_root)
+    store.init_project(config_hash=config_hash)
+
+    records_written = 0
+    candidate_count = 0
+    redacted_candidates = 0
+    pending_files = 0
+    not_analyzed_files = 0
+    processing_files = 0
+    error_files = 0
+
+    for file_path in files:
+        rel_path = normalize_relative_path(project_root, file_path)
+        candidate_map = {
+            candidate.candidate_id: candidate
+            for candidate in candidates_by_file.get(rel_path, [])
+        }
+        candidates = sorted(
+            candidate_map.values(),
+            key=lambda item: (-item.priority, item.candidate_id),
+        )
+        file_hash = sha256_file(Path(file_path))
+        record = store.upsert_scan_record(
+            file_path=file_path,
+            file_hash=file_hash,
+            language=language_for_path(file_path),
+            candidates=candidates,
+            config_hash=config_hash,
+        )
+        records_written += 1
+        candidate_count += len(candidates)
+        redacted_candidates += sum(1 for candidate in candidates if candidate.redacted)
+        if record.status == STATUS_PENDING:
+            pending_files += 1
+        elif record.status == STATUS_NOT_ANALYZED:
+            not_analyzed_files += 1
+        elif record.status == STATUS_PROCESSING:
+            processing_files += 1
+        elif record.status == STATUS_ERROR:
+            error_files += 1
+
+    summary = AuditScanSummary(
+        project_id=project_id,
+        project_root=str(project_root),
+        files_scanned=len(files),
+        records_written=records_written,
+        candidate_count=candidate_count,
+        redacted_candidates=redacted_candidates,
+        pending_files=pending_files,
+        processing_files=processing_files,
+        not_analyzed_files=not_analyzed_files,
+        error_files=error_files,
+        complete=(
+            pending_files == 0 and processing_files == 0 and error_files == 0
+        ),
+    )
+    run_id = f"scan-{uuid4().hex[:12]}"
+    store.write_run(
+        run_id,
+        {
+            "mode": "scan_only",
+            "summary": summary.to_dict(),
+        },
+    )
+    return summary, store
+
+
+def _project_root(path: str | Path) -> Path:
+    target = Path(path).resolve()
+    return target.parent if target.is_file() else target
+
+
+def _discover_audit_files(
+    path: str | Path,
+    *,
+    project_root: Path,
+    changed_files: list[str | Path] | None,
+    exclude_folders: list[str],
+) -> list[Path]:
+    if changed_files is not None:
+        files = []
+        for item in changed_files:
+            try:
+                rel = normalize_relative_path(project_root, item)
+            except ValueError:
+                continue
+            candidate = project_root / rel
+            if should_exclude_path(candidate, project_root, exclude_folders):
+                continue
+            if _is_audit_file(candidate) and candidate.exists():
+                files.append(candidate.resolve())
+        return sorted(set(files))
+
+    discovered = discover_source_files(
+        path,
+        [ext for ext in DEEP_AUDIT_EXTENSIONS if ext != ".env"],
+        exclude_folders=exclude_folders,
+    )
+    target = Path(path).resolve()
+    root = target.parent if target.is_file() else target
+    if target.is_file():
+        if _is_audit_file(target) and not should_exclude_path(
+            target, root, exclude_folders
+        ):
+            discovered.append(target)
+    else:
+        for env_file in target.rglob(".env*"):
+            if not _is_audit_file(env_file):
+                continue
+            if should_exclude_path(env_file, target, exclude_folders):
+                continue
+            discovered.append(env_file.resolve())
+    return sorted(set(discovered))
+
+
+def _is_audit_file(path: Path) -> bool:
+    if path.name == ".env" or path.name.startswith(".env."):
+        return True
+    return path.suffix.lower() in DEEP_AUDIT_EXTENSIONS
+
+
+def _build_static_candidates(
+    files: list[Path],
+    *,
+    project_root: Path,
+    static_result: dict[str, Any],
+) -> dict[str, list[AuditCandidate]]:
+    source_cache = _source_cache(files, project_root=project_root)
+    candidates_by_file: dict[str, list[AuditCandidate]] = {
+        normalize_relative_path(project_root, file_path): [] for file_path in files
+    }
+
+    for finding in static_result.get("danger", []) or []:
+        try:
+            rel_path = _finding_rel_path(finding, project_root)
+        except ValueError:
+            continue
+        if rel_path not in candidates_by_file:
+            continue
+        candidates_by_file[rel_path].append(
+            _candidate_from_finding(
+                finding,
+                rel_path=rel_path,
+                source=source_cache.get(rel_path, ""),
+                kind="static_finding",
+                redacted=False,
+            )
+        )
+
+    for finding in static_result.get("secrets", []) or []:
+        try:
+            rel_path = _finding_rel_path(finding, project_root)
+        except ValueError:
+            continue
+        if rel_path not in candidates_by_file:
+            continue
+        candidates_by_file[rel_path].append(
+            _candidate_from_finding(
+                finding,
+                rel_path=rel_path,
+                source=source_cache.get(rel_path, ""),
+                kind="static_finding",
+                redacted=True,
+                reason_prefix="Secret candidate redacted before persistence",
+            )
+        )
+
+    return candidates_by_file
+
+
+def _merge_direct_secret_findings(
+    static_result: dict[str, Any],
+    files: list[Path],
+    *,
+    project_root: Path,
+) -> None:
+    seen = {
+        (
+            str(item.get("file") or ""),
+            int(item.get("line") or 1),
+            str(item.get("rule_id") or ""),
+            str(item.get("provider") or ""),
+        )
+        for item in static_result.get("secrets", []) or []
+        if isinstance(item, dict)
+    }
+    secrets = list(static_result.get("secrets", []) or [])
+    for file_path in files:
+        rel_path = normalize_relative_path(project_root, file_path)
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        findings = scan_secrets_ctx(
+            {
+                "relpath": rel_path,
+                "lines": source.splitlines(True),
+                "tree": None,
+            }
+        )
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            key = (
+                str(finding.get("file") or ""),
+                int(finding.get("line") or 1),
+                str(finding.get("rule_id") or ""),
+                str(finding.get("provider") or ""),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            secrets.append(finding)
+    static_result["secrets"] = secrets
+
+
+def _add_repo_activation_candidates(
+    candidates_by_file: dict[str, list[AuditCandidate]],
+    files: list[Path],
+    *,
+    project_root: Path,
+    static_result: dict[str, Any],
+) -> None:
+    static_findings = {
+        "security": list(static_result.get("danger", []) or []),
+        "secrets": list(static_result.get("secrets", []) or []),
+        "quality": [],
+    }
+    python_files = [
+        file_path for file_path in files if file_path.suffix.lower() == ".py"
+    ]
+    index = build_repo_activation_index(
+        python_files,
+        project_root=project_root,
+        static_findings=static_findings,
+    )
+    for meta in index.by_path.values():
+        try:
+            rel_path = normalize_relative_path(project_root, meta.path)
+        except ValueError:
+            continue
+        if rel_path not in candidates_by_file:
+            continue
+        reasons = list(
+            meta.entrypoint_reasons
+            + meta.registration_hints
+            + meta.security_hints
+        )
+        if not reasons:
+            continue
+        reason = "; ".join(reasons[:3])
+        candidate_id = _candidate_id(
+            rel_path=rel_path,
+            kind="entrypoint",
+            rule_id="SKY-AUDIT-ENTRYPOINT",
+            line=1,
+            symbol=meta.module,
+            code_hash=sha256_text(reason)[:16],
+        )
+        candidates_by_file[rel_path].append(
+            AuditCandidate(
+                candidate_id=candidate_id,
+                kind="entrypoint",
+                rule_id="SKY-AUDIT-ENTRYPOINT",
+                line=1,
+                severity_hint="medium",
+                reason=reason,
+                priority=450 + min(meta.review_score, 250),
+                symbol=meta.module,
+                code_hash=sha256_text(reason)[:16],
+                data={
+                    "review_score": meta.review_score,
+                    "prefer_full_file_review": meta.prefer_full_file_review,
+                },
+            )
+        )
+
+
+def _add_path_signal_candidates(
+    candidates_by_file: dict[str, list[AuditCandidate]],
+    files: list[Path],
+    *,
+    project_root: Path,
+) -> None:
+    for file_path in files:
+        rel_path = normalize_relative_path(project_root, file_path)
+        lowered = rel_path.lower()
+        matched = [token for token in SECURITY_PATH_TOKENS if token in lowered]
+        if not matched:
+            continue
+        reason = "Path suggests security-sensitive surface: " + ", ".join(matched[:4])
+        candidate_id = _candidate_id(
+            rel_path=rel_path,
+            kind="path_signal",
+            rule_id="SKY-AUDIT-PATH",
+            line=1,
+            code_hash=sha256_text(reason)[:16],
+        )
+        candidates_by_file.setdefault(rel_path, []).append(
+            AuditCandidate(
+                candidate_id=candidate_id,
+                kind="path_signal",
+                rule_id="SKY-AUDIT-PATH",
+                line=1,
+                severity_hint="medium",
+                reason=reason,
+                priority=350,
+                code_hash=sha256_text(reason)[:16],
+                data={"matched_tokens": matched},
+            )
+        )
+
+
+def _candidate_from_finding(
+    finding: dict[str, Any],
+    *,
+    rel_path: str,
+    source: str,
+    kind: str,
+    redacted: bool,
+    reason_prefix: str | None = None,
+) -> AuditCandidate:
+    line = int(finding.get("line") or finding.get("lineno") or 1)
+    rule_id = str(finding.get("rule_id") or "SKY-AUDIT")
+    severity = str(finding.get("severity") or "medium").lower()
+    message = str(finding.get("message") or rule_id)
+    safe_finding = sanitize_for_audit(finding)
+    code_hash = code_region_hash(source, line)
+    reason = sanitize_for_audit(message)
+    if reason_prefix:
+        reason = f"{reason_prefix}: {reason}"
+    symbol = finding.get("symbol") or finding.get("name")
+    candidate_id = _candidate_id(
+        rel_path=rel_path,
+        kind=kind,
+        rule_id=rule_id,
+        line=line,
+        symbol=str(symbol) if symbol else None,
+        source_kind=str(finding.get("source")) if finding.get("source") else None,
+        sink_kind=str(finding.get("sink")) if finding.get("sink") else None,
+        code_hash=code_hash,
+    )
+    return AuditCandidate(
+        candidate_id=candidate_id,
+        kind=kind,
+        rule_id=rule_id,
+        line=line,
+        severity_hint=severity,
+        reason=str(reason),
+        evidence="static",
+        redacted=redacted,
+        priority=SEVERITY_PRIORITY.get(severity, 400),
+        symbol=str(symbol) if symbol else None,
+        source_kind=str(finding.get("source")) if finding.get("source") else None,
+        sink_kind=str(finding.get("sink")) if finding.get("sink") else None,
+        code_hash=code_hash,
+        data=safe_finding if isinstance(safe_finding, dict) else {},
+    )
+
+
+def _candidate_id(
+    *,
+    rel_path: str,
+    kind: str,
+    rule_id: str,
+    line: int,
+    symbol: str | None = None,
+    source_kind: str | None = None,
+    sink_kind: str | None = None,
+    code_hash: str | None = None,
+) -> str:
+    payload = json.dumps(
+        {
+            "path": rel_path,
+            "kind": kind,
+            "rule_id": rule_id,
+            "line": line if not code_hash else None,
+            "symbol": symbol,
+            "source_kind": source_kind,
+            "sink_kind": sink_kind,
+            "code_hash": code_hash,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "cand-" + sha256_text(payload)[:16]
+
+
+def _finding_rel_path(finding: dict[str, Any], project_root: Path) -> str:
+    file_value = finding.get("file") or finding.get("path") or ""
+    return normalize_relative_path(project_root, file_value)
+
+
+def _source_cache(files: list[Path], *, project_root: Path) -> dict[str, str]:
+    cache: dict[str, str] = {}
+    for file_path in files:
+        rel_path = normalize_relative_path(project_root, file_path)
+        try:
+            cache[rel_path] = file_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            cache[rel_path] = ""
+    return cache

--- a/skylos/audit_processor.py
+++ b/skylos/audit_processor.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from skylos.audit_redaction import redact_text, sanitize_for_audit
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    STATUS_ANALYZED,
+    STATUS_ERROR,
+    STATUS_NOT_ANALYZED,
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    STATUS_SKIPPED,
+    AuditFileRecord,
+    AuditProcessSummary,
+    code_region_hash,
+    normalize_relative_path,
+    sha256_text,
+    utc_now,
+)
+
+SECURITY_AUDIT_ISSUE = "security_audit"
+PYTHON_LANGUAGE = "python"
+
+
+def process_deep_audit_records(
+    *,
+    store: AuditStore,
+    analyzer: Any,
+    model: str,
+    provider: str | None = None,
+    limit: int | None = None,
+    force: bool = False,
+    run_id: str | None = None,
+) -> AuditProcessSummary:
+    run_id = run_id or f"process-{uuid4().hex[:12]}"
+    records = [record for record in store.iter_file_records() if record.candidates]
+    locked_files = 0
+    run_error_files = 0
+    processed_files = 0
+    findings_added = 0
+
+    queue: list[AuditFileRecord] = []
+    for record in sorted(records, key=_record_sort_key):
+        if record.language != PYTHON_LANGUAGE:
+            if _is_active_record(record, force=force):
+                _mark_unsupported(store, record, run_id=run_id)
+            continue
+
+        if _has_secret_candidate(record):
+            if _is_active_record(record, force=force):
+                _mark_secret_skipped(store, record, run_id=run_id)
+            continue
+
+        if _should_process_record(
+            record,
+            force=force,
+            model=model,
+            provider=provider,
+        ):
+            queue.append(record)
+
+    total_queue = len(queue)
+    if limit is not None and limit >= 0:
+        queue = queue[:limit]
+    limited = len(queue) < total_queue
+
+    for queued in queue:
+        if queued.status == STATUS_ANALYZED:
+            queued.status = STATUS_PENDING
+            store.write_file_record(queued)
+
+        if not store.acquire_lock(queued.file, run_id=run_id):
+            locked_files += 1
+            continue
+
+        record = store.read_file_record(queued.file)
+        if record is None:
+            locked_files += 1
+            continue
+
+        file_path = store.project_root / record.file
+        try:
+            result = _analyze_file_with_redaction(analyzer, file_path)
+            findings = _normalize_findings(result, record=record, file_path=file_path)
+        except Exception as exc:
+            store.mark_error(record.file, f"Agent processing failed: {exc}")
+            run_error_files += 1
+            continue
+
+        existing_by_id = {
+            str(item.get("audit_finding_id")): item
+            for item in record.findings
+            if isinstance(item, dict) and item.get("audit_finding_id")
+        }
+        merged = [
+            item
+            for item in record.findings
+            if not (
+                isinstance(item, dict)
+                and item.get("audit_finding_id") in existing_by_id
+            )
+        ]
+        for finding in findings:
+            finding_id = str(finding.get("audit_finding_id"))
+            if finding_id not in existing_by_id:
+                findings_added += 1
+            existing_by_id[finding_id] = finding
+        merged.extend(existing_by_id.values())
+
+        record.status = STATUS_ANALYZED
+        record.locked_by_run_id = None
+        record.locked_at = None
+        record.last_analyzed_at = utc_now()
+        record.findings = sanitize_for_audit(merged)
+        record.analysis_history.append(
+            sanitize_for_audit(
+                {
+                    "stage": "agent_process",
+                    "run_id": run_id,
+                    "model": model,
+                    "provider": provider,
+                    "findings_count": len(findings),
+                    "candidate_count": len(record.candidates),
+                    "at": utc_now(),
+                }
+            )
+        )
+        store.write_file_record(record)
+        processed_files += 1
+
+    state_counts = _audit_state_counts(store, model=model, provider=provider)
+    remaining = state_counts["unresolved"]
+    summary = AuditProcessSummary(
+        run_id=run_id,
+        project_id=store.project_id,
+        project_root=str(store.project_root),
+        considered_files=len(records),
+        processed_files=processed_files,
+        findings_added=findings_added,
+        skipped_secret_files=state_counts[STATUS_SKIPPED],
+        unsupported_files=state_counts[STATUS_NOT_ANALYZED],
+        locked_files=locked_files,
+        error_files=state_counts[STATUS_ERROR],
+        remaining_pending_files=remaining,
+        limited=limited,
+        complete=(
+            remaining == 0
+            and not limited
+            and locked_files == 0
+            and run_error_files == 0
+        ),
+        pending_files=state_counts[STATUS_PENDING],
+        processing_files=state_counts[STATUS_PROCESSING],
+        analyzed_files=(
+            state_counts[STATUS_ANALYZED] - state_counts["stale_analyzed"]
+        ),
+        stale_analyzed_files=state_counts["stale_analyzed"],
+    )
+    store.write_run(
+        run_id,
+        {
+            "mode": "process",
+            "summary": summary.to_dict(),
+        },
+    )
+    return summary
+
+
+def _record_sort_key(record: AuditFileRecord) -> tuple[int, str]:
+    return (
+        -max((candidate.priority for candidate in record.candidates), default=0),
+        record.file,
+    )
+
+
+def _is_active_record(record: AuditFileRecord, *, force: bool) -> bool:
+    if force:
+        return record.status in {
+            STATUS_PENDING,
+            STATUS_PROCESSING,
+            STATUS_ANALYZED,
+            STATUS_ERROR,
+            STATUS_NOT_ANALYZED,
+            STATUS_SKIPPED,
+        }
+    return record.status in {STATUS_PENDING, STATUS_PROCESSING, STATUS_ERROR}
+
+
+def _should_process_record(
+    record: AuditFileRecord,
+    *,
+    force: bool,
+    model: str,
+    provider: str | None,
+) -> bool:
+    if record.status == STATUS_ANALYZED:
+        if force:
+            return True
+        return not _agent_context_matches(record, model=model, provider=provider)
+    return record.status in {STATUS_PENDING, STATUS_PROCESSING, STATUS_ERROR}
+
+
+def _agent_context_matches(
+    record: AuditFileRecord,
+    *,
+    model: str,
+    provider: str | None,
+) -> bool:
+    for item in reversed(record.analysis_history):
+        if not isinstance(item, dict) or item.get("stage") != "agent_process":
+            continue
+        return item.get("model") == model and item.get("provider") == provider
+    return False
+
+
+def _is_unresolved_record(
+    record: AuditFileRecord,
+    *,
+    model: str,
+    provider: str | None,
+) -> bool:
+    if not record.candidates:
+        return False
+    if record.status in {
+        STATUS_PENDING,
+        STATUS_PROCESSING,
+        STATUS_ERROR,
+        STATUS_NOT_ANALYZED,
+        STATUS_SKIPPED,
+    }:
+        return True
+    if record.status == STATUS_ANALYZED:
+        return not _agent_context_matches(record, model=model, provider=provider)
+    return False
+
+
+def _has_secret_candidate(record: AuditFileRecord) -> bool:
+    return any(
+        candidate.redacted or candidate.rule_id.startswith("SKY-S")
+        for candidate in record.candidates
+    )
+
+
+def _mark_unsupported(
+    store: AuditStore, record: AuditFileRecord, *, run_id: str
+) -> None:
+    current = store.read_file_record(record.file)
+    if current is None:
+        return
+    current.status = STATUS_NOT_ANALYZED
+    current.locked_by_run_id = None
+    current.locked_at = None
+    current.analysis_history.append(
+        sanitize_for_audit(
+            {
+                "stage": "unsupported_agent_language",
+                "run_id": run_id,
+                "language": current.language,
+                "reason": (
+                    "Deep Mode agent processing currently supports Python files only."
+                ),
+                "at": utc_now(),
+            }
+        )
+    )
+    store.write_file_record(current)
+
+
+def _mark_secret_skipped(
+    store: AuditStore, record: AuditFileRecord, *, run_id: str
+) -> None:
+    current = store.read_file_record(record.file)
+    if current is None:
+        return
+    current.status = STATUS_SKIPPED
+    current.locked_by_run_id = None
+    current.locked_at = None
+    current.analysis_history.append(
+        sanitize_for_audit(
+            {
+                "stage": "secret_context_skipped",
+                "run_id": run_id,
+                "reason": (
+                    "Secret-bearing files are not sent to LLM processing in this phase."
+                ),
+                "at": utc_now(),
+            }
+        )
+    )
+    store.write_file_record(current)
+
+
+def _normalize_findings(
+    findings: Any,
+    *,
+    record: AuditFileRecord,
+    file_path: Path,
+) -> list[dict[str, Any]]:
+    if hasattr(findings, "findings"):
+        findings = findings.findings
+    normalized = []
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        source = ""
+
+    for finding in findings or []:
+        if hasattr(finding, "to_dict"):
+            payload = finding.to_dict()
+        elif isinstance(finding, dict):
+            payload = dict(finding)
+        else:
+            continue
+        payload = sanitize_for_audit(payload)
+        payload["audit_finding_id"] = _finding_id(payload, record=record, source=source)
+        normalized.append(payload)
+    return normalized
+
+
+def _analyze_file_with_redaction(analyzer: Any, file_path: Path) -> Any:
+    source = file_path.read_text(encoding="utf-8", errors="ignore")
+    redacted_source = redact_text(source)
+
+    get_agent = getattr(analyzer, "_get_agent", None)
+    if callable(get_agent):
+        agent = get_agent(SECURITY_AUDIT_ISSUE)
+        context = _build_redacted_context(analyzer, redacted_source, file_path)
+        return agent.analyze(redacted_source, str(file_path), context=context)
+
+    whole_file_analyzer = getattr(analyzer, "_analyze_whole_file", None)
+    if callable(whole_file_analyzer):
+        return whole_file_analyzer(
+            redacted_source,
+            str(file_path),
+            issue_types=[SECURITY_AUDIT_ISSUE],
+        )
+
+    if redacted_source != source:
+        raise RuntimeError(
+            "Deep Mode refused to send unredacted source to an analyzer that does "
+            "not support in-memory redacted review"
+        )
+
+    return analyzer.analyze_file(
+        file_path,
+        issue_types=[SECURITY_AUDIT_ISSUE],
+    )
+
+
+def _build_redacted_context(analyzer: Any, source: str, file_path: Path) -> str | None:
+    context_builder = getattr(analyzer, "context_builder", None)
+    if context_builder is None:
+        return None
+
+    config = getattr(analyzer, "config", None)
+    repo_context_map = getattr(config, "repo_context_map", {}) or {}
+    repo_metadata = (
+        repo_context_map.get(str(file_path))
+        or repo_context_map.get(file_path.as_posix())
+        or repo_context_map.get(file_path.name)
+    )
+
+    try:
+        return context_builder.build_analysis_context(
+            source,
+            file_path=str(file_path),
+            defs_map=None,
+            include_review_hints=False,
+            repo_metadata=repo_metadata,
+        )
+    except TypeError:
+        return context_builder.build_analysis_context(
+            source,
+            file_path=str(file_path),
+            defs_map=None,
+            include_review_hints=False,
+        )
+
+
+def _finding_id(
+    finding: dict[str, Any],
+    *,
+    record: AuditFileRecord,
+    source: str,
+) -> str:
+    location = (
+        finding.get("location") if isinstance(finding.get("location"), dict) else {}
+    )
+    line = int(finding.get("line") or location.get("line") or 1)
+    payload = {
+        "path": normalize_relative_path(record.project_root, record.file),
+        "rule_id": finding.get("rule_id"),
+        "issue_type": finding.get("issue_type"),
+        "symbol": finding.get("symbol"),
+        "code_hash": code_region_hash(source, line),
+    }
+    return "finding-" + sha256_text(str(sorted(payload.items())))[:16]
+
+
+def _audit_state_counts(
+    store: AuditStore,
+    *,
+    model: str,
+    provider: str | None,
+) -> dict[str, int]:
+    counts = {
+        STATUS_PENDING: 0,
+        STATUS_PROCESSING: 0,
+        STATUS_ERROR: 0,
+        STATUS_NOT_ANALYZED: 0,
+        STATUS_SKIPPED: 0,
+        STATUS_ANALYZED: 0,
+        "stale_analyzed": 0,
+        "unresolved": 0,
+    }
+    for record in store.iter_file_records():
+        if not record.candidates:
+            continue
+        if record.status in counts:
+            counts[record.status] += 1
+        if (
+            record.status == STATUS_ANALYZED
+            and not _agent_context_matches(record, model=model, provider=provider)
+        ):
+            counts["stale_analyzed"] += 1
+        if _is_unresolved_record(record, model=model, provider=provider):
+            counts["unresolved"] += 1
+    return counts

--- a/skylos/audit_redaction.py
+++ b/skylos/audit_redaction.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+REDACTION = "[REDACTED_SECRET]"
+
+SECRET_KEYWORDS = {
+    "access_token",
+    "api_key",
+    "auth",
+    "authorization",
+    "bearer",
+    "credential",
+    "key",
+    "match",
+    "password",
+    "private_key",
+    "raw",
+    "secret",
+    "token",
+    "value",
+}
+
+SECRET_PATTERNS = (
+    re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr|gpat)_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,48}\b"),
+    re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b"),
+    re.compile(r"\b(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA)[0-9A-Z]{16}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z\-_]{35}\b"),
+    re.compile(r"\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bSK[0-9a-fA-F]{32}\b"),
+    re.compile(r"-----BEGIN (?:RSA|DSA|EC|OPENSSH|PGP) PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)AWS_SECRET_ACCESS_KEY\s*[:=]\s*[A-Za-z0-9/+=]{40}"
+    ),
+    re.compile(
+        r"(?i)\b(?:token|api[_-]?key|secret|password|passwd|pwd|auth[_-]?token)"
+        r"\s*[:=]\s*['\"][^'\"]{12,}['\"]"
+    ),
+)
+
+
+def redact_text(text: str) -> str:
+    redacted = text
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub(REDACTION, redacted)
+    return redacted
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(token in lowered for token in SECRET_KEYWORDS)
+
+
+def sanitize_for_audit(value: Any, *, key: str | None = None) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    if isinstance(value, str):
+        if key and _is_sensitive_key(key) and "preview" not in key.lower():
+            return REDACTION
+        return redact_text(value)
+
+    if isinstance(value, list):
+        return [sanitize_for_audit(item) for item in value]
+
+    if isinstance(value, tuple):
+        return [sanitize_for_audit(item) for item in value]
+
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for item_key, item_value in value.items():
+            safe_key = str(item_key)
+            sanitized[safe_key] = sanitize_for_audit(item_value, key=safe_key)
+        return sanitized
+
+    return str(value)

--- a/skylos/audit_store.py
+++ b/skylos/audit_store.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import skylos
+from skylos.audit_redaction import sanitize_for_audit
+from skylos.audit_types import (
+    CANDIDATE_ENGINE_VERSION,
+    DEFAULT_PROJECT_ID,
+    SCHEMA_VERSION,
+    STATUS_ANALYZED,
+    STATUS_ERROR,
+    STATUS_NOT_ANALYZED,
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    STATUS_SKIPPED,
+    AuditCandidate,
+    AuditFileRecord,
+    normalize_relative_path,
+    utc_now,
+)
+
+
+class AuditStore:
+    def __init__(
+        self,
+        project_root: str | Path,
+        *,
+        project_id: str = DEFAULT_PROJECT_ID,
+        audit_root: str | Path | None = None,
+    ) -> None:
+        self.project_root = Path(project_root).resolve()
+        self.project_id = project_id
+        base = (
+            Path(audit_root).resolve()
+            if audit_root
+            else self.project_root / ".skylos" / "audit"
+        )
+        self.project_dir = base / "projects" / project_id
+        self.files_dir = self.project_dir / "files"
+        self.runs_dir = self.project_dir / "runs"
+        self.exports_dir = self.project_dir / "exports"
+
+    def init_project(self, *, config_hash: str) -> None:
+        self.files_dir.mkdir(parents=True, exist_ok=True)
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+        self.exports_dir.mkdir(parents=True, exist_ok=True)
+        self._write_json_atomic(
+            self.project_dir / "project.json",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "project_id": self.project_id,
+                "project_root": str(self.project_root),
+                "skylos_version": skylos.__version__,
+                "candidate_engine_version": CANDIDATE_ENGINE_VERSION,
+                "updated_at": utc_now(),
+            },
+        )
+        self._write_json_atomic(
+            self.project_dir / "config.json",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "config_hash": config_hash,
+                "updated_at": utc_now(),
+            },
+        )
+
+    def encoded_record_name(self, rel_path: str) -> str:
+        normalized = rel_path.replace("\\", "/")
+        encoded = base64.urlsafe_b64encode(normalized.encode("utf-8")).decode("ascii")
+        return encoded.rstrip("=") + ".json"
+
+    def decoded_record_name(self, filename: str) -> str | None:
+        if not filename.endswith(".json"):
+            return None
+        stem = filename[:-5]
+        padding = "=" * (-len(stem) % 4)
+        try:
+            return base64.urlsafe_b64decode(stem + padding).decode("utf-8")
+        except Exception:
+            return None
+
+    def record_path(self, file_path: str | Path) -> Path:
+        rel_path = normalize_relative_path(self.project_root, file_path)
+        return self.files_dir / self.encoded_record_name(rel_path)
+
+    def read_file_record(self, file_path: str | Path) -> AuditFileRecord | None:
+        requested_rel_path = normalize_relative_path(self.project_root, file_path)
+        record_path = self.record_path(file_path)
+        try:
+            payload = json.loads(record_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        try:
+            record = AuditFileRecord.from_dict(payload)
+        except (KeyError, TypeError, ValueError):
+            return None
+        if record.project_id != self.project_id:
+            return None
+        if Path(record.project_root).resolve() != self.project_root:
+            return None
+        try:
+            record_rel_path = normalize_relative_path(self.project_root, record.file)
+        except ValueError:
+            return None
+        if record_rel_path != requested_rel_path:
+            return None
+        return record
+
+    def iter_file_records(self) -> list[AuditFileRecord]:
+        records: list[AuditFileRecord] = []
+        if not self.files_dir.exists():
+            return records
+        for record_file in sorted(self.files_dir.glob("*.json")):
+            rel_path = self.decoded_record_name(record_file.name)
+            if not rel_path:
+                continue
+            record = self.read_file_record(rel_path)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def write_file_record(self, record: AuditFileRecord) -> None:
+        if record.project_id != self.project_id:
+            raise ValueError("Audit record project_id mismatch")
+        if Path(record.project_root).resolve() != self.project_root:
+            raise ValueError("Audit record project_root mismatch")
+        normalize_relative_path(self.project_root, record.file)
+        self.files_dir.mkdir(parents=True, exist_ok=True)
+        payload = sanitize_for_audit(record.to_dict())
+        self._write_json_atomic(self.record_path(record.file), payload)
+
+    def upsert_scan_record(
+        self,
+        *,
+        file_path: str | Path,
+        file_hash: str,
+        language: str,
+        candidates: list[AuditCandidate],
+        config_hash: str,
+        now: str | None = None,
+    ) -> AuditFileRecord:
+        rel_path = normalize_relative_path(self.project_root, file_path)
+        now = now or utc_now()
+        existing = self.read_file_record(rel_path)
+        candidate_map = {candidate.candidate_id: candidate for candidate in candidates}
+        ordered_candidates = sorted(
+            candidate_map.values(), key=lambda item: (-item.priority, item.candidate_id)
+        )
+
+        status = STATUS_PENDING if ordered_candidates else STATUS_NOT_ANALYZED
+        preserve_history = False
+        if existing and self._record_matches_current_scan(
+            existing,
+            file_hash=file_hash,
+            config_hash=config_hash,
+        ):
+            preserve_history = True
+            existing_ids = {candidate.candidate_id for candidate in existing.candidates}
+            new_ids = set(candidate_map)
+            if existing.status == STATUS_ANALYZED and existing_ids == new_ids:
+                status = STATUS_ANALYZED
+            elif existing.status == STATUS_PROCESSING:
+                status = STATUS_PROCESSING
+            elif existing.status == STATUS_ERROR and existing_ids == new_ids:
+                status = STATUS_ERROR
+
+        record = AuditFileRecord(
+            project_id=self.project_id,
+            project_root=str(self.project_root),
+            file=rel_path,
+            file_hash=file_hash,
+            language=language,
+            status=status,
+            candidates=ordered_candidates,
+            findings=(
+                sanitize_for_audit(list(existing.findings))
+                if existing and preserve_history
+                else []
+            ),
+            analysis_history=(
+                sanitize_for_audit(list(existing.analysis_history))
+                if existing and preserve_history
+                else []
+            ),
+            revalidation=(
+                sanitize_for_audit(list(existing.revalidation))
+                if existing and preserve_history
+                else []
+            ),
+            locked_by_run_id=(
+                existing.locked_by_run_id
+                if existing and preserve_history and status == STATUS_PROCESSING
+                else None
+            ),
+            locked_at=(
+                existing.locked_at
+                if existing and preserve_history and status == STATUS_PROCESSING
+                else None
+            ),
+            last_scanned_at=now,
+            last_analyzed_at=(
+                existing.last_analyzed_at if existing and preserve_history else None
+            ),
+            skylos_version=skylos.__version__,
+            config_hash=config_hash,
+            candidate_engine_version=CANDIDATE_ENGINE_VERSION,
+        )
+        self.write_file_record(record)
+        return record
+
+    def acquire_lock(
+        self,
+        file_path: str | Path,
+        *,
+        run_id: str,
+        stale_after_seconds: int = 3600,
+        now: str | None = None,
+    ) -> bool:
+        record = self.read_file_record(file_path)
+        if record is None:
+            return False
+        if record.status == STATUS_ANALYZED:
+            return False
+        if record.status in {STATUS_NOT_ANALYZED, STATUS_SKIPPED}:
+            return False
+        now = now or utc_now()
+        if (
+            record.status == STATUS_PROCESSING
+            and record.locked_by_run_id
+            and record.locked_by_run_id != run_id
+            and not self._lock_is_stale(record.locked_at, stale_after_seconds)
+        ):
+            return False
+        record.status = STATUS_PROCESSING
+        record.locked_by_run_id = run_id
+        record.locked_at = now
+        self.write_file_record(record)
+        return True
+
+    def mark_error(self, file_path: str | Path, message: str) -> None:
+        record = self.read_file_record(file_path)
+        if record is None:
+            return
+        record.status = STATUS_ERROR
+        record.locked_by_run_id = None
+        record.locked_at = None
+        record.analysis_history.append(
+            {
+                "stage": "error",
+                "message": sanitize_for_audit(message),
+                "at": utc_now(),
+            }
+        )
+        self.write_file_record(record)
+
+    def write_run(self, run_id: str, payload: dict[str, Any]) -> Path:
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+        run_path = self.runs_dir / f"{run_id}.json"
+        merged = {
+            "schema_version": SCHEMA_VERSION,
+            "project_id": self.project_id,
+            "project_root": str(self.project_root),
+            "run_id": run_id,
+            "created_at": utc_now(),
+            **sanitize_for_audit(payload),
+        }
+        self._write_json_atomic(run_path, merged)
+        return run_path
+
+    def _record_matches_current_scan(
+        self,
+        record: AuditFileRecord,
+        *,
+        file_hash: str,
+        config_hash: str,
+    ) -> bool:
+        return (
+            record.schema_version == SCHEMA_VERSION
+            and record.file_hash == file_hash
+            and record.config_hash == config_hash
+            and record.candidate_engine_version == CANDIDATE_ENGINE_VERSION
+            and record.skylos_version == skylos.__version__
+        )
+
+    def _lock_is_stale(self, locked_at: str | None, stale_after_seconds: int) -> bool:
+        if not locked_at:
+            return True
+        try:
+            locked = datetime.fromisoformat(locked_at)
+        except ValueError:
+            return True
+        if locked.tzinfo is None:
+            locked = locked.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - locked
+        return age.total_seconds() >= stale_after_seconds
+
+    def _write_json_atomic(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        tmp_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, path)

--- a/skylos/audit_types.py
+++ b/skylos/audit_types.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import skylos
+
+SCHEMA_VERSION = 1
+CANDIDATE_ENGINE_VERSION = "deep-audit-v1"
+DEFAULT_PROJECT_ID = "default"
+
+STATUS_PENDING = "pending"
+STATUS_PROCESSING = "processing"
+STATUS_ANALYZED = "analyzed"
+STATUS_ERROR = "error"
+STATUS_NOT_ANALYZED = "not_analyzed"
+STATUS_SKIPPED = "skipped"
+
+VALID_STATUSES = {
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    STATUS_ANALYZED,
+    STATUS_ERROR,
+    STATUS_NOT_ANALYZED,
+    STATUS_SKIPPED,
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def stable_json_hash(value: Any) -> str:
+    try:
+        payload = json.dumps(value, sort_keys=True, default=str, separators=(",", ":"))
+    except TypeError:
+        payload = repr(value)
+    return sha256_text(payload)
+
+
+def normalize_relative_path(project_root: str | Path, file_path: str | Path) -> str:
+    root = Path(project_root).resolve()
+    candidate = Path(file_path)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve()
+    try:
+        rel = resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Audit path escapes project root: {file_path}") from exc
+    return rel.as_posix()
+
+
+def language_for_path(path: str | Path) -> str:
+    path_obj = Path(path)
+    if path_obj.name == ".env" or path_obj.name.startswith(".env."):
+        return "env"
+    suffix = path_obj.suffix.lower()
+    return {
+        ".py": "python",
+        ".pyi": "python",
+        ".pyw": "python",
+        ".ts": "typescript",
+        ".tsx": "typescript",
+        ".js": "javascript",
+        ".jsx": "javascript",
+        ".go": "go",
+        ".java": "java",
+        ".php": "php",
+        ".rs": "rust",
+        ".dart": "dart",
+        ".env": "env",
+        ".yaml": "yaml",
+        ".yml": "yaml",
+        ".json": "json",
+        ".toml": "toml",
+        ".ini": "ini",
+        ".cfg": "config",
+        ".conf": "config",
+    }.get(suffix, suffix.lstrip(".") or "unknown")
+
+
+def code_region_hash(source: str, line: int | None, *, radius: int = 2) -> str:
+    lines = source.splitlines()
+    if not lines:
+        return sha256_text("")
+    if not line or line < 1:
+        region = "\n".join(lines[: min(len(lines), radius * 2 + 1)])
+    else:
+        start = max(0, line - 1 - radius)
+        end = min(len(lines), line + radius)
+        region = "\n".join(lines[start:end])
+    normalized = "\n".join(part.strip() for part in region.splitlines() if part.strip())
+    return sha256_text(normalized)[:16]
+
+
+@dataclass
+class AuditCandidate:
+    candidate_id: str
+    kind: str
+    rule_id: str
+    line: int
+    severity_hint: str
+    reason: str
+    evidence: str = "static"
+    redacted: bool = False
+    priority: int = 0
+    symbol: str | None = None
+    source_kind: str | None = None
+    sink_kind: str | None = None
+    code_hash: str | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "candidate_id": self.candidate_id,
+            "kind": self.kind,
+            "rule_id": self.rule_id,
+            "line": self.line,
+            "severity_hint": self.severity_hint,
+            "reason": self.reason,
+            "evidence": self.evidence,
+            "redacted": self.redacted,
+            "priority": self.priority,
+            "symbol": self.symbol,
+            "source_kind": self.source_kind,
+            "sink_kind": self.sink_kind,
+            "code_hash": self.code_hash,
+            "data": dict(self.data),
+        }
+        return {key: value for key, value in payload.items() if value is not None}
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "AuditCandidate":
+        return cls(
+            candidate_id=str(payload["candidate_id"]),
+            kind=str(payload["kind"]),
+            rule_id=str(payload.get("rule_id") or "SKY-AUDIT"),
+            line=int(payload.get("line") or 1),
+            severity_hint=str(payload.get("severity_hint") or "medium").lower(),
+            reason=str(payload.get("reason") or ""),
+            evidence=str(payload.get("evidence") or "static"),
+            redacted=bool(payload.get("redacted", False)),
+            priority=int(payload.get("priority") or 0),
+            symbol=str(payload["symbol"]) if payload.get("symbol") else None,
+            source_kind=(
+                str(payload["source_kind"]) if payload.get("source_kind") else None
+            ),
+            sink_kind=str(payload["sink_kind"]) if payload.get("sink_kind") else None,
+            code_hash=str(payload["code_hash"]) if payload.get("code_hash") else None,
+            data=dict(payload.get("data") or {}),
+        )
+
+
+@dataclass
+class AuditFileRecord:
+    project_id: str
+    project_root: str
+    file: str
+    file_hash: str
+    language: str
+    status: str
+    candidates: list[AuditCandidate] = field(default_factory=list)
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    analysis_history: list[dict[str, Any]] = field(default_factory=list)
+    revalidation: list[dict[str, Any]] = field(default_factory=list)
+    locked_by_run_id: str | None = None
+    locked_at: str | None = None
+    last_scanned_at: str | None = None
+    last_analyzed_at: str | None = None
+    skylos_version: str = skylos.__version__
+    config_hash: str = ""
+    candidate_engine_version: str = CANDIDATE_ENGINE_VERSION
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "project_id": self.project_id,
+            "project_root": self.project_root,
+            "file": self.file,
+            "file_hash": self.file_hash,
+            "language": self.language,
+            "status": self.status,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "findings": list(self.findings),
+            "analysis_history": list(self.analysis_history),
+            "revalidation": list(self.revalidation),
+            "locked_by_run_id": self.locked_by_run_id,
+            "locked_at": self.locked_at,
+            "last_scanned_at": self.last_scanned_at,
+            "last_analyzed_at": self.last_analyzed_at,
+            "skylos_version": self.skylos_version,
+            "config_hash": self.config_hash,
+            "candidate_engine_version": self.candidate_engine_version,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "AuditFileRecord":
+        schema_version = int(payload.get("schema_version") or 0)
+        if schema_version != SCHEMA_VERSION:
+            raise ValueError(f"Unsupported audit schema version: {schema_version}")
+
+        status = str(payload.get("status") or "")
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Unsupported audit file status: {status}")
+
+        return cls(
+            schema_version=schema_version,
+            project_id=str(payload["project_id"]),
+            project_root=str(payload["project_root"]),
+            file=str(payload["file"]),
+            file_hash=str(payload["file_hash"]),
+            language=str(payload.get("language") or "unknown"),
+            status=status,
+            candidates=[
+                AuditCandidate.from_dict(item)
+                for item in payload.get("candidates") or []
+                if isinstance(item, dict)
+            ],
+            findings=[
+                dict(item)
+                for item in payload.get("findings") or []
+                if isinstance(item, dict)
+            ],
+            analysis_history=[
+                dict(item)
+                for item in payload.get("analysis_history") or []
+                if isinstance(item, dict)
+            ],
+            revalidation=[
+                dict(item)
+                for item in payload.get("revalidation") or []
+                if isinstance(item, dict)
+            ],
+            locked_by_run_id=(
+                str(payload["locked_by_run_id"])
+                if payload.get("locked_by_run_id")
+                else None
+            ),
+            locked_at=str(payload["locked_at"]) if payload.get("locked_at") else None,
+            last_scanned_at=(
+                str(payload["last_scanned_at"])
+                if payload.get("last_scanned_at")
+                else None
+            ),
+            last_analyzed_at=(
+                str(payload["last_analyzed_at"])
+                if payload.get("last_analyzed_at")
+                else None
+            ),
+            skylos_version=str(payload.get("skylos_version") or skylos.__version__),
+            config_hash=str(payload.get("config_hash") or ""),
+            candidate_engine_version=str(
+                payload.get("candidate_engine_version") or ""
+            ),
+        )
+
+
+@dataclass
+class AuditScanSummary:
+    project_id: str
+    project_root: str
+    files_scanned: int
+    records_written: int
+    candidate_count: int
+    redacted_candidates: int
+    pending_files: int
+    not_analyzed_files: int
+    processing_files: int = 0
+    error_files: int = 0
+    complete: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "project_root": self.project_root,
+            "files_scanned": self.files_scanned,
+            "records_written": self.records_written,
+            "candidate_count": self.candidate_count,
+            "redacted_candidates": self.redacted_candidates,
+            "pending_files": self.pending_files,
+            "processing_files": self.processing_files,
+            "not_analyzed_files": self.not_analyzed_files,
+            "error_files": self.error_files,
+            "complete": self.complete,
+        }
+
+
+@dataclass
+class AuditProcessSummary:
+    run_id: str
+    project_id: str
+    project_root: str
+    considered_files: int
+    processed_files: int
+    findings_added: int
+    skipped_secret_files: int
+    unsupported_files: int
+    locked_files: int
+    error_files: int
+    remaining_pending_files: int
+    limited: bool
+    complete: bool
+    pending_files: int = 0
+    processing_files: int = 0
+    analyzed_files: int = 0
+    stale_analyzed_files: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "project_id": self.project_id,
+            "project_root": self.project_root,
+            "considered_files": self.considered_files,
+            "processed_files": self.processed_files,
+            "findings_added": self.findings_added,
+            "skipped_secret_files": self.skipped_secret_files,
+            "unsupported_files": self.unsupported_files,
+            "locked_files": self.locked_files,
+            "error_files": self.error_files,
+            "remaining_pending_files": self.remaining_pending_files,
+            "limited": self.limited,
+            "complete": self.complete,
+            "pending_files": self.pending_files,
+            "processing_files": self.processing_files,
+            "analyzed_files": self.analyzed_files,
+            "stale_analyzed_files": self.stale_analyzed_files,
+        }

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -3237,6 +3237,64 @@ def _build_agent_parser():
         help="Interactive file selection (with --security)",
     )
 
+    p_audit = agent_sub.add_parser(
+        "audit",
+        help="Deep security audit state and candidate workflow",
+    )
+    p_audit.add_argument("path", nargs="?", default=".")
+    _add_agent_model_arg(p_audit)
+    _add_agent_provider_arg(p_audit)
+    _add_agent_base_url_arg(p_audit)
+    p_audit.add_argument(
+        "--deep",
+        action="store_true",
+        help="Enable the explicit Deep Mode audit workflow",
+    )
+    p_audit.add_argument(
+        "--scan-only",
+        action="store_true",
+        help="Create/update static audit candidates without LLM calls",
+    )
+    p_audit.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume pending Deep Mode processing work",
+    )
+    p_audit.add_argument(
+        "--force",
+        action="store_true",
+        help="Force Deep Mode reprocessing for already analyzed files",
+    )
+    p_audit.add_argument(
+        "--changed",
+        action="store_true",
+        help="Restrict scan-only candidate discovery to git-changed files",
+    )
+    p_audit.add_argument(
+        "--base",
+        default=None,
+        help="Base ref for changed-file scans (reserved for CI gating)",
+    )
+    p_audit.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit Deep Mode agent processing; scan-only records all candidates",
+    )
+    p_audit.add_argument(
+        "--fail-on",
+        choices=["critical", "high", "medium", "low"],
+        default=None,
+        help="Reserved for Deep Mode CI gating",
+    )
+    p_audit.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+    )
+    p_audit.add_argument("--out", "--output", "-o", dest="output")
+    _add_agent_quiet_arg(p_audit)
+
     p_remediate = agent_sub.add_parser(
         "remediate",
         help="Scan, fix, test, and create PR for security/quality issues",
@@ -4096,6 +4154,195 @@ def main() -> None:
                 finally:
                     server.server_close()
                 sys.exit(0)
+
+        if cmd == "audit":
+            if not getattr(agent_args, "deep", False):
+                console.print(
+                    "[bad]Deep audit is explicit. Re-run with `--deep`.[/bad]"
+                )
+                sys.exit(2)
+
+            if getattr(agent_args, "base", None):
+                console.print(
+                    "[warn]Deep audit `--base` support belongs to the CI phase "
+                    "and is not enabled yet.[/warn]"
+                )
+                sys.exit(2)
+
+            if getattr(agent_args, "fail_on", None):
+                console.print(
+                    "[warn]Deep audit `--fail-on` support belongs to the CI phase "
+                    "and is not enabled yet.[/warn]"
+                )
+                sys.exit(2)
+
+            if getattr(agent_args, "scan_only", False) and getattr(
+                agent_args, "resume", False
+            ):
+                console.print(
+                    "[warn]Deep audit `--resume` requires processing mode, "
+                    "not `--scan-only`.[/warn]"
+                )
+                sys.exit(2)
+
+            if getattr(agent_args, "scan_only", False) and getattr(
+                agent_args, "force", False
+            ):
+                console.print(
+                    "[warn]Deep audit `--force` requires processing mode, "
+                    "not `--scan-only`.[/warn]"
+                )
+                sys.exit(2)
+
+            if getattr(agent_args, "changed", False) and not getattr(
+                agent_args, "scan_only", False
+            ):
+                console.print(
+                    "[warn]Deep audit processing with `--changed` belongs to the "
+                    "CI phase and is not enabled yet. Use `--scan-only --changed` "
+                    "for changed-file candidate discovery.[/warn]"
+                )
+                sys.exit(2)
+
+            audit_path = pathlib.Path(agent_args.path)
+            if not audit_path.exists():
+                console.print(f"[bad]Path not found: {audit_path}[/bad]")
+                sys.exit(1)
+
+            changed_files = None
+            if getattr(agent_args, "changed", False):
+                changed_files = get_git_changed_files(audit_path)
+                if not changed_files:
+                    if not getattr(agent_args, "quiet", False):
+                        console.print("[dim]No changed files[/dim]")
+                    sys.exit(0)
+
+            from skylos.audit_candidates import scan_deep_audit_candidates
+
+            summary, store = scan_deep_audit_candidates(
+                audit_path,
+                changed_files=changed_files,
+            )
+            audit_project_root = pathlib.Path(summary.project_root)
+            process_summary = None
+            mode = "deep_scan_only"
+
+            if not getattr(agent_args, "scan_only", False):
+                if not _ensure_llm_support():
+                    Console().print("[bold red]Agent module not available[/bold red]")
+                    sys.exit(1)
+
+                model = agent_args.model
+                provider_override = getattr(agent_args, "provider", None)
+                if provider_override and model == "gpt-4.1":
+                    provider_default_models = {
+                        "anthropic": "claude-sonnet-4-20250514",
+                        "google": "gemini/gemini-2.0-flash",
+                        "mistral": "mistral/mistral-large-latest",
+                        "groq": "groq/llama3-70b-8192",
+                        "deepseek": "deepseek/deepseek-chat",
+                        "xai": "xai/grok-2",
+                        "together": (
+                            "together/meta-llama/"
+                            "Meta-Llama-3-70B-Instruct-Turbo"
+                        ),
+                        "ollama": "ollama/llama3",
+                    }
+                    if provider_override in provider_default_models:
+                        model = provider_default_models[provider_override]
+
+                provider, api_key, base_url, is_local = resolve_llm_runtime(
+                    model=model,
+                    provider_override=provider_override,
+                    base_url_override=getattr(agent_args, "base_url", None),
+                    console=console,
+                    allow_prompt=_is_tty(),
+                )
+                if base_url:
+                    os.environ["OPENAI_BASE_URL"] = base_url
+                    os.environ["SKYLOS_LLM_BASE_URL"] = base_url
+                if api_key is None or api_key == "":
+                    if not is_local:
+                        env_var = PROVIDERS.get(provider) or f"{provider.upper()}_API_KEY"
+                        console.print(
+                            f"[bad]No {env_var} configured. Run `skylos key` or "
+                            "set the environment variable.[/bad]"
+                        )
+                        sys.exit(1)
+
+                project_cfg = load_config(audit_project_root)
+                config = _build_analyzer_config(
+                    model=model,
+                    api_key=api_key,
+                    provider=provider,
+                    base_url=base_url,
+                    quiet=getattr(agent_args, "quiet", False),
+                    enable_security=True,
+                    enable_quality=False,
+                    prompt_templates=project_cfg.get("templates"),
+                    prompt_template_root=audit_project_root,
+                )
+                analyzer = SkylosLLM(config)
+
+                from skylos.audit_processor import process_deep_audit_records
+
+                process_summary = process_deep_audit_records(
+                    store=store,
+                    analyzer=analyzer,
+                    model=model,
+                    provider=provider,
+                    limit=getattr(agent_args, "limit", None),
+                    force=getattr(agent_args, "force", False),
+                )
+                mode = "deep_process"
+
+            payload = {
+                "mode": mode,
+                "summary": summary.to_dict(),
+                "audit_project_dir": str(store.project_dir),
+            }
+            if process_summary is not None:
+                payload["processing"] = process_summary.to_dict()
+
+            if agent_args.output:
+                pathlib.Path(agent_args.output).write_text(
+                    json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+
+            if agent_args.format == "json":
+                if not getattr(agent_args, "quiet", False):
+                    print(json.dumps(payload, indent=2, sort_keys=True))
+            elif not getattr(agent_args, "quiet", False):
+                heading = "scan-only" if process_summary is None else "scan"
+                console.print(
+                    f"[brand]Deep audit {heading}:[/brand] static queue updated"
+                )
+                console.print(f"  Project: {summary.project_root}")
+                console.print(f"  Files scanned: {summary.files_scanned}")
+                console.print(f"  Candidates: {summary.candidate_count}")
+                console.print(f"  Redacted candidates: {summary.redacted_candidates}")
+                console.print(f"  Pending files: {summary.pending_files}")
+                console.print(f"  Processing files: {summary.processing_files}")
+                console.print(f"  Error files: {summary.error_files}")
+                console.print(f"  Not analyzed: {summary.not_analyzed_files}")
+                if process_summary is not None:
+                    console.print("[brand]Deep audit processing:[/brand] finished")
+                    console.print(f"  Processed files: {process_summary.processed_files}")
+                    console.print(f"  Findings added: {process_summary.findings_added}")
+                    console.print(
+                        f"  Skipped secret files: "
+                        f"{process_summary.skipped_secret_files}"
+                    )
+                    console.print(
+                        f"  Unsupported files: {process_summary.unsupported_files}"
+                    )
+                    console.print(
+                        f"  Remaining work: "
+                        f"{process_summary.remaining_pending_files}"
+                    )
+                console.print(f"  Store: {store.project_dir}")
+            sys.exit(0)
 
         if not _ensure_llm_support():
             Console().print("[bold red]Agent module not available[/bold red]")

--- a/skylos/cli_shared.py
+++ b/skylos/cli_shared.py
@@ -19,13 +19,25 @@ def get_git_changed_files(root_path):
         ".php",
         ".rs",
         ".dart",
+        ".env",
+        ".yaml",
+        ".yml",
+        ".json",
+        ".toml",
+        ".ini",
+        ".cfg",
+        ".conf",
     }
 
     def _collect_supported(output, repo_root):
         files = []
         for line in output.splitlines():
             full_path = pathlib.Path(repo_root) / line
-            if full_path.suffix.lower() not in supported_exts:
+            if (
+                full_path.name != ".env"
+                and not full_path.name.startswith(".env.")
+                and full_path.suffix.lower() not in supported_exts
+            ):
                 continue
             if full_path.exists():
                 files.append(full_path)

--- a/skylos/help.py
+++ b/skylos/help.py
@@ -27,6 +27,11 @@ COMMANDS = [
         "group": "AI Agent",
     },
     {
+        "name": "skylos agent audit <path> --deep --scan-only",
+        "desc": "Create/update the persistent Deep Mode audit queue",
+        "group": "AI Agent",
+    },
+    {
         "name": "skylos agent verify <path>",
         "desc": "LLM-verify dead code (100% accuracy)",
         "group": "AI Agent",

--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -275,7 +275,14 @@ def run_static_on_files(
     if project_root is None:
         project_root = _infer_root(files[0])
 
+    project_root_path = pathlib.Path(project_root).resolve()
     target_files = {_norm(f) for f in files}
+
+    def _norm_static_item_file(item_file):
+        item_path = pathlib.Path(item_file or "")
+        if not item_path.is_absolute():
+            item_path = project_root_path / item_path
+        return _norm(item_path)
 
     try:
         from skylos.sync import get_custom_rules
@@ -325,7 +332,7 @@ def run_static_on_files(
         filtered[key] = []
         for item in full_result.get(key, []) or []:
             item_file = item.get("file", "")
-            if _norm(item_file) in target_files:
+            if _norm_static_item_file(item_file) in target_files:
                 filtered[key].append(item)
 
     if "analysis_summary" in full_result:

--- a/skylos/rules/danger/danger_net/ssrf_flow.py
+++ b/skylos/rules/danger/danger_net/ssrf_flow.py
@@ -209,6 +209,77 @@ def _is_interpolated_string(node):
     return False
 
 
+def _safe_expr_text(node: ast.AST | None, max_length: int = 160) -> str:
+    if node is None:
+        return "unknown"
+    try:
+        text = ast.unparse(node)
+    except Exception:
+        text = type(node).__name__
+    text = " ".join(str(text).split())
+    if len(text) > max_length:
+        return text[: max_length - 3] + "..."
+    return text or "unknown"
+
+
+def _request_base_name(node: ast.AST | None) -> str | None:
+    current = node
+    while isinstance(current, (ast.Attribute, ast.Subscript)):
+        current = current.value
+    if isinstance(current, ast.Name):
+        return current.id
+    return None
+
+
+def _source_label(node: ast.AST, *, interpolated: bool) -> str:
+    if _request_base_name(node) == "request":
+        return "request-derived URL value"
+    if isinstance(node, ast.Name):
+        return f"tainted variable `{node.id}`"
+    if isinstance(node, ast.JoinedStr) or interpolated:
+        return "interpolated URL expression"
+    return "tainted URL expression"
+
+
+def _ssrf_security_evidence(
+    *,
+    symbol: str,
+    sink: str,
+    url_arg: ast.AST,
+    interpolated: bool,
+) -> dict:
+    source = _source_label(url_arg, interpolated=interpolated)
+    expression = _safe_expr_text(url_arg)
+    entrypoint = symbol if symbol and symbol != "<module>" else None
+
+    evidence = {
+        "evidence_kind": "source_to_sink",
+        "source": source,
+        "sink": sink,
+        "path": [
+            source,
+            f"url expression `{expression}`",
+            f"HTTP sink `{sink}`",
+        ],
+        "guards_seen": [],
+        "guards_missing": [
+            "URL host or scheme allowlist",
+            "private, loopback, and metadata host rejection",
+        ],
+        "confidence_reason": (
+            "Untrusted URL data can influence the outbound HTTP request target."
+        ),
+        "test_hint": (
+            "Assert untrusted input cannot control the request host and private "
+            "or metadata URLs are rejected before the HTTP client call."
+        ),
+        "fix_shape": "validate and allowlist the URL before the HTTP request",
+    }
+    if entrypoint:
+        evidence["entrypoint"] = entrypoint
+    return evidence
+
+
 class _SSRFFlowChecker(TaintVisitor):
     HTTP_METHODS = {"get", "post", "put", "delete", "head", "options", "request"}
 
@@ -258,6 +329,29 @@ class _SSRFFlowChecker(TaintVisitor):
 
         return False
 
+    def _append_finding(self, node: ast.Call, url_arg: ast.AST, sink: str) -> None:
+        interpolated = _is_interpolated_string(url_arg)
+        symbol = self._current_symbol()
+        self.findings.append(
+            {
+                "rule_id": "SKY-D216",
+                "severity": "CRITICAL",
+                "message": "Possible SSRF: tainted URL passed to HTTP client.",
+                "file": str(self.file_path),
+                "line": node.lineno,
+                "col": node.col_offset,
+                "symbol": symbol,
+                "metadata": {
+                    "security_evidence": _ssrf_security_evidence(
+                        symbol=symbol,
+                        sink=sink,
+                        url_arg=url_arg,
+                        interpolated=interpolated,
+                    )
+                },
+            }
+        )
+
     def visit_Call(self, node):
         qn = _qualified_name_from_call(node)
 
@@ -270,34 +364,14 @@ class _SSRFFlowChecker(TaintVisitor):
                     if _is_interpolated_string(url_arg) or _tainted_url_is_ssrf_relevant(
                         self, url_arg
                     ):
-                        self.findings.append(
-                            {
-                                "rule_id": "SKY-D216",
-                                "severity": "CRITICAL",
-                                "message": "Possible SSRF: tainted URL passed to HTTP client.",
-                                "file": str(self.file_path),
-                                "line": node.lineno,
-                                "col": node.col_offset,
-                                "symbol": self._current_symbol(),
-                            }
-                        )
+                        self._append_finding(node, url_arg, qn)
 
         if qn and qn.endswith(".urlopen") and node.args:
             url_arg = node.args[0]
             if _is_interpolated_string(url_arg) or _tainted_url_is_ssrf_relevant(
                 self, url_arg
             ):
-                self.findings.append(
-                    {
-                        "rule_id": "SKY-D216",
-                        "severity": "CRITICAL",
-                        "message": "Possible SSRF: tainted URL passed to HTTP client.",
-                        "file": str(self.file_path),
-                        "line": node.lineno,
-                        "col": node.col_offset,
-                        "symbol": self._current_symbol(),
-                    }
-                )
+                self._append_finding(node, url_arg, qn)
 
         self.generic_visit(node)
 

--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -205,7 +205,10 @@ def scan_ctx(
     ignore_tests=True,
 ):
     rel_path = ctx.get("relpath", "")
-    if not rel_path.endswith(ALLOWED_FILE_SUFFIXES):
+    rel_name = rel_path.replace("\\", "/").rsplit("/", 1)[-1]
+    if not rel_path.endswith(ALLOWED_FILE_SUFFIXES) and not rel_name.startswith(
+        ".env."
+    ):
         return []
 
     if ignore_tests and IS_TEST_PATH.search(rel_path.replace("\\", "/")):

--- a/test/test_audit_candidates.py
+++ b/test/test_audit_candidates.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skylos import audit_candidates
+from skylos.audit_store import AuditStore
+from skylos.audit_types import AuditFileRecord, sha256_file
+
+
+def _fake_github_token() -> str:
+    return "ghp_" + "1234567890abcdef" + "1234567890abcdef" + "123456"
+
+
+def _fake_stripe_token() -> str:
+    return "sk_" + "live_" + "1234567890abcdef" + "1234567890abcdef"
+
+
+def test_scan_deep_audit_candidates_redacts_secret_payloads(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env_file = repo / ".env"
+    raw_secret = _fake_github_token()
+    env_file.write_text(f'GITHUB_TOKEN="{raw_secret}"\n', encoding="utf-8")
+
+    def fake_static(files, **kwargs):
+        return {
+            "danger": [],
+            "secrets": [
+                {
+                    "rule_id": "SKY-S101",
+                    "severity": "CRITICAL",
+                    "provider": "github",
+                    "message": "Potential github secret detected",
+                    "file": str(env_file),
+                    "line": 1,
+                    "value": raw_secret,
+                    "preview": "ghp_...3456",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(env_file)
+    stored = store.record_path(env_file).read_text(encoding="utf-8")
+
+    assert summary.candidate_count == 1
+    assert summary.redacted_candidates == 1
+    assert record is not None
+    assert record.language == "env"
+    secret_candidates = [
+        candidate for candidate in record.candidates if candidate.rule_id == "SKY-S101"
+    ]
+    assert len(secret_candidates) == 1
+    assert secret_candidates[0].redacted is True
+    assert raw_secret not in stored
+
+
+def test_scan_deep_audit_candidates_detects_real_env_secret(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    raw_secret = _fake_github_token()
+    env_file = repo / ".env"
+    env_file.write_text(f'GITHUB_TOKEN="{raw_secret}"\n', encoding="utf-8")
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(env_file)
+    stored = store.record_path(env_file).read_text(encoding="utf-8")
+
+    assert summary.files_scanned == 1
+    assert summary.candidate_count >= 1
+    assert summary.complete is False
+    assert record is not None
+    assert record.status == "pending"
+    assert any(candidate.rule_id == "SKY-S101" for candidate in record.candidates)
+    assert raw_secret not in stored
+
+
+def test_scan_deep_audit_candidates_detects_env_variant_secret(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env_file = repo / ".env.production"
+    env_file.write_text(
+        f'API_KEY="{_fake_stripe_token()}"\n',
+        encoding="utf-8",
+    )
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(env_file)
+
+    assert summary.files_scanned == 1
+    assert record is not None
+    assert record.language == "env"
+    assert any(candidate.rule_id == "SKY-S101" for candidate in record.candidates)
+
+
+def test_scan_deep_audit_candidates_is_stable_across_reruns(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+
+    def fake_static(files, **kwargs):
+        return {
+            "danger": [
+                {
+                    "rule_id": "SKY-D201",
+                    "severity": "CRITICAL",
+                    "message": "Use of eval() detected",
+                    "file": str(app),
+                    "line": 1,
+                }
+            ],
+            "secrets": [],
+        }
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    audit_candidates.scan_deep_audit_candidates(repo)
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(app)
+
+    assert summary.records_written == 1
+    assert record is not None
+    ids = [candidate.candidate_id for candidate in record.candidates]
+    assert len(ids) == len(set(ids))
+
+
+def test_scan_deep_audit_candidates_records_non_candidate_files(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "plain.py"
+    app.write_text("print('clean')\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        audit_candidates,
+        "run_static_on_files",
+        lambda files, **kwargs: {"danger": [], "secrets": []},
+    )
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(app)
+    payload = json.loads(store.record_path(app).read_text(encoding="utf-8"))
+
+    assert summary.files_scanned == 1
+    assert record is not None
+    assert record.status == "not_analyzed"
+    assert payload["candidates"] == []
+
+
+def test_scan_deep_audit_candidates_changed_files_respect_excludes(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    audit_file = (
+        repo / ".skylos" / "audit" / "projects" / "default" / "files" / "x.json"
+    )
+    audit_file.parent.mkdir(parents=True)
+    audit_file.write_text(
+        f'{{"api_key":"{_fake_stripe_token()}"}}\n',
+        encoding="utf-8",
+    )
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+
+    seen = {}
+
+    def fake_static(files, **kwargs):
+        seen["files"] = [Path(file_path).name for file_path in files]
+        return {"danger": [], "secrets": []}
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    summary, _store = audit_candidates.scan_deep_audit_candidates(
+        repo,
+        changed_files=[audit_file, app],
+    )
+
+    assert summary.files_scanned == 1
+    assert seen["files"] == ["app.py"]
+
+
+def test_audit_store_rejects_record_with_mismatched_internal_file(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    other = repo / "other.py"
+    app.write_text("print('app')\n", encoding="utf-8")
+    other.write_text("print('other')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = AuditFileRecord(
+        project_id="default",
+        project_root=str(repo.resolve()),
+        file="other.py",
+        file_hash=sha256_file(other),
+        language="python",
+        status="pending",
+        config_hash="cfg",
+    )
+    store.record_path(app).write_text(
+        json.dumps(record.to_dict()),
+        encoding="utf-8",
+    )
+
+    assert store.read_file_record(app) is None
+
+
+def test_scan_deep_audit_candidates_reports_processing_records_incomplete(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+
+    def fake_static(files, **kwargs):
+        return {
+            "danger": [
+                {
+                    "rule_id": "SKY-D201",
+                    "severity": "CRITICAL",
+                    "message": "Use of eval() detected",
+                    "file": str(app),
+                    "line": 1,
+                }
+            ],
+            "secrets": [],
+        }
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    _summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(app)
+    assert record is not None
+    record.status = "processing"
+    store.write_file_record(record)
+
+    summary, _store = audit_candidates.scan_deep_audit_candidates(repo)
+
+    assert summary.processing_files == 1
+    assert summary.complete is False
+
+
+def test_scan_deep_audit_candidates_reports_error_records_incomplete(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+
+    def fake_static(files, **kwargs):
+        return {
+            "danger": [
+                {
+                    "rule_id": "SKY-D201",
+                    "severity": "CRITICAL",
+                    "message": "Use of eval() detected",
+                    "file": str(app),
+                    "line": 1,
+                }
+            ],
+            "secrets": [],
+        }
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    _summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(app)
+    assert record is not None
+    record.status = "error"
+    store.write_file_record(record)
+
+    summary, _store = audit_candidates.scan_deep_audit_candidates(repo)
+
+    assert summary.error_files == 1
+    assert summary.complete is False

--- a/test/test_audit_cli.py
+++ b/test/test_audit_cli.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import skylos.cli as cli
+from skylos.audit_types import AuditProcessSummary, AuditScanSummary
+
+
+def test_agent_audit_deep_scan_only_runs_without_llm_support(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = tmp_path / "audit.json"
+
+    called = {}
+
+    def fake_scan(path, *, changed_files=None):
+        called["path"] = Path(path)
+        called["changed_files"] = changed_files
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=1,
+                redacted_candidates=0,
+                pending_files=1,
+                not_analyzed_files=0,
+            ),
+            SimpleNamespace(
+                project_dir=repo / ".skylos" / "audit" / "projects" / "default"
+            ),
+        )
+
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+
+    def fail_if_llm_checked():
+        raise AssertionError("LLM support should not be checked")
+
+    monkeypatch.setattr(cli, "_ensure_llm_support", fail_if_llm_checked)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--scan-only",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert called["path"] == repo
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["mode"] == "deep_scan_only"
+    assert payload["summary"]["candidate_count"] == 1
+
+
+def test_agent_audit_requires_explicit_deep_flag(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(cli.sys, "argv", ["skylos", "agent", "audit", str(repo)])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_scan_only_rejects_unimplemented_ci_flags(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--scan-only",
+            "--fail-on",
+            "high",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_scan_only_rejects_unimplemented_processing_flags(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--scan-only",
+            "--resume",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_scan_only_rejects_force_until_processing_exists(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--scan-only",
+            "--force",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_processing_rejects_changed_until_ci_phase(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--changed",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_deep_processing_runs_after_scan(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = tmp_path / "audit.json"
+    store = SimpleNamespace(
+        project_dir=repo / ".skylos" / "audit" / "projects" / "default"
+    )
+    calls = {}
+
+    def fake_scan(path, *, changed_files=None):
+        calls["scan_path"] = Path(path)
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=1,
+                redacted_candidates=0,
+                pending_files=1,
+                not_analyzed_files=0,
+                complete=False,
+            ),
+            store,
+        )
+
+    def fake_process(**kwargs):
+        calls["process"] = kwargs
+        return AuditProcessSummary(
+            run_id="process-one",
+            project_id="default",
+            project_root=str(repo),
+            considered_files=1,
+            processed_files=1,
+            findings_added=1,
+            skipped_secret_files=0,
+            unsupported_files=0,
+            locked_files=0,
+            error_files=0,
+            remaining_pending_files=0,
+            limited=False,
+            complete=True,
+        )
+
+    class FakeLLM:
+        def __init__(self, config):
+            self.config = config
+
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+    monkeypatch.setattr(
+        "skylos.audit_processor.process_deep_audit_records",
+        fake_process,
+    )
+    monkeypatch.setattr(cli, "_ensure_llm_support", lambda: True)
+    monkeypatch.setattr(cli, "_build_analyzer_config", lambda **kwargs: kwargs)
+    monkeypatch.setattr(cli, "SkylosLLM", FakeLLM)
+    monkeypatch.setattr(
+        cli,
+        "resolve_llm_runtime",
+        lambda **kwargs: ("ollama", None, None, True),
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--limit",
+            "3",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["mode"] == "deep_process"
+    assert payload["processing"]["processed_files"] == 1
+    assert calls["process"]["limit"] == 3
+    assert calls["process"]["force"] is False

--- a/test/test_audit_processor.py
+++ b/test/test_audit_processor.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.audit_processor import process_deep_audit_records
+from skylos.audit_redaction import REDACTION
+from skylos.audit_store import AuditStore
+from skylos.audit_types import AuditCandidate, sha256_file
+
+
+def _fake_github_token() -> str:
+    return "ghp_" + "1234567890abcdef" + "1234567890abcdef" + "123456"
+
+
+class FakeAnalyzer:
+    def __init__(self):
+        self.calls: list[Path] = []
+
+    def analyze_file(self, file_path, issue_types=None):
+        self.calls.append(Path(file_path))
+        return [
+            {
+                "rule_id": "SKY-L001",
+                "issue_type": "security",
+                "severity": "high",
+                "message": f"Finding in {Path(file_path).name}",
+                "location": {"file": str(file_path), "line": 1},
+                "confidence": "high",
+            }
+        ]
+
+
+class CapturingAgent:
+    def __init__(self):
+        self.sources: list[str] = []
+
+    def analyze(self, source, file_path, defs_map=None, context=None):
+        self.sources.append(source)
+        return []
+
+
+class AgentBackedAnalyzer:
+    def __init__(self):
+        self.agent = CapturingAgent()
+
+    def _get_agent(self, agent_type):
+        return self.agent
+
+
+class ExplodingAgent:
+    def analyze(self, source, file_path, defs_map=None, context=None):
+        raise RuntimeError(f"adapter down with token={_fake_github_token()}")
+
+
+class ExplodingAnalyzer:
+    def __init__(self):
+        self.agent = ExplodingAgent()
+
+    def _get_agent(self, agent_type):
+        return self.agent
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    priority: int = 800,
+    rule_id: str = "SKY-D999",
+    redacted: bool = False,
+) -> AuditCandidate:
+    return AuditCandidate(
+        candidate_id=candidate_id,
+        kind="static_finding",
+        rule_id=rule_id,
+        line=1,
+        severity_hint="high",
+        reason="candidate",
+        redacted=redacted,
+        priority=priority,
+        code_hash=candidate_id,
+    )
+
+
+def _write_record(
+    store: AuditStore,
+    file_path: Path,
+    *,
+    language: str = "python",
+    candidates: list[AuditCandidate] | None = None,
+    status: str | None = None,
+):
+    record = store.upsert_scan_record(
+        file_path=file_path,
+        file_hash=sha256_file(file_path),
+        language=language,
+        candidates=candidates or [_candidate("cand")],
+        config_hash="cfg",
+    )
+    if status:
+        record.status = status
+        store.write_file_record(record)
+    return record
+
+
+def _mark_analyzed_for_context(
+    store: AuditStore,
+    record,
+    *,
+    model: str = "test-model",
+    provider: str | None = None,
+):
+    record.status = "analyzed"
+    record.analysis_history.append(
+        {
+            "stage": "agent_process",
+            "run_id": "prior-run",
+            "model": model,
+            "provider": provider,
+        }
+    )
+    store.write_file_record(record)
+    return record
+
+
+def test_process_deep_audit_records_prioritizes_and_respects_limit(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    high = repo / "high.py"
+    low = repo / "low.py"
+    high.write_text("eval(user_input)\n", encoding="utf-8")
+    low.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, low, candidates=[_candidate("low", priority=100)])
+    _write_record(store, high, candidates=[_candidate("high", priority=900)])
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        limit=1,
+        run_id="run-one",
+    )
+
+    assert [path.name for path in analyzer.calls] == ["high.py"]
+    assert summary.processed_files == 1
+    assert summary.limited is True
+    assert summary.complete is False
+    assert store.read_file_record(high).status == "analyzed"
+    assert store.read_file_record(low).status == "pending"
+
+
+def test_process_deep_audit_records_skips_secret_candidates(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    raw_secret = _fake_github_token()
+    app.write_text(f'TOKEN="{raw_secret}"\n', encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(
+        store,
+        app,
+        candidates=[
+            _candidate(
+                "secret",
+                rule_id="SKY-S101",
+                redacted=True,
+            )
+        ],
+    )
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-secret",
+    )
+    stored = store.record_path(app).read_text(encoding="utf-8")
+
+    assert analyzer.calls == []
+    assert summary.skipped_secret_files == 1
+    assert summary.remaining_pending_files == 1
+    assert summary.complete is False
+    assert store.read_file_record(app).status == "skipped"
+    assert raw_secret not in stored
+
+    rerun_summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-secret-rerun",
+    )
+
+    assert analyzer.calls == []
+    assert rerun_summary.skipped_secret_files == 1
+    assert rerun_summary.remaining_pending_files == 1
+    assert rerun_summary.complete is False
+
+
+def test_process_deep_audit_records_redacts_incidental_secrets_before_agent_call(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    raw_secret = _fake_github_token()
+    app.write_text(
+        f'TOKEN="{raw_secret}"\n'
+        "def handler(user_input):\n"
+        "    return eval(user_input)\n",
+        encoding="utf-8",
+    )
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, candidates=[_candidate("danger")])
+
+    analyzer = AgentBackedAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-redact",
+    )
+
+    assert summary.processed_files == 1
+    assert len(analyzer.agent.sources) == 1
+    assert raw_secret not in analyzer.agent.sources[0]
+    assert REDACTION in analyzer.agent.sources[0]
+    assert store.read_file_record(app).status == "analyzed"
+
+
+def test_process_deep_audit_records_marks_agent_errors_without_raw_secret(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text(
+        "def handler(user_input):\n    return eval(user_input)\n",
+        encoding="utf-8",
+    )
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app)
+
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=ExplodingAnalyzer(),
+        model="test-model",
+        run_id="run-error",
+    )
+
+    record = store.read_file_record(app)
+    stored = store.record_path(app).read_text(encoding="utf-8")
+
+    assert summary.error_files == 1
+    assert summary.complete is False
+    assert record is not None
+    assert record.status == "error"
+    assert _fake_github_token() not in stored
+    assert REDACTION in stored
+
+
+def test_process_deep_audit_records_marks_unsupported_languages(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.ts"
+    app.write_text("eval(userInput)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, language="typescript")
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-ts",
+    )
+
+    assert analyzer.calls == []
+    assert summary.unsupported_files == 1
+    assert summary.remaining_pending_files == 1
+    assert summary.complete is False
+    assert store.read_file_record(app).status == "not_analyzed"
+
+    rerun_summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-ts-rerun",
+    )
+
+    assert analyzer.calls == []
+    assert rerun_summary.unsupported_files == 1
+    assert rerun_summary.remaining_pending_files == 1
+    assert rerun_summary.complete is False
+
+
+def test_process_deep_audit_records_skips_analyzed_with_same_context_unless_forced(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _write_record(store, app)
+    _mark_analyzed_for_context(store, record)
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-skip",
+    )
+
+    assert analyzer.calls == []
+    assert summary.processed_files == 0
+
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        force=True,
+        run_id="run-force",
+    )
+
+    assert [path.name for path in analyzer.calls] == ["app.py"]
+    assert summary.processed_files == 1
+
+
+def test_process_deep_audit_records_reprocesses_stale_model_context(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _write_record(store, app)
+    _mark_analyzed_for_context(store, record, model="old-model", provider="old")
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="new-model",
+        provider="new",
+        run_id="run-new-context",
+    )
+
+    updated = store.read_file_record(app)
+
+    assert [path.name for path in analyzer.calls] == ["app.py"]
+    assert summary.processed_files == 1
+    assert summary.complete is True
+    assert updated is not None
+    assert updated.analysis_history[-1]["model"] == "new-model"
+    assert updated.analysis_history[-1]["provider"] == "new"
+
+
+def test_process_deep_audit_records_respects_fresh_locks(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app)
+    assert store.acquire_lock(app, run_id="other-run")
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-main",
+    )
+
+    assert analyzer.calls == []
+    assert summary.locked_files == 1
+    assert store.read_file_record(app).status == "processing"
+
+
+def test_process_deep_audit_records_recovers_stale_locks(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _write_record(store, app)
+    record.status = "processing"
+    record.locked_by_run_id = "old-run"
+    record.locked_at = "2000-01-01T00:00:00+00:00"
+    store.write_file_record(record)
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-main",
+    )
+
+    assert [path.name for path in analyzer.calls] == ["app.py"]
+    assert summary.processed_files == 1
+    assert store.read_file_record(app).status == "analyzed"
+
+
+def test_process_deep_audit_records_merges_duplicate_findings(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app)
+
+    analyzer = FakeAnalyzer()
+    process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-one",
+    )
+    process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        force=True,
+        run_id="run-two",
+    )
+
+    record = store.read_file_record(app)
+    assert record is not None
+    assert len(record.findings) == 1

--- a/test/test_audit_store.py
+++ b/test/test_audit_store.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    STATUS_ANALYZED,
+    STATUS_PENDING,
+    AuditCandidate,
+    sha256_file,
+    utc_now,
+)
+
+
+def _fake_github_token() -> str:
+    return "ghp_" + "1234567890abcdef" + "1234567890abcdef" + "123456"
+
+
+def _candidate(candidate_id: str = "cand-one") -> AuditCandidate:
+    return AuditCandidate(
+        candidate_id=candidate_id,
+        kind="static_finding",
+        rule_id="SKY-D999",
+        line=1,
+        severity_hint="high",
+        reason="test candidate",
+        priority=800,
+        code_hash="abc123",
+    )
+
+
+def test_audit_store_writes_and_reads_file_record(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('hello')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = store.upsert_scan_record(
+        file_path=source,
+        file_hash=sha256_file(source),
+        language="python",
+        candidates=[_candidate()],
+        config_hash="cfg",
+    )
+
+    loaded = store.read_file_record("app.py")
+
+    assert record.status == STATUS_PENDING
+    assert loaded is not None
+    assert loaded.file == "app.py"
+    assert loaded.candidates[0].candidate_id == "cand-one"
+    assert store.record_path("app.py").exists()
+
+
+def test_audit_store_rerun_deduplicates_candidates(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('hello')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    for _ in range(2):
+        store.upsert_scan_record(
+            file_path=source,
+            file_hash=sha256_file(source),
+            language="python",
+            candidates=[_candidate(), _candidate()],
+            config_hash="cfg",
+        )
+
+    loaded = store.read_file_record("app.py")
+
+    assert loaded is not None
+    assert [candidate.candidate_id for candidate in loaded.candidates] == ["cand-one"]
+
+
+def test_audit_store_file_hash_change_invalidates_prior_findings(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('hello')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = store.upsert_scan_record(
+        file_path=source,
+        file_hash=sha256_file(source),
+        language="python",
+        candidates=[_candidate()],
+        config_hash="cfg",
+    )
+    record.status = STATUS_ANALYZED
+    record.findings = [{"rule_id": "OLD"}]
+    record.analysis_history = [{"stage": "old"}]
+    store.write_file_record(record)
+
+    source.write_text("print('changed')\n", encoding="utf-8")
+    updated = store.upsert_scan_record(
+        file_path=source,
+        file_hash=sha256_file(source),
+        language="python",
+        candidates=[_candidate()],
+        config_hash="cfg",
+    )
+
+    assert updated.status == STATUS_PENDING
+    assert updated.findings == []
+    assert updated.analysis_history == []
+
+
+def test_audit_store_rejects_corrupted_json(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('hello')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    path = store.record_path(source)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    assert store.read_file_record(source) is None
+
+
+def test_audit_store_root_confines_paths(tmp_path: Path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside.py"
+    repo.mkdir()
+    outside.write_text("print('no')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+
+    with pytest.raises(ValueError):
+        store.record_path(outside)
+
+
+def test_audit_store_recovers_stale_lock(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('hello')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    store.upsert_scan_record(
+        file_path=source,
+        file_hash=sha256_file(source),
+        language="python",
+        candidates=[_candidate()],
+        config_hash="cfg",
+    )
+
+    assert store.acquire_lock(source, run_id="run-one", now=utc_now())
+    assert not store.acquire_lock(source, run_id="run-two", stale_after_seconds=3600)
+
+    record = store.read_file_record(source)
+    assert record is not None
+    record.locked_at = "2000-01-01T00:00:00+00:00"
+    store.write_file_record(record)
+
+    assert store.acquire_lock(source, run_id="run-two", stale_after_seconds=3600)
+
+
+def test_audit_store_sanitizes_preserved_history_and_errors(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    raw_secret = _fake_github_token()
+    source.write_text("print('hello')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = store.upsert_scan_record(
+        file_path=source,
+        file_hash=sha256_file(source),
+        language="python",
+        candidates=[_candidate()],
+        config_hash="cfg",
+    )
+    record.status = STATUS_ANALYZED
+    record.analysis_history = [{"prompt": raw_secret}]
+    record.findings = [{"message": raw_secret}]
+    record.revalidation = [{"reason": raw_secret}]
+    store.write_file_record(record)
+
+    updated = store.upsert_scan_record(
+        file_path=source,
+        file_hash=sha256_file(source),
+        language="python",
+        candidates=[_candidate()],
+        config_hash="cfg",
+    )
+    stored = store.record_path(source).read_text(encoding="utf-8")
+
+    assert updated.status == STATUS_ANALYZED
+    assert raw_secret not in stored
+    assert "[REDACTED_SECRET]" in stored
+
+    store.mark_error(source, f"failed with {raw_secret}")
+    stored = store.record_path(source).read_text(encoding="utf-8")
+
+    assert raw_secret not in stored

--- a/test/test_sarif_exporter.py
+++ b/test/test_sarif_exporter.py
@@ -170,8 +170,11 @@ def test_results_include_skylos_metadata_when_present():
             "category": "SECURITY",
             "metadata": {
                 "security_evidence": {
+                    "evidence_kind": "source_to_sink",
+                    "entrypoint": "admin_handler",
                     "contract_id": "admin-route-auth",
                     "missing_guards": ["require_admin"],
+                    "path": ["request", "handler", "response"],
                 }
             },
         }
@@ -181,6 +184,9 @@ def test_results_include_skylos_metadata_when_present():
     result = sarif["runs"][0]["results"][0]
 
     assert result["properties"]["skylos_metadata"]["security_evidence"] == {
+        "evidence_kind": "source_to_sink",
+        "entrypoint": "admin_handler",
         "contract_id": "admin-route-auth",
         "missing_guards": ["require_admin"],
+        "path": ["request", "handler", "response"],
     }

--- a/test/test_security_verifier.py
+++ b/test/test_security_verifier.py
@@ -136,3 +136,37 @@ def test_normalize_findings_preserves_security_review_metadata():
     assert metadata["ci_blocking"] is False
     assert metadata["security_evidence"] == "review_supported"
     assert metadata["review_verdict"] == "SUPPORTED"
+
+
+def test_normalize_findings_preserves_existing_security_evidence_packet():
+    packet = {
+        "evidence_kind": "source_to_sink",
+        "entrypoint": "fetch_url",
+        "source": "tainted variable `url`",
+        "sink": "requests.get",
+        "path": ["tainted variable `url`", "HTTP sink `requests.get`"],
+        "guards_missing": ["URL host or scheme allowlist"],
+    }
+
+    normalized = api._normalize_findings(
+        [
+            {
+                "file": "app.py",
+                "line": 8,
+                "message": "Possible SSRF",
+                "rule_id": "SKY-D216",
+                "severity": "CRITICAL",
+                "metadata": {"security_evidence": packet},
+                "_source": "static",
+                "_confidence": "high",
+            }
+        ],
+        "SECURITY",
+        "/repo",
+        extract_metadata=True,
+    )
+
+    metadata = normalized[0]["metadata"]
+    assert metadata["source"] == "static"
+    assert metadata["confidence"] == "high"
+    assert metadata["security_evidence"] == packet

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -12,6 +12,10 @@ def _rule_ids(findings):
     return {f["rule_id"] for f in findings}
 
 
+def _ssrf_findings(findings):
+    return [f for f in findings if f["rule_id"] == "SKY-D216"]
+
+
 def _scan_one(tmp_path: Path, name, code):
     file_path = _write(tmp_path, name, code)
     return scan_ctx(tmp_path, [file_path])
@@ -21,6 +25,21 @@ def test_requests_tainted_url_flags(tmp_path):
     code = "import requests\ndef f():\n    u = input()\n    requests.get(u)\n"
     out = _scan_one(tmp_path, "ssrf_req.py", code)
     assert "SKY-D216" in _rule_ids(out)
+
+
+def test_requests_tainted_url_includes_security_evidence(tmp_path):
+    code = "import requests\ndef fetch_url(url):\n    return requests.get(url)\n"
+    out = _scan_one(tmp_path, "ssrf_evidence.py", code)
+    finding = _ssrf_findings(out)[0]
+
+    evidence = finding["metadata"]["security_evidence"]
+    assert evidence["evidence_kind"] == "source_to_sink"
+    assert evidence["entrypoint"] == "fetch_url"
+    assert evidence["source"] == "tainted variable `url`"
+    assert evidence["sink"] == "requests.get"
+    assert "URL host or scheme allowlist" in evidence["guards_missing"]
+    assert "test_hint" in evidence
+    assert "fix_shape" in evidence
 
 
 def test_httpx_tainted_url_flags(tmp_path):
@@ -33,6 +52,16 @@ def test_urllib_urlopen_tainted_url_flags(tmp_path):
     code = "import urllib.request as u\ndef f(x):\n    u.urlopen(f'http://{x}')\n"
     out = _scan_one(tmp_path, "ssrf_urlopen.py", code)
     assert "SKY-D216" in _rule_ids(out)
+
+
+def test_urllib_urlopen_security_evidence_names_sink(tmp_path):
+    code = "import urllib.request as u\ndef f(x):\n    u.urlopen(f'http://{x}')\n"
+    out = _scan_one(tmp_path, "ssrf_urlopen_evidence.py", code)
+    evidence = _ssrf_findings(out)[0]["metadata"]["security_evidence"]
+
+    assert evidence["sink"] == "u.urlopen"
+    assert evidence["source"] == "interpolated URL expression"
+    assert any("HTTP sink `u.urlopen`" == step for step in evidence["path"])
 
 
 def test_requests_constant_url_ok(tmp_path):


### PR DESCRIPTION
## Summary

Adds the Deep Mode audit foundation. These include
  1. persistent audit state under `.skylos/audit`
  2. static-first candidate discovery with redacted secrets
  3. `skylos agent audit . --deep --scan-only`
  4. resumable Python agent processing with locks and stale-lock recovery
  5. privacy protections so raw secrets are not persisted or sent to agent processing

## Tests

`pytest .` 