### PR TITLE
fix(cli): redact secrets in llm reports

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1342,6 +1342,11 @@ def _llm_report_code_block(
     return ""
 
 
+def _llm_report_secret_block(finding: dict) -> str:
+    preview = finding.get("preview") or "****"
+    return f"\n```\n>>> secret preview | {preview}\n```\n"
+
+
 def _format_llm_report_section(finding_num, finding, label, code_block):
     rule_id = finding.get("rule_id", "")
     severity = finding.get("severity", "INFO")
@@ -1376,7 +1381,11 @@ def _generate_llm_report(result: dict, project_root: pathlib.Path) -> str:
     for finding_num, (finding, label) in enumerate(all_findings, 1):
         file_path = finding.get("file", "")
         line = finding.get("line", 0)
-        code_block = _llm_report_code_block(file_path, line, project_root, file_cache)
+        code_block = (
+            _llm_report_secret_block(finding)
+            if label == "Secrets"
+            else _llm_report_code_block(file_path, line, project_root, file_cache)
+        )
         sections.append(
             _format_llm_report_section(finding_num, finding, label, code_block)
         )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -629,6 +629,35 @@ def test_generate_llm_report_formats_findings_and_defaults_dead_code(tmp_path):
     assert result["unused_functions"][0]["severity"] == "MEDIUM"
 
 
+def test_generate_llm_report_uses_secret_preview_without_source_context(tmp_path):
+    raw_secret = "ghp_" + "1234567890" + "abcdefghijklmnop" + "qrstuvwxyzABCD"
+    src = tmp_path / "settings.py"
+    src.write_text(f'TOKEN = "{raw_secret}"\n', encoding="utf-8")
+    result = {
+        "danger": [],
+        "secrets": [
+            {
+                "rule_id": "SKY-S101",
+                "severity": "CRITICAL",
+                "provider": "github",
+                "message": "Potential github secret detected",
+                "file": str(src),
+                "line": 1,
+                "preview": "ghp_…ABCD",
+            }
+        ],
+        "quality": [],
+        "custom_rules": [],
+    }
+
+    report = cli._generate_llm_report(result, tmp_path)
+
+    assert "## 1. SKY-S101 | CRITICAL | Secrets" in report
+    assert "ghp_…ABCD" in report
+    assert raw_secret not in report
+    assert 'TOKEN = "' not in report
+
+
 def test_llm_report_code_block_returns_empty_for_invalid_line(tmp_path):
     src = tmp_path / "app.py"
     src.write_text("print('ok')\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
  - stop embedding raw source context for `Secrets` findings in reports
  - render masked secret values instead
  - preserve source context for non-secret findings

## Tests
  - `pytest test/test_cli.py -k "generate_llm_report or llm_report_code_block"`
  - `pytest test/test_cli.py`
