### PR TITLE
feat(cli): improve terminal scan output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@
 ## What Is Skylos?
 
 Skylos is an open-source static analysis tool and CI/CD PR gate for Python,
-TypeScript, JavaScript, Java, Go, PHP, and Rust repositories. It combines dead
-code detection, security scanning, secrets detection, code quality checks, and
-AI-generated code guardrails in one local-first workflow.
+TypeScript, JavaScript, Java, Go, PHP, Rust, and Dart repositories. It combines
+dead code detection, security scanning, secrets detection, code quality checks,
+and AI-generated code guardrails in one local-first workflow.
 
 If you use tools like Vulture, Bandit, Semgrep, CodeQL, or GitHub Advanced
 Security, Skylos is designed to complement that workflow with framework-aware
@@ -103,6 +103,8 @@ Need more commands? Read the [CLI Reference](https://docs.skylos.dev/cli-referen
 | First dead-code scan | `skylos .` | Finds unused functions, classes, imports, files, and framework entrypoint mistakes | [Dead code docs](https://docs.skylos.dev/dead-code-detection) |
 | Security and quality audit | `skylos . -a` | Adds dangerous flow, secrets, dependency, and quality checks | [Security docs](https://docs.skylos.dev/security-analysis) |
 | PR gate | `skylos cicd init` | Generates a GitHub Actions workflow with annotations and failure thresholds | [CI/CD guide](https://docs.skylos.dev/ci-cd) |
+| Readable terminal report | `skylos . --format pretty` | Groups findings by file with severity badges, snippets, and copyable `file:line` locations | [CLI output modes](./docs/cli-output.md) |
+| Selectable terminal triage | `skylos . --tui` | Opens a keyboard-driven category list, finding list, and detail pane | [CLI output modes](./docs/cli-output.md) |
 | IDE/test-script output | `skylos --format concise src/test.py` | Prints only `file:line` findings and exits non-zero when findings exist | [CLI Reference](https://docs.skylos.dev/cli-reference) |
 | Changed-lines review | `skylos . -a --diff origin/main` | Keeps findings focused on active work instead of legacy debt | [Quality gate docs](https://docs.skylos.dev/quality-gate) |
 | Runtime-assisted dead-code check | `skylos . --trace` | Uses runtime traces to reduce dynamic-code false positives | [Smart tracing](https://docs.skylos.dev/smart-tracing) |
@@ -198,6 +200,7 @@ credential names, sensitive files, and network calls that must set timeouts.
 | Go | Yes | Partial | Partial | dead-code and selected security benchmark coverage |
 | PHP | Yes | Yes | Partial | PHP parser coverage plus taint-style security sinks and sources |
 | Rust | Yes | Yes | Partial | Rust parser coverage plus security sink/source checks |
+| Dart | Yes | Yes | Partial | Dart parser coverage plus selected security sinks and sources |
 
 See [Rules Reference](https://docs.skylos.dev/rules-reference) for rule families
 and scanner scope.
@@ -254,9 +257,11 @@ metadata, and supports monorepo subprojects through `--scan-path`.
 | Install options, source install, and Docker | [Installation](https://docs.skylos.dev/installation) |
 | First scan and core workflows | [Quick Start](https://docs.skylos.dev/quick-start) |
 | CLI commands, flags, and examples | [CLI Reference](https://docs.skylos.dev/cli-reference) |
+| CLI output modes, pretty reports, and TUI controls | [CLI Output Modes](./docs/cli-output.md) |
 | CI setup, PR gates, annotations, and branch protection | [CI/CD](https://docs.skylos.dev/ci-cd) |
 | Dead-code behavior and framework awareness | [Dead Code Detection](https://docs.skylos.dev/dead-code-detection) |
 | Security scanning and taint analysis | [Security Analysis](https://docs.skylos.dev/security-analysis) |
+| Rule ID prefixes and product terminology | [Rule Dictionary](./dictionary.md) |
 | Agent scan, verification, remediation, and model setup | [AI Features](https://docs.skylos.dev/ai-features) |
 | AI defense checks and LLM guardrails | [AI Defense](https://docs.skylos.dev/ai-defense) |
 | MCP server setup | [MCP Server](https://docs.skylos.dev/mcp-server) |

--- a/README_CN.md
+++ b/README_CN.md
@@ -26,7 +26,7 @@
 
 ## Skylos 是什么？
 
-Skylos 是一款面向 Python、TypeScript、JavaScript、Java 和 Go 仓库的开源静态分析工具与 CI/CD PR 门控。它把死代码检测、安全扫描、密钥检测、代码质量检查和 AI 生成代码防护整合进一个本地优先的工作流。
+Skylos 是一款面向 Python、TypeScript、JavaScript、Java、Go、PHP、Rust 和 Dart 仓库的开源静态分析工具与 CI/CD PR 门控。它把死代码检测、安全扫描、密钥检测、代码质量检查和 AI 生成代码防护整合进一个本地优先的工作流。
 
 如果你使用 Vulture 检测死代码、Bandit 做安全检查，或使用 Semgrep、CodeQL、GitHub Advanced Security 做 CI 门控，Skylos 可以作为补充：它更关注框架感知的死代码检测、差异感知的回归检查，以及适合 PR 审查的反馈。
 
@@ -61,6 +61,8 @@ git push
 | 第一次死代码扫描 | `skylos .` | 发现未使用的函数、类、导入、文件和框架入口点问题 | [死代码文档](https://docs.skylos.dev/dead-code-detection) |
 | 安全与质量审计 | `skylos . -a` | 增加危险数据流、密钥、依赖和质量检查 | [安全文档](https://docs.skylos.dev/security-analysis) |
 | PR 门控 | `skylos cicd init` | 生成带注释和失败阈值的 GitHub Actions 工作流 | [CI/CD 指南](https://docs.skylos.dev/ci-cd) |
+| 更易读的终端报告 | `skylos . --format pretty` | 按文件分组展示发现，包含严重级别标记、代码片段和可复制的 `file:line` 位置 | [CLI Output Modes](./docs/cli-output.md) |
+| 可选择的终端界面 | `skylos . --tui` | 打开键盘驱动的分类列表、发现列表和详情面板 | [CLI Output Modes](./docs/cli-output.md) |
 | 只审查变更行 | `skylos . -a --diff origin/main` | 聚焦当前 PR，避免被历史债务淹没 | [质量门控](https://docs.skylos.dev/quality-gate) |
 | 运行时辅助死代码检测 | `skylos . --trace` | 用测试运行轨迹降低动态代码误报 | [Smart Tracing](https://docs.skylos.dev/smart-tracing) |
 | AI 辅助审查 | `skylos agent scan .` | 静态分析加可选 LLM 审查和修复建议 | [AI Features](https://docs.skylos.dev/ai-features) |
@@ -118,6 +120,9 @@ docker run --rm -v "$PWD":/work -w /work ghcr.io/duriantaco/skylos:latest . --js
 | TypeScript / JavaScript | 是 | 是 | 是 | Tree-sitter 解析、包图可达性、框架约定 |
 | Java | 是 | 是 | 是 | Tree-sitter 解析和结构化安全流分析 |
 | Go | 是 | 部分 | 部分 | 死代码和部分安全基准覆盖 |
+| PHP | 是 | 是 | 部分 | PHP parser 覆盖，加上污点式安全 sinks 和 sources |
+| Rust | 是 | 是 | 部分 | Rust parser 覆盖，加上安全 sinks 和 sources |
+| Dart | 是 | 是 | 部分 | Dart parser 覆盖，加上部分安全 sinks 和 sources |
 
 规则族和扫描范围请看 [Rules Reference](https://docs.skylos.dev/rules-reference)。
 
@@ -160,9 +165,11 @@ Skylos 有已提交的死代码、安全、质量和 Agent 审查回归基准。
 | 安装、源码安装和 Docker | [Installation](https://docs.skylos.dev/installation) |
 | 第一次扫描和核心工作流 | [Quick Start](https://docs.skylos.dev/quick-start) |
 | CLI 命令、flags 和示例 | [CLI Reference](https://docs.skylos.dev/cli-reference) |
+| CLI 输出模式、pretty 报告和 TUI 快捷键 | [CLI Output Modes](./docs/cli-output.md) |
 | CI 设置、PR 门控、注释和分支保护 | [CI/CD](https://docs.skylos.dev/ci-cd) |
 | 死代码行为和框架感知 | [Dead Code Detection](https://docs.skylos.dev/dead-code-detection) |
 | 安全扫描和污点分析 | [Security Analysis](https://docs.skylos.dev/security-analysis) |
+| Rule ID 前缀和产品术语 | [Rule Dictionary](./dictionary.md) |
 | Agent 扫描、验证、修复和模型设置 | [AI Features](https://docs.skylos.dev/ai-features) |
 | AI 防御和 LLM guardrails | [AI Defense](https://docs.skylos.dev/ai-defense) |
 | MCP server 设置 | [MCP Server](https://docs.skylos.dev/mcp-server) |

--- a/dictionary.md
+++ b/dictionary.md
@@ -1,185 +1,365 @@
-# Skylos Rule Dictionary
+# Skylos Rule Dictionary and Product Glossary
 
-Rule IDs are unified across languages — same vulnerability, same ID.
+This file is the repo-local glossary for public Skylos terminology and emitted
+rule IDs. Keep it aligned with `README.md`, `README_CN.md`, `docs/*.md`, CLI
+help text, and rule implementations.
+
+Rule IDs use a stable public prefix:
+
+| Prefix | Meaning |
+|:---|:---|
+| `SKY-D` | Security and danger findings |
+| `SKY-S` | Secrets findings |
+| `SKY-SCA` | Software composition / dependency vulnerability findings |
+| `SKY-SC` | Security contract regression findings |
+| `SKY-L` | Logic, AI-code mistake, and resilience findings |
+| `SKY-Q` | Quality, complexity, coupling, and architecture findings |
+| `SKY-C` | Structure and clone findings |
+| `SKY-P` | Performance findings |
+| `SKY-U`, `SKY-DC`, `SKY-UC` | Dead-code, LLM dead-code report, and unreachable-code findings |
+| `SKY-T` | Typing practice findings |
+| `SKY-F` | Framework practice findings |
+| `SKY-R` | Repository policy findings |
+| `SKY-E` | Analyzer inventory / export findings |
+| `SKY-G` | Raw Go engine findings before remapping |
+| `SKY-CIRC` | Circular dependency finding |
+
+## Product Glossary
+
+| Term | Meaning |
+|:---|:---|
+| Skylos | Local-first static analysis and PR gate for dead code, security, secrets, quality, dependency, and AI-code issues. |
+| Local-first | Core static analysis runs on the developer machine or CI runner without requiring cloud upload or LLM calls. |
+| Core scan | `skylos .`; dead-code focused scan. |
+| Full audit | `skylos . -a`; enables security, secrets, dependency, and quality checks in addition to dead code. |
+| Dead code | Unused functions, classes, imports, variables, parameters, files, unnecessary exports, and unreachable code. |
+| Security / danger | Potentially exploitable code paths such as injection, SSRF, path traversal, weak crypto, unsafe deserialization, and CI/CD supply-chain risk. |
+| Secrets | Hardcoded credentials, tokens, API keys, and client-side exposure of server-only values. |
+| Quality | Maintainability, complexity, architecture, resilience, typing, framework practice, and repo policy issues. |
+| AI code mistakes | Hallucinated security calls, phantom decorators, unfinished stubs, disabled controls, placeholder data, stale mocks, and missing timeouts. |
+| LLM app defense | `skylos defend .`; checks LLM integrations for guardrails such as tool safety, output validation, rate limits, and prompt-injection exposure. |
+| Prompt templates | Maintainer-provided files under `[tool.skylos.templates]` that extend built-in LLM prompts without replacing safety and JSON-output contracts. |
+| Vibe dictionary | Project-specific keyword extensions under `[tool.skylos.vibe]` for phantom security names, credential names, sensitive files, and timeout-required calls. |
+| Quality gate | A threshold-based pass/fail decision used locally or in CI. |
+| Diff-aware scan | `--diff <base>` limits reporting to changed work so old debt does not drown out the current PR. |
+| Baseline | A saved set of accepted existing findings so only new or changed findings fail a gate. |
+| Suppression | An inline or config-level exception for an intentional finding, usually using `skylos: ignore[SKY-...]`. |
+| Smart tracing | `--trace`; runtime-assisted dead-code verification used to reduce false positives in dynamic Python code. |
+| Technical debt | `skylos debt .`; ranks maintainability hotspots and debt trends. |
+| TUI | `--tui`; screen-only selectable terminal interface with category list, finding list, and detail pane. |
+| Pretty output | `--format pretty`; compact file-grouped terminal output with severity rails, snippets, and copyable `file:line` locations. |
+| Concise output | `--format concise`; plain `file:line` output for editors, scripts, and agents. |
+| Structured output | `--format json`, `--format llm`, or `--format github` for machines, LLM consumers, and GitHub annotations. |
+| Upload / Cloud workflow | Optional upload of scan results to Skylos Cloud; not required for local analysis. |
+| MCP server | Integration surface for AI agents and coding assistants. |
+| SCA | Software composition analysis for dependency vulnerability findings. |
+
+## CLI Output Modes
+
+| Mode | Command | Intended Use |
+|:---|:---|:---|
+| Rich/default | `skylos .` | Existing full terminal report. |
+| Pretty | `skylos . --format pretty` | Human terminal triage with grouped findings and copyable locations. |
+| Concise | `skylos . --format concise` | Editors, test scripts, and agents that need plain `file:line` findings. |
+| JSON | `skylos . --format json` or `skylos . --json` | Structured machine output. |
+| LLM | `skylos . --format llm` or `skylos . --llm` | LLM-oriented structured report with code context. |
+| GitHub | `skylos . --format github` or `skylos . --github` | GitHub annotation output. |
+| TUI | `skylos . --tui` | Screen-only selectable keyboard-driven terminal triage. |
+
+See [docs/cli-output.md](./docs/cli-output.md).
 
 ## Security / Danger (SKY-D)
 
-| ID | Severity | Name | Languages | CWE | OWASP |
-|----|----------|------|-----------|-----|-------|
-| D201 | HIGH | eval() usage | Python, TS | CWE-95 | A03:2021 |
-| D202 | HIGH | Dynamic code execution (exec, new Function, setTimeout string) | Python, TS | CWE-95 | A03:2021 |
-| D203 | CRITICAL | os.system() | Python | — | A03:2021 |
-| D204 | CRITICAL | pickle.load | Python | — | A08:2021 |
-| D205 | CRITICAL | pickle.loads | Python | — | A08:2021 |
-| D206 | HIGH | yaml.load without SafeLoader | Python | — | — |
-| D207 | MEDIUM | Weak hash (MD5) | Python, TS, Go | CWE-328 | — |
-| D208 | MEDIUM | Weak hash (SHA1) | Python, TS, Go | CWE-328 | — |
-| D209 | HIGH | subprocess shell=True | Python | — | A03:2021 |
-| D210 | HIGH | TLS verification disabled | Python, Go | — | A02:2021 |
-| D211 | CRITICAL | SQL injection | Python, TS, Go | CWE-89 | A03:2021 |
-| D212 | CRITICAL | Command injection | Python, TS, Go | CWE-78 | A03:2021 |
-| D214 | HIGH | Broken access control | Python | — | A01:2021 |
-| D215 | HIGH | Path traversal | Python, Go | CWE-22 | A01:2021 |
-| D216 | CRITICAL | SSRF | Python, TS, Go, Java | CWE-918 | A10:2021 |
-| D217 | CRITICAL | SQL injection (ORM — sqlalchemy.text, pandas.read_sql, Django .raw) | Python | CWE-89 | A03:2021 |
-| D222 | MEDIUM | Dependency hallucination | Python | — | — |
-| D223 | MEDIUM | Undeclared third-party dependency | Python | — | — |
-| D226 | CRITICAL | XSS (mark_safe, innerHTML, outerHTML, document.write, dangerouslySetInnerHTML) | Python, TS | CWE-79 | A03:2021 |
-| D227 | HIGH | XSS: unsafe template rendering | Python | CWE-79 | A03:2021 |
-| D228 | HIGH | XSS: unescaped HTML output | Python | CWE-79 | A03:2021 |
-| D230 | HIGH | Open redirect | Python, TS, Go, Java | CWE-601 | A01:2021 |
-| D231 | HIGH | CORS misconfiguration | Python | — | A05:2021 |
-| D232 | CRITICAL | JWT vulnerability (algorithms=none, verify=False) | Python | — | A02:2021 |
-| D233 | CRITICAL | Unsafe deserialization (marshal, shelve, jsonpickle, dill) | Python | — | A08:2021 |
-| D234 | HIGH | Mass assignment (Django Meta.fields='\_\_all\_\_') | Python | — | A01:2021 |
-| D245 | HIGH | Dynamic require() with variable argument | TS | CWE-94 | A03:2021 |
-| D246 | HIGH | JWT decode without verification | TS | CWE-347 | A02:2021 |
-| D247 | MEDIUM | CORS wildcard origin | TS | CWE-942 | A05:2021 |
-| D248 | MEDIUM | Hardcoded internal URL (localhost/127.0.0.1) | TS | CWE-798 | — |
-| D250 | MEDIUM | Insecure randomness (Math.random) | TS | CWE-330 | — |
-| D251 | HIGH | Sensitive data in logs | TS | CWE-532 | — |
-| D252 | MEDIUM | Insecure cookie (missing httpOnly/secure) | TS | CWE-614 | — |
-| D253 | MEDIUM | Timing-unsafe comparison | TS | CWE-208 | — |
-| D260 | HIGH–CRITICAL | Prompt injection (AI Supply Chain Security) | All text files | — | — |
-| D270 | MEDIUM | Sensitive data in localStorage/sessionStorage | TS | CWE-922 | — |
-| D271 | MEDIUM | Error info disclosure in HTTP response | TS | CWE-209 | — |
-| D510 | HIGH | Prototype pollution (\_\_proto\_\_) | TS | CWE-1321 | — |
+Rule IDs are unified across languages where the same vulnerability exists.
+
+| ID | Severity | Name | Languages / Scope | CWE / OWASP |
+|:---|:---|:---|:---|:---|
+| D200 | varies | Dangerous function call family | Python | wrapper for D201-D210, D233, D235, D250 |
+| D201 | HIGH-CRITICAL | Dynamic code execution: `eval` | Python, TS/JS, Java, audit | CWE-95 / A03 |
+| D202 | HIGH-CRITICAL | Dynamic code execution: `exec`, `new Function`, string timers | Python, TS/JS | CWE-95 / A03 |
+| D203 | CRITICAL | OS command execution: `os.system` / process sinks | Python, Java | CWE-78 / A03 |
+| D204 | CRITICAL | Unsafe deserialization: `pickle.load` and language equivalents | Python, Java, PHP, audit | A08 |
+| D205 | CRITICAL | Unsafe deserialization: `pickle.loads` | Python | A08 |
+| D206 | HIGH | `yaml.load` without SafeLoader | Python | A08 |
+| D207 | MEDIUM | Weak hash: MD5 | Python, TS/JS, Go, Java | CWE-328 |
+| D208 | MEDIUM | Weak hash: SHA1 | Python, TS/JS, Go, Java | CWE-328 |
+| D209 | HIGH | `subprocess` with `shell=True` | Python | CWE-78 / A03 |
+| D210 | HIGH | TLS verification disabled | Python, Go | A02 |
+| D211 | CRITICAL | SQL injection | Python, TS/JS, Go, Java, PHP, audit | CWE-89 / A03 |
+| D212 | CRITICAL | Command injection | Python, TS/JS, Go, Java, Rust, Dart, audit | CWE-78 / A03 |
+| D214 | HIGH | Broken access control | Python | A01 |
+| D215 | HIGH | Path traversal and archive extraction traversal | Python, TS/JS, Go, Java, PHP, Rust, Dart | CWE-22 / A01 |
+| D216 | CRITICAL | Server-side request forgery | Python, TS/JS, Go, Java, Dart, audit | CWE-918 / A10 |
+| D217 | CRITICAL | Raw SQL / ORM SQL injection | Python | CWE-89 / A03 |
+| D220 | CRITICAL | SQL injection in added code / diff validation | MCP code-change validator | CWE-89 / A03 |
+| D222 | MEDIUM | Dependency hallucination | Python | AI supply-chain |
+| D223 | MEDIUM | Undeclared third-party dependency | Python | supply-chain |
+| D226 | CRITICAL | XSS: unsafe DOM or HTML rendering | Python, TS/JS, Java, audit | CWE-79 / A03 |
+| D227 | HIGH | XSS: unsafe template rendering | Python | CWE-79 / A03 |
+| D228 | HIGH | XSS: unescaped HTML output | Python | CWE-79 / A03 |
+| D230 | HIGH | Open redirect | Python, TS/JS, Go, Java, audit | CWE-601 / A01 |
+| D231 | HIGH | CORS misconfiguration | Python | A05 |
+| D232 | CRITICAL | JWT verification disabled or unsafe algorithm | Python | A02 |
+| D233 | HIGH-CRITICAL | Unsafe deserialization: marshal, shelve, jsonpickle, dill | Python | A08 |
+| D234 | HIGH | Mass assignment | Python | A01 |
+| D235 | HIGH | Remote command execution via `exec_command` | Python | CWE-78 |
+| D240 | CRITICAL | MCP tool description poisoning | Python, Java | A03 |
+| D241 | HIGH | MCP unauthenticated transport | Python, Java | A07 |
+| D242 | HIGH | MCP permissive URI / path traversal | Python | A01 |
+| D243 | CRITICAL | MCP server bound to `0.0.0.0` | Python | exposure |
+| D244 | CRITICAL | MCP hardcoded secrets in tool params | Python | CWE-798 |
+| D245 | HIGH | Dynamic `require()` with variable argument | TS/JS | CWE-94 / A03 |
+| D246 | HIGH | JWT decode without verification | TS/JS | CWE-347 / A02 |
+| D247 | MEDIUM | CORS wildcard origin | TS/JS | CWE-942 / A05 |
+| D248 | MEDIUM | Hardcoded internal URL | TS/JS | CWE-798 |
+| D250 | MEDIUM | Insecure randomness for security-sensitive values | Python, TS/JS, Go, Java | CWE-330 |
+| D251 | HIGH | Sensitive data in logs | TS/JS | CWE-532 |
+| D252 | MEDIUM | Insecure cookie flags | TS/JS, Go, Java | CWE-614 |
+| D253 | MEDIUM | Timing-unsafe comparison | TS/JS, Java | CWE-208 |
+| D260 | HIGH-CRITICAL | Prompt injection scanner | Text, config, prompt, and source files | AI supply-chain |
+| D270 | MEDIUM | Sensitive data in `localStorage` / `sessionStorage` | TS/JS | CWE-922 |
+| D271 | MEDIUM | Error information disclosure in HTTP responses | TS/JS | CWE-209 |
+| D280 | HIGH | Next.js mutating API route missing auth checks | TS/JS | A01 |
+| D281 | HIGH | SQL injection in server actions via template literals | TS/JS | CWE-89 |
+| D282 | HIGH | Webhook handler missing signature verification | Python, TS/JS | CWE-347 |
+| D510 | HIGH | Prototype pollution via `__proto__` | TS/JS | CWE-1321 |
 
 ### AI Supply Chain Security
 
 | ID | Severity | Name | File Types | Details |
-|----|----------|------|------------|---------|
-| D260 | HIGH–CRITICAL | Prompt Injection Scanner | .py, .md, .rst, .txt, .yaml, .yml, .json, .toml, .env | Multi-file scanner with text canonicalization |
+|:---|:---|:---|:---|:---|
+| D260 | HIGH-CRITICAL | Prompt injection scanner | `.py`, `.md`, `.rst`, `.txt`, `.yaml`, `.yml`, `.json`, `.toml`, `.env` | Multi-file scanner with text canonicalization |
 
 Finding types:
-- `literal_payload` — direct injection phrase (instruction override, role hijacking, suppression, exfiltration)
-- `hidden_char` — zero-width / invisible Unicode (U+200B–U+202E)
-- `obfuscated_payload` — base64-encoded string decodes to injection content
-- `mixed_script` — Cyrillic/Greek homoglyphs mixed with Latin text
-- `risky_placement` — injection in high-risk file (README) or prompt-related YAML/JSON field
+
+- `literal_payload`: direct instruction override, role hijacking, suppression, or exfiltration phrase.
+- `hidden_char`: zero-width or invisible Unicode.
+- `obfuscated_payload`: encoded string that decodes to injection content.
+- `mixed_script`: Cyrillic or Greek homoglyphs mixed with Latin text.
+- `risky_placement`: injection in a high-risk README, prompt field, YAML, or JSON field.
 
 ### MCP Server Security
 
-| ID | Severity | Name | Languages | OWASP |
-|----|----------|------|-----------|-------|
-| D240 | CRITICAL | MCP tool description poisoning | Python | A03:2021 |
-| D241 | HIGH | MCP unauthenticated transport | Python | A07:2021 |
-| D242 | HIGH | MCP permissive URI / path traversal | Python | — |
-| D243 | CRITICAL | MCP server bound to 0.0.0.0 | Python | — |
-| D244 | CRITICAL | MCP hardcoded secrets in tool params | Python | — |
+| ID | Severity | Name | Languages |
+|:---|:---|:---|:---|
+| D240 | CRITICAL | MCP tool description poisoning | Python, Java |
+| D241 | HIGH | MCP unauthenticated transport | Python, Java |
+| D242 | HIGH | MCP permissive URI / path traversal | Python |
+| D243 | CRITICAL | MCP server bound to `0.0.0.0` | Python |
+| D244 | CRITICAL | MCP hardcoded secrets in tool params | Python |
+
+### CI/CD Security
+
+| ID | Severity | Name | Provider |
+|:---|:---|:---|:---|
+| D290 | HIGH | Dangerous trigger (`pull_request_target`, `workflow_run`) | GitHub Actions |
+| D291 | MEDIUM-HIGH | Missing or excessive permissions | GitHub Actions |
+| D292 | MEDIUM | Unpinned action or reusable workflow | GitHub Actions |
+| D293 | MEDIUM | Checkout persists credentials | GitHub Actions |
+| D294 | HIGH | Template injection from untrusted context | GitHub Actions |
+| D295 | HIGH | Self-hosted runner exposure | GitHub Actions |
+| D296 | MEDIUM | Unpinned container image | GitHub Actions |
+| D297 | HIGH | Secrets inheritance into reusable workflow | GitHub Actions |
+| D298 | MEDIUM | Overprovisioned secrets | GitHub Actions |
+| D299 | HIGH | Secret used outside protected environment | GitHub Actions |
+| D300 | HIGH | Unsafe environment file write | GitHub Actions |
+| D301 | HIGH | Hardcoded container credentials | GitHub Actions |
+| D302 | HIGH | Broad GitHub App token permissions | GitHub Actions |
+| D303 | MEDIUM | Unsound `contains()` condition | GitHub Actions |
+| D304 | MEDIUM | Spoofable bot condition | GitHub Actions |
+| D305 | MEDIUM | Unsound multiline condition | GitHub Actions |
+| D306 | HIGH | Insecure commands enabled | GitHub Actions |
+| D307 | MEDIUM | Anonymous action/workflow definition | GitHub Actions |
+| D308 | HIGH | Cache poisoning risk | GitHub Actions |
+| D309 | HIGH | Broad secret environment exposure | GitHub Actions |
+| D310 | HIGH | OIDC token exposed to local build script | GitHub Actions |
+| D311 | MEDIUM | Lax artifact upload | GitHub Actions |
+| D312 | MEDIUM | JavaScript install scripts in CI | GitHub Actions |
+| D313 | MEDIUM | Privileged job missing timeout | GitHub Actions |
+| D314 | HIGH | Mutable container image | GitLab CI |
+| D315 | HIGH | Unpinned external include | GitLab CI |
+| D316 | HIGH | Literal secret variable | GitLab CI |
+| D317 | HIGH | Untrusted eval | GitLab CI |
+| D318 | HIGH | Docker-in-Docker TLS disabled | GitLab CI |
+| D319 | HIGH | OIDC local-script exposure | GitLab CI |
+| D320 | HIGH | Release cache poisoning risk | GitLab CI |
+| D321 | MEDIUM | Privileged job missing timeout | GitLab CI |
+| D322 | MEDIUM | Dynamic runner tag | GitLab CI |
+| D323 | MEDIUM | Ambiguous secret token | GitLab CI |
 
 ## Secrets (SKY-S)
 
-| ID | Severity | Name | Languages | CWE |
-|----|----------|------|-----------|-----|
-| S101 | CRITICAL | Hardcoded secret / API key (prefix match + Shannon entropy) | All | CWE-798 |
+| ID | Severity | Name | Languages / Scope | CWE |
+|:---|:---|:---|:---|:---|
+| S101 | CRITICAL | Hardcoded secret / API key | Python, TS/JS, Java, Go, config files | CWE-798 |
+| S102 | HIGH | Server-only environment variable exposed to client component | TS/JS, Next.js | CWE-200 |
 
-## Go-Specific (SKY-G)
+## Security Contracts (SKY-SC)
 
-These have no cross-language equivalent and keep their own IDs.
-Go rules that DO have equivalents (G211, G212, etc.) are remapped to their unified D-series IDs automatically.
+| ID | Severity | Name | Scope |
+|:---|:---|:---|:---|
+| SC001 | HIGH | Security contract regression | Diff-aware CI/CD review |
 
-| ID | Severity | Name | Details |
-|----|----------|------|---------|
-| G203 | HIGH | Defer in loop | Resource leak risk |
-| G206 | HIGH | Unsafe package usage | unsafe stdlib package |
-| G209 | MEDIUM | Weak RNG | math/rand instead of crypto/rand |
-| G221 | MEDIUM | Insecure cookie | Missing HttpOnly/Secure flags |
-| G260 | HIGH | Unclosed resource | os.Open/sql.Open without defer .Close() |
-| G280 | HIGH | Weak TLS version | TLS 1.0/1.1 configured |
+## Go-Specific Raw Rules (SKY-G)
 
-## Logic (SKY-L)
+The Go engine may emit `SKY-G` IDs. Cross-language equivalents are remapped to
+`SKY-D` before normal reporting where possible.
 
-| ID | Severity | Name | Languages | CWE |
-|----|----------|------|-----------|-----|
-| L001 | HIGH | Mutable default argument | Python | CWE-665 |
-| L002 | MEDIUM | Bare except block | Python | — |
-| L003 | LOW | Dangerous comparison (== True/False/None) | Python | — |
-| L004 | MEDIUM | Anti-pattern try block (too broad) | Python | — |
-| L005 | LOW | Unused exception variable | Python | — |
-| L006 | MEDIUM | Inconsistent return (some paths implicit None) | Python | — |
-| L007 | MEDIUM–HIGH | Empty error handler (except: pass, suppress(Exception)) | Python | — |
-| L008 | MEDIUM | Missing resource cleanup (no context manager) | Python | CWE-404 |
-| L009 | LOW–HIGH | Debug leftover (print, breakpoint, pdb.set_trace) | Python | — |
-| L010 | MEDIUM | Security TODO/FIXME marker left in code | Python | CWE-546 |
-| L011 | MEDIUM–HIGH | Disabled security control (verify=False, csrf_exempt, DEBUG=True) | Python | CWE-295 |
-| L012 | CRITICAL | Phantom function call (hallucinated security function) | Python | CWE-476 |
-| L013 | HIGH | Insecure randomness for security values (random.* for tokens/passwords) | Python | CWE-330 |
-| L014 | HIGH | Hardcoded credential (password="admin123", DSN with embedded creds) | Python | CWE-798 |
-| L017 | MEDIUM | Error information disclosure (str(e) in HTTP response) | Python | CWE-209 |
-| L016 | MEDIUM | Undefined config — `os.getenv("ENABLE_X")` feature flag never defined | Python | — |
-| L020 | HIGH | Overly broad file permissions (chmod 0o777, sensitive file perms) | Python | CWE-732 |
-| L023 | CRITICAL | Phantom decorator — `@require_auth`, `@rate_limit` never defined/imported | Python | CWE-476 |
-| L024 | HIGH | Stale mock — `mock.patch("mod.func")` targets function that no longer exists | Python | — |
-| L026 | MEDIUM | Unfinished generation — function body is only `pass`, `...`, or `raise NotImplementedError` | Python | — |
-| L031 | MEDIUM | Missing network timeout — `requests.*`, `httpx.*`, or `urlopen()` without `timeout=` | Python | CWE-400 |
-
-## Quality (SKY-Q, SKY-C, SKY-P)
-
-### Complexity & Structure
-
-| ID | Severity | Name | Languages | Threshold |
-|----|----------|------|-----------|-----------|
-| Q301 | WARN–CRITICAL | Cyclomatic complexity | All | >10 |
-| Q302 | MEDIUM | Deep nesting | All | >3 levels |
-| C303 | MEDIUM | Too many arguments | All | >5 required / >10 total |
-| C304 | MEDIUM | Function too long | All | >50 lines |
-| Q305 | MEDIUM | Duplicate condition in if-else-if chain | TS | — |
-| Q401 | HIGH | Async blocking call (time.sleep, requests in async) | Python | — |
-| Q402 | MEDIUM | Await in loop (prefer Promise.all) | TS | — |
-| Q501 | MEDIUM | God class | Python | >20 methods or >15 attrs |
-| Q502 | MEDIUM–HIGH | God file | Python | >500 code lines, >40 definitions, or >25 top-level definitions |
-| Q701 | MEDIUM | High coupling (CBO) | Python | — |
-| Q702 | MEDIUM | Low cohesion (LCOM) | Python | — |
-
-### Performance
-
-| ID | Severity | Name | Languages |
-|----|----------|------|-----------|
-| P401 | LOW | Memory risk: file.read() / readlines() | Python |
-| P402 | LOW | Memory risk: pandas.read_csv without chunksize | Python |
-| P403 | LOW | Nested loop O(N^2) | All |
-
-### Architecture
-
-| ID | Severity | Name | Languages |
-|----|----------|------|-----------|
-| Q801 | MEDIUM | High architectural instability | Python |
-| Q802 | MEDIUM | Distance from main sequence | Python |
-| Q803 | MEDIUM | Zone of Pain / Zone of Uselessness | Python |
-| Q804 | MEDIUM | Dependency Inversion Principle violation | Python |
-| CIRC | — | Circular dependency | Python |
-
-## Dead Code (SKY-U, SKY-UC)
-
-| ID | Severity | Name | Languages |
-|----|----------|------|-----------|
-| U001 | INFO | Unused import | Python |
-| U002 | INFO | Unused variable | Python |
-| U003 | INFO | Unused function | Python |
-| U004 | INFO | Unused class | Python |
-| UC001 | MEDIUM | Unreachable code (after return/raise/break) | Python |
-| UC002 | MEDIUM | Unreachable code (after return/throw/break/continue) | TS |
-
-## Other
-
-| ID | Severity | Name | Languages |
-|----|----------|------|-----------|
-| E002 | — | Empty/docstring-only file | Python |
-| C401 | — | Module reachability | Python |
-| SCA-* | varies | Software Composition Analysis (CVE scanning) | Python |
-
-## Go Rule Remap Table
-
-When the Go binary outputs these IDs, they are translated to unified IDs before reporting:
-
-| Go Binary Output | Unified ID | Vulnerability |
-|------------------|------------|---------------|
+| Go Output | Unified ID | Vulnerability |
+|:---|:---|:---|
+| SKY-G203 | SKY-G203 | Defer in loop / resource leak risk |
+| SKY-G206 | SKY-G206 | Unsafe package usage |
 | SKY-G207 | SKY-D207 | Weak MD5 |
 | SKY-G208 | SKY-D208 | Weak SHA1 |
-| SKY-G210 | SKY-D210 | TLS disabled |
+| SKY-G209 | SKY-D250 | Weak random source |
+| SKY-G210 | SKY-D210 | TLS verification disabled |
 | SKY-G211 | SKY-D211 | SQL injection |
 | SKY-G212 | SKY-D212 | Command injection |
 | SKY-G215 | SKY-D215 | Path traversal |
 | SKY-G216 | SKY-D216 | SSRF |
 | SKY-G220 | SKY-D230 | Open redirect |
+| SKY-G221 | SKY-D252 | Insecure cookie flags |
+| SKY-G260 | SKY-G260 | Unclosed resource |
+| SKY-G280 | SKY-G280 | Weak TLS version |
+| SKY-G305 | SKY-D215 | Archive extraction path traversal |
+
+## Logic and AI-Code Mistakes (SKY-L)
+
+| ID | Severity | Name | Languages |
+|:---|:---|:---|:---|
+| L001 | HIGH | Mutable default argument | Python |
+| L002 | MEDIUM | Bare `except` block | Python |
+| L003 | LOW | Dangerous comparison (`== True`, `== False`, `== None`) | Python |
+| L004 | MEDIUM | Anti-pattern try block / too broad scope | Python |
+| L005 | LOW | Unused exception variable | Python |
+| L006 | MEDIUM | Inconsistent return paths | Python |
+| L007 | MEDIUM-HIGH | Empty error handler | Python |
+| L008 | MEDIUM | Missing resource cleanup | Python |
+| L009 | LOW-HIGH | Debug leftover | Python |
+| L010 | MEDIUM | Security TODO/FIXME marker left in code | Python |
+| L011 | MEDIUM-HIGH | Disabled security control | Python |
+| L012 | CRITICAL | Phantom function call / hallucinated security function | Python |
+| L013 | HIGH | Insecure randomness for security values | Python |
+| L014 | HIGH | Hardcoded credential in code | Python |
+| L016 | MEDIUM | Undefined config / ghost feature flag | Python |
+| L017 | MEDIUM | Error information disclosure | Python |
+| L020 | HIGH | Overly broad file permissions | Python |
+| L021 | HIGH | Security control regression | Diff-aware review |
+| L023 | CRITICAL | Phantom decorator | Python |
+| L024 | HIGH | Stale mock target | Python |
+| L026 | MEDIUM | Unfinished generated function | Python |
+| L027 | LOW-MEDIUM | Duplicate string literal | Python |
+| L028 | MEDIUM | Too many return statements | Python |
+| L029 | MEDIUM | Boolean positional parameter trap | Python |
+| L030 | MEDIUM | Broad exception with trivial handler | Python |
+| L031 | MEDIUM | Missing network timeout | Python |
+| L032 | MEDIUM | Mock or placeholder production data | Python |
+| L033 | MEDIUM | No-effect statement | Python |
+
+## Quality, Structure, Architecture, and Performance
+
+| ID | Severity | Name | Languages / Scope | Threshold / Notes |
+|:---|:---|:---|:---|:---|
+| Q301 | WARN-CRITICAL | Cyclomatic complexity | Python, TS/JS, Java, Go | default >10 |
+| Q302 | MEDIUM | Deep nesting | Python, TS/JS, Java, Go | default >3 |
+| Q305 | MEDIUM | Duplicate condition / duplicate branch body | Python, TS/JS | control-flow correctness |
+| Q306 | MEDIUM | Cognitive complexity | Python | Sonar-style cognitive complexity |
+| Q401 | HIGH | Async blocking call | Python | blocking calls inside async code |
+| Q402 | MEDIUM | Await in loop | TS/JS | prefer batching |
+| Q501 | MEDIUM | God class | Python | excessive methods or attributes |
+| Q502 | MEDIUM-HIGH | God file | Python | excessive file size / definitions |
+| Q701 | MEDIUM | High coupling | Python | CBO-style signal |
+| Q702 | MEDIUM | Low cohesion | Python | LCOM-style signal |
+| Q801 | MEDIUM | High architectural instability | Python |
+| Q802 | MEDIUM | Distance from main sequence | Python |
+| Q803 | MEDIUM | Zone of Pain / Zone of Uselessness | Python |
+| Q804 | MEDIUM | Dependency Inversion Principle violation | Python |
+| Q805 | MEDIUM | Architecture layer policy violation | Python |
+| C303 | MEDIUM | Too many arguments | Python, TS/JS, Java, Go | default >5 required / >10 total |
+| C304 | MEDIUM | Function too long | Python, TS/JS, Java, Go | default >50 lines |
+| C401 | MEDIUM | Duplicated implementation fragments | Python |
+| P401 | LOW | Memory risk: `file.read()` / `readlines()` | Python |
+| P402 | LOW | Memory risk: `pandas.read_csv` without `chunksize` | Python |
+| P403 | LOW | Nested loop O(N^2) | Python / generic |
+| T101 | MEDIUM | Missing public parameter type annotation | Python |
+| T102 | MEDIUM | Missing public return type annotation | Python |
+| F101 | MEDIUM | FastAPI response model / return typing practice | Python |
+| F102 | HIGH | Framework endpoint missing object-level authorization guard | Python |
+| R101 | MEDIUM | Repository missing Python type-check command | Repo policy |
+| R102 | MEDIUM | Repository missing Python lint command | Repo policy |
+| R103 | MEDIUM | Repository missing Skylos quality gate | Repo policy |
+| R104 | MEDIUM | Repository missing pre-commit config | Repo policy |
+| R105 | MEDIUM | Repository missing TypeScript type-check command | Repo policy |
+| CIRC | varies | Circular dependency | Python |
+
+## Dead Code and Reachability
+
+| ID | Severity | Name | Scope |
+|:---|:---|:---|:---|
+| U001 | INFO | Unused function | Upload/API normalized dead-code category |
+| U002 | INFO | Unused import | Upload/API normalized dead-code category |
+| U003 | INFO | Unused variable | Upload/API normalized dead-code category |
+| U004 | INFO | Unused class | Upload/API normalized dead-code category |
+| U005 | MEDIUM | Declared dependency appears unused | Python dependencies |
+| U006 | INFO | Unused parameter | Debt normalized dead-code category |
+| DC001 | MEDIUM | Unused function | LLM report dead-code ID |
+| DC002 | LOW | Unused import | LLM report dead-code ID |
+| DC003 | MEDIUM | Unused class | LLM report dead-code ID |
+| DC004 | LOW | Unused variable | LLM report dead-code ID |
+| DC005 | LOW | Unused parameter | LLM report dead-code ID |
+| DC006 | LOW | Empty or unused file | LLM report dead-code ID |
+| UC001 | MEDIUM | Unreachable code after control-flow exit | Python |
+| UC002 | MEDIUM | Unreachable code after return/throw/break/continue | TS/JS, Java |
+| E002 | LOW | Empty or docstring-only file | Python |
+| E003 | LOW | Unused TypeScript/JavaScript file | TS/JS |
+| E004 | LOW | Unnecessary export | TS/JS |
+
+Pretty output and the TUI use short display labels such as
+`dead-code/function`, `dead-code/import`, `dead-code/class`,
+`dead-code/variable`, `dead-code/parameter`, and `dead-code/file`. Those labels
+are UI grouping text, not stable rule IDs; use the `SKY-*` IDs above for
+suppression, integrations, and public references.
+
+## Dependency Vulnerabilities
+
+| ID | Severity | Name | Scope |
+|:---|:---|:---|:---|
+| SCA-* | varies | Software composition analysis vulnerability | Dependency manifests / installed packages |
+
+## Aggregate, Alias, and Workflow IDs
+
+These IDs appear in API normalization, audit workflows, LLM schemas, prompts, or
+agent workflows. They are not always emitted as first-class static-analysis
+findings.
+
+| ID | Meaning |
+|:---|:---|
+| SKY-D000 | Generic security fallback ID for normalized external findings. |
+| SKY-Q000 | Generic quality fallback ID for normalized external findings. |
+| SKY-S000 | Generic secret fallback ID for normalized external findings. |
+| SKY-SCA-000 | Generic dependency fallback ID for normalized external findings. |
+| SKY-U000 | Generic dead-code fallback ID for agent workflows. |
+| SKY-D101 | Legacy compliance alias for code injection. |
+| SKY-D102 | Legacy compliance alias for code injection. |
+| SKY-D103 | Legacy compliance alias for insecure deserialization. |
+| SKY-AUDIT | Deep-audit candidate or artifact marker. |
+| SKY-AUDIT-ENTRYPOINT | Deep-audit entrypoint candidate marker. |
+| SKY-AUDIT-PATH | Deep-audit security-sensitive path candidate marker. |
+| SKY-DEAD | LLM dead-code verifier marker. |
+| SKY-DEAD-CHALLENGE | LLM dead-code challenge marker. |
+| SKY-DEBT | Agent command-center debt marker. |
+| SKY-FIX | Agent remediation / fix generation marker. |
+| SKY-L000 | Generic logic fallback ID for LLM schemas. |
+| SKY-C399 | Structure placeholder ID used in prompt examples. |
+| SKY-Q499 | Quality placeholder ID used in prompt examples. |
+| SKY-P499 | Performance placeholder ID used in prompt examples. |
+| SKY-S199 | Secret placeholder ID used in prompt examples. |
+
+Prompt text may also use range notation such as `SKY-D226-228`,
+`SKY-L001-004`, or `SKY-P401-403` to describe groups of concrete rule IDs.
+
+## Custom Rules
+
+Custom rule packs may emit project-defined IDs from `.skylos/rules/*.yml`.
+Prefer a stable project prefix, for example `ORG-SEC001`, to avoid colliding
+with Skylos-owned `SKY-*` IDs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Skylos Docs
+
+This repository keeps lightweight local docs for features that need examples close to the code. The public docs site remains at <https://docs.skylos.dev>.
+
+| Topic | Page |
+|:---|:---|
+| CLI output modes, pretty reports, and TUI controls | [CLI Output Modes](./cli-output.md) |
+| Rule ID prefixes and product terminology | [Rule Dictionary](../dictionary.md) |

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -1,0 +1,87 @@
+# CLI Output Modes
+
+Skylos keeps the default terminal output stable for existing scripts and copy/paste workflows, then offers opt-in formats for more focused use cases.
+
+## Human Terminal Output
+
+Use the default `rich` format when you want the existing full report:
+
+```bash
+skylos .
+skylos . -a
+```
+
+Use `pretty` when you want a compact, file-grouped terminal report:
+
+```bash
+skylos . --format pretty
+skylos . -a --format pretty --limit 20
+```
+
+`--format pretty` groups findings by file, shows severity badges and rails, keeps `file:line` locations copyable, includes source snippets when available, and suppresses the large banner and follow-up prompts. It is intended for interactive terminal review, PR comments, and quick local triage.
+
+Example shape:
+
+```text
+Skylos static analysis  3 issues  1 file analyzed
+  unused functions: 2  unused variables: 1
+
+  src/app.py · 3 issues
+
+    █  LOW  dead-code/function  Unused function: old_handler
+      Dead Code  src/app.py:42
+      def old_handler() -> None:
+      Fix: Remove the unused function if it is not public API.
+```
+
+Write the same pretty report to a file with `--output`:
+
+```bash
+skylos . --format pretty --output skylos-report.txt
+```
+
+## Copyable And Machine Output
+
+Use `concise` when an editor, test script, or agent needs plain `file:line` findings and a non-zero exit code when findings exist:
+
+```bash
+skylos . --format concise
+```
+
+Use `json`, `llm`, or `github` for structured consumers:
+
+```bash
+skylos . --format json
+skylos . --format llm
+skylos . --format github
+```
+
+The legacy flags still work:
+
+```bash
+skylos . --json
+skylos . --llm
+skylos . --github
+```
+
+## Selectable Terminal UI
+
+Use the TUI when you want keyboard-driven triage:
+
+```bash
+skylos . --tui
+skylos . -a --tui
+```
+
+The TUI uses a category sidebar plus a selectable finding list and detail pane. Common controls:
+
+| Key | Action |
+|:---|:---|
+| `j` / `k` | Move through findings |
+| `/` | Search current findings |
+| `f` | Cycle severity filter |
+| `Tab` / `Shift+Tab` | Move between categories |
+| `o` | Open the selected finding in `$EDITOR` |
+| `q` | Quit |
+
+`--tui` requires an interactive terminal and is screen-only, so it cannot be combined with `--output`. For saved reports, CI, scripts, and logs, prefer `--format concise`, `--format json`, or `--format pretty`.

--- a/skylos/audit/candidates.py
+++ b/skylos/audit/candidates.py
@@ -148,6 +148,7 @@ def scan_deep_audit_candidates(
 
     store = AuditStore(project_root, project_id=project_id, audit_root=audit_root)
     store.init_project(config_hash=config_hash)
+    store.set_current_scan_files(files)
     deleted_records = store.mark_deleted_records(allowed_files=changed_files)
 
     records_written = 0

--- a/skylos/audit/processor.py
+++ b/skylos/audit/processor.py
@@ -38,7 +38,7 @@ def process_deep_audit_records(
     run_id: str | None = None,
 ) -> AuditProcessSummary:
     run_id = run_id or f"process-{uuid4().hex[:12]}"
-    allowed = _normalized_allowed_files(store, allowed_files)
+    allowed = store.processing_scope(allowed_files)
     records = [
         record
         for record in store.iter_file_records()
@@ -144,7 +144,7 @@ def process_deep_audit_records(
         store,
         model=model,
         provider=provider,
-        allowed_files=allowed_files,
+        allowed_files=allowed,
     )
     remaining = state_counts["unresolved"]
     summary = AuditProcessSummary(
@@ -190,8 +190,10 @@ def _record_sort_key(record: AuditFileRecord) -> tuple[int, str]:
 
 def _normalized_allowed_files(
     store: AuditStore,
-    allowed_files: list[str | Path] | None,
+    allowed_files: list[str | Path] | set[str] | None,
 ) -> set[str] | None:
+    if isinstance(allowed_files, set):
+        return set(allowed_files)
     if allowed_files is None:
         return None
     allowed: set[str] = set()
@@ -443,7 +445,7 @@ def _audit_state_counts(
     *,
     model: str,
     provider: str | None,
-    allowed_files: list[str | Path] | None = None,
+    allowed_files: list[str | Path] | set[str] | None = None,
 ) -> dict[str, int]:
     allowed = _normalized_allowed_files(store, allowed_files)
     counts = {

--- a/skylos/audit/revalidator.py
+++ b/skylos/audit/revalidator.py
@@ -11,7 +11,6 @@ from skylos.audit.types import (
     STATUS_DELETED,
     AuditFileRecord,
     AuditRevalidationSummary,
-    normalize_relative_path,
     sha256_text,
     utc_now,
 )
@@ -33,7 +32,7 @@ def revalidate_deep_audit_findings(
     run_id: str | None = None,
 ) -> AuditRevalidationSummary:
     run_id = run_id or f"revalidate-{uuid4().hex[:12]}"
-    allowed = _normalized_allowed_files(store, allowed_files)
+    allowed = store.processing_scope(allowed_files)
     records = [
         record
         for record in store.iter_file_records()
@@ -142,21 +141,6 @@ def revalidate_deep_audit_findings(
         },
     )
     return summary
-
-
-def _normalized_allowed_files(
-    store: AuditStore,
-    allowed_files: list[str | Path] | None,
-) -> set[str] | None:
-    if allowed_files is None:
-        return None
-    allowed: set[str] = set()
-    for file_path in allowed_files:
-        try:
-            allowed.add(normalize_relative_path(store.project_root, file_path))
-        except ValueError:
-            continue
-    return allowed
 
 
 def _has_secret_candidate(record: AuditFileRecord) -> bool:

--- a/skylos/audit/store.py
+++ b/skylos/audit/store.py
@@ -46,6 +46,7 @@ class AuditStore:
         self.files_dir = self.project_dir / "files"
         self.runs_dir = self.project_dir / "runs"
         self.exports_dir = self.project_dir / "exports"
+        self.current_scan_files: set[str] | None = None
 
     def init_project(self, *, config_hash: str) -> None:
         self.files_dir.mkdir(parents=True, exist_ok=True)
@@ -127,6 +128,26 @@ class AuditStore:
             if record is not None:
                 records.append(record)
         return records
+
+    def set_current_scan_files(self, files: list[str | Path]) -> None:
+        current: set[str] = set()
+        for file_path in files:
+            try:
+                current.add(normalize_relative_path(self.project_root, file_path))
+            except ValueError:
+                continue
+        self.current_scan_files = current
+
+    def processing_scope(
+        self,
+        allowed_files: list[str | Path] | set[str] | None = None,
+    ) -> set[str] | None:
+        requested = self._normalized_allowed_files(allowed_files)
+        if self.current_scan_files is None:
+            return requested if requested is not None else set()
+        if requested is None:
+            return set(self.current_scan_files)
+        return requested & self.current_scan_files
 
     def write_file_record(self, record: AuditFileRecord) -> None:
         if record.project_id != self.project_id:

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2344,6 +2344,18 @@ def render_results(
         _render_sca(console, limit, result.get("dependency_vulnerabilities", []) or [])
 
 
+def render_pretty_results(
+    console: Console,
+    result: dict,
+    *,
+    root_path=None,
+    limit=None,
+):
+    from skylos.ui.terminal_report import render_pretty_results as render_impl
+
+    return render_impl(console, result, root_path=root_path, limit=limit)
+
+
 def _write_rich_report_output(
     output_file: str,
     result: dict,
@@ -2365,6 +2377,28 @@ def _write_rich_report_output(
         root_path=root_path,
         limit=limit,
         copy_badge=False,
+    )
+    pathlib.Path(output_file).write_text(buffer.getvalue(), encoding="utf-8")
+
+
+def _write_pretty_report_output(
+    output_file: str,
+    result: dict,
+    *,
+    root_path=None,
+    limit=None,
+):
+    buffer = StringIO()
+    file_console = Console(
+        theme=_skylos_console_theme(),
+        file=buffer,
+        force_terminal=False,
+    )
+    render_pretty_results(
+        file_console,
+        result,
+        root_path=root_path,
+        limit=limit,
     )
     pathlib.Path(output_file).write_text(buffer.getvalue(), encoding="utf-8")
 
@@ -2932,6 +2966,16 @@ def _print_main_scan_banner(args, console, final_exclude_folders):
         return True
 
     if _is_main_machine_output(args):
+        return False
+
+    if getattr(args, "format", "rich") == "pretty":
+        console.print(
+            f"[brand]skylos[/brand] [muted]v{skylos.__version__} · scanning...[/muted]"
+        )
+        if final_exclude_folders and getattr(args, "verbose", False):
+            console.print(
+                f"[muted]excluding: {', '.join(sorted(final_exclude_folders))}[/muted]"
+            )
         return False
 
     banner = (

--- a/skylos/cli_core/main_parser.py
+++ b/skylos/cli_core/main_parser.py
@@ -6,7 +6,10 @@ from collections.abc import Callable, Sequence
 
 def build_main_parser(*, version: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Find dead code, secrets, and risky flows in Python, JS/TS, Go, Java, PHP, and Rust",
+        description=(
+            "Find dead code, secrets, and risky flows in Python, JS/TS, Go, "
+            "Java, PHP, Rust, and Dart"
+        ),
         epilog="""
 Run 'skylos commands' for a full list of all available commands.
 Run 'skylos tour' for a guided walkthrough of capabilities.
@@ -117,9 +120,12 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
     )
     parser.add_argument(
         "--format",
-        choices=("rich", "json", "llm", "github", "concise"),
+        choices=("rich", "pretty", "json", "llm", "github", "concise"),
         default="rich",
-        help="Output format. Use 'concise' for IDE-friendly file:line findings only.",
+        help=(
+            "Output format. Use 'pretty' for grouped human output or "
+            "'concise' for IDE-friendly file:line findings only."
+        ),
     )
     parser.set_defaults(concise=False)
     parser.add_argument(

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -33,6 +33,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
     _render_upload_failure = cli_module._render_upload_failure
     _run_pre_analysis_steps = cli_module._run_pre_analysis_steps
     _strict_scan_exit_code = cli_module._strict_scan_exit_code
+    _write_pretty_report_output = cli_module._write_pretty_report_output
     _write_rich_report_output = cli_module._write_rich_report_output
     comment_out_unused_function = cli_module.comment_out_unused_function
     comment_out_unused_import = cli_module.comment_out_unused_import
@@ -45,6 +46,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
     print_badge = cli_module.print_badge
     remove_unused_function = cli_module.remove_unused_function
     remove_unused_import = cli_module.remove_unused_import
+    render_pretty_results = cli_module.render_pretty_results
     render_results = cli_module.render_results
     run_analyze = cli_module.run_analyze
     run_gate_interaction = cli_module.run_gate_interaction
@@ -54,6 +56,13 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
 
     parser = _build_main_parser()
     args = _parse_main_cli_args(parser, argv)
+    if getattr(args, "tui", False):
+        if getattr(args, "output", None):
+            parser.error(
+                "--tui is screen-only; use --format pretty --output for a file report"
+            )
+        if not _is_tty():
+            parser.error("--tui requires an interactive terminal")
     args._explicit_upload_requested = bool(getattr(args, "upload", False))
     context = _build_main_scan_context(args)
     project_root = context.project_root
@@ -91,7 +100,11 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 trace_file=trace_file,
             )
 
-        if machine_output:
+        quiet_analysis_output = (
+            machine_output or getattr(args, "format", "rich") == "pretty"
+        )
+
+        if quiet_analysis_output:
             analyzer_logger = logging.getLogger("Skylos")
             analyzer_logger_level = analyzer_logger.level
             analyzer_logger.setLevel(logging.WARNING)
@@ -673,21 +686,36 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 category=_cli_category,
                 file_filter=_cli_file_filter,
             )
-        render_results(
-            console,
-            display_result,
-            tree=args.tree,
-            root_path=project_root,
-            limit=_cli_limit,
-        )
-        if args.output:
-            _write_rich_report_output(
-                args.output,
+        if getattr(args, "format", "rich") == "pretty":
+            render_pretty_results(
+                console,
+                display_result,
+                root_path=project_root,
+                limit=_cli_limit,
+            )
+            if args.output:
+                _write_pretty_report_output(
+                    args.output,
+                    display_result,
+                    root_path=project_root,
+                    limit=_cli_limit,
+                )
+        else:
+            render_results(
+                console,
                 display_result,
                 tree=args.tree,
                 root_path=project_root,
                 limit=_cli_limit,
             )
+            if args.output:
+                _write_rich_report_output(
+                    args.output,
+                    display_result,
+                    tree=args.tree,
+                    root_path=project_root,
+                    limit=_cli_limit,
+                )
 
     unused_total = sum(
         len(result.get(k, []))
@@ -701,20 +729,26 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
     )
     danger_count = len(result.get("danger", []) or [])
     quality_count = len(result.get("quality", []) or [])
-    print_badge(
-        unused_total,
-        logging.getLogger("skylos"),
-        danger_enabled=bool(danger_count),
-        danger_count=danger_count,
-        quality_enabled=bool(quality_count),
-        quality_count=quality_count,
-    )
+    if getattr(args, "format", "rich") != "pretty":
+        print_badge(
+            unused_total,
+            logging.getLogger("skylos"),
+            danger_enabled=bool(danger_count),
+            danger_count=danger_count,
+            quality_enabled=bool(quality_count),
+            quality_count=quality_count,
+        )
 
     strict_exit_code = _strict_scan_exit_code(result, args)
     if strict_exit_code:
         raise SystemExit(strict_exit_code)
 
-    if (not args.json) and _is_tty() and (not args.upload):
+    if (
+        not args.json
+        and getattr(args, "format", "rich") != "pretty"
+        and _is_tty()
+        and (not args.upload)
+    ):
         total_findings = 0
         for k in (
             "unused_functions",

--- a/skylos/core/cli_shared.py
+++ b/skylos/core/cli_shared.py
@@ -47,7 +47,7 @@ _SAFE_ADDOPTS_VALUE_OPTIONS = frozenset(
 )
 
 _SAFE_ADDOPTS_CHOICES = {
-    "--format": {"rich", "json", "llm", "github", "concise"},
+    "--format": {"rich", "pretty", "json", "llm", "github", "concise"},
     "--severity": {"critical", "high", "medium", "low"},
 }
 

--- a/skylos/debt/engine.py
+++ b/skylos/debt/engine.py
@@ -36,7 +36,7 @@ _DEAD_CODE_RULE_IDS: dict[str, str] = {
     "unused_imports": "SKY-U002",
     "unused_variables": "SKY-U003",
     "unused_classes": "SKY-U004",
-    "unused_parameters": "SKY-U005",
+    "unused_parameters": "SKY-U006",
 }
 
 

--- a/skylos/ui/terminal_report.py
+++ b/skylos/ui/terminal_report.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from rich.console import Console
+from rich.text import Text
+
+from skylos.api_snippets import _resolve_snippet_path
+
+
+CATEGORY_SPECS = (
+    ("danger", "Security", "security issue"),
+    ("secrets", "Secret", "secret detected"),
+    ("quality", "Quality", "quality issue"),
+    ("custom_rules", "Custom", "custom rule"),
+    ("dependency_vulnerabilities", "Dependency", "dependency vulnerability"),
+    ("unused_functions", "Dead Code", "unused function"),
+    ("unused_imports", "Dead Code", "unused import"),
+    ("unused_classes", "Dead Code", "unused class"),
+    ("unused_variables", "Dead Code", "unused variable"),
+    ("unused_parameters", "Dead Code", "unused parameter"),
+    ("unused_files", "Dead Code", "unused file"),
+    ("unused_fixtures", "Dead Code", "unused fixture"),
+)
+
+DEAD_CODE_TYPES = {
+    "unused_functions": "function",
+    "unused_imports": "import",
+    "unused_classes": "class",
+    "unused_variables": "variable",
+    "unused_parameters": "parameter",
+    "unused_files": "file",
+    "unused_fixtures": "fixture",
+}
+
+SEVERITY_STYLES = {
+    "CRITICAL": "bold white on magenta",
+    "HIGH": "bold white on red",
+    "MEDIUM": "bold black on yellow",
+    "LOW": "bold white on blue",
+    "INFO": "dim",
+}
+
+SEVERITY_RANK = {
+    "CRITICAL": 0,
+    "HIGH": 1,
+    "MEDIUM": 2,
+    "LOW": 3,
+    "INFO": 4,
+}
+
+SUMMARY_CATEGORIES = (
+    "unused_functions",
+    "unused_imports",
+    "unused_parameters",
+    "unused_variables",
+    "unused_classes",
+    "quality",
+    "custom_rules",
+    "danger",
+    "secrets",
+    "dependency_vulnerabilities",
+)
+
+
+@dataclass(frozen=True)
+class PrettyFinding:
+    category: str
+    category_label: str
+    fallback_label: str
+    file: str
+    line: int
+    severity: str
+    rule: str
+    title: str
+    snippet: str
+    fix: str
+
+
+def render_pretty_results(
+    console: Console,
+    result: dict,
+    *,
+    root_path=None,
+    limit: int | None = None,
+) -> None:
+    findings = collect_pretty_findings(result, root_path=root_path, limit=limit)
+    total_files = (result.get("analysis_summary") or {}).get("total_files", "?")
+
+    header = Text.assemble(
+        ("Skylos", "bold cyan"),
+        (" static analysis", "bold"),
+        (f"  {len(findings)} issue{'s' if len(findings) != 1 else ''}", "dim"),
+        (f"  {total_files} file{'s' if total_files != 1 else ''} analyzed", "dim"),
+    )
+    console.print(header)
+
+    summary = _summary_line(result)
+    if summary.plain:
+        console.print(summary)
+    console.print()
+
+    if not findings:
+        console.print(Text("  No findings to display.", style="bold green"))
+        return
+
+    by_file: dict[str, list[PrettyFinding]] = {}
+    for finding in findings:
+        by_file.setdefault(finding.file, []).append(finding)
+
+    for file_path in sorted(by_file):
+        file_findings = sorted(
+            by_file[file_path],
+            key=lambda f: (SEVERITY_RANK.get(f.severity, 99), f.line, f.rule),
+        )
+        short_path = _shorten_path(file_path, root_path)
+        count = len(file_findings)
+        console.print(
+            Text.assemble(
+                ("  ", ""),
+                (short_path, "bold"),
+                (" · ", "dim"),
+                (f"{count} issue{'s' if count != 1 else ''}", "dim"),
+            )
+        )
+        console.print()
+
+        for finding in file_findings:
+            _print_finding(console, finding, short_path)
+        console.print()
+
+    _print_footer(console, findings)
+
+
+def collect_pretty_findings(
+    result: dict,
+    *,
+    root_path=None,
+    limit: int | None = None,
+) -> list[PrettyFinding]:
+    source_cache: dict[str, list[str] | None] = {}
+    findings: list[PrettyFinding] = []
+
+    for category, category_label, fallback_label in CATEGORY_SPECS:
+        items = list(result.get(category, []) or [])
+        if limit is not None:
+            items = items[:limit]
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            findings.append(
+                _make_pretty_finding(
+                    category,
+                    category_label,
+                    fallback_label,
+                    item,
+                    root_path=root_path,
+                    source_cache=source_cache,
+                )
+            )
+
+    return findings
+
+
+def _make_pretty_finding(
+    category: str,
+    category_label: str,
+    fallback_label: str,
+    item: dict,
+    *,
+    root_path=None,
+    source_cache: dict[str, list[str] | None],
+) -> PrettyFinding:
+    file_path = str(item.get("file") or item.get("file_path") or "?")
+    line = _line_number(item)
+    severity = _severity(item, category)
+    rule = _rule_id(item, category)
+    title = _title(item, category, fallback_label)
+    snippet = _snippet(item, category, root_path=root_path, source_cache=source_cache)
+    fix = _fix(item, category)
+    return PrettyFinding(
+        category=category,
+        category_label=category_label,
+        fallback_label=fallback_label,
+        file=file_path,
+        line=line,
+        severity=severity,
+        rule=rule,
+        title=title,
+        snippet=snippet,
+        fix=fix,
+    )
+
+
+def _print_finding(console: Console, finding: PrettyFinding, short_path: str) -> None:
+    first = Text.assemble(
+        ("    ", ""),
+        ("█", _severity_rail_style(finding.severity)),
+        (" ", ""),
+        (
+            _severity_badge(finding.severity),
+            SEVERITY_STYLES.get(finding.severity, "dim"),
+        ),
+        (" ", ""),
+        (finding.rule, "cyan"),
+        ("  ", ""),
+        (_truncate(finding.title, 140), ""),
+    )
+    console.print(first)
+
+    meta = Text.assemble(
+        ("      ", ""),
+        (finding.category_label, "dim"),
+        ("  ", "dim"),
+        (f"{short_path}:{finding.line}", "dim"),
+    )
+    console.print(meta)
+
+    if finding.snippet:
+        console.print(
+            Text.assemble(
+                ("      ", ""),
+                (_truncate(finding.snippet.strip(), 140), "dim"),
+            )
+        )
+
+    if finding.fix:
+        console.print(Text.assemble(("      Fix: ", "bold green"), (finding.fix, "")))
+
+    console.print()
+
+
+def _print_footer(console: Console, findings: list[PrettyFinding]) -> None:
+    counts: dict[str, int] = {}
+    for finding in findings:
+        counts[finding.severity] = counts.get(finding.severity, 0) + 1
+
+    console.print(Text("  " + "─" * 52, style="dim"))
+    parts: list[Text] = [
+        Text(
+            f"  {len(findings)} issue{'s' if len(findings) != 1 else ''}",
+            style="bold",
+        )
+    ]
+    for severity in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"):
+        count = counts.get(severity, 0)
+        if not count:
+            continue
+        parts.append(Text("  "))
+        parts.append(_summary_badge(severity, count))
+
+    line = Text()
+    for part in parts:
+        line.append(part)
+    console.print(line)
+
+
+def _summary_line(result: dict) -> Text:
+    parts: list[Text] = []
+    for category in SUMMARY_CATEGORIES:
+        count = len(result.get(category, []) or [])
+        if not count:
+            continue
+        label = category.replace("unused_", "unused ").replace("_", " ")
+        if parts:
+            parts.append(Text("  "))
+        parts.append(Text(f"{label}: {count}", style="dim"))
+
+    if not parts:
+        return Text()
+
+    line = Text("  ")
+    for part in parts:
+        line.append(part)
+    return line
+
+
+def _summary_badge(severity: str, count: int) -> Text:
+    style = SEVERITY_STYLES.get(severity, "dim")
+    return Text(f" {count} {severity.lower()} ", style=style)
+
+
+def _severity_badge(severity: str) -> str:
+    label = severity.upper()
+    if label == "CRITICAL":
+        return " CRITICAL "
+    if label == "HIGH":
+        return " HIGH "
+    if label == "MEDIUM":
+        return " MEDIUM "
+    if label == "LOW":
+        return " LOW "
+    return " INFO "
+
+
+def _severity_rail_style(severity: str) -> str:
+    label = severity.upper()
+    if label == "CRITICAL":
+        return "magenta"
+    if label == "HIGH":
+        return "red"
+    if label == "MEDIUM":
+        return "yellow"
+    if label == "LOW":
+        return "blue"
+    return "dim"
+
+
+def _shorten_path(path: str, root_path=None) -> str:
+    if not path or path == "?":
+        return "?"
+
+    raw = Path(path)
+    root = Path(root_path) if root_path is not None else Path.cwd()
+
+    try:
+        if raw.is_absolute():
+            return str(raw.resolve().relative_to(root.resolve()))
+    except (OSError, ValueError):
+        pass
+
+    text = str(path)
+    parts = text.replace("\\", "/").split("/")
+    if raw.is_absolute() and len(parts) > 4:
+        return ".../" + "/".join(parts[-3:])
+    return text
+
+
+def _line_number(item: dict) -> int:
+    raw = item.get("line") or item.get("line_number") or item.get("lineno") or 1
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _severity(item: dict, category: str) -> str:
+    raw = item.get("severity")
+    if raw:
+        label = str(raw).strip().upper()
+        if label:
+            return label
+    if category in {"danger", "secrets", "dependency_vulnerabilities"}:
+        return "HIGH"
+    if category in {"quality", "custom_rules"}:
+        return "MEDIUM"
+    return "LOW"
+
+
+def _rule_id(item: dict, category: str) -> str:
+    rule = item.get("rule_id") or item.get("rule") or item.get("code") or item.get("id")
+    if rule:
+        return str(rule)
+    if category in DEAD_CODE_TYPES:
+        return f"dead-code/{DEAD_CODE_TYPES[category]}"
+    return category.replace("_", "-")
+
+
+def _title(item: dict, category: str, fallback_label: str) -> str:
+    if category in DEAD_CODE_TYPES:
+        name = item.get("name") or item.get("simple_name") or item.get("symbol")
+        if name:
+            return f"Unused {DEAD_CODE_TYPES[category]}: {name}"
+
+    if category == "dependency_vulnerabilities":
+        meta = item.get("metadata") or {}
+        pkg = meta.get("package_name")
+        version = meta.get("package_version")
+        vuln = meta.get("display_id") or meta.get("vuln_id") or item.get("rule_id")
+        if pkg:
+            package = f"{pkg}@{version}" if version else str(pkg)
+            suffix = f" ({vuln})" if vuln else ""
+            return f"Vulnerable dependency: {package}{suffix}"
+
+    for key in ("message", "msg", "detail", "description", "reason"):
+        value = item.get(key)
+        if value:
+            return str(value)
+
+    return fallback_label
+
+
+def _snippet(
+    item: dict,
+    category: str,
+    *,
+    root_path=None,
+    source_cache: dict[str, list[str] | None],
+) -> str:
+    if category == "secrets":
+        preview = item.get("preview")
+        return str(preview) if preview else ""
+
+    for key in ("snippet", "line_text", "source_line"):
+        value = item.get(key)
+        if value:
+            return str(value).splitlines()[0]
+
+    return _read_source_line(item, root_path=root_path, source_cache=source_cache)
+
+
+def _fix(item: dict, category: str) -> str:
+    for key in ("suggestion", "fix", "remediation", "recommendation"):
+        value = item.get(key)
+        if value:
+            return str(value)
+
+    if category == "dependency_vulnerabilities":
+        meta = item.get("metadata") or {}
+        fixed = meta.get("fixed_version")
+        if fixed:
+            return f"Upgrade to {fixed}"
+
+    if category in DEAD_CODE_TYPES:
+        return f"Remove the unused {DEAD_CODE_TYPES[category]} if it is not public API."
+
+    return ""
+
+
+def _read_source_line(
+    item: dict,
+    *,
+    root_path=None,
+    source_cache: dict[str, list[str] | None],
+) -> str:
+    file_path = item.get("file") or item.get("file_path")
+    if not file_path:
+        return ""
+
+    raw_path = Path(str(file_path))
+    lookup_path = raw_path
+    if not raw_path.is_absolute() and root_path is not None:
+        lookup_path = Path(root_path) / raw_path
+
+    path = _resolve_snippet_path(str(lookup_path), repo_root=root_path)
+    if path is None:
+        return ""
+
+    cache_key = str(path)
+    if cache_key not in source_cache:
+        try:
+            source_cache[cache_key] = path.read_text(
+                encoding="utf-8", errors="ignore"
+            ).splitlines()
+        except OSError:
+            source_cache[cache_key] = None
+
+    lines = source_cache[cache_key]
+    if not lines:
+        return ""
+
+    line = _line_number(item)
+    if line > len(lines):
+        return ""
+    return lines[line - 1].strip()
+
+
+def _truncate(text: str, width: int) -> str:
+    if len(text) <= width:
+        return text
+    return text[: max(0, width - 3)] + "..."

--- a/skylos/ui/tui.py
+++ b/skylos/ui/tui.py
@@ -9,9 +9,6 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.reactive import reactive
 from textual.widgets import (
-    DataTable,
-    Footer,
-    Header,
     Input,
     Label,
     ListItem,
@@ -21,10 +18,17 @@ from textual.widgets import (
 from rich.text import Text
 
 SEVERITY_COLORS = {
-    "CRITICAL": "red bold",
-    "HIGH": "#ff8800",
-    "MEDIUM": "yellow",
-    "LOW": "dim",
+    "CRITICAL": "#ffffff on #8232b4 bold",
+    "HIGH": "#ffffff on #b43128 bold",
+    "MEDIUM": "#1f170f on #d6b86f bold",
+    "LOW": "#ffffff on #346aa8 bold",
+}
+
+SEVERITY_FG = {
+    "CRITICAL": "#b47de0",
+    "HIGH": "#e07162",
+    "MEDIUM": "#d6b86f",
+    "LOW": "#7ba5d6",
 }
 
 CATEGORIES = [
@@ -184,6 +188,89 @@ class CategoryItem(ListItem):
         yield Label(f" {self._label}  [{style}]{self._count}[/{style}]")
 
 
+class FindingItem(ListItem):
+    def __init__(
+        self,
+        category: str,
+        row: tuple,
+        item: dict,
+        root_path=None,
+    ) -> None:
+        super().__init__()
+        self.category = category
+        self.row = row
+        self.item = item
+        self.root_path = root_path
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._render_row())
+
+    def _render_row(self) -> Text:
+        severity = _finding_severity(self.category, self.item, self.row)
+        style = SEVERITY_COLORS.get(severity, "dim")
+        accent = SEVERITY_FG.get(severity, "dim")
+        title = _finding_title(self.category, self.item, self.row)
+        rule = _finding_rule(self.category, self.item, self.row)
+        loc = _loc(self.item, self.root_path)
+        meta = self.category.replace("_", " ").title()
+
+        text = Text.assemble(
+            (" ", ""),
+            ("█", accent),
+            (" ", ""),
+            (f" {severity} ", style),
+            (" ", ""),
+            (rule, "cyan"),
+            ("  ", ""),
+            (title, "bold"),
+            "\n",
+            ("   ", ""),
+            (loc, "dim"),
+            ("  ·  ", "dim"),
+            (meta, "dim"),
+        )
+        return text
+
+
+def _finding_severity(category: str, item: dict, row: tuple) -> str:
+    raw = item.get("severity")
+    if raw:
+        return str(raw).upper()
+    if category in {"security", "secrets", "dependencies"}:
+        return "HIGH"
+    if category == "quality":
+        return "MEDIUM"
+    return "LOW"
+
+
+def _finding_rule(category: str, item: dict, row: tuple) -> str:
+    if category == "dead_code":
+        return f"dead-code/{str(row[0]).lower().replace(' ', '-')}"
+    if category == "security":
+        return str(row[0])
+    if category == "secrets":
+        return str(row[0])
+    if category == "dependencies":
+        return str(row[1])
+    if category == "quality":
+        return str(row[0])
+    return str(item.get("rule_id") or item.get("rule") or category)
+
+
+def _finding_title(category: str, item: dict, row: tuple) -> str:
+    if category == "dead_code":
+        return f"Unused {str(row[0]).lower()}: {row[1]}"
+    if category == "security":
+        return str(row[2])
+    if category == "secrets":
+        return str(row[1])
+    if category == "dependencies":
+        return f"{row[0]}  {row[3]}"
+    if category == "quality":
+        return f"{row[1]}  {row[2]}"
+    return str(item.get("message") or item.get("reason") or "Finding")
+
+
 class OverviewPanel(VerticalScroll):
     def __init__(self, result: dict, category_data: dict, **kw) -> None:
         super().__init__(**kw)
@@ -268,9 +355,7 @@ class OverviewPanel(VerticalScroll):
 class DetailPanel(Static):
     def show_detail(self, category: str, item: dict, root_path=None) -> None:
         lines: list[str] = []
-        file_path = item.get("file", "?")
-        line_no = item.get("line", "?")
-        lines.append(f"  [bold]File:[/bold]  {file_path}:{line_no}")
+        lines.append(f"  [bold]File:[/bold]  {_loc(item, root_path)}")
 
         if category == "dead_code":
             conf = item.get("confidence", "?")
@@ -353,11 +438,22 @@ class SkylosApp(App):
     TITLE = "Skylos"
 
     CSS = """
+    Screen {
+        background: #14110e;
+        color: #d8c7a3;
+    }
+    #topbar {
+        dock: top;
+        height: 3;
+        background: #2c251c;
+        color: #ddbf7a;
+        padding: 1 2;
+    }
     #sidebar {
-        width: 26;
+        width: 24;
         dock: left;
-        background: $surface;
-        border-right: solid $primary-background;
+        background: #221c15;
+        border-right: solid #4a3c2b;
     }
     #sidebar ListView {
         height: 1fr;
@@ -368,21 +464,32 @@ class SkylosApp(App):
     }
     #main-area {
         height: 1fr;
+        background: #14110e;
     }
     #overview-panel {
         height: 1fr;
         padding: 1 2;
+        background: #181410;
     }
-    #findings-table {
+    #findings-area {
         height: 1fr;
     }
+    #findings-list {
+        width: 42%;
+        height: 1fr;
+        background: #221c15;
+        border: solid #4a3c2b;
+    }
+    #findings-list ListItem {
+        height: 3;
+        padding: 0 1;
+    }
     #detail-panel {
-        height: auto;
-        max-height: 14;
-        background: $surface;
-        border-top: solid $primary-background;
-        padding: 1 0;
-        display: none;
+        width: 58%;
+        height: 1fr;
+        background: #181410;
+        border: solid #4a3c2b;
+        padding: 1 2;
     }
     #detail-panel.visible {
         display: block;
@@ -397,14 +504,16 @@ class SkylosApp(App):
     #status-bar {
         dock: bottom;
         height: 1;
-        background: $primary-background;
-        color: $text;
+        background: #3a2f22;
+        color: #ffffff;
         padding: 0 2;
     }
     """
 
     BINDINGS = [
         Binding("q", "quit", "Quit", priority=True),
+        Binding("j", "cursor_down", "Down", show=False, priority=True),
+        Binding("k", "cursor_up", "Up", show=False, priority=True),
         Binding("slash", "toggle_search", "Search", key_display="/", priority=True),
         Binding("f", "cycle_severity", "Severity Filter", priority=True),
         Binding("tab", "next_category", "Next Tab", priority=True),
@@ -446,7 +555,7 @@ class SkylosApp(App):
                 self.category_counts[cat_key] = len(rows)
 
     def compose(self) -> ComposeResult:
-        yield Header(show_clock=False)
+        yield Static("", id="topbar")
         with Horizontal():
             with Vertical(id="sidebar"):
                 yield ListView(
@@ -460,51 +569,55 @@ class SkylosApp(App):
                 yield OverviewPanel(
                     self.result, self.category_data, id="overview-panel"
                 )
-                yield DataTable(id="findings-table")
-                yield DetailPanel("", id="detail-panel")
+                with Horizontal(id="findings-area"):
+                    yield ListView(id="findings-list")
+                    yield DetailPanel("", id="detail-panel")
         yield Input(placeholder="Type to search...", id="search-input")
         yield Static("", id="status-bar")
-        yield Footer()
 
     def on_mount(self) -> None:
-        table = self.query_one("#findings-table", DataTable)
-        table.display = False
-        table.cursor_type = "row"
+        self.query_one("#findings-area", Horizontal).display = False
         self._update_status()
         self.query_one("#category-list", ListView).focus()
 
     def _show_category(self, cat_key: str) -> None:
         self.active_category = cat_key
         overview = self.query_one("#overview-panel", OverviewPanel)
-        table = self.query_one("#findings-table", DataTable)
+        findings_area = self.query_one("#findings-area", Horizontal)
         detail = self.query_one("#detail-panel", DetailPanel)
         detail.remove_class("visible")
 
         if cat_key == "overview":
             overview.display = True
-            table.display = False
+            findings_area.display = False
         else:
             overview.display = False
-            table.display = True
-            self._populate_table(cat_key)
+            findings_area.display = True
+            self._populate_findings(cat_key)
 
         self._update_status()
 
-    def _populate_table(self, cat_key: str) -> None:
-        table = self.query_one("#findings-table", DataTable)
-        table.clear(columns=True)
+    def _populate_findings(self, cat_key: str) -> None:
+        finding_list = self.query_one("#findings-list", ListView)
+        finding_list.clear()
 
         cols, rows, raw = self.category_data.get(cat_key, ([], [], []))
         if not cols:
+            self._sync_detail_panel()
             return
 
-        for col in cols:
-            table.add_column(col, key=col)
-
         filtered = self._filtered_rows(cat_key)
-        for i, (row, _) in enumerate(filtered):
-            styled = self._style_row(row)
-            table.add_row(*styled, key=str(i))
+        finding_list.extend(
+            [
+                FindingItem(cat_key, row, item, self.root_path)
+                for row, item in filtered
+            ]
+        )
+        if filtered:
+            finding_list.index = 0
+        else:
+            finding_list.index = None
+        self._sync_detail_panel()
 
     def _filtered_rows(self, cat_key: str) -> list[tuple[tuple, dict]]:
         _, rows, raw = self.category_data.get(cat_key, ([], [], []))
@@ -566,7 +679,7 @@ class SkylosApp(App):
             inp.value = ""
             self._focus_main()
             if self.active_category != "overview":
-                self._populate_table(self.active_category)
+                self._populate_findings(self.active_category)
 
     def action_cycle_severity(self) -> None:
         if self._search_active():
@@ -576,28 +689,30 @@ class SkylosApp(App):
         self.severity_filter = cycle[(idx + 1) % len(cycle)]
         self._update_status()
         if self.active_category != "overview":
-            self._populate_table(self.active_category)
+            self._populate_findings(self.active_category)
+
+    def action_cursor_down(self) -> None:
+        if self._search_active() or self.active_category == "overview":
+            return
+        self.query_one("#findings-list", ListView).action_cursor_down()
+        self._sync_detail_panel()
+
+    def action_cursor_up(self) -> None:
+        if self._search_active() or self.active_category == "overview":
+            return
+        self.query_one("#findings-list", ListView).action_cursor_up()
+        self._sync_detail_panel()
 
     def action_show_detail(self) -> None:
         if self.active_category == "overview":
             return
-        table = self.query_one("#findings-table", DataTable)
-        cursor = table.cursor_row
-        filtered = self._filtered_rows(self.active_category)
-        if 0 <= cursor < len(filtered):
-            _, item = filtered[cursor]
-            detail = self.query_one("#detail-panel", DetailPanel)
-            detail.show_detail(self.active_category, item, self.root_path)
-            detail.add_class("visible")
+        self._sync_detail_panel()
 
     def action_open_editor(self) -> None:
         if self._search_active() or self.active_category == "overview":
             return
-        table = self.query_one("#findings-table", DataTable)
-        cursor = table.cursor_row
-        filtered = self._filtered_rows(self.active_category)
-        if 0 <= cursor < len(filtered):
-            _, item = filtered[cursor]
+        item = self._selected_item()
+        if item is not None:
             file_path = item.get("file")
             line = item.get("line", 1)
             editor = os.environ.get("EDITOR", "vi")
@@ -606,39 +721,66 @@ class SkylosApp(App):
                     subprocess.call([editor, f"+{line}", file_path])
 
     def action_dismiss(self) -> None:
-        self.query_one("#detail-panel", DetailPanel).remove_class("visible")
         inp = self.query_one("#search-input", Input)
         if inp.has_class("visible"):
             inp.remove_class("visible")
             self.search_query = ""
             inp.value = ""
             if self.active_category != "overview":
-                self._populate_table(self.active_category)
+                self._populate_findings(self.active_category)
+        elif self.active_category == "overview":
+            self.query_one("#detail-panel", DetailPanel).remove_class("visible")
+        else:
+            self._sync_detail_panel()
         self._focus_main()
 
     def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
         item = event.item
         if isinstance(item, CategoryItem):
             self._show_category(item.cat_key)
+        elif isinstance(item, FindingItem):
+            self._sync_detail_panel()
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         item = event.item
         if isinstance(item, CategoryItem):
             self._show_category(item.cat_key)
             if item.cat_key != "overview":
-                self.query_one("#findings-table", DataTable).focus()
+                self.query_one("#findings-list", ListView).focus()
+        elif isinstance(item, FindingItem):
+            self._sync_detail_panel()
 
     def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id == "search-input":
             self.search_query = event.value
             if self.active_category != "overview":
-                self._populate_table(self.active_category)
+                self._populate_findings(self.active_category)
 
     def _focus_main(self) -> None:
         if self.active_category == "overview":
             self.query_one("#category-list", ListView).focus()
         else:
-            self.query_one("#findings-table", DataTable).focus()
+            self.query_one("#findings-list", ListView).focus()
+
+    def _selected_item(self) -> dict | None:
+        if self.active_category == "overview":
+            return None
+        finding_list = self.query_one("#findings-list", ListView)
+        filtered = self._filtered_rows(self.active_category)
+        index = finding_list.index
+        if index is not None and 0 <= index < len(filtered):
+            _, item = filtered[index]
+            return item
+        return None
+
+    def _sync_detail_panel(self) -> None:
+        detail = self.query_one("#detail-panel", DetailPanel)
+        item = self._selected_item()
+        if item is None:
+            detail.update("  [dim]No finding selected.[/dim]")
+            return
+        detail.show_detail(self.active_category, item, self.root_path)
+        detail.add_class("visible")
 
     def _update_status(self) -> None:
         total = sum(
@@ -646,8 +788,12 @@ class SkylosApp(App):
         )
         sev = self.severity_filter or "ALL"
         cat = self.active_category.replace("_", " ").title()
+        self.query_one("#topbar", Static).update(
+            f"[bold #ddbf7a]skylos tui[/bold #ddbf7a]  "
+            f"[dim]{self.root_path or '.'}[/dim]"
+        )
         bar = self.query_one("#status-bar", Static)
-        bar.update(f" Findings: {total}  │  Severity: {sev}  │  {cat}")
+        bar.update(f" findings {total}  |  severity {sev}  |  {cat}  |  j/k move  / search  o open  q quit")
 
 
 def run_tui(result: dict, root_path=None) -> None:

--- a/test/test_audit_candidates.py
+++ b/test/test_audit_candidates.py
@@ -221,6 +221,7 @@ def test_scan_deep_audit_candidates_records_non_candidate_files(
     assert record is not None
     assert record.status == "not_analyzed"
     assert payload["candidates"] == []
+    assert store.current_scan_files == {"plain.py"}
 
 
 def test_scan_deep_audit_candidates_marks_deleted_records(tmp_path: Path, monkeypatch):

--- a/test/test_audit_processor.py
+++ b/test/test_audit_processor.py
@@ -98,6 +98,7 @@ def _write_record(
     if status:
         record.status = status
         store.write_file_record(record)
+    store.set_current_scan_files([*(store.current_scan_files or ()), file_path])
     return record
 
 
@@ -176,6 +177,62 @@ def test_process_deep_audit_records_respects_allowed_file_scope(tmp_path: Path):
     assert summary.processed_files == 1
     assert summary.complete is True
     assert store.read_file_record(old).status == "pending"
+
+
+def test_process_deep_audit_records_defaults_to_current_scan_scope(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    hidden = repo / ".git" / "config"
+    hidden.parent.mkdir()
+    hidden.write_text(
+        "[remote]\n  url = https://token@example.invalid/repo\n",
+        encoding="utf-8",
+    )
+    app = repo / "app.py"
+    app.write_text("print('ok')\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, hidden, candidates=[_candidate("poison", priority=900)])
+    store.set_current_scan_files([app])
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-current-scope",
+    )
+
+    assert analyzer.calls == []
+    assert summary.considered_files == 0
+    assert summary.processed_files == 0
+    assert summary.complete is True
+    assert store.read_file_record(hidden).status == "pending"
+
+
+def test_process_deep_audit_records_without_scope_fails_closed(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, candidates=[_candidate("candidate", priority=900)])
+    store.current_scan_files = None
+
+    analyzer = FakeAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-no-scope",
+    )
+
+    assert analyzer.calls == []
+    assert summary.considered_files == 0
+    assert summary.processed_files == 0
+    assert summary.complete is True
+    assert store.read_file_record(app).status == "pending"
 
 
 def test_process_deep_audit_records_skips_secret_candidates(tmp_path: Path):

--- a/test/test_audit_revalidator.py
+++ b/test/test_audit_revalidator.py
@@ -70,6 +70,7 @@ def _write_analyzed_record(
         }
     ]
     store.write_file_record(record)
+    store.set_current_scan_files([*(store.current_scan_files or ()), path])
     return record
 
 
@@ -237,6 +238,64 @@ def test_revalidate_deep_audit_findings_skips_secret_candidate_records(
     assert verifier.calls == []
     assert summary.skipped_findings == 1
     assert summary.complete is False
+
+
+def test_revalidate_deep_audit_findings_defaults_to_current_scan_scope(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    hidden = repo / ".git" / "config"
+    hidden.parent.mkdir()
+    hidden.write_text(
+        "[remote]\n  url = https://token@example.invalid/repo\n",
+        encoding="utf-8",
+    )
+    app = repo / "app.py"
+    app.write_text("print('ok')\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, hidden)
+    store.set_current_scan_files([app])
+
+    verifier = FakeVerifier("true_positive")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        run_id="run-current-scope",
+    )
+
+    assert verifier.calls == []
+    assert summary.considered_findings == 0
+    assert summary.revalidated_findings == 0
+    assert summary.complete is True
+
+
+def test_revalidate_deep_audit_findings_without_scope_fails_closed(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("eval(user_input)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_analyzed_record(store, app)
+    store.current_scan_files = None
+
+    verifier = FakeVerifier("true_positive")
+    summary = revalidate_deep_audit_findings(
+        store=store,
+        verifier=verifier,
+        model="test-model",
+        run_id="run-no-scope",
+    )
+
+    assert verifier.calls == []
+    assert summary.considered_findings == 0
+    assert summary.revalidated_findings == 0
+    assert summary.complete is True
 
 
 def test_revalidate_deep_audit_findings_challenges_uncertain_verdicts(

--- a/test/test_cli_addopts_safety.py
+++ b/test/test_cli_addopts_safety.py
@@ -70,3 +70,15 @@ def test_parse_main_cli_args_still_accepts_user_command_separator():
     assert args.json is True
     assert args.path == ["."]
     assert args.command == ["echo", "ok"]
+
+
+def test_parse_main_cli_args_accepts_pretty_format():
+    parser = build_main_parser(version="test")
+
+    args = parse_main_cli_args(parser, [".", "--format", "pretty"], addopts_loader=list)
+
+    assert args.format == "pretty"
+    assert args.json is False
+    assert args.llm is False
+    assert args.github is False
+    assert args.concise is False

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -118,8 +118,19 @@ def _snapshot(project: str) -> DebtSnapshot:
 
 
 def test_collect_debt_signals_maps_dimensions_and_dead_code():
+    result = {
+        **SAMPLE_RESULT,
+        "unused_parameters": [
+            {
+                "name": "unused_context",
+                "file": "/repo/app/services.py",
+                "line": 21,
+                "confidence": 80,
+            }
+        ],
+    }
     signals = collect_debt_signals(
-        SAMPLE_RESULT,
+        result,
         project_root=cli.Path("/repo"),
     )
 
@@ -127,6 +138,7 @@ def test_collect_debt_signals_maps_dimensions_and_dead_code():
     assert ("SKY-Q301", "complexity") in dimensions
     assert ("SKY-Q804", "architecture") in dimensions
     assert ("SKY-U001", "dead_code") in dimensions
+    assert ("SKY-U006", "dead_code") in dimensions
 
 
 def test_collect_debt_signals_skips_paths_outside_project_root(tmp_path):

--- a/test/test_terminal_report.py
+++ b/test/test_terminal_report.py
@@ -1,0 +1,84 @@
+from rich.console import Console
+
+from skylos.ui.terminal_report import collect_pretty_findings, render_pretty_results
+
+
+def _recording_console() -> Console:
+    return Console(record=True, width=120, force_terminal=False)
+
+
+def test_pretty_renderer_groups_findings_by_file_and_keeps_copyable_locations(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text(
+        "def handler(user_id):\n"
+        "    cursor.execute(f'SELECT * FROM users WHERE id={user_id}')\n",
+        encoding="utf-8",
+    )
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "danger": [
+            {
+                "rule_id": "SKY-D211",
+                "severity": "HIGH",
+                "message": "SQL injection risk",
+                "file": str(source),
+                "line": 2,
+            }
+        ],
+    }
+
+    console = _recording_console()
+    render_pretty_results(console, result, root_path=tmp_path)
+    output = console.export_text()
+
+    assert "Skylos static analysis" in output
+    assert "src/app.py · 1 issue" in output
+    assert " HIGH  SKY-D211  SQL injection risk" in output
+    assert "src/app.py:2" in output
+    assert "cursor.execute" in output
+    assert "╭" not in output
+
+
+def test_pretty_renderer_uses_secret_preview_instead_of_source_line(tmp_path):
+    source = tmp_path / ".env"
+    source.write_text("API_KEY=sk_live_real_secret_value\n", encoding="utf-8")
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "secrets": [
+            {
+                "provider": "stripe",
+                "message": "Stripe key found",
+                "preview": "sk_live_****",
+                "file": str(source),
+                "line": 1,
+            }
+        ],
+    }
+
+    console = _recording_console()
+    render_pretty_results(console, result, root_path=tmp_path)
+    output = console.export_text()
+
+    assert "sk_live_****" in output
+    assert "sk_live_real_secret_value" not in output
+
+
+def test_collect_pretty_findings_applies_per_category_limit(tmp_path):
+    result = {
+        "unused_functions": [
+            {"name": "old_a", "file": "a.py", "line": 1},
+            {"name": "old_b", "file": "b.py", "line": 2},
+        ],
+        "quality": [
+            {"message": "too complex", "file": "c.py", "line": 3},
+            {"message": "too nested", "file": "d.py", "line": 4},
+        ],
+    }
+
+    findings = collect_pretty_findings(result, root_path=tmp_path, limit=1)
+
+    assert [finding.title for finding in findings] == [
+        "too complex",
+        "Unused function: old_a",
+    ]

--- a/test/test_tui.py
+++ b/test/test_tui.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from unittest.mock import patch, Mock
 
@@ -7,6 +8,8 @@ from skylos.ui.tui import (
     prepare_category_data,
     CATEGORIES,
     DEAD_CODE_KEYS,
+    DetailPanel,
+    ListView,
     SEVERITY_COLORS,
     SkylosApp,
     run_tui,
@@ -370,6 +373,21 @@ class TestSkylosAppInit:
         assert app.active_category == "overview"
         assert app.severity_filter is None
         assert app.search_query == ""
+
+    def test_show_category_selects_first_row_and_syncs_detail(self, sample_result):
+        async def run():
+            app = SkylosApp(sample_result, root_path=".")
+            async with app.run_test() as pilot:
+                app._show_category("security")
+                await pilot.pause()
+                finding_list = app.query_one("#findings-list", ListView)
+                detail = app.query_one("#detail-panel", DetailPanel)
+
+                assert finding_list.index == 0
+                assert detail.has_class("visible")
+                assert "SKY-D211" in str(detail.render())
+
+        asyncio.run(run())
 
 
 class TestRunTui:


### PR DESCRIPTION
## Summary

  - Add opt-in `--format pretty` scan output with grouped findings, severity rails, snippets, and copyable `file:line` locations
  - Redesign the scan TUI into a selectable triage view with category navigation, finding details, keyboard movement, filtering, and open-in-editor support
  - Update README and `dictionary.md`

## Tests

  - `pytest test/test_debt.py test/test_terminal_report.py test/test_tui.py test/test_cli_addopts_safety.py`
  - `skylos --format pretty --no-upload --no-provenance --force --limit 2 skylos-demo/app/utils/ids.py`