### PR TITLE
fix(mcp): require client auth for network transport

### DIFF
--- a/skylos_mcp/Dockerfile
+++ b/skylos_mcp/Dockerfile
@@ -10,6 +10,7 @@ RUN pip install --no-cache-dir -e ".[all]" "mcp[cli]>=1.0.0"
 
 ENV MCP_TRANSPORT=sse
 ENV PORT=8080
+# Set SKYLOS_MCP_TOKEN at runtime; network transports fail closed without it.
 EXPOSE 8080
 
 ENTRYPOINT ["python", "-u", "-m", "skylos_mcp.server"]

--- a/skylos_mcp/auth.py
+++ b/skylos_mcp/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import hmac
 import os
 import time
 from dataclasses import dataclass, field
@@ -27,6 +28,10 @@ UNAUTHENTICATED_TOOLS = {"analyze"}
 
 UNAUTH_DAILY_LIMIT = 5
 UNAUTH_WINDOW_SECONDS = 86400
+MCP_CLIENT_TOKEN_ENV = "SKYLOS_MCP_TOKEN"
+MCP_AUTH_SCOPE = "skylos:mcp"
+MCP_NETWORK_TRANSPORTS = {"sse", "streamable-http"}
+MCP_CLIENT_TOKEN_MIN_LENGTH = 16
 
 
 @dataclass
@@ -76,11 +81,94 @@ class AuthSession:
         self._unauth_calls.append(time.time())
 
 
+@dataclass(frozen=True)
+class MCPNetworkAuth:
+    auth: Any
+    token_verifier: Any
+
+
+class StaticMCPTokenVerifier:
+    def __init__(self, expected_token: str):
+        self._expected_token = expected_token
+
+    async def verify_token(self, token: str) -> Any | None:
+        if not hmac.compare_digest(token, self._expected_token):
+            return None
+
+        from mcp.server.auth.provider import AccessToken
+
+        return AccessToken(
+            token=token,
+            client_id="skylos-mcp-client",
+            scopes=[MCP_AUTH_SCOPE],
+        )
+
+
 _session = AuthSession()
 
 
 def get_session() -> AuthSession:
     return _session
