### PR TITLE
fix(defend): require explicit policy files

### DIFF
--- a/skylos/commands/defend_cmd.py
+++ b/skylos/commands/defend_cmd.py
@@ -169,7 +169,8 @@ def run_defend_command(
 
     policy = None
     try:
-        policy = load_policy(def_args.policy_file)
+        if def_args.policy_file:
+            policy = load_policy(def_args.policy_file)
     except (FileNotFoundError, ValueError, ImportError) as e:
         console.print(f"[bold red]Policy error: {e}[/bold red]")
         return 1

--- a/skylos/core/suite.py
+++ b/skylos/core/suite.py
@@ -198,7 +198,7 @@ def run_suite(
 
     from skylos.debt import build_debt_snapshot
     from skylos.defend.engine import run_defense_checks
-    from skylos.defend.policy import compute_owasp_coverage, load_policy
+    from skylos.defend.policy import compute_owasp_coverage
     from skylos.defend.report import format_defense_json
     from skylos.discover.detector import _collect_ai_files, detect_integrations
 
@@ -307,7 +307,7 @@ def run_suite(
         except Exception as exc:
             provenance_section["error"] = str(exc)
 
-    policy = load_policy(None)
+    policy = None
 
     with progress_factory(
         SpinnerColumn(),

--- a/skylos/defend/policy.py
+++ b/skylos/defend/policy.py
@@ -64,23 +64,10 @@ class DefensePolicy:
 
 
 def load_policy(path: str | Path | None = None) -> Optional[DefensePolicy]:
-    if path is not None:
-        policy_path = Path(path)
-    else:
-        candidates = [
-            Path("skylos-defend.yaml"),
-            Path("skylos-defend.yml"),
-            Path(".skylos-defend.yaml"),
-            Path(".skylos-defend.yml"),
-        ]
-        policy_path = None
-        for candidate in candidates:
-            if candidate.exists():
-                policy_path = candidate
-                break
+    if path is None:
+        return None
 
-        if policy_path is None:
-            return None
+    policy_path = Path(path)
 
     if not policy_path.exists():
         raise FileNotFoundError(f"Policy file not found: {policy_path}")

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -714,6 +714,86 @@ def test_defend_command_rejects_invalid_owasp_version(tmp_path):
     assert "Unsupported OWASP version" in console.print.call_args.args[0]
 
 
+def test_defend_command_ignores_repo_policy_without_explicit_flag(tmp_path, monkeypatch):
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "app.py").write_text(
+        """
+import openai
+client = openai.OpenAI()
+
+def run():
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    return eval(response.choices[0].message.content)
+""",
+        encoding="utf-8",
+    )
+    (target / "skylos-defend.yaml").write_text(
+        "rules:\n  no-dangerous-sink:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+    console = Mock()
+    monkeypatch.chdir(target)
+
+    from skylos.commands.defend_cmd import run_defend_command
+
+    with patch("builtins.print"):
+        exit_code = run_defend_command(
+            [".", "--json", "--fail-on", "critical"],
+            console_factory=lambda: console,
+            progress_factory=lambda *args, **kwargs: _progress_ctx(),
+        )
+
+    assert exit_code == 1
+
+
+def test_defend_command_applies_policy_when_explicit(tmp_path, monkeypatch):
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "app.py").write_text(
+        """
+import openai
+client = openai.OpenAI()
+
+def run():
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    return eval(response.choices[0].message.content)
+""",
+        encoding="utf-8",
+    )
+    policy_path = target / "skylos-defend.yaml"
+    policy_path.write_text(
+        "rules:\n  no-dangerous-sink:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+    console = Mock()
+    monkeypatch.chdir(target)
+
+    from skylos.commands.defend_cmd import run_defend_command
+
+    with patch("builtins.print"):
+        exit_code = run_defend_command(
+            [
+                ".",
+                "--json",
+                "--fail-on",
+                "critical",
+                "--policy",
+                str(policy_path),
+            ],
+            console_factory=lambda: console,
+            progress_factory=lambda *args, **kwargs: _progress_ctx(),
+        )
+
+    assert exit_code == 0
+
+
 def test_defend_command_json_upload_formats_once(tmp_path):
     target = tmp_path / "repo"
     target.mkdir()

--- a/test/test_defend.py
+++ b/test/test_defend.py
@@ -552,6 +552,28 @@ class TestPolicy:
             finally:
                 os.chdir(orig)
 
+    def test_load_policy_does_not_discover_repo_local_file_by_default(self):
+        pytest.importorskip("yaml")
+
+        with tempfile.TemporaryDirectory() as d:
+            import os
+
+            policy_path = Path(d) / "skylos-defend.yaml"
+            policy_path.write_text(
+                "rules:\n  no-dangerous-sink:\n    enabled: false\n",
+                encoding="utf-8",
+            )
+
+            orig = os.getcwd()
+            os.chdir(d)
+            try:
+                assert load_policy() is None
+                explicit = load_policy(policy_path)
+                assert explicit is not None
+                assert explicit.rules["no-dangerous-sink"]["enabled"] is False
+            finally:
+                os.chdir(orig)
+
 
 class TestOWASPCoverage:
     def test_coverage_all_passing(self):


### PR DESCRIPTION
## Summary

  - stop `skylos defend` from auto-loading repository-local `skylos-defend.yaml`
  - require operators to pass `--policy` before policy rule overrides affect defense checks
  - remove implicit defend policy loading from the core suite path


## Tests

  - verified repo-local policy is ignored unless explicitly passed with `--policy`
  - `pytest -q test/test_defend.py test/test_cli_refactor_guardrails.py`
  - commit hook passed