### PR TITLE
fix(go): detect variable shell exec flags

### DIFF
--- a/skylos/engines/go/internal/analyzer/analyzer.go
+++ b/skylos/engines/go/internal/analyzer/analyzer.go
@@ -521,6 +521,79 @@ func shellCommandArgIndex(shellName string, args []ast.Expr) (int, bool) {
 	return 0, false
 }
 
+func (a *Analyzer) hasVariablePotentialShellCommandArg(shellName string, args []ast.Expr) bool {
+	// A non-literal shell option can still be "-c", "/c", or "-Command";
+	// treat the following variable argument as a possible command string.
+	switch shellBaseName(shellName) {
+	case "sh", "bash", "dash", "zsh", "ksh":
+		for i := 1; i < len(args); i++ {
+			value, ok := stringLiteralValue(args[i])
+			if !ok {
+				if i+1 < len(args) && a.isVariable(args[i+1]) {
+					return true
+				}
+				continue
+			}
+			if value == "--" {
+				return false
+			}
+			if posixShellOptionTakesOperand(value) {
+				if i+1 >= len(args) {
+					return false
+				}
+				i++
+				continue
+			}
+			if strings.HasPrefix(value, "-") {
+				if !strings.HasPrefix(value, "--") && strings.Contains(value[1:], "c") {
+					return i+1 < len(args) && a.isVariable(args[i+1])
+				}
+				continue
+			}
+			return false
+		}
+	case "cmd":
+		for i := 1; i < len(args); i++ {
+			value, ok := stringLiteralValue(args[i])
+			if !ok {
+				if i+1 < len(args) && a.isVariable(args[i+1]) {
+					return true
+				}
+				continue
+			}
+			if strings.EqualFold(value, "/c") || strings.EqualFold(value, "/k") {
+				return i+1 < len(args) && a.isVariable(args[i+1])
+			}
+			if strings.HasPrefix(value, "/") {
+				continue
+			}
+			return false
+		}
+	case "powershell", "pwsh":
+		for i := 1; i < len(args); i++ {
+			value, ok := stringLiteralValue(args[i])
+			if !ok {
+				if i+1 < len(args) && a.isVariable(args[i+1]) {
+					return true
+				}
+				continue
+			}
+			normalized := strings.ToLower(value)
+			switch normalized {
+			case "-file", "/file", "-f", "/f":
+				return false
+			case "-command", "-c", "/command", "/c", "-encodedcommand", "-enc", "/encodedcommand", "/enc":
+				return i+1 < len(args) && a.isVariable(args[i+1])
+			}
+			if strings.HasPrefix(value, "-") || strings.HasPrefix(value, "/") {
+				continue
+			}
+			return false
+		}
+	}
+	return false
+}
+
 func (a *Analyzer) isUnsafeExecCommand(call *ast.CallExpr, funcName string) bool {
 	args := call.Args
 	if funcName == "CommandContext" {
@@ -542,7 +615,7 @@ func (a *Analyzer) isUnsafeExecCommand(call *ast.CallExpr, funcName string) bool
 	}
 	commandIndex, ok := shellCommandArgIndex(commandName, args)
 	if !ok {
-		return false
+		return a.hasVariablePotentialShellCommandArg(commandName, args)
 	}
 	return a.isVariable(args[commandIndex])
 }

--- a/skylos/engines/go/internal/analyzer/analyzer_exec_command_test.go
+++ b/skylos/engines/go/internal/analyzer/analyzer_exec_command_test.go
@@ -1,0 +1,186 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExecCommandShellCommandInjectionDetection(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		wantRule bool
+	}{
+		{
+			name: "literal shell flag with variable command",
+			source: `package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	userInput := os.Args[1]
+	exec.Command("sh", "-c", userInput).Run()
+}
+`,
+			wantRule: true,
+		},
+		{
+			name: "variable shell flag with variable command",
+			source: `package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	flag := "-c"
+	userInput := os.Args[1]
+	exec.Command("sh", flag, userInput).Run()
+}
+`,
+			wantRule: true,
+		},
+		{
+			name: "command context variable shell flag with variable command",
+			source: `package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	flag := "-c"
+	userInput := os.Args[1]
+	exec.CommandContext(context.Background(), "sh", flag, userInput).Run()
+}
+`,
+			wantRule: true,
+		},
+		{
+			name: "variable option before literal shell flag with variable command",
+			source: `package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	option := "-x"
+	userInput := os.Args[1]
+	exec.Command("sh", option, "-c", userInput).Run()
+}
+`,
+			wantRule: true,
+		},
+		{
+			name: "variable shell flag with literal command",
+			source: `package main
+
+import "os/exec"
+
+func main() {
+	flag := "-c"
+	exec.Command("sh", flag, "echo ok").Run()
+}
+`,
+			wantRule: false,
+		},
+		{
+			name: "non shell command with variable argument",
+			source: `package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	branch := os.Args[1]
+	exec.Command("git", "checkout", branch).Run()
+}
+`,
+			wantRule: false,
+		},
+		{
+			name: "literal shell script with variable argument",
+			source: `package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	userInput := os.Args[1]
+	exec.Command("sh", "script.sh", userInput).Run()
+}
+`,
+			wantRule: false,
+		},
+		{
+			name: "powershell file mode with variable arguments",
+			source: `package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	script := os.Args[1]
+	arg := os.Args[2]
+	exec.Command("powershell", "-File", script, arg).Run()
+}
+`,
+			wantRule: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := analyzeGoSource(t, tc.source)
+			gotRule := hasRule(findings, "SKY-G212")
+			if gotRule != tc.wantRule {
+				t.Fatalf("SKY-G212 presence = %v, want %v; findings: %#v", gotRule, tc.wantRule, findings)
+			}
+		})
+	}
+}
+
+func analyzeGoSource(t *testing.T, source string) []string {
+	t.Helper()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := New().AnalyzeDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		rules = append(rules, finding.RuleID)
+	}
+	return rules
+}
+
+func hasRule(rules []string, ruleID string) bool {
+	for _, rule := range rules {
+		if rule == ruleID {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixed a Go analyzer false negative where `os/exec.Command` shell execution was missed when the shell execution flag was stored in a variable or other non-literal expression. The change keeps the newer precision behavior for ordinary non-shell commands. 

## Tests

  - `go test ./...`
