### PR TITLE
fix(vscode): gate dead-code preview by workspace trust

### DIFF
--- a/editors/vscode/out/commandcenter.js
+++ b/editors/vscode/out/commandcenter.js
@@ -241,7 +241,9 @@ class SkylosCommandCenterProvider {
             nodes.push(new EmptyNode("No ranked actions", "The repo agent did not surface anything urgent"));
             return nodes;
         }
-        nodes.push(new InfoNode("Preview dead code removal", "Run LLM-verified fix generation", "trash", "skylos.fixDeadCode"));
+        if (vscode.workspace.isTrusted) {
+            nodes.push(new InfoNode("Preview dead code removal", "Run LLM-verified fix generation", "trash", "skylos.fixDeadCode"));
+        }
         nodes.push(...actions.map((action) => new ActionNode(action)));
         return nodes;
     }

--- a/editors/vscode/out/extension.js
+++ b/editors/vscode/out/extension.js
@@ -434,6 +434,10 @@ function activate(context) {
             vscode.window.showWarningMessage("Skylos: Open a folder first.");
             return;
         }
+        if (!vscode.workspace.isTrusted) {
+            vscode.window.showWarningMessage("Skylos: Trust this workspace before previewing dead code removal.");
+            return;
+        }
         const skylosBin = (0, config_1.getSkylosBin)();
         const { spawn: spawnProc } = await Promise.resolve().then(() => require("child_process"));
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Skylos: Generating dead code removal plan..." }, () => new Promise((resolve, reject) => {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -39,7 +39,7 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
-      "description": "Skylos disables automatic execution in untrusted workspaces and ignores workspace-controlled executable and AI endpoint configuration.",
+      "description": "Skylos disables automatic and command-triggered workspace execution in untrusted workspaces and ignores workspace-controlled executable and AI endpoint configuration.",
       "restrictedConfigurations": [
         "skylos.path",
         "skylos.runOnSave",
@@ -89,7 +89,12 @@
       { "command": "skylos.commandCenterDismiss", "title": "Skylos: Dismiss Automation Action", "icon": "$(close)" },
       { "command": "skylos.commandCenterSnooze", "title": "Skylos: Snooze Automation Action", "icon": "$(clock)" },
       { "command": "skylos.commandCenterRestoreTriaged", "title": "Skylos: Restore Automation Action", "icon": "$(history)" },
-      { "command": "skylos.fixDeadCode", "title": "Skylos: Preview Dead Code Removal", "icon": "$(trash)" }
+      {
+        "command": "skylos.fixDeadCode",
+        "title": "Skylos: Preview Dead Code Removal",
+        "icon": "$(trash)",
+        "enablement": "isWorkspaceTrusted"
+      }
     ],
     "viewsContainers": {
       "activitybar": [

--- a/editors/vscode/src/commandcenter.ts
+++ b/editors/vscode/src/commandcenter.ts
@@ -290,7 +290,9 @@ export class SkylosCommandCenterProvider implements vscode.TreeDataProvider<Comm
       return nodes;
     }
 
-    nodes.push(new InfoNode("Preview dead code removal", "Run LLM-verified fix generation", "trash", "skylos.fixDeadCode"));
+    if (vscode.workspace.isTrusted) {
+      nodes.push(new InfoNode("Preview dead code removal", "Run LLM-verified fix generation", "trash", "skylos.fixDeadCode"));
+    }
     nodes.push(...actions.map((action) => new ActionNode(action)));
     return nodes;
   }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -566,6 +566,10 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showWarningMessage("Skylos: Open a folder first.");
         return;
       }
+      if (!vscode.workspace.isTrusted) {
+        vscode.window.showWarningMessage("Skylos: Trust this workspace before previewing dead code removal.");
+        return;
+      }
 
       const skylosBin = getSkylosBin();
       const { spawn: spawnProc } = await import("child_process");

--- a/editors/vscode/test/workspaceExecutionSecurity.test.js
+++ b/editors/vscode/test/workspaceExecutionSecurity.test.js
@@ -23,6 +23,7 @@ test("workspace trust limits automatic scan execution", () => {
   const trust = pkg.capabilities.untrustedWorkspaces;
 
   assert.equal(trust.supported, "limited");
+  assert.match(trust.description, /command-triggered workspace execution/);
   assert.ok(trust.restrictedConfigurations.includes("skylos.path"));
   assert.ok(trust.restrictedConfigurations.includes("skylos.runOnSave"));
   assert.ok(trust.restrictedConfigurations.includes("skylos.scanOnOpen"));
@@ -34,4 +35,20 @@ test("runtime ignores workspace executable settings", () => {
   assert.match(source, /inspect<string>\("path"\)/);
   assert.doesNotMatch(source, /get<string>\("path",\s*"skylos"\)/);
   assert.match(source, /vscode\.workspace\.isTrusted/);
+});
+
+test("dead-code preview command is gated by workspace trust", () => {
+  const pkg = readPackageJson();
+  const command = pkg.contributes.commands.find((entry) => entry.command === "skylos.fixDeadCode");
+  const source = fs.readFileSync(path.join(__dirname, "..", "src", "extension.ts"), "utf8");
+  const commandCenter = fs.readFileSync(path.join(__dirname, "..", "src", "commandcenter.ts"), "utf8");
+
+  assert.equal(command.enablement, "isWorkspaceTrusted");
+  assert.match(source, /Skylos: Trust this workspace before previewing dead code removal\./);
+  assert.match(commandCenter, /if \(vscode\.workspace\.isTrusted\) \{\s*nodes\.push\(new InfoNode\("Preview dead code removal"/);
+
+  const guardIndex = source.indexOf("Skylos: Trust this workspace before previewing dead code removal.");
+  const spawnIndex = source.indexOf("spawnProc(skylosBin");
+  assert.ok(guardIndex >= 0);
+  assert.ok(spawnIndex > guardIndex);
 });


### PR DESCRIPTION
## Summary

  - Gates `skylos.fixDeadCode` with `isWorkspaceTrusted`.
  - Adds a runtime Workspace Trust check before spawning `skylos agent verify --fix`.
  - Hides the Command Center “Preview dead code removal” shortcut in untrusted workspaces.
  - Keeps generated `out/` extension files in sync.

## Tests

  - `npm run test` in `editors/vscode`
  - `pytest test/test_cwe78_pip_install.py`