### PR TITLE
fix(ci): keep parity venv outside checkout

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -14,9 +14,14 @@ on:
       - "skylos/**"
       - "test/test_fast_parity.py"
 
+permissions:
+  contents: read
+
 jobs:
   parity:
     runs-on: ubuntu-latest
+    env:
+      SK_PARITY_VENV: ${{ runner.temp }}/skylos-parity-venv
     steps:
       - uses: actions/checkout@v4
 
@@ -39,17 +44,16 @@ jobs:
 
       - name: Install skylos
         run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          pip install -e ".[test]"
+          rm -rf "${SK_PARITY_VENV}"
+          python -m venv "${SK_PARITY_VENV}"
+          "${SK_PARITY_VENV}/bin/python" -m pip install -e ".[test]"
 
       - name: Install maturin and build skylos-fast
         run: |
-          . .venv/bin/activate
-          pip install maturin
-          cd rust && maturin develop --release
+          "${SK_PARITY_VENV}/bin/python" -m pip install maturin
+          cd rust
+          VIRTUAL_ENV="${SK_PARITY_VENV}" "${SK_PARITY_VENV}/bin/python" -m maturin develop --release
 
       - name: Run parity tests
         run: |
-          . .venv/bin/activate
-          pytest test/test_fast_parity.py -v --tb=short
+          "${SK_PARITY_VENV}/bin/python" -m pytest test/test_fast_parity.py -v --tb=short


### PR DESCRIPTION
## Summary

  - Creates the parity virtualenv under `${{ runner.temp }}` instead of the repo checkout.
  - Removes activation-based PATH resolution and any previous temp venv before creation.
  - Invokes `pip`, `maturin`, and `pytest` through the explicit trusted venv Python path.
  - Adds `permissions: contents: read` for least-privilege workflow token access.

## Manual tests and validation

  - Parsed `.github/workflows/parity.yml` with PyYAML
  - staged gate passed