### PR TITLE
ci: check rules docs parity

### DIFF
--- a/.github/workflows/rules-docs-parity.yml
+++ b/.github/workflows/rules-docs-parity.yml
@@ -1,0 +1,44 @@
+name: Rules docs parity
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - ".github/workflows/rules-docs-parity.yml"
+      - "scripts/check_rule_docs_parity.py"
+      - "skylos/rules/catalog.py"
+  pull_request:
+    paths:
+      - ".github/workflows/rules-docs-parity.yml"
+      - "scripts/check_rule_docs_parity.py"
+      - "skylos/rules/catalog.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rules-docs-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Skylos
+        uses: actions/checkout@v4
+        with:
+          path: skylos
+          persist-credentials: false
+
+      - name: Checkout Skylos docs
+        uses: actions/checkout@v4
+        with:
+          repository: duriantaco/skylos-docs
+          path: skylos-docs
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check rules docs parity
+        run: |
+          python skylos/scripts/check_rule_docs_parity.py \
+            --rules-reference skylos-docs/docs/rules-reference.mdx

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Create a starter local rule pack:
 ```bash
 skylos rules init
 skylos rules validate .skylos/rules/local.yml
+skylos rules list --json
+skylos rules list cross --json
+skylos rules list --packs --json
+skylos cache stats
 ```
 
 Generate a GitHub Actions PR gate:

--- a/scripts/check_rule_docs_parity.py
+++ b/scripts/check_rule_docs_parity.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+RULE_ID_RE = re.compile(r"SKY-CIRC|SKY-[A-Z]+[0-9]{3}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check Skylos rule catalog IDs against docs/rules-reference.mdx."
+    )
+    parser.add_argument(
+        "--rules-reference",
+        type=Path,
+        default=_default_rules_reference_path(),
+        help="Path to skylos-docs/docs/rules-reference.mdx.",
+    )
+    parser.add_argument(
+        "--allow-catalog-extra",
+        action="store_true",
+        help="Allow catalog IDs that are not yet documented.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+    from skylos.rules.catalog import get_rule_catalog
+
+    rules_reference = args.rules_reference.expanduser()
+    if not rules_reference.is_file():
+        print(f"Rules reference not found: {rules_reference}", file=sys.stderr)
+        return 2
+
+    docs_text = rules_reference.read_text(encoding="utf-8")
+    docs_ids = set(RULE_ID_RE.findall(docs_text))
+    catalog_ids = set()
+
+    for item in get_rule_catalog():
+        rule_id = str(item.get("id", ""))
+        if rule_id:
+            catalog_ids.add(rule_id)
+
+    missing_from_catalog = sorted(docs_ids - catalog_ids)
+    missing_from_docs = sorted(catalog_ids - docs_ids)
+
+    print(f"Docs rule IDs: {len(docs_ids)}")
+    print(f"Catalog rule IDs: {len(catalog_ids)}")
+
+    failed = False
+
+    if missing_from_catalog:
+        failed = True
+        print("Docs IDs missing from catalog:")
+        for rule_id in missing_from_catalog:
+            print(f"  {rule_id}")
+
+    if missing_from_docs:
+        if args.allow_catalog_extra:
+            print("Catalog IDs not yet documented:")
+        else:
+            failed = True
+            print("Catalog IDs missing from docs:")
+
+        for rule_id in missing_from_docs:
+            print(f"  {rule_id}")
+
+    if failed:
+        return 1
+
+    print("Rule catalog and docs are in parity.")
+    return 0
+
+
+def _default_rules_reference_path() -> Path:
+    configured = os.environ.get("SKYLOS_RULES_REFERENCE")
+    if configured:
+        return Path(configured)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    return repo_root.parent / "skylos-docs" / "docs" / "rules-reference.mdx"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2027,57 +2027,9 @@ def _render_result_tree(console: Console, result, root_path=None):
 
 
 def _display_rule_name(rule_id):
-    RULE_TITLES = {
-        "SKY-D201": "Dynamic code execution (eval)",
-        "SKY-D202": "Dynamic code execution (exec)",
-        "SKY-D203": "OS command execution (os.system)",
-        "SKY-D204": "Unsafe deserialization (pickle.load)",
-        "SKY-D205": "Unsafe deserialization (pickle.loads)",
-        "SKY-D206": "Unsafe YAML load (no SafeLoader)",
-        "SKY-D207": "Weak hash (MD5)",
-        "SKY-D208": "Weak hash (SHA1)",
-        "SKY-D209": "Shell execution (subprocess shell=True)",
-        "SKY-D210": "TLS verification disabled (requests verify=False)",
-        "SKY-D211": "SQL injection (cursor)",
-        "SKY-D212": "Possible command injection (os.system): tainted input",
-        "SKY-D222": "Dependency hallucination",
-        "SKY-D223": "Undeclared third-party dependency",
-        "SKY-D290": "GitHub Actions dangerous trigger",
-        "SKY-D291": "GitHub Actions excessive permissions",
-        "SKY-D292": "GitHub Actions unpinned action",
-        "SKY-D293": "GitHub Actions persisted checkout credentials",
-        "SKY-D294": "GitHub Actions template injection",
-        "SKY-D295": "GitHub Actions self-hosted runner",
-        "SKY-D296": "GitHub Actions unpinned container image",
-        "SKY-D297": "GitHub Actions secrets inheritance",
-        "SKY-D298": "GitHub Actions overprovisioned secrets",
-        "SKY-D299": "GitHub Actions secret outside environment",
-        "SKY-D300": "GitHub Actions unsafe environment file write",
-        "SKY-D301": "GitHub Actions hardcoded container credential",
-        "SKY-D302": "GitHub Actions broad GitHub App token",
-        "SKY-D303": "GitHub Actions unsound contains condition",
-        "SKY-D304": "GitHub Actions spoofable bot condition",
-        "SKY-D305": "GitHub Actions unsound multiline condition",
-        "SKY-D306": "GitHub Actions insecure commands enabled",
-        "SKY-D307": "GitHub Actions anonymous definition",
-        "SKY-D308": "GitHub Actions cache poisoning risk",
-        "SKY-D309": "GitHub Actions broad secret environment",
-        "SKY-D310": "GitHub Actions OIDC build-script exposure",
-        "SKY-D311": "GitHub Actions lax artifact upload",
-        "SKY-D312": "GitHub Actions JavaScript install scripts",
-        "SKY-D313": "GitHub Actions privileged job missing timeout",
-        "SKY-D314": "GitLab CI mutable container image",
-        "SKY-D315": "GitLab CI unpinned external include",
-        "SKY-D316": "GitLab CI literal secret variable",
-        "SKY-D317": "GitLab CI untrusted eval",
-        "SKY-D318": "GitLab CI Docker-in-Docker TLS disabled",
-        "SKY-D319": "GitLab CI OIDC local-script exposure",
-        "SKY-D320": "GitLab CI release cache poisoning risk",
-        "SKY-D321": "GitLab CI privileged job missing timeout",
-        "SKY-D322": "GitLab CI dynamic runner tag",
-        "SKY-D323": "GitLab CI ambiguous secret token",
-    }
-    return RULE_TITLES.get(rule_id, "Security issue")
+    from skylos.rules.catalog import get_rule_name
+
+    return get_rule_name(rule_id)
 
 
 def _verification_proof(danger_finding):

--- a/skylos/commands/cache_cmd.py
+++ b/skylos/commands/cache_cmd.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 from rich.console import Console
+from rich.text import Text
 
-from skylos.core.result_cache import RUN_CACHE_DIR, clear_run_cache
+from skylos.core.result_cache import RUN_CACHE_DIR, clear_run_cache, run_cache_stats
 
 
 def run_cache_command(argv: list[str], *, console_factory=Console) -> int:
@@ -23,20 +25,103 @@ def run_cache_command(argv: list[str], *, console_factory=Console) -> int:
         help="Project path whose .skylos/cache/runs directory should be removed.",
     )
 
