### PR TITLE
fix(ssrf): flag uppercase f-string URL bases

### DIFF
--- a/skylos/rules/danger/danger_net/ssrf_flow.py
+++ b/skylos/rules/danger/danger_net/ssrf_flow.py
@@ -90,10 +90,6 @@ def _has_safe_base_url(node):
             if len(parts) > 1 and "/" in parts[1]:
                 return True
 
-    if isinstance(first, ast.FormattedValue):
-        if isinstance(first.value, ast.Name) and first.value.id.isupper():
-            return True
-
     return False
 
 

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -84,6 +84,16 @@ def test_requests_fixed_host_interpolated_path_ok(tmp_path):
     assert "SKY-D216" not in _rule_ids(out)
 
 
+def test_requests_uppercase_fstring_base_variable_flags(tmp_path):
+    code = (
+        "import requests\n"
+        "def f(BASE_URL):\n"
+        "    requests.get(f'{BASE_URL}/health', timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_uppercase_base.py", code)
+    assert "SKY-D216" in _rule_ids(out)
+
+
 def test_requests_fixed_host_urljoin_path_ok(tmp_path):
     code = (
         "from urllib.parse import urljoin\n"


### PR DESCRIPTION
## Summary

  - remove the uppercase-variable shortcut from SSRF f-string safe-base detection
  - keep literal fixed-host f-strings treated as safe

## Tests

  - `pytest test/test_ssrf.py`
  - `pytest test/test_security_benchmark.py`
  - `pytest .`