### PR TITLE
fix(login): require callback state

### DIFF
--- a/skylos/cloud/login.py
+++ b/skylos/cloud/login.py
@@ -165,7 +165,7 @@ def browser_login(console=None, base_url=None):
 
     if console:
         console.print("\n[bold]Opening browser to connect to Skylos Cloud...[/bold]")
-        console.print(f"[dim]If the browser doesn't open, visit:[/dim]")
+        console.print("[dim]If the browser doesn't open, visit:[/dim]")
         console.print(f"  {connect_url}\n")
     else:
         print("\nOpening browser to connect to Skylos Cloud...")
@@ -321,26 +321,26 @@ def get_current_connection(base_url=None):
 
 def _print_connected_result(result, console=None):
     if console:
-        console.print(f"\n[good]Connected to Skylos Cloud![/good]")
+        console.print("\n[good]Connected to Skylos Cloud![/good]")
         console.print(f"  Project:      {result.project_name}")
         console.print(f"  Organization: {result.org_name}")
         console.print(f"  Plan:         {result.plan.capitalize()}")
         if result.repo_subpath:
             console.print(f"  Project root: {result.repo_subpath}")
-        console.print(f"\n  Scans will auto-upload on every run.")
-        console.print(f"  Use [bold]--no-upload[/bold] to skip.")
+        console.print("\n  Scans will auto-upload on every run.")
+        console.print("  Use [bold]--no-upload[/bold] to skip.")
         console.print(
             f"\n  [dim]For MCP/AI agents: export SKYLOS_API_KEY={result.token}[/dim]"
         )
     else:
-        print(f"\nConnected to Skylos Cloud!")
+        print("\nConnected to Skylos Cloud!")
         print(f"  Project:      {result.project_name}")
         print(f"  Organization: {result.org_name}")
         print(f"  Plan:         {result.plan.capitalize()}")
         if result.repo_subpath:
             print(f"  Project root: {result.repo_subpath}")
-        print(f"\n  Scans will auto-upload on every run.")
-        print(f"  Use --no-upload to skip.")
+        print("\n  Scans will auto-upload on every run.")
+        print("  Use --no-upload to skip.")
         print(f"\n  For MCP/AI agents: export SKYLOS_API_KEY={result.token}")
 
 
@@ -402,7 +402,7 @@ def _parse_callback_request(path: str, *, expected_state: str | None):
 
     params = parse_qs(parsed.query)
     provided_state = params.get("state", [None])[0]
-    if expected_state and provided_state and provided_state != expected_state:
+    if expected_state and provided_state != expected_state:
         return "invalid_state", None
 
     error = params.get("error", [None])[0]

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -1,13 +1,21 @@
 from unittest.mock import Mock
 
-import pytest
-
 import skylos.cloud.login as loginmod
 
 
 def test_parse_callback_request_rejects_state_mismatch():
     outcome, payload = loginmod._parse_callback_request(
         "/callback?token=abc&project_id=proj_1&state=wrong",
+        expected_state="expected",
+    )
+
+    assert outcome == "invalid_state"
+    assert payload is None
+
+
+def test_parse_callback_request_rejects_missing_state_when_expected():
+    outcome, payload = loginmod._parse_callback_request(
+        "/callback?token=abc&project_id=proj_1",
         expected_state="expected",
     )
 


### PR DESCRIPTION
## Summary

  - require browser login callbacks to include the exact expected `state`
  - reject callbacks where `state` is missing while a login state is active
  - keep token verification through `whoami` before saving credentials
  - add regression coverage for missing-state callback rejection

  ## Validation

  - Confirmed post-fix that the same callback returns `invalid_state`
  - `pytest test/test_login.py test/test_sync.py`