### PR TITLE
fix(llm): minimize changed-file review context

### DIFF
--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -579,7 +579,11 @@ def run_pipeline(
         review_index=review_index,
     )
     phase_2b_repo_context = review_index.context_map_for(phase_2b_files)
-    force_full_file_paths = review_index.force_full_file_paths_for(phase_2b_files)
+    force_full_file_paths = (
+        set()
+        if safe_changed_files is not None
+        else review_index.force_full_file_paths_for(phase_2b_files)
+    )
 
     low_conf = [f for f in dead_code_findings if f.get("confidence", 100) < 20]
     if low_conf:
@@ -737,8 +741,8 @@ def run_pipeline(
             ),
             parallel=True,
             max_workers=_max_workers,
-            smart_filter=not (path.is_file() or bool(safe_changed_files)),
-            full_file_review=path.is_file() or bool(safe_changed_files),
+            smart_filter=not path.is_file(),
+            full_file_review=path.is_file(),
             repo_context_map=phase_2b_repo_context,
             force_full_file_paths=force_full_file_paths,
         )

--- a/test/test_llm_analyzer.py
+++ b/test/test_llm_analyzer.py
@@ -336,6 +336,46 @@ def test_force_full_file_paths_uses_whole_file_review(tmp_path, monkeypatch):
     assert len(out) == 1
 
 
+def test_smart_filter_context_omits_unrelated_module_secret(tmp_path, monkeypatch):
+    fp = tmp_path / "review.py"
+    source = (
+        "TOP_SECRET = 'do-not-send'\n\n"
+        "def handler(user_input):\n"
+        "    return eval(user_input)\n"
+    )
+    fp.write_text(source, encoding="utf-8")
+
+    cfg = AnalyzerConfig(
+        quiet=True,
+        enable_security=True,
+        enable_quality=True,
+        full_file_review=False,
+        smart_filter=True,
+    )
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    seen_contexts = []
+
+    def fake_analyze_whole_file(
+        source,
+        file_path,
+        defs_map=None,
+        chunk_start_line=1,
+        issue_types=None,
+        **kwargs,
+    ):
+        seen_contexts.append(source)
+        return []
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_analyze_whole_file)
+
+    assert llm.analyze_file(fp) == []
+    assert seen_contexts
+    assert any("handler" in context for context in seen_contexts)
+    assert all("TOP_SECRET" not in context for context in seen_contexts)
+
+
 def test_quality_selector_flags_simple_but_long_review_function():
     cfg = AnalyzerConfig(quiet=True, enable_security=False, enable_quality=True)
     llm = SkylosLLM(cfg)

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -1188,7 +1188,7 @@ class TestPipelinePhase2b:
     @patch(P_PROGRESS)
     @patch(P_LLM)
     @patch(P_LLM_CONF)
-    def test_changed_scan_uses_full_file_review_and_repo_context(
+    def test_changed_scan_keeps_llm_context_minimized_and_repo_context(
         self, mock_conf, mock_llm, _prog, _static, tmp_path
     ):
         proj = tmp_path / "proj"
@@ -1201,18 +1201,31 @@ class TestPipelinePhase2b:
 
         mock_conf.side_effect = lambda **kwargs: SimpleNamespace(**kwargs)
         mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+        fake_review_index = MagicMock()
+        fake_review_index.context_map_for.return_value = {
+            str(py_file.resolve()): "review_score=80"
+        }
+        fake_review_index.force_full_file_paths_for.return_value = {
+            str(py_file.resolve())
+        }
 
-        run_pipeline(
-            path=str(proj),
-            model="t",
-            api_key="k",
-            agent_args=_agent_args(skip_verification=True),
-            console=_console(),
-            changed_files=[str(py_file)],
-        )
+        with patch(
+            "skylos.pipeline.build_repo_activation_index",
+            return_value=fake_review_index,
+        ):
+            run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(skip_verification=True),
+                console=_console(),
+                changed_files=[str(py_file)],
+            )
 
         conf_kwargs = mock_conf.call_args.kwargs
-        assert conf_kwargs["full_file_review"] is True
+        assert conf_kwargs["smart_filter"] is True
+        assert conf_kwargs["full_file_review"] is False
+        assert conf_kwargs["force_full_file_paths"] == set()
         repo_context_map = conf_kwargs["repo_context_map"]
         assert str(py_file.resolve()) in repo_context_map
         assert "review_score=" in repo_context_map[str(py_file.resolve())]


### PR DESCRIPTION
## Summary
  - stop forcing full file LLM review for changed-file scans and disable repo-activation `force_full_file_paths` during changed file scans
  - keep smart filtering enabled when `changed_files` is present
  - preserve full file review for explicit single file scans

## Why
  Changed file scans should scope which files are reviewed, not expand each changed file into a
  full file LLM prompt. 

## Tests
  - `pytest -q test/test_pipeline.py test/test_llm_analyzer.py`