### PR TITLE
fix(login): avoid printing saved api token

### DIFF
--- a/skylos/cloud/login.py
+++ b/skylos/cloud/login.py
@@ -320,6 +320,11 @@ def get_current_connection(base_url=None):
 
 
 def _print_connected_result(result, console=None):
+    mcp_hint = (
+        "Token saved locally. For MCP/AI agents, set SKYLOS_API_KEY "
+        "through your private secret manager."
+    )
+
     if console:
         console.print("\n[good]Connected to Skylos Cloud![/good]")
         console.print(f"  Project:      {result.project_name}")
@@ -329,9 +334,7 @@ def _print_connected_result(result, console=None):
             console.print(f"  Project root: {result.repo_subpath}")
         console.print("\n  Scans will auto-upload on every run.")
         console.print("  Use [bold]--no-upload[/bold] to skip.")
-        console.print(
-            f"\n  [dim]For MCP/AI agents: export SKYLOS_API_KEY={result.token}[/dim]"
-        )
+        console.print(f"\n  [dim]{mcp_hint}[/dim]")
     else:
         print("\nConnected to Skylos Cloud!")
         print(f"  Project:      {result.project_name}")
@@ -341,7 +344,7 @@ def _print_connected_result(result, console=None):
             print(f"  Project root: {result.repo_subpath}")
         print("\n  Scans will auto-upload on every run.")
         print("  Use --no-upload to skip.")
-        print(f"\n  For MCP/AI agents: export SKYLOS_API_KEY={result.token}")
+        print(f"\n  {mcp_hint}")
 
 
 def run_login(console=None, base_url=None):

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -137,3 +137,47 @@ def test_run_login_existing_cancel_keeps_current(monkeypatch):
     assert result is existing
     manual.assert_not_called()
     save.assert_not_called()
+
+
+def test_print_connected_result_plain_output_omits_raw_token(capsys):
+    raw_token = "skylos_sensitive_login_token_1234567890"
+    result = loginmod.LoginResult(
+        token=raw_token,
+        project_id="proj_123",
+        project_name="Project",
+        org_name="Org",
+        plan="pro",
+    )
+
+    loginmod._print_connected_result(result)
+
+    output = capsys.readouterr().out
+    assert raw_token not in output
+    assert "export SKYLOS_API_KEY=" not in output
+    assert "Token saved locally" in output
+
+
+def test_print_connected_result_console_output_omits_raw_token():
+    raw_token = "skylos_sensitive_login_token_1234567890"
+    result = loginmod.LoginResult(
+        token=raw_token,
+        project_id="proj_123",
+        project_name="Project",
+        org_name="Org",
+        plan="pro",
+    )
+
+    class CaptureConsole:
+        def __init__(self):
+            self.messages = []
+
+        def print(self, message="", *args, **kwargs):
+            self.messages.append(str(message))
+
+    console = CaptureConsole()
+    loginmod._print_connected_result(result, console=console)
+
+    output = "\n".join(console.messages)
+    assert raw_token not in output
+    assert "export SKYLOS_API_KEY=" not in output
+    assert "Token saved locally" in output


### PR DESCRIPTION
## Summary
  - stop printing the raw Skylos API token after successful login
  - replace the `SKYLOS_API_KEY=...` export hint with a safe local-token/secret-manager hint

  ## Tests
  - `pytest test/test_login.py`