+    stats_parser = subparsers.add_parser("stats", help="Show cached run data size.")
+    stats_parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Project path whose .skylos/cache/runs directory should be inspected.",
+    )
+    stats_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print cache stats as JSON.",
+    )
+
     args = parser.parse_args(argv)
     console = console_factory()
 
-    if args.cache_command != "clear":
+    if args.cache_command is None:
         parser.print_help()
         return 0
 
     root = Path(args.path).resolve()
     if root.is_file():
         root = root.parent
+
+    if args.cache_command == "stats":
+        stats = run_cache_stats(root)
+        if args.json:
+            _write_json(console, stats)
+        else:
+            _print_cache_stats(console, stats)
+        return 0
+
+    if args.cache_command != "clear":
+        parser.print_help()
+        return 0
+
     removed = clear_run_cache(root)
     cache_path = root / RUN_CACHE_DIR
     if removed:
-        console.print(f"[green]Cleared run cache:[/green] {cache_path}")
+        console.print(
+            Text.assemble(("Cleared run cache: ", "green"), _safe_terminal_text(cache_path))
+        )
     else:
-        console.print(f"[dim]No run cache found:[/dim] {cache_path}")
+        console.print(
+            Text.assemble(("No run cache found: ", "dim"), _safe_terminal_text(cache_path))
+        )
     return 0
+
+
+def _print_cache_stats(console, stats: dict) -> None:
+    path = _safe_terminal_text(stats.get("path", ""))
+    if not stats.get("exists"):
+        console.print(Text.assemble(("No run cache found: ", "dim"), path))
+        return
+
+    console.print(Text.assemble(("Run cache: ", "bold"), path))
+    console.print(f"  Files:       {int(stats.get('files', 0))}")
+    console.print(f"  Directories: {int(stats.get('directories', 0))}")
+    console.print(f"  Size:        {_format_bytes(int(stats.get('bytes', 0)))}")
+    if stats.get("symlinks") or stats.get("other_entries") or stats.get("skipped"):
+        console.print(f"  Symlinks:    {int(stats.get('symlinks', 0))}")
+        console.print(f"  Skipped:     {int(stats.get('skipped', 0))}")
+    if stats.get("errors"):
+        console.print(f"  Errors:      {int(stats.get('errors', 0))}")
+    if stats.get("truncated"):
+        console.print(
+            f"  [yellow]Truncated after {int(stats.get('max_entries', 0))} entries[/yellow]"
+        )
+    if stats.get("error"):
+        console.print(
+            Text.assemble(("  Error:       ", "red"), _safe_terminal_text(stats["error"]))
+        )
+
+
+def _write_json(console, payload: dict) -> None:
+    output = json.dumps(payload, sort_keys=True) + "\n"
+    stream = getattr(console, "file", None)
+    if stream is not None and hasattr(stream, "write"):
+        stream.write(output)
+        stream.flush()
+    else:
+        console.print(output, markup=False, end="")
+
+
+def _safe_terminal_text(value) -> str:
+    text = str(value)
+    return "".join(
+        ch if (ch >= " " and ch != "\x7f") else f"\\x{ord(ch):02x}" for ch in text
+    )
+
+
+def _format_bytes(size: int) -> str:
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    value = float(max(size, 0))
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024

