### PR TITLE
fix(api): redact secret upload snippets

### DIFF
--- a/skylos/api_findings.py
+++ b/skylos/api_findings.py
@@ -43,6 +43,7 @@ def _normalize_findings(
     processed = []
     for item in items or []:
         finding = dict(item)
+        category_upper = category.upper()
 
         rid = (
             finding.get("rule_id")
@@ -99,7 +100,9 @@ def _normalize_findings(
                     finding.get("detail") or finding.get("msg") or "Issue"
                 )
 
-        if file_abs and line:
+        if category_upper == "SECRET":
+            finding.pop("snippet", None)
+        elif file_abs and line:
             finding["snippet"] = (
                 finding.get("snippet")
                 or extract_snippet(file_abs, line, repo_root=git_root)

--- a/skylos/api_payloads.py
+++ b/skylos/api_payloads.py
@@ -198,7 +198,7 @@ def _compact_upload_finding(
     tool_rule_id = finding.get("tool_rule_id")
     if tool_rule_id:
         compact["tool_rule_id"] = str(tool_rule_id)[:100]
-    if include_snippet:
+    if include_snippet and compact["category"] != "SECRET":
         snippet = _truncate_upload_text(finding.get("snippet"), 240)
         if snippet:
             compact["snippet"] = snippet

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -369,6 +369,41 @@ class TestSkylosApi(unittest.TestCase):
                 extract_snippet(str(link), 1, context=0, repo_root=str(repo))
             )
 
+    def test_secret_findings_do_not_upload_snippets(self):
+        raw_secret = 'token = "ghp_FULL_SECRET_TOKEN_ABCD"'
+        findings = api._normalize_result_sections(
+            {
+                "secrets": [
+                    {
+                        "file": "secret.py",
+                        "line": 1,
+                        "message": "masked preview ghp_...ABCD",
+                        "snippet": raw_secret,
+                    }
+                ]
+            },
+            api.UPLOAD_FINDING_SPECS,
+            None,
+            extract_metadata=True,
+        )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["category"], "SECRET")
+        self.assertNotIn("snippet", findings[0])
+
+        sarif = api.SarifExporter(findings).generate()
+        region = sarif["runs"][0]["results"][0]["locations"][0][
+            "physicalLocation"
+        ]["region"]
+        self.assertNotIn("snippet", region)
+
+        compatibility_payload = api._build_compatibility_inline_payload(
+            findings,
+            {"secrets": []},
+            {"commit_hash": "c", "branch": "b", "actor": "a"},
+        )
+        self.assertNotIn("snippet", compatibility_payload["findings"][0])
+
     @patch("skylos.api.get_project_token")
     @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
     @patch("skylos.api.get_git_root", return_value=None)


### PR DESCRIPTION
## Summary
  - omit snippets from SECRET findings during upload normalization
  - defensively skip SECRET snippets in compact compatibility upload payloads
  - keep existing root/symlink containment for generated snippets

## Tests
  - Confirmed post-fix that the same SECRET finding carries no snippet in those upload outputs
  - `pytest test/test_api.py`