### PR TITLE
fix(vscode): make scan-on-open trusted opt-in

### DIFF
--- a/editors/vscode/out/config.js
+++ b/editors/vscode/out/config.js
@@ -61,7 +61,7 @@ function isRunOnSave() {
     return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, cfg().get("runOnSave", true));
 }
 function isScanOnOpen() {
-    return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, cfg().get("scanOnOpen", true));
+    return (0, configCore_1.shouldRunWorkspaceAutomation)(vscode.workspace.isTrusted, (0, configCore_1.trustedConfigBoolean)(cfg().inspect("scanOnOpen"), false));
 }
 function isRealtimeAIEnabled() {
     return vscode.workspace.isTrusted && (0, configCore_1.trustedConfigBoolean)(cfg().inspect("enableRealtimeAI"), false);

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -270,7 +270,8 @@
         },
         "skylos.scanOnOpen": {
           "type": "boolean",
-          "default": true,
+          "default": false,
+          "scope": "machine",
           "description": "Auto scan the first supported file you open in the session"
         },
         "skylos.showPopup": {

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -46,7 +46,7 @@ export function isRunOnSave(): boolean {
 export function isScanOnOpen(): boolean {
   return shouldRunWorkspaceAutomation(
     vscode.workspace.isTrusted,
-    cfg().get<boolean>("scanOnOpen", true),
+    trustedConfigBoolean(cfg().inspect<boolean>("scanOnOpen"), false),
   );
 }
 

--- a/editors/vscode/test/workspaceExecutionSecurity.test.js
+++ b/editors/vscode/test/workspaceExecutionSecurity.test.js
@@ -18,6 +18,14 @@ test("executable configuration is not workspace-scoped", () => {
   assert.equal(pathConfig.scope, "machine");
 });
 
+test("scan-on-open is opt-in and not workspace-scoped", () => {
+  const pkg = readPackageJson();
+  const scanOnOpenConfig = pkg.contributes.configuration.properties["skylos.scanOnOpen"];
+
+  assert.equal(scanOnOpenConfig.scope, "machine");
+  assert.equal(scanOnOpenConfig.default, false);
+});
+
 test("workspace trust limits automatic scan execution", () => {
   const pkg = readPackageJson();
   const trust = pkg.capabilities.untrustedWorkspaces;
@@ -32,6 +40,8 @@ test("runtime ignores workspace executable settings", () => {
   const source = readConfigSource();
 
   assert.match(source, /inspect<string>\("path"\)/);
+  assert.match(source, /inspect<boolean>\("scanOnOpen"\)/);
   assert.doesNotMatch(source, /get<string>\("path",\s*"skylos"\)/);
+  assert.doesNotMatch(source, /get<boolean>\("scanOnOpen",\s*true\)/);
   assert.match(source, /vscode\.workspace\.isTrusted/);
 });


### PR DESCRIPTION
## Summary

  - Changes `skylos.scanOnOpen` to default `false`.
  - Marks `skylos.scanOnOpen` as `machine` scoped.
  - Resolves scan-on-open through trusted configuration inspection instead of effective workspace config.
  - Keeps generated `out/config.js` in sync.

## Tests

  - `npm run test` in `editors/vscode`