### PR TITLE
refactor(cli): split suite command flow

### DIFF
--- a/skylos/commands/suite_cmd.py
+++ b/skylos/commands/suite_cmd.py
@@ -87,6 +87,362 @@ def _static_upload_failed_quality_gate(upload_result: dict) -> bool:
     return passed is False
 
 
+def _build_suite_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skylos suite",
+        description=(
+            "Run the full local Skylos suite: static analysis, technical debt, "
+            "AI defense, and provenance summary"
+        ),
+    )
+    parser.add_argument("path", nargs="?", default=".", help="Path to scan")
+    parser.add_argument(
+        "--json", action="store_true", dest="output_json", help="Output as JSON"
+    )
+    parser.add_argument(
+        "-o", "--output", dest="output_file", help="Write output to file"
+    )
+    parser.add_argument(
+        "--exclude",
+        nargs="+",
+        default=None,
+        help="Additional folders to exclude",
+    )
+    parser.add_argument(
+        "--confidence",
+        "-c",
+        type=int,
+        default=60,
+        help="Confidence threshold for static dead-code findings (0-100)",
+    )
+    parser.add_argument(
+        "--diff-base",
+        default=None,
+        help="Base ref for provenance detection (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--no-provenance",
+        action="store_true",
+        help="Disable automatic AI provenance summary",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload selected scan families to Skylos Cloud as separate scans in one suite bundle",
+    )
+    parser.add_argument(
+        "--families",
+        default="static,defense,debt",
+        help=(
+            "Comma-separated upload families for --upload. Choices: static,defense,debt"
+        ),
+    )
+    parser.add_argument(
+        "--static-categories",
+        default="danger,quality,secrets,dead_code,dependency",
+        help=(
+            "Comma-separated code-scan categories to upload inside the static family. "
+            "Choices: danger,quality,secrets,dead_code,dependency"
+        ),
+    )
+    return parser
+
+
+def _validate_suite_target(console, target: Path) -> bool:
+    if not target.exists():
+        console.print(f"[red]Error: path does not exist: {target}[/red]")
+        return False
+
+    if not target.is_dir():
+        console.print(
+            f"[red]Error: suite expects a directory, got file: {target}. "
+            "Use `skylos <file>` for single-file static analysis.[/red]"
+        )
+        return False
+
+    return True
+
+
+def _build_suite_excludes(
+    args: argparse.Namespace,
+    target: Path,
+    *,
+    parse_exclude_folders_func,
+    load_config_func,
+) -> set[str]:
+    exclude = set(
+        parse_exclude_folders_func(
+            use_defaults=True,
+            config_exclude_folders=load_config_func(target).get("exclude"),
+        )
+    )
+    if args.exclude:
+        exclude.update(args.exclude)
+    return exclude
+
+
+def _parse_suite_upload_selections(args: argparse.Namespace, console):
+    try:
+        selected_families = _parse_csv_selection(
+            args.families,
+            _VALID_UPLOAD_FAMILIES,
+        )
+        selected_static_categories = _parse_csv_selection(
+            args.static_categories,
+            _VALID_STATIC_UPLOAD_CATEGORIES,
+        )
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        return None, None, 1
+
+    return selected_families, selected_static_categories, 0
+
+
+def _run_suite_report(
+    args: argparse.Namespace,
+    target: Path,
+    exclude: set[str],
+    *,
+    console,
+    progress_factory,
+    run_analyze_func,
+    get_git_root_func,
+):
+    try:
+        report = run_suite(
+            target,
+            conf=args.confidence,
+            exclude_folders=sorted(exclude),
+            run_analyze_func=run_analyze_func,
+            progress_factory=progress_factory,
+            console=console,
+            output_json=args.output_json,
+            no_provenance=args.no_provenance,
+            diff_base=args.diff_base,
+            get_git_root_func=get_git_root_func,
+        )
+    except (FileNotFoundError, ValueError, ImportError) as exc:
+        console.print(f"[bold red]Suite error: {exc}[/bold red]")
+        return None, 1
+
+    return report, 0
+
+
+def _format_suite_output(args: argparse.Namespace, report: dict) -> str:
+    if args.output_json:
+        return format_suite_json(report)
+    return format_suite_table(report)
+
+
+def _write_suite_output(args: argparse.Namespace, console, output: str) -> int:
+    if args.output_file:
+        try:
+            Path(args.output_file).write_text(  # skylos: ignore[SKY-D215] user-selected suite output path
+                output,
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            console.print(f"[red]Error writing output file: {exc}[/red]")
+            return 1
+        console.print(f"[green]Output written to {args.output_file}[/green]")
+    elif args.output_json:
+        print(output)
+    else:
+        console.print(output)
+
+    return 0
+
+
+def _build_suite_upload_manifests(
+    report: dict,
+    selected_families: list[str],
+    selected_static_categories: list[str],
+) -> list[dict]:
+    from skylos.cloud.upload_manifest import (
+        build_code_scan_manifest,
+        build_defense_manifest,
+        build_debt_manifest,
+    )
+
+    manifest_families = []
+    if "static" in selected_families:
+        manifest_families.append(
+            build_code_scan_manifest(
+                selected_static_categories,
+                provenance_attached=bool(
+                    ((report.get("static") or {}).get("provenance"))
+                ),
+            )
+        )
+    if "defense" in selected_families:
+        manifest_families.append(build_defense_manifest())
+    if "debt" in selected_families:
+        manifest_families.append(build_debt_manifest())
+    return manifest_families
+
+
+def _print_suite_upload_manifest(
+    args: argparse.Namespace,
+    console,
+    report: dict,
+    selected_families: list[str],
+    selected_static_categories: list[str],
+    *,
+    scan_bundle_id: str | None,
+) -> None:
+    if args.output_json:
+        return
+
+    from skylos.cloud.upload_manifest import print_upload_manifest
+
+    manifest_families = _build_suite_upload_manifests(
+        report,
+        selected_families,
+        selected_static_categories,
+    )
+    print_upload_manifest(console, manifest_families, bundle_id=scan_bundle_id)
+
+
+def _upload_static_suite_family(
+    args: argparse.Namespace,
+    console,
+    report: dict,
+    selected_static_categories: list[str],
+    *,
+    scan_bundle_id: str | None,
+    upload_report_func,
+) -> int:
+    static_upload_result = _build_static_upload_result(
+        report.get("static") or {},
+        selected_static_categories,
+    )
+    static_upload = upload_report_func(
+        static_upload_result,
+        quiet=args.output_json,
+        scan_bundle_id=scan_bundle_id,
+    )
+    if not static_upload.get("success"):
+        if not args.output_json:
+            console.print(
+                f"[red]Static upload failed: {static_upload.get('error', 'Unknown')}[/red]"
+            )
+        return 1
+
+    if _static_upload_failed_quality_gate(static_upload):
+        if not args.output_json:
+            console.print(
+                "[red]Static upload failed the Skylos Cloud quality gate.[/red]"
+            )
+        return 1
+
+    return 0
+
+
+def _upload_defense_suite_family(
+    args: argparse.Namespace,
+    console,
+    report: dict,
+    *,
+    scan_bundle_id: str | None,
+    upload_defense_report_func,
+) -> int:
+    defense_upload = upload_defense_report_func(
+        json.dumps(report.get("defense") or {}),
+        quiet=args.output_json,
+        scan_bundle_id=scan_bundle_id,
+    )
+    if defense_upload.get("success"):
+        return 0
+
+    if not args.output_json:
+        console.print(
+            f"[red]Defense upload failed: {defense_upload.get('error', 'Unknown')}[/red]"
+        )
+    return 1
+
+
+def _upload_debt_suite_family(
+    args: argparse.Namespace,
+    console,
+    report: dict,
+    *,
+    scan_bundle_id: str | None,
+    upload_debt_report_func,
+) -> int:
+    debt_upload = upload_debt_report_func(
+        report.get("debt") or {},
+        quiet=args.output_json,
+        scan_bundle_id=scan_bundle_id,
+    )
+    if debt_upload.get("success"):
+        return 0
+
+    if not args.output_json:
+        console.print(
+            f"[red]Debt upload failed: {debt_upload.get('error', 'Unknown')}[/red]"
+        )
+    return 1
+
+
+def _upload_suite_report(
+    args: argparse.Namespace,
+    console,
+    report: dict,
+    selected_families: list[str],
+    selected_static_categories: list[str],
+    *,
+    upload_report_func,
+    upload_defense_report_func,
+    upload_debt_report_func,
+) -> int:
+    if not args.upload:
+        return 0
+
+    upload_failures = 0
+    scan_bundle_id = str(uuid.uuid4()) if len(selected_families) > 1 else None
+    _print_suite_upload_manifest(
+        args,
+        console,
+        report,
+        selected_families,
+        selected_static_categories,
+        scan_bundle_id=scan_bundle_id,
+    )
+
+    if "static" in selected_families:
+        upload_failures += _upload_static_suite_family(
+            args,
+            console,
+            report,
+            selected_static_categories,
+            scan_bundle_id=scan_bundle_id,
+            upload_report_func=upload_report_func,
+        )
+
+    if "defense" in selected_families:
+        upload_failures += _upload_defense_suite_family(
+            args,
+            console,
+            report,
+            scan_bundle_id=scan_bundle_id,
+            upload_defense_report_func=upload_defense_report_func,
+        )
+
+    if "debt" in selected_families:
+        upload_failures += _upload_debt_suite_family(
+            args,
+            console,
+            report,
+            scan_bundle_id=scan_bundle_id,
+            upload_debt_report_func=upload_debt_report_func,
+        )
+
+    if upload_failures:
+        return 1
+
+    return 0
+
+
 def run_suite_command(
     argv: list[str],
     *,
@@ -100,219 +456,50 @@ def run_suite_command(
     upload_defense_report_func,
     upload_debt_report_func,
 ) -> int:
-    suite_parser = argparse.ArgumentParser(
-        prog="skylos suite",
-        description=(
-            "Run the full local Skylos suite: static analysis, technical debt, "
-            "AI defense, and provenance summary"
-        ),
-    )
-    suite_parser.add_argument("path", nargs="?", default=".", help="Path to scan")
-    suite_parser.add_argument(
-        "--json", action="store_true", dest="output_json", help="Output as JSON"
-    )
-    suite_parser.add_argument(
-        "-o", "--output", dest="output_file", help="Write output to file"
-    )
-    suite_parser.add_argument(
-        "--exclude",
-        nargs="+",
-        default=None,
-        help="Additional folders to exclude",
-    )
-    suite_parser.add_argument(
-        "--confidence",
-        "-c",
-        type=int,
-        default=60,
-        help="Confidence threshold for static dead-code findings (0-100)",
-    )
-    suite_parser.add_argument(
-        "--diff-base",
-        default=None,
-        help="Base ref for provenance detection (default: auto-detect)",
-    )
-    suite_parser.add_argument(
-        "--no-provenance",
-        action="store_true",
-        help="Disable automatic AI provenance summary",
-    )
-    suite_parser.add_argument(
-        "--upload",
-        action="store_true",
-        help="Upload selected scan families to Skylos Cloud as separate scans in one suite bundle",
-    )
-    suite_parser.add_argument(
-        "--families",
-        default="static,defense,debt",
-        help=(
-            "Comma-separated upload families for --upload. Choices: static,defense,debt"
-        ),
-    )
-    suite_parser.add_argument(
-        "--static-categories",
-        default="danger,quality,secrets,dead_code,dependency",
-        help=(
-            "Comma-separated code-scan categories to upload inside the static family. "
-            "Choices: danger,quality,secrets,dead_code,dependency"
-        ),
-    )
-
-    suite_args = suite_parser.parse_args(argv)
+    parser = _build_suite_parser()
+    args = parser.parse_args(argv)
     console = console_factory()
 
-    target = Path(suite_args.path).resolve()
-    if not target.exists():
-        console.print(f"[red]Error: path does not exist: {target}[/red]")
-        return 1
-    if not target.is_dir():
-        console.print(
-            f"[red]Error: suite expects a directory, got file: {target}. "
-            "Use `skylos <file>` for single-file static analysis.[/red]"
-        )
+    target = Path(args.path).resolve()
+    if not _validate_suite_target(console, target):
         return 1
 
-    exclude = set(
-        parse_exclude_folders_func(
-            use_defaults=True,
-            config_exclude_folders=load_config_func(target).get("exclude"),
-        )
+    exclude = _build_suite_excludes(
+        args,
+        target,
+        parse_exclude_folders_func=parse_exclude_folders_func,
+        load_config_func=load_config_func,
     )
-    if suite_args.exclude:
-        exclude.update(suite_args.exclude)
-
-    try:
-        selected_families = _parse_csv_selection(
-            suite_args.families,
-            _VALID_UPLOAD_FAMILIES,
-        )
-        selected_static_categories = _parse_csv_selection(
-            suite_args.static_categories,
-            _VALID_STATIC_UPLOAD_CATEGORIES,
-        )
-    except ValueError as exc:
-        console.print(f"[red]Error: {exc}[/red]")
-        return 1
-
-    try:
-        report = run_suite(
-            target,
-            conf=suite_args.confidence,
-            exclude_folders=sorted(exclude),
-            run_analyze_func=run_analyze_func,
-            progress_factory=progress_factory,
-            console=console,
-            output_json=suite_args.output_json,
-            no_provenance=suite_args.no_provenance,
-            diff_base=suite_args.diff_base,
-            get_git_root_func=get_git_root_func,
-        )
-    except (FileNotFoundError, ValueError, ImportError) as exc:
-        console.print(f"[bold red]Suite error: {exc}[/bold red]")
-        return 1
-
-    output = (
-        format_suite_json(report)
-        if suite_args.output_json
-        else format_suite_table(report)
+    selected_families, selected_static_categories, selection_error = (
+        _parse_suite_upload_selections(args, console)
     )
+    if selection_error:
+        return selection_error
 
-    if suite_args.output_file:
-        try:
-            Path(suite_args.output_file).write_text(output, encoding="utf-8")
-        except OSError as exc:
-            console.print(f"[red]Error writing output file: {exc}[/red]")
-            return 1
-        console.print(f"[green]Output written to {suite_args.output_file}[/green]")
-    elif suite_args.output_json:
-        print(output)
-    else:
-        console.print(output)
+    report, suite_error = _run_suite_report(
+        args,
+        target,
+        exclude,
+        console=console,
+        progress_factory=progress_factory,
+        run_analyze_func=run_analyze_func,
+        get_git_root_func=get_git_root_func,
+    )
+    if suite_error:
+        return suite_error
 
-    if not suite_args.upload:
-        return 0
+    output = _format_suite_output(args, report)
+    write_error = _write_suite_output(args, console, output)
+    if write_error:
+        return write_error
 
-    upload_failures = 0
-    scan_bundle_id = str(uuid.uuid4()) if len(selected_families) > 1 else None
-
-    if not suite_args.output_json:
-        from skylos.cloud.upload_manifest import (
-            build_code_scan_manifest,
-            build_defense_manifest,
-            build_debt_manifest,
-            print_upload_manifest,
-        )
-
-        manifest_families = []
-        if "static" in selected_families:
-            manifest_families.append(
-                build_code_scan_manifest(
-                    selected_static_categories,
-                    provenance_attached=bool(
-                        ((report.get("static") or {}).get("provenance"))
-                    ),
-                )
-            )
-        if "defense" in selected_families:
-            manifest_families.append(build_defense_manifest())
-        if "debt" in selected_families:
-            manifest_families.append(build_debt_manifest())
-        print_upload_manifest(
-            console,
-            manifest_families,
-            bundle_id=scan_bundle_id,
-        )
-
-    if "static" in selected_families:
-        static_upload_result = _build_static_upload_result(
-            report.get("static") or {},
-            selected_static_categories,
-        )
-        static_upload = upload_report_func(
-            static_upload_result,
-            quiet=suite_args.output_json,
-            scan_bundle_id=scan_bundle_id,
-        )
-        if not static_upload.get("success"):
-            upload_failures += 1
-            if not suite_args.output_json:
-                console.print(
-                    f"[red]Static upload failed: {static_upload.get('error', 'Unknown')}[/red]"
-                )
-        elif _static_upload_failed_quality_gate(static_upload):
-            upload_failures += 1
-            if not suite_args.output_json:
-                console.print(
-                    "[red]Static upload failed the Skylos Cloud quality gate.[/red]"
-                )
-
-    if "defense" in selected_families:
-        defense_upload = upload_defense_report_func(
-            json.dumps(report.get("defense") or {}),
-            quiet=suite_args.output_json,
-            scan_bundle_id=scan_bundle_id,
-        )
-        if not defense_upload.get("success"):
-            upload_failures += 1
-            if not suite_args.output_json:
-                console.print(
-                    f"[red]Defense upload failed: {defense_upload.get('error', 'Unknown')}[/red]"
-                )
-
-    if "debt" in selected_families:
-        debt_upload = upload_debt_report_func(
-            report.get("debt") or {},
-            quiet=suite_args.output_json,
-            scan_bundle_id=scan_bundle_id,
-        )
-        if not debt_upload.get("success"):
-            upload_failures += 1
-            if not suite_args.output_json:
-                console.print(
-                    f"[red]Debt upload failed: {debt_upload.get('error', 'Unknown')}[/red]"
-                )
-
-    if upload_failures:
-        return 1
-
-    return 0
+    return _upload_suite_report(
+        args,
+        console,
+        report,
+        selected_families,
+        selected_static_categories,
+        upload_report_func=upload_report_func,
+        upload_defense_report_func=upload_defense_report_func,
+        upload_debt_report_func=upload_debt_report_func,
+    )

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1,6 +1,6 @@
 import io
 import json
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from rich.console import Console
 from rich.progress import Progress
@@ -123,6 +123,185 @@ def test_suite_rejects_file_paths(tmp_path):
     )
 
     assert exit_code == 1
+
+
+def test_suite_table_output_preserves_run_and_formatter_args(tmp_path):
+    report = {"summary": {"static": {}}, "static": {}, "debt": {}, "defense": {}}
+    console = Mock()
+    parse_exclude = Mock(return_value=[".git", "dist"])
+    load_config = Mock(return_value={"exclude": ["build"]})
+    run_analyze = Mock(return_value="{}")
+    get_git_root = Mock(return_value=None)
+
+    with (
+        patch("skylos.commands.suite_cmd.run_suite", return_value=report) as runner,
+        patch(
+            "skylos.commands.suite_cmd.format_suite_table",
+            return_value="suite table",
+        ) as formatter,
+    ):
+        exit_code = run_suite_command(
+            [
+                str(tmp_path),
+                "--confidence",
+                "77",
+                "--diff-base",
+                "origin/main",
+                "--no-provenance",
+                "--exclude",
+                "custom",
+            ],
+            console_factory=lambda: console,
+            progress_factory=Progress,
+            parse_exclude_folders_func=parse_exclude,
+            load_config_func=load_config,
+            run_analyze_func=run_analyze,
+            get_git_root_func=get_git_root,
+            upload_report_func=_noop_upload,
+            upload_defense_report_func=_noop_upload,
+            upload_debt_report_func=_noop_upload,
+        )
+
+    assert exit_code == 0
+    load_config.assert_called_once_with(tmp_path.resolve())
+    parse_exclude.assert_called_once_with(
+        use_defaults=True,
+        config_exclude_folders=["build"],
+    )
+    runner.assert_called_once_with(
+        tmp_path.resolve(),
+        conf=77,
+        exclude_folders=[".git", "custom", "dist"],
+        run_analyze_func=run_analyze,
+        progress_factory=Progress,
+        console=console,
+        output_json=False,
+        no_provenance=True,
+        diff_base="origin/main",
+        get_git_root_func=get_git_root,
+    )
+    formatter.assert_called_once_with(report)
+    console.print.assert_called_once_with("suite table")
+
+
+def test_suite_json_output_file_writes_formatted_output(tmp_path):
+    output_file = tmp_path / "suite.json"
+    console = Mock()
+    report = {"summary": {"static": {}}, "static": {}, "debt": {}, "defense": {}}
+
+    with (
+        patch("skylos.commands.suite_cmd.run_suite", return_value=report),
+        patch(
+            "skylos.commands.suite_cmd.format_suite_json",
+            return_value='{"suite":true}',
+        ),
+    ):
+        exit_code = run_suite_command(
+            [str(tmp_path), "--json", "--output", str(output_file)],
+            console_factory=lambda: console,
+            progress_factory=Progress,
+            parse_exclude_folders_func=lambda **kwargs: [],
+            load_config_func=lambda _path: {},
+            run_analyze_func=lambda *_args, **_kwargs: "{}",
+            get_git_root_func=lambda: None,
+            upload_report_func=_noop_upload,
+            upload_defense_report_func=_noop_upload,
+            upload_debt_report_func=_noop_upload,
+        )
+
+    assert exit_code == 0
+    assert output_file.read_text(encoding="utf-8") == '{"suite":true}'
+    console.print.assert_called_once_with(
+        f"[green]Output written to {output_file}[/green]"
+    )
+
+
+def test_suite_table_upload_preserves_bundle_and_payloads(tmp_path):
+    static_result = _static_result(str(tmp_path))
+    report = {
+        "static": {
+            **static_result,
+            "provenance": {"enabled": True},
+        },
+        "debt": {"score": {"score_pct": 82}, "hotspots": [{"file": "app.py"}]},
+        "defense": {"summary": {"score_pct": 100}},
+        "summary": {"static": {}},
+    }
+    console = Mock()
+    uploaded = {}
+
+    def _upload_static(payload, **kwargs):
+        uploaded["static_payload"] = payload
+        uploaded["static_kwargs"] = kwargs
+        return {"success": True}
+
+    def _upload_defense(payload, **kwargs):
+        uploaded["defense_payload"] = payload
+        uploaded["defense_kwargs"] = kwargs
+        return {"success": True}
+
+    def _upload_debt(payload, **kwargs):
+        uploaded["debt_payload"] = payload
+        uploaded["debt_kwargs"] = kwargs
+        return {"success": True}
+
+    with (
+        patch("skylos.commands.suite_cmd.run_suite", return_value=report),
+        patch("skylos.commands.suite_cmd.format_suite_table", return_value="suite"),
+        patch("skylos.commands.suite_cmd.uuid.uuid4", return_value="bundle-123"),
+        patch(
+            "skylos.cloud.upload_manifest.build_code_scan_manifest",
+            return_value="code-manifest",
+        ) as build_code,
+        patch(
+            "skylos.cloud.upload_manifest.build_defense_manifest",
+            return_value="defense-manifest",
+        ),
+        patch(
+            "skylos.cloud.upload_manifest.build_debt_manifest",
+            return_value="debt-manifest",
+        ),
+        patch("skylos.cloud.upload_manifest.print_upload_manifest") as print_manifest,
+    ):
+        exit_code = run_suite_command(
+            [str(tmp_path), "--upload"],
+            console_factory=lambda: console,
+            progress_factory=Progress,
+            parse_exclude_folders_func=lambda **kwargs: [],
+            load_config_func=lambda _path: {},
+            run_analyze_func=lambda *_args, **_kwargs: json.dumps(static_result),
+            get_git_root_func=lambda: None,
+            upload_report_func=_upload_static,
+            upload_defense_report_func=_upload_defense,
+            upload_debt_report_func=_upload_debt,
+        )
+
+    assert exit_code == 0
+    assert uploaded["static_kwargs"] == {
+        "quiet": False,
+        "scan_bundle_id": "bundle-123",
+    }
+    assert uploaded["defense_kwargs"] == {
+        "quiet": False,
+        "scan_bundle_id": "bundle-123",
+    }
+    assert uploaded["debt_kwargs"] == {
+        "quiet": False,
+        "scan_bundle_id": "bundle-123",
+    }
+    assert uploaded["defense_payload"] == json.dumps(report["defense"])
+    assert uploaded["debt_payload"] == report["debt"]
+    assert "danger" in uploaded["static_payload"]
+    build_code.assert_called_once_with(
+        ["danger", "quality", "secrets", "dead_code", "dependency"],
+        provenance_attached=True,
+    )
+    print_manifest.assert_called_once_with(
+        console,
+        ["code-manifest", "defense-manifest", "debt-manifest"],
+        bundle_id="bundle-123",
+    )
+    console.print.assert_called_once_with("suite")
 
 
 def test_main_suite_subcommand_calls_run_suite_and_exits(monkeypatch):


### PR DESCRIPTION
 ## Summary
  - Split `skylos suite` command handling into focused helpers for parsing, validation, suite execution, formatting, output writing, upload manifests, and per-family uploads.
  - Added characterization coverage for table output, JSON file output, run/formatter arguments, upload bundle IDs, upload payloads, and manifest printing.

  ## Validation
  - pytest test/test_suite.py`
  - pytest test/test_cli_refactor_guardrails.py`
  - pre-commit run skylos-gate --files skylos/commands/suite_cmd.py test/test_suite.py`