### PR TITLE
fix(vscode): trust executable configuration

### DIFF
--- a/editors/vscode/out/config.js
+++ b/editors/vscode/out/config.js
@@ -38,11 +38,12 @@ exports.isFixPreviewFirst = isFixPreviewFirst;
 exports.getPostFixCommand = getPostFixCommand;
 const vscode = require("vscode");
 const types_1 = require("./types");
+const configCore_1 = require("./configCore");
 function cfg() {
     return vscode.workspace.getConfiguration("skylos");
 }
 function getSkylosBin() {
-    return cfg().get("path", "skylos");
+    return (0, configCore_1.resolveTrustedExecutablePath)(cfg().inspect("path"), "skylos");
 }
 function getConfidenceThreshold() {
     return cfg().get("confidence", 80);
@@ -57,10 +58,10 @@ function isFeatureEnabled(feature) {
     return cfg().get(key, true);
 }
 function isRunOnSave() {
-    return cfg().get("runOnSave", true);
+    return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, cfg().get("runOnSave", true));
 }
 function isScanOnOpen() {
-    return cfg().get("scanOnOpen", true);
+    return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, cfg().get("scanOnOpen", true));
 }
 function isRealtimeAIEnabled() {
     return cfg().get("enableRealtimeAI", false);
@@ -102,10 +103,10 @@ function getCommandCenterLimit() {
     return cfg().get("commandCenterLimit", 10);
 }
 function isCommandCenterRefreshOnOpen() {
-    return cfg().get("commandCenterRefreshOnOpen", false);
+    return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, cfg().get("commandCenterRefreshOnOpen", false));
 }
 function isCommandCenterRefreshOnSave() {
-    return cfg().get("commandCenterRefreshOnSave", false);
+    return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, cfg().get("commandCenterRefreshOnSave", false));
 }
 function getCommandCenterStateFile() {
     return cfg().get("commandCenterStateFile", "").trim();

--- a/editors/vscode/out/configCore.js
+++ b/editors/vscode/out/configCore.js
@@ -1,8 +1,22 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.shouldWarnMissingLocalAI = shouldWarnMissingLocalAI;
+exports.resolveTrustedExecutablePath = resolveTrustedExecutablePath;
+exports.shouldRunWorkspaceAutomation = shouldRunWorkspaceAutomation;
 function shouldWarnMissingLocalAI(options) {
     return options.realtimeAIEnabled
         && options.provider === "local"
         && !String(options.localBaseUrl ?? "").trim();
+}
+function resolveTrustedExecutablePath(inspection, fallback = "skylos") {
+    const globalValue = inspection?.globalValue?.trim();
+    if (globalValue)
+        return globalValue;
+    const defaultValue = inspection?.defaultValue?.trim();
+    if (defaultValue)
+        return defaultValue;
+    return fallback;
+}
+function shouldRunWorkspaceAutomation(workspaceTrusted, enabled) {
+    return workspaceTrusted && enabled;
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -36,6 +36,20 @@
     "onCommand:skylos.doctor"
   ],
   "main": "./out/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Skylos disables automatic workspace scan execution in untrusted workspaces and ignores workspace-controlled executable configuration.",
+      "restrictedConfigurations": [
+        "skylos.path",
+        "skylos.runOnSave",
+        "skylos.scanOnOpen",
+        "skylos.commandCenterRefreshOnOpen",
+        "skylos.commandCenterRefreshOnSave",
+        "skylos.postFixCommand"
+      ]
+    }
+  },
   "contributes": {
     "commands": [
       { "command": "skylos.scan", "title": "Skylos: Scan Workspace", "icon": "$(refresh)" },
@@ -208,6 +222,7 @@
         "skylos.path": {
           "type": "string",
           "default": "skylos",
+          "scope": "machine",
           "description": "Path to the skylos executable"
         },
         "skylos.confidence": {
@@ -445,6 +460,7 @@
         "skylos.postFixCommand": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "description": "Shell command to run after applying an AI Assist fix (e.g. 'npm test', 'pytest -x'). Leave empty to skip."
         }
       }

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -1,12 +1,13 @@
 import * as vscode from "vscode";
 import { SUPPORTED_LANGUAGES, type AIProvider } from "./types";
+import { resolveTrustedExecutablePath, shouldRunWorkspaceAutomation } from "./configCore";
 
 function cfg(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration("skylos");
 }
 
 export function getSkylosBin(): string {
-  return cfg().get<string>("path", "skylos");
+  return resolveTrustedExecutablePath(cfg().inspect<string>("path"), "skylos");
 }
 
 export function getConfidenceThreshold(): number {
@@ -28,11 +29,17 @@ export function isFeatureEnabled(feature: "secrets" | "danger" | "quality"): boo
 }
 
 export function isRunOnSave(): boolean {
-  return cfg().get<boolean>("runOnSave", true);
+  return shouldRunWorkspaceAutomation(
+    vscode.workspace.isTrusted,
+    cfg().get<boolean>("runOnSave", true),
+  );
 }
 
 export function isScanOnOpen(): boolean {
-  return cfg().get<boolean>("scanOnOpen", true);
+  return shouldRunWorkspaceAutomation(
+    vscode.workspace.isTrusted,
+    cfg().get<boolean>("scanOnOpen", true),
+  );
 }
 
 export function isRealtimeAIEnabled(): boolean {
@@ -88,11 +95,17 @@ export function getCommandCenterLimit(): number {
 }
 
 export function isCommandCenterRefreshOnOpen(): boolean {
-  return cfg().get<boolean>("commandCenterRefreshOnOpen", false);
+  return shouldRunWorkspaceAutomation(
+    vscode.workspace.isTrusted,
+    cfg().get<boolean>("commandCenterRefreshOnOpen", false),
+  );
 }
 
 export function isCommandCenterRefreshOnSave(): boolean {
-  return cfg().get<boolean>("commandCenterRefreshOnSave", false);
+  return shouldRunWorkspaceAutomation(
+    vscode.workspace.isTrusted,
+    cfg().get<boolean>("commandCenterRefreshOnSave", false),
+  );
 }
 
 export function getCommandCenterStateFile(): string {

--- a/editors/vscode/src/configCore.ts
+++ b/editors/vscode/src/configCore.ts
@@ -7,3 +7,25 @@ export function shouldWarnMissingLocalAI(options: {
     && options.provider === "local"
     && !String(options.localBaseUrl ?? "").trim();
 }
+
+export interface ConfigurationInspection<T> {
+  defaultValue?: T;
+  globalValue?: T;
+}
+
+export function resolveTrustedExecutablePath(
+  inspection: ConfigurationInspection<string> | undefined,
+  fallback = "skylos",
+): string {
+  const globalValue = inspection?.globalValue?.trim();
+  if (globalValue) return globalValue;
+
+  const defaultValue = inspection?.defaultValue?.trim();
+  if (defaultValue) return defaultValue;
+
+  return fallback;
+}
+
+export function shouldRunWorkspaceAutomation(workspaceTrusted: boolean, enabled: boolean): boolean {
+  return workspaceTrusted && enabled;
+}

--- a/editors/vscode/test/configCore.test.js
+++ b/editors/vscode/test/configCore.test.js
@@ -1,7 +1,11 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-const { shouldWarnMissingLocalAI } = require("../out/configCore");
+const {
+  resolveTrustedExecutablePath,
+  shouldRunWorkspaceAutomation,
+  shouldWarnMissingLocalAI,
+} = require("../out/configCore");
 
 test("shouldWarnMissingLocalAI only warns for enabled local AI without base URL", () => {
   assert.equal(shouldWarnMissingLocalAI({
@@ -24,4 +28,24 @@ test("shouldWarnMissingLocalAI only warns for enabled local AI without base URL"
     provider: "openai",
     localBaseUrl: "",
   }), false);
+});
+
+test("resolveTrustedExecutablePath ignores workspace executable values", () => {
+  assert.equal(resolveTrustedExecutablePath({
+    defaultValue: "skylos",
+    globalValue: "/usr/local/bin/skylos",
+    workspaceValue: "./malicious-tool",
+    workspaceFolderValue: "./folder-tool",
+  }), "/usr/local/bin/skylos");
+
+  assert.equal(resolveTrustedExecutablePath({
+    defaultValue: "skylos",
+    workspaceValue: "./malicious-tool",
+  }), "skylos");
+});
+
+test("shouldRunWorkspaceAutomation requires workspace trust", () => {
+  assert.equal(shouldRunWorkspaceAutomation(true, true), true);
+  assert.equal(shouldRunWorkspaceAutomation(false, true), false);
+  assert.equal(shouldRunWorkspaceAutomation(true, false), false);
 });

--- a/editors/vscode/test/workspaceExecutionSecurity.test.js
+++ b/editors/vscode/test/workspaceExecutionSecurity.test.js
@@ -1,0 +1,37 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+function readPackageJson() {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
+}
+
+function readConfigSource() {
+  return fs.readFileSync(path.join(__dirname, "..", "src", "config.ts"), "utf8");
+}
+
+test("executable configuration is not workspace-scoped", () => {
+  const pkg = readPackageJson();
+  const pathConfig = pkg.contributes.configuration.properties["skylos.path"];
+
+  assert.equal(pathConfig.scope, "machine");
+});
+
+test("workspace trust limits automatic scan execution", () => {
+  const pkg = readPackageJson();
+  const trust = pkg.capabilities.untrustedWorkspaces;
+
+  assert.equal(trust.supported, "limited");
+  assert.ok(trust.restrictedConfigurations.includes("skylos.path"));
+  assert.ok(trust.restrictedConfigurations.includes("skylos.runOnSave"));
+  assert.ok(trust.restrictedConfigurations.includes("skylos.scanOnOpen"));
+});
+
+test("runtime ignores workspace executable settings", () => {
+  const source = readConfigSource();
+
+  assert.match(source, /inspect<string>\("path"\)/);
+  assert.doesNotMatch(source, /get<string>\("path",\s*"skylos"\)/);
+  assert.match(source, /vscode\.workspace\.isTrusted/);
+});


### PR DESCRIPTION
## Summary

  - mark `skylos.path` as machine-scoped so workspaces cannot set the executable
  - ignore workspace/folder executable config at runtime and use only global/default values
  - declare limited Workspace Trust support and restrict execution-related settings
  - require trusted workspaces for automatic scan triggers like run-on-save, scan-on-open, and
  automation refresh

## Tests

  - `npm run test` in `editors/vscode`