### PR TITLE
feat(debt): explain score breakdown

### DIFF
--- a/skylos/commands/debt_cmd.py
+++ b/skylos/commands/debt_cmd.py
@@ -2,6 +2,70 @@ import argparse
 from pathlib import Path
 
 
+def _resolve_gate_settings(debt_args, policy) -> tuple[int | None, str | None]:
+    min_score = debt_args.min_score
+    if policy and policy.gate_min_score is not None and min_score is None:
+        min_score = policy.gate_min_score
+
+    fail_on_status = debt_args.fail_on_status
+    if policy and policy.gate_fail_on_status and not fail_on_status:
+        fail_on_status = policy.gate_fail_on_status
+
+    return min_score, fail_on_status
+
+
+def _baseline_status_counts(snapshot) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for hotspot in snapshot.hotspots:
+        status = hotspot.baseline_status
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def _gate_failures(snapshot, *, min_score, fail_on_status) -> list[str]:
+    failures: list[str] = []
+    if min_score is not None and snapshot.score.score_pct < min_score:
+        failures.append(
+            f"score {snapshot.score.score_pct}% is below min_score {min_score}%"
+        )
+
+    if fail_on_status:
+        counts = _baseline_status_counts(snapshot)
+        if fail_on_status == "new_or_worsened":
+            count = counts.get("new", 0) + counts.get("worsened", 0)
+            if count:
+                failures.append(
+                    f"{count} hotspot(s) are new or worsened versus baseline"
+                )
+        else:
+            count = counts.get(fail_on_status, 0)
+            if count:
+                failures.append(
+                    f"{count} hotspot(s) have baseline status {fail_on_status}"
+                )
+
+    return failures
+
+
+def _record_gate_summary(snapshot, *, min_score, fail_on_status) -> list[str]:
+    if min_score is None and not fail_on_status:
+        return []
+
+    failures = _gate_failures(
+        snapshot,
+        min_score=min_score,
+        fail_on_status=fail_on_status,
+    )
+    snapshot.summary["gate"] = {
+        "passed": not failures,
+        "min_score": min_score,
+        "fail_on_status": fail_on_status,
+        "failures": failures,
+        "status_counts": _baseline_status_counts(snapshot),
+    }
+    return failures
+
+
 def run_debt_command(
     argv: list[str],
     *,
@@ -301,6 +365,13 @@ def run_debt_command(
         history_path = append_debt_history(snapshot.project, snapshot)
         console.print(f"[dim]Debt history appended to {history_path}[/dim]")
 
+    min_score, fail_on_status = _resolve_gate_settings(debt_args, policy)
+    gate_failures = _record_gate_summary(
+        snapshot,
+        min_score=min_score,
+        fail_on_status=fail_on_status,
+    )
+
     if debt_args.output_json:
         output = format_debt_json(snapshot)
     else:
@@ -344,22 +415,4 @@ def run_debt_command(
                     f"[red]Upload failed: {upload_result.get('error', 'Unknown')}[/red]"
                 )
 
-    exit_code = 1 if upload_failed else 0
-    min_score = debt_args.min_score
-    if policy and policy.gate_min_score is not None and min_score is None:
-        min_score = policy.gate_min_score
-    if min_score is not None and snapshot.score.score_pct < min_score:
-        exit_code = 1
-
-    fail_on_status = debt_args.fail_on_status
-    if policy and policy.gate_fail_on_status and not fail_on_status:
-        fail_on_status = policy.gate_fail_on_status
-    if fail_on_status:
-        statuses = {hotspot.baseline_status for hotspot in snapshot.hotspots}
-        if fail_on_status == "new_or_worsened":
-            if {"new", "worsened"} & statuses:
-                exit_code = 1
-        elif fail_on_status in statuses:
-            exit_code = 1
-
-    return exit_code
+    return 1 if upload_failed or gate_failures else 0

--- a/skylos/debt/engine.py
+++ b/skylos/debt/engine.py
@@ -6,7 +6,12 @@ from pathlib import Path
 from typing import Any
 
 from skylos.debt.result import DebtSignal, DebtSnapshot
-from skylos.debt.scoring import build_hotspots, compute_debt_score
+from skylos.debt.scoring import (
+    build_hotspots,
+    build_score_breakdown,
+    compute_debt_score,
+    score_model_metadata,
+)
 from skylos.core.file_discovery import find_git_root
 
 DEBT_VERSION = "1.0"
@@ -246,6 +251,12 @@ def build_debt_snapshot(
         },
         "project_hotspot_count": len(all_hotspots),
         "visible_hotspot_count": len(hotspots),
+        "score_breakdown": build_score_breakdown(
+            all_hotspots,
+            score=score,
+            total_loc=total_loc,
+        ),
+        "score_model": score_model_metadata(),
     }
 
     return DebtSnapshot(

--- a/skylos/debt/report.py
+++ b/skylos/debt/report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from skylos.debt.result import DebtSnapshot
+from skylos.debt.scoring import DIMENSION_WEIGHTS, SEVERITY_WEIGHTS
 
 
 def _ordered_hotspots(snapshot: DebtSnapshot, top: int | None) -> list:
@@ -68,11 +69,151 @@ def _hotspot_status(hotspot) -> str:
     return status
 
 
+def _score_breakdown_lines(snapshot: DebtSnapshot) -> list[str]:
+    breakdown = (snapshot.summary or {}).get("score_breakdown") or {}
+    dimensions = breakdown.get("dimensions") or []
+    if not dimensions:
+        return []
+
+    lines = ["", "Score Breakdown:"]
+    for item in dimensions[:5]:
+        dimension = item.get("dimension") or "unknown"
+        points = float(item.get("points") or 0.0)
+        share_pct = float(item.get("share_pct") or 0.0)
+        signal_count = int(item.get("signal_count") or 0)
+        weight = float(item.get("weight") or DIMENSION_WEIGHTS.get(dimension, 1.0))
+        lines.append(
+            f"  {dimension}: {points:.2f} pts ({share_pct:.1f}%) from "
+            f"{signal_count} signal(s), weight={weight:.2f}"
+        )
+
+    top_rules = breakdown.get("top_rules") or []
+    if top_rules:
+        rendered_rules = ", ".join(
+            f"{rule.get('rule_id')} {float(rule.get('points') or 0.0):.2f} pts"
+            for rule in top_rules[:5]
+        )
+        lines.append(f"  Top rules: {rendered_rules}")
+    return lines
+
+
+def _score_model_lines(snapshot: DebtSnapshot) -> list[str]:
+    model = (snapshot.summary or {}).get("score_model") or {}
+    breakdown = (snapshot.summary or {}).get("score_breakdown") or {}
+    if not model and not breakdown:
+        return []
+
+    severity_bits = " ".join(
+        f"{severity}={weight}" for severity, weight in SEVERITY_WEIGHTS.items()
+    )
+    dimension_bits = " ".join(
+        f"{dimension}={weight:.2f}"
+        for dimension, weight in DIMENSION_WEIGHTS.items()
+    )
+    lines = ["", "How Score Is Calculated:"]
+    lines.append(
+        "  score_pct = clamp(round(100 - "
+        f"{snapshot.score.total_points:.2f}/{snapshot.score.normalizer:.2f}), 0, 100) "
+        f"= {snapshot.score.score_pct}%"
+    )
+    lines.append(
+        "  signal points = severity weight * dimension weight * magnitude; "
+        "metrics above threshold can scale up to 3.0x"
+    )
+    lines.append(
+        f"  weights: severity {severity_bits}; dimension {dimension_bits}"
+    )
+    lines.append(
+        "  hotspot score = signal points + 2 pts for each extra debt dimension "
+        "in the same file"
+    )
+    included_sources = model.get("included_sources") or []
+    if included_sources:
+        lines.append(f"  included sources: {', '.join(included_sources)}")
+    if breakdown.get("breadth_bonus_points"):
+        lines.append(
+            "  breadth bonus total: "
+            f"{float(breakdown.get('breadth_bonus_points') or 0.0):.2f} pts"
+        )
+    return lines
+
+
+def _gate_lines(summary: dict) -> list[str]:
+    gate = summary.get("gate") or {}
+    if not gate:
+        return []
+
+    status = "passed" if gate.get("passed", True) else "failed"
+    lines = ["", f"Gate: {status}"]
+    min_score = gate.get("min_score")
+    fail_on_status = gate.get("fail_on_status")
+    if min_score is not None:
+        lines.append(f"  min_score={min_score}")
+    if fail_on_status:
+        lines.append(f"  fail_on_status={fail_on_status}")
+    for failure in gate.get("failures") or []:
+        lines.append(f"  - {failure}")
+    return lines
+
+
+def _signal_location(signal) -> str:
+    if signal.file and signal.line:
+        return f"{signal.file}:{signal.line}"
+    if signal.file:
+        return signal.file
+    return "-"
+
+
+def _metric_detail(signal) -> str:
+    parts = []
+    if signal.metric_value is not None:
+        parts.append(f"metric={signal.metric_value}")
+    if signal.threshold is not None:
+        parts.append(f"threshold={signal.threshold}")
+    return " ".join(parts)
+
+
+def _signal_detail(signal) -> str:
+    detail = _metric_detail(signal)
+    if detail:
+        return f"{detail} points={signal.points:.2f}"
+    return f"points={signal.points:.2f}"
+
+
 def _signal_lines(hotspot) -> list[str]:
     return [
-        f"    - [{signal.rule_id}] {signal.message} (points={signal.points:.2f})"
+        (
+            f"    - {signal.rule_id} | {str(signal.severity).upper()} | "
+            f"{signal.dimension} | {_signal_location(signal)} | "
+            f"{signal.message} ({_signal_detail(signal)})"
+        )
         for signal in hotspot.signals[:3]
     ]
+
+
+def _strongest_severity(hotspot) -> str:
+    if not hotspot.signals:
+        return "LOW"
+    return max(
+        (str(signal.severity).upper() for signal in hotspot.signals),
+        key=lambda severity: SEVERITY_WEIGHTS.get(severity, 1),
+    )
+
+
+def _hotspot_explanation_line(hotspot) -> str:
+    breadth_bonus = max(0, int(hotspot.dimension_count) - 1) * 2
+    priority_bonus = round(
+        float(getattr(hotspot, "priority_score", hotspot.score))
+        - float(hotspot.score),
+        2,
+    )
+    return (
+        "    why: "
+        f"primary={hotspot.primary_dimension}, "
+        f"strongest={_strongest_severity(hotspot)}, "
+        f"breadth_bonus={breadth_bonus:.2f}, "
+        f"priority_bonus={priority_bonus:.2f}"
+    )
 
 
 def _advisory_lines(hotspot) -> list[str]:
@@ -94,6 +235,7 @@ def _hotspot_lines(index: int, hotspot) -> list[str]:
             f"{_hotspot_status(hotspot)}"
         )
     ]
