### PR TITLE
fix(precommit): avoid module shadowing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,27 +8,8 @@ repos:
     hooks:
       - id: skylos-gate
         name: Skylos Staged Gate
-        entry: python -m skylos.cli
-        language: python
-        additional_dependencies:
-          - "inquirer>=3.0.3"
-          - "libcst>=1.8.2"
-          - "rich>=14.0.0"
-          - "textual>=1.0.0"
-          - "keyring>=25.6.0,!=3.4.2"
-          - "requests"
-          - "tree-sitter>=0.25.2"
-          - "tree-sitter-typescript>=0.23.2"
-          - "tree-sitter-go>=0.23.0"
-          - "tree-sitter-java>=0.23.0"
-          - "tree-sitter-php>=0.24.1"
-          - "tree-sitter-rust>=0.24.2"
-          - "tomli>=2.0.1; python_version < '3.11'"
-          - "pyyaml"
-          - "networkx"
-          - "pyperclip"
-          - "ca9>=0.1.0"
-          - "mcp>=1.0.0"
+        entry: skylos
+        language: system
         pass_filenames: false
         require_serial: true
         args: ["agent", "pre-commit", "."]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: skylos-scan
   name: skylos (report only)
-  entry: python -m skylos.cli
+  entry: skylos
   language: python
   types_or: [python]
   pass_filenames: false
@@ -9,9 +9,9 @@
 
 - id: skylos-defend
   name: skylos AI defense gate
-  entry: python -m skylos.cli defend
+  entry: skylos
   language: python
   types_or: [python]
   pass_filenames: false
   require_serial: true
-  args: [".", "--fail-on", "critical"]
+  args: ["defend", ".", "--fail-on", "critical"]

--- a/skylos/cloud/sync.py
+++ b/skylos/cloud/sync.py
@@ -634,29 +634,6 @@ def cmd_pull():
         sys.exit(1)
 
 
-PRECOMMIT_HOOK_DEPENDENCIES = [
-    "inquirer>=3.0.3",
-    "libcst>=1.8.2",
-    "rich>=14.0.0",
-    "textual>=1.0.0",
-    "keyring>=25.6.0,!=3.4.2",
-    "requests",
-    "tree-sitter>=0.25.2",
-    "tree-sitter-typescript>=0.23.2",
-    "tree-sitter-go>=0.23.0",
-    "tree-sitter-java>=0.23.0",
-    "tree-sitter-php>=0.24.1",
-    "tree-sitter-rust>=0.24.2",
-    "tree-sitter-dart-orchard>=0.3.2",
-    "tomli>=2.0.1; python_version < '3.11'",
-    "pyyaml",
-    "networkx",
-    "pyperclip",
-    "ca9>=0.1.0",
-    "mcp>=1.0.0",
-]
-
-
 def create_precommit_config():
     precommit_path = Path(".pre-commit-config.yaml")
 
@@ -664,11 +641,7 @@ def create_precommit_config():
         print("  ⚠️  .pre-commit-config.yaml already exists (skipping)")
         return False
 
-    dependency_lines = "\n".join(
-        f'          - "{dependency}"' for dependency in PRECOMMIT_HOOK_DEPENDENCIES
-    )
-
-    config_content = f"""# Skylos pre-commit configuration
+    config_content = """# Skylos pre-commit configuration
 # Fast staged-only local hook.
 # Checks security, secrets, and quality in staged source/config files.
 # Full repo and diff-aware enforcement runs in CI.
@@ -678,10 +651,8 @@ repos:
     hooks:
       - id: skylos-gate
         name: Skylos Staged Gate
-        entry: python -m skylos.cli
-        language: python
-        additional_dependencies:
-{dependency_lines}
+        entry: skylos
+        language: system
         pass_filenames: false
         require_serial: true
         args: ["agent", "pre-commit", "."]

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -608,16 +608,24 @@ def test_create_precommit_config_limits_gate_to_pre_commit(tmp_path, monkeypatch
     assert "Fast staged-only local hook." in content
     assert "Full repo and diff-aware enforcement runs in CI." in content
     assert "stages: [pre-commit]" in content
-    assert "entry: python -m skylos.cli" in content
-    assert "language: python" in content
-    assert "additional_dependencies:" in content
-    assert '- "rich>=14.0.0"' in content
-    assert '- "libcst>=1.8.2"' in content
-    assert '- "tree-sitter-php>=0.24.1"' in content
-    assert '- "tree-sitter-rust>=0.24.2"' in content
-    assert "- \"tomli>=2.0.1; python_version < '3.11'\"" in content
+    assert "entry: skylos" in content
+    assert "language: system" in content
+    assert "additional_dependencies:" not in content
+    assert "python -m skylos.cli" not in content
     assert 'args: ["agent", "pre-commit", "."]' in content
     assert "--gate" not in content
+
+
+def test_published_precommit_hooks_use_console_entrypoint():
+    content = Path(__file__).resolve().parents[1].joinpath(
+        ".pre-commit-hooks.yaml"
+    ).read_text(encoding="utf-8")
+    hooks = {hook["id"]: hook for hook in syncmod.yaml.safe_load(content)}
+
+    assert "python -m skylos.cli" not in content
+    assert hooks["skylos-scan"]["entry"] == "skylos"
+    assert hooks["skylos-defend"]["entry"] == "skylos"
+    assert hooks["skylos-defend"]["args"] == ["defend", ".", "--fail-on", "critical"]
 
 
 def test_cmd_setup_installs_shell_only_pre_push_hook(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
  - switch published pre-commit hooks from `python -m skylos.cli` to the installed `skylos` console entrypoint
  - move the `defend` subcommand into hook args so `skylos-defend` no longer resolves `skylos.cli` from the target repo
  - update generated local pre-commit config to use `entry: skylos` with `language: system`

## Tests
  - verified the fixed console-script path does not import the repo-local shadow module
  - `pytest test/test_sync.py`
  - `pre-commit validate-config .pre-commit-config.yaml`
  - `pre-commit validate-manifest .pre-commit-hooks.yaml`