### PR TITLE
fix(cli): prevent help from creating artifacts

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2379,6 +2379,36 @@ EARLY_COMMAND_HANDLERS = {
 }
 
 
+def _is_first_level_help_request(argv):
+    return len(argv) == 2 and argv[1] in {"-h", "--help"}
+
+
+def _run_early_command_help(command):
+    from skylos.help import COMMANDS
+
+    console = Console()
+    matches = [
+        item
+        for item in COMMANDS
+        if item.get("name", "").split()[:2] == ["skylos", command]
+    ]
+    if not matches:
+        console.print(f"[bold]Usage:[/bold] skylos {command} [options]")
+        console.print("\nRun [bold]skylos commands[/bold] for all commands.")
+        return 0
+
+    console.print("[bold]Usage:[/bold]")
+    for item in matches:
+        console.print(f"  {item['name']}")
+
+    console.print("\n[bold]Description:[/bold]")
+    for item in matches:
+        console.print(f"  {item['desc']}")
+
+    console.print("\nRun [bold]skylos commands[/bold] for all commands.")
+    return 0
+
+
 def _dispatch_early_command(argv):
     if not argv:
         return _run_command_overview([])
@@ -2386,6 +2416,9 @@ def _dispatch_early_command(argv):
     handler_name = EARLY_COMMAND_HANDLERS.get(argv[0])
     if handler_name is None:
         return None
+
+    if _is_first_level_help_request(argv):
+        return _run_early_command_help(argv[0])
 
     return globals()[handler_name](argv[1:])
 

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -171,6 +171,36 @@ def test_cli_guardrail_init_dispatch_exits_zero(monkeypatch):
     mock_init.assert_called_once_with()
 
 
+@pytest.mark.parametrize("help_flag", ["--help", "-h"])
+def test_cli_guardrail_init_help_has_no_side_effects(
+    tmp_path, monkeypatch, help_flag
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["skylos", "init", help_flag])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert not (tmp_path / "pyproject.toml").exists()
+
+
+@pytest.mark.parametrize("help_flag", ["--help", "-h"])
+def test_cli_guardrail_baseline_help_has_no_side_effects(
+    tmp_path, monkeypatch, help_flag
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["skylos", "baseline", help_flag])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert not (tmp_path / "--help").exists()
+    assert not (tmp_path / "-h").exists()
+    assert not (tmp_path / ".skylos").exists()
+
+
 def test_cli_guardrail_whitelist_dispatch_preserves_argv(monkeypatch):
     monkeypatch.setattr(
         sys,


### PR DESCRIPTION
Fixes #338.

## Summary

Prevents subcommands from treating `--help` / `-h` as real command input before argparse can handle help. This stops commands like `skylos init --help` from creating other artifacts.

## Tests

  - `pytest  test/test_cli_refactor_guardrails.py`