+    lines.append(_hotspot_explanation_line(hotspot))
     lines.extend(_signal_lines(hotspot))
     lines.extend(_advisory_lines(hotspot))
     return lines
@@ -119,6 +261,9 @@ def format_debt_table(snapshot: DebtSnapshot, *, top: int | None = None) -> str:
     )
     if baseline:
         lines.append(_baseline_line(baseline))
+    lines.extend(_gate_lines(summary))
+    lines.extend(_score_breakdown_lines(snapshot))
+    lines.extend(_score_model_lines(snapshot))
 
     if not hotspots:
         lines.append("")

--- a/skylos/debt/scoring.py
+++ b/skylos/debt/scoring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import Any
 
 from skylos.debt.result import DebtHotspot, DebtScore, DebtSignal
 
@@ -192,3 +193,108 @@ def compute_debt_score(
         signal_count=signal_count,
         scope="project",
     )
+
+
+def _share_pct(points: float, total: float) -> float:
+    if total <= 0:
+        return 0.0
+    return round((points / total) * 100, 1)
+
+
+def _score_normalizer_description(total_loc: int) -> str:
+    if total_loc > 0:
+        return "total_loc / 250"
+    return "hotspot_count"
+
+
+def build_score_breakdown(
+    hotspots: list[DebtHotspot],
+    *,
+    score: DebtScore,
+    total_loc: int = 0,
+    top_rules: int = 10,
+) -> dict[str, Any]:
+    dimension_stats: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"signal_count": 0, "points": 0.0}
+    )
+    rule_stats: dict[tuple[str, str], dict[str, Any]] = defaultdict(
+        lambda: {"signal_count": 0, "points": 0.0}
+    )
+
+    for hotspot in hotspots:
+        for signal in hotspot.signals:
+            dimension = signal.dimension or "unknown"
+            rule_id = signal.rule_id or "UNKNOWN"
+            dimension_stats[dimension]["signal_count"] += 1
+            dimension_stats[dimension]["points"] += float(signal.points or 0.0)
+            rule_key = (dimension, rule_id)
+            rule_stats[rule_key]["dimension"] = dimension
+            rule_stats[rule_key]["rule_id"] = rule_id
+            rule_stats[rule_key]["signal_count"] += 1
+            rule_stats[rule_key]["points"] += float(signal.points or 0.0)
+
+    signal_points = round(
+        sum(
+            float(signal.points or 0.0)
+            for hotspot in hotspots
+            for signal in hotspot.signals
+        ),
+        2,
+    )
+    breadth_bonus_points = round(
+        sum(max(0, int(hotspot.dimension_count) - 1) * 2 for hotspot in hotspots),
+        2,
+    )
+
+    dimensions = [
+        {
+            "dimension": dimension,
+            "signal_count": int(stats["signal_count"]),
+            "points": round(float(stats["points"]), 2),
+            "share_pct": _share_pct(float(stats["points"]), signal_points),
+            "weight": DIMENSION_WEIGHTS.get(dimension, 1.0),
+        }
+        for dimension, stats in dimension_stats.items()
+    ]
+    dimensions.sort(key=lambda item: (-item["points"], item["dimension"]))
+
+    rules = [
+        {
+            "rule_id": str(stats["rule_id"]),
+            "dimension": str(stats["dimension"]),
+            "signal_count": int(stats["signal_count"]),
+            "points": round(float(stats["points"]), 2),
+            "share_pct": _share_pct(float(stats["points"]), signal_points),
+        }
+        for stats in rule_stats.values()
+    ]
+    rules.sort(key=lambda item: (-item["points"], item["rule_id"]))
+
+    return {
+        "signal_points": signal_points,
+        "breadth_bonus_points": breadth_bonus_points,
+        "dimensions": dimensions,
+        "top_rules": rules[:top_rules],
+        "formula": "score_pct = clamp(round(100 - total_points / normalizer), 0, 100)",
+        "total_points": score.total_points,
+        "normalizer": score.normalizer,
+        "normalizer_source": _score_normalizer_description(total_loc),
+    }
+
+
+def score_model_metadata() -> dict[str, Any]:
+    return {
+        "included_sources": ["quality", "dead_code"],
+        "signal_formula": "severity_weight * dimension_weight * magnitude",
+        "severity_weights": dict(SEVERITY_WEIGHTS),
+        "dimension_weights": dict(DIMENSION_WEIGHTS),
+        "magnitude": (
+            "1.0 by default; when metric_value exceeds threshold, "
+            "adds min((metric_value - threshold) / threshold, 2.0)"
+        ),
+        "magnitude_cap": 3.0,
+        "hotspot_formula": "sum(signal_points) + 2 points for each extra dimension in the file",
+        "priority_formula": (
+            "hotspot score plus changed-file, baseline-status, and strongest-severity bonuses"
+        ),
+    }

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -184,6 +184,14 @@ def test_run_debt_analysis_builds_snapshot():
     assert snapshot.total_loc == 500
     assert snapshot.score.hotspot_count == len(snapshot.hotspots)
     assert snapshot.summary["dimensions"]["complexity"] == 1
