### PR TITLE
feat(security): complete deep audit workflow phases

### DIFF
--- a/skylos/audit_candidates.py
+++ b/skylos/audit_candidates.py
@@ -6,6 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 from skylos.audit_redaction import sanitize_for_audit
+from skylos.audit_polyglot import build_polyglot_signal_candidates
 from skylos.audit_store import AuditStore
 from skylos.audit_types import (
     DEFAULT_PROJECT_ID,
@@ -84,6 +85,7 @@ def scan_deep_audit_candidates(
     project_id: str = DEFAULT_PROJECT_ID,
     changed_files: list[str | Path] | None = None,
     exclude_folders: list[str] | None = None,
+    exclude_paths: list[str | Path] | None = None,
     audit_root: str | Path | None = None,
 ) -> tuple[AuditScanSummary, AuditStore]:
     project_root = _project_root(path)
@@ -110,6 +112,7 @@ def scan_deep_audit_candidates(
         project_root=project_root,
         changed_files=changed_files,
         exclude_folders=parsed_excludes,
+        exclude_paths=exclude_paths,
     )
     static_result = run_static_on_files(
         files,
@@ -129,6 +132,11 @@ def scan_deep_audit_candidates(
         files,
         project_root=project_root,
         static_result=static_result,
+    )
+    _add_polyglot_signal_candidates(
+        candidates_by_file,
+        files,
+        project_root=project_root,
     )
     _add_repo_activation_candidates(
         candidates_by_file,
@@ -216,7 +224,9 @@ def _discover_audit_files(
     project_root: Path,
     changed_files: list[str | Path] | None,
     exclude_folders: list[str],
+    exclude_paths: list[str | Path] | None,
 ) -> list[Path]:
+    excluded_paths = _normalized_exclude_paths(project_root, exclude_paths)
     if changed_files is not None:
         files = []
         for item in changed_files:
@@ -226,6 +236,8 @@ def _discover_audit_files(
                 continue
             candidate = project_root / rel
             if should_exclude_path(candidate, project_root, exclude_folders):
+                continue
+            if _is_excluded_output_path(candidate, project_root, excluded_paths):
                 continue
             if _is_audit_file(candidate) and candidate.exists():
                 files.append(candidate.resolve())
@@ -241,6 +253,8 @@ def _discover_audit_files(
     if target.is_file():
         if _is_audit_file(target) and not should_exclude_path(
             target, root, exclude_folders
+        ) and not _is_excluded_output_path(
+            target, project_root, excluded_paths
         ):
             discovered.append(target)
     else:
@@ -249,14 +263,52 @@ def _discover_audit_files(
                 continue
             if should_exclude_path(env_file, target, exclude_folders):
                 continue
+            if _is_excluded_output_path(env_file, project_root, excluded_paths):
+                continue
             discovered.append(env_file.resolve())
-    return sorted(set(discovered))
+    return sorted(
+        {
+            file_path.resolve()
+            for file_path in discovered
+            if not _is_excluded_output_path(file_path, project_root, excluded_paths)
+        }
+    )
 
 
 def _is_audit_file(path: Path) -> bool:
     if path.name == ".env" or path.name.startswith(".env."):
         return True
     return path.suffix.lower() in DEEP_AUDIT_EXTENSIONS
+
+
+def _normalized_exclude_paths(
+    project_root: Path,
+    exclude_paths: list[str | Path] | None,
+) -> set[str]:
+    excluded: set[str] = set()
+    for item in exclude_paths or []:
+        try:
+            excluded.add(normalize_relative_path(project_root, item))
+        except ValueError:
+            continue
+    return excluded
+
+
+def _is_excluded_output_path(
+    path: Path,
+    project_root: Path,
+    excluded_paths: set[str],
+) -> bool:
+    if not excluded_paths:
+        return False
+    try:
+        rel_path = normalize_relative_path(project_root, path)
+    except ValueError:
+        return False
+    return any(
+        rel_path == excluded or rel_path.startswith(f"{excluded}/")
+        for excluded in excluded_paths
+    )
 
 
 def _build_static_candidates(
@@ -414,6 +466,27 @@ def _add_repo_activation_candidates(
                 },
             )
         )
+
+
+def _add_polyglot_signal_candidates(
+    candidates_by_file: dict[str, list[AuditCandidate]],
+    files: list[Path],
+    *,
+    project_root: Path,
+) -> None:
+    for file_path in files:
+        rel_path = normalize_relative_path(project_root, file_path)
+        existing = candidates_by_file.setdefault(rel_path, [])
+        existing_locations = {
+            (candidate.rule_id, candidate.line) for candidate in existing
+        }
+        for candidate in build_polyglot_signal_candidates(
+            file_path, project_root=project_root
+        ):
+            if (candidate.rule_id, candidate.line) in existing_locations:
+                continue
+            existing.append(candidate)
+            existing_locations.add((candidate.rule_id, candidate.line))
 
 
 def _add_path_signal_candidates(

--- a/skylos/audit_ci.py
+++ b/skylos/audit_ci.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    STATUS_ANALYZED,
+    STATUS_ERROR,
+    STATUS_NOT_ANALYZED,
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    STATUS_SKIPPED,
+    AuditCIGateSummary,
+    AuditProcessSummary,
+    normalize_relative_path,
+)
+
+SEVERITY_RANK = {
+    "info": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+
+def evaluate_deep_audit_ci_gate(
+    *,
+    store: AuditStore,
+    fail_on: str,
+    model: str | None = None,
+    provider: str | None = None,
+    allowed_files: list[str | Path] | None = None,
+    process_summary: AuditProcessSummary | None = None,
+) -> AuditCIGateSummary:
+    threshold = _severity_value(fail_on)
+    allowed = _normalized_allowed_files(store, allowed_files)
+    counts = {
+        "findings": 0,
+        "pending": 0,
+        "not_analyzed": 0,
+        "skipped": 0,
+        "error": 0,
+        "locked": 0,
+        "stale_analyzed": 0,
+        "limited": 0,
+    }
+
+    for record in store.iter_file_records():
+        if allowed is not None and record.file not in allowed:
+            continue
+        if not record.candidates and not record.findings:
+            continue
+
+        high_risk_candidates = [
+            candidate
+            for candidate in record.candidates
+            if _severity_value(candidate.severity_hint) >= threshold
+        ]
+        high_risk_candidate_count = len(high_risk_candidates)
+
+        if record.status == STATUS_PENDING:
+            counts["pending"] += high_risk_candidate_count
+        elif record.status == STATUS_NOT_ANALYZED:
+            counts["not_analyzed"] += high_risk_candidate_count
+        elif record.status == STATUS_SKIPPED:
+            counts["skipped"] += high_risk_candidate_count
+        elif record.status == STATUS_ERROR:
+            counts["error"] += high_risk_candidate_count
+        elif record.status == STATUS_PROCESSING:
+            counts["locked"] += high_risk_candidate_count
+        elif (
+            record.status == STATUS_ANALYZED
+            and model is not None
+            and not _agent_context_matches(record, model=model, provider=provider)
+        ):
+            counts["stale_analyzed"] += high_risk_candidate_count
+
+        for finding in record.findings:
+            if not isinstance(finding, dict):
+                continue
+            if _finding_is_refuted(record, finding):
+                continue
+            if _severity_value(finding.get("severity")) >= threshold:
+                counts["findings"] += 1
+
+    unresolved = sum(
+        counts[key]
+        for key in [
+            "pending",
+            "not_analyzed",
+            "skipped",
+            "error",
+            "locked",
+            "stale_analyzed",
+        ]
+    )
+    if process_summary and process_summary.limited and unresolved:
+        counts["limited"] = 1
+
+    exit_code = 1 if any(counts.values()) else 0
+    return AuditCIGateSummary(
+        fail_on=fail_on,
+        exit_code=exit_code,
+        blocking_counts=counts,
+        complete=exit_code == 0,
+        reason=_gate_reason(counts),
+    )
+
+
+def _normalized_allowed_files(
+    store: AuditStore,
+    allowed_files: list[str | Path] | None,
+) -> set[str] | None:
+    if allowed_files is None:
+        return None
+    allowed: set[str] = set()
+    for file_path in allowed_files:
+        try:
+            allowed.add(normalize_relative_path(store.project_root, file_path))
+        except ValueError:
+            continue
+    return allowed
+
+
+def _severity_value(value: Any) -> int:
+    return SEVERITY_RANK.get(str(value or "info").lower(), 0)
+
+
+def _agent_context_matches(record, *, model: str, provider: str | None) -> bool:
+    for item in reversed(record.analysis_history):
+        if not isinstance(item, dict) or item.get("stage") != "agent_process":
+            continue
+        return item.get("model") == model and item.get("provider") == provider
+    return False
+
+
+def _finding_is_refuted(record, finding: dict[str, Any]) -> bool:
+    finding_id = str(finding.get("audit_finding_id") or "")
+    if not finding_id:
+        return False
+    for item in reversed(record.revalidation):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("finding_id") or "") != finding_id:
+            continue
+        verdict = str(item.get("verdict") or "").lower()
+        return verdict in {"false_positive", "fixed"}
+    return False
+
+
+def _gate_reason(counts: dict[str, int]) -> str:
+    if counts["findings"]:
+        return "supported or unresolved findings meet the failure threshold"
+    if counts["error"]:
+        return "deep audit processing errors remain"
+    if counts["pending"]:
+        return "pending high-risk deep audit work remains"
+    if counts["not_analyzed"]:
+        return "unsupported high-risk deep audit work remains"
+    if counts["skipped"]:
+        return "skipped high-risk deep audit work remains"
+    if counts["locked"]:
+        return "locked high-risk deep audit work remains"
+    if counts["stale_analyzed"]:
+        return "stale analyzed high-risk deep audit work remains"
+    if counts["limited"]:
+        return "limited deep audit run left high-risk work unresolved"
+    return "no blocking deep audit work at or above threshold"

--- a/skylos/audit_export.py
+++ b/skylos/audit_export.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import skylos
+from skylos.audit_redaction import sanitize_for_audit
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    STATUS_ANALYZED,
+    STATUS_ERROR,
+    STATUS_NOT_ANALYZED,
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    STATUS_SKIPPED,
+    AuditFileRecord,
+    normalize_relative_path,
+    sha256_text,
+)
+from skylos.sarif_exporter import SarifExporter
+
+SEVERITY_RANK = {
+    "info": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+EXPORT_VERDICTS = {
+    "true_positive",
+    "false_positive",
+    "fixed",
+    "uncertain",
+    "pending",
+    "not_analyzed",
+    "error",
+    "skipped",
+}
+
+MARKDOWN_FORMATS = {"md", "markdown"}
+SUPPORTED_EXPORT_FORMATS = {"json", "sarif", "md", "markdown", "md-dir"}
+
+
+def build_deep_audit_export(
+    *,
+    store: AuditStore,
+    min_severity: str | None = None,
+    verdicts: list[str] | tuple[str, ...] | set[str] | str | None = None,
+    allowed_files: list[str | Path] | None = None,
+) -> dict[str, Any]:
+    allowed = _normalized_allowed_files(store, allowed_files)
+    records = [
+        record
+        for record in store.iter_file_records()
+        if allowed is None or record.file in allowed
+    ]
+    entries = _build_entries(records)
+    severity_filter = _normalize_severity(min_severity) if min_severity else None
+    verdict_filter = _normalize_verdict_filter(verdicts)
+    filtered_entries = [
+        entry
+        for entry in entries
+        if _entry_matches(entry, severity_filter, verdict_filter)
+    ]
+
+    return sanitize_for_audit(
+        {
+            "schema_version": 1,
+            "tool": "Skylos Deep Audit",
+            "skylos_version": skylos.__version__,
+            "project_id": store.project_id,
+            "project_root": str(store.project_root),
+            "filters": {
+                "min_severity": severity_filter,
+                "verdicts": sorted(verdict_filter) if verdict_filter else [],
+            },
+            "completion": _completion(records),
+            "entry_count": len(filtered_entries),
+            "entries": filtered_entries,
+            "records": [record.to_dict() for record in records],
+        }
+    )
+
+
+def render_deep_audit_export(
+    export: dict[str, Any],
+    export_format: str,
+) -> str:
+    normalized = _normalize_export_format(export_format)
+    if normalized == "json":
+        return json.dumps(export, indent=2, sort_keys=True) + "\n"
+    if normalized == "sarif":
+        return json.dumps(_export_to_sarif(export), indent=2, sort_keys=True) + "\n"
+    if normalized in MARKDOWN_FORMATS:
+        return _export_to_markdown(export) + "\n"
+    raise ValueError(f"Unsupported Deep Mode export format: {export_format}")
+
+
+def write_deep_audit_export(
+    export: dict[str, Any],
+    output: str | Path,
+    export_format: str,
+) -> list[Path]:
+    normalized = _normalize_export_format(export_format)
+    output_path = _resolve_deep_audit_export_path(output)
+    if normalized == "md-dir":
+        return _write_markdown_directory(export, output_path)
+    rendered = render_deep_audit_export(export, normalized)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
+    return [output_path]
+
+
+def _resolve_deep_audit_export_path(output: str | Path) -> Path:
+    output_path = Path(output).expanduser()
+    if not output_path.name:
+        raise ValueError("Deep audit export output path must include a file name")
+    if output_path.exists() and output_path.is_dir():
+        raise ValueError(f"Deep audit export output is a directory: {output_path}")
+    return output_path
+
+
+def _normalized_allowed_files(
+    store: AuditStore,
+    allowed_files: list[str | Path] | None,
+) -> set[str] | None:
+    if allowed_files is None:
+        return None
+    allowed: set[str] = set()
+    for file_path in allowed_files:
+        try:
+            allowed.add(normalize_relative_path(store.project_root, file_path))
+        except ValueError:
+            continue
+    return allowed
+
+
+def _build_entries(records: list[AuditFileRecord]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for record in records:
+        for finding in record.findings:
+            if isinstance(finding, dict):
+                entries.append(_finding_entry(record, finding))
+
+        if record.status in {
+            STATUS_PENDING,
+            STATUS_PROCESSING,
+            STATUS_NOT_ANALYZED,
+            STATUS_ERROR,
+            STATUS_SKIPPED,
+        }:
+            entries.extend(_candidate_entries(record))
+
+    return sorted(entries, key=_entry_sort_key)
+
+
+def _finding_entry(
+    record: AuditFileRecord,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    finding_id = _finding_id(finding)
+    latest = _latest_revalidation(record, finding_id)
+    verdict = str((latest or {}).get("verdict") or "uncertain").lower()
+    if verdict not in EXPORT_VERDICTS:
+        verdict = "uncertain"
+    severity = _normalize_severity(
+        finding.get("severity") or finding.get("issue_severity") or "medium"
+    )
+    line = _int_or_default(
+        finding.get("line_number") or finding.get("line") or finding.get("lineno"),
+        1,
+    )
+    rule_id = str(finding.get("rule_id") or finding.get("rule") or "SKY-AUDIT")
+    message = str(finding.get("message") or finding.get("title") or rule_id)
+    return sanitize_for_audit(
+        {
+            "type": "finding",
+            "id": finding_id,
+            "file": record.file,
+            "line": line,
+            "rule_id": rule_id,
+            "severity": severity,
+            "message": message,
+            "status": record.status,
+            "verdict": verdict,
+            "verdict_reason": (latest or {}).get("reason"),
+            "redacted": False,
+            "source": "agent",
+            "finding": finding,
+        }
+    )
+
+
+def _candidate_entries(record: AuditFileRecord) -> list[dict[str, Any]]:
+    verdict = _record_status_verdict(record.status)
+    entries = []
+    for candidate in record.candidates:
+        entries.append(
+            sanitize_for_audit(
+                {
+                    "type": "candidate",
+                    "id": candidate.candidate_id,
+                    "file": record.file,
+                    "line": candidate.line,
+                    "rule_id": candidate.rule_id,
+                    "severity": _normalize_severity(candidate.severity_hint),
+                    "message": candidate.reason,
+                    "status": record.status,
+                    "verdict": verdict,
+                    "redacted": candidate.redacted,
+                    "source": candidate.evidence,
+                    "kind": candidate.kind,
+                    "symbol": candidate.symbol,
+                }
+            )
+        )
+    return entries
+
+
+def _record_status_verdict(status: str) -> str:
+    if status in {STATUS_PENDING, STATUS_PROCESSING}:
+        return "pending"
+    if status == STATUS_NOT_ANALYZED:
+        return "not_analyzed"
+    if status == STATUS_ERROR:
+        return "error"
+    if status == STATUS_SKIPPED:
+        return "skipped"
+    return "uncertain"
+
+
+def _completion(records: list[AuditFileRecord]) -> dict[str, Any]:
+    status_counts = {
+        STATUS_PENDING: 0,
+        STATUS_PROCESSING: 0,
+        STATUS_ANALYZED: 0,
+        STATUS_NOT_ANALYZED: 0,
+        STATUS_ERROR: 0,
+        STATUS_SKIPPED: 0,
+    }
+    candidate_count = 0
+    finding_count = 0
+    redacted_candidates = 0
+    skipped_candidates = 0
+    for record in records:
+        if record.status in status_counts:
+            status_counts[record.status] += 1
+        candidate_count += len(record.candidates)
+        finding_count += len(record.findings)
+        redacted_candidates += sum(1 for item in record.candidates if item.redacted)
+        if record.status == STATUS_SKIPPED:
+            skipped_candidates += len(record.candidates)
+
+    unresolved_files = (
+        status_counts[STATUS_PENDING]
+        + status_counts[STATUS_PROCESSING]
+        + status_counts[STATUS_NOT_ANALYZED]
+        + status_counts[STATUS_ERROR]
+        + status_counts[STATUS_SKIPPED]
+    )
+    return {
+        "complete": unresolved_files == 0,
+        "total_files": len(records),
+        "files_with_candidates": sum(1 for record in records if record.candidates),
+        "candidate_count": candidate_count,
+        "finding_count": finding_count,
+        "redacted_candidates": redacted_candidates,
+        "skipped_candidates": skipped_candidates,
+        "pending_files": status_counts[STATUS_PENDING],
+        "processing_files": status_counts[STATUS_PROCESSING],
+        "analyzed_files": status_counts[STATUS_ANALYZED],
+        "not_analyzed_files": status_counts[STATUS_NOT_ANALYZED],
+        "error_files": status_counts[STATUS_ERROR],
+        "skipped_files": status_counts[STATUS_SKIPPED],
+    }
+
+
+def _latest_revalidation(
+    record: AuditFileRecord,
+    finding_id: str,
+) -> dict[str, Any] | None:
+    for entry in reversed(record.revalidation):
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("finding_id") or "") == finding_id:
+            return entry
+    return None
+
+
+def _finding_id(finding: dict[str, Any]) -> str:
+    existing = finding.get("audit_finding_id")
+    if existing:
+        return str(existing)
+    payload = json.dumps(finding, sort_keys=True, default=str)
+    return "finding-" + sha256_text(payload)[:16]
+
+
+def _entry_matches(
+    entry: dict[str, Any],
+    severity_filter: str | None,
+    verdict_filter: set[str] | None,
+) -> bool:
+    if severity_filter and _severity_value(entry.get("severity")) < _severity_value(
+        severity_filter
+    ):
+        return False
+    if verdict_filter and str(entry.get("verdict") or "").lower() not in verdict_filter:
+        return False
+    return True
+
+
+def _normalize_verdict_filter(
+    verdicts: list[str] | tuple[str, ...] | set[str] | str | None,
+) -> set[str] | None:
+    if verdicts is None:
+        return None
+    raw_items: list[str]
+    if isinstance(verdicts, str):
+        raw_items = [verdicts]
+    else:
+        raw_items = [str(item) for item in verdicts]
+    normalized: set[str] = set()
+    for item in raw_items:
+        for part in item.split(","):
+            verdict = part.strip().lower()
+            if verdict:
+                normalized.add(verdict)
+    return normalized or None
+
+
+def _normalize_severity(value: Any) -> str:
+    severity = str(value or "info").strip().lower()
+    return severity if severity in SEVERITY_RANK else "info"
+
+
+def _severity_value(value: Any) -> int:
+    return SEVERITY_RANK.get(str(value or "info").lower(), 0)
+
+
+def _entry_sort_key(entry: dict[str, Any]) -> tuple[int, str, int, str, str]:
+    return (
+        -_severity_value(entry.get("severity")),
+        str(entry.get("file") or ""),
+        _int_or_default(entry.get("line"), 1),
+        str(entry.get("rule_id") or ""),
+        str(entry.get("id") or ""),
+    )
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    return result if result > 0 else default
+
+
+def _normalize_export_format(export_format: str) -> str:
+    normalized = str(export_format or "json").lower()
+    if normalized not in SUPPORTED_EXPORT_FORMATS:
+        raise ValueError(f"Unsupported Deep Mode export format: {export_format}")
+    return normalized
+
+
+def _export_to_sarif(export: dict[str, Any]) -> dict[str, Any]:
+    findings = [_entry_to_sarif_finding(entry) for entry in export.get("entries", [])]
+    sarif = SarifExporter(
+        findings,
+        tool_name="Skylos Deep Audit",
+        version=skylos.__version__,
+    ).generate()
+    run = sarif["runs"][0]
+    run.setdefault("properties", {})["deep_audit"] = {
+        "project_id": export.get("project_id"),
+        "completion": export.get("completion", {}),
+        "filters": export.get("filters", {}),
+        "entry_count": export.get("entry_count", 0),
+    }
+    return sarif
+
+
+def _entry_to_sarif_finding(entry: dict[str, Any]) -> dict[str, Any]:
+    message = str(entry.get("message") or entry.get("rule_id") or "Deep audit entry")
+    verdict = str(entry.get("verdict") or "uncertain")
+    return {
+        "rule_id": entry.get("rule_id") or "SKY-AUDIT",
+        "severity": str(entry.get("severity") or "info").upper(),
+        "message": f"[{verdict}] {message}",
+        "file": entry.get("file"),
+        "line": entry.get("line") or 1,
+        "category": "SECURITY",
+        "kind": entry.get("type"),
+        "metadata": {
+            "deep_audit_id": entry.get("id"),
+            "verdict": verdict,
+            "status": entry.get("status"),
+            "redacted": entry.get("redacted", False),
+            "source": entry.get("source"),
+        },
+    }
+
+
+def _export_to_markdown(export: dict[str, Any]) -> str:
+    completion = export.get("completion") or {}
+    lines = [
+        "# Skylos Deep Audit Report",
+        "",
+        f"- Project: `{_md_inline(export.get('project_root'))}`",
+        f"- Complete: `{str(completion.get('complete', False)).lower()}`",
+        f"- Entries: `{export.get('entry_count', 0)}`",
+        f"- Files: `{completion.get('total_files', 0)}`",
+        f"- Pending files: `{completion.get('pending_files', 0)}`",
+        f"- Not analyzed files: `{completion.get('not_analyzed_files', 0)}`",
+        f"- Error files: `{completion.get('error_files', 0)}`",
+        f"- Skipped files: `{completion.get('skipped_files', 0)}`",
+        "",
+    ]
+    filters = export.get("filters") or {}
+    if filters.get("min_severity") or filters.get("verdicts"):
+        lines.extend(
+            [
+                "## Filters",
+                "",
+                f"- Minimum severity: `{filters.get('min_severity') or 'none'}`",
+                f"- Verdicts: `{', '.join(filters.get('verdicts') or []) or 'none'}`",
+                "",
+            ]
+        )
+
+    entries = list(export.get("entries") or [])
+    if not entries:
+        lines.extend(["## Entries", "", "No Deep Mode entries matched the filters."])
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            "## Entries",
+            "",
+            "| Severity | Verdict | Status | Rule | Location | Message |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for entry in entries:
+        location = f"{entry.get('file')}:{entry.get('line') or 1}"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _md_cell(entry.get("severity")),
+                    _md_cell(entry.get("verdict")),
+                    _md_cell(entry.get("status")),
+                    _md_cell(entry.get("rule_id")),
+                    _md_cell(location),
+                    _md_cell(entry.get("message")),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def _write_markdown_directory(
+    export: dict[str, Any],
+    output_dir: Path,
+) -> list[Path]:
+    if output_dir.exists() and not output_dir.is_dir():
+        raise ValueError(f"Markdown directory output is not a directory: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written = []
+    index_path = output_dir / "index.md"
+    index_path.write_text(_export_to_markdown(export) + "\n", encoding="utf-8")
+    written.append(index_path)
+
+    for index, entry in enumerate(export.get("entries") or [], start=1):
+        entry_path = output_dir / _entry_markdown_filename(entry, index)
+        entry_path.write_text(_entry_to_markdown(entry) + "\n", encoding="utf-8")
+        written.append(entry_path)
+    return written
+
+
+def _entry_markdown_filename(entry: dict[str, Any], index: int) -> str:
+    rule = _slug(entry.get("rule_id") or "audit")
+    file_slug = _slug(str(entry.get("file") or "unknown").replace("/", "-"))
+    severity = _slug(entry.get("severity") or "info")
+    return f"{index:03d}-{severity}-{rule}-{file_slug}.md"
+
+
+def _entry_to_markdown(entry: dict[str, Any]) -> str:
+    lines = [
+        f"# {_md_inline(entry.get('rule_id') or 'Deep Audit Entry')}",
+        "",
+        f"- Severity: `{_md_inline(entry.get('severity'))}`",
+        f"- Verdict: `{_md_inline(entry.get('verdict'))}`",
+        f"- Status: `{_md_inline(entry.get('status'))}`",
+        f"- Location: `{_md_inline(entry.get('file'))}:{entry.get('line') or 1}`",
+        f"- Type: `{_md_inline(entry.get('type'))}`",
+        "",
+        "## Message",
+        "",
+        str(entry.get("message") or "").strip() or "(no message)",
+    ]
+    reason = entry.get("verdict_reason")
+    if reason:
+        lines.extend(["", "## Verdict Reason", "", str(reason)])
+    return "\n".join(lines)
+
+
+def _slug(value: Any) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", str(value or "").strip().lower())
+    slug = slug.strip("-._")
+    return slug[:80] or "entry"
+
+
+def _md_cell(value: Any) -> str:
+    text = str(value if value is not None else "")
+    text = text.replace("\n", " ").replace("|", "\\|")
+    return text.strip()
+
+
+def _md_inline(value: Any) -> str:
+    return str(value if value is not None else "").replace("`", "\\`")

--- a/skylos/audit_polyglot.py
+++ b/skylos/audit_polyglot.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from skylos.audit_redaction import sanitize_for_audit
+from skylos.audit_types import (
+    AuditCandidate,
+    code_region_hash,
+    language_for_path,
+    normalize_relative_path,
+    sha256_text,
+)
+
+
+@dataclass(frozen=True)
+class PolyglotSignalRule:
+    rule_id: str
+    pattern_id: str
+    severity: str
+    reason: str
+    regex: re.Pattern[str]
+
+
+POLYGLOT_LANGUAGES = {
+    "typescript",
+    "javascript",
+    "go",
+    "java",
+    "php",
+    "rust",
+    "dart",
+}
+
+_TS_JS_RULES = (
+    PolyglotSignalRule(
+        rule_id="SKY-D201",
+        pattern_id="js-eval",
+        severity="high",
+        reason="Dynamic JavaScript execution should be reviewed for injection risk.",
+        regex=re.compile(r"\b(?:eval|Function)\s*\("),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D212",
+        pattern_id="js-child-process",
+        severity="high",
+        reason="Child process execution should be reviewed for command injection risk.",
+        regex=re.compile(
+            r"\b(?:child_process\.)?(?:exec|execSync|spawn|spawnSync)\s*\("
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D211",
+        pattern_id="js-sql-concat",
+        severity="high",
+        reason="SQL execution with dynamic string construction needs review.",
+        regex=re.compile(
+            r"\b(?:query|execute|raw|sql)\s*\([^;\n]*(?:\+|\$\{)",
+            re.IGNORECASE,
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D216",
+        pattern_id="js-ssrf-client",
+        severity="high",
+        reason="Outbound HTTP calls with dynamic URLs should be reviewed for SSRF.",
+        regex=re.compile(
+            r"\b(?:fetch|axios\.(?:get|post|put|request)|http\.get|https\.get)"
+            r"\s*\([^;\n]*(?:req\.|request\.|\+|\$\{)",
+            re.IGNORECASE,
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D230",
+        pattern_id="js-open-redirect",
+        severity="medium",
+        reason="Redirect sinks should be reviewed for open redirect risk.",
+        regex=re.compile(
+            r"\b(?:redirect|res\.redirect|NextResponse\.redirect)\s*\([^;\n]*"
+            r"(?:req\.|request\.|\+|\$\{)",
+            re.IGNORECASE,
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D226",
+        pattern_id="js-html-injection",
+        severity="high",
+        reason="HTML injection sinks should be reviewed for XSS risk.",
+        regex=re.compile(
+            r"\b(?:innerHTML|outerHTML|dangerouslySetInnerHTML)\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+_GO_RULES = (
+    PolyglotSignalRule(
+        rule_id="SKY-D212",
+        pattern_id="go-exec-command",
+        severity="high",
+        reason="Process execution should be reviewed for command injection risk.",
+        regex=re.compile(r"\bexec\.Command\s*\("),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D211",
+        pattern_id="go-sql-dynamic",
+        severity="high",
+        reason="SQL calls with dynamic construction need review.",
+        regex=re.compile(
+            r"\.(?:Query|QueryContext|Exec|ExecContext)\s*\([^;\n]*(?:\+|fmt\.Sprintf)"
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D216",
+        pattern_id="go-http-client",
+        severity="high",
+        reason="Outbound HTTP calls with dynamic URLs should be reviewed for SSRF.",
+        regex=re.compile(r"\bhttp\.(?:Get|Post|Do)\s*\([^;\n]*(?:r\.|req\.|\+)"),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D215",
+        pattern_id="go-file-path",
+        severity="medium",
+        reason="File access from request-controlled values should be reviewed.",
+        regex=re.compile(
+            r"\b(?:os\.Open|os\.ReadFile|ioutil\.ReadFile)\s*\([^;\n]*"
+            r"(?:r\.|req\.|Query\(|Param\()"
+        ),
+    ),
+)
+
+_JAVA_RULES = (
+    PolyglotSignalRule(
+        rule_id="SKY-D212",
+        pattern_id="java-process",
+        severity="high",
+        reason="Runtime or ProcessBuilder execution needs command injection review.",
+        regex=re.compile(r"\b(?:Runtime\.getRuntime\(\)\.exec|new\s+ProcessBuilder)\s*\("),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D211",
+        pattern_id="java-sql-dynamic",
+        severity="high",
+        reason="SQL execution with dynamic construction needs review.",
+        regex=re.compile(
+            r"\b(?:executeQuery|executeUpdate|execute|query)\s*\([^;\n]*(?:\+|request\.)",
+            re.IGNORECASE,
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D204",
+        pattern_id="java-deserialize",
+        severity="high",
+        reason="Java deserialization sinks should be reviewed for unsafe input.",
+        regex=re.compile(r"\b(?:ObjectInputStream|readObject)\b"),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D230",
+        pattern_id="java-redirect",
+        severity="medium",
+        reason="Servlet redirects should be reviewed for open redirect risk.",
+        regex=re.compile(r"\bsendRedirect\s*\([^;\n]*(?:request\.|\+)"),
+    ),
+)
+
+_PHP_RULES = (
+    PolyglotSignalRule(
+        rule_id="SKY-D212",
+        pattern_id="php-command",
+        severity="high",
+        reason="Command execution should be reviewed for injection risk.",
+        regex=re.compile(r"\b(?:shell_exec|exec|system|passthru|proc_open)\s*\("),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D211",
+        pattern_id="php-sql-dynamic",
+        severity="high",
+        reason="SQL execution with request-controlled data needs review.",
+        regex=re.compile(
+            r"\b(?:mysqli_query|mysql_query|pg_query|->query)\s*\([^;\n]*"
+            r"(?:\$_(?:GET|POST|REQUEST)|\.)",
+            re.IGNORECASE,
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D204",
+        pattern_id="php-unserialize",
+        severity="high",
+        reason="unserialize on external data can lead to object injection.",
+        regex=re.compile(r"\bunserialize\s*\([^;\n]*\$_(?:GET|POST|REQUEST|COOKIE)"),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D230",
+        pattern_id="php-redirect",
+        severity="medium",
+        reason="Location headers should be reviewed for open redirect risk.",
+        regex=re.compile(r"\bheader\s*\(\s*['\"]Location:[^;\n]*(?:\$_|\.)"),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D215",
+        pattern_id="php-file-path",
+        severity="medium",
+        reason="File access from external parameters should be reviewed.",
+        regex=re.compile(
+            r"\b(?:file_get_contents|fopen|readfile|include|require)\s*\("
+            r"[^;\n]*\$_(?:GET|POST|REQUEST)",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+_RUST_RULES = (
+    PolyglotSignalRule(
+        rule_id="SKY-D212",
+        pattern_id="rust-command",
+        severity="high",
+        reason="Process execution should be reviewed for command injection risk.",
+        regex=re.compile(r"\bCommand::new\s*\("),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D211",
+        pattern_id="rust-sql-dynamic",
+        severity="high",
+        reason="SQL query construction with format or interpolation needs review.",
+        regex=re.compile(r"\b(?:sqlx::query|query)\s*\(\s*(?:format!|&format!)"),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D216",
+        pattern_id="rust-http-client",
+        severity="high",
+        reason="Outbound HTTP calls with dynamic URLs should be reviewed for SSRF.",
+        regex=re.compile(r"\breqwest::(?:get|Client::new)\s*\([^;\n]*(?:url|format!)"),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D215",
+        pattern_id="rust-file-path",
+        severity="medium",
+        reason="File access with dynamic paths should be reviewed.",
+        regex=re.compile(r"\bfs::(?:read|read_to_string|File::open)\s*\([^;\n]*(?:path|req|param)"),
+    ),
+)
+
+_DART_RULES = (
+    PolyglotSignalRule(
+        rule_id="SKY-D212",
+        pattern_id="dart-process",
+        severity="high",
+        reason="Process execution should be reviewed for command injection risk.",
+        regex=re.compile(r"\bProcess\.(?:run|start)\s*\("),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D216",
+        pattern_id="dart-http-client",
+        severity="high",
+        reason="Outbound HTTP calls with dynamic URLs should be reviewed for SSRF.",
+        regex=re.compile(r"\bhttp\.(?:get|post|put|delete)\s*\([^;\n]*(?:Uri\.parse|url)"),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D230",
+        pattern_id="dart-redirect",
+        severity="medium",
+        reason="Redirect sinks should be reviewed for open redirect risk.",
+        regex=re.compile(r"\bredirect\s*\([^;\n]*(?:request|query|url)", re.IGNORECASE),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D215",
+        pattern_id="dart-file-path",
+        severity="medium",
+        reason="File access with dynamic paths should be reviewed.",
+        regex=re.compile(r"\bFile\s*\([^;\n]*(?:path|request|query|param)"),
+    ),
+)
+
+_RULES_BY_LANGUAGE = {
+    "typescript": _TS_JS_RULES,
+    "javascript": _TS_JS_RULES,
+    "go": _GO_RULES,
+    "java": _JAVA_RULES,
+    "php": _PHP_RULES,
+    "rust": _RUST_RULES,
+    "dart": _DART_RULES,
+}
+
+_SEVERITY_PRIORITY = {
+    "critical": 1000,
+    "high": 800,
+    "medium": 500,
+    "low": 200,
+    "info": 100,
+}
+
+
+def build_polyglot_signal_candidates(
+    file_path: str | Path,
+    *,
+    project_root: str | Path,
+) -> list[AuditCandidate]:
+    language = language_for_path(file_path)
+    rules = _RULES_BY_LANGUAGE.get(language)
+    if not rules:
+        return []
+
+    try:
+        path = _resolve_polyglot_source_path(file_path, project_root=project_root)
+        source = path.read_text(encoding="utf-8", errors="ignore")
+    except (OSError, ValueError):
+        return []
+
+    rel_path = normalize_relative_path(project_root, path)
+    candidates: list[AuditCandidate] = []
+    seen: set[tuple[str, int, str]] = set()
+    for line_no, line in enumerate(source.splitlines(), start=1):
+        for rule in rules:
+            if not rule.regex.search(line):
+                continue
+            key = (rule.rule_id, line_no, rule.pattern_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(
+                AuditCandidate(
+                    candidate_id=_candidate_id(
+                        rel_path=rel_path,
+                        language=language,
+                        rule=rule,
+                        line=line_no,
+                        source=source,
+                    ),
+                    kind="polyglot_static_signal",
+                    rule_id=rule.rule_id,
+                    line=line_no,
+                    severity_hint=rule.severity,
+                    reason=rule.reason,
+                    evidence="static",
+                    redacted=False,
+                    priority=_SEVERITY_PRIORITY.get(rule.severity, 400),
+                    code_hash=code_region_hash(source, line_no),
+                    data=sanitize_for_audit(
+                        {
+                            "language": language,
+                            "pattern_id": rule.pattern_id,
+                            "phase": "deep-mode-phase7",
+                        }
+                    ),
+                )
+            )
+    return candidates
+
+
+def _resolve_polyglot_source_path(
+    file_path: str | Path,
+    *,
+    project_root: str | Path,
+) -> Path:
+    root = Path(project_root).resolve()
+    rel_path = normalize_relative_path(root, file_path)
+    candidate = (root / rel_path).resolve()
+    candidate.relative_to(root)
+    return candidate
+
+
+def _candidate_id(
+    *,
+    rel_path: str,
+    language: str,
+    rule: PolyglotSignalRule,
+    line: int,
+    source: str,
+) -> str:
+    payload = "|".join(
+        [
+            rel_path,
+            language,
+            rule.rule_id,
+            rule.pattern_id,
+            str(line),
+            code_region_hash(source, line),
+        ]
+    )
+    return "cand-poly-" + sha256_text(payload)[:16]

--- a/skylos/audit_processor.py
+++ b/skylos/audit_processor.py
@@ -33,10 +33,16 @@ def process_deep_audit_records(
     provider: str | None = None,
     limit: int | None = None,
     force: bool = False,
+    allowed_files: list[str | Path] | None = None,
     run_id: str | None = None,
 ) -> AuditProcessSummary:
     run_id = run_id or f"process-{uuid4().hex[:12]}"
-    records = [record for record in store.iter_file_records() if record.candidates]
+    allowed = _normalized_allowed_files(store, allowed_files)
+    records = [
+        record
+        for record in store.iter_file_records()
+        if record.candidates and (allowed is None or record.file in allowed)
+    ]
     locked_files = 0
     run_error_files = 0
     processed_files = 0
@@ -131,7 +137,12 @@ def process_deep_audit_records(
         store.write_file_record(record)
         processed_files += 1
 
-    state_counts = _audit_state_counts(store, model=model, provider=provider)
+    state_counts = _audit_state_counts(
+        store,
+        model=model,
+        provider=provider,
+        allowed_files=allowed_files,
+    )
     remaining = state_counts["unresolved"]
     summary = AuditProcessSummary(
         run_id=run_id,
@@ -174,6 +185,21 @@ def _record_sort_key(record: AuditFileRecord) -> tuple[int, str]:
         -max((candidate.priority for candidate in record.candidates), default=0),
         record.file,
     )
+
+
+def _normalized_allowed_files(
+    store: AuditStore,
+    allowed_files: list[str | Path] | None,
+) -> set[str] | None:
+    if allowed_files is None:
+        return None
+    allowed: set[str] = set()
+    for file_path in allowed_files:
+        try:
+            allowed.add(normalize_relative_path(store.project_root, file_path))
+        except ValueError:
+            continue
+    return allowed
 
 
 def _is_active_record(record: AuditFileRecord, *, force: bool) -> bool:
@@ -253,20 +279,31 @@ def _mark_unsupported(
     current.status = STATUS_NOT_ANALYZED
     current.locked_by_run_id = None
     current.locked_at = None
-    current.analysis_history.append(
-        sanitize_for_audit(
-            {
-                "stage": "unsupported_agent_language",
-                "run_id": run_id,
-                "language": current.language,
-                "reason": (
-                    "Deep Mode agent processing currently supports Python files only."
-                ),
-                "at": utc_now(),
-            }
+    if not _has_unsupported_language_history(current):
+        current.analysis_history.append(
+            sanitize_for_audit(
+                {
+                    "stage": "unsupported_agent_language",
+                    "run_id": run_id,
+                    "language": current.language,
+                    "reason": (
+                        "Deep Mode agent processing currently supports "
+                        "Python files only."
+                    ),
+                    "at": utc_now(),
+                }
+            )
         )
-    )
     store.write_file_record(current)
+
+
+def _has_unsupported_language_history(record: AuditFileRecord) -> bool:
+    return any(
+        isinstance(item, dict)
+        and item.get("stage") == "unsupported_agent_language"
+        and item.get("language") == record.language
+        for item in record.analysis_history
+    )
 
 
 def _mark_secret_skipped(
@@ -405,7 +442,9 @@ def _audit_state_counts(
     *,
     model: str,
     provider: str | None,
+    allowed_files: list[str | Path] | None = None,
 ) -> dict[str, int]:
+    allowed = _normalized_allowed_files(store, allowed_files)
     counts = {
         STATUS_PENDING: 0,
         STATUS_PROCESSING: 0,
@@ -417,6 +456,8 @@ def _audit_state_counts(
         "unresolved": 0,
     }
     for record in store.iter_file_records():
+        if allowed is not None and record.file not in allowed:
+            continue
         if not record.candidates:
             continue
         if record.status in counts:

--- a/skylos/audit_revalidator.py
+++ b/skylos/audit_revalidator.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from skylos.audit_redaction import redact_text, sanitize_for_audit
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    AuditFileRecord,
+    AuditRevalidationSummary,
+    normalize_relative_path,
+    sha256_text,
+    utc_now,
+)
+
+VALID_VERDICTS = {"true_positive", "false_positive", "fixed", "uncertain"}
+SECURITY_AUDIT_ISSUE = "security_audit"
+
+
+def revalidate_deep_audit_findings(
+    *,
+    store: AuditStore,
+    verifier: Any,
+    model: str,
+    provider: str | None = None,
+    force: bool = False,
+    challenge: bool = False,
+    allowed_files: list[str | Path] | None = None,
+    limit: int | None = None,
+    run_id: str | None = None,
+) -> AuditRevalidationSummary:
+    run_id = run_id or f"revalidate-{uuid4().hex[:12]}"
+    allowed = _normalized_allowed_files(store, allowed_files)
+    records = [
+        record
+        for record in store.iter_file_records()
+        if record.findings and (allowed is None or record.file in allowed)
+    ]
+
+    considered = 0
+    revalidated = 0
+    challenged = 0
+    skipped = 0
+    errors = 0
+    verdict_counts = {
+        "true_positive": 0,
+        "false_positive": 0,
+        "fixed": 0,
+        "uncertain": 0,
+    }
+
+    for record in records:
+        current = store.read_file_record(record.file)
+        if current is None:
+            continue
+
+        if _has_secret_candidate(current):
+            skipped += len(current.findings)
+            continue
+
+        for finding in list(current.findings):
+            if limit is not None and limit >= 0 and revalidated >= limit:
+                break
+            if not isinstance(finding, dict):
+                continue
+            finding_id = _finding_id(finding)
+            considered += 1
+            if challenge and _latest_verdict(current, finding_id) != "uncertain":
+                continue
+            if not force and _has_current_verdict(
+                current,
+                finding_id,
+                model=model,
+                provider=provider,
+                challenge=challenge,
+            ):
+                continue
+
+            try:
+                verdict = _verify_finding(
+                    verifier,
+                    store=store,
+                    record=current,
+                    finding=finding,
+                    mode="challenge" if challenge else "revalidate",
+                )
+            except Exception as exc:
+                verdict = {
+                    "verdict": "uncertain",
+                    "reason": f"Revalidation failed: {exc}",
+                }
+                errors += 1
+
+            normalized = _normalize_verdict(verdict)
+            entry = sanitize_for_audit(
+                {
+                    "finding_id": finding_id,
+                    "verdict": normalized["verdict"],
+                    "reason": normalized["reason"],
+                    "model": model,
+                    "provider": provider,
+                    "run_id": run_id,
+                    "mode": "challenge" if challenge else "revalidate",
+                    "revalidated_at": utc_now(),
+                }
+            )
+            current.revalidation.append(entry)
+            verdict_counts[normalized["verdict"]] += 1
+            revalidated += 1
+            if challenge:
+                challenged += 1
+
+        store.write_file_record(current)
+
+    summary = AuditRevalidationSummary(
+        run_id=run_id,
+        project_id=store.project_id,
+        project_root=str(store.project_root),
+        considered_findings=considered,
+        revalidated_findings=revalidated,
+        challenged_findings=challenged,
+        skipped_findings=skipped,
+        error_findings=errors,
+        true_positive=verdict_counts["true_positive"],
+        false_positive=verdict_counts["false_positive"],
+        fixed=verdict_counts["fixed"],
+        uncertain=verdict_counts["uncertain"],
+        forced=force,
+        challenge=challenge,
+        complete=skipped == 0 and errors == 0,
+    )
+    store.write_run(
+        run_id,
+        {
+            "mode": "challenge" if challenge else "revalidate",
+            "summary": summary.to_dict(),
+        },
+    )
+    return summary
+
+
+def _normalized_allowed_files(
+    store: AuditStore,
+    allowed_files: list[str | Path] | None,
+) -> set[str] | None:
+    if allowed_files is None:
+        return None
+    allowed: set[str] = set()
+    for file_path in allowed_files:
+        try:
+            allowed.add(normalize_relative_path(store.project_root, file_path))
+        except ValueError:
+            continue
+    return allowed
+
+
+def _has_secret_candidate(record: AuditFileRecord) -> bool:
+    return any(
+        candidate.redacted or candidate.rule_id.startswith("SKY-S")
+        for candidate in record.candidates
+    )
+
+
+def _finding_id(finding: dict[str, Any]) -> str:
+    existing = finding.get("audit_finding_id")
+    if existing:
+        return str(existing)
+    payload = json.dumps(finding, sort_keys=True, default=str)
+    return "finding-" + sha256_text(payload)[:16]
+
+
+def _has_current_verdict(
+    record: AuditFileRecord,
+    finding_id: str,
+    *,
+    model: str,
+    provider: str | None,
+    challenge: bool,
+) -> bool:
+    mode = "challenge" if challenge else "revalidate"
+    return any(
+        isinstance(item, dict)
+        and str(item.get("finding_id") or "") == finding_id
+        and item.get("model") == model
+        and item.get("provider") == provider
+        and item.get("mode", "revalidate") == mode
+        for item in record.revalidation
+    )
+
+
+def _latest_verdict(record: AuditFileRecord, finding_id: str) -> str | None:
+    for item in reversed(record.revalidation):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("finding_id") or "") == finding_id:
+            return str(item.get("verdict") or "").lower()
+    return None
+
+
+def _verify_finding(
+    verifier: Any,
+    *,
+    store: AuditStore,
+    record: AuditFileRecord,
+    finding: dict[str, Any],
+    mode: str,
+) -> dict[str, Any]:
+    context = _build_revalidation_context(store, record, finding, mode=mode)
+    verify_finding = getattr(verifier, "verify_finding", None)
+    if callable(verify_finding):
+        return verify_finding(
+            finding=sanitize_for_audit(finding),
+            context=context,
+            file_path=record.file,
+            mode=mode,
+        )
+
+    adapter_payload = _verify_with_agent_adapter(verifier, context=context, mode=mode)
+    if adapter_payload is not None:
+        return adapter_payload
+
+    return {
+        "verdict": "uncertain",
+        "reason": "No Deep Mode revalidation adapter was available.",
+    }
+
+
+def _build_revalidation_context(
+    store: AuditStore,
+    record: AuditFileRecord,
+    finding: dict[str, Any],
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    file_path = store.project_root / record.file
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        source = ""
+    return sanitize_for_audit(
+        {
+            "mode": mode,
+            "file": record.file,
+            "language": record.language,
+            "status": record.status,
+            "finding": finding,
+            "candidates": [candidate.to_dict() for candidate in record.candidates],
+            "analysis_history": record.analysis_history[-5:],
+            "redacted_source": redact_text(source),
+        }
+    )
+
+
+def _verify_with_agent_adapter(
+    verifier: Any,
+    *,
+    context: dict[str, Any],
+    mode: str,
+) -> dict[str, Any] | None:
+    get_agent = getattr(verifier, "_get_agent", None)
+    if not callable(get_agent):
+        return None
+    agent = get_agent(SECURITY_AUDIT_ISSUE)
+    get_adapter = getattr(agent, "get_adapter", None)
+    if not callable(get_adapter):
+        return None
+    adapter = get_adapter()
+    complete = getattr(adapter, "complete", None)
+    if not callable(complete):
+        return None
+
+    system = (
+        "You are Skylos Deep Mode revalidator. Return JSON only with keys "
+        "verdict and reason. verdict must be one of true_positive, "
+        "false_positive, fixed, uncertain."
+    )
+    user = json.dumps(context, indent=2, sort_keys=True)
+    response = complete(system, user)
+    if not response:
+        return None
+    try:
+        payload = json.loads(str(response))
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _normalize_verdict(payload: dict[str, Any] | None) -> dict[str, str]:
+    verdict = str((payload or {}).get("verdict") or "uncertain").lower()
+    verdict_map = {
+        "supported": "true_positive",
+        "true": "true_positive",
+        "tp": "true_positive",
+        "refuted": "false_positive",
+        "false": "false_positive",
+        "fp": "false_positive",
+    }
+    verdict = verdict_map.get(verdict, verdict)
+    if verdict not in VALID_VERDICTS:
+        verdict = "uncertain"
+    reason = str((payload or {}).get("reason") or "").strip()
+    if not reason:
+        reason = "No reason provided."
+    return {"verdict": verdict, "reason": reason}

--- a/skylos/audit_store.py
+++ b/skylos/audit_store.py
@@ -156,13 +156,13 @@ class AuditStore:
         )
 
         status = STATUS_PENDING if ordered_candidates else STATUS_NOT_ANALYZED
-        preserve_history = False
-        if existing and self._record_matches_current_scan(
+        preserve_history = existing is not None
+        current_scan_matches = existing and self._record_matches_current_scan(
             existing,
             file_hash=file_hash,
             config_hash=config_hash,
-        ):
-            preserve_history = True
+        )
+        if existing and current_scan_matches:
             existing_ids = {candidate.candidate_id for candidate in existing.candidates}
             new_ids = set(candidate_map)
             if existing.status == STATUS_ANALYZED and existing_ids == new_ids:
@@ -182,17 +182,17 @@ class AuditStore:
             candidates=ordered_candidates,
             findings=(
                 sanitize_for_audit(list(existing.findings))
-                if existing and preserve_history
+                if preserve_history
                 else []
             ),
             analysis_history=(
                 sanitize_for_audit(list(existing.analysis_history))
-                if existing and preserve_history
+                if preserve_history
                 else []
             ),
             revalidation=(
                 sanitize_for_audit(list(existing.revalidation))
-                if existing and preserve_history
+                if preserve_history
                 else []
             ),
             locked_by_run_id=(
@@ -207,7 +207,7 @@ class AuditStore:
             ),
             last_scanned_at=now,
             last_analyzed_at=(
-                existing.last_analyzed_at if existing and preserve_history else None
+                existing.last_analyzed_at if preserve_history else None
             ),
             skylos_version=skylos.__version__,
             config_hash=config_hash,

--- a/skylos/audit_types.py
+++ b/skylos/audit_types.py
@@ -343,3 +343,59 @@ class AuditProcessSummary:
             "analyzed_files": self.analyzed_files,
             "stale_analyzed_files": self.stale_analyzed_files,
         }
+
+
+@dataclass
+class AuditCIGateSummary:
+    fail_on: str
+    exit_code: int
+    blocking_counts: dict[str, int]
+    complete: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fail_on": self.fail_on,
+            "exit_code": self.exit_code,
+            "blocking_counts": dict(self.blocking_counts),
+            "complete": self.complete,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class AuditRevalidationSummary:
+    run_id: str
+    project_id: str
+    project_root: str
+    considered_findings: int
+    revalidated_findings: int
+    challenged_findings: int
+    skipped_findings: int
+    error_findings: int
+    true_positive: int
+    false_positive: int
+    fixed: int
+    uncertain: int
+    forced: bool
+    challenge: bool
+    complete: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "project_id": self.project_id,
+            "project_root": self.project_root,
+            "considered_findings": self.considered_findings,
+            "revalidated_findings": self.revalidated_findings,
+            "challenged_findings": self.challenged_findings,
+            "skipped_findings": self.skipped_findings,
+            "error_findings": self.error_findings,
+            "true_positive": self.true_positive,
+            "false_positive": self.false_positive,
+            "fixed": self.fixed,
+            "uncertain": self.uncertain,
+            "forced": self.forced,
+            "challenge": self.challenge,
+            "complete": self.complete,
+        }

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -211,6 +211,26 @@ def _list_dirty_relevant_paths(project_root: Path, is_relevant_path) -> list[str
     return relevant
 
 
+def _deep_audit_output_exclude_paths(
+    audit_path: pathlib.Path,
+    output_path: str | None,
+) -> list[pathlib.Path] | None:
+    if not output_path:
+        return None
+
+    target = audit_path.resolve()
+    project_root = target.parent if target.is_file() else target
+    output = pathlib.Path(output_path).expanduser()
+    if not output.is_absolute():
+        output = pathlib.Path.cwd() / output
+    output = output.resolve()
+    try:
+        output.relative_to(project_root)
+    except ValueError:
+        return None
+    return [output]
+
+
 def _create_precommit_snapshot(project_root: Path):
     snapshot_dir = tempfile.TemporaryDirectory(prefix="skylos_precommit_")
     snapshot_root = Path(snapshot_dir.name).resolve()
@@ -2096,10 +2116,14 @@ def run_whitelist(pattern=None, reason=None, show=False):
     return run_whitelist_impl(pattern=pattern, reason=reason, show=show)
 
 
-def get_git_changed_files(root_path):
+def get_git_changed_files(root_path, base_ref=None, *, strict_base=False):
     from skylos.cli_shared import get_git_changed_files as get_git_changed_files_impl
 
-    return get_git_changed_files_impl(root_path)
+    return get_git_changed_files_impl(
+        root_path,
+        base_ref=base_ref,
+        strict_base=strict_base,
+    )
 
 
 def estimate_cost(files):
@@ -3301,12 +3325,12 @@ def _build_agent_parser():
     p_audit.add_argument(
         "--changed",
         action="store_true",
-        help="Restrict scan-only candidate discovery to git-changed files",
+        help="Restrict Deep Mode audit work to git-changed files",
     )
     p_audit.add_argument(
         "--base",
         default=None,
-        help="Base ref for changed-file scans (reserved for CI gating)",
+        help="Base ref for changed-file scans",
     )
     p_audit.add_argument(
         "--limit",
@@ -3318,12 +3342,43 @@ def _build_agent_parser():
         "--fail-on",
         choices=["critical", "high", "medium", "low"],
         default=None,
-        help="Reserved for Deep Mode CI gating",
+        help="Exit 1 when Deep Mode work at or above this severity remains",
+    )
+    p_audit.add_argument(
+        "--revalidate",
+        action="store_true",
+        help="Persistently revalidate stored Deep Mode findings",
+    )
+    p_audit.add_argument(
+        "--challenge",
+        action="store_true",
+        help="Challenge prior uncertain Deep Mode revalidation verdicts",
     )
     p_audit.add_argument(
         "--format",
-        choices=["table", "json"],
+        choices=["table", "json", "sarif", "md", "markdown", "md-dir"],
         default="table",
+    )
+    p_audit.add_argument(
+        "--severity",
+        choices=["critical", "high", "medium", "low", "info"],
+        default=None,
+        help="Filter Deep Mode export entries to this severity or higher",
+    )
+    p_audit.add_argument(
+        "--verdict",
+        action="append",
+        choices=[
+            "true_positive",
+            "false_positive",
+            "fixed",
+            "uncertain",
+            "pending",
+            "not_analyzed",
+            "error",
+            "skipped",
+        ],
+        help="Filter Deep Mode export entries by verdict/status",
     )
     p_audit.add_argument("--out", "--output", "-o", dest="output")
     _add_agent_quiet_arg(p_audit)
@@ -4195,20 +4250,6 @@ def main() -> None:
                 )
                 sys.exit(2)
 
-            if getattr(agent_args, "base", None):
-                console.print(
-                    "[warn]Deep audit `--base` support belongs to the CI phase "
-                    "and is not enabled yet.[/warn]"
-                )
-                sys.exit(2)
-
-            if getattr(agent_args, "fail_on", None):
-                console.print(
-                    "[warn]Deep audit `--fail-on` support belongs to the CI phase "
-                    "and is not enabled yet.[/warn]"
-                )
-                sys.exit(2)
-
             if getattr(agent_args, "scan_only", False) and getattr(
                 agent_args, "resume", False
             ):
@@ -4227,13 +4268,20 @@ def main() -> None:
                 )
                 sys.exit(2)
 
-            if getattr(agent_args, "changed", False) and not getattr(
-                agent_args, "scan_only", False
+            if getattr(agent_args, "scan_only", False) and getattr(
+                agent_args, "revalidate", False
             ):
                 console.print(
-                    "[warn]Deep audit processing with `--changed` belongs to the "
-                    "CI phase and is not enabled yet. Use `--scan-only --changed` "
-                    "for changed-file candidate discovery.[/warn]"
+                    "[warn]Deep audit `--revalidate` requires revalidation mode, "
+                    "not `--scan-only`.[/warn]"
+                )
+                sys.exit(2)
+
+            if getattr(agent_args, "challenge", False) and not getattr(
+                agent_args, "revalidate", False
+            ):
+                console.print(
+                    "[warn]Deep audit `--challenge` requires `--revalidate`.[/warn]"
                 )
                 sys.exit(2)
 
@@ -4243,8 +4291,19 @@ def main() -> None:
                 sys.exit(1)
 
             changed_files = None
-            if getattr(agent_args, "changed", False):
-                changed_files = get_git_changed_files(audit_path)
+            changed_scope = bool(getattr(agent_args, "changed", False)) or bool(
+                getattr(agent_args, "base", None)
+            )
+            if changed_scope:
+                try:
+                    changed_files = get_git_changed_files(
+                        audit_path,
+                        base_ref=getattr(agent_args, "base", None),
+                        strict_base=bool(getattr(agent_args, "base", None)),
+                    )
+                except ValueError as exc:
+                    console.print(f"[bad]{exc}[/bad]")
+                    sys.exit(2)
                 if not changed_files:
                     if not getattr(agent_args, "quiet", False):
                         console.print("[dim]No changed files[/dim]")
@@ -4252,12 +4311,21 @@ def main() -> None:
 
             from skylos.audit_candidates import scan_deep_audit_candidates
 
+            output_exclude_paths = _deep_audit_output_exclude_paths(
+                audit_path,
+                getattr(agent_args, "output", None),
+            )
+            scan_kwargs = {"changed_files": changed_files}
+            if output_exclude_paths:
+                scan_kwargs["exclude_paths"] = output_exclude_paths
             summary, store = scan_deep_audit_candidates(
                 audit_path,
-                changed_files=changed_files,
+                **scan_kwargs,
             )
             audit_project_root = pathlib.Path(summary.project_root)
             process_summary = None
+            revalidation_summary = None
+            ci_summary = None
             mode = "deep_scan_only"
 
             if not getattr(agent_args, "scan_only", False):
@@ -4317,17 +4385,51 @@ def main() -> None:
                 )
                 analyzer = SkylosLLM(config)
 
-                from skylos.audit_processor import process_deep_audit_records
+                if getattr(agent_args, "revalidate", False):
+                    from skylos.audit_revalidator import (
+                        revalidate_deep_audit_findings,
+                    )
 
-                process_summary = process_deep_audit_records(
+                    revalidation_summary = revalidate_deep_audit_findings(
+                        store=store,
+                        verifier=analyzer,
+                        model=model,
+                        provider=provider,
+                        limit=getattr(agent_args, "limit", None),
+                        force=getattr(agent_args, "force", False),
+                        challenge=getattr(agent_args, "challenge", False),
+                        allowed_files=changed_files if changed_scope else None,
+                    )
+                    mode = (
+                        "deep_challenge"
+                        if getattr(agent_args, "challenge", False)
+                        else "deep_revalidate"
+                    )
+                else:
+                    from skylos.audit_processor import process_deep_audit_records
+
+                    process_summary = process_deep_audit_records(
+                        store=store,
+                        analyzer=analyzer,
+                        model=model,
+                        provider=provider,
+                        limit=getattr(agent_args, "limit", None),
+                        force=getattr(agent_args, "force", False),
+                        allowed_files=changed_files if changed_scope else None,
+                    )
+                    mode = "deep_process"
+
+            if getattr(agent_args, "fail_on", None):
+                from skylos.audit_ci import evaluate_deep_audit_ci_gate
+
+                ci_summary = evaluate_deep_audit_ci_gate(
                     store=store,
-                    analyzer=analyzer,
-                    model=model,
-                    provider=provider,
-                    limit=getattr(agent_args, "limit", None),
-                    force=getattr(agent_args, "force", False),
+                    fail_on=getattr(agent_args, "fail_on"),
+                    model=locals().get("model"),
+                    provider=locals().get("provider"),
+                    allowed_files=changed_files if changed_scope else None,
+                    process_summary=process_summary,
                 )
-                mode = "deep_process"
 
             payload = {
                 "mode": mode,
@@ -4336,16 +4438,77 @@ def main() -> None:
             }
             if process_summary is not None:
                 payload["processing"] = process_summary.to_dict()
+            if revalidation_summary is not None:
+                payload["revalidation"] = revalidation_summary.to_dict()
+            if ci_summary is not None:
+                payload["ci"] = ci_summary.to_dict()
 
-            if agent_args.output:
+            export_payload = None
+            export_format = getattr(agent_args, "format", "table")
+            if export_format in {"json", "sarif", "md", "markdown", "md-dir"}:
+                iter_records = getattr(store, "iter_file_records", None)
+                if callable(iter_records):
+                    from skylos.audit_export import build_deep_audit_export
+
+                    export_payload = build_deep_audit_export(
+                        store=store,
+                        min_severity=getattr(agent_args, "severity", None),
+                        verdicts=getattr(agent_args, "verdict", None),
+                        allowed_files=changed_files if changed_scope else None,
+                    )
+                    payload["export"] = export_payload
+
+            if export_format in {"sarif", "md", "markdown", "md-dir"}:
+                if export_payload is None:
+                    console.print(
+                        "[bad]Deep audit export requires persisted audit state.[/bad]"
+                    )
+                    sys.exit(1)
+
+                from skylos.audit_export import (
+                    render_deep_audit_export,
+                    write_deep_audit_export,
+                )
+
+                if agent_args.output:
+                    written_paths = write_deep_audit_export(
+                        export_payload,
+                        agent_args.output,
+                        export_format,
+                    )
+                    if not getattr(agent_args, "quiet", False):
+                        console.print(
+                            f"[dim]Written {len(written_paths)} export file(s) "
+                            f"to {agent_args.output}[/dim]"
+                        )
+                elif export_format == "md-dir":
+                    default_output = store.exports_dir / "markdown"
+                    written_paths = write_deep_audit_export(
+                        export_payload,
+                        default_output,
+                        export_format,
+                    )
+                    if not getattr(agent_args, "quiet", False):
+                        console.print(
+                            f"[dim]Written {len(written_paths)} export file(s) "
+                            f"to {default_output}[/dim]"
+                        )
+                elif not getattr(agent_args, "quiet", False):
+                    print(
+                        render_deep_audit_export(export_payload, export_format),
+                        end="",
+                    )
+            elif agent_args.output:
                 pathlib.Path(agent_args.output).write_text(
                     json.dumps(payload, indent=2, sort_keys=True) + "\n",
                     encoding="utf-8",
                 )
 
-            if agent_args.format == "json":
+            if export_format == "json":
                 if not getattr(agent_args, "quiet", False):
                     print(json.dumps(payload, indent=2, sort_keys=True))
+            elif export_format in {"sarif", "md", "markdown", "md-dir"}:
+                pass
             elif not getattr(agent_args, "quiet", False):
                 heading = "scan-only" if process_summary is None else "scan"
                 console.print(
@@ -4374,8 +4537,25 @@ def main() -> None:
                         f"  Remaining work: "
                         f"{process_summary.remaining_pending_files}"
                     )
+                if revalidation_summary is not None:
+                    console.print("[brand]Deep audit revalidation:[/brand] finished")
+                    console.print(
+                        f"  Revalidated findings: "
+                        f"{revalidation_summary.revalidated_findings}"
+                    )
+                    console.print(
+                        f"  Challenged findings: "
+                        f"{revalidation_summary.challenged_findings}"
+                    )
+                    console.print(
+                        f"  Uncertain verdicts: {revalidation_summary.uncertain}"
+                    )
+                if ci_summary is not None:
+                    console.print(
+                        f"[brand]Deep audit CI:[/brand] {ci_summary.reason}"
+                    )
                 console.print(f"  Store: {store.project_dir}")
-            sys.exit(0)
+            sys.exit(ci_summary.exit_code if ci_summary is not None else 0)
 
         if not _ensure_llm_support():
             Console().print("[bold red]Agent module not available[/bold red]")

--- a/skylos/cli_shared.py
+++ b/skylos/cli_shared.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 
-def get_git_changed_files(root_path):
+def get_git_changed_files(root_path, base_ref=None, *, strict_base=False):
     supported_exts = {
         ".py",
         ".go",
@@ -54,6 +54,21 @@ def get_git_changed_files(root_path):
             .decode("utf-8")
             .strip()
         )
+        if base_ref:
+            try:
+                output = subprocess.check_output(
+                    ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+                    cwd=repo_root,
+                    stderr=subprocess.DEVNULL,
+                    timeout=30,
+                ).decode("utf-8")
+                return _collect_supported(output, repo_root)
+            except Exception as exc:
+                if strict_base:
+                    message = f"Unable to diff against base ref {base_ref}"
+                    raise ValueError(message) from exc
+                return []
+
         output = subprocess.check_output(
             ["git", "diff", "--name-only", "HEAD"],
             cwd=repo_root,
@@ -75,7 +90,9 @@ def get_git_changed_files(root_path):
             return _collect_supported(output, repo_root)
         except Exception:
             return []
-    except Exception:
+    except Exception as exc:
+        if strict_base:
+            raise ValueError("Unable to discover git changed files") from exc
         return []
 
 

--- a/test/test_audit_candidates.py
+++ b/test/test_audit_candidates.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from skylos import audit_candidates
 from skylos.audit_store import AuditStore
 from skylos.audit_types import AuditFileRecord, sha256_file
@@ -189,6 +191,35 @@ def test_scan_deep_audit_candidates_changed_files_respect_excludes(
     assert seen["files"] == ["app.py"]
 
 
+def test_scan_deep_audit_candidates_excludes_active_output_path(
+    tmp_path: Path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("print('ok')\n", encoding="utf-8")
+    out = repo / "audit.json"
+    out.write_text('{"previous": true}\n', encoding="utf-8")
+    seen = {}
+
+    def fake_static(files, **kwargs):
+        seen["files"] = sorted(Path(file_path).name for file_path in files)
+        return {"danger": [], "secrets": []}
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(
+        repo,
+        exclude_paths=[out],
+    )
+
+    assert summary.files_scanned == 1
+    assert seen["files"] == ["app.py"]
+    assert store.read_file_record(app) is not None
+    assert store.read_file_record(out) is None
+
+
 def test_audit_store_rejects_record_with_mismatched_internal_file(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -286,3 +317,95 @@ def test_scan_deep_audit_candidates_reports_error_records_incomplete(
 
     assert summary.error_files == 1
     assert summary.complete is False
+
+
+@pytest.mark.parametrize(
+    ("filename", "source", "language", "rule_id"),
+    [
+        (
+            "route.ts",
+            "import cp from 'child_process';\ncp.exec(userInput);\n",
+            "typescript",
+            "SKY-D212",
+        ),
+        (
+            "handler.js",
+            "export function get(req) { return fetch(req.query.url); }\n",
+            "javascript",
+            "SKY-D216",
+        ),
+        (
+            "main.go",
+            "package main\n"
+            "import \"os/exec\"\n"
+            "func run(name string) { exec.Command(name) }\n",
+            "go",
+            "SKY-D212",
+        ),
+        (
+            "Controller.java",
+            "class Controller {\n"
+            "  void run(String cmd) throws Exception {\n"
+            "    Runtime.getRuntime().exec(cmd);\n"
+            "  }\n"
+            "}\n",
+            "java",
+            "SKY-D212",
+        ),
+        (
+            "index.php",
+            "<?php system($_GET['cmd']); ?>\n",
+            "php",
+            "SKY-D212",
+        ),
+        (
+            "main.rs",
+            "use std::process::Command;\n"
+            "fn run(cmd: &str) { Command::new(cmd).spawn(); }\n",
+            "rust",
+            "SKY-D212",
+        ),
+        (
+            "main.dart",
+            "import 'dart:io';\nvoid run(String cmd) { Process.run(cmd, []); }\n",
+            "dart",
+            "SKY-D212",
+        ),
+    ],
+)
+def test_scan_deep_audit_candidates_ingests_polyglot_static_signals(
+    tmp_path: Path,
+    monkeypatch,
+    filename: str,
+    source: str,
+    language: str,
+    rule_id: str,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / filename
+    target.write_text(source, encoding="utf-8")
+    monkeypatch.setattr(
+        audit_candidates,
+        "run_static_on_files",
+        lambda files, **kwargs: {"danger": [], "secrets": []},
+    )
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(target)
+
+    assert summary.candidate_count >= 1
+    assert record is not None
+    assert record.language == language
+    assert record.status == "pending"
+    assert any(
+        candidate.kind == "polyglot_static_signal" and candidate.rule_id == rule_id
+        for candidate in record.candidates
+    )
+
+    first_ids = [candidate.candidate_id for candidate in record.candidates]
+    _summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    rerun = store.read_file_record(target)
+
+    assert rerun is not None
+    assert [candidate.candidate_id for candidate in rerun.candidates] == first_ids

--- a/test/test_audit_ci.py
+++ b/test/test_audit_ci.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.audit_ci import evaluate_deep_audit_ci_gate
+from skylos.audit_store import AuditStore
+from skylos.audit_types import AuditCandidate, AuditProcessSummary, sha256_file
+
+
+def _candidate(candidate_id: str, *, severity: str = "high") -> AuditCandidate:
+    return AuditCandidate(
+        candidate_id=candidate_id,
+        kind="static_finding",
+        rule_id="SKY-D999",
+        line=1,
+        severity_hint=severity,
+        reason="candidate",
+        priority=800,
+    )
+
+
+def _write_record(
+    store: AuditStore,
+    path: Path,
+    *,
+    severity: str = "high",
+    status: str = "pending",
+):
+    record = store.upsert_scan_record(
+        file_path=path,
+        file_hash=sha256_file(path),
+        language="python",
+        candidates=[_candidate(path.name, severity=severity)],
+        config_hash="cfg",
+    )
+    record.status = status
+    store.write_file_record(record)
+    return record
+
+
+def test_ci_gate_fails_for_pending_candidate_at_threshold(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, severity="high")
+
+    summary = evaluate_deep_audit_ci_gate(store=store, fail_on="high")
+
+    assert summary.exit_code == 1
+    assert summary.blocking_counts["pending"] == 1
+    assert summary.complete is False
+
+
+def test_ci_gate_passes_for_candidates_below_threshold(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, severity="medium")
+
+    summary = evaluate_deep_audit_ci_gate(store=store, fail_on="high")
+
+    assert summary.exit_code == 0
+    assert summary.blocking_counts["pending"] == 0
+
+
+def test_ci_gate_ignores_false_positive_revalidated_findings(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _write_record(store, app, status="analyzed")
+    record.findings = [
+        {
+            "audit_finding_id": "finding-one",
+            "severity": "critical",
+            "message": "critical finding",
+        }
+    ]
+    record.revalidation = [
+        {
+            "finding_id": "finding-one",
+            "verdict": "false_positive",
+            "model": "test-model",
+        }
+    ]
+    store.write_file_record(record)
+
+    summary = evaluate_deep_audit_ci_gate(store=store, fail_on="high")
+
+    assert summary.exit_code == 0
+    assert summary.blocking_counts["findings"] == 0
+
+
+def test_ci_gate_limited_run_blocks_when_unresolved_threshold_work_remains(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, severity="critical")
+    process_summary = AuditProcessSummary(
+        run_id="run",
+        project_id="default",
+        project_root=str(repo),
+        considered_files=1,
+        processed_files=0,
+        findings_added=0,
+        skipped_secret_files=0,
+        unsupported_files=0,
+        locked_files=0,
+        error_files=0,
+        remaining_pending_files=1,
+        limited=True,
+        complete=False,
+    )
+
+    summary = evaluate_deep_audit_ci_gate(
+        store=store,
+        fail_on="high",
+        process_summary=process_summary,
+    )
+
+    assert summary.exit_code == 1
+    assert summary.blocking_counts["limited"] == 1
+
+
+def test_ci_gate_blocks_unsupported_not_analyzed_polyglot_work(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "route.ts"
+    app.write_text(
+        "import cp from 'child_process';\ncp.exec(userInput);\n",
+        encoding="utf-8",
+    )
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, severity="high", status="not_analyzed")
+
+    summary = evaluate_deep_audit_ci_gate(store=store, fail_on="high")
+
+    assert summary.exit_code == 1
+    assert summary.blocking_counts["not_analyzed"] == 1
+    assert summary.complete is False

--- a/test/test_audit_cli.py
+++ b/test/test_audit_cli.py
@@ -7,7 +7,15 @@ from types import SimpleNamespace
 import pytest
 
 import skylos.cli as cli
-from skylos.audit_types import AuditProcessSummary, AuditScanSummary
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    AuditCIGateSummary,
+    AuditCandidate,
+    AuditProcessSummary,
+    AuditRevalidationSummary,
+    AuditScanSummary,
+    sha256_file,
+)
 
 
 def test_agent_audit_deep_scan_only_runs_without_llm_support(
@@ -85,11 +93,54 @@ def test_agent_audit_requires_explicit_deep_flag(tmp_path: Path, monkeypatch):
     assert exc.value.code == 2
 
 
-def test_agent_audit_scan_only_rejects_unimplemented_ci_flags(
+def test_agent_audit_scan_only_runs_ci_gate(
     tmp_path: Path, monkeypatch
 ):
     repo = tmp_path / "repo"
     repo.mkdir()
+    out = tmp_path / "audit.json"
+    store = SimpleNamespace(
+        project_dir=repo / ".skylos" / "audit" / "projects" / "default"
+    )
+
+    def fake_scan(path, *, changed_files=None):
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=1,
+                redacted_candidates=0,
+                pending_files=1,
+                not_analyzed_files=0,
+            ),
+            store,
+        )
+
+    def fake_gate(**kwargs):
+        return AuditCIGateSummary(
+            fail_on="high",
+            exit_code=1,
+            blocking_counts={
+                "findings": 0,
+                "pending": 1,
+                "not_analyzed": 0,
+                "skipped": 0,
+                "error": 0,
+                "locked": 0,
+                "stale_analyzed": 0,
+                "limited": 0,
+            },
+            complete=False,
+            reason="pending high-risk deep audit work remains",
+        )
+
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+    monkeypatch.setattr("skylos.audit_ci.evaluate_deep_audit_ci_gate", fake_gate)
     monkeypatch.setattr(
         cli.sys,
         "argv",
@@ -102,13 +153,158 @@ def test_agent_audit_scan_only_rejects_unimplemented_ci_flags(
             "--scan-only",
             "--fail-on",
             "high",
+            "--format",
+            "json",
+            "--output",
+            str(out),
         ],
     )
 
     with pytest.raises(SystemExit) as exc:
         cli.main()
 
-    assert exc.value.code == 2
+    assert exc.value.code == 1
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ci"]["blocking_counts"]["pending"] == 1
+
+
+def test_agent_audit_scan_only_writes_sarif_export_from_persisted_state(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    out = tmp_path / "audit.sarif.json"
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    store.upsert_scan_record(
+        file_path=app,
+        file_hash=sha256_file(app),
+        language="python",
+        candidates=[
+            AuditCandidate(
+                candidate_id="candidate-one",
+                kind="static_finding",
+                rule_id="SKY-D999",
+                line=1,
+                severity_hint="high",
+                reason="dangerous sink",
+                priority=800,
+            )
+        ],
+        config_hash="cfg",
+    )
+
+    def fake_scan(path, *, changed_files=None):
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=1,
+                redacted_candidates=0,
+                pending_files=1,
+                not_analyzed_files=0,
+                complete=False,
+            ),
+            store,
+        )
+
+    def fail_if_llm_checked():
+        raise AssertionError("LLM support should not be checked")
+
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+    monkeypatch.setattr(cli, "_ensure_llm_support", fail_if_llm_checked)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--scan-only",
+            "--format",
+            "sarif",
+            "--severity",
+            "high",
+            "--verdict",
+            "pending",
+            "--output",
+            str(out),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    sarif = json.loads(out.read_text(encoding="utf-8"))
+    assert exc.value.code == 0
+    assert sarif["version"] == "2.1.0"
+    assert sarif["runs"][0]["results"][0]["ruleId"] == "SKY-D999"
+    assert sarif["runs"][0]["properties"]["deep_audit"]["entry_count"] == 1
+
+
+def test_agent_audit_excludes_repo_local_output_from_scan(
+    tmp_path: Path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = repo / "audit.json"
+    called = {}
+
+    def fake_scan(path, *, changed_files=None, exclude_paths=None):
+        called["exclude_paths"] = exclude_paths
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=0,
+                redacted_candidates=0,
+                pending_files=0,
+                not_analyzed_files=1,
+                complete=True,
+            ),
+            SimpleNamespace(
+                project_dir=repo / ".skylos" / "audit" / "projects" / "default"
+            ),
+        )
+
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--scan-only",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert called["exclude_paths"] == [out.resolve()]
 
 
 def test_agent_audit_scan_only_rejects_unimplemented_processing_flags(
@@ -152,30 +348,6 @@ def test_agent_audit_scan_only_rejects_force_until_processing_exists(
             "--deep",
             "--scan-only",
             "--force",
-        ],
-    )
-
-    with pytest.raises(SystemExit) as exc:
-        cli.main()
-
-    assert exc.value.code == 2
-
-
-def test_agent_audit_processing_rejects_changed_until_ci_phase(
-    tmp_path: Path, monkeypatch
-):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    monkeypatch.setattr(
-        cli.sys,
-        "argv",
-        [
-            "skylos",
-            "agent",
-            "audit",
-            str(repo),
-            "--deep",
-            "--changed",
         ],
     )
 
@@ -276,3 +448,256 @@ def test_agent_audit_deep_processing_runs_after_scan(tmp_path: Path, monkeypatch
     assert payload["processing"]["processed_files"] == 1
     assert calls["process"]["limit"] == 3
     assert calls["process"]["force"] is False
+
+
+def test_agent_audit_changed_processing_scopes_scan_and_processing(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    changed = repo / "changed.py"
+    changed.write_text("eval(user_input)\n", encoding="utf-8")
+    store = SimpleNamespace(
+        project_dir=repo / ".skylos" / "audit" / "projects" / "default"
+    )
+    calls = {}
+
+    def fake_scan(path, *, changed_files=None):
+        calls["scan_changed_files"] = changed_files
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=1,
+                redacted_candidates=0,
+                pending_files=1,
+                not_analyzed_files=0,
+                complete=False,
+            ),
+            store,
+        )
+
+    def fake_process(**kwargs):
+        calls["process"] = kwargs
+        return AuditProcessSummary(
+            run_id="process-one",
+            project_id="default",
+            project_root=str(repo),
+            considered_files=1,
+            processed_files=1,
+            findings_added=0,
+            skipped_secret_files=0,
+            unsupported_files=0,
+            locked_files=0,
+            error_files=0,
+            remaining_pending_files=0,
+            limited=False,
+            complete=True,
+        )
+
+    class FakeLLM:
+        def __init__(self, config):
+            self.config = config
+
+    monkeypatch.setattr(cli, "get_git_changed_files", lambda *a, **k: [changed])
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+    monkeypatch.setattr(
+        "skylos.audit_processor.process_deep_audit_records",
+        fake_process,
+    )
+    monkeypatch.setattr(cli, "_ensure_llm_support", lambda: True)
+    monkeypatch.setattr(cli, "_build_analyzer_config", lambda **kwargs: kwargs)
+    monkeypatch.setattr(cli, "SkylosLLM", FakeLLM)
+    monkeypatch.setattr(
+        cli,
+        "resolve_llm_runtime",
+        lambda **kwargs: ("ollama", None, None, True),
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", "agent", "audit", str(repo), "--deep", "--changed"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert calls["scan_changed_files"] == [changed]
+    assert calls["process"]["allowed_files"] == [changed]
+
+
+def test_agent_audit_invalid_base_ref_exits_without_full_scan(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def fake_changed(*args, **kwargs):
+        raise ValueError("Unable to diff against base ref nope")
+
+    def fail_scan(*args, **kwargs):
+        raise AssertionError("scan should not run for invalid base")
+
+    monkeypatch.setattr(cli, "get_git_changed_files", fake_changed)
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fail_scan,
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--changed",
+            "--base",
+            "nope",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_scan_only_rejects_revalidate(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--scan-only",
+            "--revalidate",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_challenge_requires_revalidate(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", "agent", "audit", str(repo), "--deep", "--challenge"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_agent_audit_revalidate_runs_after_scan(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = tmp_path / "audit.json"
+    store = SimpleNamespace(
+        project_dir=repo / ".skylos" / "audit" / "projects" / "default"
+    )
+    calls = {}
+
+    def fake_scan(path, *, changed_files=None):
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=1,
+                redacted_candidates=0,
+                pending_files=0,
+                not_analyzed_files=0,
+                complete=True,
+            ),
+            store,
+        )
+
+    def fake_revalidate(**kwargs):
+        calls["revalidate"] = kwargs
+        return AuditRevalidationSummary(
+            run_id="revalidate-one",
+            project_id="default",
+            project_root=str(repo),
+            considered_findings=1,
+            revalidated_findings=1,
+            challenged_findings=1,
+            skipped_findings=0,
+            error_findings=0,
+            true_positive=0,
+            false_positive=1,
+            fixed=0,
+            uncertain=0,
+            forced=True,
+            challenge=True,
+            complete=True,
+        )
+
+    class FakeLLM:
+        def __init__(self, config):
+            self.config = config
+
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+    monkeypatch.setattr(
+        "skylos.audit_revalidator.revalidate_deep_audit_findings",
+        fake_revalidate,
+    )
+    monkeypatch.setattr(cli, "_ensure_llm_support", lambda: True)
+    monkeypatch.setattr(cli, "_build_analyzer_config", lambda **kwargs: kwargs)
+    monkeypatch.setattr(cli, "SkylosLLM", FakeLLM)
+    monkeypatch.setattr(
+        cli,
+        "resolve_llm_runtime",
+        lambda **kwargs: ("ollama", None, None, True),
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--revalidate",
+            "--challenge",
+            "--force",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert exc.value.code == 0
+    assert payload["mode"] == "deep_challenge"
+    assert payload["revalidation"]["false_positive"] == 1
+    assert calls["revalidate"]["force"] is True
+    assert calls["revalidate"]["challenge"] is True

--- a/test/test_audit_export.py
+++ b/test/test_audit_export.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skylos.audit_export import (
+    build_deep_audit_export,
+    render_deep_audit_export,
+    write_deep_audit_export,
+)
+from skylos.audit_store import AuditStore
+from skylos.audit_types import (
+    STATUS_ANALYZED,
+    STATUS_NOT_ANALYZED,
+    STATUS_PENDING,
+    STATUS_SKIPPED,
+    AuditCandidate,
+    sha256_file,
+)
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    severity: str = "high",
+    redacted: bool = False,
+    reason: str = "candidate",
+) -> AuditCandidate:
+    return AuditCandidate(
+        candidate_id=candidate_id,
+        kind="static_finding",
+        rule_id="SKY-D999",
+        line=2,
+        severity_hint=severity,
+        reason=reason,
+        redacted=redacted,
+        priority=800,
+    )
+
+
+def _record(
+    store: AuditStore,
+    path: Path,
+    *,
+    status: str = STATUS_PENDING,
+    candidate: AuditCandidate | None = None,
+):
+    record = store.upsert_scan_record(
+        file_path=path,
+        file_hash=sha256_file(path),
+        language="python",
+        candidates=[candidate or _candidate(path.name)],
+        config_hash="cfg",
+    )
+    record.status = status
+    store.write_file_record(record)
+    return record
+
+
+def test_json_export_includes_completion_skipped_counts_and_redacts_secrets(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    secret = repo / "secret.py"
+    raw_token = "ghp_123456789012345678901234"
+    secret.write_text(f"TOKEN = '{raw_token}'\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+
+    analyzed = _record(store, app, status=STATUS_ANALYZED)
+    analyzed.findings = [
+        {
+            "audit_finding_id": "finding-one",
+            "rule_id": "SKY-D001",
+            "severity": "critical",
+            "message": "command injection",
+            "line": 1,
+        }
+    ]
+    analyzed.revalidation = [
+        {
+            "finding_id": "finding-one",
+            "verdict": "true_positive",
+            "reason": "sink remains reachable",
+        }
+    ]
+    store.write_file_record(analyzed)
+
+    _record(
+        store,
+        secret,
+        status=STATUS_SKIPPED,
+        candidate=_candidate(
+            "secret-candidate",
+            redacted=True,
+            reason=f"secret-bearing context {raw_token}",
+        ),
+    )
+
+    export = build_deep_audit_export(store=store)
+    rendered = json.dumps(export, sort_keys=True)
+
+    assert export["completion"]["complete"] is False
+    assert export["completion"]["analyzed_files"] == 1
+    assert export["completion"]["skipped_files"] == 1
+    assert export["completion"]["skipped_candidates"] == 1
+    assert {entry["verdict"] for entry in export["entries"]} == {
+        "true_positive",
+        "skipped",
+    }
+    assert raw_token not in rendered
+    assert "[REDACTED_SECRET]" in rendered
+
+
+def test_export_filters_by_min_severity_and_verdict(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    low = repo / "low.py"
+    low.write_text("print('ok')\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+
+    high_record = _record(store, app, status=STATUS_ANALYZED)
+    high_record.findings = [
+        {
+            "audit_finding_id": "finding-high",
+            "rule_id": "SKY-D001",
+            "severity": "high",
+            "message": "high finding",
+            "line": 1,
+        }
+    ]
+    high_record.revalidation = [
+        {"finding_id": "finding-high", "verdict": "fixed", "reason": "patched"}
+    ]
+    store.write_file_record(high_record)
+    _record(
+        store,
+        low,
+        status=STATUS_PENDING,
+        candidate=_candidate("low-candidate", severity="low"),
+    )
+
+    export = build_deep_audit_export(
+        store=store,
+        min_severity="high",
+        verdicts=["fixed"],
+    )
+
+    assert export["entry_count"] == 1
+    assert export["entries"][0]["id"] == "finding-high"
+    assert export["entries"][0]["verdict"] == "fixed"
+
+
+def test_export_surfaces_not_analyzed_polyglot_work(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "route.ts"
+    app.write_text(
+        "import cp from 'child_process';\ncp.exec(userInput);\n",
+        encoding="utf-8",
+    )
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _record(
+        store,
+        app,
+        status=STATUS_NOT_ANALYZED,
+        candidate=_candidate("ts-candidate", severity="high"),
+    )
+
+    export = build_deep_audit_export(store=store, verdicts=["not_analyzed"])
+
+    assert export["completion"]["complete"] is False
+    assert export["completion"]["not_analyzed_files"] == 1
+    assert export["entry_count"] == 1
+    assert export["entries"][0]["verdict"] == "not_analyzed"
+
+
+def test_sarif_export_includes_results_rules_and_completion(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _record(store, app, status=STATUS_ANALYZED)
+    record.findings = [
+        {
+            "audit_finding_id": "finding-one",
+            "rule_id": "SKY-D001",
+            "severity": "high",
+            "message": "high finding",
+            "line": 1,
+        }
+    ]
+    store.write_file_record(record)
+
+    export = build_deep_audit_export(store=store)
+    sarif = json.loads(render_deep_audit_export(export, "sarif"))
+
+    run = sarif["runs"][0]
+    assert sarif["version"] == "2.1.0"
+    assert run["tool"]["driver"]["rules"][0]["id"] == "SKY-D001"
+    assert run["results"][0]["ruleId"] == "SKY-D001"
+    assert run["properties"]["deep_audit"]["completion"]["analyzed_files"] == 1
+
+
+def test_markdown_export_and_directory_are_stable(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _record(store, app, status=STATUS_ANALYZED)
+    record.findings = [
+        {
+            "audit_finding_id": "finding-one",
+            "rule_id": "SKY-D001",
+            "severity": "high",
+            "message": "high finding",
+            "line": 1,
+        }
+    ]
+    record.revalidation = [
+        {"finding_id": "finding-one", "verdict": "uncertain", "reason": "needs review"}
+    ]
+    store.write_file_record(record)
+
+    export = build_deep_audit_export(store=store)
+    markdown = render_deep_audit_export(export, "md")
+    out_dir = tmp_path / "audit-report"
+    written = write_deep_audit_export(export, out_dir, "md-dir")
+
+    assert "# Skylos Deep Audit Report" in markdown
+    assert (
+        "| high | uncertain | analyzed | SKY-D001 | app.py:1 | high finding |"
+        in markdown
+    )
+    assert [path.name for path in written] == [
+        "index.md",
+        "001-high-sky-d001-app.py.md",
+    ]
+    assert (out_dir / "index.md").exists()
+    assert (out_dir / "001-high-sky-d001-app.py.md").exists()

--- a/test/test_audit_processor.py
+++ b/test/test_audit_processor.py
@@ -150,6 +150,34 @@ def test_process_deep_audit_records_prioritizes_and_respects_limit(tmp_path: Pat
     assert store.read_file_record(low).status == "pending"
 
 
+def test_process_deep_audit_records_respects_allowed_file_scope(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    changed = repo / "changed.py"
+    old = repo / "old.py"
+    changed.write_text("eval(user_input)\n", encoding="utf-8")
+    old.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, changed, candidates=[_candidate("changed", priority=100)])
+    _write_record(store, old, candidates=[_candidate("old", priority=900)])
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        allowed_files=[changed],
+        run_id="run-changed",
+    )
+
+    assert [path.name for path in analyzer.calls] == ["changed.py"]
+    assert summary.considered_files == 1
+    assert summary.processed_files == 1
+    assert summary.complete is True
+    assert store.read_file_record(old).status == "pending"
+
+
 def test_process_deep_audit_records_skips_secret_candidates(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -284,7 +312,13 @@ def test_process_deep_audit_records_marks_unsupported_languages(tmp_path: Path):
     assert summary.unsupported_files == 1
     assert summary.remaining_pending_files == 1
     assert summary.complete is False
-    assert store.read_file_record(app).status == "not_analyzed"
+    record = store.read_file_record(app)
+    assert record.status == "not_analyzed"
+    assert [
+        item.get("stage")
+        for item in record.analysis_history
+        if isinstance(item, dict)
+    ] == ["unsupported_agent_language"]
 
     rerun_summary = process_deep_audit_records(
         store=store,
@@ -297,6 +331,23 @@ def test_process_deep_audit_records_marks_unsupported_languages(tmp_path: Path):
     assert rerun_summary.unsupported_files == 1
     assert rerun_summary.remaining_pending_files == 1
     assert rerun_summary.complete is False
+
+    forced_summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        force=True,
+        run_id="run-ts-force",
+    )
+    forced_record = store.read_file_record(app)
+
+    assert analyzer.calls == []
+    assert forced_summary.unsupported_files == 1
+    assert [
+        item.get("stage")
+        for item in forced_record.analysis_history
+        if isinstance(item, dict)
+    ] == ["unsupported_agent_language"]
 
 
 def test_process_deep_audit_records_skips_analyzed_with_same_context_unless_forced(

--- a/test/test_audit_revalidator.py
+++ b/test/test_audit_revalidator.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.audit_redaction import REDACTION
+from skylos.audit_revalidator import revalidate_deep_audit_findings
+from skylos.audit_store import AuditStore
+from skylos.audit_types import AuditCandidate, sha256_file
+
+
+def _fake_github_token() -> str:
+    return "ghp_" + "1234567890abcdef" + "1234567890abcdef" + "123456"
+
+
+class FakeVerifier:
+    def __init__(self, verdict: str = "true_positive"):
+        self.verdict = verdict
+        self.calls: list[dict] = []
+
+    def verify_finding(self, *, finding, context, file_path, mode):
+        self.calls.append(
+            {
+                "finding": finding,
+                "context": context,
+                "file_path": file_path,
+                "mode": mode,
+            }
+        )
+        return {"verdict": self.verdict, "reason": f"{mode} verdict"}
+
+
+def _candidate(
+    candidate_id: str = "cand",
+    *,
+    rule_id: str = "SKY-D999",
+    redacted: bool = False,
+) -> AuditCandidate:
+    return AuditCandidate(
+        candidate_id=candidate_id,
+        kind="static_finding",
+        rule_id=rule_id,
+        line=1,
+        severity_hint="high",
+        reason="candidate",
+        redacted=redacted,
+        priority=800,
+    )
+
+
+def _write_analyzed_record(
+    store: AuditStore,
+    path: Path,
+    *,
+    candidates: list[AuditCandidate] | None = None,
+):
+    record = store.upsert_scan_record(
+        file_path=path,
+        file_hash=sha256_file(path),
+        language="python",
+        candidates=candidates or [_candidate()],
+        config_hash="cfg",
+    )
+    record.status = "analyzed"
+    record.findings = [
+        {
+            "audit_finding_id": "finding-one",
+            "severity": "high",
+            "message": "finding",
+            "location": {"file": str(path), "line": 1},
+        }
+    ]
+    store.write_file_record(record)
+    return record
+
+
+def test_revalidate_deep_audit_findings_appends_verdict_without_deleting(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, app)
+
+    verifier = FakeVerifier("true_positive")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        provider="test",
+        run_id="run-revalidate",
+    )
+    record = store.read_file_record(app)
+
+    assert summary.revalidated_findings == 1
+    assert summary.true_positive == 1
+    assert record is not None
+    assert len(record.findings) == 1
+    assert record.revalidation[-1]["finding_id"] == "finding-one"
+    assert record.revalidation[-1]["verdict"] == "true_positive"
+    assert verifier.calls[0]["file_path"] == "app.py"
+
+
+def test_revalidate_deep_audit_findings_skips_same_context_unless_forced(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, app)
+
+    verifier = FakeVerifier("true_positive")
+    revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        provider="test",
+        run_id="run-one",
+    )
+    revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        provider="test",
+        run_id="run-two",
+    )
+    forced = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        provider="test",
+        force=True,
+        run_id="run-force",
+    )
+
+    record = store.read_file_record(app)
+
+    assert len(verifier.calls) == 2
+    assert forced.revalidated_findings == 1
+    assert record is not None
+    assert len(record.revalidation) == 2
+
+
+def test_revalidate_deep_audit_findings_can_mark_changed_file_fixed(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, app)
+
+    app.write_text("print('fixed')\n", encoding="utf-8")
+    rescanned = store.upsert_scan_record(
+        file_path=app,
+        file_hash=sha256_file(app),
+        language="python",
+        candidates=[],
+        config_hash="cfg",
+    )
+
+    assert rescanned.status == "not_analyzed"
+    assert len(rescanned.findings) == 1
+
+    verifier = FakeVerifier("fixed")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        provider="test",
+        force=True,
+        run_id="run-fixed",
+    )
+    record = store.read_file_record(app)
+
+    assert summary.revalidated_findings == 1
+    assert summary.fixed == 1
+    assert record is not None
+    assert record.revalidation[-1]["verdict"] == "fixed"
+
+
+def test_revalidate_deep_audit_findings_redacts_context_before_verifier(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    raw_secret = _fake_github_token()
+    app.write_text(f'TOKEN="{raw_secret}"\neval(user_input)\n', encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, app)
+
+    verifier = FakeVerifier("uncertain")
+    revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        run_id="run-redact",
+    )
+
+    context = verifier.calls[0]["context"]
+    assert raw_secret not in str(context)
+    assert REDACTION in str(context)
+
+
+def test_revalidate_deep_audit_findings_skips_secret_candidate_records(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("TOKEN='secret'\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(
+        store,
+        app,
+        candidates=[_candidate("secret", rule_id="SKY-S101", redacted=True)],
+    )
+
+    verifier = FakeVerifier("true_positive")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        run_id="run-secret",
+    )
+
+    assert verifier.calls == []
+    assert summary.skipped_findings == 1
+    assert summary.complete is False
+
+
+def test_revalidate_deep_audit_findings_challenges_uncertain_verdicts(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _write_analyzed_record(store, app)
+    record.revalidation = [
+        {
+            "finding_id": "finding-one",
+            "verdict": "uncertain",
+            "model": "old-model",
+            "mode": "revalidate",
+        }
+    ]
+    store.write_file_record(record)
+
+    verifier = FakeVerifier("false_positive")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        challenge=True,
+        run_id="run-challenge",
+    )
+    updated = store.read_file_record(app)
+
+    assert summary.challenged_findings == 1
+    assert summary.false_positive == 1
+    assert verifier.calls[0]["mode"] == "challenge"
+    assert updated is not None
+    assert updated.revalidation[-1]["mode"] == "challenge"

--- a/test/test_audit_store.py
+++ b/test/test_audit_store.py
@@ -79,7 +79,9 @@ def test_audit_store_rerun_deduplicates_candidates(tmp_path: Path):
     assert [candidate.candidate_id for candidate in loaded.candidates] == ["cand-one"]
 
 
-def test_audit_store_file_hash_change_invalidates_prior_findings(tmp_path: Path):
+def test_audit_store_file_hash_change_resets_status_but_preserves_history(
+    tmp_path: Path,
+):
     repo = tmp_path / "repo"
     repo.mkdir()
     source = repo / "app.py"
@@ -109,8 +111,8 @@ def test_audit_store_file_hash_change_invalidates_prior_findings(tmp_path: Path)
     )
 
     assert updated.status == STATUS_PENDING
-    assert updated.findings == []
-    assert updated.analysis_history == []
+    assert updated.findings == [{"rule_id": "OLD"}]
+    assert updated.analysis_history == [{"stage": "old"}]
 
 
 def test_audit_store_rejects_corrupted_json(tmp_path: Path):

--- a/test/test_cli_uncovered_paths.py
+++ b/test/test_cli_uncovered_paths.py
@@ -252,6 +252,43 @@ def test_get_git_changed_files_on_error_returns_empty(tmp_path):
     assert files == []
 
 
+def test_get_git_changed_files_with_base_ref_uses_pr_diff(tmp_path):
+    root = tmp_path
+    (root / "changed.py").write_text("x=1", encoding="utf-8")
+    seen = []
+
+    def fake_check_output(cmd, cwd=None, stderr=None, **kwargs):
+        seen.append(cmd)
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return str(root).encode("utf-8")
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return b"changed.py\n"
+        raise AssertionError("unexpected cmd")
+
+    with patch("skylos.cli.subprocess.check_output", side_effect=fake_check_output):
+        files = cli.get_git_changed_files(root, base_ref="origin/main")
+
+    assert files == [root / "changed.py"]
+    assert ["git", "diff", "--name-only", "origin/main...HEAD"] in seen
+
+
+def test_get_git_changed_files_strict_base_raises_on_invalid_ref(tmp_path):
+    root = tmp_path
+
+    def fake_check_output(cmd, cwd=None, stderr=None, **kwargs):
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return str(root).encode("utf-8")
+        raise Exception("bad ref")
+
+    with patch("skylos.cli.subprocess.check_output", side_effect=fake_check_output):
+        with pytest.raises(ValueError):
+            cli.get_git_changed_files(
+                root,
+                base_ref="origin/nope",
+                strict_base=True,
+            )
+
+
 def test_estimate_cost_counts_chars(tmp_path):
     f1 = tmp_path / "a.py"
     f2 = tmp_path / "b.py"


### PR DESCRIPTION
## Summary

  - Add changed-file/base-ref scoping and CI `--fail-on` semantics
  - Add persistent finding revalidation and challenge mode
  - Add JSON/SARIF/Markdown exports from persisted audit state
  - Add polyglot static candidate ingestion for TS/JS, Go, Java, PHP, Rust, and Dart
  - Make unsupported non-Python agent processing explicit via `not_analyzed`
  - Fixed repo-local `--out` self-ingestion so exported audit files do not pollute later scans
  - Preserve historical findings across file changes so `--revalidate --force` can mark stale findings as `fixed`

## Testing

  - `pytest -q`
  - Manual smoke confirmed repo-local `audit.json` was not self-ingested