### PR TITLE
chore(typescript): remove unused analysis import

### DIFF
--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -4,7 +4,6 @@ import fnmatch
 import glob
 import json
 import os
-import re
 import shlex
 from collections import defaultdict
 from dataclasses import dataclass


### PR DESCRIPTION
## Summary
  - Remove an unused `re` import from the TypeScript analysis visitor