### PR TITLE
fix(audit): scope deep processing to current scan

### DIFF
--- a/skylos/audit/candidates.py
+++ b/skylos/audit/candidates.py
@@ -148,6 +148,7 @@ def scan_deep_audit_candidates(
 
     store = AuditStore(project_root, project_id=project_id, audit_root=audit_root)
     store.init_project(config_hash=config_hash)
+    store.set_current_scan_files(files)
     deleted_records = store.mark_deleted_records(allowed_files=changed_files)
 
     records_written = 0

--- a/skylos/audit/processor.py
+++ b/skylos/audit/processor.py
@@ -38,7 +38,7 @@ def process_deep_audit_records(
     run_id: str | None = None,
 ) -> AuditProcessSummary:
     run_id = run_id or f"process-{uuid4().hex[:12]}"
-    allowed = _normalized_allowed_files(store, allowed_files)
+    allowed = store.processing_scope(allowed_files)
     records = [
         record
         for record in store.iter_file_records()
@@ -144,7 +144,7 @@ def process_deep_audit_records(
         store,
         model=model,
         provider=provider,
-        allowed_files=allowed_files,
+        allowed_files=allowed,
     )
     remaining = state_counts["unresolved"]
     summary = AuditProcessSummary(
@@ -190,8 +190,10 @@ def _record_sort_key(record: AuditFileRecord) -> tuple[int, str]:
 
 def _normalized_allowed_files(
     store: AuditStore,
-    allowed_files: list[str | Path] | None,
+    allowed_files: list[str | Path] | set[str] | None,
 ) -> set[str] | None:
+    if isinstance(allowed_files, set):
+        return set(allowed_files)
     if allowed_files is None:
         return None
     allowed: set[str] = set()
@@ -443,7 +445,7 @@ def _audit_state_counts(
     *,
     model: str,
     provider: str | None,
-    allowed_files: list[str | Path] | None = None,
+    allowed_files: list[str | Path] | set[str] | None = None,
 ) -> dict[str, int]:
     allowed = _normalized_allowed_files(store, allowed_files)
     counts = {

--- a/skylos/audit/revalidator.py
+++ b/skylos/audit/revalidator.py
@@ -11,7 +11,6 @@ from skylos.audit.types import (
     STATUS_DELETED,
     AuditFileRecord,
     AuditRevalidationSummary,
-    normalize_relative_path,
     sha256_text,
     utc_now,
 )
@@ -33,7 +32,7 @@ def revalidate_deep_audit_findings(
     run_id: str | None = None,
 ) -> AuditRevalidationSummary:
     run_id = run_id or f"revalidate-{uuid4().hex[:12]}"
-    allowed = _normalized_allowed_files(store, allowed_files)
+    allowed = store.processing_scope(allowed_files)
     records = [
         record
         for record in store.iter_file_records()
@@ -142,21 +141,6 @@ def revalidate_deep_audit_findings(
         },
     )
     return summary
-
-
-def _normalized_allowed_files(
-    store: AuditStore,
-    allowed_files: list[str | Path] | None,
-) -> set[str] | None:
-    if allowed_files is None:
-        return None
-    allowed: set[str] = set()
-    for file_path in allowed_files:
-        try:
-            allowed.add(normalize_relative_path(store.project_root, file_path))
-        except ValueError:
-            continue
-    return allowed
 
 
 def _has_secret_candidate(record: AuditFileRecord) -> bool:

--- a/skylos/audit/store.py
+++ b/skylos/audit/store.py
@@ -46,6 +46,7 @@ class AuditStore:
         self.files_dir = self.project_dir / "files"
         self.runs_dir = self.project_dir / "runs"
         self.exports_dir = self.project_dir / "exports"
+        self.current_scan_files: set[str] | None = None
 
     def init_project(self, *, config_hash: str) -> None:
         self.files_dir.mkdir(parents=True, exist_ok=True)
@@ -127,6 +128,26 @@ class AuditStore:
             if record is not None:
                 records.append(record)
         return records
+
+    def set_current_scan_files(self, files: list[str | Path]) -> None:
+        current: set[str] = set()
+        for file_path in files:
+            try:
+                current.add(normalize_relative_path(self.project_root, file_path))
+            except ValueError:
+                continue
+        self.current_scan_files = current
+
+    def processing_scope(
+        self,
+        allowed_files: list[str | Path] | set[str] | None = None,
+    ) -> set[str] | None:
+        requested = self._normalized_allowed_files(allowed_files)
+        if self.current_scan_files is None:
+            return requested if requested is not None else set()
+        if requested is None:
+            return set(self.current_scan_files)
+        return requested & self.current_scan_files
 
     def write_file_record(self, record: AuditFileRecord) -> None:
         if record.project_id != self.project_id:

--- a/test/test_audit_candidates.py
+++ b/test/test_audit_candidates.py
@@ -221,6 +221,7 @@ def test_scan_deep_audit_candidates_records_non_candidate_files(
     assert record is not None
     assert record.status == "not_analyzed"
     assert payload["candidates"] == []
+    assert store.current_scan_files == {"plain.py"}
 
 
 def test_scan_deep_audit_candidates_marks_deleted_records(tmp_path: Path, monkeypatch):

--- a/test/test_audit_processor.py
+++ b/test/test_audit_processor.py
@@ -98,6 +98,7 @@ def _write_record(
     if status:
         record.status = status
         store.write_file_record(record)
+    store.set_current_scan_files([*(store.current_scan_files or ()), file_path])
     return record
 
 
@@ -176,6 +177,62 @@ def test_process_deep_audit_records_respects_allowed_file_scope(tmp_path: Path):
     assert summary.processed_files == 1
     assert summary.complete is True
     assert store.read_file_record(old).status == "pending"
+
+
+def test_process_deep_audit_records_defaults_to_current_scan_scope(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    hidden = repo / ".git" / "config"
+    hidden.parent.mkdir()
+    hidden.write_text(
+        "[remote]\n  url = https://token@example.invalid/repo\n",
+        encoding="utf-8",
+    )
+    app = repo / "app.py"
+    app.write_text("print('ok')\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, hidden, candidates=[_candidate("poison", priority=900)])
+    store.set_current_scan_files([app])
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-current-scope",
+    )
+
+    assert analyzer.calls == []
+    assert summary.considered_files == 0
+    assert summary.processed_files == 0
+    assert summary.complete is True
+    assert store.read_file_record(hidden).status == "pending"
+
+
+def test_process_deep_audit_records_without_scope_fails_closed(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, candidates=[_candidate("candidate", priority=900)])
+    store.current_scan_files = None
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-no-scope",
+    )
+
+    assert analyzer.calls == []
+    assert summary.considered_files == 0
+    assert summary.processed_files == 0
+    assert summary.complete is True
+    assert store.read_file_record(app).status == "pending"
 
 
 def test_process_deep_audit_records_skips_secret_candidates(tmp_path: Path):

--- a/test/test_audit_revalidator.py
+++ b/test/test_audit_revalidator.py
@@ -70,6 +70,7 @@ def _write_analyzed_record(
         }
     ]
     store.write_file_record(record)
+    store.set_current_scan_files([*(store.current_scan_files or ()), path])
     return record
 
 
@@ -237,6 +238,64 @@ def test_revalidate_deep_audit_findings_skips_secret_candidate_records(
     assert verifier.calls == []
     assert summary.skipped_findings == 1
     assert summary.complete is False
+
+
+def test_revalidate_deep_audit_findings_defaults_to_current_scan_scope(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    hidden = repo / ".git" / "config"
+    hidden.parent.mkdir()
+    hidden.write_text(
+        "[remote]\n  url = https://token@example.invalid/repo\n",
+        encoding="utf-8",
+    )
+    app = repo / "app.py"
+    app.write_text("print('ok')\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, hidden)
+    store.set_current_scan_files([app])
+
+    verifier = FakeVerifier("true_positive")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        run_id="run-current-scope",
+    )
+
+    assert verifier.calls == []
+    assert summary.considered_findings == 0
+    assert summary.revalidated_findings == 0
+    assert summary.complete is True
+
+
+def test_revalidate_deep_audit_findings_without_scope_fails_closed(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, app)
+    store.current_scan_files = None
+
+    verifier = FakeVerifier("true_positive")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        run_id="run-no-scope",
+    )
+
+    assert verifier.calls == []
+    assert summary.considered_findings == 0
+    assert summary.revalidated_findings == 0
+    assert summary.complete is True
 
 
 def test_revalidate_deep_audit_findings_challenges_uncertain_verdicts(


### PR DESCRIPTION
## Summary

  - Records the current Deep Mode scan file set on the returned `AuditStore`.
  - Scopes `process_deep_audit_records()` to the current scan set before reading files
  - Makes direct processor calls without current scan scope or explicit `allowed_files` fail closed.

## Tests
  - `pytest test/test_audit_candidates.py test/test_audit_processor.py test/test_audit_revalidator.py test/
  test_audit_cli.py`