### PR TITLE
fix(analyzer): escape dynamic reference patterns

### DIFF
--- a/skylos/analysis/implicit_refs.py
+++ b/skylos/analysis/implicit_refs.py
@@ -3,6 +3,11 @@ import json
 from pathlib import Path
 
 
+def _compile_pattern_ref(pattern):
+    escaped = re.escape(pattern).replace(r"\*", ".*")
+    return re.compile(f"^{escaped}$")
+
+
 class ImplicitRefTracker:
     def __init__(self):
         self.known_refs = set()
@@ -27,7 +32,7 @@ class ImplicitRefTracker:
 
     def add_pattern_ref(self, pattern, confidence, source_module=None):
         self.pattern_refs.append((pattern, confidence))
-        regex = re.compile("^" + pattern.replace("*", ".*") + "$")
+        regex = _compile_pattern_ref(pattern)
         self._compiled_patterns.append((regex, confidence, pattern, source_module))
 
     def should_mark_as_used(self, definition):

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1335,6 +1335,24 @@ class TestClass:
             finally:
                 Path(f.name).unlink()
 
+    def test_proc_file_keeps_findings_when_dynamic_fstring_pattern_has_regex_chars(
+        self, tmp_path
+    ):
+        file_path = tmp_path / "dynamic_pattern.py"
+        file_path.write_text(
+            'def hidden(name, obj):\n'
+            '    eval("1+1")\n'
+            '    return getattr(obj, f"bad({name}", None)\n',
+            encoding="utf-8",
+        )
+
+        out = proc_file(str(file_path), "dynamic_pattern")
+        danger_findings = out[7]
+        pattern_tracker = out[9]
+
+        assert "SKY-D201" in {f.get("rule_id") for f in danger_findings}
+        assert pattern_tracker is not None
+
     def test_proc_file_with_tuple_args(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write("def test(): pass")

--- a/test/test_implicit_refs.py
+++ b/test/test_implicit_refs.py
@@ -91,6 +91,19 @@ class TestImplicitRefTracker:
 
         assert found is False
 
+    def test_pattern_metacharacters_are_literal_except_wildcard(self):
+        tracker = ImplicitRefTracker()
+        tracker.add_pattern_ref("bad(*", 70)
+
+        found, confidence, reason = tracker.should_mark_as_used(
+            MockDefinition("bad(handler")
+        )
+
+        assert found is True
+        assert confidence == 70
+        assert "bad(*" in reason
+        assert tracker.should_mark_as_used(MockDefinition("badxhandler"))[0] is False
+
     def test_multiple_patterns_first_wins(self):
         tracker = ImplicitRefTracker()
         tracker.add_pattern_ref("handle_*", 70)


### PR DESCRIPTION
## Summary
  - escape source-derived dynamic reference patterns before compiling regexes
  - preserve Skylos `*` wildcard matching behavior

## Why
  F-string dynamic dispatch patterns came from scanned source code and were compiled as raw
  regexes.

## Tests
  - `pytest test/test_implicit_refs.py test/test_dynamic_patterns.py`
