### PR TITLE
feat(cache): add opt-in trace phase cache

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1757,6 +1757,7 @@ class Skylos:
         changed_files=None,
         grep_verify=True,
         enable_sca=False,
+        trace_file=None,
     ) -> str:
         if not isinstance(path, (str, list, tuple)):
             raise TypeError(
@@ -1878,9 +1879,16 @@ class Skylos:
         root = project_root
         self._project_root = project_root
 
-        trace_path = project_root / ".skylos_trace"
-        if trace_path.exists():
-            pattern_tracker.load_trace(str(trace_path))
+        if trace_file is not False:
+            trace_path = (
+                project_root / ".skylos_trace"
+                if trace_file is None
+                else Path(trace_file)
+            )
+            if not trace_path.is_absolute():
+                trace_path = project_root / trace_path
+            if trace_path.exists():
+                pattern_tracker.load_trace(str(trace_path))
 
         all_secrets = []
         all_dangers = []
@@ -3214,6 +3222,7 @@ def analyze(
     changed_files=None,
     grep_verify=True,
     enable_sca=False,
+    trace_file=None,
 ) -> str:
     return Skylos().analyze(
         path,
@@ -3228,6 +3237,7 @@ def analyze(
         changed_files,
         grep_verify=grep_verify,
         enable_sca=enable_sca,
+        trace_file=trace_file,
     )
 
 

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -16,6 +16,13 @@ from skylos.constants import (
 )
 from skylos.config import load_config
 from skylos.cloud.credentials import PROVIDERS
+from skylos.core.result_cache import (
+    build_trace_cache_key,
+    load_trace_cache,
+    read_trace_payload,
+    save_trace_cache,
+    write_trace_payload,
+)
 
 from pathlib import Path
 import pathlib
@@ -2309,6 +2316,12 @@ def _run_clean_command(argv):
     return run_clean_command(argv)
 
 
+def _run_cache_command(argv):
+    from skylos.commands.cache_cmd import run_cache_command
+
+    return run_cache_command(argv, console_factory=Console)
+
+
 def run_debt_command(argv):
     from skylos.commands.debt_cmd import run_debt_command as run_debt_command_impl
     from skylos.api import upload_debt_report
@@ -2556,6 +2569,7 @@ EARLY_COMMAND_HANDLERS = {
     "badge": "_run_badge_command",
     "whitelist": "_run_whitelist_command",
     "clean": "_run_clean_command",
+    "cache": "_run_cache_command",
     "doctor": "_run_doctor_command",
     "whoami": "_run_whoami_command",
     "login": "_run_login_command",
@@ -2657,6 +2671,21 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
         "--trace",
         action="store_true",
         help="Run tests with call tracing to capture dynamic dispatch (e.g., visitor patterns)",
+    )
+    parser.add_argument(
+        "--cache",
+        action="store_true",
+        help="Cache successful --trace pytest call-tracing runs.",
+    )
+    parser.add_argument(
+        "--refresh-cache",
+        action="store_true",
+        help="Rerun --trace and overwrite its cache entry.",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable trace cache even when --cache is set.",
     )
     parser.add_argument(
         "--coverage",
@@ -3181,8 +3210,19 @@ def _print_main_scan_banner(args, console, final_exclude_folders):
     return False
 
 
+def _trace_cache_requested(args) -> bool:
+    if not getattr(args, "trace", False):
+        return False
+    if getattr(args, "no_cache", False):
+        return False
+    if getattr(args, "pytest_fixtures", False):
+        return False
+    return bool(getattr(args, "cache", False) or getattr(args, "refresh_cache", False))
+
+
 def _run_pre_analysis_steps(args, project_root, console):
     pytest_fixtures_ok = None
+    trace_file_for_analysis = None
     quiet_output = _is_main_machine_output(args)
 
     if args.coverage:
@@ -3221,7 +3261,40 @@ def _run_pre_analysis_steps(args, project_root, console):
         if not quiet_output:
             console.print("[brand]Running tests with call tracing...[/brand]")
 
-        trace_script = textwrap.dedent(f"""\
+        trace_file = project_root / ".skylos_trace"
+        trace_cache_enabled = _trace_cache_requested(args)
+        trace_cache_key = None
+        trace_cache_fingerprint = None
+        trace_cache_hit = False
+
+        if trace_cache_enabled:
+            trace_cache_key, trace_cache_fingerprint = build_trace_cache_key(
+                project_root,
+                args.path,
+                pytest_args=["-q"],
+                pytest_fixtures=bool(args.pytest_fixtures),
+                return_fingerprint=True,
+            )
+            if not getattr(args, "refresh_cache", False):
+                cached_entry = load_trace_cache(project_root, trace_cache_key)
+                if cached_entry is not None:
+                    write_trace_payload(trace_file, cached_entry["trace"])
+                    trace_file_for_analysis = trace_file
+                    trace_cache_hit = True
+                    if not quiet_output:
+                        console.print(
+                            "[brand]Trace cache hit:[/brand] reusing cached pytest call trace."
+                        )
+
+        if not trace_cache_hit:
+            try:
+                trace_file.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+            trace_script = textwrap.dedent(f"""\
 import os
 import sys
 sys.path.insert(0, {str(project_root)!r})
@@ -3249,28 +3322,50 @@ sys.exit(ret)
 
 """)
 
-        trace_result = subprocess.run(
-            [sys.executable, "-c", trace_script],
-            cwd=project_root,
-            capture_output=True,
-            text=True,
-        )
+            trace_result = subprocess.run(
+                [sys.executable, "-c", trace_script],
+                cwd=project_root,
+                capture_output=True,
+                text=True,
+            )
 
-        trace_file = project_root / ".skylos_trace"
-
-        if trace_result.returncode != 0 and not quiet_output:
-            if trace_file.exists() and trace_file.stat().st_size > 0:
-                console.print(
-                    "[warn]Tests had failures, but trace data was collected.[/warn]"
-                )
+            trace_payload = read_trace_payload(trace_file)
+            if trace_payload is not None:
+                trace_file_for_analysis = trace_file
             else:
+                trace_file_for_analysis = False
+
+            if trace_result.returncode != 0 and not quiet_output:
+                if trace_payload is not None:
+                    console.print(
+                        "[warn]Tests had failures, but trace data was collected.[/warn]"
+                    )
+                else:
+                    console.print(
+                        "[warn]Trace run failed; continuing without trace.[/warn]"
+                    )
+                    if trace_result.stderr:
+                        console.print(trace_result.stderr)
+            elif trace_payload is None and not quiet_output:
                 console.print(
-                    "[warn]Trace run failed; continuing without trace.[/warn]"
+                    "[warn]Trace run completed but no usable trace was produced.[/warn]"
                 )
-                if trace_result.stderr:
-                    console.print(trace_result.stderr)
-        elif not quiet_output:
-            console.print("[good]Trace data collected[/good]")
+            elif not quiet_output:
+                console.print("[good]Trace data collected[/good]")
+
+            if (
+                trace_cache_enabled
+                and trace_cache_key is not None
+                and trace_payload is not None
+                and trace_result.returncode == 0
+            ):
+                save_trace_cache(
+                    project_root,
+                    trace_cache_key,
+                    trace_payload,
+                    pytest_returncode=trace_result.returncode,
+                    fingerprint_summary=trace_cache_fingerprint,
+                )
 
     if args.pytest_fixtures and (not args.coverage) and (not args.trace):
         if not quiet_output:
@@ -3355,6 +3450,7 @@ sys.exit(ret)
         pytest_fixtures_ok=pytest_fixtures_ok,
         custom_rules_data=custom_rules_data,
         changed_files=changed_files,
+        trace_file=trace_file_for_analysis,
     )
 
 
@@ -5508,6 +5604,7 @@ def main() -> None:
     pytest_fixtures_ok = pre_analysis.pytest_fixtures_ok
     custom_rules_data = pre_analysis.custom_rules_data
     changed_files = pre_analysis.changed_files
+    trace_file = pre_analysis.trace_file
 
     try:
         scan_path = args.path if len(args.path) > 1 else args.path[0]
@@ -5525,6 +5622,7 @@ def main() -> None:
                 changed_files=changed_files,
                 grep_verify=not getattr(args, "no_grep_verify", False),
                 enable_sca=bool(args.sca),
+                trace_file=trace_file,
             )
 
         if machine_output:

--- a/skylos/commands/cache_cmd.py
+++ b/skylos/commands/cache_cmd.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from rich.console import Console
+
+from skylos.core.result_cache import RUN_CACHE_DIR, clear_run_cache
+
+
+def run_cache_command(argv: list[str], *, console_factory=Console) -> int:
+    parser = argparse.ArgumentParser(
+        prog="skylos cache",
+        description="Manage Skylos analysis caches.",
+    )
+    subparsers = parser.add_subparsers(dest="cache_command")
+
+    clear_parser = subparsers.add_parser("clear", help="Clear cached run data.")
+    clear_parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Project path whose .skylos/cache/runs directory should be removed.",
+    )
+
+    args = parser.parse_args(argv)
+    console = console_factory()
+
+    if args.cache_command != "clear":
+        parser.print_help()
+        return 0
+
+    root = Path(args.path).resolve()
+    if root.is_file():
+        root = root.parent
+    removed = clear_run_cache(root)
+    cache_path = root / RUN_CACHE_DIR
+    if removed:
+        console.print(f"[green]Cleared run cache:[/green] {cache_path}")
+    else:
+        console.print(f"[dim]No run cache found:[/dim] {cache_path}")
+    return 0

--- a/skylos/core/result_cache.py
+++ b/skylos/core/result_cache.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any
+
+import skylos
+
+SCHEMA_VERSION = 1
+CACHE_KIND_TRACE = "trace"
+RUN_CACHE_DIR = Path(".skylos") / "cache" / "runs"
+TRACE_CACHE_DIR = RUN_CACHE_DIR / "v1" / "trace"
+
+TRACE_ENV_VARS = (
+    "PYTHONPATH",
+    "PYTEST_ADDOPTS",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+    "SKYLOS_ADDOPTS",
+    "SKYLOS_CUSTOM_RULES",
+    "TOX_ENV_NAME",
+    "CI",
+    "GITHUB_ACTIONS",
+)
+
+TRACE_EXCLUDE_PATTERNS = (
+    "site-packages",
+    "venv",
+    ".venv",
+    "pytest",
+    "_pytest",
+)
+
+SOURCE_EXTENSIONS = {
+    ".py",
+    ".pyi",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
+    ".go",
+    ".java",
+    ".php",
+    ".rs",
+    ".dart",
+}
+
+RELEVANT_FILENAMES = {
+    ".pre-commit-config.yaml",
+    ".pre-commit-config.yml",
+    "Cargo.lock",
+    "Cargo.toml",
+    "Pipfile",
+    "Pipfile.lock",
+    "build.gradle",
+    "build.gradle.kts",
+    "composer.json",
+    "composer.lock",
+    "constraints.txt",
+    "go.mod",
+    "go.sum",
+    "gradle.lockfile",
+    "package-lock.json",
+    "package.json",
+    "pdm.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "pom.xml",
+    "pubspec.lock",
+    "pubspec.yaml",
+    "pyproject.toml",
+    "pytest.ini",
+    "requirements.txt",
+    "setup.cfg",
+    "setup.py",
+    "tox.ini",
+    "uv.lock",
+    "yarn.lock",
+}
+
+RELEVANT_GLOBS = (
+    "requirements*.txt",
+    "constraints*.txt",
+)
+
+SKYLOS_CONFIG_PATHS = {
+    ".skylos/config.yaml",
+    ".skylos/config.yml",
+}
+
+EXCLUDED_DIRS = {
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    "dist",
+    "build",
+    "target",
+}
+
+
+def build_trace_cache_key(
+    project_root: str | Path,
+    scan_paths: str | Path | list[str | Path] | tuple[str | Path, ...],
+    *,
+    pytest_args: list[str] | tuple[str, ...] | None = None,
+    pytest_fixtures: bool = False,
+    env: dict[str, str] | None = None,
+    return_fingerprint: bool = False,
+) -> str | tuple[str, dict[str, Any]]:
+    """Build a correctness-first cache key for the pytest call-trace phase."""
+    root = _normalize_root(project_root)
+    env_map = env if env is not None else os.environ
+    normalized_pytest_args = list(pytest_args or ["-q"])
+
+    files = _fingerprinted_files(root)
+    fingerprint = {
+        "schema_version": SCHEMA_VERSION,
+        "cache_kind": CACHE_KIND_TRACE,
+        "skylos_version": skylos.__version__,
+        "python": _python_fingerprint(),
+        "trace_options": {
+            "pytest_args": normalized_pytest_args,
+            "pytest_fixtures": bool(pytest_fixtures),
+            "tracer_exclude_patterns": list(TRACE_EXCLUDE_PATTERNS),
+            "sys_executable": sys.executable,
+        },
+        "scan_paths": _normalize_scan_paths(root, scan_paths),
+        "env": _hash_selected_env(env_map),
+        "files": files,
+    }
+    key = _sha256_json(fingerprint)
+    if return_fingerprint:
+        return key, _fingerprint_summary(fingerprint, key)
+    return key
+
+
+def load_trace_cache(project_root: str | Path, key: str) -> dict[str, Any] | None:
+    path = _trace_cache_path(project_root, key)
+    try:
+        entry = json.loads(
+            path.read_text(encoding="utf-8")  # skylos: ignore[SKY-D215] project-local trace cache
+        )
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("schema_version") != SCHEMA_VERSION:
+        return None
+    if entry.get("cache_kind") != CACHE_KIND_TRACE:
+        return None
+    if entry.get("key") != key:
+        return None
+    if not isinstance(entry.get("trace"), dict):
+        return None
+    if not isinstance(entry["trace"].get("calls", []), list):
+        return None
+    if not isinstance(entry.get("pytest_returncode"), int):
+        return None
+    return entry
+
+
+def save_trace_cache(
+    project_root: str | Path,
+    key: str,
+    trace_payload: dict[str, Any],
+    *,
+    pytest_returncode: int,
+    fingerprint_summary: dict[str, Any] | None = None,
+) -> Path | None:
+    if pytest_returncode != 0 or not _is_valid_trace_payload(trace_payload):
+        return None
+
+    root = _normalize_root(project_root)
+    path = _trace_cache_path(root, key)
+    entry = {
+        "schema_version": SCHEMA_VERSION,
+        "cache_kind": CACHE_KIND_TRACE,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "key": key,
+        "skylos_version": skylos.__version__,
+        "python": _python_fingerprint(),
+        "fingerprint": fingerprint_summary or {},
+        "pytest_returncode": int(pytest_returncode),
+        "trace": trace_payload,
+    }
+    _write_json_atomic(path, entry)
+    return path
+
+
+def clear_run_cache(project_root: str | Path) -> bool:
+    root = _normalize_root(project_root)
+    path = root / RUN_CACHE_DIR
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=True))
+    except (OSError, ValueError):
+        return False
+    if path.is_symlink():
+        return False
+    if not path.exists():
+        return False
+    shutil.rmtree(path)  # skylos: ignore[SKY-D215] guarded project-local cache directory
+    return True
+
+
+def read_trace_payload(trace_file: str | Path) -> dict[str, Any] | None:
+    path = Path(trace_file)
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8")  # skylos: ignore[SKY-D215] local trace file
+        )
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not _is_valid_trace_payload(payload):
+        return None
+    return payload
+
+
+def write_trace_payload(trace_file: str | Path, trace_payload: dict[str, Any]) -> None:
+    if not _is_valid_trace_payload(trace_payload):
+        raise ValueError("invalid trace payload")
+    _write_json_atomic(Path(trace_file), trace_payload)
+
+
+def _trace_cache_path(project_root: str | Path, key: str) -> Path:
+    return _normalize_root(project_root) / TRACE_CACHE_DIR / f"{key}.json"
+
+
+def _normalize_root(project_root: str | Path) -> Path:
+    root = Path(project_root).resolve()
+    if root.is_file():
+        root = root.parent
+    return root
+
+
+def _python_fingerprint() -> dict[str, str]:
+    return {
+        "version": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "platform": sys.platform,
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+    }
+
+
+def _normalize_scan_paths(
+    project_root: Path,
+    scan_paths: str | Path | list[str | Path] | tuple[str | Path, ...],
+) -> list[str]:
+    if isinstance(scan_paths, (str, Path)):
+        raw_paths = [scan_paths]
+    else:
+        raw_paths = list(scan_paths)
+
+    normalized = []
+    for raw in raw_paths:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = (Path.cwd() / path).resolve()
+        else:
+            path = path.resolve()
+        try:
+            normalized.append(path.relative_to(project_root).as_posix() or ".")
+        except ValueError:
+            normalized.append(str(path))
+    return sorted(normalized)
+
+
+def _hash_selected_env(env: dict[str, str]) -> dict[str, str | None]:
+    values: dict[str, str | None] = {}
+    for name in TRACE_ENV_VARS:
+        if name not in env:
+            values[name] = None
+            continue
+        value = str(env.get(name, ""))
+        values[name] = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return values
+
+
+def _fingerprinted_files(project_root: Path) -> list[dict[str, Any]]:
+    files = _git_visible_files(project_root)
+    if files is None:
+        files = _walk_visible_files(project_root)
+
+    fingerprinted = []
+    seen = set()
+    for path in files:
+        abs_path = path if path.is_absolute() else project_root / path
+        try:
+            rel = abs_path.relative_to(project_root)
+        except ValueError:
+            continue
+        rel_posix = rel.as_posix()
+        if rel_posix in seen:
+            continue
+        seen.add(rel_posix)
+        if _is_excluded_rel(rel) or not _is_relevant_rel(rel):
+            continue
+        digest = _content_digest(abs_path)
+        if digest is None:
+            continue
+        fingerprinted.append(
+            {
+                "path": rel_posix,
+                "sha256": digest["sha256"],
+                "size": digest["size"],
+                "kind": digest["kind"],
+            }
+        )
+
+    fingerprinted.sort(key=lambda item: item["path"])
+    return fingerprinted
+
+
+def _git_visible_files(project_root: Path) -> list[Path] | None:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    files = []
+    for line in result.stdout.splitlines():
+        rel = line.strip()
+        if not rel:
+            continue
+        files.append(project_root / rel)
+    return files
+
+
+def _walk_visible_files(project_root: Path) -> list[Path]:
+    files = []
+    for dirpath, dirnames, filenames in os.walk(project_root):
+        base = Path(dirpath)
+        keep_dirs = []
+        for dirname in dirnames:
+            try:
+                rel = (base / dirname).resolve().relative_to(project_root)
+            except (OSError, ValueError):
+                continue
+            if not _is_excluded_rel(rel):
+                keep_dirs.append(dirname)
+        dirnames[:] = keep_dirs
+
+        for filename in filenames:
+            files.append(base / filename)
+    return files
+
+
+def _is_excluded_rel(rel: Path) -> bool:
+    parts = rel.parts
+    if any(part in EXCLUDED_DIRS for part in parts):
+        return True
+    if len(parts) >= 2 and parts[0] == ".skylos" and parts[1] == "cache":
+        return True
+    return False
+
+
+def _is_relevant_rel(rel: Path) -> bool:
+    rel_posix = rel.as_posix()
+    if rel_posix in SKYLOS_CONFIG_PATHS:
+        return True
+    if rel.suffix.lower() in SOURCE_EXTENSIONS:
+        return True
+    if rel.name in RELEVANT_FILENAMES:
+        return True
+    return any(fnmatchcase(rel.name, pattern) for pattern in RELEVANT_GLOBS)
+
+
+def _content_digest(path: Path) -> dict[str, Any] | None:
+    try:
+        stat = path.lstat()
+    except OSError:
+        return None
+
+    if path.is_symlink():
+        try:
+            target = os.readlink(path)
+        except OSError:
+            return None
+        return {
+            "sha256": hashlib.sha256(f"symlink:{target}".encode("utf-8")).hexdigest(),
+            "size": len(target),
+            "kind": "symlink",
+        }
+
+    if not path.is_file():
+        return None
+
+    h = hashlib.sha256()
+    try:
+        with path.open(
+            "rb"
+        ) as handle:  # skylos: ignore[SKY-D215] hashing project files for trace cache key
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                h.update(chunk)
+    except OSError:
+        return None
+
+    return {"sha256": h.hexdigest(), "size": stat.st_size, "kind": "file"}
+
+
+def _fingerprint_summary(
+    fingerprint: dict[str, Any],
+    key: str,
+) -> dict[str, Any]:
+    files = fingerprint.get("files", [])
+    return {
+        "key": key,
+        "file_count": len(files),
+        "files_digest": _sha256_json(files),
+        "scan_paths": fingerprint.get("scan_paths", []),
+        "trace_options": fingerprint.get("trace_options", {}),
+        "env": fingerprint.get("env", {}),
+    }
+
+
+def _sha256_json(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _is_valid_trace_payload(payload: Any) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    calls = payload.get("calls")
+    if not isinstance(calls, list):
+        return False
+    return True
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            tmp_name = handle.name
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if tmp_name:
+            try:
+                if os.path.exists(tmp_name):
+                    os.unlink(tmp_name)
+            except OSError:
+                pass

--- a/skylos/llm/entry_points.py
+++ b/skylos/llm/entry_points.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EntryPoint:
+    name: str
+    source: str
+    reason: str
+
+
+@dataclass
+class RepoFacts:
+    config_files: dict[str, str] = field(default_factory=dict)
+    pytest_class_patterns: list[str] = field(default_factory=lambda: ["Test"])
+    pytest_function_patterns: list[str] = field(default_factory=lambda: ["test"])
+    mkdocs_hook_files: set[str] = field(default_factory=set)
+
+
+ENTRY_POINT_SYSTEM = """\
+You are a Python project analyst. Given project configuration files, identify ALL \
+entry points — functions or modules that are invoked externally (CLI commands, web \
+routes, scheduled tasks, test hooks, plugin registrations).
+
+Return JSON: {"entry_points": [{"name": "qualified.name", "source": "file", "reason": "..."}]}
+
+Only include entry points you can confirm from the config. Do not speculate.\
+"""
+
+ENTRY_POINT_USER = """\
+Analyze these project configuration files to find entry points that a static \
+analyzer might miss.
+
+{config_contents}
+
+Known entry points already detected by static analysis:
+{known_entry_points}
+
+Find any ADDITIONAL entry points referenced in these configs that are NOT in the \
+known list above. Focus on:
+- console_scripts / gui_scripts in pyproject.toml or setup.cfg
+- CMD / ENTRYPOINT in Dockerfile
+- Celery tasks, APScheduler jobs
+- MkDocs hooks registered in mkdocs.yml / mkdocs.yaml
+- pytest plugins and fixtures registered in conftest.py
+- Click/Typer command groups registered via entry_points
+- ASGI/WSGI application references
+- GitHub Actions workflow steps that invoke Python
+- package.json "main", "bin", "scripts" entries (TypeScript/JS)
+- Next.js/Vite/Webpack entry points and page routes
+- Go main() functions referenced in go.mod or Dockerfile
+- Java main classes in pom.xml/build.gradle, Spring Boot @SpringBootApplication
+- Rust binary targets in Cargo.toml [[bin]] sections
+
+JSON response:\
+"""
+
+
+def _gather_config_files(project_root: Path) -> dict[str, str]:
+    candidates = [
+        # Python
+        "pyproject.toml",
+        "setup.py",
+        "setup.cfg",
+        "pytest.ini",
+        "tox.ini",
+        "mkdocs.yml",
+        "mkdocs.yaml",
+        "conftest.py",
+        "manage.py",
+        "app.py",
+        "wsgi.py",
+        "asgi.py",
+        # TypeScript/JS
+        "package.json",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "next.config.js",
+        "next.config.mjs",
+        "next.config.ts",
+        "vite.config.ts",
+        "vite.config.js",
+        "webpack.config.js",
+        "jest.config.js",
+        "jest.config.ts",
+        ".eslintrc.json",
+        ".eslintrc.js",
+        # Go
+        "go.mod",
+        "go.sum",
+        # Java
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "settings.gradle",
+        "settings.gradle.kts",
+        # Rust
+        "Cargo.toml",
+        "Cargo.lock",
+        # Universal
+        "Dockerfile",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        "Makefile",
+        "Procfile",
+    ]
+
+    configs = {}
+    for pattern in candidates:
+        if "*" in pattern:
+            for p in project_root.glob(pattern):
+                try:
+                    text = p.read_text(encoding="utf-8", errors="ignore")
+                    if len(text) > 10_000:
+                        text = text[:10_000] + "\n... (truncated)"
+                    configs[str(p.relative_to(project_root))] = text
+                except Exception:
+                    pass
+        else:
+            p = project_root / pattern
+            if p.exists():
+                try:
+                    text = p.read_text(encoding="utf-8", errors="ignore")
+                    if len(text) > 10_000:
+                        text = text[:10_000] + "\n... (truncated)"
+                    configs[pattern] = text
+                except Exception:
+                    pass
+
+    return configs
+
+
+def _load_pytest_patterns_from_text(raw_value: Any) -> list[str]:
+    if isinstance(raw_value, list):
+        return [str(v).strip() for v in raw_value if str(v).strip()]
+    if isinstance(raw_value, str):
+        lines = [
+            line.strip().strip('"').strip("'")
+            for line in raw_value.splitlines()
+            if line.strip()
+        ]
+        return lines
+    return []
+
+
+def _parse_mkdocs_hook_files(configs: dict[str, str]) -> set[str]:
+    hook_files: set[str] = set()
+    for name in ("mkdocs.yml", "mkdocs.yaml"):
+        text = configs.get(name, "")
+        if not text:
+            continue
+        in_hooks = False
+        hooks_indent = 0
+        for raw_line in text.splitlines():
+            line = raw_line.rstrip()
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            indent = len(line) - len(line.lstrip())
+            if stripped == "hooks:":
+                in_hooks = True
+                hooks_indent = indent
+                continue
+            if in_hooks:
+                if indent <= hooks_indent and not stripped.startswith("- "):
+                    in_hooks = False
+                    continue
+                if stripped.startswith("- "):
+                    hook_path = stripped[2:].strip().strip('"').strip("'")
+                    if hook_path:
+                        hook_files.add(hook_path.replace("\\", "/"))
+    return hook_files
+
+
+def _build_repo_facts(
+    project_root: Path,
+    *,
+    gather_config_files: Callable[[Path], dict[str, str]] | None = None,
+) -> RepoFacts:
+    import configparser
+    import tomllib
+
+    configs = (gather_config_files or _gather_config_files)(project_root)
+    facts = RepoFacts(config_files=configs)
+
+    pyproject_path = project_root / "pyproject.toml"
+    if pyproject_path.exists():
+        try:
+            with pyproject_path.open("rb") as handle:
+                pyproject = tomllib.load(handle)
+            ini_options = (
+                pyproject.get("tool", {}).get("pytest", {}).get("ini_options", {})
+            )
+            class_patterns = _load_pytest_patterns_from_text(
+                ini_options.get("python_classes")
+            )
+            function_patterns = _load_pytest_patterns_from_text(
+                ini_options.get("python_functions")
+            )
+            if class_patterns:
+                facts.pytest_class_patterns = class_patterns
+            if function_patterns:
+                facts.pytest_function_patterns = function_patterns
+        except Exception:
+            pass
+
+    parser = configparser.ConfigParser()
+    for cfg_name, section in (
+        ("pytest.ini", "pytest"),
+        ("tox.ini", "pytest"),
+        ("setup.cfg", "tool:pytest"),
+    ):
+        cfg_path = project_root / cfg_name
+        if not cfg_path.exists():
+            continue
+        try:
+            parser.read(cfg_path, encoding="utf-8")
+            if not parser.has_section(section):
+                continue
+            class_patterns = _load_pytest_patterns_from_text(
+                parser.get(section, "python_classes", fallback="")
+            )
+            function_patterns = _load_pytest_patterns_from_text(
+                parser.get(section, "python_functions", fallback="")
+            )
+            if class_patterns:
+                facts.pytest_class_patterns = class_patterns
+            if function_patterns:
+                facts.pytest_function_patterns = function_patterns
+        except Exception:
+            continue
+
+    facts.mkdocs_hook_files = _parse_mkdocs_hook_files(configs)
+    return facts
+
+
+def _matches_pytest_pattern(name: str, patterns: list[str]) -> bool:
+    import fnmatch
+
+    for pattern in patterns:
+        if name.startswith(pattern):
+            return True
+        if any(ch in pattern for ch in "*?[") and fnmatch.fnmatch(name, pattern):
+            return True
+    return False
+
+
+def _entry_point_cache_path(project_root: Path) -> Path:
+    return project_root / ".skylos" / "cache" / "entry_points.json"
+
+
+def _config_files_hash(configs: dict[str, str]) -> str:
+    import hashlib
+
+    content = json.dumps(configs, sort_keys=True)
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+def discover_entry_points(
+    agent: Any,
+    project_root: Path,
+    known_entry_points: list[str],
+    *,
+    llm_call: Callable[[Any, str, str], str] | None = None,
+    gather_config_files: Callable[[Path], dict[str, str]] | None = None,
+    entry_point_cache_path: Callable[[Path], Path] | None = None,
+    config_files_hash: Callable[[dict[str, str]], str] | None = None,
+    log: logging.Logger | None = None,
+) -> list[EntryPoint]:
+    configs = (gather_config_files or _gather_config_files)(project_root)
+    if not configs:
+        return []
+
+    cache_path = (entry_point_cache_path or _entry_point_cache_path)(project_root)
+    current_hash = (config_files_hash or _config_files_hash)(configs)
+    if cache_path.exists():
+        try:
+            cached = json.loads(cache_path.read_text())
+            if cached.get("hash") == current_hash:
+                return [
+                    EntryPoint(
+                        name=ep["name"], source=ep["source"], reason=ep["reason"]
+                    )
+                    for ep in cached.get("entry_points", [])
+                    if ep.get("name") and ep["name"] not in known_entry_points
+                ]
+        except Exception:
+            pass
+
+    config_text = []
+    for name, content in configs.items():
+        config_text.append(f"=== {name} ===\n{content}\n")
+
+    known_text = "\n".join(f"  - {ep}" for ep in known_entry_points[:50]) or "  (none)"
+
+    user = ENTRY_POINT_USER.format(
+        config_contents="\n".join(config_text),
+        known_entry_points=known_text,
+    )
+
+    try:
+        response = (
+            llm_call(agent, ENTRY_POINT_SYSTEM, user)
+            if llm_call
+            else agent._call_llm(ENTRY_POINT_SYSTEM, user)
+        )
+        if not response:
+            return []
+        clean = response.strip()
+        if clean.startswith("```"):
+            clean = clean.split("\n", 1)[-1]
+        if clean.endswith("```"):
+            clean = clean.rsplit("```", 1)[0]
+        clean = clean.strip()
+
+        data = json.loads(clean)
+        results = []
+        all_discovered = []
+        for ep in data.get("entry_points", []):
+            name = ep.get("name", "")
+            if name:
+                all_discovered.append(
+                    {
+                        "name": name,
+                        "source": ep.get("source", "config"),
+                        "reason": ep.get("reason", ""),
+                    }
+                )
+                if name not in known_entry_points:
+                    results.append(
+                        EntryPoint(
+                            name=name,
+                            source=ep.get("source", "config"),
+                            reason=ep.get("reason", ""),
+                        )
+                    )
+
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(
+                json.dumps(
+                    {"hash": current_hash, "entry_points": all_discovered}, indent=2
+                )
+            )
+        except Exception:
+            pass
+
+        return results
+
+    except (json.JSONDecodeError, Exception) as e:
+        (log or logger).warning(f"Entry point discovery failed: {e}")
+        return []

--- a/skylos/llm/verify_orchestrator.py
+++ b/skylos/llm/verify_orchestrator.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from . import entry_points as _entry_points
 from .dead_code_verifier import (
     DeadCodeVerifierAgent,
     Verdict,
@@ -42,11 +43,10 @@ VALID_VERIFICATION_MODES = {
 }
 
 
-@dataclass
-class EntryPoint:
-    name: str
-    source: str
-    reason: str
+EntryPoint = _entry_points.EntryPoint
+RepoFacts = _entry_points.RepoFacts
+ENTRY_POINT_SYSTEM = _entry_points.ENTRY_POINT_SYSTEM
+ENTRY_POINT_USER = _entry_points.ENTRY_POINT_USER
 
 
 @dataclass
@@ -100,238 +100,19 @@ class VerifyStats:
     elapsed_seconds: float = 0.0
 
 
-@dataclass
-class RepoFacts:
-    config_files: dict[str, str] = field(default_factory=dict)
-    pytest_class_patterns: list[str] = field(default_factory=lambda: ["Test"])
-    pytest_function_patterns: list[str] = field(default_factory=lambda: ["test"])
-    mkdocs_hook_files: set[str] = field(default_factory=set)
-
-
-ENTRY_POINT_SYSTEM = """\
-You are a Python project analyst. Given project configuration files, identify ALL \
-entry points — functions or modules that are invoked externally (CLI commands, web \
-routes, scheduled tasks, test hooks, plugin registrations).
-
-Return JSON: {"entry_points": [{"name": "qualified.name", "source": "file", "reason": "..."}]}
-
-Only include entry points you can confirm from the config. Do not speculate.\
-"""
-
-ENTRY_POINT_USER = """\
-Analyze these project configuration files to find entry points that a static \
-analyzer might miss.
-
-{config_contents}
-
-Known entry points already detected by static analysis:
-{known_entry_points}
-
-Find any ADDITIONAL entry points referenced in these configs that are NOT in the \
-known list above. Focus on:
-- console_scripts / gui_scripts in pyproject.toml or setup.cfg
-- CMD / ENTRYPOINT in Dockerfile
-- Celery tasks, APScheduler jobs
-- MkDocs hooks registered in mkdocs.yml / mkdocs.yaml
-- pytest plugins and fixtures registered in conftest.py
-- Click/Typer command groups registered via entry_points
-- ASGI/WSGI application references
-- GitHub Actions workflow steps that invoke Python
-- package.json "main", "bin", "scripts" entries (TypeScript/JS)
-- Next.js/Vite/Webpack entry points and page routes
-- Go main() functions referenced in go.mod or Dockerfile
-- Java main classes in pom.xml/build.gradle, Spring Boot @SpringBootApplication
-- Rust binary targets in Cargo.toml [[bin]] sections
-
-JSON response:\
-"""
-
-
 def _gather_config_files(project_root: Path) -> dict[str, str]:
-    candidates = [
-        # Python
-        "pyproject.toml",
-        "setup.py",
-        "setup.cfg",
-        "pytest.ini",
-        "tox.ini",
-        "mkdocs.yml",
-        "mkdocs.yaml",
-        "conftest.py",
-        "manage.py",
-        "app.py",
-        "wsgi.py",
-        "asgi.py",
-        # TypeScript/JS
-        "package.json",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "next.config.js",
-        "next.config.mjs",
-        "next.config.ts",
-        "vite.config.ts",
-        "vite.config.js",
-        "webpack.config.js",
-        "jest.config.js",
-        "jest.config.ts",
-        ".eslintrc.json",
-        ".eslintrc.js",
-        # Go
-        "go.mod",
-        "go.sum",
-        # Java
-        "pom.xml",
-        "build.gradle",
-        "build.gradle.kts",
-        "settings.gradle",
-        "settings.gradle.kts",
-        # Rust
-        "Cargo.toml",
-        "Cargo.lock",
-        # Universal
-        "Dockerfile",
-        "docker-compose.yml",
-        "docker-compose.yaml",
-        ".github/workflows/*.yml",
-        ".github/workflows/*.yaml",
-        "Makefile",
-        "Procfile",
-    ]
-
-    configs = {}
-    for pattern in candidates:
-        if "*" in pattern:
-            for p in project_root.glob(pattern):
-                try:
-                    text = p.read_text(encoding="utf-8", errors="ignore")
-                    if len(text) > 10_000:
-                        text = text[:10_000] + "\n... (truncated)"
-                    configs[str(p.relative_to(project_root))] = text
-                except Exception:
-                    pass
-        else:
-            p = project_root / pattern
-            if p.exists():
-                try:
-                    text = p.read_text(encoding="utf-8", errors="ignore")
-                    if len(text) > 10_000:
-                        text = text[:10_000] + "\n... (truncated)"
-                    configs[pattern] = text
-                except Exception:
-                    pass
-
-    return configs
-
-
-def _load_pytest_patterns_from_text(raw_value: Any) -> list[str]:
-    if isinstance(raw_value, list):
-        return [str(v).strip() for v in raw_value if str(v).strip()]
-    if isinstance(raw_value, str):
-        lines = [
-            line.strip().strip('"').strip("'")
-            for line in raw_value.splitlines()
-            if line.strip()
-        ]
-        return lines
-    return []
-
-
-def _parse_mkdocs_hook_files(configs: dict[str, str]) -> set[str]:
-    hook_files: set[str] = set()
-    for name in ("mkdocs.yml", "mkdocs.yaml"):
-        text = configs.get(name, "")
-        if not text:
-            continue
-        in_hooks = False
-        hooks_indent = 0
-        for raw_line in text.splitlines():
-            line = raw_line.rstrip()
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            indent = len(line) - len(line.lstrip())
-            if stripped == "hooks:":
-                in_hooks = True
-                hooks_indent = indent
-                continue
-            if in_hooks:
-                if indent <= hooks_indent and not stripped.startswith("- "):
-                    in_hooks = False
-                    continue
-                if stripped.startswith("- "):
-                    hook_path = stripped[2:].strip().strip('"').strip("'")
-                    if hook_path:
-                        hook_files.add(hook_path.replace("\\", "/"))
-    return hook_files
+    return _entry_points._gather_config_files(project_root)
 
 
 def _build_repo_facts(project_root: Path) -> RepoFacts:
-    import configparser
-    import tomllib
-
-    configs = _gather_config_files(project_root)
-    facts = RepoFacts(config_files=configs)
-
-    pyproject_path = project_root / "pyproject.toml"
-    if pyproject_path.exists():
-        try:
-            with pyproject_path.open("rb") as handle:
-                pyproject = tomllib.load(handle)
-            ini_options = (
-                pyproject.get("tool", {}).get("pytest", {}).get("ini_options", {})
-            )
-            class_patterns = _load_pytest_patterns_from_text(
-                ini_options.get("python_classes")
-            )
-            function_patterns = _load_pytest_patterns_from_text(
-                ini_options.get("python_functions")
-            )
-            if class_patterns:
-                facts.pytest_class_patterns = class_patterns
-            if function_patterns:
-                facts.pytest_function_patterns = function_patterns
-        except Exception:
-            pass
-
-    parser = configparser.ConfigParser()
-    for cfg_name, section in (
-        ("pytest.ini", "pytest"),
-        ("tox.ini", "pytest"),
-        ("setup.cfg", "tool:pytest"),
-    ):
-        cfg_path = project_root / cfg_name
-        if not cfg_path.exists():
-            continue
-        try:
-            parser.read(cfg_path, encoding="utf-8")
-            if not parser.has_section(section):
-                continue
-            class_patterns = _load_pytest_patterns_from_text(
-                parser.get(section, "python_classes", fallback="")
-            )
-            function_patterns = _load_pytest_patterns_from_text(
-                parser.get(section, "python_functions", fallback="")
-            )
-            if class_patterns:
-                facts.pytest_class_patterns = class_patterns
-            if function_patterns:
-                facts.pytest_function_patterns = function_patterns
-        except Exception:
-            continue
-
-    facts.mkdocs_hook_files = _parse_mkdocs_hook_files(configs)
-    return facts
+    return _entry_points._build_repo_facts(
+        project_root,
+        gather_config_files=_gather_config_files,
+    )
 
 
 def _matches_pytest_pattern(name: str, patterns: list[str]) -> bool:
-    import fnmatch
-
-    for pattern in patterns:
-        if name.startswith(pattern):
-            return True
-        if any(ch in pattern for ch in "*?[") and fnmatch.fnmatch(name, pattern):
-            return True
-    return False
+    return _entry_points._matches_pytest_pattern(name, patterns)
 
 
 def _class_node_for_finding(source: str, finding: dict) -> Any | None:
@@ -532,14 +313,11 @@ def _parameter_contract_evidence(
 
 
 def _entry_point_cache_path(project_root: Path) -> Path:
-    return project_root / ".skylos" / "cache" / "entry_points.json"
+    return _entry_points._entry_point_cache_path(project_root)
 
 
 def _config_files_hash(configs: dict[str, str]) -> str:
-    import hashlib
-
-    content = json.dumps(configs, sort_keys=True)
-    return hashlib.sha256(content.encode()).hexdigest()[:16]
+    return _entry_points._config_files_hash(configs)
 
 
 def discover_entry_points(
@@ -547,86 +325,16 @@ def discover_entry_points(
     project_root: Path,
     known_entry_points: list[str],
 ) -> list[EntryPoint]:
-    configs = _gather_config_files(project_root)
-    if not configs:
-        return []
-
-    cache_path = _entry_point_cache_path(project_root)
-    current_hash = _config_files_hash(configs)
-    if cache_path.exists():
-        try:
-            cached = json.loads(cache_path.read_text())
-            if cached.get("hash") == current_hash:
-                return [
-                    EntryPoint(
-                        name=ep["name"], source=ep["source"], reason=ep["reason"]
-                    )
-                    for ep in cached.get("entry_points", [])
-                    if ep.get("name") and ep["name"] not in known_entry_points
-                ]
-        except Exception:
-            pass
-
-    config_text = []
-    for name, content in configs.items():
-        config_text.append(f"=== {name} ===\n{content}\n")
-
-    known_text = "\n".join(f"  - {ep}" for ep in known_entry_points[:50]) or "  (none)"
-
-    user = ENTRY_POINT_USER.format(
-        config_contents="\n".join(config_text),
-        known_entry_points=known_text,
+    return _entry_points.discover_entry_points(
+        agent,
+        project_root,
+        known_entry_points,
+        llm_call=_call_llm_with_retry,
+        gather_config_files=_gather_config_files,
+        entry_point_cache_path=_entry_point_cache_path,
+        config_files_hash=_config_files_hash,
+        log=logger,
     )
-
-    try:
-        response = _call_llm_with_retry(agent, ENTRY_POINT_SYSTEM, user)
-        if not response:
-            return []
-        clean = response.strip()
-        if clean.startswith("```"):
-            clean = clean.split("\n", 1)[-1]
-        if clean.endswith("```"):
-            clean = clean.rsplit("```", 1)[0]
-        clean = clean.strip()
-
-        data = json.loads(clean)
-        results = []
-        all_discovered = []
-        for ep in data.get("entry_points", []):
-            name = ep.get("name", "")
-            if name:
-                all_discovered.append(
-                    {
-                        "name": name,
-                        "source": ep.get("source", "config"),
-                        "reason": ep.get("reason", ""),
-                    }
-                )
-                if name not in known_entry_points:
-                    results.append(
-                        EntryPoint(
-                            name=name,
-                            source=ep.get("source", "config"),
-                            reason=ep.get("reason", ""),
-                        )
-                    )
-
-        # Save cache
-        try:
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            cache_path.write_text(
-                json.dumps(
-                    {"hash": current_hash, "entry_points": all_discovered}, indent=2
-                )
-            )
-        except Exception:
-            pass
-
-        return results
-
-    except (json.JSONDecodeError, Exception) as e:
-        logger.warning(f"Entry point discovery failed: {e}")
-        return []
 
 
 GRAPH_VERIFY_SYSTEM = """\

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -121,7 +121,12 @@ COMMANDS = [
     {"name": "skylos doctor", "desc": "Check installation health", "group": "Utility"},
     {
         "name": "skylos clean",
-        "desc": "Remove cache and state files",
+        "desc": "Interactively remove dead code",
+        "group": "Utility",
+    },
+    {
+        "name": "skylos cache clear [path]",
+        "desc": "Clear cached run data",
         "group": "Utility",
     },
     {

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -173,6 +173,41 @@ class TestSkylos:
 
         assert not skylos._should_exclude_file(file_path, root, None)
 
+    def test_trace_file_false_ignores_existing_project_root_trace(self, tmp_path):
+        module = tmp_path / "app.py"
+        module.write_text(
+            "def root_traced():\n"
+            "    return 1\n"
+            "\n"
+            "def unused():\n"
+            "    return 2\n",
+            encoding="utf-8",
+        )
+        (tmp_path / ".skylos_trace").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "calls": [
+                        {
+                            "file": str(module),
+                            "function": "root_traced",
+                            "line": 1,
+                            "count": 1,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+        )
+        names = {item.get("name") for item in result.get("unused_functions", [])}
+
+        assert "root_traced" in names
+        assert "unused" in names
+
     @patch("skylos.analyzer.Path")
     def test_get_python_files_single_file(self, mock_path, skylos):
         mock_file = Mock()

--- a/test/test_result_cache.py
+++ b/test/test_result_cache.py
@@ -1,0 +1,114 @@
+from skylos.core.result_cache import (
+    TRACE_CACHE_DIR,
+    build_trace_cache_key,
+    load_trace_cache,
+    save_trace_cache,
+)
+
+
+def test_trace_cache_key_is_stable_for_same_inputs(tmp_path):
+    (tmp_path / "app.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    key1 = build_trace_cache_key(tmp_path, [tmp_path])
+    key2 = build_trace_cache_key(tmp_path, [tmp_path])
+
+    assert key1 == key2
+
+
+def test_trace_cache_key_changes_for_relevant_content(tmp_path):
+    app = tmp_path / "app.py"
+    pyproject = tmp_path / "pyproject.toml"
+    lockfile = tmp_path / "uv.lock"
+    app.write_text("def f():\n    return 1\n", encoding="utf-8")
+    pyproject.write_text("[tool.pytest.ini_options]\n", encoding="utf-8")
+    lockfile.write_text("version = 1\n", encoding="utf-8")
+
+    source_key = build_trace_cache_key(tmp_path, [tmp_path])
+    app.write_text("def f():\n    return 2\n", encoding="utf-8")
+    assert build_trace_cache_key(tmp_path, [tmp_path]) != source_key
+
+    config_key = build_trace_cache_key(tmp_path, [tmp_path])
+    pyproject.write_text(
+        "[tool.pytest.ini_options]\naddopts = '-q'\n",
+        encoding="utf-8",
+    )
+    assert build_trace_cache_key(tmp_path, [tmp_path]) != config_key
+
+    lock_key = build_trace_cache_key(tmp_path, [tmp_path])
+    lockfile.write_text("version = 2\n", encoding="utf-8")
+    assert build_trace_cache_key(tmp_path, [tmp_path]) != lock_key
+
+
+def test_corrupt_trace_cache_entry_is_a_miss(tmp_path):
+    (tmp_path / "app.py").write_text("def f(): pass\n", encoding="utf-8")
+    key = build_trace_cache_key(tmp_path, [tmp_path])
+    cache_path = tmp_path / TRACE_CACHE_DIR / f"{key}.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("{not-json", encoding="utf-8")
+
+    assert load_trace_cache(tmp_path, key) is None
+
+
+def test_trace_cache_save_and_load_round_trips_payload(tmp_path):
+    (tmp_path / "app.py").write_text("def f(): pass\n", encoding="utf-8")
+    key, fingerprint = build_trace_cache_key(
+        tmp_path,
+        [tmp_path],
+        return_fingerprint=True,
+    )
+    payload = {
+        "version": 1,
+        "calls": [
+            {
+                "file": str(tmp_path / "app.py"),
+                "function": "f",
+                "line": 1,
+                "count": 1,
+            }
+        ],
+    }
+
+    path = save_trace_cache(
+        tmp_path,
+        key,
+        payload,
+        pytest_returncode=0,
+        fingerprint_summary=fingerprint,
+    )
+    entry = load_trace_cache(tmp_path, key)
+
+    assert path is not None
+    assert entry is not None
+    assert entry["trace"] == payload
+    assert entry["pytest_returncode"] == 0
+
+
+def test_trace_cache_excludes_generated_directories(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    ignored = tmp_path / ".venv"
+    ignored.mkdir()
+    (ignored / "ignored.py").write_text("def ignored(): pass\n", encoding="utf-8")
+
+    key = build_trace_cache_key(tmp_path, [tmp_path])
+    (ignored / "ignored.py").write_text(
+        "def ignored():\n    return 42\n",
+        encoding="utf-8",
+    )
+
+    assert build_trace_cache_key(tmp_path, [tmp_path]) == key
+
+
+def test_trace_cache_does_not_save_failed_trace_runs(tmp_path):
+    payload = {"version": 1, "calls": []}
+    path = save_trace_cache(
+        tmp_path,
+        "abc",
+        payload,
+        pytest_returncode=1,
+        fingerprint_summary={},
+    )
+
+    assert path is None
+    assert not (tmp_path / TRACE_CACHE_DIR / "abc.json").exists()

--- a/test/test_trace_cache_cli.py
+++ b/test/test_trace_cache_cli.py
@@ -1,0 +1,250 @@
+import json
+import io
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from rich.console import Console
+
+import skylos.cli as cli
+from skylos.core.result_cache import (
+    TRACE_CACHE_DIR,
+    build_trace_cache_key,
+    save_trace_cache,
+)
+from skylos.commands.cache_cmd import run_cache_command
+
+
+def _args(root, **overrides):
+    data = {
+        "path": [str(root)],
+        "coverage": False,
+        "trace": True,
+        "pytest_fixtures": False,
+        "cache": True,
+        "refresh_cache": False,
+        "no_cache": False,
+        "json": True,
+        "llm": False,
+        "github": False,
+        "concise": False,
+        "verbose": False,
+        "diff_base": None,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _console():
+    return Console(file=io.StringIO())
+
+
+def _write_minimal_project(root):
+    (root / "app.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+
+def _trace_payload(root):
+    return {
+        "version": 1,
+        "calls": [
+            {
+                "file": str(root / "app.py"),
+                "function": "f",
+                "line": 1,
+                "count": 1,
+            }
+        ],
+    }
+
+
+def test_trace_cache_miss_runs_trace_subprocess(tmp_path):
+    _write_minimal_project(tmp_path)
+
+    def fake_run(*_args, **_kwargs):
+        (tmp_path / ".skylos_trace").write_text(
+            json.dumps(_trace_payload(tmp_path)),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with (
+        patch("skylos.core.result_cache._git_visible_files", return_value=None),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run) as mock_run,
+    ):
+        result = cli._run_pre_analysis_steps(_args(tmp_path), tmp_path, _console())
+
+    assert mock_run.called
+    assert result.trace_file == tmp_path / ".skylos_trace"
+
+
+def test_trace_cache_hit_skips_trace_subprocess_and_writes_trace(tmp_path):
+    _write_minimal_project(tmp_path)
+    key, fingerprint = build_trace_cache_key(
+        tmp_path,
+        [tmp_path],
+        return_fingerprint=True,
+    )
+    payload = _trace_payload(tmp_path)
+    save_trace_cache(
+        tmp_path,
+        key,
+        payload,
+        pytest_returncode=0,
+        fingerprint_summary=fingerprint,
+    )
+
+    with (
+        patch("skylos.core.result_cache._git_visible_files", return_value=None),
+        patch("skylos.cli.subprocess.run") as mock_run,
+    ):
+        result = cli._run_pre_analysis_steps(_args(tmp_path), tmp_path, _console())
+
+    assert not mock_run.called
+    assert result.trace_file == tmp_path / ".skylos_trace"
+    assert (
+        json.loads((tmp_path / ".skylos_trace").read_text(encoding="utf-8"))
+        == payload
+    )
+
+
+def test_refresh_cache_runs_subprocess_despite_hit(tmp_path):
+    _write_minimal_project(tmp_path)
+    key, fingerprint = build_trace_cache_key(
+        tmp_path,
+        [tmp_path],
+        return_fingerprint=True,
+    )
+    save_trace_cache(
+        tmp_path,
+        key,
+        _trace_payload(tmp_path),
+        pytest_returncode=0,
+        fingerprint_summary=fingerprint,
+    )
+
+    def fake_run(*_args, **_kwargs):
+        (tmp_path / ".skylos_trace").write_text(
+            json.dumps(_trace_payload(tmp_path)),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with (
+        patch("skylos.core.result_cache._git_visible_files", return_value=None),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run) as mock_run,
+    ):
+        cli._run_pre_analysis_steps(
+            _args(tmp_path, refresh_cache=True),
+            tmp_path,
+            _console(),
+        )
+
+    assert mock_run.called
+
+
+def test_no_cache_disables_trace_cache_even_with_cache_flag(tmp_path):
+    _write_minimal_project(tmp_path)
+    key, fingerprint = build_trace_cache_key(
+        tmp_path,
+        [tmp_path],
+        return_fingerprint=True,
+    )
+    save_trace_cache(
+        tmp_path,
+        key,
+        _trace_payload(tmp_path),
+        pytest_returncode=0,
+        fingerprint_summary=fingerprint,
+    )
+
+    def fake_run(*_args, **_kwargs):
+        (tmp_path / ".skylos_trace").write_text(
+            json.dumps(_trace_payload(tmp_path)),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("skylos.cli.subprocess.run", side_effect=fake_run) as mock_run:
+        cli._run_pre_analysis_steps(
+            _args(tmp_path, no_cache=True),
+            tmp_path,
+            _console(),
+        )
+
+    assert mock_run.called
+
+
+def test_trace_cache_bypassed_with_pytest_fixtures(tmp_path):
+    _write_minimal_project(tmp_path)
+
+    def fake_run(*_args, **_kwargs):
+        (tmp_path / ".skylos_trace").write_text(
+            json.dumps(_trace_payload(tmp_path)),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("skylos.cli.subprocess.run", side_effect=fake_run) as mock_run:
+        cli._run_pre_analysis_steps(
+            _args(tmp_path, pytest_fixtures=True),
+            tmp_path,
+            _console(),
+        )
+
+    assert mock_run.called
+    assert not (tmp_path / TRACE_CACHE_DIR).exists()
+
+
+def test_trace_failure_without_payload_disables_stale_trace_for_analysis(
+    tmp_path,
+    monkeypatch,
+):
+    _write_minimal_project(tmp_path)
+    stale_trace = tmp_path / ".skylos_trace"
+    stale_trace.write_text(json.dumps(_trace_payload(tmp_path)), encoding="utf-8")
+    observed = {}
+
+    def fake_analyze(*_args, **kwargs):
+        observed["trace_file"] = kwargs.get("trace_file")
+        return json.dumps(
+            {
+                "unused_functions": [],
+                "unused_imports": [],
+                "unused_classes": [],
+                "unused_variables": [],
+                "unused_parameters": [],
+                "analysis_summary": {"total_files": 1},
+            }
+        )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", str(tmp_path), "--trace", "--json", "--no-provenance"],
+    )
+
+    with (
+        patch(
+            "skylos.cli.subprocess.run",
+            return_value=SimpleNamespace(returncode=1, stderr="boom"),
+        ),
+        patch("skylos.cli.run_analyze", side_effect=fake_analyze),
+    ):
+        cli.main()
+
+    assert observed["trace_file"] is False
+    assert not stale_trace.exists()
+
+
+def test_cache_clear_command_removes_run_cache(tmp_path):
+    run_cache = tmp_path / ".skylos" / "cache" / "runs" / "v1"
+    run_cache.mkdir(parents=True)
+    (run_cache / "entry.json").write_text("{}", encoding="utf-8")
+
+    code = run_cache_command(
+        ["clear", str(tmp_path)],
+        console_factory=lambda: _console(),
+    )
+
+    assert code == 0
+    assert not (tmp_path / ".skylos" / "cache" / "runs").exists()

--- a/test/test_trace_file_analyzer.py
+++ b/test/test_trace_file_analyzer.py
@@ -1,0 +1,87 @@
+import json
+
+from skylos.analyzer import analyze
+
+
+def _write_project(root):
+    module = root / "app.py"
+    module.write_text(
+        "\n".join(
+            [
+                "def root_traced():",
+                "    return 1",
+                "",
+                "def alt_traced():",
+                "    return 2",
+                "",
+                "def truly_unused():",
+                "    return 3",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return module
+
+
+def _write_trace(path, module, function, line):
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "calls": [
+                    {
+                        "file": str(module),
+                        "function": function,
+                        "line": line,
+                        "count": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _unused_function_names(result):
+    return {item.get("name") for item in result.get("unused_functions", [])}
+
+
+def test_analyzer_trace_file_loads_only_explicit_path(tmp_path):
+    module = _write_project(tmp_path)
+    _write_trace(tmp_path / ".skylos_trace", module, "root_traced", 1)
+    alt_trace = tmp_path / "alt_trace.json"
+    _write_trace(alt_trace, module, "alt_traced", 4)
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=alt_trace)
+    )
+    names = _unused_function_names(result)
+
+    assert "alt_traced" not in names
+    assert "root_traced" in names
+    assert "truly_unused" in names
+
+
+def test_analyzer_trace_file_false_ignores_project_root_trace(tmp_path):
+    module = _write_project(tmp_path)
+    _write_trace(tmp_path / ".skylos_trace", module, "root_traced", 1)
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+    )
+    names = _unused_function_names(result)
+
+    assert "root_traced" in names
+    assert "alt_traced" in names
+
+
+def test_analyzer_default_trace_file_preserves_legacy_root_trace(tmp_path):
+    module = _write_project(tmp_path)
+    _write_trace(tmp_path / ".skylos_trace", module, "root_traced", 1)
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    names = _unused_function_names(result)
+
+    assert "root_traced" not in names
+    assert "alt_traced" in names


### PR DESCRIPTION
## Summary
  - Opt-in trace phase cache for `skylos --trace --cache`.
  - Reuse pytest call trace payloads when source/test/config inputs are unchanged.
  - Add `--refresh-cache`, `--no-cache`, and `skylos cache clear [path]`.
  - Prevents stale `.skylos_trace` reuse after failed explicit trace runs.

  ## Testing
  - `pytest test/test_cli_coverage.py test/test_trace_cache_cli.py test/test_result_cache.py test/test_trace_file_analyzer.py`
  - `pytest test/test_tracer.py test/test_cli_uncovered_paths.py test/test_grep_cache.py`
  - `pytest test/test_analyzer.py -k trace`
  - `pytest test/test_cli.py test/test_cli_uncovered_paths.py test/test_cli_refactor_guardrails.py`

  ## Measurement
  - Uncached trace reruns: `1.492s`, `1.830s`
  - Cached cold run: `1.617s`
  - Cached warm run: `0.958s`
  - Normal scan benchmark: median `0.935s`, passed `8.0s` budget