### PR TITLE
fix(mcp): harden remediation test execution

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -3409,7 +3409,7 @@ def _build_agent_parser():
 
     p_remediate = agent_sub.add_parser(
         "remediate",
-        help="Scan, fix, test, and create PR for security/quality issues",
+        help="Scan, fix, optionally test, and create PR for security/quality issues",
     )
     p_remediate.add_argument("path", nargs="?", default=".")
     _add_agent_model_arg(p_remediate)
@@ -3435,7 +3435,12 @@ def _build_agent_parser():
     p_remediate.add_argument(
         "--test-cmd",
         default=None,
-        help="Custom test command (default: auto-detect)",
+        help="Trusted custom test command to run without a shell",
+    )
+    p_remediate.add_argument(
+        "--auto-test",
+        action="store_true",
+        help="Opt in to auto-detected project tests after applying fixes",
     )
     p_remediate.add_argument(
         "--severity",
@@ -5159,12 +5164,16 @@ def main() -> None:
 
                 from skylos.llm.cleanup_orchestrator import CleanupOrchestrator
 
+                test_cmd = getattr(agent_args, "test_cmd", None)
+                auto_test = getattr(agent_args, "auto_test", False)
                 orchestrator = CleanupOrchestrator(
                     model=model,
                     api_key=api_key,
                     provider=provider,
                     base_url=base_url,
-                    test_cmd=getattr(agent_args, "test_cmd", None),
+                    test_cmd=test_cmd,
+                    allow_test_execution=bool(test_cmd) or auto_test,
+                    auto_detect_tests=auto_test,
                     standards_path=standards_path,
                 )
 
@@ -5203,13 +5212,17 @@ def main() -> None:
             else:
                 from skylos.llm.orchestrator import RemediationAgent
 
+                test_cmd = getattr(agent_args, "test_cmd", None)
+                auto_test = getattr(agent_args, "auto_test", False)
                 agent = RemediationAgent(
                     model=model,
                     api_key=api_key,
-                    test_cmd=getattr(agent_args, "test_cmd", None),
+                    test_cmd=test_cmd,
                     severity_filter=getattr(agent_args, "severity", None),
                     provider=provider,
                     base_url=base_url,
+                    allow_test_execution=bool(test_cmd) or auto_test,
+                    auto_detect_tests=auto_test,
                 )
 
                 summary = agent.run(

--- a/skylos/llm/agents.py
+++ b/skylos/llm/agents.py
@@ -712,6 +712,8 @@ class CleanupAgent:
         *,
         standards_path=None,
         test_cmd=None,
+        allow_test_execution=False,
+        auto_detect_tests=False,
         max_fixes=20,
         dry_run=False,
         quiet=False,
@@ -724,6 +726,8 @@ class CleanupAgent:
             provider=getattr(self.config, "provider", None),
             base_url=getattr(self.config, "base_url", None),
             test_cmd=test_cmd,
+            allow_test_execution=allow_test_execution,
+            auto_detect_tests=auto_detect_tests,
             standards_path=standards_path,
         )
         return orchestrator.run(path, max_fixes=max_fixes, dry_run=dry_run, quiet=quiet)

--- a/skylos/llm/cleanup_orchestrator.py
+++ b/skylos/llm/cleanup_orchestrator.py
@@ -269,6 +269,8 @@ class CleanupOrchestrator:
         provider: str | None = None,
         base_url: str | None = None,
         test_cmd: str | None = None,
+        allow_test_execution: bool = False,
+        auto_detect_tests: bool = False,
         standards_path: str | Path | None = None,
     ):
         self.config = AgentConfig(model=model, api_key=api_key)
@@ -277,6 +279,8 @@ class CleanupOrchestrator:
         if base_url:
             self.config.base_url = base_url
         self.test_cmd = test_cmd
+        self.allow_test_execution = allow_test_execution
+        self.auto_detect_tests = auto_detect_tests
         self.standards_text = _load_standards(standards_path)
         self._adapter = None
 
@@ -359,7 +363,10 @@ class CleanupOrchestrator:
         else:
             project_root = target.parent
         executor = RemediationExecutor(
-            test_cmd=self.test_cmd, project_root=project_root
+            test_cmd=self.test_cmd,
+            project_root=project_root,
+            allow_test_execution=self.allow_test_execution,
+            auto_detect_tests=self.auto_detect_tests,
         )
 
         for idx, item in enumerate(all_items, 1):

