### PR TITLE
fix(sync): reject symlinked repo link

### DIFF
--- a/skylos/cloud/sync.py
+++ b/skylos/cloud/sync.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import json
+import stat
+import tempfile
 from pathlib import Path
 from datetime import datetime, timezone
 import subprocess
@@ -81,12 +83,8 @@ def _find_repo_root():
 
 
 def _linked_project_id(repo_root: Path):
-    p = repo_root / SKYLOS_DIR / LINK_FILE
-    if not p.exists():
-        return None
-    try:
-        data = json.loads(p.read_text() or "{}")
-    except Exception:
+    data = _read_link(repo_root)
+    if not data:
         return None
     repo_subpath = _current_repo_subpath(repo_root)
     subpath_entry = _project_entry_for_subpath(data, repo_subpath)
@@ -95,7 +93,10 @@ def _linked_project_id(repo_root: Path):
 
 
 def _read_link(repo_root: Path):
-    p = repo_root / SKYLOS_DIR / LINK_FILE
+    try:
+        p = _ensure_safe_link_path(repo_root, create_dir=False)
+    except AuthError:
+        return {}
     if not p.exists():
         return {}
     try:
@@ -132,6 +133,84 @@ def _project_entry_for_subpath(link: dict, repo_subpath: str) -> dict:
     return {}
 
 
