### PR TITLE
fix(api): validate artifact upload destinations

### DIFF
--- a/skylos/api_artifacts.py
+++ b/skylos/api_artifacts.py
@@ -193,6 +193,7 @@ def upload_artifact(
                         data=handle,
                         headers=req_headers,
                         timeout=timeout,
+                        allow_redirects=False,
                     )
                 elif method == "POST":
                     file_field = instruction.get("file_field") or "file"
@@ -209,6 +210,7 @@ def upload_artifact(
                         },
                         headers=headers,
                         timeout=timeout,
+                        allow_redirects=False,
                     )
                 else:
                     return {

--- a/skylos/api_urls.py
+++ b/skylos/api_urls.py
@@ -1,16 +1,27 @@
 import ipaddress
+import os
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
 __all__ = [
     "_append_query_param",
+    "_artifact_upload_host_allowed",
     "_host_is_private_or_metadata",
     "_normalize_http_url",
     "_validate_api_request_url",
     "_validate_artifact_upload_url",
     "_validate_github_oidc_request_url",
 ]
+
+
+_ARTIFACT_UPLOAD_HOST_ALLOWLIST_ENV = "SKYLOS_ARTIFACT_UPLOAD_HOST_ALLOWLIST"
+_DEFAULT_ARTIFACT_UPLOAD_HOST_ALLOWLIST = frozenset(
+    {
+        "skylos.dev",
+        "*.skylos.dev",
+    }
+)
 
 
 def _normalize_http_url(
@@ -41,6 +52,37 @@ def _normalize_http_url(
             parsed.fragment,
         )
     )
+
+
+def _artifact_upload_host_patterns() -> tuple[str, ...]:
+    patterns = list(sorted(_DEFAULT_ARTIFACT_UPLOAD_HOST_ALLOWLIST))
+    configured = os.getenv(_ARTIFACT_UPLOAD_HOST_ALLOWLIST_ENV, "").strip()
+    if not configured:
+        return tuple(patterns)
+    for item in configured.split(","):
+        pattern = item.strip().lower().rstrip(".")
+        if not pattern:
+            continue
+        if "://" in pattern:
+            pattern = (urlsplit(pattern).hostname or "").rstrip(".").lower()
+        if pattern:
+            patterns.append(pattern)
+    return tuple(patterns)
+
+
+def _artifact_upload_host_allowed(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    host = hostname.rstrip(".").lower()
+    for pattern in _artifact_upload_host_patterns():
+        if pattern.startswith("*."):
+            suffix = pattern[1:]
+            if host.endswith(suffix) and host != suffix.lstrip("."):
+                return True
+            continue
+        if pattern == host:
+            return True
+    return False
 
 
 def _host_is_private_or_metadata(hostname: str | None) -> bool:
@@ -81,6 +123,8 @@ def _validate_artifact_upload_url(url: Any) -> str:
     parsed = urlsplit(safe_url)
     if _host_is_private_or_metadata(parsed.hostname):
         raise ValueError("upload URL host is not allowed")
+    if not _artifact_upload_host_allowed(parsed.hostname):
+        raise ValueError("upload URL host is not in the artifact upload allowlist")
     return safe_url
 
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -763,7 +763,7 @@ class TestSkylosApi(unittest.TestCase):
                     "key": "scan-key",
                     "upload": {
                         "method": "PUT",
-                        "url": "https://upload.example.com/report",
+                        "url": "https://uploads.skylos.dev/report",
                         "headers": {"x-test": "1"},
                     },
                 },
@@ -772,7 +772,7 @@ class TestSkylosApi(unittest.TestCase):
                     "key": "definitions-key",
                     "upload": {
                         "method": "PUT",
-                        "url": "https://upload.example.com/definitions",
+                        "url": "https://uploads.skylos.dev/definitions",
                     },
                 },
             },
@@ -816,6 +816,8 @@ class TestSkylosApi(unittest.TestCase):
         self.assertEqual(
             mock_post.call_args_list[1].kwargs["timeout"], api.UPLOAD_TIMEOUT
         )
+        for call in mock_put.call_args_list:
+            self.assertIs(call.kwargs["allow_redirects"], False)
 
         init_payload = mock_post.call_args_list[0].kwargs["json"]
         self.assertEqual(init_payload["upload_protocol_version"], 1)
@@ -880,7 +882,7 @@ class TestSkylosApi(unittest.TestCase):
                     "artifact_id": "artifact-defs",
                     "upload": {
                         "method": "PUT",
-                        "url": "https://upload.example.com/definitions",
+                        "url": "https://uploads.skylos.dev/definitions",
                     },
                 }
             },
