### PR TITLE
fix(cicd): quote generated PR base refs

### DIFF
--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -77,17 +77,16 @@ def generate_workflow(
     if analysis_flags:
         analysis_flags = " " + analysis_flags
     baseline_flag = " --baseline" if use_baseline else ""
-    pr_base_ref = "origin/${{ github.base_ref || 'main' }}"
-
     upload_flag = ""
     if use_upload:
         upload_flag = " --upload"
     analysis_run = "\n".join(
         [
             '          if [ "${{ github.event_name }}" = "pull_request" ]; then',
+            '            pr_base_ref="origin/${GITHUB_BASE_REF:-main}"',
             (
                 f"            skylos {scan_target}{analysis_flags}{baseline_flag}{upload_flag} "
-                f"--diff-base {pr_base_ref} --diff {pr_base_ref} "
+                '--diff-base "$pr_base_ref" --diff "$pr_base_ref" '
                 "--json -o skylos-results.json"
             ),
             "          else",
@@ -135,8 +134,14 @@ def generate_workflow(
         review_args.append("--llm-input skylos-llm-results.json")
     if use_defend:
         review_args.append("--defense-input defense-results.json")
-    review_args.extend([f"--diff-base {pr_base_ref}", "--evidence-cards"])
+    review_args.extend(['--diff-base "$pr_base_ref"', "--evidence-cards"])
     review_command = "skylos cicd review " + " ".join(review_args)
+    review_run = "\n".join(
+        [
+            '          pr_base_ref="origin/${GITHUB_BASE_REF:-main}"',
+            f"          {review_command}",
+        ]
+    )
 
     permissions_block = """permissions:
   contents: read
@@ -191,7 +196,8 @@ jobs:
 
       - name: PR Review Comments
         if: github.event_name == 'pull_request' && always()
-        run: {review_command}
+        run: |
+{review_run}
         env:
           GH_TOKEN: ${{{{ github.token }}}}
 {

--- a/test/test_cicd_workflow.py
+++ b/test/test_cicd_workflow.py
@@ -62,8 +62,20 @@ def test_workflow_omits_baseline_when_disabled():
 
 def test_workflow_pull_request_analysis_is_diff_aware():
     content = generate_workflow()
-    assert "--diff-base origin/${{ github.base_ref || 'main' }}" in content
-    assert "--diff origin/${{ github.base_ref || 'main' }}" in content
+    assert 'pr_base_ref="origin/${GITHUB_BASE_REF:-main}"' in content
+    assert '--diff-base "$pr_base_ref"' in content
+    assert '--diff "$pr_base_ref"' in content
+    assert "github.base_ref" not in content
+
+
+def test_workflow_quotes_base_ref_in_pr_review_step():
+    content = generate_workflow()
+    parsed = yaml.safe_load(content)
+    steps = parsed["jobs"]["skylos"]["steps"]
+    pr_review = next(s for s in steps if s.get("name") == "PR Review Comments")
+    assert 'pr_base_ref="origin/${GITHUB_BASE_REF:-main}"' in pr_review["run"]
+    assert '--diff-base "$pr_base_ref"' in pr_review["run"]
+    assert "github.base_ref" not in pr_review["run"]
 
 
 def test_workflow_no_llm_by_default():


### PR DESCRIPTION
## Summary
 
  - Computes `pr_base_ref` at runtime from `GITHUB_BASE_REF`.
  - Passes the base ref to `skylos` as a quoted shell variable.
  - Applies the same quoting pattern to both "Run Skylos Analysis" & "PR Review Comments"

  ## Tests
  - `pytest -q test/test_cicd_workflow.py`