### PR TITLE
fix(ci): configure parity venv path at runtime

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -20,10 +20,11 @@ permissions:
 jobs:
   parity:
     runs-on: ubuntu-latest
-    env:
-      SK_PARITY_VENV: ${{ runner.temp }}/skylos-parity-venv
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure parity venv path
+        run: echo "SK_PARITY_VENV=${RUNNER_TEMP}/skylos-parity-venv" >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- Move the parity venv path out of job-level env so the workflow no longer evaluates the unsupported runner context there
- Configure SK_PARITY_VENV through GITHUB_ENV using RUNNER_TEMP at runtime

## Validation

- python -m pytest -q test/test_fast_parity.py
- git diff --check HEAD~1..HEAD