--- a/skylos/commands/rules_cmd.py
+++ b/skylos/commands/rules_cmd.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import argparse
+import json
+import stat
 from pathlib import Path
 
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
+
+from skylos.rules.catalog import get_rule_catalog
+
+MAX_RULE_PACK_BYTES = 1_000_000
 
 
 def run_rules_command(argv, *, console_factory=Console) -> int:
@@ -19,7 +26,18 @@ def run_rules_command(argv, *, console_factory=Console) -> int:
     p_install = rules_sub.add_parser("install", help="Install a rule pack or YAML URL")
     p_install.add_argument("pack_or_url", help="Pack name or URL to a .yml/.yaml file")
 
-    rules_sub.add_parser("list", help="List installed community rules")
+    p_list = rules_sub.add_parser("list", help="List built-in rules")
+    p_list.add_argument(
+        "terms",
+        nargs="*",
+        help="Optional rule search text, or 'json' for JSON output.",
+    )
+    p_list.add_argument("--json", action="store_true", help="Print rules as JSON")
+    p_list.add_argument(
+        "--packs",
+        action="store_true",
+        help="List installed community rule packs instead of built-in rules.",
+    )
 
     p_remove = rules_sub.add_parser("remove", help="Remove an installed rule pack")
     p_remove.add_argument("name", help="Name of the rule pack to remove")
@@ -48,7 +66,20 @@ def run_rules_command(argv, *, console_factory=Console) -> int:
     if rules_args.rules_cmd == "install":
         return install_rules(console, rules_dir, rules_args.pack_or_url)
     if rules_args.rules_cmd == "list":
-        return list_rules(console, rules_dir)
+        list_terms = list(rules_args.terms or [])
+        json_alias = False
+        if not rules_args.json and list_terms and list_terms[-1].casefold() == "json":
+            json_alias = True
+            list_terms = list_terms[:-1]
+        json_output = bool(rules_args.json or json_alias)
+        query_terms = list_terms
+        return list_rules(
+            console,
+            rules_dir,
+            json_output=json_output,
+            query=" ".join(query_terms),
+            packs=bool(rules_args.packs),
+        )
     if rules_args.rules_cmd == "remove":
         return remove_rules(console, rules_dir, rules_args.name)
     if rules_args.rules_cmd == "validate":
@@ -186,20 +217,56 @@ def install_rules(console, rules_dir, pack_or_url):
     return 0
 
 
-def list_rules(console, rules_dir):
+def list_rules(console, rules_dir, *, json_output=False, query="", packs=False):
+    if packs:
+        return list_rule_packs(console, rules_dir, json_output=json_output)
+
+    payload = _collect_builtin_rule_metadata(query)
+    if json_output:
+        _write_json(console, payload)
+        return 0
+
+    rules = payload["rules"]
+    if not rules:
+        console.print("[dim]No built-in rules matched.[/dim]")
+        return 0
+
+    table = Table(title="Built-in Rules")
+    table.add_column("Rule", style="bold")
+    table.add_column("Name")
+    table.add_column("Category")
+    table.add_column("Severity")
+
+    for rule in rules:
+        table.add_row(
+            Text(_safe_terminal_text(rule.get("id", ""))),
+            Text(_safe_terminal_text(rule.get("name", ""))),
+            Text(_safe_terminal_text(rule.get("category", ""))),
+            Text(_safe_terminal_text(rule.get("severity") or "-")),
+        )
+
+    console.print(table)
+    return 0
+
+
+def list_rule_packs(console, rules_dir, *, json_output=False):
     try:
         import yaml
     except ImportError:
         console.print("[red]PyYAML is required. Install with: pip install pyyaml[/red]")
         return 1
 
+    payload = _collect_rule_pack_metadata(rules_dir, yaml)
+    if json_output:
+        _write_json(console, payload)
+        return 0
+
     if not rules_dir.exists():
         console.print("[dim]No community rules installed.[/dim]")
         console.print("Run [bold]skylos rules install <pack>[/bold] to get started.")
         return 0
 
-    yml_files = sorted(rules_dir.glob("*.yml"))
-    if not yml_files:
+    if not payload["packs"]:
         console.print("[dim]No community rules installed.[/dim]")
         console.print("Run [bold]skylos rules install <pack>[/bold] to get started.")
         return 0
@@ -207,18 +274,141 @@ def list_rules(console, rules_dir):
     table = Table(title="Installed Community Rules")
     table.add_column("Pack", style="bold")
     table.add_column("Rules", justify="right")
+    table.add_column("Status")
     table.add_column("Source")
 
-    for f in yml_files:
-        try:
-            data = yaml.safe_load(f.read_text())
-            rule_count = len(data.get("rules", [])) if data else 0
-            table.add_row(f.stem, str(rule_count), str(f))
-        except Exception:
-            table.add_row(f.stem, "?", str(f))
+    for pack in payload["packs"]:
+        rule_count = pack.get("rules")
+        table.add_row(
+            Text(_safe_terminal_text(pack.get("name", ""))),
+            Text("?" if rule_count is None else str(rule_count)),
+            Text(_safe_terminal_text(pack.get("status", ""))),
+            Text(_safe_terminal_text(pack.get("path", ""))),
+        )
 
     console.print(table)
     return 0
