### PR TITLE
refactor(config): route CI scanners through registry

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1809,28 +1809,26 @@ class Skylos:
             }
             if enable_danger:
                 try:
-                    from skylos.rules.danger.github_actions import scan_github_actions
+                    from skylos.rules.config import scan_config_files
 
                     scan_target = _first if _first.is_file() else project_root
-                    github_actions_findings = scan_github_actions(
+                    config_findings = scan_config_files(
                         scan_target,
                         changed_files=changed_files,
                         ignore=project_ignore,
                     )
-                    if github_actions_findings:
+                    if config_findings:
                         from skylos.rules.compliance import (
                             enrich_findings_with_compliance,
                         )
 
                         result["danger"] = enrich_findings_with_compliance(
-                            github_actions_findings
+                            config_findings
                         )
-                        result["analysis_summary"]["danger_count"] = len(
-                            github_actions_findings
-                        )
+                        result["analysis_summary"]["danger_count"] = len(config_findings)
                 except Exception:
                     if os.getenv("SKYLOS_DEBUG"):
-                        logger.error("GitHub Actions scan failed", exc_info=True)
+                        logger.error("Config scan failed", exc_info=True)
             return json.dumps(result)
 
         logger.info(f"Analyzing {len(files)} files...")
@@ -2381,19 +2379,19 @@ class Skylos:
 
         if enable_danger:
             try:
-                from skylos.rules.danger.github_actions import scan_github_actions
+                from skylos.rules.config import scan_config_files
 
                 scan_target = _first if _first.is_file() else project_root
-                github_actions_findings = scan_github_actions(
+                config_findings = scan_config_files(
                     scan_target,
                     changed_files=changed_files,
                     ignore=project_ignore,
                 )
-                if github_actions_findings:
-                    all_dangers.extend(github_actions_findings)
+                if config_findings:
+                    all_dangers.extend(config_findings)
             except Exception:
                 if os.getenv("SKYLOS_DEBUG"):
-                    logger.error("GitHub Actions scan failed", exc_info=True)
+                    logger.error("Config scan failed", exc_info=True)
 
             try:
                 from skylos.rules.danger.danger_hallucination.dependency_hallucination import (

--- a/skylos/rules/config/__init__.py
+++ b/skylos/rules/config/__init__.py
@@ -1,0 +1,3 @@
+from skylos.rules.config.registry import scan_config_files
+
+__all__ = ["scan_config_files"]

--- a/skylos/rules/config/cicd/__init__.py
+++ b/skylos/rules/config/cicd/__init__.py
@@ -1,0 +1,3 @@
+from skylos.rules.config.cicd.github_actions import scan_github_actions
+
+__all__ = ["scan_github_actions"]

--- a/skylos/rules/config/cicd/github_actions.py
+++ b/skylos/rules/config/cicd/github_actions.py
@@ -7,6 +7,8 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from skylos.rules.config.findings import config_finding
+
 try:
     import yaml
 except ImportError:  # pragma: no cover - PyYAML is a runtime dependency.
@@ -167,22 +169,18 @@ def _finding(
     severity: str,
     value: str,
 ) -> dict[str, Any]:
-    return {
-        "rule_id": rule_id,
-        "kind": "github_actions",
-        "severity": severity,
-        "type": "workflow",
-        "name": name,
-        "simple_name": name,
-        "value": value,
-        "threshold": 0,
-        "message": message,
-        "file": str(file),
-        "basename": file.name,
-        "line": max(1, line),
-        "col": 0,
-        "category": "SECURITY",
-    }
+    return config_finding(
+        rule_id=rule_id,
+        domain="cicd",
+        provider="github_actions",
+        name=name,
+        message=message,
+        file=file,
+        line=line,
+        severity=severity,
+        value=value,
+        finding_type="workflow",
+    )
 
 
 def _is_workflow_file(path: Path) -> bool:

--- a/skylos/rules/config/findings.py
+++ b/skylos/rules/config/findings.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def config_finding(
+    *,
+    rule_id: str,
+    domain: str,
+    provider: str,
+    name: str,
+    message: str,
+    file: Path,
+    line: int,
+    severity: str,
+    value: str,
+    finding_type: str,
+) -> dict[str, Any]:
+    return {
+        "rule_id": rule_id,
+        "kind": "config",
+        "domain": domain,
+        "provider": provider,
+        "severity": severity,
+        "type": finding_type,
+        "name": name,
+        "simple_name": name,
+        "value": value,
+        "threshold": 0,
+        "message": message,
+        "file": str(file),
+        "basename": file.name,
+        "line": max(1, line),
+        "col": 0,
+        "category": "SECURITY",
+    }

--- a/skylos/rules/config/registry.py
+++ b/skylos/rules/config/registry.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from skylos.rules.config.cicd.github_actions import scan_github_actions
+
+
+def scan_config_files(
+    root: str | Path,
+    *,
+    changed_files: set[str] | None = None,
+    ignore: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    findings.extend(
+        scan_github_actions(root, changed_files=changed_files, ignore=ignore)
+    )
+    return findings

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -1,18 +1,16 @@
 import json
 
 from skylos.analyzer import analyze
-from skylos.rules.danger.github_actions import scan_github_actions
+from skylos.rules.config import scan_config_files
+from skylos.rules.config.cicd.github_actions import scan_github_actions
 
 
 def _rule_ids(findings):
     return {finding["rule_id"] for finding in findings}
 
 
-def test_github_actions_scanner_detects_workflow_supply_chain_risks(tmp_path):
-    workflows = tmp_path / ".github" / "workflows"
-    workflows.mkdir(parents=True)
-    workflow = workflows / "ci.yml"
-    workflow.write_text(
+def _write_risky_workflow(path):
+    path.write_text(
         """
 name: CI
 on:
@@ -27,6 +25,13 @@ jobs:
         encoding="utf-8",
     )
 
+
+def test_github_actions_scanner_detects_workflow_supply_chain_risks(tmp_path):
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    workflow = workflows / "ci.yml"
+    _write_risky_workflow(workflow)
+
     findings = scan_github_actions(tmp_path)
 
     assert {
@@ -36,6 +41,12 @@ jobs:
         "SKY-D293",
         "SKY-D294",
     }.issubset(_rule_ids(findings))
+    assert {
+        "kind": "config",
+        "domain": "cicd",
+        "provider": "github_actions",
+        "type": "workflow",
+    }.items() <= findings[0].items()
 
 
 def test_github_actions_scanner_accepts_pinned_minimal_workflow(tmp_path):
@@ -88,12 +99,54 @@ jobs:
         encoding="utf-8",
     )
 
-    findings = scan_github_actions(
+    findings = scan_config_files(
         repo,
         changed_files={str(outside_workflow), "../outside/.github/workflows/ci.yml"},
     )
 
     assert findings == []
+
+
+def test_config_scanner_routes_single_github_actions_file(tmp_path):
+    workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True)
+    _write_risky_workflow(workflow)
+
+    findings = scan_config_files(workflow)
+
+    assert {"SKY-D290", "SKY-D292", "SKY-D294"}.issubset(_rule_ids(findings))
+
+
+def test_config_scanner_ignores_unowned_config_files(tmp_path):
+    for relative in (
+        "app.py",
+        "config.yml",
+        ".gitlab-ci.yml",
+        "Jenkinsfile",
+        "Dockerfile",
+        "main.tf",
+    ):
+        path = tmp_path / relative
+        path.write_text(
+            """
+name: CI
+on:
+  pull_request_target:
+jobs:
+  test:
+    script:
+      - echo test
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+    assert scan_config_files(tmp_path) == []
+    assert scan_config_files(tmp_path / "app.py") == []
+    assert scan_config_files(tmp_path / "config.yml") == []
+    assert scan_config_files(tmp_path / ".gitlab-ci.yml") == []
+    assert scan_config_files(tmp_path / "Jenkinsfile") == []
+    assert scan_config_files(tmp_path / "Dockerfile") == []
+    assert scan_config_files(tmp_path / "main.tf") == []
 
 
 def test_github_actions_scanner_detects_extended_offline_risks(tmp_path):


### PR DESCRIPTION
## Summary

Routes CI security scanning through a registry. The GitHub Actions scanner still runs from `--danger` as before, but it is no longer wired directly into `analyzer.py`. This keeps the feature focused. 

## Changes

    - Added `skylos.rules.config` as the registry/facade for security-relevant repository config scanning.
    - Moved the GitHub Actions scanner under `skylos.rules.config.cicd`.
    - Replaced direct analyzer imports of the GitHub Actions scanner with `scan_config_files(...)`.

  ## Validation

    - `pytest test/test_github_actions_security.py test/test_cicd_evidence.py test/test_cicd_review.py test/test_analyzer.py`