### PR TITLE
fix(debt): contain advisor excerpts to project root

### DIFF
--- a/skylos/debt/advisor.py
+++ b/skylos/debt/advisor.py
@@ -79,6 +79,24 @@ def _safe_excerpt(path: Path, line: int, radius: int = 3, max_chars: int = 1200)
     return excerpt
 
 
+def _resolve_signal_path(project_root: Path, signal_file: str) -> Path | None:
+    if not signal_file:
+        return None
+
+    root = project_root.resolve()
+    candidate = Path(signal_file)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+
+    try:
+        resolved = candidate.resolve()
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+
+    return resolved
+
+
 def _signal_prompt_lines(hotspot: DebtHotspot) -> list[str]:
     lines = []
     for signal in hotspot.signals[:5]:
@@ -92,7 +110,9 @@ def _signal_prompt_lines(hotspot: DebtHotspot) -> list[str]:
 def _excerpt_sections(hotspot: DebtHotspot, *, project_root: Path) -> list[str]:
     sections = []
     for signal in hotspot.signals[:3]:
-        file_path = project_root / signal.file
+        file_path = _resolve_signal_path(project_root, signal.file)
+        if file_path is None:
+            continue
         excerpt = _safe_excerpt(file_path, signal.line)
         if excerpt:
             sections.append(f"[{signal.file}:{signal.line}]\n{excerpt}")

--- a/skylos/debt/engine.py
+++ b/skylos/debt/engine.py
@@ -58,12 +58,15 @@ def _project_root(path: Path) -> Path:
 def _relative_path(file_path: str, project_root: Path) -> str:
     if not file_path:
         return ""
+    root = project_root.resolve()
+    candidate = Path(file_path)
+    if not candidate.is_absolute():
+        candidate = root / candidate
     try:
-        return str(Path(file_path).resolve().relative_to(project_root)).replace(
-            "\\", "/"
-        )
-    except Exception:
-        return str(file_path).replace("\\", "/")
+        resolved = candidate.resolve()
+        return str(resolved.relative_to(root)).replace("\\", "/")
+    except (OSError, ValueError):
+        return ""
 
 
 def _normalize_changed_files(
@@ -72,7 +75,9 @@ def _normalize_changed_files(
 ) -> set[str]:
     normalized: set[str] = set()
     for file_path in changed_files or []:
-        normalized.add(_relative_path(str(file_path), project_root))
+        rel = _relative_path(str(file_path), project_root)
+        if rel:
+            normalized.add(rel)
     return normalized
 
 
@@ -186,10 +191,12 @@ def collect_debt_signals(
 ) -> list[DebtSignal]:
     signals: list[DebtSignal] = []
     changed = _normalize_changed_files(changed_files, project_root)
-    changed_only = bool(changed)
+    changed_only = bool(changed_files)
 
     for finding in result.get("quality", []) or []:
         file_path = _relative_path(str(finding.get("file") or ""), project_root)
+        if not file_path:
+            continue
         if changed_only and file_path not in changed:
             continue
         signals.append(_build_quality_signal(finding, file_path=file_path))
@@ -197,6 +204,8 @@ def collect_debt_signals(
     for category, rule_id in _DEAD_CODE_RULE_IDS.items():
         for item in result.get(category, []) or []:
             file_path = _relative_path(str(item.get("file") or ""), project_root)
+            if not file_path:
+                continue
             if changed_only and file_path not in changed:
                 continue
             signals.append(

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -129,6 +129,42 @@ def test_collect_debt_signals_maps_dimensions_and_dead_code():
     assert ("SKY-U001", "dead_code") in dimensions
 
 
+def test_collect_debt_signals_skips_paths_outside_project_root(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("def outside():\n    return True\n", encoding="utf-8")
+    result = {
+        "analysis_summary": {"total_files": 1, "total_loc": 2},
+        "quality": [
+            {
+                "rule_id": "SKY-Q301",
+                "severity": "HIGH",
+                "file": str(outside),
+                "line": 1,
+                "name": "outside",
+                "message": "Outside-root finding",
+            }
+        ],
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+    }
+
+    assert collect_debt_signals(result, project_root=root) == []
+
+    link = root / "leak.py"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        return
+
+    result["quality"][0]["file"] = str(link)
+    assert collect_debt_signals(result, project_root=root) == []
+
+
 def test_god_file_signal_becomes_modularity_debt_hotspot():
     result = {
         "analysis_summary": {"total_files": 1, "total_loc": 700},
@@ -172,6 +208,19 @@ def test_collect_debt_signals_filters_to_changed_files():
     assert len(signals) == 1
     assert signals[0].file == "app/services.py"
     assert signals[0].dimension == "complexity"
+
+
+def test_collect_debt_signals_ignores_invalid_changed_files(tmp_path):
+    outside = tmp_path / "outside.py"
+    outside.write_text("def outside():\n    return True\n", encoding="utf-8")
+
+    signals = collect_debt_signals(
+        SAMPLE_RESULT,
+        project_root=cli.Path("/repo"),
+        changed_files=[outside],
+    )
+
+    assert signals == []
 
 
 def test_run_debt_analysis_builds_snapshot():
@@ -434,6 +483,64 @@ def test_user_prompt_includes_signals_architecture_and_excerpt(tmp_path):
     assert "Architecture context:" in prompt
     assert "- mean_distance=1.2" in prompt
     assert "[app/services.py:20]" in prompt
+
+
+def test_debt_advisor_skips_outside_root_signal_excerpts(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("OUTSIDE_DEBT_CANARY = True\n", encoding="utf-8")
+    signal = DebtSignal(
+        fingerprint="complexity:SKY-Q301:outside.py:1:outside",
+        dimension="complexity",
+        rule_id="SKY-Q301",
+        severity="HIGH",
+        file=str(outside),
+        line=1,
+        subject="outside",
+        message="Outside-root debt signal",
+        points=14.0,
+    )
+    hotspot = DebtHotspot(
+        fingerprint="hotspot:outside.py",
+        file=str(outside),
+        score=14.0,
+        signal_count=1,
+        dimension_count=1,
+        primary_dimension="complexity",
+        signals=[signal],
+    )
+    advisor = _stub_debt_advisor(
+        json.dumps(
+            {
+                "summary": "Summary.",
+                "root_cause": "Root cause.",
+                "refactor_steps": [],
+                "remediation_notes": [],
+                "confidence": "medium",
+            }
+        )
+    )
+
+    advisory = advisor.summarize_hotspot(hotspot, project_root=root)
+    user_prompt = advisor.adapter.complete.call_args.args[1]
+
+    assert advisory is not None
+    assert "OUTSIDE_DEBT_CANARY" not in user_prompt
+    assert "No code excerpts available." in user_prompt
+
+    link = root / "leak.py"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        return
+
+    signal.file = "leak.py"
+    hotspot.file = "leak.py"
+    advisor.summarize_hotspot(hotspot, project_root=root)
+    user_prompt = advisor.adapter.complete.call_args.args[1]
+    assert "OUTSIDE_DEBT_CANARY" not in user_prompt
+    assert "No code excerpts available." in user_prompt
 
 
 def _stub_debt_advisor(payload: str, *, model: str = "gpt-4.1") -> DebtAdvisor:


### PR DESCRIPTION
## Summary
  - skip debt signals whose resolved paths are outside the project root
  - prevent debt advisor excerpts from following absolute paths or symlink escapes outside the scan root
  - keep invalid changed-file paths from broadening debt analysis scope

## Tests

  - verified the fixed advisor omits outside-root excerpts: `canary_in_prompt: False`
  - `pytest test/test_debt.py`