### PR TITLE
fix(audit): contain audit file discovery

### DIFF
--- a/skylos/audit/candidates.py
+++ b/skylos/audit/candidates.py
@@ -218,6 +218,23 @@ def _project_root(path: str | Path) -> Path:
     return target.parent if target.is_file() else target
 
 
+def _resolve_audit_file(path: Path, project_root: Path) -> Path | None:
+    candidate = Path(path)
+    if candidate.is_symlink():
+        return None
+    if not _is_audit_file(candidate):
+        return None
+    try:
+        root = project_root.resolve(strict=True)
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
 def _discover_audit_files(
     path: str | Path,
     *,
@@ -239,8 +256,9 @@ def _discover_audit_files(
                 continue
             if _is_excluded_output_path(candidate, project_root, excluded_paths):
                 continue
-            if _is_audit_file(candidate) and candidate.exists():
-                files.append(candidate.resolve())
+            resolved = _resolve_audit_file(candidate, project_root)
+            if resolved is not None:
+                files.append(resolved)
         return sorted(set(files))
 
     discovered = discover_source_files(
@@ -251,25 +269,27 @@ def _discover_audit_files(
     target = Path(path).resolve()
     root = target.parent if target.is_file() else target
     if target.is_file():
+        resolved_target = _resolve_audit_file(target, project_root)
         if (
-            _is_audit_file(target)
+            resolved_target is not None
             and not should_exclude_path(target, root, exclude_folders)
             and not _is_excluded_output_path(target, project_root, excluded_paths)
         ):
-            discovered.append(target)
+            discovered.append(resolved_target)
     else:
         for env_file in target.rglob(".env*"):
-            if not _is_audit_file(env_file):
-                continue
             if should_exclude_path(env_file, target, exclude_folders):
                 continue
             if _is_excluded_output_path(env_file, project_root, excluded_paths):
                 continue
-            discovered.append(env_file.resolve())
+            resolved_env = _resolve_audit_file(env_file, project_root)
+            if resolved_env is not None:
+                discovered.append(resolved_env)
     return sorted(
         {
-            file_path.resolve()
+            resolved
             for file_path in discovered
+            if (resolved := _resolve_audit_file(file_path, project_root)) is not None
             if not _is_excluded_output_path(file_path, project_root, excluded_paths)
         }
     )

--- a/test/test_audit_candidates.py
+++ b/test/test_audit_candidates.py
@@ -100,6 +100,71 @@ def test_scan_deep_audit_candidates_detects_env_variant_secret(tmp_path: Path):
     assert any(candidate.rule_id == "SKY-S101" for candidate in record.candidates)
 
 
+def test_scan_deep_audit_candidates_skips_symlinked_audit_files(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    py_secret = outside / "py_secret"
+    env_secret = outside / "env_secret"
+    py_secret.write_text("PY_OUTSIDE\n", encoding="utf-8")
+    env_secret.write_text("AWS_SECRET_ACCESS_KEY=ENV_OUTSIDE\n", encoding="utf-8")
+    try:
+        (repo / "leak.py").symlink_to(py_secret)
+        (repo / ".env").symlink_to(env_secret)
+    except OSError:
+        pytest.skip("symlinks are not supported on this filesystem")
+
+    seen = {}
+
+    def fake_static(files, **kwargs):
+        seen["files"] = list(files)
+        return {"danger": [], "secrets": []}
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+
+    assert summary.files_scanned == 0
+    assert seen["files"] == []
+    assert store.iter_file_records() == []
+
+
+def test_scan_deep_audit_candidates_changed_files_skip_symlinked_audit_files(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    env_secret = outside / "env_secret"
+    env_secret.write_text("AWS_SECRET_ACCESS_KEY=ENV_CHANGED_OUTSIDE\n", encoding="utf-8")
+    link = repo / ".env"
+    try:
+        link.symlink_to(env_secret)
+    except OSError:
+        pytest.skip("symlinks are not supported on this filesystem")
+
+    seen = {}
+
+    def fake_static(files, **kwargs):
+        seen["files"] = list(files)
+        return {"danger": [], "secrets": []}
+
+    monkeypatch.setattr(audit_candidates, "run_static_on_files", fake_static)
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(
+        repo,
+        changed_files=[link],
+    )
+
+    assert summary.files_scanned == 0
+    assert seen["files"] == []
+    assert store.iter_file_records() == []
+
+
 def test_scan_deep_audit_candidates_is_stable_across_reruns(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
  - require Deep Mode audit candidates to be non-symlink regular files inside the project root
  - apply the containment guard to changed-file audit inputs
  - apply the same guard to `.env*` audit discovery

## Tests
  - `pytest -q test/test_audit_candidates.py test/test_security_taskflow.py`
  - `pytest -q test/test_file_discovery.py test/test_llm_analyzer.py`
