### PR TITLE
fix(cache): harden grep cache writes

### DIFF
--- a/skylos/core/grep_cache.py
+++ b/skylos/core/grep_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import threading
 import time
 from pathlib import Path
@@ -14,6 +15,7 @@ CACHE_DIR = ".skylos/cache"
 CACHE_FILE = "grep_results.json"
 MAX_ENTRIES = 10_000
 HASH_BYTES = 8192
+MAX_CACHE_BYTES = 5 * 1024 * 1024
 
 
 def file_content_hash(file_path: str | Path) -> str:
@@ -97,16 +99,93 @@ class GrepCache:
         with self._lock:
             return len(self._entries)
 
+    def _cache_path(self, project_root: str | Path, *, create: bool = False) -> Path | None:
+        try:
+            root = Path(project_root).resolve(strict=True)
+        except OSError:
+            return None
+
+        cache_dir = root / CACHE_DIR
+        for directory in (root / ".skylos", cache_dir):
+            try:
+                if directory.is_symlink():
+                    return None
+                if directory.exists():
+                    resolved = directory.resolve(strict=True)
+                    resolved.relative_to(root)
+                    if not directory.is_dir():
+                        return None
+                elif create:
+                    directory.mkdir(mode=0o700)
+                else:
+                    return None
+            except (OSError, ValueError):
+                return None
+
+        path = cache_dir / CACHE_FILE
+        try:
+            if path.is_symlink():
+                return None
+            if path.exists():
+                resolved = path.resolve(strict=True)
+                resolved.relative_to(cache_dir.resolve(strict=True))
+                if not path.is_file():
+                    return None
+        except (OSError, ValueError):
+            return None
+
+        return path
+
+    def _read_cache_text(self, path: Path) -> str | None:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(path, flags)  # skylos: ignore[SKY-D215] guarded project-local grep cache path
+        except OSError:
+            return None
+        try:
+            with os.fdopen(fd, "r", encoding="utf-8") as f:
+                return f.read(MAX_CACHE_BYTES + 1)
+        except OSError:
+            return None
+
+    def _normalize_entries(self, raw_entries: Any) -> dict[str, dict[str, Any]]:
+        if not isinstance(raw_entries, dict):
+            return {}
+
+        normalized: dict[str, dict[str, Any]] = {}
+        for key, value in raw_entries.items():
+            if len(normalized) >= MAX_ENTRIES:
+                break
+            if not isinstance(key, str) or not isinstance(value, dict):
+                continue
+            results = value.get("results")
+            if not isinstance(results, list) or not all(
+                isinstance(item, str) for item in results
+            ):
+                continue
+            normalized[key] = {
+                "results": results,
+                "last_access": _coerce_timestamp(value.get("last_access")),
+                "created": _coerce_timestamp(value.get("created")),
+            }
+        return normalized
+
     def load(self, project_root: str | Path) -> None:
-        path = Path(project_root) / CACHE_DIR / CACHE_FILE
-        if not path.exists():
+        path = self._cache_path(project_root)
+        if path is None:
             return
         try:
-            data = json.loads(
-                path.read_text(encoding="utf-8")
-            )  # skylos: ignore[SKY-D215] project-local cache file
+            if path.stat().st_size > MAX_CACHE_BYTES:
+                return
+            text = self._read_cache_text(path)
+            if text is None or len(text.encode("utf-8")) > MAX_CACHE_BYTES:
+                return
+            data = json.loads(text)
+            entries = self._normalize_entries(data.get("entries", {}))
             with self._lock:
-                self._entries = data.get("entries", {})
+                self._entries = entries
                 self._dirty = False
             logger.debug("Loaded %d grep cache entries", len(self._entries))
         except Exception as e:
@@ -119,15 +198,44 @@ class GrepCache:
             data = {"version": 1, "entries": dict(self._entries)}
             self._dirty = False
 
-        path = Path(project_root) / CACHE_DIR / CACHE_FILE
+        path = self._cache_path(project_root, create=True)
+        if path is None:
+            with self._lock:
+                self._dirty = True
+            return
+
+        payload = json.dumps(data)
+        temp_path = path.with_name(
+            f".{CACHE_FILE}.{os.getpid()}.{threading.get_ident()}.tmp"
+        )
         try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(
-                json.dumps(data), encoding="utf-8"
-            )  # skylos: ignore[SKY-D215] project-local cache file
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            fd = os.open(temp_path, flags, 0o600)  # skylos: ignore[SKY-D215] guarded project-local grep cache temp path
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(payload)
+                    f.flush()
+                    os.fsync(f.fileno())
+            except Exception:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                raise
+            os.replace(temp_path, path)
             logger.debug("Saved %d grep cache entries", len(data["entries"]))
         except Exception as e:
             logger.debug("Failed to save grep cache: %s", e)
