### PR TITLE
fix(cli): write rich output reports to file

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import pathlib
 import skylos
 from collections import defaultdict
+from io import StringIO
 import subprocess
 import textwrap
 
@@ -638,8 +639,8 @@ class CleanFormatter(logging.Formatter):
         return record.getMessage()
 
 
-def setup_logger(output_file=None):
-    theme = Theme(
+def _skylos_console_theme():
+    return Theme(
         {
             "good": "bold green",
             "warn": "bold yellow",
@@ -648,7 +649,10 @@ def setup_logger(output_file=None):
             "brand": "bold cyan",
         }
     )
-    console = Console(theme=theme)
+
+
+def setup_logger(output_file=None):
+    console = Console(theme=_skylos_console_theme())
 
     logger = logging.getLogger("skylos")
     logger.setLevel(logging.INFO)
@@ -1591,7 +1595,7 @@ def _score_style(score):
     return "bad"
 
 
-def _render_grade(console: Console, grade_data):
+def _render_grade(console: Console, grade_data, *, copy_badge: bool = True):
     from skylos.reporting.grader import generate_badge_url
 
     overall = grade_data["overall"]
@@ -1645,17 +1649,18 @@ def _render_grade(console: Console, grade_data):
         )
     )
 
-    try:
-        import pyperclip
+    if copy_badge:
+        try:
+            import pyperclip
 
-        pyperclip.copy(badge_markdown)
-        console.print("[good]Copied to clipboard![/good]")
-    except ImportError:
-        console.print(
-            "[muted]Install pyperclip for auto-copy: pip install pyperclip[/muted]"
-        )
-    except (pyperclip.PyperclipException, OSError) as exc:
-        logger.debug("Failed to copy badge markdown to clipboard: %s", exc)
+            pyperclip.copy(badge_markdown)
+            console.print("[good]Copied to clipboard![/good]")
+        except ImportError:
+            console.print(
+                "[muted]Install pyperclip for auto-copy: pip install pyperclip[/muted]"
+            )
+        except (pyperclip.PyperclipException, OSError) as exc:
+            logger.debug("Failed to copy badge markdown to clipboard: %s", exc)
 
     console.print()
 
@@ -2187,7 +2192,15 @@ def _render_sca(console: Console, limit, items):
     )
 
 
-def render_results(console: Console, result, tree=False, root_path=None, limit=None):
+def render_results(
+    console: Console,
+    result,
+    tree=False,
+    root_path=None,
+    limit=None,
+    *,
+    copy_badge: bool = True,
+):
     summ = result.get("analysis_summary", {})
     console.print(
         Panel.fit(
@@ -2229,7 +2242,7 @@ def render_results(console: Console, result, tree=False, root_path=None, limit=N
 
     grade_data = result.get("grade")
     if grade_data:
-        _render_grade(console, grade_data)
+        _render_grade(console, grade_data, copy_badge=copy_badge)
 
     if tree:
         _render_result_tree(console, result, root_path=root_path)
@@ -2292,6 +2305,31 @@ def render_results(console: Console, result, tree=False, root_path=None, limit=N
             console, root_path, limit, result.get("custom_rules", []) or []
         )
         _render_sca(console, limit, result.get("dependency_vulnerabilities", []) or [])
+
+
+def _write_rich_report_output(
+    output_file: str,
+    result: dict,
+    *,
+    tree: bool = False,
+    root_path=None,
+    limit=None,
+):
+    buffer = StringIO()
+    file_console = Console(
+        theme=_skylos_console_theme(),
+        file=buffer,
+        force_terminal=False,
+    )
+    render_results(
+        file_console,
+        result,
+        tree=tree,
+        root_path=root_path,
+        limit=limit,
+        copy_badge=False,
+    )
+    pathlib.Path(output_file).write_text(buffer.getvalue(), encoding="utf-8")
 
 
 def run_init():
@@ -3048,7 +3086,7 @@ def _build_main_scan_context(args):
         args.sca = True
 
     project_root = _resolve_main_project_root(args.path)
-    logger = setup_logger(args.output)
+    logger = setup_logger()
     console = logger.console
 
     if args.verbose:
@@ -6234,6 +6272,14 @@ def main() -> None:
             root_path=project_root,
             limit=_cli_limit,
         )
+        if args.output:
+            _write_rich_report_output(
+                args.output,
+                display_result,
+                tree=args.tree,
+                root_path=project_root,
+                limit=_cli_limit,
+            )
 
     unused_total = sum(
         len(result.get(k, []))

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1102,6 +1102,46 @@ def test_main_concise_clean_output_prints_nothing(monkeypatch):
     progress.assert_not_called()
 
 
+def test_main_rich_output_writes_report_file(monkeypatch, tmp_path):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [{"name": "dead", "file": "app.py", "line": 1}],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+    output_path = tmp_path / "skylos.txt"
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            ".",
+            "--output",
+            str(output_path),
+            "--no-provenance",
+            "--no-upload",
+        ],
+    )
+
+    with (
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+    ):
+        cli.main()
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "Python Static Analysis Results" in output
+    assert "Unused Functions" in output
+    assert "dead" in output
+
+
 def test_main_json_strict_failure_exits_nonzero(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},


### PR DESCRIPTION
Fixes #358

## Summary

  - Make main `--output` write the default rich scan report instead of only attaching a log file handler.
  - Render file output through Rich console so `skylos --output skylos.txt` produces the same report content seen in terminal
  - Avoid clipboard side effects when rendering the secondary file copy of the grade badge.

  ## Tests

  - `pytest test/test_cli.py`