+
+
+def _network_auth_base_url(host: str, port: int) -> str:
+    public_url = os.getenv("SKYLOS_MCP_PUBLIC_URL", "").strip().rstrip("/")
+    if public_url:
+        return public_url
+
+    normalized_host = host.strip() or "127.0.0.1"
+    if normalized_host in {"0.0.0.0", "::"}:
+        normalized_host = "127.0.0.1"
+    elif ":" in normalized_host and not normalized_host.startswith("["):
+        normalized_host = f"[{normalized_host}]"
+
+    return f"http://{normalized_host}:{port}"
+
+
+def build_mcp_network_auth(transport: str, *, host: str, port: int) -> MCPNetworkAuth | None:
+    if transport not in MCP_NETWORK_TRANSPORTS:
+        return None
+
+    token = os.getenv(MCP_CLIENT_TOKEN_ENV, "").strip()
+    if not token:
+        raise RuntimeError(
+            f"{transport} MCP transport requires {MCP_CLIENT_TOKEN_ENV}. "
+            "SKYLOS_API_KEY only authenticates this server to Skylos Cloud; "
+            "clients must send their own bearer token."
+        )
+    if len(token) < MCP_CLIENT_TOKEN_MIN_LENGTH:
+        raise RuntimeError(
+            f"{MCP_CLIENT_TOKEN_ENV} must be at least "
+            f"{MCP_CLIENT_TOKEN_MIN_LENGTH} characters."
+        )
+
+    from mcp.server.auth.settings import AuthSettings
+
+    base_url = _network_auth_base_url(host, port)
+    return MCPNetworkAuth(
+        auth=AuthSettings(
+            issuer_url=base_url,
+            resource_server_url=base_url,
+            required_scopes=[MCP_AUTH_SCOPE],
+        ),
+        token_verifier=StaticMCPTokenVerifier(token),
+    )
+
+
+def check_mcp_client_context(required: bool) -> tuple[bool, str]:
+    if not required:
+        return (True, "")
+
+    try:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+    except Exception:
+        return (False, "MCP client authentication is required for network transports.")
+
+    access_token = get_access_token()
+    if access_token is None or MCP_AUTH_SCOPE not in access_token.scopes:
+        return (False, "MCP client authentication is required for network transports.")
+
+    return (True, "")
 
 
 def _validate_with_cloud(api_key: str) -> dict[str, Any] | None:

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 
 from skylos_mcp.auth import (
+    build_mcp_network_auth,
+    check_mcp_client_context,
     initialize_auth,
     check_tool_access,
     deduct_credits,
@@ -40,6 +42,7 @@ RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
 _results_cache: dict[str, dict[str, Any]] = {}
 _RUN_ID_RE = re.compile(r"^[a-f0-9]{12}$")
+_REQUIRE_MCP_CLIENT_AUTH_CONTEXT = False
 
 
 def _make_run_id(tool: str, path: str, ts: str) -> str:
@@ -646,6 +649,12 @@ def _health_score_payload(result: dict) -> dict:
 
 
 def _gate(tool_name: str) -> str | None:
+    client_allowed, client_err = check_mcp_client_context(
+        _REQUIRE_MCP_CLIENT_AUTH_CONTEXT
+    )
+    if not client_allowed:
+        return json.dumps({"error": client_err})
+
     allowed, err = check_tool_access(tool_name)
     if not allowed:
         return json.dumps({"error": err})
@@ -1080,17 +1089,27 @@ def _register_tools(mcp):
 
 
 def main():
+    global _REQUIRE_MCP_CLIENT_AUTH_CONTEXT
+
     try:
         from mcp.server.fastmcp import FastMCP
 
         initialize_auth()
 
         transport = os.getenv("MCP_TRANSPORT", "stdio")
+        _REQUIRE_MCP_CLIENT_AUTH_CONTEXT = transport in ("sse", "streamable-http")
 
         if transport in ("sse", "streamable-http"):
             host = os.getenv("MCP_BIND", "127.0.0.1")
             port = int(os.getenv("PORT", "8080"))
-            mcp_server = FastMCP(name="skylos", host=host, port=port)
+            network_auth = build_mcp_network_auth(transport, host=host, port=port)
+            mcp_server = FastMCP(
+                name="skylos",
+                host=host,
+                port=port,
+                auth=network_auth.auth,
+                token_verifier=network_auth.token_verifier,
+            )
         else:
             mcp_server = FastMCP(name="skylos")
 

--- a/test/test_mcp_auth.py
+++ b/test/test_mcp_auth.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 import time
 from unittest.mock import patch, MagicMock
 
@@ -6,10 +7,13 @@ import pytest
 
 mcp = pytest.importorskip("mcp", reason="mcp not installed")
 
-from skylos_mcp.auth import (
+from skylos_mcp.auth import (  # noqa: E402
     AuthSession,
+    MCP_AUTH_SCOPE,
     TOOL_CREDIT_MAP,
     UNAUTH_DAILY_LIMIT,
+    build_mcp_network_auth,
+    check_mcp_client_context,
     check_tool_access,
     deduct_credits,
     initialize_auth,
@@ -371,6 +375,107 @@ class TestInitializeAuth:
             assert session.rate_limit_per_hour == 5000
 
 
+class TestMCPNetworkClientAuth:
+    def test_client_context_not_required_for_stdio(self):
+        allowed, err = check_mcp_client_context(required=False)
+
+        assert allowed is True
+        assert err == ""
+
+    def test_client_context_required_blocks_without_authenticated_request(self):
+        allowed, err = check_mcp_client_context(required=True)
+
+        assert allowed is False
+        assert "MCP client authentication is required" in err
+
+    def test_stdio_transport_does_not_require_client_token(self):
+        with patch.dict("os.environ", {"SKYLOS_MCP_TOKEN": ""}):
+            auth_config = build_mcp_network_auth("stdio", host="127.0.0.1", port=8080)
+
+        assert auth_config is None
+
+    def test_network_transport_requires_client_token_even_with_server_key(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "SKYLOS_API_KEY": "server-cloud-key",
+                "SKYLOS_MCP_TOKEN": "",
+            },
+        ):
+            with pytest.raises(RuntimeError, match="requires SKYLOS_MCP_TOKEN"):
+                build_mcp_network_auth("sse", host="0.0.0.0", port=8080)
+
+    def test_network_transport_rejects_weak_client_token(self):
+        with patch.dict("os.environ", {"SKYLOS_MCP_TOKEN": "short"}):
+            with pytest.raises(RuntimeError, match="at least 16 characters"):
+                build_mcp_network_auth("streamable-http", host="127.0.0.1", port=8080)
+
+    def test_network_verifier_accepts_client_token_not_server_key(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "SKYLOS_API_KEY": "server-cloud-key",
+                "SKYLOS_MCP_TOKEN": "client-token-123456",
+            },
+        ):
+            auth_config = build_mcp_network_auth(
+                "streamable-http",
+                host="127.0.0.1",
+                port=8080,
+            )
+
+        assert auth_config is not None
+        assert auth_config.auth.required_scopes == [MCP_AUTH_SCOPE]
+
+        accepted = asyncio.run(
+            auth_config.token_verifier.verify_token("client-token-123456")
+        )
+        rejected = asyncio.run(
+            auth_config.token_verifier.verify_token("server-cloud-key")
+        )
+
+        assert accepted is not None
+        assert accepted.client_id == "skylos-mcp-client"
+        assert accepted.scopes == [MCP_AUTH_SCOPE]
+        assert rejected is None
+
+    def test_streamable_http_rejects_missing_or_server_key_bearer(self):
+        from mcp.server.fastmcp import FastMCP
+        from starlette.testclient import TestClient
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SKYLOS_API_KEY": "server-cloud-key",
+                "SKYLOS_MCP_TOKEN": "client-token-123456",
+            },
+        ):
+            auth_config = build_mcp_network_auth(
+                "streamable-http",
+                host="127.0.0.1",
+                port=8080,
+            )
+
+        assert auth_config is not None
+        app = FastMCP(
+            name="skylos",
+            host="127.0.0.1",
+            port=8080,
+            auth=auth_config.auth,
+            token_verifier=auth_config.token_verifier,
+        ).streamable_http_app()
+        client = TestClient(app)
+
+        assert client.get("/mcp").status_code == 401
+        assert (
+            client.get(
+                "/mcp",
+                headers={"Authorization": "Bearer server-cloud-key"},
+            ).status_code
+            == 401
+        )
+
+
 class TestGateIntegration:
     def _set_session(self, **kwargs):
         import skylos_mcp.auth as auth_mod
