### PR TITLE
fix(pipeline): review ordinary files in llm-only scans

### DIFF
--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -575,7 +575,7 @@ def run_pipeline(
         files,
         static_findings,
         changed_files=safe_changed_files,
-        force_include_files=path.is_file(),
+        force_include_files=path.is_file() or getattr(agent_args, "llm_only", False),
         review_index=review_index,
     )
     phase_2b_repo_context = review_index.context_map_for(phase_2b_files)

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -436,6 +436,31 @@ class TestPipelinePhase1:
         mock_analyze.assert_not_called()
 
     @patch(P_LLM)
+    @patch(P_ANALYZE)
+    @patch(P_PROGRESS)
+    def test_llm_only_directory_scan_reviews_ordinary_python_files(
+        self, _prog, mock_analyze, mock_llm, tmp_path
+    ):
+        mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        ordinary = proj / "views.py"
+        ordinary.write_text("def render():\n    return 'ok'\n", encoding="utf-8")
+
+        run_pipeline(
+            path=str(proj),
+            model="t",
+            api_key="k",
+            agent_args=_agent_args(llm_only=True),
+            console=_console(),
+        )
+
+        mock_analyze.assert_not_called()
+        analyze_files_args = mock_llm.return_value.analyze_files.call_args[0][0]
+        assert [str(f) for f in analyze_files_args] == [str(ordinary)]
+
+    @patch(P_LLM)
     @patch(P_STATIC_FN, return_value=_fresh_static())
     @patch(P_PROGRESS)
     def test_generates_message_for_dead_code(self, _prog, _static, mock_llm, tmp_path):


### PR DESCRIPTION
## Summary

- Make directory llm-only scans force-include requested Python files instead of applying the high-signal Phase 2b selector
- Add regression coverage for an ordinary views.py file with no static findings
- Preserve static skipping behavior for llm-only mode

## Validation

- pytest -q test/test_pipeline.py
- git diff --check