+    assert snapshot.summary["score_breakdown"]["dimensions"][0]["dimension"] == (
+        "complexity"
+    )
+    assert snapshot.summary["score_breakdown"]["top_rules"][0]["rule_id"] == "SKY-Q301"
+    assert snapshot.summary["score_model"]["included_sources"] == [
+        "quality",
+        "dead_code",
+    ]
 
 
 def test_run_debt_analysis_changed_mode_keeps_project_score_and_filters_hotspots():
@@ -212,6 +220,10 @@ def test_build_debt_snapshot_reuses_static_result():
     assert snapshot.total_loc == 500
     assert snapshot.score.hotspot_count == len(snapshot.hotspots)
     assert snapshot.summary["dimensions"]["complexity"] == 1
+    assert snapshot.summary["score_breakdown"]["signal_points"] == 41.15
+    assert snapshot.summary["score_model"]["signal_formula"] == (
+        "severity_weight * dimension_weight * magnitude"
+    )
 
 
 def test_build_hotspots_changed_files_raise_priority_not_structural_score():
@@ -537,6 +549,14 @@ def test_format_debt_table_renders_hotspot_advisory_and_delta():
         "1. app/services.py | score=14.00 | priority=16.50 | "
         "signals=1 | dimensions=complexity | worsened (+1.25)"
     ) in rendered
