### PR TITLE
fix(release): scope PyPI token to upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,8 @@ jobs:
               exit 1
               ;;
           esac
-          if [[ ! "$tag" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+          semver_re='^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)([.](0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?([+]([0-9A-Za-z-]+([.][0-9A-Za-z-]+)*))?$'
+          if [[ ! "$tag" =~ $semver_re ]]; then
             echo "Expected a semantic release tag like v4.2.1, got: $tag" >&2
             exit 1
           fi
@@ -156,13 +157,21 @@ jobs:
           name: dist
           path: dist
 
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install publish tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "packaging>=24.2" "twine>=6.1.0"
+
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install "packaging>=24.2" "twine>=6.1.0"
           python -m twine upload --skip-existing dist/*
 
   container:

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -1,4 +1,7 @@
 import json
+from pathlib import Path
+
+import yaml
 
 from skylos.analyzer import analyze
 from skylos.rules.config import scan_config_files
@@ -7,6 +10,10 @@ from skylos.rules.config.cicd.github_actions import scan_github_actions
 
 def _rule_ids(findings):
     return {finding["rule_id"] for finding in findings}
+
+
+def _publish_workflow():
+    return yaml.safe_load(Path(".github/workflows/publish.yml").read_text())
 
 
 def _write_risky_workflow(path):
@@ -280,6 +287,28 @@ jobs:
         "SKY-D312",
         "SKY-D313",
     }.issubset(_rule_ids(findings))
+
+
+def test_publish_workflow_keeps_pypi_token_out_of_tool_install():
+    workflow = _publish_workflow()
+    publish_steps = workflow["jobs"]["publish"]["steps"]
+    install_step = next(s for s in publish_steps if s.get("name") == "Install publish tools")
+    upload_step = next(s for s in publish_steps if s.get("name") == "Publish to PyPI")
+
+    assert "TWINE_PASSWORD" not in install_step.get("env", {})
+    assert "pip install" in install_step["run"]
+    assert upload_step["env"]["TWINE_PASSWORD"] == "${{ secrets.PYPI_TOKEN }}"
+    assert "pip install" not in upload_step["run"]
+    assert "twine upload" in upload_step["run"]
+
+
+def test_publish_workflow_validates_strict_semver_release_tags():
+    workflow = _publish_workflow()
+    build_steps = workflow["jobs"]["build"]["steps"]
+    resolve_step = next(s for s in build_steps if s.get("name") == "Resolve release tag input")
+
+    assert "semver_re=" in resolve_step["run"]
+    assert "(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)" in resolve_step["run"]
 
 
 def test_analyzer_reports_github_actions_dangers_without_source_files(tmp_path):


### PR DESCRIPTION
## Summary
  - move PyPI publish-tool installation into a separate no-secret step
  - keep `TWINE_PASSWORD` scoped only to the final `twine upload` step
  - tighten release tag validation to strict SemVer-style `vMAJOR.MINOR.PATCH`

## Tests

  - `pytest test/test_github_actions_security.py`
  - `pytest test/test_github_actions_security.py test/test_cicd_workflow.py`