### PR TITLE
fix(secrets): scope hash suppression to candidates

### DIFF
--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -106,15 +106,18 @@ SAFE_TEST_HINTS = {
 
 _IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-KNOWN_HASH_RE = re.compile(
+KNOWN_HASH_VALUE_RE = re.compile(
     r"(?i)"
-    r"(?:sha(?:1|224|256|384|512)[-:])"  # sha256-..., sha512:...
-    r"|(?:\b[0-9a-f]{40}\b)"  # git SHA-1 (exactly 40 hex)
-    r"|(?:\b[0-9a-f]{64}\b)"  # SHA-256 hex digest (exactly 64 hex)
-    r"|(?:\"integrity\"\s*:)"  # npm integrity field
-    r"|(?:\"hash\"\s*:\s*\")"  # generic hash field in JSON
-    r"|(?:\"checksum\"\s*:)"  # checksum field
-    r"|(?:\"resolved\"\s*:\s*\"https?://)"  # npm resolved URL
+    r"(?:sha(?:1|224|256|384|512)[-:].+)"
+    r"|(?:[0-9a-f]{40})"
+    r"|(?:[0-9a-f]{64})"
+)
+KNOWN_HASH_FIELD_PREFIX_RE = re.compile(
+    r"""(?ix)
+    (?:^|[\s,{])
+    ['"]?(?:integrity|hash|checksum|resolved)['"]?
+    \s*[:=]\s*['"]?$
+"""
 )
 
 IGNORE_DIRECTIVE = "skylos: ignore[SKY-S101]"
@@ -179,14 +182,30 @@ def _has_bare_token_charset_mix(s):
 def _find_generic_value(line_content):
     keyed_match = GENERIC_KEYED_VALUE.search(line_content)
     if keyed_match:
-        return keyed_match.group("val"), False, keyed_match.start("val")
+        keyed_token = keyed_match.group("val")
+        keyed_start = keyed_match.start("val")
+        if not _is_known_hash_candidate(keyed_token, line_content, keyed_start):
+            return keyed_token, False, keyed_start
 
     for bare_match in BARE_GENERIC_VALUE.finditer(line_content):
         bare_token = bare_match.group("bare")
-        if _has_bare_token_charset_mix(bare_token):
-            return bare_token, True, bare_match.start("bare")
+        bare_start = bare_match.start("bare")
+        if not _has_bare_token_charset_mix(bare_token):
+            continue
+        if _is_known_hash_candidate(bare_token, line_content, bare_start):
+            continue
+        return bare_token, True, bare_start
 
     return None
+
+
+def _is_known_hash_candidate(token: str, line_content: str, start: int) -> bool:
+    clean_token = token.strip()
+    if KNOWN_HASH_VALUE_RE.fullmatch(clean_token):
+        return True
+
+    prefix = line_content[:start]
+    return bool(KNOWN_HASH_FIELD_PREFIX_RE.search(prefix))
 
 
 def _docstring_lines(tree):
@@ -362,7 +381,7 @@ def scan_ctx(
 
         in_tests = bool(IS_TEST_PATH.search(rel_path.replace("\\", "/")))
 
-        if in_tests or KNOWN_HASH_RE.search(line_content):
+        if in_tests:
             generic_value = None
         else:
             generic_value = _find_generic_value(line_content)

--- a/test/test_secrets.py
+++ b/test/test_secrets.py
@@ -238,6 +238,31 @@ def test_known_hashes_not_flagged_as_generic(line):
     assert generic == []
 
 
+def test_hash_marker_does_not_suppress_generic_secret_on_same_line():
+    token = "aB3dE5fG7hI9jK2lM4nO6pQ8rS0-tU1vW2xY3zZ"
+    src = f'api_key = "{token}"  # sha256-deadbeef\n'
+    ctx = _ctx_from_source(src)
+
+    generic = [f for f in scan_ctx(ctx) if f["provider"] == "generic"]
+
+    assert len(generic) == 1
+    assert generic[0]["preview"] == "aB3d…Y3zZ"
+
+
+def test_json_hash_field_does_not_suppress_later_generic_secret():
+    token = "aB3dE5fG7hI9jK2lM4nO6pQ8rS0-tU1vW2xY3zZ"
+    src = (
+        '{"hash": "sha256-deadbeef", '
+        f'"api_key": "{token}"}}\n'
+    )
+    ctx = _ctx_from_source(src, rel="config.json")
+
+    generic = [f for f in scan_ctx(ctx) if f["provider"] == "generic"]
+
+    assert len(generic) == 1
+    assert generic[0]["preview"] == "aB3d…Y3zZ"
+
+
 def test_real_secret_on_hash_line_still_caught_by_provider():
     src = '"integrity": "ghp_1234567890abcdef1234567890abcdef1234"\n'
     ctx = _ctx_from_source(src, rel="config.json")


### PR DESCRIPTION
## Summary
  - stop suppressing generic secret detection for an entire line when a hash marker is present
  - skip only generic candidates that are themselves hash/checksum-like values or scoped to hash fields

## Tests
  - `pytest test/test_secrets.py test/test_secrets_nonpy.py test/test_s102.py`