### PR TITLE
fix(webhook): bound verification pattern scans

### DIFF
--- a/skylos/rules/danger/danger_webhook/webhook_flow.py
+++ b/skylos/rules/danger/danger_webhook/webhook_flow.py
@@ -36,6 +36,11 @@ _REQUEST_BODY_HINTS = (
     "json.loads(request.body",
 )
 
+_WEBHOOK_VERIFY_WINDOW_CHARS = 4096
+_WEBHOOK_VERIFY_MAX_CANDIDATES = 64
+_WEBHOOK_CONSTRUCTOR_PATTERN = re.compile(r"\bWebhook\s*\(", re.I)
+_WEBHOOK_INSTANCE_VERIFY_PATTERN = re.compile(r"\.verify\s*\(", re.I)
+
 _VERIFY_PATTERNS = (
     re.compile(r"\bconstruct_event\s*\(", re.I),
     re.compile(r"\bconstructevent\s*\(", re.I),
@@ -49,7 +54,6 @@ _VERIFY_PATTERNS = (
     re.compile(r"\bvalidatewebhook\s*\(", re.I),
     re.compile(r"\bhmac\.compare_digest\s*\(", re.I),
     re.compile(r"\bhmac\.new\s*\(", re.I),
-    re.compile(r"\bWebhook\s*\([^)]*\).*?\.verify\s*\(", re.I | re.S),
     re.compile(r"\bWebhook\.verify\s*\(", re.I),
 )
 
@@ -138,8 +142,20 @@ def _uses_request_body(text: str) -> bool:
     return any(hint in lower for hint in _REQUEST_BODY_HINTS)
 
 
+def _has_webhook_instance_verification(text: str) -> bool:
+    for index, match in enumerate(_WEBHOOK_CONSTRUCTOR_PATTERN.finditer(text)):
+        if index >= _WEBHOOK_VERIFY_MAX_CANDIDATES:
+            return False
+        window = text[match.end() : match.end() + _WEBHOOK_VERIFY_WINDOW_CHARS]
+        if _WEBHOOK_INSTANCE_VERIFY_PATTERN.search(window):
+            return True
+    return False
+
+
 def _has_signature_verification(text: str) -> bool:
-    return any(pattern.search(text) for pattern in _VERIFY_PATTERNS)
+    return any(pattern.search(text) for pattern in _VERIFY_PATTERNS) or (
+        _has_webhook_instance_verification(text)
+    )
 
 
 class _WebhookSignatureChecker(ast.NodeVisitor):

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -212,6 +212,11 @@ _WEBHOOK_BODY_HINTS = (
     "raw_body",
 )
 
+_WEBHOOK_VERIFY_WINDOW_CHARS = 4096
+_WEBHOOK_VERIFY_MAX_CANDIDATES = 64
+_WEBHOOK_CONSTRUCTOR_PATTERN = re.compile(r"\bnew\s+Webhook\s*\(")
+_WEBHOOK_INSTANCE_VERIFY_PATTERN = re.compile(r"\.verify\s*\(")
+
 _WEBHOOK_VERIFY_PATTERNS = (
     re.compile(r"\bconstructEvent\s*\("),
     re.compile(r"\bconstruct_event\s*\(", re.I),
@@ -226,7 +231,6 @@ _WEBHOOK_VERIFY_PATTERNS = (
     re.compile(r"\bcrypto\.timingSafeEqual\s*\("),
     re.compile(r"\btimingSafeEqual\s*\("),
     re.compile(r"\bcreateHmac\s*\("),
-    re.compile(r"\bnew\s+Webhook\s*\([^)]*\).*?\.verify\s*\(", re.S),
     re.compile(r"\bWebhook\.verify\s*\("),
 )
 
@@ -932,8 +936,22 @@ def _has_webhook_body_use(source_text: str) -> bool:
     return any(hint in lower for hint in _WEBHOOK_BODY_HINTS)
 
 
+def _has_webhook_instance_verification(source_text: str) -> bool:
+    for index, match in enumerate(_WEBHOOK_CONSTRUCTOR_PATTERN.finditer(source_text)):
+        if index >= _WEBHOOK_VERIFY_MAX_CANDIDATES:
+            return False
+        window = source_text[
+            match.end() : match.end() + _WEBHOOK_VERIFY_WINDOW_CHARS
+        ]
+        if _WEBHOOK_INSTANCE_VERIFY_PATTERN.search(window):
+            return True
+    return False
+
+
 def _has_webhook_signature_verification(source_text: str) -> bool:
-    return any(pattern.search(source_text) for pattern in _WEBHOOK_VERIFY_PATTERNS)
+    return any(
+        pattern.search(source_text) for pattern in _WEBHOOK_VERIFY_PATTERNS
+    ) or _has_webhook_instance_verification(source_text)
 
 
 def _has_inbound_webhook_post(source_text: str) -> bool:

--- a/test/test_webhook_signature.py
+++ b/test/test_webhook_signature.py
@@ -4,7 +4,9 @@ import ast
 import textwrap
 
 from skylos.rules.danger.danger import scan_file_with_tree
+from skylos.rules.danger.danger_webhook import webhook_flow
 from skylos.visitors.languages.typescript import scan_typescript_file
+from skylos.visitors.languages.typescript import danger as ts_danger
 
 
 def _scan_python(code: str, filename: str = "app.py") -> list[dict]:
@@ -62,6 +64,24 @@ def test_fastapi_stripe_webhook_with_construct_event_is_safe():
     assert "SKY-D282" not in _rule_ids(findings)
 
 
+def test_fastapi_stripe_webhook_with_instance_verify_is_safe():
+    findings = _scan_python(
+        """
+        app = make_app()
+
+        @app.post("/stripe/webhook")
+        async def stripe_webhook(request):
+            body = await request.body()
+            sig = request.headers.get("stripe-signature")
+            webhook = Webhook(STRIPE_WEBHOOK_SECRET)
+            event = webhook.verify(body, sig)
+            return {"ok": True, "event": event}
+        """
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
 def test_flask_github_webhook_with_hmac_compare_is_safe():
     findings = _scan_python(
         """
@@ -94,6 +114,26 @@ def test_non_webhook_callback_route_is_not_flagged():
     )
 
     assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_python_many_unverified_webhook_constructors_still_flags():
+    constructors = "\n".join(
+        f"            candidate_{index} = Webhook('secret-{index}')"
+        for index in range(250)
+    )
+    findings = _scan_python(
+        f"""
+        app = make_app()
+
+        @app.post("/stripe/webhook")
+        async def stripe_webhook(request):
+            event = await request.json()
+{constructors}
+            return event
+        """
+    )
+
+    assert "SKY-D282" in _rule_ids(findings)
 
 
 def test_python_test_path_is_not_flagged():
@@ -147,6 +187,24 @@ def test_nextjs_stripe_webhook_with_construct_event_is_safe(tmp_path):
     assert "SKY-D282" not in _rule_ids(findings)
 
 
+def test_nextjs_stripe_webhook_with_instance_verify_is_safe(tmp_path):
+    findings = _scan_ts(
+        tmp_path,
+        """
+        export async function POST(req: Request) {
+          const body = await req.text();
+          const sig = req.headers.get("stripe-signature");
+          const webhook = new Webhook(process.env.STRIPE_WEBHOOK_SECRET!);
+          const event = webhook.verify(body, sig);
+          return Response.json({ received: true, event });
+        }
+        """,
+        "app/api/stripe/webhook/route.ts",
+    )
+
+    assert "SKY-D282" not in _rule_ids(findings)
+
+
 def test_express_github_webhook_with_hmac_is_safe(tmp_path):
     findings = _scan_ts(
         tmp_path,
@@ -181,6 +239,26 @@ def test_non_webhook_post_route_is_not_flagged(tmp_path):
     assert "SKY-D282" not in _rule_ids(findings)
 
 
+def test_typescript_many_unverified_webhook_constructors_still_flags(tmp_path):
+    constructors = "\n".join(
+        f"          const candidate{index} = new Webhook('secret-{index}');"
+        for index in range(250)
+    )
+    findings = _scan_ts(
+        tmp_path,
+        f"""
+        export async function POST(req: Request) {{
+          const event = await req.json();
+{constructors}
+          return Response.json(event);
+        }}
+        """,
+        "app/api/stripe/webhook/route.ts",
+    )
+
+    assert "SKY-D282" in _rule_ids(findings)
+
+
 def test_typescript_test_file_is_not_flagged(tmp_path):
     findings = _scan_ts(
         tmp_path,
@@ -194,3 +272,11 @@ def test_typescript_test_file_is_not_flagged(tmp_path):
     )
 
     assert "SKY-D282" not in _rule_ids(findings)
+
+
+def test_webhook_verification_patterns_do_not_use_unbounded_cross_text_regex():
+    python_patterns = [pattern.pattern for pattern in webhook_flow._VERIFY_PATTERNS]
+    ts_patterns = [pattern.pattern for pattern in ts_danger._WEBHOOK_VERIFY_PATTERNS]
+
+    assert all(".*?" not in pattern for pattern in python_patterns)
+    assert all(".*?" not in pattern for pattern in ts_patterns)


### PR DESCRIPTION
## Summary

  - Removes unbounded cross-text `.*? ... .verify(` regexes from Python and TS webhook rules.
  - Adds bounded constructor-window checks for instance `.verify(...)` usage.
  - Caps constructor candidates inspected per file or function.
  - Keeps direct verification patterns eg. `construct_event`, `createHmac`, `timingSafeEqual`, and `Webhook.verify`.

## Tests

  - `pytest test/test_webhook_signature.py`