### PR TITLE
fix(llm): contain cleanup file access

### DIFF
--- a/skylos/llm/cleanup_orchestrator.py
+++ b/skylos/llm/cleanup_orchestrator.py
@@ -260,6 +260,19 @@ Produce the corrected file. Fix ONLY this violation.\
 _SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 
 
+def _resolved_contained_file(path: Path, root: Path) -> Path | None:
+    if path.is_symlink():
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
 class CleanupOrchestrator:
     def __init__(
         self,
@@ -305,7 +318,7 @@ class CleanupOrchestrator:
         log = console.print if not quiet else (lambda *a, **kw: None)
 
         result = CleanupResult()
-        target = Path(path).resolve()
+        target = Path(path)
 
         files = self._collect_files(target, include_patterns, exclude_patterns)
         log(f"[bold]Phase 1:[/bold] Collected {len(files)} files to analyze")
@@ -402,14 +415,24 @@ class CleanupOrchestrator:
         include_patterns: list[str] | None = None,
         exclude_patterns: list[str] | None = None,
     ) -> list[Path]:
+        try:
+            scan_root = (
+                path.parent.resolve(strict=True)
+                if path.is_file()
+                else path.resolve(strict=True)
+            )
+        except OSError:
+            return []
+
         if path.is_file():
             if path.suffix in CODE_EXTENSIONS:
-                return [path]
+                resolved = _resolved_contained_file(path, scan_root)
+                return [resolved] if resolved is not None else []
             return []
 
         files = []
         for fp in sorted(path.rglob("*")):
-            if not fp.is_file():
+            if fp.is_symlink() or not fp.is_file():
                 continue
             if fp.suffix not in CODE_EXTENSIONS:
                 continue
@@ -418,16 +441,23 @@ class CleanupOrchestrator:
                 continue
             if any(p.endswith(".egg-info") for p in fp.relative_to(path).parts):
                 continue
+            resolved = _resolved_contained_file(fp, scan_root)
+            if resolved is None:
+                continue
             try:
-                if fp.stat().st_size > MAX_FILE_SIZE:
+                if resolved.stat().st_size > MAX_FILE_SIZE:
                     continue
             except OSError:
                 continue
-            files.append(fp)
+            files.append(resolved)
 
         return files
 
     def _analyze_file(self, file_path: Path, log) -> list[CleanupItem]:
+        if file_path.is_symlink():
+            log(f"  [dim]Skipping symlinked file {file_path}[/dim]")
+            return []
+
         source = file_path.read_text(encoding="utf-8", errors="replace")
         lines = source.splitlines()
         if len(lines) > MAX_FILE_LINES:
@@ -475,6 +505,10 @@ class CleanupOrchestrator:
         if not fp.exists():
             item.status = "skipped"
             item.skip_reason = "file not found"
+            return
+        if not executor.is_safe_file_path(str(fp)):
+            item.status = "skipped"
+            item.skip_reason = "file outside project root or symlink"
             return
 
         source = fp.read_text(encoding="utf-8", errors="replace")

--- a/skylos/llm/executor.py
+++ b/skylos/llm/executor.py
@@ -43,9 +43,25 @@ class RemediationExecutor:
         self.auto_detect_tests = auto_detect_tests
         self._backups: dict[str, str] = {}
 
-    def apply_fix(self, file_path: str, fixed_code: str) -> bool:
+    def _safe_file_path(self, file_path: str) -> Path | None:
         p = Path(file_path)
-        if not p.exists():
+        if p.is_symlink():
+            return None
+        try:
+            resolved = p.resolve(strict=True)
+            resolved.relative_to(self.project_root)
+        except (OSError, ValueError):
+            return None
+        if not resolved.is_file():
+            return None
+        return resolved
+
+    def is_safe_file_path(self, file_path: str) -> bool:
+        return self._safe_file_path(file_path) is not None
+
+    def apply_fix(self, file_path: str, fixed_code: str) -> bool:
+        p = self._safe_file_path(file_path)
+        if p is None:
             return False
         try:
             original = p.read_text(encoding="utf-8")
@@ -56,12 +72,15 @@ class RemediationExecutor:
             return False
 
     def revert_fix(self, file_path: str) -> bool:
-        key = str(Path(file_path))
+        p = self._safe_file_path(file_path)
+        if p is None:
+            return False
+        key = str(p)
         original = self._backups.pop(key, None)
         if original is None:
             return False
         try:
-            Path(file_path).write_text(original, encoding="utf-8")
+            p.write_text(original, encoding="utf-8")
             return True
         except OSError:
             return False

--- a/test/test_agent_remediate.py
+++ b/test/test_agent_remediate.py
@@ -258,6 +258,42 @@ class TestRemediationExecutor:
         executor = RemediationExecutor(project_root=tmp_path)
         assert executor.apply_fix("/nonexistent", "content") is False
 
