### PR TITLE
fix(cli): gate coverage test execution

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -3073,42 +3073,53 @@ def _trace_subprocess_command(
     ]
 
 
+def _coverage_execution_allowed(args) -> bool:
+    return bool(getattr(args, "allow_coverage_execution", False))
+
+
 def _run_pre_analysis_steps(args, project_root, console):
     pytest_fixtures_ok = None
     trace_file_for_analysis = None
     quiet_output = _is_main_machine_output(args)
 
     if args.coverage:
-        if not quiet_output:
-            console.print("[brand]Running tests with coverage...[/brand]")
-
-        cmd = ["coverage", "run", "-m", "pytest", "-q"]
-        env = os.environ.copy()
-
-        if args.pytest_fixtures:
-            env["SKYLOS_UNUSED_FIXTURES_OUT"] = str(
-                project_root / ".skylos_unused_fixtures.json"
-            )
-            cmd += ["-p", "skylos.plugins.pytest_unused_fixtures"]
-
-        pytest_result = subprocess.run(
-            cmd,
-            cwd=project_root,
-            capture_output=True,
-            env=env,
-        )
-
-        if pytest_result.returncode != 0:
+        if not _coverage_execution_allowed(args):
             if not quiet_output:
-                console.print("[warn]pytest failed, trying unittest...[/warn]")
-            subprocess.run(
-                ["coverage", "run", "-m", "unittest", "discover"],
+                console.print(
+                    "[warn]Skipping --coverage test execution. "
+                    "Re-run with --allow-coverage-execution only for trusted repositories.[/warn]"
+                )
+        else:
+            if not quiet_output:
+                console.print("[brand]Running tests with coverage...[/brand]")
+
+            cmd = ["coverage", "run", "-m", "pytest", "-q"]
+            env = os.environ.copy()
+
+            if args.pytest_fixtures:
+                env["SKYLOS_UNUSED_FIXTURES_OUT"] = str(
+                    project_root / ".skylos_unused_fixtures.json"
+                )
+                cmd += ["-p", "skylos.plugins.pytest_unused_fixtures"]
+
+            pytest_result = subprocess.run(
+                cmd,
                 cwd=project_root,
                 capture_output=True,
+                env=env,
             )
 
-        if not quiet_output:
-            console.print("[good]Coverage data collected[/good]")
+            if pytest_result.returncode != 0:
+                if not quiet_output:
+                    console.print("[warn]pytest failed, trying unittest...[/warn]")
+                subprocess.run(
+                    ["coverage", "run", "-m", "unittest", "discover"],
+                    cwd=project_root,
+                    capture_output=True,
+                )
+
+            if not quiet_output:
+                console.print("[good]Coverage data collected[/good]")
 
     if args.trace:
         if not quiet_output:

--- a/skylos/cli_core/main_parser.py
+++ b/skylos/cli_core/main_parser.py
@@ -56,7 +56,18 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
     parser.add_argument(
         "--coverage",
         action="store_true",
-        help="Run tests with coverage before analysis",
+        help=(
+            "Use coverage data during analysis. Does not execute project tests unless "
+            "--allow-coverage-execution is also set."
+        ),
+    )
+    parser.add_argument(
+        "--allow-coverage-execution",
+        action="store_true",
+        help=(
+            "Allow --coverage to execute pytest/unittest in the target project. "
+            "Only use for trusted repositories."
+        ),
     )
     parser.add_argument(
         "--pytest-fixtures",

--- a/test/test_cli_coverage.py
+++ b/test/test_cli_coverage.py
@@ -13,7 +13,16 @@ class TestCoverageFlag:
         mock_analyze.return_value = '{"unused_functions": [], "unused_imports": [], "unused_classes": [], "unused_variables": [], "unused_parameters": [], "analysis_summary": {"total_files": 1}}'
 
         with patch.object(
-            sys, "argv", ["skylos", ".", "--coverage", "--json", "--no-provenance"]
+            sys,
+            "argv",
+            [
+                "skylos",
+                ".",
+                "--coverage",
+                "--allow-coverage-execution",
+                "--json",
+                "--no-provenance",
+            ],
         ):
             try:
                 main()
@@ -22,6 +31,30 @@ class TestCoverageFlag:
 
         calls = mock_run.call_args_list
         assert any("coverage" in str(call) and "pytest" in str(call) for call in calls)
+
+    @patch("skylos.cli.subprocess.run")
+    @patch("skylos.cli.run_analyze")
+    def test_coverage_skips_test_execution_without_trust_flag(
+        self, mock_analyze, mock_run
+    ):
+        """--coverage must not execute project tests unless the repo is trusted."""
+        from skylos.cli import main
+
+        mock_analyze.return_value = '{"unused_functions": [], "unused_imports": [], "unused_classes": [], "unused_variables": [], "unused_parameters": [], "analysis_summary": {"total_files": 1}}'
+
+        with patch.object(
+            sys, "argv", ["skylos", ".", "--coverage", "--json", "--no-provenance"]
+        ):
+            try:
+                main()
+            except SystemExit:
+                pass
+
+        coverage_calls = [
+            call for call in mock_run.call_args_list if "coverage" in str(call)
+        ]
+        assert coverage_calls == []
+        mock_analyze.assert_called_once()
 
     @patch("skylos.cli.subprocess.run")
     @patch("skylos.cli.run_analyze")
@@ -35,7 +68,16 @@ class TestCoverageFlag:
         mock_analyze.return_value = '{"unused_functions": [], "unused_imports": [], "unused_classes": [], "unused_variables": [], "unused_parameters": [], "analysis_summary": {"total_files": 1}}'
 
         with patch.object(
-            sys, "argv", ["skylos", ".", "--coverage", "--json", "--no-provenance"]
+            sys,
+            "argv",
+            [
+                "skylos",
+                ".",
+                "--coverage",
+                "--allow-coverage-execution",
+                "--json",
+                "--no-provenance",
+            ],
         ):
             try:
                 main()
@@ -68,7 +110,16 @@ class TestCoverageFlag:
         mock_analyze.side_effect = track_analyze
 
         with patch.object(
-            sys, "argv", ["skylos", ".", "--coverage", "--json", "--no-provenance"]
+            sys,
+            "argv",
+            [
+                "skylos",
+                ".",
+                "--coverage",
+                "--allow-coverage-execution",
+                "--json",
+                "--no-provenance",
+            ],
         ):
             try:
                 main()
@@ -89,7 +140,14 @@ class TestCoverageFlag:
         with patch.object(
             sys,
             "argv",
-            ["skylos", "/some/project", "--coverage", "--json", "--no-provenance"],
+            [
+                "skylos",
+                "/some/project",
+                "--coverage",
+                "--allow-coverage-execution",
+                "--json",
+                "--no-provenance",
+            ],
         ):
             try:
                 main()
@@ -132,7 +190,15 @@ class TestCoverageFlag:
         with patch.object(
             sys,
             "argv",
-            ["skylos", ".", "--coverage", "--danger", "--json", "--no-provenance"],
+            [
+                "skylos",
+                ".",
+                "--coverage",
+                "--allow-coverage-execution",
+                "--danger",
+                "--json",
+                "--no-provenance",
+            ],
         ):
             try:
                 main()
@@ -161,7 +227,16 @@ class TestCoverageIntegration:
 
         with patch.object(Path, "exists", return_value=True):
             with patch.object(
-                sys, "argv", ["skylos", ".", "--coverage", "--json", "--no-provenance"]
+                sys,
+                "argv",
+                [
+                    "skylos",
+                    ".",
+                    "--coverage",
+                    "--allow-coverage-execution",
+                    "--json",
+                    "--no-provenance",
+                ],
             ):
                 try:
                     main()

--- a/test/test_cli_uncovered_paths.py
+++ b/test/test_cli_uncovered_paths.py
@@ -463,7 +463,7 @@ def test_main_writes_sarif_and_prints_json(tmp_path, monkeypatch):
         patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
         patch("skylos.cli.SarifExporter") as SarifExporter,
         patch("builtins.print") as p,
-        patch("builtins.open", create=True) as mock_open,
+        patch("builtins.open", create=True),
     ):
         exp = Mock()
         exp.generate = Mock(return_value={"runs": [{}]})
@@ -490,7 +490,13 @@ def test_shorten_path_returns_absolute_when_outside_cwd(tmp_path, monkeypatch):
 
 
 def test_main_coverage_runs_pytest_then_unittest_on_failure(tmp_path, monkeypatch):
-    test_args = ["skylos", str(tmp_path), "--coverage", "--json"]
+    test_args = [
+        "skylos",
+        str(tmp_path),
+        "--coverage",
+        "--allow-coverage-execution",
+        "--json",
+    ]
     monkeypatch.setattr(sys, "argv", test_args)
 
     result = {


### PR DESCRIPTION
## Summary

  - make `--coverage` non-executing by default so scans do not run repository-controlled pytest/unittest code
  - add `--allow-coverage-execution` for explicitly trusted repositories
  - keep the existing coverage collection path available only behind that opt-in

## Tests

  - `pytest test/test_cli_coverage.py`