### PR TITLE
fix(ci): avoid PR-controlled scanner execution

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
           uv venv --python "$PYTHON_VERSION"
-          uv pip install --python .venv/bin/python -e .
+          # Keep this workflow from executing PR-controlled package/build code.
           uv pip install --python .venv/bin/python pre-commit ruff mypy
 
       - name: Validate pre-commit config

--- a/.github/workflows/skylos.yaml
+++ b/.github/workflows/skylos.yaml
@@ -6,6 +6,9 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -13,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -25,17 +29,26 @@ jobs:
       - uses: astral-sh/setup-uv@v4
 
       - name: Build repo Go engine
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/skylos-go-build /tmp/skylos-go-gopath
           cd skylos/engines/go
           GOCACHE=/tmp/skylos-go-build GOPATH=/tmp/skylos-go-gopath go build -o skylos-go ./cmd/skylos-go
 
-      - name: Use repo skylos (not PyPI)
+      - name: Install trusted Skylos for pull requests
+        if: github.event_name == 'pull_request'
+        run: |
+          uv venv --python 3.11
+          uv pip install --python .venv/bin/python "skylos>=4.7.0"
+          .venv/bin/skylos --version
+
+      - name: Use repo Skylos on trusted refs
+        if: github.event_name != 'pull_request'
         run: |
           uv venv --python 3.11
           uv pip install --python .venv/bin/python -e .
-          python -c "import skylos; print('skylos from:', skylos.__file__)"
-          python -c "import skylos.visitors.languages; print('languages OK')"
+          .venv/bin/python -c "import skylos; print('skylos from:', skylos.__file__)"
+          .venv/bin/python -c "import skylos.visitors.languages; print('languages OK')"
 
       - name: Resolve diff base
         id: diff
@@ -58,9 +71,9 @@ jobs:
         run: |
           echo "REPORT=$REPORT" >> "$GITHUB_OUTPUT"
           if [ -n "$DIFF_BASE" ]; then
-            .venv/bin/python -m skylos.cli . --quality --danger --secrets --diff-base "$DIFF_BASE" --diff "$DIFF_BASE" --json -o "$REPORT"
+            .venv/bin/skylos . --quality --danger --secrets --diff-base "$DIFF_BASE" --diff "$DIFF_BASE" --json -o "$REPORT"
           else
-            .venv/bin/python -m skylos.cli . --quality --danger --secrets --baseline --json -o "$REPORT"
+            .venv/bin/skylos . --quality --danger --secrets --baseline --json -o "$REPORT"
           fi
 
       - name: Report findings (advisory)
@@ -68,14 +81,14 @@ jobs:
         env:
           REPORT: ${{ steps.scan.outputs.REPORT }}
         run: |
-          .venv/bin/python -m skylos.cli cicd gate --input "$REPORT" --summary --advisory
+          .venv/bin/skylos cicd gate --input "$REPORT" --summary --advisory
 
       - name: GitHub annotations
         if: always()
         env:
           REPORT: ${{ steps.scan.outputs.REPORT }}
         run: |
-          .venv/bin/python -m skylos.cli cicd annotate --input "$REPORT"
+          .venv/bin/skylos cicd annotate --input "$REPORT"
 
       - name: Upload report artifact
         if: always()

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -20,6 +20,10 @@ def _tests_workflow():
     return yaml.safe_load(Path(".github/workflows/tests.yaml").read_text())
 
 
+def _skylos_workflow():
+    return yaml.safe_load(Path(".github/workflows/skylos.yaml").read_text())
+
+
 def _composite_action():
     return yaml.safe_load(Path("action.yml").read_text())
 
@@ -376,6 +380,35 @@ def test_tests_workflow_pins_codecov_and_limits_permissions():
     assert len(action_ref) == 40
     assert all(c in "0123456789abcdef" for c in action_ref)
     assert codecov_step["with"]["token"] == "${{ secrets.CODECOV_TOKEN }}"
+
+
+def test_skylos_pr_workflow_uses_trusted_scanner_package():
+    workflow = _skylos_workflow()
+    assert workflow["permissions"] == {"contents": "read"}
+
+    steps = workflow["jobs"]["scan"]["steps"]
+    checkout_step = next(s for s in steps if s.get("uses") == "actions/checkout@v4")
+    assert checkout_step["with"]["persist-credentials"] is False
+
+    go_build_step = next(s for s in steps if s.get("name") == "Build repo Go engine")
+    assert go_build_step["if"] == "github.event_name != 'pull_request'"
+
+    pr_install_step = next(
+        s for s in steps if s.get("name") == "Install trusted Skylos for pull requests"
+    )
+    assert pr_install_step["if"] == "github.event_name == 'pull_request'"
+    assert '"skylos>=4.7.0"' in pr_install_step["run"]
+    assert "-e ." not in pr_install_step["run"]
+
+    local_install_step = next(
+        s for s in steps if s.get("name") == "Use repo Skylos on trusted refs"
+    )
+    assert local_install_step["if"] == "github.event_name != 'pull_request'"
+    assert "-e ." in local_install_step["run"]
+
+    scan_step = next(s for s in steps if s.get("name") == "Run Skylos")
+    assert "python -m skylos.cli" not in scan_step["run"]
+    assert ".venv/bin/skylos" in scan_step["run"]
 
 
 def test_composite_action_validates_and_quotes_max_comments_input():


### PR DESCRIPTION
## Summary
  - install trusted Skylos from PyPI for pull_request advisory scans
  - keep editable installs and repo Go engine builds limited to trusted push workflow runs
  - remove editable package installation from the pre-commit advisory workflow

## Tests
  - pytest -q test/test_github_actions_security.py
  - pre-commit validate-config