### PR TITLE
fix(security): polish Deep Mode audit states

### DIFF
--- a/skylos/audit_candidates.py
+++ b/skylos/audit_candidates.py
@@ -148,6 +148,7 @@ def scan_deep_audit_candidates(
 
     store = AuditStore(project_root, project_id=project_id, audit_root=audit_root)
     store.init_project(config_hash=config_hash)
+    deleted_records = store.mark_deleted_records(allowed_files=changed_files)
 
     records_written = 0
     candidate_count = 0
@@ -198,9 +199,8 @@ def scan_deep_audit_candidates(
         processing_files=processing_files,
         not_analyzed_files=not_analyzed_files,
         error_files=error_files,
-        complete=(
-            pending_files == 0 and processing_files == 0 and error_files == 0
-        ),
+        deleted_files=len(deleted_records),
+        complete=(pending_files == 0 and processing_files == 0 and error_files == 0),
     )
     run_id = f"scan-{uuid4().hex[:12]}"
     store.write_run(
@@ -251,10 +251,10 @@ def _discover_audit_files(
     target = Path(path).resolve()
     root = target.parent if target.is_file() else target
     if target.is_file():
-        if _is_audit_file(target) and not should_exclude_path(
-            target, root, exclude_folders
-        ) and not _is_excluded_output_path(
-            target, project_root, excluded_paths
+        if (
+            _is_audit_file(target)
+            and not should_exclude_path(target, root, exclude_folders)
+            and not _is_excluded_output_path(target, project_root, excluded_paths)
         ):
             discovered.append(target)
     else:
@@ -434,9 +434,7 @@ def _add_repo_activation_candidates(
         if rel_path not in candidates_by_file:
             continue
         reasons = list(
-            meta.entrypoint_reasons
-            + meta.registration_hints
-            + meta.security_hints
+            meta.entrypoint_reasons + meta.registration_hints + meta.security_hints
         )
         if not reasons:
             continue

--- a/skylos/audit_ci.py
+++ b/skylos/audit_ci.py
@@ -6,6 +6,7 @@ from typing import Any
 from skylos.audit_store import AuditStore
 from skylos.audit_types import (
     STATUS_ANALYZED,
+    STATUS_DELETED,
     STATUS_ERROR,
     STATUS_NOT_ANALYZED,
     STATUS_PENDING,
@@ -49,6 +50,8 @@ def evaluate_deep_audit_ci_gate(
 
     for record in store.iter_file_records():
         if allowed is not None and record.file not in allowed:
+            continue
+        if record.status == STATUS_DELETED:
             continue
         if not record.candidates and not record.findings:
             continue

--- a/skylos/audit_export.py
+++ b/skylos/audit_export.py
@@ -10,6 +10,7 @@ from skylos.audit_redaction import sanitize_for_audit
 from skylos.audit_store import AuditStore
 from skylos.audit_types import (
     STATUS_ANALYZED,
+    STATUS_DELETED,
     STATUS_ERROR,
     STATUS_NOT_ANALYZED,
     STATUS_PENDING,
@@ -38,6 +39,7 @@ EXPORT_VERDICTS = {
     "not_analyzed",
     "error",
     "skipped",
+    "deleted",
 }
 
 MARKDOWN_FORMATS = {"md", "markdown"}
@@ -50,12 +52,21 @@ def build_deep_audit_export(
     min_severity: str | None = None,
     verdicts: list[str] | tuple[str, ...] | set[str] | str | None = None,
     allowed_files: list[str | Path] | None = None,
+    include_deleted: bool = False,
 ) -> dict[str, Any]:
     allowed = _normalized_allowed_files(store, allowed_files)
-    records = [
+    all_records = [
         record
         for record in store.iter_file_records()
         if allowed is None or record.file in allowed
+    ]
+    deleted_records = [
+        record for record in all_records if record.status == STATUS_DELETED
+    ]
+    records = [
+        record
+        for record in all_records
+        if include_deleted or record.status != STATUS_DELETED
     ]
     entries = _build_entries(records)
     severity_filter = _normalize_severity(min_severity) if min_severity else None
@@ -77,7 +88,10 @@ def build_deep_audit_export(
                 "min_severity": severity_filter,
                 "verdicts": sorted(verdict_filter) if verdict_filter else [],
             },
-            "completion": _completion(records),
+            "completion": _completion(
+                records,
+                deleted_file_count=0 if include_deleted else len(deleted_records),
+            ),
             "entry_count": len(filtered_entries),
             "entries": filtered_entries,
             "records": [record.to_dict() for record in records],
@@ -151,6 +165,7 @@ def _build_entries(records: list[AuditFileRecord]) -> list[dict[str, Any]]:
             STATUS_NOT_ANALYZED,
             STATUS_ERROR,
             STATUS_SKIPPED,
+            STATUS_DELETED,
         }:
             entries.extend(_candidate_entries(record))
 
@@ -162,8 +177,12 @@ def _finding_entry(
     finding: dict[str, Any],
 ) -> dict[str, Any]:
     finding_id = _finding_id(finding)
-    latest = _latest_revalidation(record, finding_id)
-    verdict = str((latest or {}).get("verdict") or "uncertain").lower()
+    if record.status == STATUS_DELETED:
+        latest = None
+        verdict = "deleted"
+    else:
+        latest = _latest_revalidation(record, finding_id)
+        verdict = str((latest or {}).get("verdict") or "uncertain").lower()
     if verdict not in EXPORT_VERDICTS:
         verdict = "uncertain"
     severity = _normalize_severity(
@@ -229,10 +248,16 @@ def _record_status_verdict(status: str) -> str:
         return "error"
     if status == STATUS_SKIPPED:
         return "skipped"
+    if status == STATUS_DELETED:
+        return "deleted"
     return "uncertain"
 
 
-def _completion(records: list[AuditFileRecord]) -> dict[str, Any]:
+def _completion(
+    records: list[AuditFileRecord],
+    *,
+    deleted_file_count: int = 0,
+) -> dict[str, Any]:
     status_counts = {
         STATUS_PENDING: 0,
         STATUS_PROCESSING: 0,
@@ -240,13 +265,18 @@ def _completion(records: list[AuditFileRecord]) -> dict[str, Any]:
         STATUS_NOT_ANALYZED: 0,
         STATUS_ERROR: 0,
         STATUS_SKIPPED: 0,
+        STATUS_DELETED: 0,
     }
     candidate_count = 0
     finding_count = 0
     redacted_candidates = 0
     skipped_candidates = 0
+    no_candidate_files = 0
     for record in records:
-        if record.status in status_counts:
+        has_audit_work = bool(record.candidates or record.findings)
+        if record.status == STATUS_NOT_ANALYZED and not has_audit_work:
+            no_candidate_files += 1
+        elif record.status in status_counts:
             status_counts[record.status] += 1
         candidate_count += len(record.candidates)
         finding_count += len(record.findings)
@@ -275,6 +305,8 @@ def _completion(records: list[AuditFileRecord]) -> dict[str, Any]:
         "not_analyzed_files": status_counts[STATUS_NOT_ANALYZED],
         "error_files": status_counts[STATUS_ERROR],
         "skipped_files": status_counts[STATUS_SKIPPED],
+        "deleted_files": status_counts[STATUS_DELETED] + deleted_file_count,
+        "no_candidate_files": no_candidate_files,
     }
 
 
@@ -416,6 +448,8 @@ def _export_to_markdown(export: dict[str, Any]) -> str:
         f"- Not analyzed files: `{completion.get('not_analyzed_files', 0)}`",
         f"- Error files: `{completion.get('error_files', 0)}`",
         f"- Skipped files: `{completion.get('skipped_files', 0)}`",
+        f"- Deleted files: `{completion.get('deleted_files', 0)}`",
+        f"- No-candidate files: `{completion.get('no_candidate_files', 0)}`",
         "",
     ]
     filters = export.get("filters") or {}

--- a/skylos/audit_processor.py
+++ b/skylos/audit_processor.py
@@ -8,6 +8,7 @@ from skylos.audit_redaction import redact_text, sanitize_for_audit
 from skylos.audit_store import AuditStore
 from skylos.audit_types import (
     STATUS_ANALYZED,
+    STATUS_DELETED,
     STATUS_ERROR,
     STATUS_NOT_ANALYZED,
     STATUS_PENDING,
@@ -41,7 +42,9 @@ def process_deep_audit_records(
     records = [
         record
         for record in store.iter_file_records()
-        if record.candidates and (allowed is None or record.file in allowed)
+        if record.candidates
+        and record.status != STATUS_DELETED
+        and (allowed is None or record.file in allowed)
     ]
     locked_files = 0
     run_error_files = 0
@@ -165,9 +168,7 @@ def process_deep_audit_records(
         ),
         pending_files=state_counts[STATUS_PENDING],
         processing_files=state_counts[STATUS_PROCESSING],
-        analyzed_files=(
-            state_counts[STATUS_ANALYZED] - state_counts["stale_analyzed"]
-        ),
+        analyzed_files=(state_counts[STATUS_ANALYZED] - state_counts["stale_analyzed"]),
         stale_analyzed_files=state_counts["stale_analyzed"],
     )
     store.write_run(
@@ -458,13 +459,14 @@ def _audit_state_counts(
     for record in store.iter_file_records():
         if allowed is not None and record.file not in allowed:
             continue
+        if record.status == STATUS_DELETED:
+            continue
         if not record.candidates:
             continue
         if record.status in counts:
             counts[record.status] += 1
-        if (
-            record.status == STATUS_ANALYZED
-            and not _agent_context_matches(record, model=model, provider=provider)
+        if record.status == STATUS_ANALYZED and not _agent_context_matches(
+            record, model=model, provider=provider
         ):
             counts["stale_analyzed"] += 1
         if _is_unresolved_record(record, model=model, provider=provider):

--- a/skylos/audit_revalidator.py
+++ b/skylos/audit_revalidator.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from skylos.audit_redaction import redact_text, sanitize_for_audit
 from skylos.audit_store import AuditStore
 from skylos.audit_types import (
+    STATUS_DELETED,
     AuditFileRecord,
     AuditRevalidationSummary,
     normalize_relative_path,
@@ -36,7 +37,9 @@ def revalidate_deep_audit_findings(
     records = [
         record
         for record in store.iter_file_records()
-        if record.findings and (allowed is None or record.file in allowed)
+        if record.findings
+        and record.status != STATUS_DELETED
+        and (allowed is None or record.file in allowed)
     ]
 
     considered = 0

--- a/skylos/audit_store.py
+++ b/skylos/audit_store.py
@@ -15,6 +15,7 @@ from skylos.audit_types import (
     SCHEMA_VERSION,
     STATUS_ANALYZED,
     STATUS_ERROR,
+    STATUS_DELETED,
     STATUS_NOT_ANALYZED,
     STATUS_PENDING,
     STATUS_PROCESSING,
@@ -137,6 +138,44 @@ class AuditStore:
         payload = sanitize_for_audit(record.to_dict())
         self._write_json_atomic(self.record_path(record.file), payload)
 
+    def mark_deleted_records(
+        self,
+        *,
+        allowed_files: list[str | Path] | None = None,
+        now: str | None = None,
+    ) -> list[AuditFileRecord]:
+        allowed = self._normalized_allowed_files(allowed_files)
+        marked: list[AuditFileRecord] = []
+        timestamp = now or utc_now()
+        for record in self.iter_file_records():
+            if allowed is not None and record.file not in allowed:
+                continue
+            source_path = self.project_root / record.file
+            if source_path.exists():
+                continue
+            if record.status == STATUS_DELETED:
+                marked.append(record)
+                continue
+            record.status = STATUS_DELETED
+            record.locked_by_run_id = None
+            record.locked_at = None
+            record.last_scanned_at = timestamp
+            record.analysis_history.append(
+                sanitize_for_audit(
+                    {
+                        "stage": "file_deleted",
+                        "reason": (
+                            "Source file no longer exists; record retained as "
+                            "audit history."
+                        ),
+                        "at": timestamp,
+                    }
+                )
+            )
+            self.write_file_record(record)
+            marked.append(record)
+        return marked
+
     def upsert_scan_record(
         self,
         *,
@@ -181,9 +220,7 @@ class AuditStore:
             status=status,
             candidates=ordered_candidates,
             findings=(
-                sanitize_for_audit(list(existing.findings))
-                if preserve_history
-                else []
+                sanitize_for_audit(list(existing.findings)) if preserve_history else []
             ),
             analysis_history=(
                 sanitize_for_audit(list(existing.analysis_history))
@@ -206,9 +243,7 @@ class AuditStore:
                 else None
             ),
             last_scanned_at=now,
-            last_analyzed_at=(
-                existing.last_analyzed_at if preserve_history else None
-            ),
+            last_analyzed_at=(existing.last_analyzed_at if preserve_history else None),
             skylos_version=skylos.__version__,
             config_hash=config_hash,
             candidate_engine_version=CANDIDATE_ENGINE_VERSION,
@@ -301,6 +336,20 @@ class AuditStore:
             locked = locked.replace(tzinfo=timezone.utc)
         age = datetime.now(timezone.utc) - locked
         return age.total_seconds() >= stale_after_seconds
+
+    def _normalized_allowed_files(
+        self,
+        allowed_files: list[str | Path] | None,
+    ) -> set[str] | None:
+        if allowed_files is None:
+            return None
+        allowed: set[str] = set()
+        for file_path in allowed_files:
+            try:
+                allowed.add(normalize_relative_path(self.project_root, file_path))
+            except ValueError:
+                continue
+        return allowed
 
     def _write_json_atomic(self, path: Path, payload: dict[str, Any]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/skylos/audit_types.py
+++ b/skylos/audit_types.py
@@ -19,6 +19,7 @@ STATUS_ANALYZED = "analyzed"
 STATUS_ERROR = "error"
 STATUS_NOT_ANALYZED = "not_analyzed"
 STATUS_SKIPPED = "skipped"
+STATUS_DELETED = "deleted"
 
 VALID_STATUSES = {
     STATUS_PENDING,
@@ -27,6 +28,7 @@ VALID_STATUSES = {
     STATUS_ERROR,
     STATUS_NOT_ANALYZED,
     STATUS_SKIPPED,
+    STATUS_DELETED,
 }
 
 
@@ -267,9 +269,7 @@ class AuditFileRecord:
             ),
             skylos_version=str(payload.get("skylos_version") or skylos.__version__),
             config_hash=str(payload.get("config_hash") or ""),
-            candidate_engine_version=str(
-                payload.get("candidate_engine_version") or ""
-            ),
+            candidate_engine_version=str(payload.get("candidate_engine_version") or ""),
         )
 
 
@@ -285,6 +285,7 @@ class AuditScanSummary:
     not_analyzed_files: int
     processing_files: int = 0
     error_files: int = 0
+    deleted_files: int = 0
     complete: bool = True
 
     def to_dict(self) -> dict[str, Any]:
@@ -299,6 +300,7 @@ class AuditScanSummary:
             "processing_files": self.processing_files,
             "not_analyzed_files": self.not_analyzed_files,
             "error_files": self.error_files,
+            "deleted_files": self.deleted_files,
             "complete": self.complete,
         }
 

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -231,6 +231,137 @@ def _deep_audit_output_exclude_paths(
     return [output]
 
 
+def _deep_audit_project_root(audit_path: pathlib.Path) -> pathlib.Path:
+    target = audit_path.resolve()
+    return target.parent if target.is_file() else target
+
+
+def _empty_changed_deep_audit_payload(
+    audit_path: pathlib.Path,
+    *,
+    fail_on: str | None,
+    export_format: str,
+    severity: str | None,
+    verdicts: list[str] | None,
+) -> tuple[dict, object | None]:
+    from skylos.audit_export import build_deep_audit_export
+    from skylos.audit_store import AuditStore
+    from skylos.audit_types import AuditCIGateSummary, AuditScanSummary
+
+    project_root = _deep_audit_project_root(audit_path)
+    store = AuditStore(project_root)
+    summary = AuditScanSummary(
+        project_id=store.project_id,
+        project_root=str(project_root),
+        files_scanned=0,
+        records_written=0,
+        candidate_count=0,
+        redacted_candidates=0,
+        pending_files=0,
+        not_analyzed_files=0,
+        complete=True,
+    )
+    payload = {
+        "mode": "deep_no_changes",
+        "changed_scope": True,
+        "no_changed_files": True,
+        "summary": summary.to_dict(),
+        "audit_project_dir": str(store.project_dir),
+        "changed_files": [],
+    }
+    if fail_on:
+        payload["ci"] = AuditCIGateSummary(
+            fail_on=fail_on,
+            exit_code=0,
+            blocking_counts={
+                "findings": 0,
+                "pending": 0,
+                "not_analyzed": 0,
+                "skipped": 0,
+                "error": 0,
+                "locked": 0,
+                "stale_analyzed": 0,
+                "limited": 0,
+            },
+            complete=True,
+            reason="no changed files to audit",
+        ).to_dict()
+
+    export_payload = None
+    if export_format in {"json", "sarif", "md", "markdown", "md-dir"}:
+        export_payload = build_deep_audit_export(
+            store=store,
+            min_severity=severity,
+            verdicts=verdicts,
+            allowed_files=[],
+        )
+        payload["export"] = export_payload
+    return payload, export_payload
+
+
+def _write_deep_audit_payload(path: str | pathlib.Path, payload: dict) -> None:
+    from skylos.audit_export import write_deep_audit_export
+
+    write_deep_audit_export(payload, path, "json")
+
+
+def _handle_empty_changed_deep_audit(
+    agent_args,
+    audit_path: pathlib.Path,
+    console,
+) -> int:
+    export_format = getattr(agent_args, "format", "table")
+    output_path = getattr(agent_args, "output", None)
+    quiet = getattr(agent_args, "quiet", False)
+    payload, export_payload = _empty_changed_deep_audit_payload(
+        audit_path,
+        fail_on=getattr(agent_args, "fail_on", None),
+        export_format=export_format,
+        severity=getattr(agent_args, "severity", None),
+        verdicts=getattr(agent_args, "verdict", None),
+    )
+
+    if export_format in {"sarif", "md", "markdown", "md-dir"}:
+        if export_payload is None:
+            return 1
+        from skylos.audit_export import (
+            render_deep_audit_export,
+            write_deep_audit_export,
+        )
+
+        if output_path:
+            written_paths = write_deep_audit_export(
+                export_payload,
+                output_path,
+                export_format,
+            )
+            if not quiet:
+                console.print(
+                    f"[dim]No changed files to audit. Written "
+                    f"{len(written_paths)} empty export file(s) to "
+                    f"{output_path}[/dim]"
+                )
+        elif not quiet:
+            print(render_deep_audit_export(export_payload, export_format), end="")
+        return 0
+
+    if output_path:
+        _write_deep_audit_payload(output_path, payload)
+
+    if export_format == "json":
+        if not quiet:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+    elif not quiet:
+        if output_path:
+            console.print(
+                f"[dim]No changed files to audit. Wrote empty audit report "
+                f"to {output_path}[/dim]"
+            )
+        else:
+            console.print("[dim]No changed files to audit.[/dim]")
+    return 0
+
+
 def _create_precommit_snapshot(project_root: Path):
     snapshot_dir = tempfile.TemporaryDirectory(prefix="skylos_precommit_")
     snapshot_root = Path(snapshot_dir.name).resolve()
@@ -341,7 +472,9 @@ def _path_suffixes(path: str) -> tuple[str, ...]:
     return tuple("/".join(parts[idx:]) for idx in range(len(parts)))
 
 
-def _build_changed_range_index(changed_ranges: list[dict]) -> dict[str, list[tuple[int, int]]]:
+def _build_changed_range_index(
+    changed_ranges: list[dict],
+) -> dict[str, list[tuple[int, int]]]:
     index: dict[str, list[tuple[int, int]]] = {}
     for entry in changed_ranges:
         key = _normalize_precommit_path(entry["file"])
@@ -2116,13 +2249,20 @@ def run_whitelist(pattern=None, reason=None, show=False):
     return run_whitelist_impl(pattern=pattern, reason=reason, show=show)
 
 
-def get_git_changed_files(root_path, base_ref=None, *, strict_base=False):
+def get_git_changed_files(
+    root_path,
+    base_ref=None,
+    *,
+    strict_base=False,
+    include_deleted=False,
+):
     from skylos.cli_shared import get_git_changed_files as get_git_changed_files_impl
 
     return get_git_changed_files_impl(
         root_path,
         base_ref=base_ref,
         strict_base=strict_base,
+        include_deleted=include_deleted,
     )
 
 
@@ -2960,10 +3100,7 @@ def _apply_config_driven_analysis_flags(args, project_cfg, console):
             args.quality = True
             enabled_from_policy.append("quality")
 
-        if (
-            enabled_from_policy
-            and not _is_main_machine_output(args)
-        ):
+        if enabled_from_policy and not _is_main_machine_output(args):
             console.print(
                 "[brand]Using synced/local Skylos policy:[/brand] enabling "
                 + ", ".join(enabled_from_policy)
@@ -3377,8 +3514,14 @@ def _build_agent_parser():
             "not_analyzed",
             "error",
             "skipped",
+            "deleted",
         ],
         help="Filter Deep Mode export entries by verdict/status",
+    )
+    p_audit.add_argument(
+        "--include-deleted",
+        action="store_true",
+        help="Include deleted Deep Mode audit records in exports",
     )
     p_audit.add_argument("--out", "--output", "-o", dest="output")
     _add_agent_quiet_arg(p_audit)
@@ -4300,14 +4443,19 @@ def main() -> None:
                         audit_path,
                         base_ref=getattr(agent_args, "base", None),
                         strict_base=bool(getattr(agent_args, "base", None)),
+                        include_deleted=True,
                     )
                 except ValueError as exc:
                     console.print(f"[bad]{exc}[/bad]")
                     sys.exit(2)
                 if not changed_files:
-                    if not getattr(agent_args, "quiet", False):
-                        console.print("[dim]No changed files[/dim]")
-                    sys.exit(0)
+                    sys.exit(
+                        _handle_empty_changed_deep_audit(
+                            agent_args,
+                            audit_path,
+                            console,
+                        )
+                    )
 
             from skylos.audit_candidates import scan_deep_audit_candidates
 
@@ -4344,8 +4492,7 @@ def main() -> None:
                         "deepseek": "deepseek/deepseek-chat",
                         "xai": "xai/grok-2",
                         "together": (
-                            "together/meta-llama/"
-                            "Meta-Llama-3-70B-Instruct-Turbo"
+                            "together/meta-llama/Meta-Llama-3-70B-Instruct-Turbo"
                         ),
                         "ollama": "ollama/llama3",
                     }
@@ -4364,7 +4511,9 @@ def main() -> None:
                     os.environ["SKYLOS_LLM_BASE_URL"] = base_url
                 if api_key is None or api_key == "":
                     if not is_local:
-                        env_var = PROVIDERS.get(provider) or f"{provider.upper()}_API_KEY"
+                        env_var = (
+                            PROVIDERS.get(provider) or f"{provider.upper()}_API_KEY"
+                        )
                         console.print(
                             f"[bad]No {env_var} configured. Run `skylos key` or "
                             "set the environment variable.[/bad]"
@@ -4455,6 +4604,7 @@ def main() -> None:
                         min_severity=getattr(agent_args, "severity", None),
                         verdicts=getattr(agent_args, "verdict", None),
                         allowed_files=changed_files if changed_scope else None,
+                        include_deleted=getattr(agent_args, "include_deleted", False),
                     )
                     payload["export"] = export_payload
 
@@ -4511,20 +4661,40 @@ def main() -> None:
                 pass
             elif not getattr(agent_args, "quiet", False):
                 heading = "scan-only" if process_summary is None else "scan"
-                console.print(
-                    f"[brand]Deep audit {heading}:[/brand] static queue updated"
-                )
-                console.print(f"  Project: {summary.project_root}")
-                console.print(f"  Files scanned: {summary.files_scanned}")
-                console.print(f"  Candidates: {summary.candidate_count}")
-                console.print(f"  Redacted candidates: {summary.redacted_candidates}")
-                console.print(f"  Pending files: {summary.pending_files}")
-                console.print(f"  Processing files: {summary.processing_files}")
-                console.print(f"  Error files: {summary.error_files}")
-                console.print(f"  Not analyzed: {summary.not_analyzed_files}")
+                if (
+                    summary.candidate_count == 0
+                    and process_summary is None
+                    and revalidation_summary is None
+                    and ci_summary is None
+                ):
+                    console.print(
+                        f"[brand]Deep audit {heading}:[/brand] no candidates found"
+                    )
+                    console.print(f"  Files scanned: {summary.files_scanned}")
+                    if summary.deleted_files:
+                        console.print(f"  Deleted records: {summary.deleted_files}")
+                    console.print(f"  Store: {store.project_dir}")
+                else:
+                    console.print(
+                        f"[brand]Deep audit {heading}:[/brand] static queue updated"
+                    )
+                    console.print(f"  Project: {summary.project_root}")
+                    console.print(f"  Files scanned: {summary.files_scanned}")
+                    console.print(f"  Candidates: {summary.candidate_count}")
+                    console.print(
+                        f"  Redacted candidates: {summary.redacted_candidates}"
+                    )
+                    console.print(f"  Pending files: {summary.pending_files}")
+                    console.print(f"  Processing files: {summary.processing_files}")
+                    console.print(f"  Error files: {summary.error_files}")
+                    console.print(f"  Not analyzed: {summary.not_analyzed_files}")
+                    if summary.deleted_files:
+                        console.print(f"  Deleted records: {summary.deleted_files}")
                 if process_summary is not None:
                     console.print("[brand]Deep audit processing:[/brand] finished")
-                    console.print(f"  Processed files: {process_summary.processed_files}")
+                    console.print(
+                        f"  Processed files: {process_summary.processed_files}"
+                    )
                     console.print(f"  Findings added: {process_summary.findings_added}")
                     console.print(
                         f"  Skipped secret files: "
@@ -4534,8 +4704,7 @@ def main() -> None:
                         f"  Unsupported files: {process_summary.unsupported_files}"
                     )
                     console.print(
-                        f"  Remaining work: "
-                        f"{process_summary.remaining_pending_files}"
+                        f"  Remaining work: {process_summary.remaining_pending_files}"
                     )
                 if revalidation_summary is not None:
                     console.print("[brand]Deep audit revalidation:[/brand] finished")
@@ -4551,9 +4720,7 @@ def main() -> None:
                         f"  Uncertain verdicts: {revalidation_summary.uncertain}"
                     )
                 if ci_summary is not None:
-                    console.print(
-                        f"[brand]Deep audit CI:[/brand] {ci_summary.reason}"
-                    )
+                    console.print(f"[brand]Deep audit CI:[/brand] {ci_summary.reason}")
                 console.print(f"  Store: {store.project_dir}")
             sys.exit(ci_summary.exit_code if ci_summary is not None else 0)
 

--- a/skylos/cli_shared.py
+++ b/skylos/cli_shared.py
@@ -7,7 +7,13 @@ import subprocess
 from pathlib import Path
 
 
-def get_git_changed_files(root_path, base_ref=None, *, strict_base=False):
+def get_git_changed_files(
+    root_path,
+    base_ref=None,
+    *,
+    strict_base=False,
+    include_deleted=False,
+):
     supported_exts = {
         ".py",
         ".go",
@@ -34,12 +40,12 @@ def get_git_changed_files(root_path, base_ref=None, *, strict_base=False):
         for line in output.splitlines():
             full_path = pathlib.Path(repo_root) / line
             if (
-                full_path.name != ".env"
-                and not full_path.name.startswith(".env.")
-                and full_path.suffix.lower() not in supported_exts
+                pathlib.Path(line).name != ".env"
+                and not pathlib.Path(line).name.startswith(".env.")
+                and pathlib.Path(line).suffix.lower() not in supported_exts
             ):
                 continue
-            if full_path.exists():
+            if full_path.exists() or include_deleted:
                 files.append(full_path)
         return files
 

--- a/test/test_audit_candidates.py
+++ b/test/test_audit_candidates.py
@@ -158,6 +158,30 @@ def test_scan_deep_audit_candidates_records_non_candidate_files(
     assert payload["candidates"] == []
 
 
+def test_scan_deep_audit_candidates_marks_deleted_records(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "deleted.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        audit_candidates,
+        "run_static_on_files",
+        lambda files, **kwargs: {"danger": [], "secrets": []},
+    )
+
+    _summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    app.unlink()
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record("deleted.py")
+
+    assert summary.deleted_files == 1
+    assert summary.files_scanned == 0
+    assert record is not None
+    assert record.status == "deleted"
+
+
 def test_scan_deep_audit_candidates_changed_files_respect_excludes(
     tmp_path: Path, monkeypatch
 ):
@@ -337,7 +361,7 @@ def test_scan_deep_audit_candidates_reports_error_records_incomplete(
         (
             "main.go",
             "package main\n"
-            "import \"os/exec\"\n"
+            'import "os/exec"\n'
             "func run(name string) { exec.Command(name) }\n",
             "go",
             "SKY-D212",

--- a/test/test_audit_cli.py
+++ b/test/test_audit_cli.py
@@ -93,9 +93,7 @@ def test_agent_audit_requires_explicit_deep_flag(tmp_path: Path, monkeypatch):
     assert exc.value.code == 2
 
 
-def test_agent_audit_scan_only_runs_ci_gate(
-    tmp_path: Path, monkeypatch
-):
+def test_agent_audit_scan_only_runs_ci_gate(tmp_path: Path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
     out = tmp_path / "audit.json"
@@ -568,6 +566,55 @@ def test_agent_audit_invalid_base_ref_exits_without_full_scan(
         cli.main()
 
     assert exc.value.code == 2
+
+
+def test_agent_audit_changed_no_files_writes_empty_json_artifact(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = tmp_path / "audit.json"
+
+    def fail_scan(*args, **kwargs):
+        raise AssertionError("scan should not run when there are no changed files")
+
+    monkeypatch.setattr(cli, "get_git_changed_files", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "skylos.audit_candidates.scan_deep_audit_candidates",
+        fail_scan,
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "audit",
+            str(repo),
+            "--deep",
+            "--changed",
+            "--scan-only",
+            "--fail-on",
+            "high",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert exc.value.code == 0
+    assert payload["mode"] == "deep_no_changes"
+    assert payload["changed_scope"] is True
+    assert payload["no_changed_files"] is True
+    assert payload["changed_files"] == []
+    assert payload["summary"]["files_scanned"] == 0
+    assert payload["ci"]["exit_code"] == 0
+    assert payload["export"]["entry_count"] == 0
 
 
 def test_agent_audit_scan_only_rejects_revalidate(tmp_path: Path, monkeypatch):

--- a/test/test_audit_export.py
+++ b/test/test_audit_export.py
@@ -11,6 +11,7 @@ from skylos.audit_export import (
 from skylos.audit_store import AuditStore
 from skylos.audit_types import (
     STATUS_ANALYZED,
+    STATUS_DELETED,
     STATUS_NOT_ANALYZED,
     STATUS_PENDING,
     STATUS_SKIPPED,
@@ -180,6 +181,62 @@ def test_export_surfaces_not_analyzed_polyglot_work(tmp_path: Path):
     assert export["completion"]["not_analyzed_files"] == 1
     assert export["entry_count"] == 1
     assert export["entries"][0]["verdict"] == "not_analyzed"
+
+
+def test_export_treats_no_candidate_files_as_complete(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "plain.py"
+    app.write_text("print('ok')\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    store.upsert_scan_record(
+        file_path=app,
+        file_hash=sha256_file(app),
+        language="python",
+        candidates=[],
+        config_hash="cfg",
+    )
+
+    export = build_deep_audit_export(store=store)
+
+    assert export["completion"]["complete"] is True
+    assert export["completion"]["no_candidate_files"] == 1
+    assert export["completion"]["not_analyzed_files"] == 0
+    assert export["entry_count"] == 0
+
+
+def test_export_excludes_deleted_records_from_active_entries(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "deleted.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = _record(store, app, status=STATUS_DELETED)
+    record.findings = [
+        {
+            "audit_finding_id": "finding-deleted",
+            "rule_id": "SKY-D001",
+            "severity": "critical",
+            "message": "old finding",
+            "line": 1,
+        }
+    ]
+    store.write_file_record(record)
+
+    export = build_deep_audit_export(store=store)
+
+    assert export["completion"]["deleted_files"] == 1
+    assert export["entry_count"] == 0
+    assert export["records"] == []
+
+    with_deleted = build_deep_audit_export(store=store, include_deleted=True)
+
+    assert with_deleted["completion"]["deleted_files"] == 1
+    assert with_deleted["entry_count"] == 2
+    assert {entry["verdict"] for entry in with_deleted["entries"]} == {"deleted"}
+    assert with_deleted["records"][0]["status"] == STATUS_DELETED
 
 
 def test_sarif_export_includes_results_rules_and_completion(tmp_path: Path):

--- a/test/test_audit_store.py
+++ b/test/test_audit_store.py
@@ -7,6 +7,7 @@ import pytest
 from skylos.audit_store import AuditStore
 from skylos.audit_types import (
     STATUS_ANALYZED,
+    STATUS_DELETED,
     STATUS_PENDING,
     AuditCandidate,
     sha256_file,
@@ -208,3 +209,34 @@ def test_audit_store_sanitizes_preserved_history_and_errors(tmp_path: Path):
     stored = store.record_path(source).read_text(encoding="utf-8")
 
     assert raw_secret not in stored
+
+
+def test_audit_store_marks_deleted_records_without_losing_history(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('hello')\n", encoding="utf-8")
+
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    record = store.upsert_scan_record(
+        file_path=source,
+        file_hash=sha256_file(source),
+        language="python",
+        candidates=[_candidate()],
+        config_hash="cfg",
+    )
+    record.status = STATUS_ANALYZED
+    record.findings = [{"audit_finding_id": "finding-one", "rule_id": "OLD"}]
+    store.write_file_record(record)
+
+    source.unlink()
+    marked = store.mark_deleted_records()
+    loaded = store.read_file_record("app.py")
+
+    assert [item.file for item in marked] == ["app.py"]
+    assert loaded is not None
+    assert loaded.status == STATUS_DELETED
+    assert loaded.findings == [{"audit_finding_id": "finding-one", "rule_id": "OLD"}]
+    assert loaded.locked_by_run_id is None
+    assert loaded.analysis_history[-1]["stage"] == "file_deleted"

--- a/test/test_cli_uncovered_paths.py
+++ b/test/test_cli_uncovered_paths.py
@@ -227,6 +227,22 @@ def test_get_git_changed_files_returns_existing_supported_files_only(tmp_path):
     assert names == ["a.py", "b.tsx", "c.go", "d.js", "e.jsx"]
 
 
+def test_get_git_changed_files_can_include_deleted_supported_files(tmp_path):
+    root = tmp_path
+
+    def fake_check_output(cmd, cwd=None, stderr=None, **kwargs):
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return str(root).encode("utf-8")
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return b"deleted.py\ndeleted.txt\n"
+        raise AssertionError("unexpected cmd")
+
+    with patch("skylos.cli.subprocess.check_output", side_effect=fake_check_output):
+        files = cli.get_git_changed_files(root, include_deleted=True)
+
+    assert files == [root / "deleted.py"]
+
+
 def test_get_git_changed_files_uses_repo_root_for_subdir_targets(tmp_path):
     root = tmp_path
     src = root / "src"


### PR DESCRIPTION
## Summary

  - Emit a JSON artifact for `--changed` runs with no changed files
  - Marks empty changed runs as scoped no-ops with `changed_scope` and `no_changed_files`
  - Treats no-candidate files as complete instead of unresolved audit work
  - Marks deleted audit records as `deleted` without deleting their history
  - Excludes deleted records from active CI/export/processing/revalidation by default
  - Adds `--include-deleted` for intentional deleted-history exports

## Tests

  - `pytest .`
  - `pre-commit run skylos-gate --all-files --verbose`