### PR TITLE
fix(secrets): restore generic value export

### DIFF
--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -75,6 +75,19 @@ BARE_GENERIC_VALUE = re.compile(
     r"(?P<bare>(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{32,}(?![A-Za-z0-9_-]))"
 )
 
+# Public compatibility pattern used by MCP diff validation. Keep this linear:
+# charset requirements for bare tokens are checked in Python by scan_ctx.
+GENERIC_VALUE = re.compile(
+    r"""(?ix)
+    (?:
+      (token|api[_-]?key|secret|password|passwd|pwd|bearer|auth[_-]?token|access[_-]?token)
+      \s*[:=]\s*(?P<q>['"])(?P<val>[^'"]{16,})(?P=q)
+    )
+    |
+    (?P<bare>(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{32,}(?![A-Za-z0-9_-]))
+"""
+)
+
 SAFE_TEST_HINTS = {
     "example",
     "sample",


### PR DESCRIPTION
## Summary

  - Fixed `main` CI failure after #410 by restoring the public `GENERIC_VALUE` export used by MCP diff validation.
  - Re-added `GENERIC_VALUE` as a compatibility regex in `skylos.rules.secrets`.
  - Kept bare-token charset validation out of the regex to avoid quadratic-time scans.
  - Preserved the secret scanner fix from #410.

  ## Validation

  - `pytest test/test_mcp_security.py`
  - `pytest test/test_secrets.py test/test_secrets_nonpy.py`