### PR TITLE
fix(pipeline): contain LLM file inputs

### DIFF
--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -201,6 +201,51 @@ def _infer_root(path) -> Path:
     return Path.cwd().resolve()
 
 
+def _resolve_pipeline_file(
+    file_path,
+    project_root: Path,
+    *,
+    require_python: bool = False,
+) -> Path | None:
+    candidate = Path(file_path)
+    if not candidate.is_absolute():
+        candidate = Path(project_root) / candidate
+    if candidate.is_symlink():
+        return None
+    if require_python and candidate.suffix.lower() != ".py":
+        return None
+    try:
+        root = Path(project_root).resolve(strict=True)
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
+def _resolve_pipeline_files(
+    file_paths,
+    project_root: Path,
+    *,
+    require_python: bool = False,
+) -> list[Path]:
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for file_path in file_paths or []:
+        resolved = _resolve_pipeline_file(
+            file_path,
+            project_root,
+            require_python=require_python,
+        )
+        if resolved is None or resolved in seen:
+            continue
+        seen.add(resolved)
+        files.append(resolved)
+    return files
+
+
 def _is_high_signal_python_file(file_path: Path) -> bool:
     normalized = str(file_path).lower().replace("\\", "/")
     basename = file_path.name.lower()
@@ -279,7 +324,14 @@ def run_static_on_files(
         project_root = _infer_root(files[0])
 
     project_root_path = pathlib.Path(project_root).resolve()
-    target_files = {_norm(f) for f in files}
+    safe_files = (
+        _resolve_pipeline_files(files, project_root_path)
+        if project_root_path.exists()
+        else [Path(f) for f in files]
+    )
+    if not safe_files:
+        return _empty_result()
+    target_files = {_norm(f) for f in safe_files}
 
     def _norm_static_item_file(item_file):
         item_path = pathlib.Path(item_file or "")
@@ -368,7 +420,13 @@ def run_pipeline(
     if not path.exists():
         console.print(f"[bad]Path not found: {path}[/bad]")
         sys.exit(1)
-    root = _infer_root(path)
+    if path.is_symlink():
+        console.print(f"[warn]Skipping symlinked pipeline path: {path}[/warn]")
+        return []
+    root = path.resolve() if path.is_dir() else path.parent.resolve()
+    safe_changed_files = (
+        _resolve_pipeline_files(changed_files, root) if changed_files else None
+    )
 
     all_findings = []
     defs_map = {}
@@ -401,10 +459,10 @@ def run_pipeline(
             ) as progress:
                 task = progress.add_task("static analysis...", total=None)
 
-                if changed_files:
+                if safe_changed_files is not None:
                     static_result = run_static_on_files(
-                        changed_files,
-                        project_root=path if path.is_dir() else path.parent,
+                        [str(file_path) for file_path in safe_changed_files],
+                        project_root=root,
                         conf=10,
                         enable_secrets=True,
                         enable_danger=True,
@@ -479,20 +537,25 @@ def run_pipeline(
             console.print(f"[warn]Static analysis failed: {e}[/warn]")
 
     if path.is_file():
-        files = [path] if path.suffix.lower() == ".py" else []
-        source_cache_files = [path]
+        safe_path = _resolve_pipeline_file(path, root)
+        files = [safe_path] if safe_path and safe_path.suffix.lower() == ".py" else []
+        source_cache_files = [safe_path] if safe_path else []
     else:
         _exc = (
             set(exclude_folders)
             if exclude_folders
             else {"__pycache__", ".git", "venv", ".venv"}
         )
-        files = discover_source_files(path, [".py"], exclude_folders=_exc)
+        files = _resolve_pipeline_files(
+            discover_source_files(path, [".py"], exclude_folders=_exc),
+            root,
+            require_python=True,
+        )
         source_cache_files = files
 
-    if changed_files:
-        source_cache_files = changed_files
-        files = [f for f in changed_files if pathlib.Path(f).suffix.lower() == ".py"]
+    if safe_changed_files is not None:
+        source_cache_files = safe_changed_files
+        files = [f for f in safe_changed_files if f.suffix.lower() == ".py"]
 
     for f in source_cache_files:
         try:
@@ -511,7 +574,7 @@ def run_pipeline(
     phase_2b_files = _select_phase_2b_files(
         files,
         static_findings,
-        changed_files=changed_files,
+        changed_files=safe_changed_files,
         force_include_files=path.is_file(),
         review_index=review_index,
     )
@@ -674,8 +737,8 @@ def run_pipeline(
             ),
             parallel=True,
             max_workers=_max_workers,
-            smart_filter=not (path.is_file() or bool(changed_files)),
-            full_file_review=path.is_file() or bool(changed_files),
+            smart_filter=not (path.is_file() or bool(safe_changed_files)),
+            full_file_review=path.is_file() or bool(safe_changed_files),
             repo_context_map=phase_2b_repo_context,
             force_full_file_paths=force_full_file_paths,
         )
@@ -867,7 +930,7 @@ def run_pipeline(
                 "llm_audit_selected_files": len(phase_2b_files),
                 "llm_audit_total_python_files": len(files),
                 "llm_audit_skipped_files": max(0, len(files) - len(phase_2b_files)),
-                "changed_files_count": len(changed_files or []),
+                "changed_files_count": len(safe_changed_files or []),
                 "with_fixes": bool(getattr(agent_args, "with_fixes", False)),
                 "verification_mode": getattr(
                     agent_args, "verification_mode", "production"

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -1043,6 +1043,97 @@ class TestPipelinePhase2b:
         analyze_files_args = mock_llm.return_value.analyze_files.call_args[0][0]
         assert [str(f) for f in analyze_files_args] == [str(py_file)]
 
+    @patch(P_STATIC_FN, return_value=_empty_result())
+    @patch(P_PROGRESS)
+    @patch(P_LLM)
+    def test_changed_scan_skips_symlinked_python_files(
+        self, mock_llm, _prog, _static, tmp_path
+    ):
+        proj = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        proj.mkdir()
+        outside.mkdir()
+        (proj / "pyproject.toml").write_text("[project]\nname='demo'\n")
+        outside_secret = outside / "secret.py"
+        outside_secret.write_text("CANARY_OUTSIDE_SECRET\n", encoding="utf-8")
+        link = proj / "auth.py"
+        try:
+            link.symlink_to(outside_secret)
+        except OSError:
+            import pytest
+
+            pytest.skip("filesystem does not allow symlink creation")
+
+        mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+
+        run_pipeline(
+            path=str(proj),
+            model="t",
+            api_key="k",
+            agent_args=_agent_args(skip_verification=True),
+            console=_console(),
+            changed_files=[str(link)],
+        )
+
+        mock_llm.return_value.analyze_files.assert_not_called()
+
+    @patch(P_STATIC_FN, return_value=_empty_result())
+    @patch(P_PROGRESS)
+    @patch(P_LLM)
+    def test_changed_scan_skips_paths_outside_project_root(
+        self, mock_llm, _prog, _static, tmp_path
+    ):
+        proj = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        proj.mkdir()
+        outside.mkdir()
+        outside_file = outside / "auth.py"
+        outside_file.write_text("CANARY_OUTSIDE_SECRET\n", encoding="utf-8")
+        mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+
+        run_pipeline(
+            path=str(proj),
+            model="t",
+            api_key="k",
+            agent_args=_agent_args(skip_verification=True),
+            console=_console(),
+            changed_files=[str(outside_file)],
+        )
+
+        mock_llm.return_value.analyze_files.assert_not_called()
+
+    @patch(P_ANALYZE)
+    @patch(P_PROGRESS)
+    @patch(P_LLM)
+    def test_single_file_scan_skips_symlinked_python_file(
+        self, mock_llm, _prog, mock_analyze, tmp_path
+    ):
+        proj = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        proj.mkdir()
+        outside.mkdir()
+        outside_secret = outside / "secret.py"
+        outside_secret.write_text("CANARY_OUTSIDE_SECRET\n", encoding="utf-8")
+        link = proj / "review.py"
+        try:
+            link.symlink_to(outside_secret)
+        except OSError:
+            import pytest
+
+            pytest.skip("filesystem does not allow symlink creation")
+
+        findings = run_pipeline(
+            path=str(link),
+            model="t",
+            api_key="k",
+            agent_args=_agent_args(skip_verification=True),
+            console=_console(),
+        )
+
+        assert findings == []
+        mock_analyze.assert_not_called()
+        mock_llm.assert_not_called()
+
     @patch(P_ANALYZE)
     @patch(P_PROGRESS)
     @patch(P_LLM)


### PR DESCRIPTION
## Summary

  - add pipeline file containment for LLM-bound file inputs
  - reject symlinked pipeline paths before static scan, source caching, or LLM analysis
  - require `changed_files` to resolve inside the requested scan root
  - use the filtered file list for static changed-file scans, repo activation, source cache, and LLM selection

## Tests
  - `pytest test/test_pipeline.py`
  - `pytest test/test_file_discovery.py test/test_llm_analyzer.py test/test_security_taskflow.py`