### PR TITLE
fix(remediation): reject edits outside scan root

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -34,6 +34,7 @@ from skylos.core.result_cache import (
     save_trace_cache,
     write_trace_payload,
 )
+from skylos.remediation.safety import resolve_remediation_path
 
 from pathlib import Path
 import pathlib
@@ -688,10 +689,9 @@ def setup_logger(output_file=None):
     return logger
 
 
-def remove_unused_import(file_path, import_name, line_number):
-    path = pathlib.Path(file_path)
-
+def remove_unused_import(file_path, import_name, line_number, *, root_path=None):
     try:
+        path = resolve_remediation_path(file_path, root_path=root_path)
         src = path.read_text(encoding="utf-8")
         new_code, changed = remove_unused_import_cst(src, import_name, line_number)
         if not changed:
@@ -704,10 +704,9 @@ def remove_unused_import(file_path, import_name, line_number):
         return False
 
 
-def remove_unused_function(file_path, function_name, line_number):
-    path = pathlib.Path(file_path)
-
+def remove_unused_function(file_path, function_name, line_number, *, root_path=None):
     try:
+        path = resolve_remediation_path(file_path, root_path=root_path)
         src = path.read_text(encoding="utf-8")
         new_code, changed = remove_unused_function_cst(src, function_name, line_number)
         if not changed:
@@ -723,11 +722,10 @@ def remove_unused_function(file_path, function_name, line_number):
 
 
 def comment_out_unused_import(
-    file_path, import_name, line_number, marker="SKYLOS DEADCODE"
+    file_path, import_name, line_number, marker="SKYLOS DEADCODE", *, root_path=None
 ):
-    path = pathlib.Path(file_path)
-
     try:
