### PR TITLE
fix(cli): sanitize pretty report text

### DIFF
--- a/skylos/ui/terminal_report.py
+++ b/skylos/ui/terminal_report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import re
 
 from rich.console import Console
 from rich.text import Text
@@ -63,6 +64,8 @@ SUMMARY_CATEGORIES = (
     "dependency_vulnerabilities",
 )
 
+_TERMINAL_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
 
 @dataclass(frozen=True)
 class PrettyFinding:
@@ -114,7 +117,7 @@ def render_pretty_results(
             by_file[file_path],
             key=lambda f: (SEVERITY_RANK.get(f.severity, 99), f.line, f.rule),
         )
-        short_path = _shorten_path(file_path, root_path)
+        short_path = _sanitize_terminal_text(_shorten_path(file_path, root_path))
         count = len(file_findings)
         console.print(
             Text.assemble(
@@ -172,13 +175,17 @@ def _make_pretty_finding(
     root_path=None,
     source_cache: dict[str, list[str] | None],
 ) -> PrettyFinding:
-    file_path = str(item.get("file") or item.get("file_path") or "?")
+    file_path = _sanitize_terminal_text(
+        str(item.get("file") or item.get("file_path") or "?")
+    )
     line = _line_number(item)
     severity = _severity(item, category)
-    rule = _rule_id(item, category)
-    title = _title(item, category, fallback_label)
-    snippet = _snippet(item, category, root_path=root_path, source_cache=source_cache)
-    fix = _fix(item, category)
+    rule = _sanitize_terminal_text(_rule_id(item, category))
+    title = _sanitize_terminal_text(_title(item, category, fallback_label))
+    snippet = _sanitize_terminal_text(
+        _snippet(item, category, root_path=root_path, source_cache=source_cache)
+    )
+    fix = _sanitize_terminal_text(_fix(item, category))
     return PrettyFinding(
         category=category,
         category_label=category_label,
@@ -460,3 +467,10 @@ def _truncate(text: str, width: int) -> str:
     if len(text) <= width:
         return text
     return text[: max(0, width - 3)] + "..."
+
+
+def _sanitize_terminal_text(text: str) -> str:
+    return _TERMINAL_CONTROL_RE.sub(
+        lambda match: f"\\x{ord(match.group()):02x}",
+        str(text),
+    )

--- a/test/test_terminal_report.py
+++ b/test/test_terminal_report.py
@@ -64,6 +64,59 @@ def test_pretty_renderer_uses_secret_preview_instead_of_source_line(tmp_path):
     assert "sk_live_real_secret_value" not in output
 
 
+def test_pretty_renderer_sanitizes_control_chars_from_finding_fields(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("def handler():\n    return None\n", encoding="utf-8")
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "danger": [
+            {
+                "rule_id": "SKY-D999",
+                "severity": "HIGH",
+                "message": "bad\x1b[2Jtitle",
+                "snippet": "payload\x1b]52;c;AAAA\x07tail",
+                "file": str(source),
+                "line": 2,
+            }
+        ],
+    }
+
+    console = _recording_console()
+    render_pretty_results(console, result, root_path=tmp_path)
+    output = console.export_text()
+
+    assert "\x1b" not in output
+    assert "\x07" not in output
+    assert "bad\\x1b[2Jtitle" in output
+    assert "payload\\x1b]52;c;AAAA\\x07tail" in output
+
+
+def test_pretty_renderer_sanitizes_control_chars_from_source_line(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("def handler():\n    eval(user)\x1b[2J\n", encoding="utf-8")
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "danger": [
+            {
+                "rule_id": "SKY-D200",
+                "severity": "HIGH",
+                "message": "Dangerous call",
+                "file": str(source),
+                "line": 2,
+            }
+        ],
+    }
+
+    console = _recording_console()
+    render_pretty_results(console, result, root_path=tmp_path)
+    output = console.export_text()
+
+    assert "\x1b" not in output
+    assert "eval(user)\\x1b[2J" in output
+
+
 def test_collect_pretty_findings_applies_per_category_limit(tmp_path):
     result = {
         "unused_functions": [


### PR DESCRIPTION
  ## Summary

  - escape C0/C1 terminal control bytes in pretty report text
  - sanitize displayed paths, rule ids, titles, snippets, and fixes before rendering

  ## Tests
  - pytest test/test_terminal_report.py test/test_cli_uncovered_paths.py