+
+
+def _collect_builtin_rule_metadata(query=""):
+    safe_query = _safe_query(query)
+    rules = get_rule_catalog(safe_query)
+    return {
+        "query": safe_query,
+        "rules": rules,
+        "source": "builtin",
+        "total_rules": len(rules),
+    }
+
+
+def _safe_query(query) -> str:
+    text = " ".join(str(query or "").split())
+    return text[:200]
+
+
+def _collect_rule_pack_metadata(rules_dir, yaml_module):
+    payload = {
+        "rules_dir": str(rules_dir),
+        "packs": [],
+        "total_packs": 0,
+        "total_rules": 0,
+    }
+    try:
+        root = Path(rules_dir).resolve(strict=True)
+    except FileNotFoundError:
+        return payload
+    except OSError as exc:
+        payload["error"] = str(exc)
+        return payload
+
+    try:
+        entries = sorted(root.iterdir(), key=lambda path: path.name)
+    except OSError as exc:
+        payload["error"] = str(exc)
+        return payload
+
+    for path in entries:
+        if path.suffix.lower() not in {".yml", ".yaml"}:
+            continue
+        pack = _inspect_rule_pack(path, root, yaml_module)
+        payload["packs"].append(pack)
+        if pack["status"] == "ok":
+            payload["total_packs"] += 1
+            payload["total_rules"] += int(pack.get("rules") or 0)
+
+    return payload
+
+
+def _inspect_rule_pack(path, rules_root, yaml_module):
+    pack = {
+        "name": path.stem,
+        "path": str(path),
+        "rules": None,
+        "status": "ok",
+    }
+
+    try:
+        file_stat = path.lstat()
+    except OSError as exc:
+        pack["status"] = "read_error"
+        pack["error"] = str(exc)
+        return pack
+
+    if path.is_symlink():
+        pack["status"] = "skipped_symlink"
+        return pack
+
+    try:
+        path.resolve(strict=True).relative_to(rules_root)
+    except (OSError, ValueError):
+        pack["status"] = "skipped_unsafe_path"
+        return pack
+
+    if not stat.S_ISREG(file_stat.st_mode):
+        pack["status"] = "skipped_non_file"
+        return pack
+
+    if file_stat.st_size > MAX_RULE_PACK_BYTES:
+        pack["status"] = "skipped_too_large"
+        pack["bytes"] = file_stat.st_size
+        return pack
+
+    try:
+        data = yaml_module.safe_load(path.read_text(encoding="utf-8"))
+    except yaml_module.YAMLError as exc:
+        pack["status"] = "invalid_yaml"
+        pack["error"] = str(exc)
+        return pack
+    except (OSError, UnicodeDecodeError) as exc:
+        pack["status"] = "read_error"
+        pack["error"] = str(exc)
+        return pack
+
+    rules = data.get("rules", []) if isinstance(data, dict) else []
+    if not isinstance(rules, list):
+        pack["status"] = "invalid_rules"
+        pack["error"] = "rules must be a list"
+        return pack
+
+    pack["rules"] = sum(1 for rule in rules if isinstance(rule, dict))
+    return pack
+
+
+def _write_json(console, payload):
+    output = json.dumps(payload, sort_keys=True) + "\n"
+    stream = getattr(console, "file", None)
+    if stream is not None and hasattr(stream, "write"):
+        stream.write(output)
+        stream.flush()
+    else:
+        console.print(output, markup=False, end="")
+
+
+def _safe_terminal_text(value) -> str:
+    text = str(value)
+    return "".join(
+        ch if (ch >= " " and ch != "\x7f") else f"\\x{ord(ch):02x}" for ch in text
+    )
 
 
 def remove_rules(console, rules_dir, name):

--- a/skylos/core/result_cache.py
+++ b/skylos/core/result_cache.py
@@ -5,6 +5,7 @@ import json
 import os
 import platform
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -19,6 +20,7 @@ SCHEMA_VERSION = 1
 CACHE_KIND_TRACE = "trace"
 RUN_CACHE_DIR = Path(".skylos") / "cache" / "runs"
 TRACE_CACHE_DIR = RUN_CACHE_DIR / "v1" / "trace"
+MAX_CACHE_STAT_ENTRIES = 100_000
 
 TRACE_ENV_VARS = (
     "PYTHONPATH",
@@ -219,6 +221,100 @@ def clear_run_cache(project_root: str | Path) -> bool:
         path
     )  # skylos: ignore[SKY-D215] guarded project-local cache directory
     return True