@@ -414,6 +519,30 @@ class TestGateIntegration:
         with patch.dict("sys.modules", {"requests": mock_req}):
             result = _gate("security_scan")
         assert result is None
+
+    def test_gate_network_context_blocks_server_key_without_client_context(self):
+        import skylos_mcp.server as server_mod
+        from skylos_mcp.server import _gate
+
+        self._set_session(
+            authenticated=True,
+            plan="enterprise",
+            api_key="server-cloud-key",
+            credits=0,
+            rate_limit_per_hour=5000,
+            validated_at=time.time(),
+        )
+
+        previous = server_mod._REQUIRE_MCP_CLIENT_AUTH_CONTEXT
+        server_mod._REQUIRE_MCP_CLIENT_AUTH_CONTEXT = True
+        try:
+            result = _gate("secrets_scan")
+        finally:
+            server_mod._REQUIRE_MCP_CLIENT_AUTH_CONTEXT = previous
+
+        assert result is not None
+        error = json.loads(result)
+        assert "MCP client authentication is required" in error["error"]
 
     def test_gate_authenticated_no_credits_blocked(self):
         from skylos_mcp.server import _gate


### PR DESCRIPTION
## Summary
  - require a separate `SKYLOS_MCP_TOKEN` for MCP `sse` and `streamable-http` transports
  - wire FastMCP bearer-token auth for network transports
  - keep `SKYLOS_API_KEY` as the server-to-Skylos Cloud credential only
  - add defense-in-depth in `_gate()` so network tool calls require authenticated MCP client context

## Tests
  - `pytest test/test_mcp_auth.py`
  - `pytest test/test_mcp_auth.py test/test_mcp_security.py test/test_mcp_summary.py test/test_mcp_rules.py`
  - `pytest test/test_cwe78_pip_install.py test/test_verify_orchestrator.py`