### PR TITLE
fix(cli): scope grades to scanned categories

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1800,8 +1800,23 @@ class Skylos:
             from skylos.reporting.grader import count_lines_of_code, compute_grade
 
             total_loc = count_lines_of_code(files)
+            grade_categories = []
+            if enable_danger:
+                grade_categories.append("security")
+            if enable_quality:
+                grade_categories.append("quality")
+            grade_categories.append("dead_code")
+            if enable_sca:
+                grade_categories.append("dependencies")
+            if enable_secrets:
+                grade_categories.append("secrets")
             result["analysis_summary"]["total_loc"] = total_loc
-            result["grade"] = compute_grade(result, total_loc)
+            result["analysis_summary"]["grade_categories"] = grade_categories
+            result["grade"] = compute_grade(
+                result,
+                total_loc,
+                included_categories=grade_categories,
+            )
         except Exception:
             if os.getenv("SKYLOS_DEBUG"):
                 traceback.print_exc()

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1627,7 +1627,18 @@ def _render_grade(console: Console, grade_data, *, copy_badge: bool = True):
     grade_table.add_column("Weight", style="muted", width=8)
     grade_table.add_column("Key Issue", overflow="fold")
 
-    for cat_name in ("security", "quality", "dead_code", "dependencies", "secrets"):
+    default_category_order = (
+        "security",
+        "quality",
+        "dead_code",
+        "dependencies",
+        "secrets",
+    )
+    category_order = grade_data.get("scanned_categories") or default_category_order
+
+    for cat_name in category_order:
+        if cat_name not in cats:
+            continue
         cat = cats[cat_name]
         display_name = cat_name.replace("_", " ").title()
         s_val = cat["score"]

--- a/skylos/reporting/grader.py
+++ b/skylos/reporting/grader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from html import escape
+from collections.abc import Iterable
 from pathlib import Path
 from urllib.parse import quote
 
@@ -28,6 +29,7 @@ CATEGORY_WEIGHTS: dict[str, float] = {
     "dependencies": 0.10,
     "secrets": 0.10,
 }
+CATEGORY_ORDER: tuple[str, ...] = tuple(CATEGORY_WEIGHTS)
 
 SEVERITY_CAPS: dict[str, int] = {
     "CRITICAL": 55,
@@ -206,7 +208,35 @@ def score_secrets(findings: list[dict]) -> tuple[int, str]:
     return score, key_issue
 
 
-def compute_grade(result: dict, total_loc: int) -> dict:
+def _included_categories(categories: Iterable[str] | None) -> list[str]:
+    if categories is None:
+        return list(CATEGORY_ORDER)
+
+    included: list[str] = []
+    for category in categories:
+        if category in CATEGORY_WEIGHTS and category not in included:
+            included.append(category)
+
+    return included or list(CATEGORY_ORDER)
+
+
+def _renormalized_weights(categories: list[str]) -> dict[str, float]:
+    total = sum(CATEGORY_WEIGHTS[category] for category in categories)
+    if total <= 0:
+        even_weight = 1.0 / len(categories)
+        return {category: even_weight for category in categories}
+    return {category: CATEGORY_WEIGHTS[category] / total for category in categories}
+
+
+def compute_grade(
+    result: dict,
+    total_loc: int,
+    *,
+    included_categories: Iterable[str] | None = None,
+) -> dict:
+    active_categories = _included_categories(included_categories)
+    active_weights = _renormalized_weights(active_categories)
+
     sec_score, sec_issue = score_security(result.get("danger") or [])
     qual_score, qual_issue = score_quality(result.get("quality") or [], total_loc)
     dc_score, dc_issue = score_dead_code(result, total_loc)
@@ -215,15 +245,22 @@ def compute_grade(result: dict, total_loc: int) -> dict:
     )
     secrets_score, secrets_issue = score_secrets(result.get("secrets") or [])
 
+    category_scores = {
+        "security": (sec_score, sec_issue),
+        "quality": (qual_score, qual_issue),
+        "dead_code": (dc_score, dc_issue),
+        "dependencies": (dep_score, dep_issue),
+        "secrets": (secrets_score, secrets_issue),
+    }
+
     overall_numeric = round(
-        sec_score * CATEGORY_WEIGHTS["security"]
-        + qual_score * CATEGORY_WEIGHTS["quality"]
-        + dc_score * CATEGORY_WEIGHTS["dead_code"]
-        + dep_score * CATEGORY_WEIGHTS["dependencies"]
-        + secrets_score * CATEGORY_WEIGHTS["secrets"]
+        sum(
+            category_scores[category][0] * active_weights[category]
+            for category in active_categories
+        )
     )
 
