### PR TITLE
fix(cicd): validate workflow scan path

### DIFF
--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -34,7 +34,10 @@ def _skylos_install_command(version: str | None = None) -> str:
 
 
 def _shell_path(path: str | Path | None) -> str:
-    raw = str(path or ".").strip() or "."
+    raw = str(path or ".")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in raw):
+        raise ValueError("scan_path must not contain control characters")
+    raw = raw.strip() or "."
     if raw.startswith("-"):
         raw = f"./{raw}"
     return shlex.quote(raw)

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -188,18 +188,22 @@ def run_cicd_command(
     if cicd_args.cicd_cmd == "init":
         from skylos.cicd.workflow import generate_workflow, write_workflow
 
-        yaml_content = generate_workflow(
-            triggers=cicd_args.triggers,
-            analysis_types=cicd_args.analysis,
-            python_version=cicd_args.python_version,
-            use_baseline=not cicd_args.no_baseline,
-            use_llm=cicd_args.llm,
-            model=cicd_args.model,
-            use_claude_security=cicd_args.claude_security,
-            use_upload=cicd_args.upload,
-            use_defend=cicd_args.defend,
-            scan_path=cicd_args.scan_path,
-        )
+        try:
+            yaml_content = generate_workflow(
+                triggers=cicd_args.triggers,
+                analysis_types=cicd_args.analysis,
+                python_version=cicd_args.python_version,
+                use_baseline=not cicd_args.no_baseline,
+                use_llm=cicd_args.llm,
+                model=cicd_args.model,
+                use_claude_security=cicd_args.claude_security,
+                use_upload=cicd_args.upload,
+                use_defend=cicd_args.defend,
+                scan_path=cicd_args.scan_path,
+            )
+        except ValueError as e:
+            console.print(f"[bold red]Invalid workflow option: {e}[/bold red]")
+            return 1
         write_workflow(yaml_content, cicd_args.output or _default_workflow_output())
         return 0
 

--- a/test/test_cicd_workflow.py
+++ b/test/test_cicd_workflow.py
@@ -1,3 +1,4 @@
+import pytest
 import yaml
 from skylos.cicd.workflow import generate_workflow
 
@@ -149,6 +150,18 @@ def test_workflow_scan_path_is_monorepo_aware():
 def test_workflow_prefixes_leading_dash_scan_path():
     content = generate_workflow(scan_path="-service")
     assert "skylos ./-service" in content
+
+
+@pytest.mark.parametrize("control_char", ["\n", "\r", "\t", "\x7f"])
+def test_workflow_rejects_scan_path_control_characters(control_char):
+    payload = f"apps/api{control_char}      - name: Injected Step"
+
+    with pytest.raises(ValueError, match="scan_path"):
+        generate_workflow(
+            scan_path=payload,
+            use_llm=True,
+            use_defend=True,
+        )
 
 
 def test_workflow_pins_installed_skylos_version():

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -913,6 +913,30 @@ def test_cicd_gate_command_reads_input_and_returns_gate_exit(tmp_path):
     assert mock_gate.call_args.kwargs["result"]["project_root"] == str(tmp_path)
 
 
+def test_cicd_init_rejects_control_characters_in_scan_path(tmp_path):
+    from skylos.commands.cicd_cmd import run_cicd_command
+
+    console = Mock()
+    output = tmp_path / "skylos.yml"
+    exit_code = run_cicd_command(
+        [
+            "init",
+            "--scan-path",
+            "apps/api\n      - name: Injected",
+            "--output",
+            str(output),
+        ],
+        console_factory=lambda: console,
+        load_config_func=lambda path: {},
+        run_gate_interaction_func=Mock(),
+        emit_github_annotations_func=Mock(),
+    )
+
+    assert exit_code == 1
+    assert not output.exists()
+    assert "Invalid workflow option" in console.print.call_args.args[0]
+
+
 def test_cicd_review_command_passes_evidence_cards_flag(tmp_path, monkeypatch):
     results_path = tmp_path / "results.json"
     results_path.write_text(json.dumps({"project_root": str(tmp_path), "danger": []}))


### PR DESCRIPTION
## Summary

  - Rejects control characters in generated workflow `scan_path` values before shell quoting.
  - Blocks newline-based YAML step injection across generated analysis, LLM, and defend commands.
  - Make `skylos cicd init` fail cleanly

  ## Testing
  - `pytest test/test_cicd_workflow.py test/test_cli_refactor_guardrails.py::test_cicd_init_rejects_control_characters_in_scan_path`