+
+
+def run_cache_stats(project_root: str | Path) -> dict[str, Any]:
+    root = _normalize_root(project_root)
+    path = root / RUN_CACHE_DIR
+    stats = {
+        "path": str(path),
+        "exists": False,
+        "files": 0,
+        "directories": 0,
+        "symlinks": 0,
+        "other_entries": 0,
+        "bytes": 0,
+        "errors": 0,
+        "skipped": 0,
+        "truncated": False,
+        "max_entries": MAX_CACHE_STAT_ENTRIES,
+    }
+
+    try:
+        root_resolved = root.resolve(strict=True)
+        path.resolve(strict=False).relative_to(root_resolved)
+    except (OSError, ValueError):
+        stats["error"] = "cache path is outside the project root"
+        return stats
+
+    try:
+        root_stat = path.lstat()
+    except FileNotFoundError:
+        return stats
+    except OSError as exc:
+        stats["errors"] += 1
+        stats["error"] = str(exc)
+        return stats
+
+    stats["exists"] = True
+    if stat.S_ISLNK(root_stat.st_mode):
+        stats["symlinks"] += 1
+        stats["skipped"] += 1
+        stats["error"] = "cache path is a symlink"
+        return stats
+    if not stat.S_ISDIR(root_stat.st_mode):
+        if stat.S_ISREG(root_stat.st_mode):
+            stats["files"] += 1
+            stats["bytes"] += root_stat.st_size
+        else:
+            stats["other_entries"] += 1
+            stats["skipped"] += 1
+        return stats
+
+    seen_entries = 0
+
+    def visit(directory: Path) -> None:
+        nonlocal seen_entries
+        if stats["truncated"]:
+            return
+
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    if seen_entries >= MAX_CACHE_STAT_ENTRIES:
+                        stats["truncated"] = True
+                        return
+                    seen_entries += 1
+
+                    try:
+                        entry_stat = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        stats["errors"] += 1
+                        stats["skipped"] += 1
+                        continue
+
+                    mode = entry_stat.st_mode
+                    if stat.S_ISLNK(mode):
+                        stats["symlinks"] += 1
+                        stats["skipped"] += 1
+                        continue
+                    if stat.S_ISDIR(mode):
+                        stats["directories"] += 1
+                        visit(Path(entry.path))
+                        continue
+                    if stat.S_ISREG(mode):
+                        stats["files"] += 1
+                        stats["bytes"] += entry_stat.st_size
+                        continue
+
+                    stats["other_entries"] += 1
+                    stats["skipped"] += 1
+        except OSError:
+            stats["errors"] += 1
+            stats["skipped"] += 1
+
+    visit(path)
+    return stats
 
 
 def read_trace_payload(trace_file: str | Path) -> dict[str, Any] | None:

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass(frozen=True)
+class RuleCatalogEntry:
+    id: str
+    name: str
+    category: str
+    severity: str | None = None
+    source: str = "builtin"
+    aliases: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["aliases"] = list(self.aliases)
+        return data
+
+# Keep this catalog aligned with skylos-docs/docs/rules-reference.mdx.
+_RULES = (
+    RuleCatalogEntry("SKY-U001", "Unused function", "dead_code"),
+    RuleCatalogEntry("SKY-U002", "Unused import", "dead_code"),
+    RuleCatalogEntry("SKY-U003", "Unused variable", "dead_code"),
+    RuleCatalogEntry("SKY-U004", "Unused class", "dead_code"),
+    RuleCatalogEntry("SKY-U005", "Unused dependency", "dead_code"),
+    RuleCatalogEntry("SKY-U006", "Unused parameter", "dead_code"),
+    RuleCatalogEntry("SKY-UC001", "Unreachable Python code", "dead_code"),
+    RuleCatalogEntry("SKY-UC002", "Unreachable statement", "dead_code"),
+    RuleCatalogEntry("SKY-C401", "Duplicated code clone", "quality"),
+    RuleCatalogEntry("SKY-CIRC", "Circular dependency", "quality"),
+    RuleCatalogEntry("SKY-Q301", "Cyclomatic complexity", "quality"),
+    RuleCatalogEntry("SKY-Q302", "Deep nesting", "quality"),
+    RuleCatalogEntry("SKY-C303", "Too many function arguments", "quality"),
+    RuleCatalogEntry("SKY-C304", "Function too long", "quality"),
+    RuleCatalogEntry("SKY-Q305", "Duplicate branch logic", "quality"),
+    RuleCatalogEntry("SKY-Q306", "Cognitive complexity", "quality"),
+    RuleCatalogEntry("SKY-Q401", "Async blocking call", "quality"),
+    RuleCatalogEntry("SKY-Q402", "Await in loop", "quality", "MEDIUM"),
+    RuleCatalogEntry("SKY-Q501", "God class", "quality"),
+    RuleCatalogEntry("SKY-Q502", "Class too large", "quality"),
+    RuleCatalogEntry("SKY-Q701", "High coupling", "quality"),
+    RuleCatalogEntry("SKY-Q702", "Low cohesion", "quality"),
+    RuleCatalogEntry("SKY-Q801", "High instability", "quality", "MEDIUM"),
+    RuleCatalogEntry("SKY-Q802", "High distance from main sequence", "quality"),
+    RuleCatalogEntry("SKY-Q803", "Architecture zone warning", "quality"),
+    RuleCatalogEntry("SKY-Q804", "Dependency inversion violation", "quality"),
+    RuleCatalogEntry("SKY-Q805", "Architecture layer policy violation", "quality"),
+    RuleCatalogEntry("SKY-L001", "Mutable default argument", "quality"),
+    RuleCatalogEntry("SKY-L002", "Bare except block", "quality"),
+    RuleCatalogEntry("SKY-L003", "Dangerous comparison", "quality"),
+    RuleCatalogEntry("SKY-L004", "Anti-pattern try block", "quality"),
+    RuleCatalogEntry("SKY-L005", "Unused exception variable", "quality"),
+    RuleCatalogEntry("SKY-L006", "Shadowed loop variable", "quality"),
+    RuleCatalogEntry("SKY-L007", "Confusing boolean expression", "quality"),
+    RuleCatalogEntry("SKY-L008", "Suspicious branch condition", "quality"),
+    RuleCatalogEntry("SKY-L009", "Debug leftover", "quality"),
+    RuleCatalogEntry("SKY-L010", "Security TODO marker", "quality"),
+    RuleCatalogEntry("SKY-L011", "Disabled security control", "quality"),
+    RuleCatalogEntry("SKY-L012", "Phantom function call", "quality"),
+    RuleCatalogEntry("SKY-L013", "Insecure randomness", "quality"),
+    RuleCatalogEntry("SKY-L014", "Hardcoded credential", "quality"),
+    RuleCatalogEntry("SKY-L016", "Undefined config", "quality"),
+    RuleCatalogEntry("SKY-L017", "Error information disclosure", "quality"),
+    RuleCatalogEntry("SKY-L020", "Overly broad file permissions", "quality"),
+    RuleCatalogEntry("SKY-L021", "Security regression", "quality"),
+    RuleCatalogEntry("SKY-L023", "Phantom decorator", "quality"),
+    RuleCatalogEntry("SKY-L024", "Stale mock", "quality"),
+    RuleCatalogEntry("SKY-L026", "Unfinished generated code", "quality"),
+    RuleCatalogEntry("SKY-L027", "Duplicate string literal", "quality"),
+    RuleCatalogEntry("SKY-L028", "Too many returns", "quality"),
+    RuleCatalogEntry("SKY-L029", "Boolean trap", "quality"),
+    RuleCatalogEntry("SKY-L030", "Broad exception with trivial handler", "quality"),
+    RuleCatalogEntry("SKY-L031", "Missing network timeout", "quality"),
+    RuleCatalogEntry("SKY-L032", "Mock or placeholder data", "quality"),
+    RuleCatalogEntry("SKY-L033", "No-effect statement", "quality"),
+    RuleCatalogEntry("SKY-P401", "Inefficient loop pattern", "quality"),
+    RuleCatalogEntry("SKY-P402", "Repeated expensive operation", "quality"),
+    RuleCatalogEntry("SKY-P403", "Suspicious performance pattern", "quality"),
+    RuleCatalogEntry("SKY-T101", "Missing type annotations", "quality"),
+    RuleCatalogEntry("SKY-T102", "Weak framework route typing", "quality"),
+    RuleCatalogEntry("SKY-F101", "Framework route missing auth", "quality"),
+    RuleCatalogEntry("SKY-F102", "Framework handler practice issue", "quality"),
+    RuleCatalogEntry("SKY-R101", "Python type-check policy", "quality", "MEDIUM"),
+    RuleCatalogEntry("SKY-R102", "Python lint policy", "quality", "LOW"),
+    RuleCatalogEntry("SKY-R103", "Skylos gate policy", "quality", "LOW"),
+    RuleCatalogEntry("SKY-R104", "Pre-commit policy", "quality", "LOW"),
+    RuleCatalogEntry("SKY-R105", "TypeScript type-check policy", "quality", "LOW"),
+    RuleCatalogEntry("SKY-E002", "Empty file", "quality", "LOW"),
+    RuleCatalogEntry("SKY-D200", "Dangerous call pattern", "security"),
+    RuleCatalogEntry("SKY-D201", "Dynamic code execution via eval", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D202", "Dynamic code execution via exec", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D203", "OS command execution", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D204", "Unsafe pickle deserialization", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D205", "Unsafe pickle.loads deserialization", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D206", "Unsafe YAML load", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D207", "Weak MD5 hash", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D208", "Weak SHA1 hash", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D209", "Subprocess shell execution", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D210", "TLS verification disabled", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D211", "SQL injection", "security", "CRITICAL", aliases=("sqli",)),
+    RuleCatalogEntry("SKY-D212", "Command injection", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D214", "Broken access control", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D215", "Path traversal", "security", "HIGH", aliases=("lfi", "file traversal")),
+    RuleCatalogEntry("SKY-D216", "Server-side request forgery", "security", "CRITICAL", aliases=("ssrf",),),
+    RuleCatalogEntry("SKY-D217", "Raw SQL execution", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D222", "Dependency hallucination", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D223", "Undeclared third-party dependency", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D226", "Cross-site scripting: untrusted content marked safe", "security", "CRITICAL",aliases=("xss", "cross site scripting", "cross-site scripting"),),
+    RuleCatalogEntry("SKY-D227", "Cross-site scripting: unsafe inline template", "security", "HIGH", aliases=("xss", "cross site scripting", "cross-site scripting"),),
+    RuleCatalogEntry("SKY-D228", "Cross-site scripting: HTML built from user input", "security", "HIGH", aliases=("xss", "cross site scripting", "cross-site scripting"),),
+    RuleCatalogEntry("SKY-D230", "Open redirect", "security", "HIGH", aliases=("redirect",)),
+    RuleCatalogEntry("SKY-D231", "Unsafe CORS configuration", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D232", "Unsafe JWT handling", "security", "CRITICAL", aliases=("jwt",)),
+    RuleCatalogEntry("SKY-D233", "Unsafe deserialization", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D234", "Mass assignment", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D235", "Remote command execution sink", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D240", "MCP tool description poisoning", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D241", "MCP unauthenticated network transport", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D242", "MCP overly permissive resource URI", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D243", "MCP network-exposed server without auth", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D244", "MCP hardcoded tool parameter secret", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D245", "Dynamic require", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D246", "JWT decode without verification", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D247", "CORS wildcard origin", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D248", "Hardcoded internal URL", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D250", "Weak random source", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D251", "Sensitive data in logs", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D252", "Insecure cookie", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D253", "Timing-unsafe comparison", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D260", "Prompt injection exposure", "security", "HIGH", aliases=("prompt injection", "hidden unicode"),),
+    RuleCatalogEntry("SKY-D270", "Sensitive data in storage", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D271", "Error information disclosure over HTTP", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D282", "Webhook signature verification issue", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D290", "GitHub Actions dangerous trigger", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D291", "GitHub Actions excessive permissions", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D292", "GitHub Actions unpinned action", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D293", "GitHub Actions persisted checkout credentials", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D294", "GitHub Actions template injection", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-D295", "GitHub Actions self-hosted runner", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D296", "GitHub Actions unpinned container image", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D297", "GitHub Actions secrets inheritance", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D298", "GitHub Actions overprovisioned secrets", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D299", "GitHub Actions secret outside environment", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D300", "GitHub Actions unsafe environment file write", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D301", "GitHub Actions hardcoded container credential", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D302", "GitHub Actions broad GitHub App token", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D303", "GitHub Actions unsound contains condition", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D304", "GitHub Actions spoofable bot condition", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D305", "GitHub Actions unsound multiline condition", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D306", "GitHub Actions insecure commands enabled", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D307", "GitHub Actions anonymous definition", "security", "LOW"),
+    RuleCatalogEntry("SKY-D308", "GitHub Actions cache poisoning risk", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D309", "GitHub Actions broad secret environment", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D310", "GitHub Actions OIDC build-script exposure", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D311", "GitHub Actions lax artifact upload", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D312", "GitHub Actions JavaScript install scripts", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D313", "GitHub Actions privileged job missing timeout", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D510", "Prototype pollution", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D314", "GitLab CI mutable container image", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D315", "GitLab CI unpinned external include", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D316", "GitLab CI literal secret variable", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D317", "GitLab CI untrusted eval", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D318", "GitLab CI Docker-in-Docker TLS disabled", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D319", "GitLab CI OIDC local-script exposure", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D320", "GitLab CI release cache poisoning risk", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D321", "GitLab CI privileged job missing timeout", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D322", "GitLab CI dynamic runner tag", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D323", "GitLab CI ambiguous secret token", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-G203", "Go defer in loop", "security", "HIGH"),
+    RuleCatalogEntry("SKY-G206", "Go unsafe package import", "security", "HIGH"),
+    RuleCatalogEntry("SKY-G207", "Go weak MD5 hash", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-G208", "Go weak SHA1 hash", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-G209", "Go weak RNG", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-G210", "Go TLS verification disabled", "security", "HIGH"),
+    RuleCatalogEntry("SKY-G211", "Go SQL injection", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-G212", "Go command injection", "security", "CRITICAL"),
+    RuleCatalogEntry("SKY-G215", "Go path traversal", "security", "HIGH"),
+    RuleCatalogEntry("SKY-G216", "Go SSRF", "security", "CRITICAL", aliases=("ssrf",)),
+    RuleCatalogEntry("SKY-G220", "Go open redirect", "security", "HIGH"),
+    RuleCatalogEntry("SKY-G221", "Go insecure cookie", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-G260", "Go unclosed resource", "security", "HIGH"),
+    RuleCatalogEntry("SKY-G280", "Go weak TLS version", "security", "HIGH"),
+    RuleCatalogEntry("SKY-S101", "Secret detected", "secrets", "CRITICAL"),
+    RuleCatalogEntry("SKY-S102", "High-entropy generic secret", "secrets", "HIGH"),
+    RuleCatalogEntry("SKY-SC001", "Smart contract security issue", "security", "HIGH"),
+)
+
+_BY_ID = {}
+for entry in _RULES:
+    if entry.id in _BY_ID:
+        raise ValueError(f"Duplicate rule ID: {entry.id}")
+    _BY_ID[entry.id] = entry
+
+
+def get_rule_catalog(query: str | None = None) -> list[dict]:
+    entries = sorted(_RULES, key=lambda entry: entry.id)
+    normalized_query = _normalize(query or "")
+
+    if normalized_query:
+        terms = normalized_query.split()
+        filtered_entries = []
+
+        for entry in entries:
+            search_text = _rule_search_text(entry)
+            matched = True
+
+            for term in terms:
+                if term not in search_text:
+                    matched = False
+                    break
+
+            if matched:
+                filtered_entries.append(entry)
+
+        entries = filtered_entries
+
+    result = []
+    for entry in entries:
+        result.append(entry.to_dict())
+    return result
+
+
+def get_rule_name(rule_id: str, default: str = "Security issue") -> str:
+    entry = _BY_ID.get(str(rule_id))
+    if entry:
+        return entry.name
+    else:
+        return default
+
+
+def _rule_search_text(entry: RuleCatalogEntry) -> str:
+    parts = [entry.id, entry.name, entry.category]
+
+    if entry.severity:
+        parts.append(entry.severity)
+
+    for alias in entry.aliases:
+        parts.append(alias)
+
+    return _normalize(" ".join(parts))
+
+
+def _normalize(value: str) -> str:
+    text = str(value)
+    text = text.casefold()
+    text = text.replace("-", " ")
+    text = text.replace("_", " ")
+    return text

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -130,6 +130,11 @@ COMMANDS = [
         "group": "Utility",
     },
     {
+        "name": "skylos cache stats [path]",
+        "desc": "Show cached run data size",
+        "group": "Utility",
+    },
+    {
         "name": "skylos sync",
         "desc": "Sync config with Skylos Cloud",
         "group": "Utility",

--- a/test/test_rules_cmd.py
+++ b/test/test_rules_cmd.py
@@ -1,7 +1,10 @@
+import io
+import json
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from rich.console import Console
 
 from skylos import cli
 from skylos.commands import rules_cmd
@@ -50,6 +53,124 @@ def test_rules_init_creates_valid_starter_pack(tmp_path, monkeypatch):
     assert written.exists()
     assert "CUSTOM-VIBE-001" in written.read_text(encoding="utf-8")
     assert rules_cmd.validate_rules(console, str(written)) == 0
+
+
+def test_rules_list_json_reports_installed_packs(tmp_path):
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "local.yml").write_text(
+        "rules:\n"
+        "  - id: LOCAL-001\n"
+        "    name: Local rule\n"
+        "    pattern:\n"
+        "      type: function\n",
+        encoding="utf-8",
+    )
+    buffer = io.StringIO()
+
+    exit_code = rules_cmd.list_rule_packs(
+        Console(file=buffer, force_terminal=False),
+        rules_dir,
+        json_output=True,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(buffer.getvalue())
+    assert payload["total_packs"] == 1
+    assert payload["total_rules"] == 1
+    assert payload["packs"][0]["name"] == "local"
+    assert payload["packs"][0]["status"] == "ok"
+
+
+def test_rules_list_json_skips_symlinked_rule_packs(tmp_path):
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    outside = tmp_path / "outside.yml"
+    outside.write_text("rules:\n  - id: OUTSIDE\n", encoding="utf-8")
+    try:
+        (rules_dir / "outside.yml").symlink_to(outside)
+    except OSError:
+        return
+    buffer = io.StringIO()
+
+    exit_code = rules_cmd.list_rule_packs(
+        Console(file=buffer, force_terminal=False),
+        rules_dir,
+        json_output=True,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(buffer.getvalue())
+    assert payload["total_packs"] == 0
+    assert payload["total_rules"] == 0
+    assert payload["packs"][0]["status"] == "skipped_symlink"
+
+
+def test_rules_list_human_escapes_terminal_control_chars(tmp_path):
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "evil\x1b[2J.yml").write_text("rules: []\n", encoding="utf-8")
+    buffer = io.StringIO()
+
+    exit_code = rules_cmd.list_rule_packs(
+        Console(file=buffer, force_terminal=False),
+        rules_dir,
+    )
+
+    assert exit_code == 0
+    output = buffer.getvalue()
+    assert "\x1b" not in output
+    assert "\\x1b" in output
+
+
+def test_rules_list_accepts_json_alias(tmp_path, monkeypatch):
+    rules_dir = tmp_path / ".skylos" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "local.yml").write_text("rules: []\n", encoding="utf-8")
+    buffer = io.StringIO()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    exit_code = rules_cmd.run_rules_command(
+        ["list", "json"],
+        console_factory=lambda: Console(file=buffer, force_terminal=False),
+    )
+
+    assert exit_code == 0
+    payload = json.loads(buffer.getvalue())
+    assert payload["source"] == "builtin"
+    assert any(rule["id"] == "SKY-D226" for rule in payload["rules"])
+
+
+def test_rules_list_filters_builtin_rules_by_rough_match():
+    buffer = io.StringIO()
+
+    exit_code = rules_cmd.run_rules_command(
+        ["list", "cross", "json"],
+        console_factory=lambda: Console(file=buffer, force_terminal=False),
+    )
+
+    assert exit_code == 0
+    payload = json.loads(buffer.getvalue())
+    rule_ids = {rule["id"] for rule in payload["rules"]}
+    assert {"SKY-D226", "SKY-D227", "SKY-D228"}.issubset(rule_ids)
+    assert "SKY-D201" not in rule_ids
+
+
+def test_rules_list_packs_json_keeps_community_pack_listing(tmp_path, monkeypatch):
+    rules_dir = tmp_path / ".skylos" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "local.yml").write_text("rules: []\n", encoding="utf-8")
+    buffer = io.StringIO()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    exit_code = rules_cmd.run_rules_command(
+        ["list", "--packs", "--json"],
+        console_factory=lambda: Console(file=buffer, force_terminal=False),
+    )
+
+    assert exit_code == 0
+    payload = json.loads(buffer.getvalue())
+    assert payload["total_packs"] == 1
 
 
 def test_rules_init_refuses_to_overwrite_without_force(tmp_path, monkeypatch):

--- a/test/test_trace_cache_cli.py
+++ b/test/test_trace_cache_cli.py
@@ -8,6 +8,7 @@ from rich.console import Console
 
 import skylos.cli as cli
 from skylos.core.result_cache import (
+    RUN_CACHE_DIR,
     TRACE_CACHE_DIR,
     build_trace_cache_key,
     save_trace_cache,
@@ -297,3 +298,29 @@ def test_cache_clear_command_removes_run_cache(tmp_path):
 
     assert code == 0
     assert not (tmp_path / ".skylos" / "cache" / "runs").exists()
+
+
+def test_cache_stats_json_skips_symlink_targets(tmp_path):
+    run_cache = tmp_path / RUN_CACHE_DIR
+    run_cache.mkdir(parents=True)
+    (run_cache / "entry.json").write_text("12345", encoding="utf-8")
+    outside = tmp_path / "outside-cache-target.txt"
+    outside.write_text("outside-data-that-must-not-count", encoding="utf-8")
+    try:
+        (run_cache / "outside.json").symlink_to(outside)
+    except OSError:
+        return
+
+    buffer = io.StringIO()
+    code = run_cache_command(
+        ["stats", str(tmp_path), "--json"],
+        console_factory=lambda: Console(file=buffer, force_terminal=False),
+    )
+
+    assert code == 0
+    payload = json.loads(buffer.getvalue())
+    assert payload["exists"] is True
+    assert payload["files"] == 1
+    assert payload["symlinks"] == 1
+    assert payload["skipped"] == 1
+    assert payload["bytes"] == 5


### PR DESCRIPTION
## Summary
- Add `skylos cache stats` with JSON output and safe cache metadata traversal
- Add `skylos rules list --json` plus rough rule search over IDs, names, categories, severities, and aliases
- Add a central built-in rule catalog used by CLI display and rules listing
- Add strict CI parity against the public `duriantaco/skylos-docs` rules reference

## Safety
- Cache stats only reads cache metadata and skips symlinks/non-regular entries
- Rule search treats user input as plain text and does not compile user-controlled regex
- Rules docs parity checks only `docs/rules-reference.mdx`, avoiding stale/example IDs in other docs pages

## Validation
- `.venv/bin/python -m pytest -q test/test_trace_cache_cli.py test/test_rules_cmd.py`
- `.venv/bin/python -m compileall -q skylos/commands/cache_cmd.py skylos/commands/rules_cmd.py skylos/core/result_cache.py skylos/rules/catalog.py skylos/cli.py`
- `.venv/bin/python scripts/check_rule_docs_parity.py --rules-reference /private/tmp/skylos-docs-rules-parity/docs/rules-reference.mdx`
- `git diff --check`