-    has_critical_security = any(
+    has_critical_security = "security" in active_categories and any(
         (f.get("severity") or "").upper() == "CRITICAL"
         for f in (result.get("danger") or [])
     )
@@ -233,17 +270,13 @@ def compute_grade(result: dict, total_loc: int) -> dict:
     overall_numeric = max(0, min(100, overall_numeric))
 
     categories = {}
-    for cat_name, score_val, issue in [
-        ("security", sec_score, sec_issue),
-        ("quality", qual_score, qual_issue),
-        ("dead_code", dc_score, dc_issue),
-        ("dependencies", dep_score, dep_issue),
-        ("secrets", secrets_score, secrets_issue),
-    ]:
+    for cat_name in active_categories:
+        score_val, issue = category_scores[cat_name]
         categories[cat_name] = {
             "score": score_val,
             "letter": score_to_letter(score_val),
-            "weight": CATEGORY_WEIGHTS[cat_name],
+            "weight": active_weights[cat_name],
+            "base_weight": CATEGORY_WEIGHTS[cat_name],
             "key_issue": issue,
         }
 
@@ -253,6 +286,7 @@ def compute_grade(result: dict, total_loc: int) -> dict:
             "letter": score_to_letter(overall_numeric),
         },
         "categories": categories,
+        "scanned_categories": active_categories,
         "total_loc": total_loc,
     }
 

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from rich.console import Console
 
 import skylos.cli as cli
 from skylos.debt.result import DebtHotspot, DebtScore, DebtSnapshot
@@ -55,6 +56,31 @@ def _progress_ctx():
     cm.__enter__ = Mock(return_value=Mock(add_task=Mock(return_value="t")))
     cm.__exit__ = Mock(return_value=False)
     return cm
+
+
+def test_cli_grade_render_only_shows_scanned_categories():
+    console = Console(record=True, width=120, theme=cli._skylos_console_theme())
+    grade_data = {
+        "overall": {"score": 85, "letter": "B"},
+        "scanned_categories": ["dead_code"],
+        "categories": {
+            "dead_code": {
+                "score": 85,
+                "letter": "B",
+                "weight": 1.0,
+                "key_issue": "10 dead symbols (5.0/1K LOC)",
+            }
+        },
+        "total_loc": 2000,
+    }
+
+    cli._render_grade(console, grade_data, copy_badge=False)
+
+    rendered = console.export_text()
+    assert "Dead Code" in rendered
+    assert "100%" in rendered
+    assert "Security" not in rendered
+    assert "Quality" not in rendered
 
 
 def test_cli_guardrail_overview_dispatch_exits_zero(monkeypatch):

--- a/test/test_grader.py
+++ b/test/test_grader.py
@@ -281,6 +281,33 @@ class TestComputeGrade:
         assert grade["categories"]["quality"]["score"] < 100
         assert grade["categories"]["dead_code"]["score"] < 100
 
+    def test_dead_code_only_grade_uses_only_dead_code_category(self):
+        result = _empty_result(unused_functions=[{"name": f"f{i}"} for i in range(10)])
+        grade = compute_grade(result, 2000, included_categories=["dead_code"])
+
+        assert grade["overall"]["score"] == 85
+        assert grade["overall"]["letter"] == "B"
+        assert grade["scanned_categories"] == ["dead_code"]
+        assert list(grade["categories"]) == ["dead_code"]
+        assert grade["categories"]["dead_code"]["weight"] == 1.0
+
+    def test_selected_grade_categories_renormalize_weights(self):
+        result = _empty_result(
+            danger=[{"severity": "HIGH", "message": "XSS"}],
+            unused_functions=[{"name": f"f{i}"} for i in range(10)],
+        )
+        grade = compute_grade(
+            result,
+            2000,
+            included_categories=["security", "dead_code"],
+        )
+
+        assert grade["scanned_categories"] == ["security", "dead_code"]
+        assert set(grade["categories"]) == {"security", "dead_code"}
+        assert round(sum(cat["weight"] for cat in grade["categories"].values()), 5) == 1
+        assert "quality" not in grade["categories"]
+        assert grade["overall"]["score"] == 76
+
 
 class TestCountLinesOfCode:
     def test_python_file(self, tmp_path):


### PR DESCRIPTION
## Summary
  - Scope codebase grade calculations to the categories that were actually scanned
  - Renormalize category weights across the active scan categories

## Why
  When users scanned only dead code, the CLI still displayed all the other categories. This skewed the results creating an "illusion" of better results

## Tests

  - `pytest test/test_grader.py test/test_cli_refactor_guardrails.py`