### PR TITLE
fix(secrets): contain config file scans

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -303,6 +303,23 @@ def _is_secret_config_candidate(path: Path) -> bool:
     return path.suffix.lower() in _SECRET_CONFIG_SUFFIXES
 
 
+def _resolve_secret_config_candidate(path: Path, root: Path) -> Path | None:
+    candidate = Path(path)
+    if candidate.is_symlink():
+        return None
+    if not _is_secret_config_candidate(candidate):
+        return None
+    try:
+        resolved_root = Path(root).resolve(strict=True)
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
 _GREP_VERIFY_TYPE_PRIORITY = {
     "method": 0,
     "function": 1,
@@ -2205,27 +2222,24 @@ class Skylos:
                     for raw_path in changed_files:
                         cfg_file = Path(raw_path)
                         if not cfg_file.is_absolute():
-                            cfg_file = (root / cfg_file).resolve()
-                        else:
-                            cfg_file = cfg_file.resolve()
+                            cfg_file = root / cfg_file
                         cfg_candidates.append(cfg_file)
                 else:
                     cfg_candidates = root.rglob("*")
 
                 for cfg_file in cfg_candidates:
                     cfg_file = Path(cfg_file)
-                    if not cfg_file.is_file():
+                    resolved_cfg = _resolve_secret_config_candidate(cfg_file, root)
+                    if resolved_cfg is None:
                         continue
-                    if not _is_secret_config_candidate(cfg_file):
-                        continue
-                    if str(cfg_file.resolve()) in scanned:
-                        continue
-                    if any(ex in cfg_file.parts for ex in (exclude_folders or [])):
+                    if str(resolved_cfg) in scanned:
                         continue
                     try:
-                        src = cfg_file.read_text(encoding="utf-8", errors="ignore")
+                        rel = str(resolved_cfg.relative_to(root))
+                        if any(ex in Path(rel).parts for ex in (exclude_folders or [])):
+                            continue
+                        src = resolved_cfg.read_text(encoding="utf-8", errors="ignore")
                         src_lines = src.splitlines(True)
-                        rel = str(cfg_file.relative_to(root))
                         ctx = {"relpath": rel, "lines": src_lines, "tree": None}
                         findings = list(_secrets_scan_ctx(ctx))
                         if findings:

--- a/skylos/api_snippets.py
+++ b/skylos/api_snippets.py
@@ -10,7 +10,10 @@ def _resolve_snippet_path(file_abs, repo_root=None) -> Path | None:
     if not file_abs:
         return None
     try:
-        candidate = Path(file_abs).resolve()
+        raw_candidate = Path(file_abs)
+        if raw_candidate.is_symlink():
+            return None
+        candidate = raw_candidate.resolve()
         if repo_root:
             root = Path(repo_root).resolve()
             try:

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -2433,6 +2433,58 @@ def test_changed_files_scans_dotenv_for_secrets(tmp_path):
     assert ".env" in scanned
 
 
+def test_config_secret_scan_skips_symlink_targets_outside_root(tmp_path):
+    (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    outside_secret = tmp_path.parent / "outside_secret"
+    outside_secret.write_text("AWS_SECRET_ACCESS_KEY=OUTSIDE\n", encoding="utf-8")
+    link = tmp_path / "config.yaml"
+    try:
+        link.symlink_to(outside_secret)
+    except OSError:
+        pytest.skip("symlinks are not supported on this filesystem")
+
+    scanned = []
+
+    def fake_secret_scan(ctx):
+        scanned.append((ctx["relpath"], "".join(ctx["lines"])))
+        return []
+
+    with patch("skylos.analyzer._secrets_scan_ctx", side_effect=fake_secret_scan):
+        json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
+
+    assert all(rel != "config.yaml" for rel, _ in scanned)
+    assert all("OUTSIDE" not in text for _, text in scanned)
+
+
+def test_changed_files_secret_scan_skips_symlink_targets_outside_root(tmp_path):
+    (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    outside_secret = tmp_path.parent / "outside_changed_secret"
+    outside_secret.write_text("AWS_SECRET_ACCESS_KEY=OUTSIDE_CHANGED\n", encoding="utf-8")
+    link = tmp_path / "config.yaml"
+    try:
+        link.symlink_to(outside_secret)
+    except OSError:
+        pytest.skip("symlinks are not supported on this filesystem")
+
+    scanned = []
+
+    def fake_secret_scan(ctx):
+        scanned.append((ctx["relpath"], "".join(ctx["lines"])))
+        return []
+
+    with patch("skylos.analyzer._secrets_scan_ctx", side_effect=fake_secret_scan):
+        json.loads(
+            analyze(
+                str(tmp_path),
+                enable_secrets=True,
+                changed_files={str(link)},
+                grep_verify=False,
+            )
+        )
+
+    assert scanned == []
+
+
 class TestRepoPhantomReferences:
     def test_resolve_analysis_root_ignores_home_git_root_without_project_marker(
         self, tmp_path, monkeypatch

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -352,6 +352,23 @@ class TestSkylosApi(unittest.TestCase):
                 extract_snippet(str(outside), 1, context=0, repo_root=str(repo))
             )
 
+    def test_extract_snippet_rejects_symlink_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = api.Path(td) / "repo"
+            outside = api.Path(td) / "outside.txt"
+            link = repo / "link.txt"
+            repo.mkdir()
+            outside.write_text("outside-secret\n", encoding="utf-8")
+            try:
+                link.symlink_to(outside)
+            except OSError:
+                self.skipTest("symlinks are not supported on this filesystem")
+
+            self.assertIsNone(extract_snippet(str(link), 1, context=0))
+            self.assertIsNone(
+                extract_snippet(str(link), 1, context=0, repo_root=str(repo))
+            )
+
     @patch("skylos.api.get_project_token")
     @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
     @patch("skylos.api.get_git_root", return_value=None)


### PR DESCRIPTION
## Summary
  - reject symlinked config files in the secrets scan path
  - require config secret candidates to resolve inside the requested scan root before reading
  - apply the same containment guard to `changed_files` secrets scans
  - prevent upload snippet extraction from dereferencing symlink paths

## Tests
  - `pytest -q test/test_analyzer.py test/test_api.py`