+    def test_apply_rejects_symlinked_file(self, tmp_path):
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        target = outside / "target.py"
+        target.write_text("original")
+        link = tmp_path / "link.py"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            import pytest
+
+            pytest.skip("filesystem does not allow symlink creation")
+
+        executor = RemediationExecutor(project_root=tmp_path)
+
+        assert executor.apply_fix(str(link), "changed") is False
+        assert target.read_text() == "original"
+
+    def test_apply_rejects_file_under_symlinked_parent(self, tmp_path):
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        target = outside / "target.py"
+        target.write_text("original")
+        link_dir = tmp_path / "linked-dir"
+        try:
+            link_dir.symlink_to(outside, target_is_directory=True)
+        except OSError:
+            import pytest
+
+            pytest.skip("filesystem does not allow symlink creation")
+
+        executor = RemediationExecutor(project_root=tmp_path)
+
+        assert executor.apply_fix(str(link_dir / "target.py"), "changed") is False
+        assert target.read_text() == "original"
+
     def test_revert_all(self, tmp_path):
         f1 = tmp_path / "a.py"
         f2 = tmp_path / "b.py"

--- a/test/test_cleanup_orchestrator.py
+++ b/test/test_cleanup_orchestrator.py
@@ -15,6 +15,7 @@ from skylos.llm.cleanup_orchestrator import (
     _build_fix_system_prompt,
     _build_fix_user_prompt,
 )
+from skylos.llm.executor import RemediationExecutor
 
 
 class TestLoadStandards:
@@ -159,6 +160,23 @@ class TestFileCollection:
         assert "small.py" in names
         assert "big.py" not in names
 
+    def test_skips_symlinked_php_file_outside_root(self, tmp_path):
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        target = outside / "secret.php"
+        target.write_text("<?php $token = 'external-secret';\n", encoding="utf-8")
+        link = tmp_path / "leak.php"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            pytest.skip("filesystem does not allow symlink creation")
+
+        orch = self._make_orchestrator()
+        files = orch._collect_files(tmp_path)
+
+        assert link not in files
+        assert target.resolve() not in files
+
 
 class TestAnalysis:
     def _make_orchestrator(self):
@@ -224,6 +242,25 @@ class TestAnalysis:
         orch._adapter = MagicMock()
 
         items = orch._analyze_file(f, lambda *a, **kw: None)
+        assert items == []
+        orch._adapter.complete.assert_not_called()
+
+    def test_analyze_file_rejects_symlink_before_llm_prompt(self, tmp_path):
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        target = outside / "secret.php"
+        target.write_text("<?php $token = 'external-secret';\n", encoding="utf-8")
+        link = tmp_path / "leak.php"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            pytest.skip("filesystem does not allow symlink creation")
+
+        orch = self._make_orchestrator()
+        orch._adapter = MagicMock()
+
+        items = orch._analyze_file(link, lambda *a, **kw: None)
+
         assert items == []
         orch._adapter.complete.assert_not_called()
 
@@ -374,6 +411,35 @@ class TestFixApplication:
         orch._apply_single_fix(item, mock_executor, lambda *a, **kw: None)
         assert item.status == "skipped"
         assert "file not found" in item.skip_reason
+
+    def test_apply_fix_rejects_symlink_before_fix_prompt(self, tmp_path):
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        target = outside / "secret.php"
+        target.write_text("<?php echo 'secret';\n", encoding="utf-8")
+        link = tmp_path / "leak.php"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            pytest.skip("filesystem does not allow symlink creation")
+
+        item = CleanupItem(
+            file=str(link),
+            line=1,
+            category="c",
+            description="d",
+            suggestion="s",
+        )
+        orch = self._make_orchestrator()
+        orch._adapter = MagicMock()
+        executor = RemediationExecutor(project_root=tmp_path)
+
+        orch._apply_single_fix(item, executor, lambda *a, **kw: None)
+
+        assert item.status == "skipped"
+        assert "outside project root" in item.skip_reason
+        assert target.read_text(encoding="utf-8") == "<?php echo 'secret';\n"
+        orch._adapter.complete.assert_not_called()
 
 
 class TestOrchestration:


### PR DESCRIPTION
## Summary

  - reject symlinked cleanup candidates before LLM analysis
  - require cleanup files to resolve inside the requested project root
  - prevent remediation writes/reverts through symlinks or outside-root paths
  - add regression coverage for PHP symlink collection, prompt disclosure, and write containment

  ## Validation

  - `pytest test/test_cleanup_orchestrator.py test/test_agent_remediate.py`
  - `pytest test/test_cli_agent_parser.py test/test_cli_llm_provider.py test/test_cli.py`