### PR TITLE
fix(vscode): harden hover markdown

### DIFF
--- a/editors/vscode/out/hover.js
+++ b/editors/vscode/out/hover.js
@@ -18,17 +18,28 @@ class SkylosHoverProvider {
         const parts = [];
         for (const f of lineFindings) {
             const md = new vscode.MarkdownString();
-            md.supportHtml = true;
-            md.isTrusted = true;
+            md.supportHtml = false;
+            md.isTrusted = false;
             const sevEmoji = getSeverityEmoji(f.severity);
             const meta = (0, rules_1.getRuleMeta)(f.ruleId);
             const ruleName = meta?.name ?? f.ruleId;
-            md.appendMarkdown(`### ${sevEmoji} ${f.ruleId} — ${ruleName}\n\n`);
-            md.appendMarkdown(`**Severity:** \`${f.severity}\`\n\n`);
-            md.appendMarkdown(`**Source:** \`${(0, provenanceCore_1.provenanceLabel)(f)}\`\n\n`);
-            md.appendMarkdown(`${f.message}\n\n`);
+            md.appendMarkdown(`### ${sevEmoji} `);
+            md.appendText(f.ruleId);
+            md.appendMarkdown(" — ");
+            md.appendText(ruleName);
+            md.appendMarkdown("\n\n");
+            md.appendMarkdown("**Severity:** ");
+            md.appendText(f.severity);
+            md.appendMarkdown("\n\n");
+            md.appendMarkdown("**Source:** ");
+            md.appendText((0, provenanceCore_1.provenanceLabel)(f));
+            md.appendMarkdown("\n\n");
+            md.appendText(f.message);
+            md.appendMarkdown("\n\n");
             if (meta?.description) {
-                md.appendMarkdown(`*${meta.description}*\n\n`);
+                md.appendMarkdown("*");
+                md.appendText(meta.description);
+                md.appendMarkdown("*\n\n");
             }
             if (f.confidence !== undefined) {
                 md.appendMarkdown(`**Confidence:** ${f.confidence}%\n\n`);
@@ -41,10 +52,14 @@ class SkylosHoverProvider {
             if (meta?.pciDss)
                 refs.push(`PCI DSS ${meta.pciDss}`);
             if (refs.length > 0) {
-                md.appendMarkdown(`**References:** ${refs.join(" | ")}\n\n`);
+                md.appendMarkdown("**References:** ");
+                md.appendText(refs.join(" | "));
+                md.appendMarkdown("\n\n");
             }
             if (meta?.fix) {
-                md.appendMarkdown(`**Fix:** ${meta.fix}\n\n`);
+                md.appendMarkdown("**Fix:** ");
+                md.appendText(meta.fix);
+                md.appendMarkdown("\n\n");
             }
             md.appendMarkdown("---\n");
             parts.push(md);

--- a/editors/vscode/src/hover.ts
+++ b/editors/vscode/src/hover.ts
@@ -20,20 +20,31 @@ export class SkylosHoverProvider implements vscode.HoverProvider {
 
     for (const f of lineFindings) {
       const md = new vscode.MarkdownString();
-      md.supportHtml = true;
-      md.isTrusted = true;
+      md.supportHtml = false;
+      md.isTrusted = false;
 
       const sevEmoji = getSeverityEmoji(f.severity);
       const meta = getRuleMeta(f.ruleId);
       const ruleName = meta?.name ?? f.ruleId;
 
-      md.appendMarkdown(`### ${sevEmoji} ${f.ruleId} — ${ruleName}\n\n`);
-      md.appendMarkdown(`**Severity:** \`${f.severity}\`\n\n`);
-      md.appendMarkdown(`**Source:** \`${provenanceLabel(f)}\`\n\n`);
-      md.appendMarkdown(`${f.message}\n\n`);
+      md.appendMarkdown(`### ${sevEmoji} `);
+      md.appendText(f.ruleId);
+      md.appendMarkdown(" — ");
+      md.appendText(ruleName);
+      md.appendMarkdown("\n\n");
+      md.appendMarkdown("**Severity:** ");
+      md.appendText(f.severity);
+      md.appendMarkdown("\n\n");
+      md.appendMarkdown("**Source:** ");
+      md.appendText(provenanceLabel(f));
+      md.appendMarkdown("\n\n");
+      md.appendText(f.message);
+      md.appendMarkdown("\n\n");
 
       if (meta?.description) {
-        md.appendMarkdown(`*${meta.description}*\n\n`);
+        md.appendMarkdown("*");
+        md.appendText(meta.description);
+        md.appendMarkdown("*\n\n");
       }
 
       if (f.confidence !== undefined) {
@@ -45,11 +56,15 @@ export class SkylosHoverProvider implements vscode.HoverProvider {
       if (meta?.cwe) refs.push(meta.cwe);
       if (meta?.pciDss) refs.push(`PCI DSS ${meta.pciDss}`);
       if (refs.length > 0) {
-        md.appendMarkdown(`**References:** ${refs.join(" | ")}\n\n`);
+        md.appendMarkdown("**References:** ");
+        md.appendText(refs.join(" | "));
+        md.appendMarkdown("\n\n");
       }
 
       if (meta?.fix) {
-        md.appendMarkdown(`**Fix:** ${meta.fix}\n\n`);
+        md.appendMarkdown("**Fix:** ");
+        md.appendText(meta.fix);
+        md.appendMarkdown("\n\n");
       }
 
       md.appendMarkdown("---\n");

--- a/editors/vscode/test/hoverSecurity.test.js
+++ b/editors/vscode/test/hoverSecurity.test.js
@@ -1,0 +1,19 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+function readHoverSource() {
+  return fs.readFileSync(path.join(__dirname, "..", "src", "hover.ts"), "utf8");
+}
+
+test("hover markdown does not trust repo-controlled finding text", () => {
+  const source = readHoverSource();
+
+  assert.doesNotMatch(source, /md\.isTrusted\s*=\s*true/);
+  assert.match(source, /md\.isTrusted\s*=\s*false/);
+  assert.match(source, /md\.supportHtml\s*=\s*false/);
+  assert.doesNotMatch(source, /appendMarkdown\(`\$\{f\.message\}/);
+  assert.doesNotMatch(source, /appendMarkdown\([^)]*f\.message/);
+  assert.match(source, /md\.appendText\(f\.message\)/);
+});


### PR DESCRIPTION
## Summary
  - disable trusted Markdown and HTML support in VS Code finding hovers
  - render finding-controlled text with `appendText()` instead of unescaped `appendMarkdown()`
  - keep hover formatting for static labels while preventing repo-controlled `command:` links from becoming active

  ## Validation
  - Confirmed `.skylos/agent_state.json` automation messages flow into hover findings
  - Confirmed the hover previously used `md.isTrusted = true` with unescaped finding messages
  - `npm test` in `editors/vscode`