### PR TITLE
test(file-discovery): cover git symlink containment

### DIFF
--- a/test/test_file_discovery.py
+++ b/test/test_file_discovery.py
@@ -1,6 +1,13 @@
+import subprocess
 from pathlib import Path
 
-from skylos.core.file_discovery import discover_source_files, should_exclude_path
+import pytest
+
+from skylos.core.file_discovery import (
+    discover_source_files,
+    list_git_visible_files,
+    should_exclude_path,
+)
 
 
 def test_should_exclude_path_honors_sonar_style_globs(tmp_path: Path):
@@ -32,5 +39,31 @@ def test_discover_source_files_skips_symlinked_file_outside_root(tmp_path: Path)
         pytest.skip("filesystem does not allow symlink creation")
 
     files = discover_source_files(repo, [".py"], respect_gitignore=False)
+
+    assert files == []
+
+
+def test_discover_source_files_skips_git_visible_symlinked_target_outside_root(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "secret.py"
+    target.write_text("TOKEN = 'outside-secret'\n", encoding="utf-8")
+    link = repo / "leak"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("filesystem does not allow symlink creation")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "leak"], cwd=repo, check=True, capture_output=True)
+
+    git_files = list_git_visible_files(repo)
+    assert git_files == [repo / "leak"]
+
+    files = discover_source_files(repo, [".py"])
 
     assert files == []


### PR DESCRIPTION
## Summary

  - verify a symlink with a benign in-repo name is not accepted because its target has a source suffix
  - assert discovery keeps returning no outside-root source files for this case


## Tests

  - `pytest test/test_file_discovery.py`