+        path = resolve_remediation_path(file_path, root_path=root_path)
         src = path.read_text(encoding="utf-8")
         new_code, changed = comment_out_unused_import_cst(
             src, import_name, line_number, marker=marker
@@ -745,11 +743,10 @@ def comment_out_unused_import(
 
 
 def comment_out_unused_function(
-    file_path, function_name, line_number, marker="SKYLOS DEADCODE"
+    file_path, function_name, line_number, marker="SKYLOS DEADCODE", *, root_path=None
 ):
-    path = pathlib.Path(file_path)
-
     try:
+        path = resolve_remediation_path(file_path, root_path=root_path)
         src = path.read_text(encoding="utf-8")
         new_code, changed = comment_out_unused_function_cst(
             src, function_name, line_number, marker=marker

--- a/skylos/commands/clean_cmd.py
+++ b/skylos/commands/clean_cmd.py
@@ -11,6 +11,7 @@ from skylos.remediation.codemods import (
     remove_unused_function_cst,
     remove_unused_import_cst,
 )
+from skylos.remediation.safety import resolve_remediation_path
 
 SUPPORTED_FINDING_TYPES = {"function", "import"}
 
@@ -21,8 +22,10 @@ def run_analyze(*args, **kwargs):
     return run_analyze_impl(*args, **kwargs)
 
 
-def _apply_codemod(file_path, transform, *transform_args, **transform_kwargs):
-    path = Path(file_path)
+def _apply_codemod(
+    file_path, transform, *transform_args, root_path=None, **transform_kwargs
+):
+    path = resolve_remediation_path(file_path, root_path=root_path)
     src = path.read_text(encoding="utf-8")
     new_code, changed = transform(src, *transform_args, **transform_kwargs)
     if changed:
@@ -46,6 +49,9 @@ def _collect_findings(items, finding_type):
 def run_clean_command(argv: list[str]) -> int:
     console = Console()
     path = argv[0] if argv else "."
+    scan_root = Path(path).resolve()
+    if scan_root.is_file():
+        scan_root = scan_root.parent
 
     console.print(
         Panel(
@@ -176,7 +182,11 @@ def run_clean_command(argv: list[str]) -> int:
                     elif finding["type"] == "function":
                         transform = comment_out_unused_function_cst
                 if transform and _apply_codemod(
-                    finding["file"], transform, finding["name"], finding["line"]
+                    finding["file"],
+                    transform,
+                    finding["name"],
+                    finding["line"],
+                    root_path=scan_root,
                 ):
                     applied += 1
             except Exception as e:

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -640,7 +640,10 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                         console.print("[warn]Applying changes…[/warn]")
                         for func in selected_functions:
                             ok = action_func_fn(
-                                func["file"], func["name"], func["line"]
+                                func["file"],
+                                func["name"],
+                                func["line"],
+                                root_path=project_root,
                             )
                             if ok:
                                 console.print(
@@ -652,7 +655,12 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                                 )
 
                         for imp in selected_imports:
-                            ok = action_func_imp(imp["file"], imp["name"], imp["line"])
+                            ok = action_func_imp(
+                                imp["file"],
+                                imp["name"],
+                                imp["line"],
+                                root_path=project_root,
+                            )
                             if ok:
                                 console.print(
                                     f"[good] ✓ {action_past} import:[/good] {imp['name']}"

--- a/skylos/remediation/safety.py
+++ b/skylos/remediation/safety.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_remediation_path(
+    file_path: str | Path, *, root_path: str | Path | None = None
+) -> Path:
+    path = Path(file_path)
+
+    if root_path is None:
+        if path.is_symlink():
+            raise ValueError(f"Refusing to modify symlinked path: {path}")
+        return path
+
+    root = Path(root_path).resolve(strict=True)
+    if root.is_file():
+        root = root.parent
+
+    candidate = path if path.is_absolute() else root / path
+    if candidate.is_symlink():
+        raise ValueError(f"Refusing to modify symlinked path: {candidate}")
+
+    resolved = candidate.resolve(strict=True)
+    if not resolved.is_file():
+        raise ValueError(f"Refusing to modify non-file path: {candidate}")
+
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Refusing to modify path outside scan root: {candidate}"
+        ) from exc
+
+    return resolved

--- a/test/test_clean_cmd.py
+++ b/test/test_clean_cmd.py
@@ -73,6 +73,41 @@ def test_clean_command_comment_out_function_uses_source_and_line(tmp_path):
     assert target.read_text(encoding="utf-8") == "# SKYLOS DEADCODE\npass\n"
 
 
+def test_clean_command_refuses_symlink_outside_scan_root(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("def unused():\n    return 1\n", encoding="utf-8")
+    link = repo / "link.py"
+    link.symlink_to(outside)
+    result = {
+        "unused_functions": [
+            {
+                "name": "unused",
+                "file": str(link),
+                "line": 1,
+                "confidence": 100,
+            }
+        ]
+    }
+    console = Mock()
+
+    with (
+        patch("skylos.commands.clean_cmd.Console", return_value=console),
+        patch("skylos.commands.clean_cmd.run_analyze", return_value=json.dumps(result)),
+        patch("builtins.input", side_effect=["c", "y"]),
+        patch(
+            "skylos.commands.clean_cmd.comment_out_unused_function_cst",
+            return_value=("# SKYLOS DEADCODE\npass\n", True),
+        ) as comment_out,
+    ):
+        exit_code = clean_cmd.run_clean_command([str(repo)])
+
+    assert exit_code == 0
+    comment_out.assert_not_called()
+    assert outside.read_text(encoding="utf-8") == "def unused():\n    return 1\n"
+
+
 def test_clean_command_skips_unsupported_findings_from_prompt(tmp_path):
     target = tmp_path / "sample.py"
     target.write_text(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -541,6 +541,32 @@ def test_comment_out_unused_function_handles_exception_and_returns_false():
     assert logerr.called
 
 
+def test_comment_out_unused_function_refuses_symlink_outside_root(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("def unused():\n    return 1\n", encoding="utf-8")
+    link = repo / "link.py"
+    link.symlink_to(outside)
+
+    ok = cli.comment_out_unused_function(link, "unused", 1, root_path=repo)
+
+    assert ok is False
+    assert outside.read_text(encoding="utf-8") == "def unused():\n    return 1\n"
+
+
+def test_remove_unused_import_refuses_file_outside_root(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("import os\n", encoding="utf-8")
+
+    ok = cli.remove_unused_import(outside, "os", 1, root_path=repo)
+
+    assert ok is False
+    assert outside.read_text(encoding="utf-8") == "import os\n"
+
+
 def test_generate_llm_report_formats_findings_and_defaults_dead_code(tmp_path):
     src = tmp_path / "app.py"
     src.write_text(


### PR DESCRIPTION
## Summary
  - prevent dead-code remediation helpers from editing symlinked paths & reject resolved edit targets outside the active scan root
  - pass scan root containment into interactive scan remediation

  ## Tests
  - pytest test/test_cli.py test/test_cli_uncovered_paths.py test/test_clean_cmd.py