### PR TITLE
fix(llm): contain source file discovery

### DIFF
--- a/skylos/core/file_discovery.py
+++ b/skylos/core/file_discovery.py
@@ -152,6 +152,19 @@ def list_git_visible_files(path: str | Path) -> list[Path] | None:
     return files
 
 
+def _resolve_contained_source_file(file_path: Path, root_path: Path) -> Path | None:
+    if file_path.is_symlink():
+        return None
+    try:
+        resolved = file_path.resolve(strict=True)
+        resolved.relative_to(root_path)
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
 def discover_source_files(
     path: str | Path,
     extensions: Iterable[str],
@@ -159,16 +172,21 @@ def discover_source_files(
     include_folders: Sequence[str] | None = None,
     respect_gitignore: bool = True,
 ) -> list[Path]:
-    target = Path(path).resolve()
+    raw_target = Path(path)
+    try:
+        target = raw_target.resolve(strict=True)
+    except OSError:
+        return []
     ext_set = {
         ext.lower() if ext.startswith(".") else f".{ext.lower()}" for ext in extensions
     }
 
-    if target.is_file():
+    if raw_target.is_file():
         if should_exclude_path(target, target.parent, exclude_folders):
             return []
         if target.suffix.lower() in ext_set:
-            return [target]
+            contained = _resolve_contained_source_file(raw_target, target.parent)
+            return [contained] if contained is not None else []
         return []
 
     if respect_gitignore:
@@ -182,7 +200,9 @@ def discover_source_files(
             for file_path in [*git_files, *forced_includes]:
                 if file_path.suffix.lower() not in ext_set:
                     continue
-                resolved = file_path.resolve()
+                resolved = _resolve_contained_source_file(file_path, target)
+                if resolved is None:
+                    continue
                 if resolved in seen:
                     continue
                 seen.add(resolved)
@@ -227,15 +247,21 @@ def discover_source_files(
                 file_path = base / filename
                 if file_path.suffix.lower() not in ext_set:
                     continue
+                resolved = _resolve_contained_source_file(file_path, target)
+                if resolved is None:
+                    continue
                 if should_include_path(file_path, target, include_folders):
-                    files.append(file_path)
+                    files.append(resolved)
                     continue
                 if should_exclude_path(file_path, target, exclude_folders):
                     continue
-                files.append(file_path)
+                files.append(resolved)
     except (OSError, PermissionError, TypeError):
         for ext in ext_set:
-            files.extend(target.glob(f"**/*{ext}"))
+            for file_path in target.glob(f"**/*{ext}"):
+                resolved = _resolve_contained_source_file(file_path, target)
+                if resolved is not None:
+                    files.append(resolved)
 
     files.sort()
     return files
@@ -253,25 +279,30 @@ def _collect_forced_included_files(
     seen = set()
     for pattern in include_folders:
         for match in _iter_include_matches(target, pattern):
+            if match.is_symlink():
+                continue
             try:
                 resolved = match.resolve()
+                resolved.relative_to(target)
             except OSError:
+                continue
+            except ValueError:
                 continue
             if resolved in seen:
                 continue
             seen.add(resolved)
             if match.is_dir():
                 for file_path in match.rglob("*"):
-                    try:
-                        if (
-                            file_path.is_file()
-                            and file_path.suffix.lower() in extensions
-                        ):
-                            files.append(file_path.resolve())
-                    except OSError:
+                    if file_path.suffix.lower() not in extensions:
                         continue
+                    contained = _resolve_contained_source_file(file_path, target)
+                    if contained is None:
+                        continue
+                    files.append(contained)
             elif match.is_file() and match.suffix.lower() in extensions:
-                files.append(resolved)
+                contained = _resolve_contained_source_file(match, target)
+                if contained is not None:
+                    files.append(contained)
     return files
 
 

--- a/skylos/llm/analyzer.py
+++ b/skylos/llm/analyzer.py
@@ -23,6 +23,18 @@ def _norm_path(path) -> str:
         return str(path)
 
 
+def _safe_llm_file(path: Path) -> Path | None:
+    if path.is_symlink():
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        return None
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
 class AnalyzerConfig:
     def __init__(
         self,
@@ -488,9 +500,11 @@ class SkylosLLM:
         issue_types=None,
     ):
         file_path = Path(file_path)
+        safe_path = _safe_llm_file(file_path)
 
-        if not file_path.exists():
+        if safe_path is None:
             return []
+        file_path = safe_path
 
         try:
             source = file_path.read_text(encoding="utf-8")
@@ -634,7 +648,10 @@ class SkylosLLM:
 
     def _count_lines(self, file_path):
         try:
-            return len(Path(file_path).read_text(encoding="utf-8").splitlines())
+            safe_path = _safe_llm_file(Path(file_path))
+            if safe_path is None:
+                return 0
+            return len(safe_path.read_text(encoding="utf-8").splitlines())
         except Exception:
             return 0
 
@@ -793,8 +810,10 @@ class SkylosLLM:
 
     def fix_issue(self, file_path, issue_line, issue_message, defs_map=None):
         file_path = Path(file_path)
-        if not file_path.exists():
+        safe_path = _safe_llm_file(file_path)
+        if safe_path is None:
             return None
+        file_path = safe_path
 
         try:
             source = file_path.read_text(encoding="utf-8")

--- a/test/test_file_discovery.py
+++ b/test/test_file_discovery.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from skylos.core.file_discovery import should_exclude_path
+from skylos.core.file_discovery import discover_source_files, should_exclude_path
 
 
 def test_should_exclude_path_honors_sonar_style_globs(tmp_path: Path):
@@ -14,3 +14,23 @@ def test_should_exclude_path_honors_sonar_style_globs(tmp_path: Path):
 
     assert should_exclude_path(generated, root, ["**/generated/**"])
     assert should_exclude_path(dist, root, ["dist/**"])
+
+
+def test_discover_source_files_skips_symlinked_file_outside_root(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "secret.py"
+    target.write_text("TOKEN = 'outside-secret'\n", encoding="utf-8")
+    link = repo / "leak.py"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        import pytest
+
+        pytest.skip("filesystem does not allow symlink creation")
+
+    files = discover_source_files(repo, [".py"], respect_gitignore=False)
+
+    assert files == []

--- a/test/test_llm_analyzer.py
+++ b/test/test_llm_analyzer.py
@@ -71,6 +71,68 @@ def test_analyze_file_returns_empty_if_missing(tmp_path):
     assert out == []
 
 
+def test_analyze_file_rejects_symlink_before_read(tmp_path, monkeypatch):
+    import pytest
+
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    target = outside / "secret.py"
+    target.write_text("def exposed():\n    return 'outside-secret'\n", encoding="utf-8")
+    link = tmp_path / "leak.py"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("filesystem does not allow symlink creation")
+
+    cfg = AnalyzerConfig(quiet=True, full_file_review=True)
+    s = SkylosLLM(cfg)
+    calls = []
+
+    def fake_analyze_whole(
+        source, file_path, defs_map=None, chunk_start_line=1, **kwargs
+    ):
+        calls.append((source, file_path))
+        return []
+
+    monkeypatch.setattr(s, "_analyze_whole_file", fake_analyze_whole)
+
+    out = s.analyze_file(link)
+
+    assert out == []
+    assert calls == []
+
+
+def test_analyze_project_skips_symlinked_python_outside_root(tmp_path, monkeypatch):
+    import pytest
+
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    target = outside / "secret.py"
+    target.write_text("def exposed():\n    return 'outside-secret'\n", encoding="utf-8")
+    link = tmp_path / "leak.py"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("filesystem does not allow symlink creation")
+
+    cfg = AnalyzerConfig(quiet=True, full_file_review=True)
+    s = SkylosLLM(cfg)
+    calls = []
+
+    def fake_analyze_whole(
+        source, file_path, defs_map=None, chunk_start_line=1, **kwargs
+    ):
+        calls.append((source, file_path))
+        return []
+
+    monkeypatch.setattr(s, "_analyze_whole_file", fake_analyze_whole)
+
+    result = s.analyze_project(tmp_path)
+
+    assert result.files_analyzed == 0
+    assert calls == []
+
+
 def test_analyze_file_small_uses_whole_file_path(tmp_path, monkeypatch):
     fp = tmp_path / "a.py"
     fp.write_text("print('hi')\n", encoding="utf-8")
@@ -125,8 +187,6 @@ def test_analyze_file_large_chunks_and_offsets_lines(tmp_path, monkeypatch):
         def analyze(self, source, file_path, defs_map=None, context=None):
             self.calls.append((file_path, context))
             return [mk_finding(file=file_path, line=2, severity=Severity.MEDIUM)]
-
-    agent = FreshAuditAgent()
 
     def fake_analyze_whole_file(
         source,


### PR DESCRIPTION
## Summary

  - reject symlinked source files during shared source discovery
  - require discovered source files to resolve inside the requested scan root
  - prevent direct LLM analyze/fix paths from reading symlinked or non-file paths

  ## Validation

  - `pytest test/test_file_discovery.py test/test_llm_analyzer.py`
  - `pytest test/test_pipeline.py`
  - `pytest test/test_agent_integration.py test/test_security_taskflow.py`
  - `pytest test/test_analyzer.py test/test_cli.py`