### PR TITLE
fix(quality): redact duplicate secret literals

### DIFF
--- a/skylos/rules/quality/logic_maintainability.py
+++ b/skylos/rules/quality/logic_maintainability.py
@@ -1,6 +1,8 @@
 import ast
+import math
 from pathlib import Path
 
+from skylos.audit.redaction import REDACTION, redact_text
 from skylos.rules.base import SkylosRule
 from skylos.rules.quality.logic_foundation import (
     _exception_type_names,
@@ -8,6 +10,57 @@ from skylos.rules.quality.logic_foundation import (
     _handler_has_real_work,
 )
 from skylos.rules.quality.logic_security import _qualified_call_name
+
+
+_SENSITIVE_LITERAL_KEYWORDS = (
+    "api_key",
+    "apikey",
+    "auth",
+    "bearer",
+    "credential",
+    "password",
+    "passwd",
+    "private_key",
+    "secret",
+    "token",
+)
+
+
+def _string_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+    counts: dict[str, int] = {}
+    for char in value:
+        counts[char] = counts.get(char, 0) + 1
+    length = len(value)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())
+
+
+def _looks_sensitive_literal(value: str) -> bool:
+    if redact_text(value) != value:
+        return True
+
+    lowered = value.lower()
+    if any(keyword in lowered for keyword in _SENSITIVE_LITERAL_KEYWORDS):
+        return True
+
+    if len(value) < 24:
+        return False
+
+    has_upper = any(char.isupper() for char in value)
+    has_lower = any(char.islower() for char in value)
+    has_digit = any(char.isdigit() for char in value)
+    has_symbol = any(char in "_-./+=" for char in value)
+    return (
+        sum((has_upper, has_lower, has_digit, has_symbol)) >= 3
+        and _string_entropy(value) >= 3.5
+    )
+
+
+def _duplicate_string_display(value: str) -> str:
+    if _looks_sensitive_literal(value):
+        return REDACTION
+    return value if len(value) <= 40 else value[:37] + "..."
 
 
 class DuplicateStringLiteralRule(SkylosRule):
@@ -105,7 +158,7 @@ class DuplicateStringLiteralRule(SkylosRule):
             if count < self.threshold:
                 continue
             severity = "MEDIUM" if count >= 6 else "LOW"
-            display = value if len(value) <= 40 else value[:37] + "..."
+            display = _duplicate_string_display(value)
             findings.append(
                 {
                     "rule_id": self.rule_id,

--- a/test/test_quality_rules.py
+++ b/test/test_quality_rules.py
@@ -530,7 +530,41 @@ def f():
 """
         rule = DuplicateStringLiteralRule()
         findings = check_code(rule, code)
-        assert any(f["rule_id"] == "SKY-L027" for f in findings)
+        finding = next(f for f in findings if f["rule_id"] == "SKY-L027")
+        assert finding["name"] == "repeated_magic_string"
+        assert "repeated_magic_string" in finding["message"]
+
+    def test_repeated_secret_like_string_is_redacted(self):
+        secret = "ghp_" + "1234567890" + "abcdefABCDEF1234567890abcd"
+        code = f'''
+def f():
+    a = "{secret}"
+    b = "{secret}"
+    c = "{secret}"
+'''
+        rule = DuplicateStringLiteralRule()
+        findings = check_code(rule, code)
+        finding = next(f for f in findings if f["rule_id"] == "SKY-L027")
+
+        assert finding["name"] == "[REDACTED_SECRET]"
+        assert finding["simple_name"] == "[REDACTED_SECRET]"
+        assert secret not in finding["message"]
+        assert secret not in repr(finding)
+
+    def test_repeated_password_like_string_is_redacted(self):
+        secret = "prod_password_value_2026"
+        code = f'''
+def f():
+    a = "{secret}"
+    b = "{secret}"
+    c = "{secret}"
+'''
+        rule = DuplicateStringLiteralRule()
+        findings = check_code(rule, code)
+        finding = next(f for f in findings if f["rule_id"] == "SKY-L027")
+
+        assert finding["name"] == "[REDACTED_SECRET]"
+        assert secret not in finding["message"]
 
     def test_unique_strings_ok(self):
         code = """


### PR DESCRIPTION
## Summary

  Redacts sensitive-looking literals from `SKY-L027` duplicate string findings.

  - Redacts known secret patterns using existing audit redaction patterns.
  - Redacts keyword-based and high-entropy token-like literals before populating `name`, `simple_name`, and `message`.
  - Adds regression coverage for token-like and password-like repeated strings.

  ## Tests

  - `pytest test/test_quality_rules.py`
