### PR TITLE
feat(cli): show grep verification summary

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -908,13 +908,13 @@ class Skylos:
                 candidate_defs[d.get("full_name", d.get("name", ""))] = defn
 
         if not candidates:
-            return
+            return 0
 
         candidates.sort(key=_grep_verify_rescue_priority)
 
         project_root = str(getattr(self, "_project_root", ""))
         if not project_root:
-            return
+            return 0
 
         grep_root = find_git_root(project_root) or Path(project_root)
         grep_cache = GrepCache()
@@ -944,6 +944,7 @@ class Skylos:
 
         if rescued:
             logger.info(f"Grep verify: rescued {rescued} findings from dead code")
+        return rescued
 
     def _apply_dead_code_liveness(self, files):
         try:
@@ -1609,6 +1610,10 @@ class Skylos:
         liveness_report = getattr(self, "_dead_code_liveness_report", None)
         if liveness_report is not None:
             result["analysis_summary"]["dead_code_liveness"] = liveness_report.to_dict()
+
+        grep_verify_report = getattr(self, "_grep_verify_report", None)
+        if grep_verify_report is not None:
+            result["analysis_summary"]["grep_verify"] = dict(grep_verify_report)
 
         if workspace_inventory is not None:
             project_root = (
@@ -2714,10 +2719,12 @@ class Skylos:
         self._propagate_transitive_dead()
         self._suppress_standalone_orm_models()
 
+        grep_verify_report = {"enabled": bool(grep_verify), "rescued_count": 0}
         if grep_verify:
             if progress_callback:
                 progress_callback(0, 1, Path("PHASE: grep verify"))
-            self._grep_verify()
+            grep_verify_report["rescued_count"] = self._grep_verify()
+        self._grep_verify_report = grep_verify_report
 
         dead_ts_files = self._find_dead_ts_files(
             files, exclude_folders, workspace_inventory=workspace_inventory

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1580,6 +1580,16 @@ def _results_pill(label, n, ok_style="good", bad_style="bad"):
     return f"[{style}]{label}: {n}[/{style}]"
 
 
+def _grep_verify_pill(summary):
+    grep_verify = summary.get("grep_verify")
+    if not isinstance(grep_verify, dict):
+        return None
+    if not grep_verify.get("enabled"):
+        return "[muted]Grep verify: off[/muted]"
+    rescued_count = int(grep_verify.get("rescued_count") or 0)
+    return f"[brand]Grep verify: on[/brand] [muted](rescued {rescued_count})[/muted]"
+
+
 def _display_cap(items, limit):
     cap = limit or len(items)
     return items[:cap], max(0, len(items) - cap)
@@ -2211,7 +2221,8 @@ def render_results(
 
     console.print(
         " ".join(
-            [
+            part
+            for part in [
                 _results_pill(
                     "Unused functions", len(result.get("unused_functions", []))
                 ),
@@ -2235,7 +2246,9 @@ def render_results(
                     ok_style="muted",
                     bad_style="muted",
                 ),
+                _grep_verify_pill(summ),
             ]
+            if part
         )
     )
     console.print()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -681,6 +681,32 @@ def test_render_results_unused_table_includes_confidence_column_and_formats():
     assert conf_cells[2] == "[dim]50%[/dim]"
 
 
+def test_render_results_shows_grep_verify_summary():
+    console = Mock()
+    result = {
+        "analysis_summary": {
+            "total_files": 1,
+            "grep_verify": {"enabled": True, "rescued_count": 3},
+        },
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_parameters": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "quality": [],
+        "danger": [],
+        "secrets": [],
+    }
+
+    cli.render_results(console, result, tree=False, root_path="/root")
+
+    printed = "\n".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "Grep verify: on" in printed
+    assert "rescued 3" in printed
+
+
 def test_render_results_tree_mode_groups_by_file_and_sorts_by_line():
     console = Mock()
 

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -470,6 +470,14 @@ class TestAnalyzerIntegration:
         }
 
         assert len(unused_names_on) <= len(unused_names_off)
+        assert result_on["analysis_summary"]["grep_verify"]["enabled"] is True
+        assert isinstance(
+            result_on["analysis_summary"]["grep_verify"]["rescued_count"], int
+        )
+        assert result_off["analysis_summary"]["grep_verify"] == {
+            "enabled": False,
+            "rescued_count": 0,
+        }
 
     def test_grep_verify_keeps_same_name_wrapper_dead(self, tmp_path):
         (tmp_path / "app.py").write_text(


### PR DESCRIPTION
## Summary
  - Add grep verification metadata to analysis summaries
  - Show whether grep verification was enabled in CLI output
  - Display x number of dead code findings were found by grep

## Why
  Users could see dead code results but had no idea that grep verification had run or whether it reduced likely false positives. 

## Tests
  - `pytest test/test_grep_verify.py test/test_cli.py`