### PR TITLE
fix(vscode): trust AI endpoint configuration

### DIFF
--- a/editors/vscode/out/config.js
+++ b/editors/vscode/out/config.js
@@ -64,7 +64,7 @@ function isScanOnOpen() {
     return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, cfg().get("scanOnOpen", true));
 }
 function isRealtimeAIEnabled() {
-    return cfg().get("enableRealtimeAI", false);
+    return vscode.workspace.isTrusted && (0, configCore_1.trustedConfigBoolean)(cfg().inspect("enableRealtimeAI"), false);
 }
 function getIdleMs() {
     return cfg().get("idleMs", 1000);
@@ -112,40 +112,44 @@ function getCommandCenterStateFile() {
     return cfg().get("commandCenterStateFile", "").trim();
 }
 function getAIProvider() {
-    return cfg().get("aiProvider", "openai");
+    return (0, configCore_1.trustedAIProvider)(cfg().inspect("aiProvider"));
 }
 function getOpenAIBaseUrl() {
     const provider = getAIProvider();
     if (provider === "local") {
         return getLocalBaseUrl();
     }
-    return cfg().get("openaiBaseUrl", "https://api.openai.com").replace(/\/+$/, "");
+    return (0, configCore_1.trustedOpenAIBaseUrl)(cfg().inspect("openaiBaseUrl"));
 }
 function getLocalBaseUrl() {
-    return (cfg().get("localBaseUrl", "") || "").replace(/\/+$/, "");
+    return (0, configCore_1.trustedLocalBaseUrl)(cfg().inspect("localBaseUrl"));
 }
 function isLocalProvider() {
     return getAIProvider() === "local";
 }
 function getAIApiKey() {
     const provider = getAIProvider();
-    if (provider === "anthropic")
-        return cfg().get("anthropicApiKey") || undefined;
+    if (provider === "anthropic") {
+        return (0, configCore_1.trustedConfigString)(cfg().inspect("anthropicApiKey")) || undefined;
+    }
     if (provider === "local") {
-        const baseUrl = cfg().get("localBaseUrl", "");
+        const baseUrl = getLocalBaseUrl();
         if (!baseUrl)
             return undefined;
-        return cfg().get("openaiApiKey") || "local";
+        return "local";
     }
-    return cfg().get("openaiApiKey") || undefined;
+    return (0, configCore_1.trustedConfigString)(cfg().inspect("openaiApiKey")) || undefined;
 }
 function getAIModel() {
     const provider = getAIProvider();
-    if (provider === "anthropic")
-        return cfg().get("anthropicModel", "claude-sonnet-4-20250514");
-    if (provider === "local")
-        return cfg().get("localModel", "") || cfg().get("openaiModel", "gpt-4o");
-    return cfg().get("openaiModel", "gpt-4o");
+    if (provider === "anthropic") {
+        return (0, configCore_1.trustedConfigString)(cfg().inspect("anthropicModel"), "claude-sonnet-4-20250514");
+    }
+    if (provider === "local") {
+        return ((0, configCore_1.trustedConfigString)(cfg().inspect("localModel"))
+            || (0, configCore_1.trustedConfigString)(cfg().inspect("openaiModel"), "gpt-4o"));
+    }
+    return (0, configCore_1.trustedConfigString)(cfg().inspect("openaiModel"), "gpt-4o");
 }
 function isLanguageSupported(langId) {
     return types_1.SUPPORTED_LANGUAGES.includes(langId);

--- a/editors/vscode/out/configCore.js
+++ b/editors/vscode/out/configCore.js
@@ -1,22 +1,91 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.DEFAULT_OPENAI_BASE_URL = void 0;
 exports.shouldWarnMissingLocalAI = shouldWarnMissingLocalAI;
+exports.trustedConfigString = trustedConfigString;
+exports.trustedConfigBoolean = trustedConfigBoolean;
 exports.resolveTrustedExecutablePath = resolveTrustedExecutablePath;
 exports.shouldRunWorkspaceAutomation = shouldRunWorkspaceAutomation;
+exports.trustedAIProvider = trustedAIProvider;
+exports.trustedOpenAIBaseUrl = trustedOpenAIBaseUrl;
+exports.trustedLocalBaseUrl = trustedLocalBaseUrl;
 function shouldWarnMissingLocalAI(options) {
     return options.realtimeAIEnabled
         && options.provider === "local"
         && !String(options.localBaseUrl ?? "").trim();
 }
-function resolveTrustedExecutablePath(inspection, fallback = "skylos") {
-    const globalValue = inspection?.globalValue?.trim();
-    if (globalValue)
+exports.DEFAULT_OPENAI_BASE_URL = "https://api.openai.com";
+function trustedConfigValue(inspection, fallback) {
+    const globalValue = inspection?.globalValue;
+    if (typeof globalValue === "string") {
+        const trimmed = globalValue.trim();
+        if (trimmed)
+            return trimmed;
+    }
+    else if (globalValue !== undefined) {
         return globalValue;
-    const defaultValue = inspection?.defaultValue?.trim();
-    if (defaultValue)
+    }
+    const defaultValue = inspection?.defaultValue;
+    if (typeof defaultValue === "string") {
+        const trimmed = defaultValue.trim();
+        if (trimmed)
+            return trimmed;
+    }
+    else if (defaultValue !== undefined) {
         return defaultValue;
+    }
     return fallback;
+}
+function trustedConfigString(inspection, fallback = "") {
+    return trustedConfigValue(inspection, fallback);
+}
+function trustedConfigBoolean(inspection, fallback = false) {
+    return trustedConfigValue(inspection, fallback);
+}
+function resolveTrustedExecutablePath(inspection, fallback = "skylos") {
+    return trustedConfigString(inspection, fallback);
 }
 function shouldRunWorkspaceAutomation(workspaceTrusted, enabled) {
     return workspaceTrusted && enabled;
+}
+function trustedAIProvider(inspection) {
+    const provider = trustedConfigString(inspection, "openai");
+    if (provider === "anthropic" || provider === "local")
+        return provider;
+    return "openai";
+}
+function trustedOpenAIBaseUrl(inspection) {
+    const configured = trustedConfigString(inspection, exports.DEFAULT_OPENAI_BASE_URL);
+    try {
+        const url = new URL(configured);
+        if (url.protocol !== "https:" || url.hostname !== "api.openai.com") {
+            return exports.DEFAULT_OPENAI_BASE_URL;
+        }
+        return url.origin.replace(/\/+$/, "");
+    }
+    catch {
+        return exports.DEFAULT_OPENAI_BASE_URL;
+    }
+}
+function isLoopbackHost(hostname) {
+    const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return (normalized === "localhost"
+        || normalized === "::1"
+        || normalized === "0:0:0:0:0:0:0:1"
+        || normalized.startsWith("127."));
+}
+function trustedLocalBaseUrl(inspection) {
+    const configured = trustedConfigString(inspection, "");
+    if (!configured)
+        return "";
+    try {
+        const url = new URL(configured);
+        if ((url.protocol !== "http:" && url.protocol !== "https:") || !isLoopbackHost(url.hostname)) {
+            return "";
+        }
+        return url.origin.replace(/\/+$/, "");
+    }
+    catch {
+        return "";
+    }
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -39,14 +39,24 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
-      "description": "Skylos disables automatic workspace scan execution in untrusted workspaces and ignores workspace-controlled executable configuration.",
+      "description": "Skylos disables automatic execution in untrusted workspaces and ignores workspace-controlled executable and AI endpoint configuration.",
       "restrictedConfigurations": [
         "skylos.path",
         "skylos.runOnSave",
         "skylos.scanOnOpen",
         "skylos.commandCenterRefreshOnOpen",
         "skylos.commandCenterRefreshOnSave",
-        "skylos.postFixCommand"
+        "skylos.postFixCommand",
+        "skylos.aiProvider",
+        "skylos.enableRealtimeAI",
+        "skylos.openaiBaseUrl",
+        "skylos.openaiApiKey",
+        "skylos.openaiModel",
+        "skylos.localBaseUrl",
+        "skylos.localModel",
+        "skylos.anthropicApiKey",
+        "skylos.anthropicModel",
+        "skylos.streamingInline"
       ]
     }
   },
@@ -378,6 +388,7 @@
           "type": "string",
           "enum": ["openai", "anthropic", "local"],
           "default": "openai",
+          "scope": "machine",
           "enumDescriptions": [
             "OpenAI (cloud)",
             "Anthropic (cloud)",
@@ -388,46 +399,55 @@
         "skylos.enableRealtimeAI": {
           "type": "boolean",
           "default": false,
+          "scope": "machine",
           "description": "Run AI Assist automatically as you edit. Static scans, Review Queue, and engine-backed findings work with this off."
         },
         "skylos.openaiBaseUrl": {
           "type": "string",
           "default": "https://api.openai.com",
+          "scope": "machine",
           "description": "Base URL for OpenAI API (only used when aiProvider is 'openai')"
         },
         "skylos.openaiApiKey": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "description": "OpenAI API key"
         },
         "skylos.openaiModel": {
           "type": "string",
           "default": "gpt-4o",
+          "scope": "machine",
           "description": "OpenAI model to use"
         },
         "skylos.localBaseUrl": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "description": "URL of your local AI server (e.g. http://localhost:11434 for Ollama, http://localhost:1234 for LM Studio)"
         },
         "skylos.localModel": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "description": "Model name on your local server (e.g. llama3.1, deepseek-coder, kimi)"
         },
         "skylos.anthropicApiKey": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "description": "Anthropic API key for AI features"
         },
         "skylos.anthropicModel": {
           "type": "string",
           "default": "claude-sonnet-4-20250514",
+          "scope": "machine",
           "description": "Anthropic model to use"
         },
         "skylos.streamingInline": {
           "type": "boolean",
           "default": false,
+          "scope": "machine",
           "description": "Show streaming inline ghost text when optional real-time AI Assist is enabled"
         },
         "skylos.enableDeadCode": {

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -1,6 +1,14 @@
 import * as vscode from "vscode";
 import { SUPPORTED_LANGUAGES, type AIProvider } from "./types";
-import { resolveTrustedExecutablePath, shouldRunWorkspaceAutomation } from "./configCore";
+import {
+  resolveTrustedExecutablePath,
+  shouldRunWorkspaceAutomation,
+  trustedAIProvider,
+  trustedConfigBoolean,
+  trustedConfigString,
+  trustedLocalBaseUrl,
+  trustedOpenAIBaseUrl,
+} from "./configCore";
 
 function cfg(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration("skylos");
@@ -43,7 +51,7 @@ export function isScanOnOpen(): boolean {
 }
 
 export function isRealtimeAIEnabled(): boolean {
-  return cfg().get<boolean>("enableRealtimeAI", false);
+  return vscode.workspace.isTrusted && trustedConfigBoolean(cfg().inspect<boolean>("enableRealtimeAI"), false);
 }
 
 export function getIdleMs(): number {
@@ -113,7 +121,7 @@ export function getCommandCenterStateFile(): string {
 }
 
 export function getAIProvider(): AIProvider {
-  return cfg().get<AIProvider>("aiProvider", "openai");
+  return trustedAIProvider(cfg().inspect<string>("aiProvider")) as AIProvider;
 }
 
 export function getOpenAIBaseUrl(): string {
@@ -121,11 +129,11 @@ export function getOpenAIBaseUrl(): string {
   if (provider === "local") {
     return getLocalBaseUrl();
   }
-  return cfg().get<string>("openaiBaseUrl", "https://api.openai.com").replace(/\/+$/, "");
+  return trustedOpenAIBaseUrl(cfg().inspect<string>("openaiBaseUrl"));
 }
 
 export function getLocalBaseUrl(): string {
-  return (cfg().get<string>("localBaseUrl", "") || "").replace(/\/+$/, "");
+  return trustedLocalBaseUrl(cfg().inspect<string>("localBaseUrl"));
 }
 
 export function isLocalProvider(): boolean {
@@ -134,20 +142,32 @@ export function isLocalProvider(): boolean {
 
 export function getAIApiKey(): string | undefined {
   const provider = getAIProvider();
-  if (provider === "anthropic") return cfg().get<string>("anthropicApiKey") || undefined;
-  if (provider === "local") {
-    const baseUrl = cfg().get<string>("localBaseUrl", "");
-    if (!baseUrl) return undefined;
-    return cfg().get<string>("openaiApiKey") || "local";
+  if (provider === "anthropic") {
+    return trustedConfigString(cfg().inspect<string>("anthropicApiKey")) || undefined;
   }
-  return cfg().get<string>("openaiApiKey") || undefined;
+  if (provider === "local") {
+    const baseUrl = getLocalBaseUrl();
+    if (!baseUrl) return undefined;
+    return "local";
+  }
+  return trustedConfigString(cfg().inspect<string>("openaiApiKey")) || undefined;
 }
 
 export function getAIModel(): string {
   const provider = getAIProvider();
-  if (provider === "anthropic") return cfg().get<string>("anthropicModel", "claude-sonnet-4-20250514");
-  if (provider === "local") return cfg().get<string>("localModel", "") || cfg().get<string>("openaiModel", "gpt-4o");
-  return cfg().get<string>("openaiModel", "gpt-4o");
+  if (provider === "anthropic") {
+    return trustedConfigString(
+      cfg().inspect<string>("anthropicModel"),
+      "claude-sonnet-4-20250514",
+    );
+  }
+  if (provider === "local") {
+    return (
+      trustedConfigString(cfg().inspect<string>("localModel"))
+      || trustedConfigString(cfg().inspect<string>("openaiModel"), "gpt-4o")
+    );
+  }
+  return trustedConfigString(cfg().inspect<string>("openaiModel"), "gpt-4o");
 }
 
 export function isLanguageSupported(langId: string): boolean {

--- a/editors/vscode/src/configCore.ts
+++ b/editors/vscode/src/configCore.ts
@@ -13,19 +13,104 @@ export interface ConfigurationInspection<T> {
   globalValue?: T;
 }
 
-export function resolveTrustedExecutablePath(
-  inspection: ConfigurationInspection<string> | undefined,
-  fallback = "skylos",
-): string {
-  const globalValue = inspection?.globalValue?.trim();
-  if (globalValue) return globalValue;
+export type TrustedAIProvider = "openai" | "anthropic" | "local";
 
-  const defaultValue = inspection?.defaultValue?.trim();
-  if (defaultValue) return defaultValue;
+export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com";
+
+function trustedConfigValue<T>(
+  inspection: ConfigurationInspection<T> | undefined,
+  fallback: T,
+): T {
+  const globalValue = inspection?.globalValue;
+  if (typeof globalValue === "string") {
+    const trimmed = globalValue.trim();
+    if (trimmed) return trimmed as T;
+  } else if (globalValue !== undefined) {
+    return globalValue;
+  }
+
+  const defaultValue = inspection?.defaultValue;
+  if (typeof defaultValue === "string") {
+    const trimmed = defaultValue.trim();
+    if (trimmed) return trimmed as T;
+  } else if (defaultValue !== undefined) {
+    return defaultValue;
+  }
 
   return fallback;
 }
 
+export function trustedConfigString(
+  inspection: ConfigurationInspection<string> | undefined,
+  fallback = "",
+): string {
+  return trustedConfigValue(inspection, fallback);
+}
+
+export function trustedConfigBoolean(
+  inspection: ConfigurationInspection<boolean> | undefined,
+  fallback = false,
+): boolean {
+  return trustedConfigValue(inspection, fallback);
+}
+
+export function resolveTrustedExecutablePath(
+  inspection: ConfigurationInspection<string> | undefined,
+  fallback = "skylos",
+): string {
+  return trustedConfigString(inspection, fallback);
+}
+
 export function shouldRunWorkspaceAutomation(workspaceTrusted: boolean, enabled: boolean): boolean {
   return workspaceTrusted && enabled;
+}
+
+export function trustedAIProvider(
+  inspection: ConfigurationInspection<string> | undefined,
+): TrustedAIProvider {
+  const provider = trustedConfigString(inspection, "openai");
+  if (provider === "anthropic" || provider === "local") return provider;
+  return "openai";
+}
+
+export function trustedOpenAIBaseUrl(
+  inspection: ConfigurationInspection<string> | undefined,
+): string {
+  const configured = trustedConfigString(inspection, DEFAULT_OPENAI_BASE_URL);
+  try {
+    const url = new URL(configured);
+    if (url.protocol !== "https:" || url.hostname !== "api.openai.com") {
+      return DEFAULT_OPENAI_BASE_URL;
+    }
+    return url.origin.replace(/\/+$/, "");
+  } catch {
+    return DEFAULT_OPENAI_BASE_URL;
+  }
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return (
+    normalized === "localhost"
+    || normalized === "::1"
+    || normalized === "0:0:0:0:0:0:0:1"
+    || normalized.startsWith("127.")
+  );
+}
+
+export function trustedLocalBaseUrl(
+  inspection: ConfigurationInspection<string> | undefined,
+): string {
+  const configured = trustedConfigString(inspection, "");
+  if (!configured) return "";
+
+  try {
+    const url = new URL(configured);
+    if ((url.protocol !== "http:" && url.protocol !== "https:") || !isLoopbackHost(url.hostname)) {
+      return "";
+    }
+    return url.origin.replace(/\/+$/, "");
+  } catch {
+    return "";
+  }
 }

--- a/editors/vscode/test/aiEndpointSecurity.test.js
+++ b/editors/vscode/test/aiEndpointSecurity.test.js
@@ -1,0 +1,58 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+function readPackageJson() {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
+}
+
+function readConfigSource() {
+  return fs.readFileSync(path.join(__dirname, "..", "src", "config.ts"), "utf8");
+}
+
+test("AI endpoint and key settings are not workspace-scoped", () => {
+  const pkg = readPackageJson();
+  const props = pkg.contributes.configuration.properties;
+
+  for (const key of [
+    "skylos.aiProvider",
+    "skylos.enableRealtimeAI",
+    "skylos.openaiBaseUrl",
+    "skylos.openaiApiKey",
+    "skylos.localBaseUrl",
+    "skylos.anthropicApiKey",
+  ]) {
+    assert.equal(props[key].scope, "machine", `${key} should be machine-scoped`);
+  }
+});
+
+test("Workspace Trust restricts AI endpoint and key settings", () => {
+  const pkg = readPackageJson();
+  const trust = pkg.capabilities.untrustedWorkspaces;
+
+  assert.equal(trust.supported, "limited");
+  for (const key of [
+    "skylos.aiProvider",
+    "skylos.enableRealtimeAI",
+    "skylos.openaiBaseUrl",
+    "skylos.openaiApiKey",
+    "skylos.localBaseUrl",
+    "skylos.anthropicApiKey",
+  ]) {
+    assert.ok(trust.restrictedConfigurations.includes(key), `${key} should be restricted`);
+  }
+});
+
+test("runtime resolves AI endpoints and keys from trusted config only", () => {
+  const source = readConfigSource();
+
+  assert.match(source, /trustedOpenAIBaseUrl\(cfg\(\)\.inspect<string>\("openaiBaseUrl"\)\)/);
+  assert.match(source, /trustedLocalBaseUrl\(cfg\(\)\.inspect<string>\("localBaseUrl"\)\)/);
+  assert.match(source, /trustedConfigString\(cfg\(\)\.inspect<string>\("openaiApiKey"\)\)/);
+  assert.match(source, /trustedConfigString\(cfg\(\)\.inspect<string>\("anthropicApiKey"\)\)/);
+  assert.match(source, /return "local";/);
+  assert.doesNotMatch(source, /cfg\(\)\.get<string>\("openaiBaseUrl"/);
+  assert.doesNotMatch(source, /cfg\(\)\.get<string>\("localBaseUrl"/);
+  assert.doesNotMatch(source, /cfg\(\)\.get<string>\("openaiApiKey"/);
+});

--- a/editors/vscode/test/configCore.test.js
+++ b/editors/vscode/test/configCore.test.js
@@ -2,9 +2,14 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 
 const {
+  DEFAULT_OPENAI_BASE_URL,
   resolveTrustedExecutablePath,
   shouldRunWorkspaceAutomation,
   shouldWarnMissingLocalAI,
+  trustedAIProvider,
+  trustedConfigString,
+  trustedLocalBaseUrl,
+  trustedOpenAIBaseUrl,
 } = require("../out/configCore");
 
 test("shouldWarnMissingLocalAI only warns for enabled local AI without base URL", () => {
@@ -48,4 +53,68 @@ test("shouldRunWorkspaceAutomation requires workspace trust", () => {
   assert.equal(shouldRunWorkspaceAutomation(true, true), true);
   assert.equal(shouldRunWorkspaceAutomation(false, true), false);
   assert.equal(shouldRunWorkspaceAutomation(true, false), false);
+});
+
+test("trustedConfigString ignores workspace values", () => {
+  assert.equal(trustedConfigString({
+    defaultValue: "default",
+    globalValue: "user-value",
+    workspaceValue: "workspace-value",
+    workspaceFolderValue: "folder-value",
+  }), "user-value");
+
+  assert.equal(trustedConfigString({
+    defaultValue: "default",
+    workspaceValue: "workspace-value",
+  }), "default");
+});
+
+test("trustedAIProvider ignores workspace provider overrides", () => {
+  assert.equal(trustedAIProvider({
+    defaultValue: "openai",
+    workspaceValue: "local",
+  }), "openai");
+  assert.equal(trustedAIProvider({
+    defaultValue: "openai",
+    globalValue: "local",
+  }), "local");
+});
+
+test("trustedOpenAIBaseUrl only allows the official OpenAI API host", () => {
+  assert.equal(trustedOpenAIBaseUrl({
+    defaultValue: "https://api.openai.com",
+    workspaceValue: "https://attacker.example",
+  }), DEFAULT_OPENAI_BASE_URL);
+
+  assert.equal(trustedOpenAIBaseUrl({
+    defaultValue: "https://api.openai.com",
+    globalValue: "https://attacker.example",
+  }), DEFAULT_OPENAI_BASE_URL);
+
+  assert.equal(trustedOpenAIBaseUrl({
+    defaultValue: "https://api.openai.com",
+    globalValue: "https://api.openai.com/v1",
+  }), DEFAULT_OPENAI_BASE_URL);
+});
+
+test("trustedLocalBaseUrl only accepts user-configured loopback endpoints", () => {
+  assert.equal(trustedLocalBaseUrl({
+    defaultValue: "",
+    workspaceValue: "https://attacker.example",
+  }), "");
+
+  assert.equal(trustedLocalBaseUrl({
+    defaultValue: "",
+    globalValue: "https://attacker.example",
+  }), "");
+
+  assert.equal(trustedLocalBaseUrl({
+    defaultValue: "",
+    globalValue: "http://localhost:11434/api",
+  }), "http://localhost:11434");
+
+  assert.equal(trustedLocalBaseUrl({
+    defaultValue: "",
+    globalValue: "http://127.0.0.1:1234",
+  }), "http://127.0.0.1:1234");
 });


### PR DESCRIPTION
## Summary

  - Restricts AI provider, endpoint, model, and API key settings to trusted/user-level config.
  - Ignores workspace-provided OpenAI/Anthropic credentials and AI endpoint overrides.
  - Requires OpenAI cloud requests to use `https://api.openai.com`.
  - Allows local AI endpoints only on loopback hosts.
  - Stops local-provider mode from reusing or sending the user’s OpenAI API key.
  
## Tests

  - `npm run test`