### PR TITLE
fix(cli): sanitize pyproject addopts

### DIFF
--- a/skylos/cli_core/main_parser.py
+++ b/skylos/cli_core/main_parser.py
@@ -332,17 +332,17 @@ def parse_main_cli_args(
     *,
     addopts_loader: Callable[[], list[str]],
 ) -> argparse.Namespace:
-    effective_argv = list(argv)
-    addopts = addopts_loader()
-    if addopts:
-        effective_argv = addopts + effective_argv
+    user_argv = list(argv)
+    addopts = list(addopts_loader() or [])
+    if "--" in addopts:
+        addopts = addopts[: addopts.index("--")]
 
-    if "--" in effective_argv:
-        split = effective_argv.index("--")
-        main_argv = effective_argv[:split]
-        cmd_argv = effective_argv[split + 1 :]
+    if "--" in user_argv:
+        split = user_argv.index("--")
+        main_argv = addopts + user_argv[:split]
+        cmd_argv = user_argv[split + 1 :]
     else:
-        main_argv = effective_argv
+        main_argv = addopts + user_argv
         cmd_argv = []
 
     if cmd_argv:

--- a/skylos/core/cli_shared.py
+++ b/skylos/core/cli_shared.py
@@ -6,6 +6,125 @@ import shlex
 import subprocess
 from pathlib import Path
 
+_SAFE_ADDOPTS_FLAGS = frozenset(
+    {
+        "--json",
+        "--github",
+        "--summary",
+        "--tree",
+        "--verbose",
+        "-v",
+        "--strict",
+        "--no-default-excludes",
+        "--secrets",
+        "--danger",
+        "--quality",
+        "--sca",
+        "--all",
+        "-a",
+        "--no-grep-verify",
+        "--baseline",
+        "--provenance",
+        "--no-provenance",
+    }
+)
+
+_SAFE_ADDOPTS_VALUE_OPTIONS = frozenset(
+    {
+        "--format",
+        "--confidence",
+        "-c",
+        "--exclude-folder",
+        "--include-folder",
+        "--diff-base",
+        "--diff",
+        "--severity",
+        "--category",
+        "--file-filter",
+        "--limit",
+        "--provenance-base",
+    }
+)
+
+_SAFE_ADDOPTS_CHOICES = {
+    "--format": {"rich", "json", "llm", "github", "concise"},
+    "--severity": {"critical", "high", "medium", "low"},
+}
+
+
+def _coerce_addopts(addopts) -> list[str]:
+    if isinstance(addopts, str):
+        return shlex.split(addopts)
+    if isinstance(addopts, list):
+        return [str(item) for item in addopts]
+    return []
+
+
+def _is_safe_addopt_value(option: str, value: str) -> bool:
+    if value == "--":
+        return False
+
+    choices = _SAFE_ADDOPTS_CHOICES.get(option)
+    if choices is not None and value not in choices:
+        return False
+
+    if option in {"--confidence", "-c"}:
+        try:
+            confidence = int(value)
+        except ValueError:
+            return False
+        return 0 <= confidence <= 100
+
+    if option == "--limit":
+        try:
+            limit = int(value)
+        except ValueError:
+            return False
+        return limit >= 0
+
+    return True
+
+
+def sanitize_addopts(addopts) -> list[str]:
+    """Return pyproject addopts that cannot select paths or execution sinks."""
+
+    tokens = _coerce_addopts(addopts)
+    sanitized: list[str] = []
+    index = 0
+
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            break
+
+        if token in _SAFE_ADDOPTS_FLAGS:
+            sanitized.append(token)
+            index += 1
+            continue
+
+        if token in _SAFE_ADDOPTS_VALUE_OPTIONS:
+            if index + 1 >= len(tokens):
+                index += 1
+                continue
+            value = tokens[index + 1]
+            if _is_safe_addopt_value(token, value):
+                sanitized.extend([token, value])
+            index += 2
+            continue
+
+        if token.startswith("--") and "=" in token:
+            option, value = token.split("=", 1)
+            if option in _SAFE_ADDOPTS_VALUE_OPTIONS and _is_safe_addopt_value(
+                option, value
+            ):
+                sanitized.append(token)
+            index += 1
+            continue
+
+        index += 1
+
+    return sanitized
+
 
 def get_git_changed_files(
     root_path,
@@ -129,10 +248,7 @@ def load_addopts(start_path: Path | None = None):
                 with open(toml_path, "rb") as f:
                     data = tomllib.load(f)
                 addopts = data.get("tool", {}).get("skylos", {}).get("addopts", [])
-                if isinstance(addopts, str):
-                    return shlex.split(addopts)
-                if isinstance(addopts, list):
-                    return list(addopts)
+                return sanitize_addopts(addopts)
             except Exception:
                 pass
             break

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1383,6 +1383,57 @@ def test_main_command_exec_success_exits_zero(monkeypatch):
     assert len(echo_calls) == 1
 
 
+def test_main_ignores_pyproject_addopts_deployment_command(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.skylos]
+addopts = [".", "--", "sh", "-c", "touch SHOULD_NOT_RUN"]
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+
+    monkeypatch.setattr(cli.sys, "argv", ["skylos", "."])
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.render_results"),
+        patch("skylos.cli.print_badge"),
+        patch(
+            "skylos.cli.upload_report",
+            return_value={"success": False, "error": "No token found"},
+        ),
+        patch("skylos.cli.subprocess.Popen") as popen,
+        patch("skylos.api.get_project_token", return_value=None),
+    ):
+        cli.main()
+
+    dangerous_calls = [
+        call
+        for call in popen.call_args_list
+        if call.args and call.args[0] == ["sh", "-c", "touch SHOULD_NOT_RUN"]
+    ]
+    assert dangerous_calls == []
+
+
 def test_main_command_exec_failure_exits_with_code(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},