+            with self._lock:
+                self._dirty = True
+        finally:
+            try:
+                if temp_path.exists() and not temp_path.is_symlink():
+                    temp_path.unlink()
+            except OSError:
+                pass
 
     def cached_search(
         self,
@@ -148,3 +256,10 @@ class GrepCache:
         results = search_fn()
         self.put(key, results)
         return results
+
+
+def _coerce_timestamp(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/test/test_grep_cache.py
+++ b/test/test_grep_cache.py
@@ -9,6 +9,7 @@ from skylos.core.grep_cache import (
     CACHE_DIR,
     CACHE_FILE,
     MAX_ENTRIES,
+    MAX_CACHE_BYTES,
     GrepCache,
     _make_key,
     file_content_hash,
@@ -252,6 +253,99 @@ class TestLoadSave:
         cache2.load(tmp_path)
         assert cache2._dirty is False
 
+    def test_save_rejects_symlinked_cache_file(self, tmp_path: Path) -> None:
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        target = outside / "target.txt"
+        target.write_text("DO_NOT_CLOBBER", encoding="utf-8")
+        cache_path = tmp_path / CACHE_DIR / CACHE_FILE
+        cache_path.parent.mkdir(parents=True)
+        try:
+            cache_path.symlink_to(target)
+        except OSError:
+            import pytest
+
+            pytest.skip("filesystem does not allow symlink creation")
+
+        cache = GrepCache()
+        cache.put("k", ["v"])
+        cache.save(tmp_path)
+
+        assert target.read_text(encoding="utf-8") == "DO_NOT_CLOBBER"
+        assert cache_path.is_symlink()
+
+    def test_save_rejects_symlinked_cache_directory(self, tmp_path: Path) -> None:
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        cache_dir = tmp_path / ".skylos" / "cache"
+        cache_dir.parent.mkdir()
+        try:
+            cache_dir.symlink_to(outside, target_is_directory=True)
+        except OSError:
+            import pytest
+
+            pytest.skip("filesystem does not allow symlink creation")
+
+        cache = GrepCache()
+        cache.put("k", ["v"])
+        cache.save(tmp_path)
+
+        assert not (outside / CACHE_FILE).exists()
+
+    def test_load_rejects_symlinked_cache_file(self, tmp_path: Path) -> None:
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        target = outside / "grep_results.json"
+        target.write_text(
+            json.dumps({"version": 1, "entries": {"k": {"results": ["v"]}}}),
+            encoding="utf-8",
+        )
+        cache_path = tmp_path / CACHE_DIR / CACHE_FILE
+        cache_path.parent.mkdir(parents=True)
+        try:
+            cache_path.symlink_to(target)
+        except OSError:
+            import pytest
+
+            pytest.skip("filesystem does not allow symlink creation")
+
+        cache = GrepCache()
+        cache.load(tmp_path)
+
+        assert cache.size == 0
+
+    def test_load_rejects_oversized_cache_file(self, tmp_path: Path) -> None:
+        cache_path = tmp_path / CACHE_DIR / CACHE_FILE
+        cache_path.parent.mkdir(parents=True)
+        cache_path.write_text(" " * (MAX_CACHE_BYTES + 1), encoding="utf-8")
+
+        cache = GrepCache()
+        cache.load(tmp_path)
+
+        assert cache.size == 0
+
+    def test_load_ignores_invalid_entry_schema(self, tmp_path: Path) -> None:
+        cache_path = tmp_path / CACHE_DIR / CACHE_FILE
+        cache_path.parent.mkdir(parents=True)
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "entries": {
+                        "bad": {"results": [1, 2]},
+                        "ok": {"results": ["match"], "last_access": "bad"},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cache = GrepCache()
+        cache.load(tmp_path)
+
+        assert cache.size == 1
+        assert cache.get("ok") == ["match"]
+
 
 class TestCachedSearch:
     def _finding(
@@ -310,7 +404,7 @@ class TestCachedSearch:
     def test_uses_name_fallback(self) -> None:
         cache = GrepCache()
         finding = {"name": "fallback_name", "full_name": "m.f", "type": "class"}
-        result = cache.cached_search("strat", finding, "h", lambda: ["ok"])
+        cache.cached_search("strat", finding, "h", lambda: ["ok"])
         key = _make_key("strat", "fallback_name", "m.f", "class", "h")
         assert cache.get(key) == ["ok"]
 


### PR DESCRIPTION
## Summary

  - reject symlinked grep cache files and cache directories
  - enforce resolved-path containment under the project cache directory
  - load cache data with no-follow open where available, size limits, and schema validation
  - save cache data through a no-follow temporary file followed by atomic replace

## Tests

  - `pytest test/test_grep_cache.py test/test_grep_verify.py`
  - `pytest test/test_analyzer.py test/test_cli.py`