--- a/skylos/llm/executor.py
+++ b/skylos/llm/executor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import hashlib
+import re
+import shlex
 import subprocess
 import sys
 import shutil
@@ -23,10 +25,22 @@ class VerifyResult:
     remaining_rule_ids: list[str] = field(default_factory=list)
 
 
+_SHELL_METACHAR_RE = re.compile(r"[;&|<>`$]")
+
+
 class RemediationExecutor:
-    def __init__(self, *, test_cmd: str | None = None, project_root: str | Path = "."):
+    def __init__(
+        self,
+        *,
+        test_cmd: str | None = None,
+        project_root: str | Path = ".",
+        allow_test_execution: bool = False,
+        auto_detect_tests: bool = False,
+    ):
         self.test_cmd = test_cmd
         self.project_root = Path(project_root).resolve()
+        self.allow_test_execution = allow_test_execution
+        self.auto_detect_tests = auto_detect_tests
         self._backups: dict[str, str] = {}
 
     def apply_fix(self, file_path: str, fixed_code: str) -> bool:
@@ -57,17 +71,34 @@ class RemediationExecutor:
             self.revert_fix(fp)
 
     def run_tests(self, timeout: int = 300) -> TestResult:
-        cmd = self.test_cmd or self._detect_test_command()
+        if not self.allow_test_execution:
+            return TestResult(
+                passed=True,
+                output="Test execution disabled.",
+                command="",
+            )
+
+        cmd = self.test_cmd
+        if not cmd and self.auto_detect_tests:
+            cmd = self._detect_test_command()
         if not cmd:
             return TestResult(passed=True, output="No test suite detected.", command="")
+
+        argv = self._safe_test_argv(cmd)
+        if argv is None:
+            return TestResult(
+                passed=False,
+                output="Rejected test command containing shell syntax.",
+                command=cmd,
+            )
 
         import time
 
         start = time.monotonic()
         try:
             result = subprocess.run(
-                cmd,
-                shell=True,
+                argv,
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -90,6 +121,15 @@ class RemediationExecutor:
             )
         except OSError as e:
             return TestResult(passed=False, output=str(e), command=cmd)
+
+    def _safe_test_argv(self, cmd: str) -> list[str] | None:
+        if _SHELL_METACHAR_RE.search(cmd):
+            return None
+        try:
+            argv = shlex.split(cmd)
+        except ValueError:
+            return None
+        return argv or None
 
     def _detect_test_command(self) -> str | None:
         root = self.project_root

--- a/skylos/llm/orchestrator.py
+++ b/skylos/llm/orchestrator.py
@@ -18,6 +18,8 @@ class RemediationAgent:
         severity_filter: str | None = None,
         provider: str | None = None,
         base_url: str | None = None,
+        allow_test_execution: bool = False,
+        auto_detect_tests: bool = False,
     ):
         self.model = model
         self.api_key = api_key
@@ -25,6 +27,8 @@ class RemediationAgent:
         self.severity_filter = severity_filter
         self.provider = provider
         self.base_url = base_url