+    assert (
+        "why: primary=complexity, strongest=HIGH, breadth_bonus=0.00, "
+        "priority_bonus=2.50"
+    ) in rendered
+    assert (
+        "SKY-Q301 | HIGH | complexity | app/services.py:20 | "
+        "Cyclomatic complexity is 18 (threshold: 10) (points=14.00)"
+    ) in rendered
     assert "advisor: Split summary and detail formatting into helpers." in rendered
     assert "step: Extract summary line builders." in rendered
     assert "step: Move hotspot rendering into a helper." in rendered
@@ -575,6 +595,24 @@ def test_format_debt_table_orders_by_priority_and_applies_top_limit():
 
     assert "1. app/core.py | score=9.00 | priority=18.00" in rendered
     assert "app/services.py" not in rendered
+
+
+def test_format_debt_table_explains_score_breakdown_and_model():
+    snapshot = build_debt_snapshot(SAMPLE_RESULT, project_root="/repo")
+
+    rendered = format_debt_table(snapshot)
+
+    assert "Score Breakdown:" in rendered
+    assert "complexity: 21.60 pts" in rendered
+    assert "Top rules: SKY-Q301 21.60 pts" in rendered
+    assert "How Score Is Calculated:" in rendered
+    assert "severity weight * dimension weight * magnitude" in rendered
+    assert "included sources: quality, dead_code" in rendered
+    assert (
+        "SKY-Q301 | HIGH | complexity | app/services.py:20 | "
+        "Cyclomatic complexity is 18 (threshold: 10) "
+        "(metric=18 threshold=10 points=21.60)"
+    ) in rendered
 
 
 def test_format_debt_history_table_renders_deltas_and_limit():
@@ -755,6 +793,30 @@ def test_cli_debt_fail_on_status_uses_baseline_comparison(tmp_path, monkeypatch)
         cli.main()
 
     assert exc.value.code == 1
+
+
+def test_cli_debt_json_min_score_includes_gate_failure(tmp_path, monkeypatch):
+    snapshot = _snapshot(str(tmp_path))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "debt", str(tmp_path), "--json", "--min-score", "95"],
+    )
+
+    with (
+        patch("skylos.debt.run_debt_analysis", return_value=snapshot),
+        patch("builtins.print") as mock_print,
+        patch("skylos.cli.Console", return_value=Mock()),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 1
+    payload = json.loads(mock_print.call_args.args[0])
+    assert payload["summary"]["gate"]["passed"] is False
+    assert payload["summary"]["gate"]["failures"] == [
+        "score 93% is below min_score 95%"
+    ]
 
 
 def test_cli_debt_uses_project_policy_for_report_top(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
  - Add score breakdown metadata to debt snapshots
  - Show debt score dimensions, top contributing rules, and scoring formula in the text report

## Why
  `skylos debt` returned a score, but nobody knows what contributed to that score or how gates were evaluated. This gives greater transparency and visibility

  ## Testing
  - `pytest test/test_debt.py`