--- a/test/test_cli_addopts_safety.py
+++ b/test/test_cli_addopts_safety.py
@@ -1,0 +1,72 @@
+from skylos.cli_core.main_parser import build_main_parser, parse_main_cli_args
+from skylos.core.cli_shared import load_addopts, sanitize_addopts
+
+
+def test_load_addopts_rejects_pyproject_command_injection(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.skylos]
+addopts = [".", "--", "sh", "-c", "touch SHOULD_NOT_RUN"]
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert load_addopts() == []
+
+
+def test_sanitize_addopts_keeps_safe_scan_options_only():
+    assert sanitize_addopts(
+        [
+            "--json",
+            "--confidence",
+            "80",
+            "--severity=high",
+            "--exclude-folder",
+            "vendor",
+            "--trace",
+            "--coverage",
+            "--allow-coverage-execution",
+            "--pytest-fixtures",
+            "--upload",
+            "--force",
+            "-f",
+            "--output",
+            "/tmp/report.json",
+        ]
+    ) == [
+        "--json",
+        "--confidence",
+        "80",
+        "--severity=high",
+        "--exclude-folder",
+        "vendor",
+    ]
+
+
+def test_parse_main_cli_args_never_gets_command_from_addopts():
+    parser = build_main_parser(version="test")
+
+    args = parse_main_cli_args(
+        parser,
+        ["."],
+        addopts_loader=lambda: ["--json", "--", "sh", "-c", "id"],
+    )
+
+    assert args.json is True
+    assert args.path == ["."]
+    assert args.command == []
+
+
+def test_parse_main_cli_args_still_accepts_user_command_separator():
+    parser = build_main_parser(version="test")
+
+    args = parse_main_cli_args(
+        parser,
+        [".", "--", "echo", "ok"],
+        addopts_loader=lambda: ["--json"],
+    )
+
+    assert args.json is True
+    assert args.path == ["."]
+    assert args.command == ["echo", "ok"]


### PR DESCRIPTION
## Summary
  - sanitize `[tool.skylos].addopts` before merging pyproject options into CLI argv
  - prevent pyproject addopts from injecting `--` deployment commands, positional paths, upload/force flags, and test-execution flags
  - keep explicit user-supplied `skylos . -- <command>` behavior working

## Tests
  - `pytest .`