+        self.allow_test_execution = allow_test_execution
+        self.auto_detect_tests = auto_detect_tests
         self.planner = RemediationPlanner(severity_filter=severity_filter)
 
     def run(
@@ -85,6 +89,8 @@ class RemediationAgent:
         executor = RemediationExecutor(
             test_cmd=self.test_cmd,
             project_root=path if path.is_dir() else path.parent,
+            allow_test_execution=self.allow_test_execution,
+            auto_detect_tests=self.auto_detect_tests,
         )
 
         fixer = self._create_fixer()

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -817,13 +817,25 @@ def _register_tools(mcp):
         if gate_err:
             return gate_err
 
+        if test_cmd:
+            return json.dumps(
+                {
+                    "error": (
+                        "MCP remediate does not accept test_cmd. "
+                        "Run trusted validation outside MCP after reviewing fixes."
+                    )
+                }
+            )
+
         try:
             from skylos.llm.orchestrator import RemediationAgent
 
             agent = RemediationAgent(
                 model=model,
-                test_cmd=test_cmd,
+                test_cmd=None,
                 severity_filter=severity,
+                allow_test_execution=False,
+                auto_detect_tests=False,
             )
             summary = agent.run(
                 path,

--- a/test/test_agent_remediate.py
+++ b/test/test_agent_remediate.py
@@ -294,17 +294,64 @@ class TestRemediationExecutor:
         executor = RemediationExecutor(project_root=tmp_path)
         result = executor.run_tests()
         assert result.passed is True
-        assert "No test suite" in result.output
+        assert "Test execution disabled" in result.output
 
     def test_run_tests_with_custom_cmd(self, tmp_path):
-        executor = RemediationExecutor(test_cmd="echo ok", project_root=tmp_path)
+        executor = RemediationExecutor(
+            test_cmd="echo ok",
+            project_root=tmp_path,
+            allow_test_execution=True,
+        )
         result = executor.run_tests()
         assert result.passed is True
 
     def test_run_tests_failure(self, tmp_path):
-        executor = RemediationExecutor(test_cmd="exit 1", project_root=tmp_path)
+        executor = RemediationExecutor(
+            test_cmd="false",
+            project_root=tmp_path,
+            allow_test_execution=True,
+        )
         result = executor.run_tests()
         assert result.passed is False
+
+    def test_run_tests_rejects_shell_metacharacters(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        executor = RemediationExecutor(
+            test_cmd=f"true; touch {marker}",
+            project_root=tmp_path,
+            allow_test_execution=True,
+        )
+
+        result = executor.run_tests()
+
+        assert result.passed is False
+        assert "Rejected test command" in result.output
+        assert not marker.exists()
+
+    def test_run_tests_does_not_auto_execute_makefile_by_default(self, tmp_path):
+        marker = tmp_path / "make-marker.txt"
+        (tmp_path / "Makefile").write_text(f"test:\n\ttouch {marker}\n")
+
+        executor = RemediationExecutor(project_root=tmp_path)
+        result = executor.run_tests()
+
+        assert result.passed is True
+        assert "Test execution disabled" in result.output
+        assert not marker.exists()
+
+    def test_run_tests_auto_detect_requires_explicit_opt_in(self, tmp_path):
+        marker = tmp_path / "make-marker.txt"
+        (tmp_path / "Makefile").write_text(f"test:\n\ttouch {marker}\n")
+
+        executor = RemediationExecutor(
+            project_root=tmp_path,
+            allow_test_execution=True,
+            auto_detect_tests=True,
+        )
+        result = executor.run_tests()
+
+        assert result.passed is True
+        assert marker.exists()
 
     def test_verify_fix(self, tmp_path):
         f = tmp_path / "test_verify.py"

--- a/test/test_mcp_summary.py
+++ b/test/test_mcp_summary.py
@@ -5,6 +5,7 @@ from skylos_mcp.server import (
     _architecture_payload,
     _health_score_payload,
     _make_summary,
+    _register_tools,
 )
 
 
@@ -102,3 +103,30 @@ def test_load_result_rejects_path_traversal_run_id(monkeypatch, tmp_path):
 
     assert mcp_server._load_result("../latest") is None
     assert mcp_server._load_result("latest/../../secret") is None
+
+
+def test_mcp_remediate_rejects_test_cmd(monkeypatch):
+    class FakeMCP:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self):
+            def decorate(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+
+            return decorate
+
+        def resource(self, *_args, **_kwargs):
+            def decorate(fn):
+                return fn
+
+            return decorate
+
+    fake = FakeMCP()
+    _register_tools(fake)
+    monkeypatch.setattr(mcp_server, "_gate", lambda _tool_name: None)
+
+    result = fake.tools["remediate"](".", test_cmd="true; touch /tmp/marker")
+
+    assert "does not accept test_cmd" in result


### PR DESCRIPTION
## Summary

  - disable remediation test execution by default
  - reject `test_cmd` in MCP `remediate`
  - run trusted CLI test commands with `shell=False`
  - require explicit CLI opt-in for auto-detected repository tests via `--auto-test`
  - reject shell metacharacters in custom test commands

## Tests

  - `pytest test/test_agent_remediate.py test/test_cleanup_orchestrator.py test/test_mcp_summary.py`
  - `pytest test/test_cli_agent_parser.py test/test_cli_llm_provider.py test/test_cli.py`
  - `pytest test/test_mcp_auth.py test/test_mcp_security.py test/test_mcp_summary.py test/test_mcp_rules.py`