### PR TITLE
fix(typescript): avoid recursive nesting scan

### DIFF
--- a/skylos/visitors/languages/typescript/quality.py
+++ b/skylos/visitors/languages/typescript/quality.py
@@ -101,30 +101,18 @@ def _get_func_nodes(root_node, lang: Language) -> list:
 
 def _max_nesting(node, depth: int = 0) -> int:
     max_depth = depth
-    cursor = node.walk()
-    visited = False
-    while True:
-        if visited:
-            if cursor.node.id == node.id:
-                break
-            if cursor.goto_next_sibling():
-                visited = False
-            elif cursor.goto_parent():
-                visited = True
-            else:
-                break
-        else:
-            current = cursor.node
-            if current.id != node.id and current.type in NESTING_NODES:
-                child_max = _max_nesting(current, depth + 1)
-                if child_max > max_depth:
-                    max_depth = child_max
-                visited = True
-                continue
-            if cursor.goto_first_child():
-                visited = False
-            else:
-                visited = True
+    stack = [(node, depth)]
+
+    while stack:
+        current, current_depth = stack.pop()
+        for child in current.children:
+            child_depth = (
+                current_depth + 1 if child.type in NESTING_NODES else current_depth
+            )
+            if child_depth > max_depth:
+                max_depth = child_depth
+            stack.append((child, child_depth))
+
     return max_depth
 
 

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -233,6 +234,25 @@ class TestTSQualityRules:
         _, _, quality, _ = _scan_ts(tmp_path, code)
         nesting = [f for f in quality if f["rule_id"] == "SKY-Q302"]
         assert len(nesting) > 0
+
+    def test_deep_nesting_does_not_exceed_python_recursion(self, tmp_path):
+        old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(200)
+        depth = 250
+        lines = ["function deep(x: number) {"]
+        lines.extend(f"if (x > {i}) {{" for i in range(depth))
+        lines.append("return x;")
+        lines.extend("}" for _ in range(depth))
+        lines.append("}")
+
+        try:
+            _, _, quality, _ = _scan_ts(tmp_path, "\n".join(lines))
+        finally:
+            sys.setrecursionlimit(old_limit)
+
+        nesting = [f for f in quality if f["rule_id"] == "SKY-Q302"]
+        assert nesting
+        assert f"nesting depth {depth}" in nesting[0]["message"]
 
     def test_too_many_params(self, tmp_path):
         code = (


### PR DESCRIPTION
## Summary

  - Replaces the recursive TypeScript nesting-depth walker with an explicit stack traversal.
  - Preserves the existing nesting-depth semantics while avoiding Python recursion-limit crashes on deeply nested TS/TSX input.

  ## Tests

  - `pytest -q test/test_typescript_expanded.py test/test_typescript.py`
