### PR TITLE
fix(security): harden VS Code webview surfaces

### DIFF
--- a/editors/vscode/out/chatview.js
+++ b/editors/vscode/out/chatview.js
@@ -4,6 +4,10 @@ exports.SkylosChatViewProvider = void 0;
 const vscode = require("vscode");
 const config_1 = require("./config");
 const scanner_1 = require("./scanner");
+const webviewSecurity_1 = require("./webviewSecurity");
+const MAX_CHAT_TEXT_LENGTH = 20000;
+const MAX_FIX_CODE_LENGTH = 200000;
+const MAX_LANGUAGE_ID_LENGTH = 64;
 class SkylosChatViewProvider {
     constructor(context) {
         this.context = context;
@@ -17,14 +21,18 @@ class SkylosChatViewProvider {
         this.view = webviewView;
         webviewView.webview.options = {
             enableScripts: true,
+            localResourceRoots: [],
         };
-        webviewView.webview.html = this.getHtml();
+        webviewView.webview.html = this.getHtml(webviewView.webview);
         webviewView.webview.onDidReceiveMessage(async (msg) => {
-            if (msg.type === "userMessage") {
+            if (isUserMessage(msg)) {
                 await this.handleUserMessage(msg.text);
             }
-            else if (msg.type === "applyFix") {
+            else if (isApplyFixMessage(msg)) {
                 await this.applyCodeFix(msg.code, msg.language);
+            }
+            else {
+                scanner_1.out.appendLine("Ignored invalid chat webview message.");
             }
         });
         if (this.history.length > 0) {
@@ -232,11 +240,14 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     persistHistory() {
         this.context.workspaceState.update("skylosChatHistory", this.history.slice(-20));
     }
-    getHtml() {
+    getHtml(webview) {
+        const nonce = (0, webviewSecurity_1.createWebviewNonce)();
+        const csp = (0, webviewSecurity_1.webviewCsp)(webview, nonce);
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${(0, webviewSecurity_1.escapeHtml)(csp)}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -365,7 +376,7 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     <button id="send">Send</button>
   </div>
 
-<script>
+<script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
   const messagesEl = document.getElementById('messages');
   const inputEl = document.getElementById('input');
@@ -386,7 +397,7 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     // Code fences
     html = html.replace(/\`\`\`(\\w*)\n([\\s\\S]*?)\`\`\`/g, (_, lang, code) => {
       const langAttr = lang || '';
-      return '<pre data-lang="' + langAttr + '"><button class="apply-btn" onclick="applyCode(this)">Apply Fix</button><code>' + code + '</code></pre>';
+      return '<pre data-lang="' + langAttr + '"><button class="apply-btn" type="button">Apply Fix</button><code>' + code + '</code></pre>';
     });
 
     // Inline code
@@ -435,12 +446,16 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
   });
 
-  window.applyCode = function(btn) {
-    const pre = btn.parentElement;
-    const code = pre.querySelector('code').textContent;
+  messagesEl.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement) || !target.classList.contains('apply-btn')) return;
+    const pre = target.closest('pre');
+    const codeEl = pre?.querySelector('code');
+    if (!pre || !codeEl) return;
+    const code = codeEl.textContent || '';
     const lang = pre.getAttribute('data-lang') || '';
     vscode.postMessage({ type: 'applyFix', code, language: lang });
-  };
+  });
 
   window.addEventListener('message', (event) => {
     const msg = event.data;
@@ -494,3 +509,19 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
 }
 exports.SkylosChatViewProvider = SkylosChatViewProvider;
 SkylosChatViewProvider.viewType = "skylosChatPanel";
+function isUserMessage(msg) {
+    return (0, webviewSecurity_1.isRecord)(msg)
+        && msg.type === "userMessage"
+        && typeof msg.text === "string"
+        && msg.text.length > 0
+        && msg.text.length <= MAX_CHAT_TEXT_LENGTH;
+}
+function isApplyFixMessage(msg) {
+    return (0, webviewSecurity_1.isRecord)(msg)
+        && msg.type === "applyFix"
+        && typeof msg.code === "string"
+        && msg.code.length > 0
+        && msg.code.length <= MAX_FIX_CODE_LENGTH
+        && (msg.language === undefined
+            || (typeof msg.language === "string" && msg.language.length <= MAX_LANGUAGE_ID_LENGTH));
+}

--- a/editors/vscode/out/dashboard.js
+++ b/editors/vscode/out/dashboard.js
@@ -4,6 +4,7 @@ exports.SkylosDashboard = void 0;
 exports.computeSecurityScore = computeSecurityScore;
 const vscode = require("vscode");
 const config_1 = require("./config");
+const webviewSecurity_1 = require("./webviewSecurity");
 const GRADE_COLOR = {
     "A+": "#4ade80", "A": "#4ade80", "A-": "#4ade80",
     "B+": "#60a5fa", "B": "#60a5fa", "B-": "#60a5fa",
@@ -54,12 +55,15 @@ class SkylosDashboard {
             this.update();
             return;
         }
-        this.panel = vscode.window.createWebviewPanel("skylosDashboard", "Skylos Security Dashboard", vscode.ViewColumn.One, { enableScripts: true });
+        this.panel = vscode.window.createWebviewPanel("skylosDashboard", "Skylos Security Dashboard", vscode.ViewColumn.One, { enableScripts: true, localResourceRoots: [] });
         this.panel.onDidDispose(() => {
             this.panel = undefined;
         }, null, this.disposables);
         this.panel.webview.onDidReceiveMessage((msg) => {
-            switch (msg.command) {
+            const command = getDashboardCommand(msg);
+            if (!command)
+                return;
+            switch (command) {
                 case "scan":
                     vscode.commands.executeCommand("skylos.scan");
                     break;
@@ -77,9 +81,11 @@ class SkylosDashboard {
     update() {
         if (!this.panel)
             return;
-        this.panel.webview.html = this.getHtml();
+        this.panel.webview.html = this.getHtml(this.panel.webview);
     }
-    getHtml() {
+    getHtml(webview) {
+        const nonce = (0, webviewSecurity_1.createWebviewNonce)();
+        const csp = (0, webviewSecurity_1.webviewCsp)(webview, nonce);
         const { score, grade, color } = computeSecurityScore(this.store);
         const counts = this.store.countBySeverity();
         const catCounts = this.store.countByCategory();
@@ -123,7 +129,7 @@ class SkylosDashboard {
             if (entries.length > 0) {
                 catGradesHtml = `<div class="cat-grades">${entries.map(([cat, g]) => {
                     const c = GRADE_COLOR[g.letter] ?? "#888";
-                    return `<div class="cat-grade-item"><span class="cat-grade-letter" style="color:${c}">${g.letter}</span><span class="cat-grade-label">${cat}</span></div>`;
+                    return `<div class="cat-grade-item"><span class="cat-grade-letter" style="color:${c}">${(0, webviewSecurity_1.escapeHtml)(g.letter)}</span><span class="cat-grade-label">${(0, webviewSecurity_1.escapeHtml)(cat)}</span></div>`;
                 }).join("")}</div>`;
             }
         }
@@ -135,7 +141,9 @@ class SkylosDashboard {
             if (summary.total_loc)
                 parts.push(`<span>${summary.total_loc.toLocaleString()} LOC</span>`);
             if (summary.languages) {
-                const langs = Object.entries(summary.languages).map(([l, n]) => `${l}: ${n}`).join(", ");
+                const langs = Object.entries(summary.languages)
+                    .map(([l, n]) => `${(0, webviewSecurity_1.escapeHtml)(l)}: ${(0, webviewSecurity_1.escapeHtml)(n)}`)
+                    .join(", ");
                 parts.push(`<span>${langs}</span>`);
             }
             if (parts.length > 0) {
@@ -160,7 +168,7 @@ class SkylosDashboard {
     <h3>&#128260; Circular Dependencies (${circularDeps.length})</h3>
     <div class="circ-list">
       ${circularDeps.slice(0, 10).map((d) => {
-                const chain = d.cycle.map((m) => m.split("/").pop()).join(" &#8594; ");
+                const chain = d.cycle.map((m) => (0, webviewSecurity_1.escapeHtml)(m.split("/").pop() ?? m)).join(" &#8594; ");
                 return `<div class="circ-item">${chain}</div>`;
             }).join("")}
       ${circularDeps.length > 10 ? `<p style="opacity:.5;font-size:12px;margin-top:8px">...and ${circularDeps.length - 10} more</p>` : ""}
@@ -177,10 +185,10 @@ class SkylosDashboard {
       ${depVulns.slice(0, 10).map((v) => {
                 const sevColor = v.severity?.toUpperCase() === "CRITICAL" ? "#ef4444" : v.severity?.toUpperCase() === "HIGH" ? "#fb923c" : "#facc15";
                 return `<tr>
-          <td class="mono">${v.package}${v.version ? `@${v.version}` : ""}</td>
-          <td><span style="color:${sevColor}">${v.severity ?? "?"}</span></td>
-          <td>${v.summary ?? v.vulnerability_id ?? ""}</td>
-          <td class="mono">${v.fix_version ?? "-"}</td>
+          <td class="mono">${(0, webviewSecurity_1.escapeHtml)(v.package)}${v.version ? `@${(0, webviewSecurity_1.escapeHtml)(v.version)}` : ""}</td>
+          <td><span style="color:${sevColor}">${(0, webviewSecurity_1.escapeHtml)(v.severity ?? "?")}</span></td>
+          <td>${(0, webviewSecurity_1.escapeHtml)(v.summary ?? v.vulnerability_id ?? "")}</td>
+          <td class="mono">${(0, webviewSecurity_1.escapeHtml)(v.fix_version ?? "-")}</td>
         </tr>`;
             }).join("")}
     </table>
@@ -190,6 +198,7 @@ class SkylosDashboard {
 <html lang="en">
 <head>
 <meta charset="UTF-8"/>
+<meta http-equiv="Content-Security-Policy" content="${(0, webviewSecurity_1.escapeHtml)(csp)}"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -259,7 +268,7 @@ ${scopeHtml}
     <div class="score-wrap">
       <div class="donut">
         <div class="donut-label">
-          <span class="donut-grade">${grade}</span>
+          <span class="donut-grade">${(0, webviewSecurity_1.escapeHtml)(grade)}</span>
           <span class="donut-score">${donutPct}/100</span>
         </div>
       </div>
@@ -298,7 +307,7 @@ ${scopeHtml}
     <h3>Categories</h3>
     <div class="cat-grid">
       ${Object.entries(catCounts)
-            .map(([cat, count]) => `<div class="cat-item"><span class="cat-icon">${catIcons[cat] ?? "&#128196;"}</span>${cat}<span class="cat-count">${count}</span></div>`)
+            .map(([cat, count]) => `<div class="cat-item"><span class="cat-icon">${catIcons[cat] ?? "&#128196;"}</span>${(0, webviewSecurity_1.escapeHtml)(cat)}<span class="cat-count">${count}</span></div>`)
             .join("")}
     </div>
   </div>
@@ -310,7 +319,7 @@ ${scopeHtml}
       <tr><th>File</th><th>Critical/High</th><th>Total</th></tr>
       ${topFiles.map(([file, c]) => {
             const short = file.split("/").slice(-2).join("/");
-            return `<tr><td class="mono">${short}</td><td>${c.critical}</td><td>${c.total}</td></tr>`;
+            return `<tr><td class="mono">${(0, webviewSecurity_1.escapeHtml)(short)}</td><td>${c.critical}</td><td>${c.total}</td></tr>`;
         }).join("")}
     </table>`}
   </div>
@@ -320,14 +329,21 @@ ${scopeHtml}
 </div>
 
 <div class="actions">
-  <button class="btn btn-primary" onclick="post('scan')">&#8635; Scan</button>
-  <button class="btn btn-secondary" onclick="post('fixAll')">&#9889; Fix All</button>
-  <button class="btn btn-secondary" onclick="post('export')">&#128196; Export</button>
+  <button class="btn btn-primary" type="button" data-command="scan">&#8635; Scan</button>
+  <button class="btn btn-secondary" type="button" data-command="fixAll">&#9889; Fix All</button>
+  <button class="btn btn-secondary" type="button" data-command="export">&#128196; Export</button>
 </div>
 
-<script>
+<script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
-function post(cmd){vscode.postMessage({command:cmd})}
+document.querySelector('.actions')?.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const command = target.dataset.command;
+  if (command === 'scan' || command === 'fixAll' || command === 'export') {
+    vscode.postMessage({ command });
+  }
+});
 </script>
 </body>
 </html>`;
@@ -338,3 +354,15 @@ function post(cmd){vscode.postMessage({command:cmd})}
     }
 }
 exports.SkylosDashboard = SkylosDashboard;
+function getDashboardCommand(msg) {
+    if (!(0, webviewSecurity_1.isRecord)(msg))
+        return undefined;
+    switch (msg.command) {
+        case "scan":
+        case "fixAll":
+        case "export":
+            return msg.command;
+        default:
+            return undefined;
+    }
+}

--- a/editors/vscode/out/detail.js
+++ b/editors/vscode/out/detail.js
@@ -5,38 +5,52 @@ const vscode = require("vscode");
 const rules_1 = require("./rules");
 const reviewCore_1 = require("./reviewCore");
 const provenanceCore_1 = require("./provenanceCore");
+const webviewSecurity_1 = require("./webviewSecurity");
 class FindingDetailPanel {
     show(finding) {
+        this.currentFinding = finding;
         if (this.panel) {
             this.panel.reveal();
         }
         else {
-            this.panel = vscode.window.createWebviewPanel("skylosFindingDetail", "Finding Detail", vscode.ViewColumn.Beside, { enableScripts: true });
-            this.panel.onDidDispose(() => { this.panel = undefined; });
+            this.panel = vscode.window.createWebviewPanel("skylosFindingDetail", "Finding Detail", vscode.ViewColumn.Beside, { enableScripts: true, localResourceRoots: [] });
+            this.messageDisposable = this.panel.webview.onDidReceiveMessage((msg) => this.handleMessage(msg));
+            this.panel.onDidDispose(() => {
+                this.panel = undefined;
+                this.currentFinding = undefined;
+                this.messageDisposable?.dispose();
+                this.messageDisposable = undefined;
+            });
         }
         this.panel.title = `[${finding.ruleId}] Detail`;
-        this.panel.webview.html = this.getHtml(finding);
-        this.panel.webview.onDidReceiveMessage((msg) => {
-            switch (msg.command) {
-                case "fix":
-                    vscode.commands.executeCommand("skylos.fix", finding.file, new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0), finding.message, false);
-                    break;
-                case "dismiss":
-                    vscode.commands.executeCommand("skylos.dismissIssue", finding.file, finding.line);
-                    this.panel?.dispose();
-                    break;
-                case "previewFix":
-                    vscode.commands.executeCommand("skylos.previewSafeFix", finding);
-                    break;
-                case "openFile":
-                    vscode.commands.executeCommand("vscode.open", vscode.Uri.file(finding.file), {
-                        selection: new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0),
-                    });
-                    break;
-            }
-        });
+        this.panel.webview.html = this.getHtml(this.panel.webview, finding);
     }
-    getHtml(f) {
+    handleMessage(msg) {
+        const command = getDetailCommand(msg);
+        const finding = this.currentFinding;
+        if (!command || !finding)
+            return;
+        switch (command) {
+            case "fix":
+                vscode.commands.executeCommand("skylos.fix", finding.file, new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0), finding.message, false);
+                break;
+            case "dismiss":
+                vscode.commands.executeCommand("skylos.dismissIssue", finding.file, finding.line);
+                this.panel?.dispose();
+                break;
+            case "previewFix":
+                vscode.commands.executeCommand("skylos.previewSafeFix", finding);
+                break;
+            case "openFile":
+                vscode.commands.executeCommand("vscode.open", vscode.Uri.file(finding.file), {
+                    selection: new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0),
+                });
+                break;
+        }
+    }
+    getHtml(webview, f) {
+        const nonce = (0, webviewSecurity_1.createWebviewNonce)();
+        const csp = (0, webviewSecurity_1.webviewCsp)(webview, nonce);
         const meta = (0, rules_1.getRuleMeta)(f.ruleId);
         const shortFile = f.file.split("/").slice(-2).join("/");
         const sevColor = getSevColor(f.severity);
@@ -64,15 +78,16 @@ class FindingDetailPanel {
         ];
         const tags = [];
         if (meta?.owasp)
-            tags.push(`<span class="tag owasp">OWASP ${escapeHtml(meta.owasp)}</span>`);
+            tags.push(`<span class="tag owasp">OWASP ${(0, webviewSecurity_1.escapeHtml)(meta.owasp)}</span>`);
         if (meta?.cwe)
-            tags.push(`<span class="tag cwe">${escapeHtml(meta.cwe)}</span>`);
+            tags.push(`<span class="tag cwe">${(0, webviewSecurity_1.escapeHtml)(meta.cwe)}</span>`);
         if (meta?.pciDss)
-            tags.push(`<span class="tag pci">PCI-DSS ${escapeHtml(meta.pciDss)}</span>`);
+            tags.push(`<span class="tag pci">PCI-DSS ${(0, webviewSecurity_1.escapeHtml)(meta.pciDss)}</span>`);
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8"/>
+<meta http-equiv="Content-Security-Policy" content="${(0, webviewSecurity_1.escapeHtml)(csp)}"/>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);background:var(--vscode-editor-background);padding:24px;line-height:1.6}
@@ -109,65 +124,77 @@ hr{border:none;border-top:1px solid var(--vscode-widget-border,rgba(255,255,255,
 </head>
 <body>
 <span class="severity">${f.severity}</span>
-<h1>${escapeHtml(meta?.name ?? f.ruleId)}</h1>
-<div class="location" onclick="post('openFile')">${escapeHtml(shortFile)}:${f.line}</div>
+<h1>${(0, webviewSecurity_1.escapeHtml)(meta?.name ?? f.ruleId)}</h1>
+<div class="location" data-command="openFile" role="button" tabindex="0">${(0, webviewSecurity_1.escapeHtml)(shortFile)}:${f.line}</div>
 
-<p class="desc"><strong>${escapeHtml(summary)}</strong></p>
-<p class="desc">${escapeHtml(f.message)}</p>
+<p class="desc"><strong>${(0, webviewSecurity_1.escapeHtml)(summary)}</strong></p>
+<p class="desc">${(0, webviewSecurity_1.escapeHtml)(f.message)}</p>
 
 ${tags.length > 0 ? `<div class="tags">${tags.join("")}</div>` : ""}
 
 <div class="decision">
-  ${decisionRows.map(([key, value]) => `<div class="k">${escapeHtml(key)}</div><div class="v">${escapeHtml(String(value))}</div>`).join("")}
+  ${decisionRows.map(([key, value]) => `<div class="k">${(0, webviewSecurity_1.escapeHtml)(key)}</div><div class="v">${(0, webviewSecurity_1.escapeHtml)(String(value))}</div>`).join("")}
 </div>
 
 <h2>Why This Is Here</h2>
 <div class="section">
-  <ul class="list">${reasons.map((reason) => `<li>${escapeHtml(reason)}</li>`).join("")}</ul>
+  <ul class="list">${reasons.map((reason) => `<li>${(0, webviewSecurity_1.escapeHtml)(reason)}</li>`).join("")}</ul>
 </div>
 
 <h2>Evidence</h2>
 <div class="section">
   ${evidence.length > 0
-            ? `<ul class="list">${evidence.map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul>`
+            ? `<ul class="list">${evidence.map((line) => `<li>${(0, webviewSecurity_1.escapeHtml)(line)}</li>`).join("")}</ul>`
             : f.snippet
                 ? `<p>Code snippet attached; no separate trace metadata was provided.</p>`
                 : `<p>No evidence trace was provided by this finding.</p>`}
-  ${f.snippet ? `<pre class="snippet">${escapeHtml(f.snippet)}</pre>` : ""}
+  ${f.snippet ? `<pre class="snippet">${(0, webviewSecurity_1.escapeHtml)(f.snippet)}</pre>` : ""}
 </div>
 
 <h2>CI Impact</h2>
-<div class="section impact"><p>${escapeHtml(ciCopy)}</p></div>
+<div class="section impact"><p>${(0, webviewSecurity_1.escapeHtml)(ciCopy)}</p></div>
 
 <h2>Fix Plan</h2>
 <div class="fix-box">
-  <h3>${escapeHtml(plan.title)}</h3>
-  <ul class="list">${plan.steps.map((step) => `<li>${escapeHtml(step)}</li>`).join("")}</ul>
+  <h3>${(0, webviewSecurity_1.escapeHtml)(plan.title)}</h3>
+  <ul class="list">${plan.steps.map((step) => `<li>${(0, webviewSecurity_1.escapeHtml)(step)}</li>`).join("")}</ul>
 </div>
 
 ${meta?.description ? `
 <h2>Description</h2>
-<div class="section"><p>${escapeHtml(meta.description)}</p></div>
+<div class="section"><p>${(0, webviewSecurity_1.escapeHtml)(meta.description)}</p></div>
 ` : ""}
 
 ${meta?.fix ? `
 <div class="fix-box">
   <h3>Rule Guidance</h3>
-  <p>${escapeHtml(meta.fix)}</p>
+  <p>${(0, webviewSecurity_1.escapeHtml)(meta.fix)}</p>
 </div>
 ` : ""}
 
 <hr/>
 <div class="actions">
-  ${f.fixPatch ? `<button class="btn btn-primary" onclick="post('previewFix')">Preview Engine Fix</button>` : ""}
-  <button class="btn btn-primary" onclick="post('fix')">Fix with AI Assist</button>
-  <button class="btn btn-secondary" onclick="post('dismiss')">Dismiss</button>
-  <button class="btn btn-secondary" onclick="post('openFile')">Go to File</button>
+  ${f.fixPatch ? `<button class="btn btn-primary" type="button" data-command="previewFix">Preview Engine Fix</button>` : ""}
+  <button class="btn btn-primary" type="button" data-command="fix">Fix with AI Assist</button>
+  <button class="btn btn-secondary" type="button" data-command="dismiss">Dismiss</button>
+  <button class="btn btn-secondary" type="button" data-command="openFile">Go to File</button>
 </div>
 
-<script>
+<script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
-function post(cmd){vscode.postMessage({command:cmd})}
+const allowedCommands = new Set(['fix', 'dismiss', 'previewFix', 'openFile']);
+function postCommandFromElement(target) {
+  if (!(target instanceof HTMLElement)) return;
+  const command = target.dataset.command;
+  if (allowedCommands.has(command)) {
+    vscode.postMessage({ command });
+  }
+}
+document.body.addEventListener('click', (event) => postCommandFromElement(event.target));
+document.body.addEventListener('keydown', (event) => {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  postCommandFromElement(event.target);
+});
 </script>
 </body>
 </html>`;
@@ -177,14 +204,6 @@ function post(cmd){vscode.postMessage({command:cmd})}
     }
 }
 exports.FindingDetailPanel = FindingDetailPanel;
-function escapeHtml(value) {
-    return value
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;");
-}
 function getSevColor(sev) {
     switch (sev.toUpperCase()) {
         case "CRITICAL":
@@ -209,4 +228,17 @@ function getFindingSummary(finding, provenance) {
         return `${provenance} finding`;
     }
     return `${provenance} finding`;
+}
+function getDetailCommand(msg) {
+    if (!(0, webviewSecurity_1.isRecord)(msg))
+        return undefined;
+    switch (msg.command) {
+        case "fix":
+        case "dismiss":
+        case "previewFix":
+        case "openFile":
+            return msg.command;
+        default:
+            return undefined;
+    }
 }

--- a/editors/vscode/out/webviewSecurity.js
+++ b/editors/vscode/out/webviewSecurity.js
@@ -1,0 +1,37 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createWebviewNonce = createWebviewNonce;
+exports.webviewCsp = webviewCsp;
+exports.escapeHtml = escapeHtml;
+exports.isRecord = isRecord;
+const crypto_1 = require("crypto");
+function createWebviewNonce() {
+    return (0, crypto_1.randomBytes)(16)
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/g, "");
+}
+function webviewCsp(webview, nonce) {
+    return [
+        "default-src 'none'",
+        "base-uri 'none'",
+        "form-action 'none'",
+        `img-src ${webview.cspSource} https: data:`,
+        `font-src ${webview.cspSource}`,
+        `style-src ${webview.cspSource} 'unsafe-inline'`,
+        `script-src 'nonce-${nonce}'`,
+        "connect-src 'none'",
+    ].join("; ");
+}
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+function isRecord(value) {
+    return typeof value === "object" && value !== null;
+}

--- a/editors/vscode/src/chatview.ts
+++ b/editors/vscode/src/chatview.ts
@@ -2,6 +2,11 @@ import * as vscode from "vscode";
 import type { SkylosFinding, ChatMessage } from "./types";
 import { getAIProvider, getAIApiKey, getAIModel, getOpenAIBaseUrl } from "./config";
 import { out } from "./scanner";
+import { createWebviewNonce, escapeHtml, isRecord, webviewCsp } from "./webviewSecurity";
+
+const MAX_CHAT_TEXT_LENGTH = 20000;
+const MAX_FIX_CODE_LENGTH = 200000;
+const MAX_LANGUAGE_ID_LENGTH = 64;
 
 export class SkylosChatViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "skylosChatPanel";
@@ -25,15 +30,18 @@ export class SkylosChatViewProvider implements vscode.WebviewViewProvider {
 
     webviewView.webview.options = {
       enableScripts: true,
+      localResourceRoots: [],
     };
 
-    webviewView.webview.html = this.getHtml();
+    webviewView.webview.html = this.getHtml(webviewView.webview);
 
-    webviewView.webview.onDidReceiveMessage(async (msg) => {
-      if (msg.type === "userMessage") {
+    webviewView.webview.onDidReceiveMessage(async (msg: unknown) => {
+      if (isUserMessage(msg)) {
         await this.handleUserMessage(msg.text);
-      } else if (msg.type === "applyFix") {
+      } else if (isApplyFixMessage(msg)) {
         await this.applyCodeFix(msg.code, msg.language);
+      } else {
+        out.appendLine("Ignored invalid chat webview message.");
       }
     });
 
@@ -285,11 +293,15 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     this.context.workspaceState.update("skylosChatHistory", this.history.slice(-20));
   }
 
-  private getHtml(): string {
+  private getHtml(webview: vscode.Webview): string {
+    const nonce = createWebviewNonce();
+    const csp = webviewCsp(webview, nonce);
+
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${escapeHtml(csp)}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -418,7 +430,7 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     <button id="send">Send</button>
   </div>
 
-<script>
+<script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
   const messagesEl = document.getElementById('messages');
   const inputEl = document.getElementById('input');
@@ -439,7 +451,7 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     // Code fences
     html = html.replace(/\`\`\`(\\w*)\n([\\s\\S]*?)\`\`\`/g, (_, lang, code) => {
       const langAttr = lang || '';
-      return '<pre data-lang="' + langAttr + '"><button class="apply-btn" onclick="applyCode(this)">Apply Fix</button><code>' + code + '</code></pre>';
+      return '<pre data-lang="' + langAttr + '"><button class="apply-btn" type="button">Apply Fix</button><code>' + code + '</code></pre>';
     });
 
     // Inline code
@@ -488,12 +500,16 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
   });
 
-  window.applyCode = function(btn) {
-    const pre = btn.parentElement;
-    const code = pre.querySelector('code').textContent;
+  messagesEl.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement) || !target.classList.contains('apply-btn')) return;
+    const pre = target.closest('pre');
+    const codeEl = pre?.querySelector('code');
+    if (!pre || !codeEl) return;
+    const code = codeEl.textContent || '';
     const lang = pre.getAttribute('data-lang') || '';
     vscode.postMessage({ type: 'applyFix', code, language: lang });
-  };
+  });
 
   window.addEventListener('message', (event) => {
     const msg = event.data;
@@ -544,4 +560,24 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
 </body>
 </html>`;
   }
+}
+
+function isUserMessage(msg: unknown): msg is { type: "userMessage"; text: string } {
+  return isRecord(msg)
+    && msg.type === "userMessage"
+    && typeof msg.text === "string"
+    && msg.text.length > 0
+    && msg.text.length <= MAX_CHAT_TEXT_LENGTH;
+}
+
+function isApplyFixMessage(msg: unknown): msg is { type: "applyFix"; code: string; language?: string } {
+  return isRecord(msg)
+    && msg.type === "applyFix"
+    && typeof msg.code === "string"
+    && msg.code.length > 0
+    && msg.code.length <= MAX_FIX_CODE_LENGTH
+    && (
+      msg.language === undefined
+      || (typeof msg.language === "string" && msg.language.length <= MAX_LANGUAGE_ID_LENGTH)
+    );
 }

--- a/editors/vscode/src/dashboard.ts
+++ b/editors/vscode/src/dashboard.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { FindingsStore } from "./store";
 import { getMaxProblems } from "./config";
+import { createWebviewNonce, escapeHtml, isRecord, webviewCsp } from "./webviewSecurity";
 
 interface ScoreResult {
   score: number;
@@ -70,15 +71,18 @@ export class SkylosDashboard {
       "skylosDashboard",
       "Skylos Security Dashboard",
       vscode.ViewColumn.One,
-      { enableScripts: true },
+      { enableScripts: true, localResourceRoots: [] },
     );
 
     this.panel.onDidDispose(() => {
       this.panel = undefined;
     }, null, this.disposables);
 
-    this.panel.webview.onDidReceiveMessage((msg) => {
-      switch (msg.command) {
+    this.panel.webview.onDidReceiveMessage((msg: unknown) => {
+      const command = getDashboardCommand(msg);
+      if (!command) return;
+
+      switch (command) {
         case "scan":
           vscode.commands.executeCommand("skylos.scan");
           break;
@@ -102,10 +106,12 @@ export class SkylosDashboard {
   private update(): void {
     if (!this.panel) 
       return;
-    this.panel.webview.html = this.getHtml();
+    this.panel.webview.html = this.getHtml(this.panel.webview);
   }
 
-  private getHtml(): string {
+  private getHtml(webview: vscode.Webview): string {
+    const nonce = createWebviewNonce();
+    const csp = webviewCsp(webview, nonce);
     const { score, grade, color } = computeSecurityScore(this.store);
     const counts = this.store.countBySeverity();
     const catCounts = this.store.countByCategory();
@@ -153,7 +159,7 @@ export class SkylosDashboard {
       if (entries.length > 0) {
         catGradesHtml = `<div class="cat-grades">${entries.map(([cat, g]) => {
           const c = GRADE_COLOR[g.letter] ?? "#888";
-          return `<div class="cat-grade-item"><span class="cat-grade-letter" style="color:${c}">${g.letter}</span><span class="cat-grade-label">${cat}</span></div>`;
+          return `<div class="cat-grade-item"><span class="cat-grade-letter" style="color:${c}">${escapeHtml(g.letter)}</span><span class="cat-grade-label">${escapeHtml(cat)}</span></div>`;
         }).join("")}</div>`;
       }
     }
@@ -164,7 +170,9 @@ export class SkylosDashboard {
       if (summary.total_files) parts.push(`<span>${summary.total_files} files</span>`);
       if (summary.total_loc) parts.push(`<span>${summary.total_loc.toLocaleString()} LOC</span>`);
       if (summary.languages) {
-        const langs = Object.entries(summary.languages).map(([l, n]) => `${l}: ${n}`).join(", ");
+        const langs = Object.entries(summary.languages)
+          .map(([l, n]) => `${escapeHtml(l)}: ${escapeHtml(n)}`)
+          .join(", ");
         parts.push(`<span>${langs}</span>`);
       }
       if (parts.length > 0) {
@@ -191,7 +199,7 @@ export class SkylosDashboard {
     <h3>&#128260; Circular Dependencies (${circularDeps.length})</h3>
     <div class="circ-list">
       ${circularDeps.slice(0, 10).map((d) => {
-        const chain = d.cycle.map((m) => m.split("/").pop()).join(" &#8594; ");
+        const chain = d.cycle.map((m) => escapeHtml(m.split("/").pop() ?? m)).join(" &#8594; ");
         return `<div class="circ-item">${chain}</div>`;
       }).join("")}
       ${circularDeps.length > 10 ? `<p style="opacity:.5;font-size:12px;margin-top:8px">...and ${circularDeps.length - 10} more</p>` : ""}
@@ -209,10 +217,10 @@ export class SkylosDashboard {
       ${depVulns.slice(0, 10).map((v) => {
         const sevColor = v.severity?.toUpperCase() === "CRITICAL" ? "#ef4444" : v.severity?.toUpperCase() === "HIGH" ? "#fb923c" : "#facc15";
         return `<tr>
-          <td class="mono">${v.package}${v.version ? `@${v.version}` : ""}</td>
-          <td><span style="color:${sevColor}">${v.severity ?? "?"}</span></td>
-          <td>${v.summary ?? v.vulnerability_id ?? ""}</td>
-          <td class="mono">${v.fix_version ?? "-"}</td>
+          <td class="mono">${escapeHtml(v.package)}${v.version ? `@${escapeHtml(v.version)}` : ""}</td>
+          <td><span style="color:${sevColor}">${escapeHtml(v.severity ?? "?")}</span></td>
+          <td>${escapeHtml(v.summary ?? v.vulnerability_id ?? "")}</td>
+          <td class="mono">${escapeHtml(v.fix_version ?? "-")}</td>
         </tr>`;
       }).join("")}
     </table>
@@ -223,6 +231,7 @@ export class SkylosDashboard {
 <html lang="en">
 <head>
 <meta charset="UTF-8"/>
+<meta http-equiv="Content-Security-Policy" content="${escapeHtml(csp)}"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
@@ -292,7 +301,7 @@ ${scopeHtml}
     <div class="score-wrap">
       <div class="donut">
         <div class="donut-label">
-          <span class="donut-grade">${grade}</span>
+          <span class="donut-grade">${escapeHtml(grade)}</span>
           <span class="donut-score">${donutPct}/100</span>
         </div>
       </div>
@@ -331,7 +340,7 @@ ${scopeHtml}
     <h3>Categories</h3>
     <div class="cat-grid">
       ${Object.entries(catCounts)
-        .map(([cat, count]) => `<div class="cat-item"><span class="cat-icon">${catIcons[cat] ?? "&#128196;"}</span>${cat}<span class="cat-count">${count}</span></div>`)
+        .map(([cat, count]) => `<div class="cat-item"><span class="cat-icon">${catIcons[cat] ?? "&#128196;"}</span>${escapeHtml(cat)}<span class="cat-count">${count}</span></div>`)
         .join("")}
     </div>
   </div>
@@ -343,7 +352,7 @@ ${scopeHtml}
       <tr><th>File</th><th>Critical/High</th><th>Total</th></tr>
       ${topFiles.map(([file, c]) => {
         const short = file.split("/").slice(-2).join("/");
-        return `<tr><td class="mono">${short}</td><td>${c.critical}</td><td>${c.total}</td></tr>`;
+        return `<tr><td class="mono">${escapeHtml(short)}</td><td>${c.critical}</td><td>${c.total}</td></tr>`;
       }).join("")}
     </table>`}
   </div>
@@ -353,14 +362,21 @@ ${scopeHtml}
 </div>
 
 <div class="actions">
-  <button class="btn btn-primary" onclick="post('scan')">&#8635; Scan</button>
-  <button class="btn btn-secondary" onclick="post('fixAll')">&#9889; Fix All</button>
-  <button class="btn btn-secondary" onclick="post('export')">&#128196; Export</button>
+  <button class="btn btn-primary" type="button" data-command="scan">&#8635; Scan</button>
+  <button class="btn btn-secondary" type="button" data-command="fixAll">&#9889; Fix All</button>
+  <button class="btn btn-secondary" type="button" data-command="export">&#128196; Export</button>
 </div>
 
-<script>
+<script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
-function post(cmd){vscode.postMessage({command:cmd})}
+document.querySelector('.actions')?.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const command = target.dataset.command;
+  if (command === 'scan' || command === 'fixAll' || command === 'export') {
+    vscode.postMessage({ command });
+  }
+});
 </script>
 </body>
 </html>`;
@@ -369,5 +385,17 @@ function post(cmd){vscode.postMessage({command:cmd})}
   dispose(): void {
     this.panel?.dispose();
     this.disposables.forEach((d) => d.dispose());
+  }
+}
+
+function getDashboardCommand(msg: unknown): "scan" | "fixAll" | "export" | undefined {
+  if (!isRecord(msg)) return undefined;
+  switch (msg.command) {
+    case "scan":
+    case "fixAll":
+    case "export":
+      return msg.command;
+    default:
+      return undefined;
   }
 }

--- a/editors/vscode/src/detail.ts
+++ b/editors/vscode/src/detail.ts
@@ -3,11 +3,16 @@ import type { SkylosFinding } from "./types";
 import { getRuleMeta } from "./rules";
 import { evidenceLines, fixPlan, isLikelyCiBlocker, priorityReasons } from "./reviewCore";
 import { provenanceLabel } from "./provenanceCore";
+import { createWebviewNonce, escapeHtml, isRecord, webviewCsp } from "./webviewSecurity";
 
 export class FindingDetailPanel {
   private panel: vscode.WebviewPanel | undefined;
+  private currentFinding: SkylosFinding | undefined;
+  private messageDisposable: vscode.Disposable | undefined;
 
   show(finding: SkylosFinding): void {
+    this.currentFinding = finding;
+
     if (this.panel) {
       this.panel.reveal();
     } else {
@@ -15,42 +20,54 @@ export class FindingDetailPanel {
         "skylosFindingDetail",
         "Finding Detail",
         vscode.ViewColumn.Beside,
-        { enableScripts: true },
+        { enableScripts: true, localResourceRoots: [] },
       );
-      this.panel.onDidDispose(() => { this.panel = undefined; });
+      this.messageDisposable = this.panel.webview.onDidReceiveMessage((msg: unknown) => this.handleMessage(msg));
+      this.panel.onDidDispose(() => {
+        this.panel = undefined;
+        this.currentFinding = undefined;
+        this.messageDisposable?.dispose();
+        this.messageDisposable = undefined;
+      });
     }
 
     this.panel.title = `[${finding.ruleId}] Detail`;
-    this.panel.webview.html = this.getHtml(finding);
-
-    this.panel.webview.onDidReceiveMessage((msg) => {
-      switch (msg.command) {
-        case "fix":
-          vscode.commands.executeCommand(
-            "skylos.fix",
-            finding.file,
-            new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0),
-            finding.message,
-            false,
-          );
-          break;
-        case "dismiss":
-          vscode.commands.executeCommand("skylos.dismissIssue", finding.file, finding.line);
-          this.panel?.dispose();
-          break;
-        case "previewFix":
-          vscode.commands.executeCommand("skylos.previewSafeFix", finding);
-          break;
-        case "openFile":
-          vscode.commands.executeCommand("vscode.open", vscode.Uri.file(finding.file), {
-            selection: new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0),
-          });
-          break;
-      }
-    });
+    this.panel.webview.html = this.getHtml(this.panel.webview, finding);
   }
 
-  private getHtml(f: SkylosFinding): string {
+  private handleMessage(msg: unknown): void {
+    const command = getDetailCommand(msg);
+    const finding = this.currentFinding;
+    if (!command || !finding) return;
+
+    switch (command) {
+      case "fix":
+        vscode.commands.executeCommand(
+          "skylos.fix",
+          finding.file,
+          new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0),
+          finding.message,
+          false,
+        );
+        break;
+      case "dismiss":
+        vscode.commands.executeCommand("skylos.dismissIssue", finding.file, finding.line);
+        this.panel?.dispose();
+        break;
+      case "previewFix":
+        vscode.commands.executeCommand("skylos.previewSafeFix", finding);
+        break;
+      case "openFile":
+        vscode.commands.executeCommand("vscode.open", vscode.Uri.file(finding.file), {
+          selection: new vscode.Range(Math.max(0, finding.line - 1), 0, Math.max(0, finding.line - 1), 0),
+        });
+        break;
+    }
+  }
+
+  private getHtml(webview: vscode.Webview, f: SkylosFinding): string {
+    const nonce = createWebviewNonce();
+    const csp = webviewCsp(webview, nonce);
     const meta = getRuleMeta(f.ruleId);
     const shortFile = f.file.split("/").slice(-2).join("/");
     const sevColor = getSevColor(f.severity);
@@ -86,6 +103,7 @@ export class FindingDetailPanel {
 <html lang="en">
 <head>
 <meta charset="UTF-8"/>
+<meta http-equiv="Content-Security-Policy" content="${escapeHtml(csp)}"/>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{font-family:var(--vscode-font-family);color:var(--vscode-foreground);background:var(--vscode-editor-background);padding:24px;line-height:1.6}
@@ -123,7 +141,7 @@ hr{border:none;border-top:1px solid var(--vscode-widget-border,rgba(255,255,255,
 <body>
 <span class="severity">${f.severity}</span>
 <h1>${escapeHtml(meta?.name ?? f.ruleId)}</h1>
-<div class="location" onclick="post('openFile')">${escapeHtml(shortFile)}:${f.line}</div>
+<div class="location" data-command="openFile" role="button" tabindex="0">${escapeHtml(shortFile)}:${f.line}</div>
 
 <p class="desc"><strong>${escapeHtml(summary)}</strong></p>
 <p class="desc">${escapeHtml(f.message)}</p>
@@ -172,15 +190,27 @@ ${meta?.fix ? `
 
 <hr/>
 <div class="actions">
-  ${f.fixPatch ? `<button class="btn btn-primary" onclick="post('previewFix')">Preview Engine Fix</button>` : ""}
-  <button class="btn btn-primary" onclick="post('fix')">Fix with AI Assist</button>
-  <button class="btn btn-secondary" onclick="post('dismiss')">Dismiss</button>
-  <button class="btn btn-secondary" onclick="post('openFile')">Go to File</button>
+  ${f.fixPatch ? `<button class="btn btn-primary" type="button" data-command="previewFix">Preview Engine Fix</button>` : ""}
+  <button class="btn btn-primary" type="button" data-command="fix">Fix with AI Assist</button>
+  <button class="btn btn-secondary" type="button" data-command="dismiss">Dismiss</button>
+  <button class="btn btn-secondary" type="button" data-command="openFile">Go to File</button>
 </div>
 
-<script>
+<script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
-function post(cmd){vscode.postMessage({command:cmd})}
+const allowedCommands = new Set(['fix', 'dismiss', 'previewFix', 'openFile']);
+function postCommandFromElement(target) {
+  if (!(target instanceof HTMLElement)) return;
+  const command = target.dataset.command;
+  if (allowedCommands.has(command)) {
+    vscode.postMessage({ command });
+  }
+}
+document.body.addEventListener('click', (event) => postCommandFromElement(event.target));
+document.body.addEventListener('keydown', (event) => {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  postCommandFromElement(event.target);
+});
 </script>
 </body>
 </html>`;
@@ -189,15 +219,6 @@ function post(cmd){vscode.postMessage({command:cmd})}
   dispose(): void {
     this.panel?.dispose();
   }
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 function getSevColor(sev: string): string {
@@ -225,4 +246,17 @@ function getFindingSummary(finding: SkylosFinding, provenance: string): string {
     return `${provenance} finding`;
   }
   return `${provenance} finding`;
+}
+
+function getDetailCommand(msg: unknown): "fix" | "dismiss" | "previewFix" | "openFile" | undefined {
+  if (!isRecord(msg)) return undefined;
+  switch (msg.command) {
+    case "fix":
+    case "dismiss":
+    case "previewFix":
+    case "openFile":
+      return msg.command;
+    default:
+      return undefined;
+  }
 }

--- a/editors/vscode/src/webviewSecurity.ts
+++ b/editors/vscode/src/webviewSecurity.ts
@@ -1,0 +1,36 @@
+import { randomBytes } from "crypto";
+import type * as vscode from "vscode";
+
+export function createWebviewNonce(): string {
+  return randomBytes(16)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+export function webviewCsp(webview: vscode.Webview, nonce: string): string {
+  return [
+    "default-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+    `img-src ${webview.cspSource} https: data:`,
+    `font-src ${webview.cspSource}`,
+    `style-src ${webview.cspSource} 'unsafe-inline'`,
+    `script-src 'nonce-${nonce}'`,
+    "connect-src 'none'",
+  ].join("; ");
+}
+
+export function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/editors/vscode/test/webviewSecurity.test.js
+++ b/editors/vscode/test/webviewSecurity.test.js
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const { createWebviewNonce, escapeHtml, webviewCsp } = require("../out/webviewSecurity");
+
+const WEBVIEW_SOURCE_FILES = [
+  "chatview.ts",
+  "dashboard.ts",
+  "detail.ts",
+];
+
+function readSource(fileName) {
+  return fs.readFileSync(path.join(__dirname, "..", "src", fileName), "utf8");
+}
+
+test("createWebviewNonce returns CSP-safe random tokens", () => {
+  const first = createWebviewNonce();
+  const second = createWebviewNonce();
+
+  assert.match(first, /^[A-Za-z0-9_-]+$/);
+  assert.notEqual(first, second);
+});
+
+test("webviewCsp restricts scripts to the generated nonce", () => {
+  const csp = webviewCsp({ cspSource: "vscode-webview://extension-id" }, "abc123");
+
+  assert.match(csp, /default-src 'none'/);
+  assert.match(csp, /base-uri 'none'/);
+  assert.match(csp, /form-action 'none'/);
+  assert.match(csp, /script-src 'nonce-abc123'/);
+  assert.doesNotMatch(csp, /script-src[^;]*'unsafe-inline'/);
+  assert.match(csp, /connect-src 'none'/);
+});
+
+test("escapeHtml escapes text for generated webview HTML", () => {
+  assert.equal(
+    escapeHtml(`<img src=x onerror="alert('x')">`),
+    "&lt;img src=x onerror=&quot;alert(&#39;x&#39;)&quot;&gt;",
+  );
+});
+
+test("script-enabled webviews use CSP nonces and no local resource roots", () => {
+  for (const fileName of WEBVIEW_SOURCE_FILES) {
+    const source = readSource(fileName);
+
+    assert.match(source, /enableScripts:\s*true/, `${fileName} should explicitly enable scripts`);
+    assert.match(source, /localResourceRoots:\s*\[\]/, `${fileName} should not expose local resources`);
+    assert.match(source, /Content-Security-Policy/, `${fileName} should set a CSP meta tag`);
+    assert.match(source, /webviewCsp\(webview,\s*nonce\)/, `${fileName} should use shared CSP generation`);
+    assert.match(source, /<script nonce="\$\{nonce\}">/, `${fileName} should nonce its script block`);
+  }
+});
+
+test("webview templates do not use inline event handlers or un-nonced scripts", () => {
+  const combined = WEBVIEW_SOURCE_FILES.map(readSource).join("\n");
+
+  assert.doesNotMatch(combined, /\son[a-z]+\s*=/i);
+  assert.doesNotMatch(combined, /javascript:/i);
+  assert.doesNotMatch(combined, /<script>/i);
+  assert.doesNotMatch(combined, /<script(?!\s+nonce=)/i);
+});
+
+test("dashboard escapes scan-originated strings before rendering HTML", () => {
+  const source = readSource("dashboard.ts");
+
+  assert.match(source, /escapeHtml\(g\.letter\)/);
+  assert.match(source, /escapeHtml\(cat\)/);
+  assert.match(source, /escapeHtml\(l\)/);
+  assert.match(source, /escapeHtml\(v\.package\)/);
+  assert.match(source, /escapeHtml\(v\.summary \?\? v\.vulnerability_id \?\? ""\)/);
+  assert.match(source, /escapeHtml\(short\)/);
+});
+
+test("detail panel registers one message listener and uses current finding state", () => {
+  const source = readSource("detail.ts");
+  const listenerCount = source.match(/onDidReceiveMessage/g)?.length ?? 0;
+
+  assert.equal(listenerCount, 1);
+  assert.match(source, /currentFinding/);
+  assert.match(source, /getDetailCommand\(msg\)/);
+});
+
+test("chat webview validates inbound messages before invoking extension actions", () => {
+  const source = readSource("chatview.ts");
+
+  assert.match(source, /isUserMessage\(msg\)/);
+  assert.match(source, /isApplyFixMessage\(msg\)/);
+  assert.match(source, /MAX_CHAT_TEXT_LENGTH/);
+  assert.match(source, /MAX_FIX_CODE_LENGTH/);
+});


### PR DESCRIPTION
## Summary

  Hardened VSCE webviews against script injection and unsafe webview message handling.

  ## Changes

  - Added shared webview security helpers for CSP nonce generation, CSP construction, HTML escaping, and record validation.
  - Added nonce-based CSP to chat, dashboard, and finding detail webviews.
  - Restricted webviews with `localResourceRoots: []`.
  - Escaped dashboard values derived from scan output before rendering.
  - Fixed finding detail panel message handling

  ## Validation

  - `npm test --prefix editors/vscode`
  - `npm run package --prefix editors/vscode -- --out /private/tmp/skylos-vscode-extension-hardening.vsix`
  - `npm audit --prefix editors/vscode --audit-level=high`