+def _ensure_safe_link_path(repo_root: Path, *, create_dir: bool = False) -> Path:
+    repo_root = Path(repo_root)
+    try:
+        resolved_repo = repo_root.resolve(strict=True)
+    except OSError as exc:
+        raise AuthError(f"Repository root is not accessible: {repo_root}") from exc
+
+    skylos_dir = resolved_repo / SKYLOS_DIR
+    try:
+        dir_stat = skylos_dir.lstat()
+    except FileNotFoundError:
+        if not create_dir:
+            return skylos_dir / LINK_FILE
+        skylos_dir.mkdir(  # skylos: ignore[SKY-D215] fixed child under resolved repo root
+            parents=True,
+            exist_ok=False,
+        )
+        dir_stat = skylos_dir.lstat()
+
+    if stat.S_ISLNK(dir_stat.st_mode):
+        raise AuthError(f"Refusing to use symlinked Skylos directory: {skylos_dir}")
+    if not stat.S_ISDIR(dir_stat.st_mode):
+        raise AuthError(f"Skylos path is not a directory: {skylos_dir}")
+
+    try:
+        resolved_skylos_dir = skylos_dir.resolve(strict=True)
+        resolved_skylos_dir.relative_to(resolved_repo)
+    except (OSError, ValueError) as exc:
+        raise AuthError(
+            f"Skylos directory must stay inside the repository: {skylos_dir}"
+        ) from exc
+
+    link_path = skylos_dir / LINK_FILE
+    try:
+        link_stat = link_path.lstat()
+    except FileNotFoundError:
+        return link_path
+
+    if stat.S_ISLNK(link_stat.st_mode):
+        raise AuthError(f"Refusing to use symlinked Skylos link file: {link_path}")
+    if not stat.S_ISREG(link_stat.st_mode):
+        raise AuthError(f"Skylos link path is not a regular file: {link_path}")
+
+    try:
+        link_path.resolve(strict=True).relative_to(resolved_skylos_dir)
+    except (OSError, ValueError) as exc:
+        raise AuthError(f"Skylos link file must stay inside {skylos_dir}") from exc
+
+    return link_path
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    tmp_path = None
+    fd = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{LINK_FILE}.",
+            suffix=".tmp",
+            dir=str(path.parent),
+            text=True,
+        )
+        tmp_path = Path(tmp_name)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
 def _write_link(
     repo_root: Path,
     project_id,
@@ -142,10 +221,7 @@ def _write_link(
     *,
     base_url=None,
 ):
-    skylos_dir = repo_root / SKYLOS_DIR
-    skylos_dir.mkdir(parents=True, exist_ok=True)
-
-    link_path = skylos_dir / LINK_FILE
+    link_path = _ensure_safe_link_path(repo_root, create_dir=True)
     existing = _read_link(repo_root)
     normalized_subpath = _normalize_repo_subpath_value(repo_subpath)
     payload = {
@@ -173,12 +249,15 @@ def _write_link(
         "linked_at": payload["linked_at"],
     }
     payload["projects"] = projects
-    link_path.write_text(json.dumps(payload, indent=2))
+    _atomic_write_text(link_path, json.dumps(payload, indent=2))
     return str(link_path)
 
 
 def _delete_link(repo_root: Path):
-    p = repo_root / SKYLOS_DIR / LINK_FILE
+    try:
+        p = _ensure_safe_link_path(repo_root, create_dir=False)
+    except AuthError:
+        return None
     if not p.exists():
         return None
     p.unlink()
@@ -441,7 +520,11 @@ def cmd_connect(token_arg=None):
 
     repo_root = _find_repo_root()
 
-    link_path, creds_path = _save_repo_link_and_token(repo_root, token, context)
+    try:
+        link_path, creds_path = _save_repo_link_and_token(repo_root, token, context)
+    except AuthError as e:
+        print(f"\n✗ {e}")
+        sys.exit(1)
 
     print(f"\nLinked repo: {repo_root}")
     print(f"Link file:   {link_path}")
@@ -740,7 +823,11 @@ def cmd_setup(token_arg=None):
 
     repo_root = _find_repo_root()
 
-    _save_repo_link_and_token(repo_root, token, context)
+    try:
+        _save_repo_link_and_token(repo_root, token, context)
+    except AuthError as e:
+        print(f"\n✗ {e}")
+        return
 
     print("✓ Connected!\n")
     print(f"  Project: {project.get('name', 'Unknown')}")

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -127,6 +127,25 @@ def test_save_token_writes_file(isolated_creds):
         assert (creds_file.parent.stat().st_mode & 0o777) == 0o700
 
 
+def test_write_link_rejects_symlinked_link_file(tmp_path):
+    repo = tmp_path / "repo"
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("keep-me", encoding="utf-8")
+    link_path = skylos_dir / "link.json"
+    try:
+        link_path.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are not available on this platform")
+
+    with pytest.raises(syncmod.AuthError):
+        syncmod._write_link(repo, "proj_123")
+
+    assert outside.read_text(encoding="utf-8") == "keep-me"
+    assert link_path.is_symlink()
+
+
 def test_get_token_uses_repo_subpath_link(isolated_creds, monkeypatch, tmp_path):
     _, creds_file = isolated_creds
     repo = tmp_path / "repo"
@@ -367,6 +386,43 @@ def test_cmd_connect_with_token_arg_saves_creds(isolated_creds, monkeypatch, cap
     assert data["plan"] == "pro"
     assert data["tokens"]["proj_123"]["project_name"] == "Proj"
     assert data["tokens"]["proj_123"]["org_name"] == "Org"
+
+
+def test_cmd_connect_refuses_symlinked_link_file(
+    isolated_creds, monkeypatch, tmp_path, capsys
+):
+    _, creds_file = isolated_creds
+    repo = tmp_path / "repo"
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("keep-me", encoding="utf-8")
+    link_path = skylos_dir / "link.json"
+    try:
+        link_path.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are not available on this platform")
+
+    def fake_api_get(endpoint, token):
+        assert endpoint == "/api/sync/whoami"
+        assert token == "TOK_ARG"
+        return {
+            "project": {"id": "proj_123", "name": "Proj"},
+            "organization": {"name": "Org"},
+            "plan": "pro",
+        }
+
+    monkeypatch.setattr(syncmod, "api_get", fake_api_get)
+    monkeypatch.setattr(syncmod, "_find_repo_root", lambda: repo)
+
+    with pytest.raises(SystemExit) as exc:
+        syncmod.cmd_connect("TOK_ARG")
+
+    assert exc.value.code == 1
+    assert outside.read_text(encoding="utf-8") == "keep-me"
+    assert link_path.is_symlink()
+    assert not creds_file.exists()
+    assert "Refusing to use symlinked Skylos link file" in capsys.readouterr().out
 
 
 def test_cmd_connect_cancel_input(monkeypatch):


### PR DESCRIPTION
## Summary

  - Added safe link path validation for `.skylos/link.json`.
  - Reject symlinked `.skylos` directories and symlinked `link.json` files.
  - Verify the resolved `.skylos` directory remains inside the repository.
  - Write link metadata through a temp file and `os.replace()`.
  - Reuse the safe link path helper for link reads/deletes.

  ## Validation

  - `pytest test/test_sync.py`