@@ -932,14 +934,14 @@ class TestSkylosApi(unittest.TestCase):
                     "artifact_id": "artifact-scan",
                     "upload": {
                         "method": "PUT",
-                        "url": "https://upload.example.com/report",
+                        "url": "https://uploads.skylos.dev/report",
                     },
                 },
                 "definitions": {
                     "artifact_id": "artifact-defs",
                     "upload": {
                         "method": "PUT",
-                        "url": "https://upload.example.com/definitions",
+                        "url": "https://uploads.skylos.dev/definitions",
                     },
                 },
             },
@@ -1005,7 +1007,7 @@ class TestSkylosApi(unittest.TestCase):
                     "artifact_id": "artifact-scan",
                     "upload": {
                         "method": "PUT",
-                        "url": "https://upload.example.com/report",
+                        "url": "https://uploads.skylos.dev/report",
                     },
                 }
             },
@@ -1183,7 +1185,7 @@ class TestSkylosApi(unittest.TestCase):
                 artifact,
                 {
                     "method": "POST",
-                    "url": "https://uploads.example.com/definitions",
+                    "url": "https://uploads.skylos.dev/definitions",
                     "fields": {"key": "artifact-key", "policy": "abc123"},
                     "file_field": "file",
                     "headers": {"x-extra": "1"},
@@ -1196,6 +1198,7 @@ class TestSkylosApi(unittest.TestCase):
         kwargs = mock_post.call_args.kwargs
         self.assertEqual(kwargs["data"]["key"], "artifact-key")
         self.assertEqual(kwargs["files"]["file"][0], "definitions.json.gz")
+        self.assertIs(kwargs["allow_redirects"], False)
 
     @patch("requests.put")
     def test_upload_artifact_rejects_private_upload_url(self, mock_put):
@@ -1224,6 +1227,75 @@ class TestSkylosApi(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertIn("Unsafe upload URL", result["error"])
         mock_put.assert_not_called()
+
+    @patch("requests.put")
+    def test_upload_artifact_rejects_unapproved_public_upload_url(self, mock_put):
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            handle.write(b"abc")
+            artifact_path = handle.name
+
+        artifact = api.UploadArtifact(
+            name="scan_report",
+            file_path=api.Path(artifact_path),
+            filename="scan-report.json.gz",
+            required=True,
+            content_type="application/json",
+            content_encoding="gzip",
+            size_bytes=3,
+            sha256="abc123",
+        )
+        try:
+            result = api.upload_artifact(
+                artifact,
+                {"method": "PUT", "url": "https://attacker.example/upload"},
+            )
+        finally:
+            artifact.cleanup()
+
+        self.assertFalse(result["success"])
+        self.assertIn("artifact upload allowlist", result["error"])
+        mock_put.assert_not_called()
+
+    @patch("requests.put")
+    def test_upload_artifact_accepts_configured_upload_host(self, mock_put):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.text = "OK"
+        mock_put.return_value = resp
+
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            handle.write(b"abc")
+            artifact_path = handle.name
+
+        artifact = api.UploadArtifact(
+            name="scan_report",
+            file_path=api.Path(artifact_path),
+            filename="scan-report.json.gz",
+            required=True,
+            content_type="application/json",
+            content_encoding="gzip",
+            size_bytes=3,
+            sha256="abc123",
+        )
+        try:
+            with patch.dict(
+                os.environ,
+                {"SKYLOS_ARTIFACT_UPLOAD_HOST_ALLOWLIST": "uploads.example.com"},
+                clear=False,
+            ):
+                result = api.upload_artifact(
+                    artifact,
+                    {"method": "PUT", "url": "https://uploads.example.com/report"},
+                )
+        finally:
+            artifact.cleanup()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            mock_put.call_args.args[0],
+            "https://uploads.example.com/report",
+        )
 
     @patch("requests.post")
     def test_post_json_with_retries_rejects_non_http_url(self, mock_post):


### PR DESCRIPTION
## Summary

  - restrict artifact upload URLs to HTTPS hosts on an allowlist
  - default artifact upload hosts to Skylos-controlled domains: `skylos.dev` and `*.skylos.dev`
  - add `SKYLOS_ARTIFACT_UPLOAD_HOST_ALLOWLIST` for self-hosted/custom upload hosts
  - disable redirects on artifact `PUT` and `POST` uploads so validated URLs cannot redirect to
  unvalidated destinations

## Tests

  - `pytest -test/test_api.py`