### PR TITLE
fix(config): validate whitelist settings

### DIFF
--- a/skylos/config.py
+++ b/skylos/config.py
@@ -74,10 +74,7 @@ _STRING_LIST_CONFIG_KEYS = {
     "lower_confidence",
 }
 _DICT_CONFIG_KEYS = {
-    "overrides",
     "non_library_dirs",
-    "whitelist_documented",
-    "whitelist_temporary",
 }
 _BOOL_CONFIG_KEYS = {
     "nudges",
@@ -268,6 +265,15 @@ def _sanitize_config(cfg: dict) -> dict:
     for key in _DICT_CONFIG_KEYS:
         safe[key] = _safe_dict(safe.get(key), DEFAULTS[key])
 
+    safe["whitelist_documented"] = _safe_string_map(
+        safe.get("whitelist_documented"),
+        DEFAULTS["whitelist_documented"],
+    )
+    safe["whitelist_temporary"] = _safe_temporary_whitelist(
+        safe.get("whitelist_temporary")
+    )
+    safe["overrides"] = _safe_overrides(safe.get("overrides"))
+
     for key in _BOOL_CONFIG_KEYS:
         safe[key] = _safe_bool(safe.get(key), DEFAULTS[key])
 
@@ -305,6 +311,55 @@ def _safe_string_list(value, default):
 
 def _safe_dict(value, default):
     return copy.deepcopy(value) if isinstance(value, dict) else copy.deepcopy(default)
+
+
+def _safe_string_map(value, default):
+    if not isinstance(value, dict):
+        return copy.deepcopy(default)
+
+    safe = {}
+    for key, item in value.items():
+        if isinstance(key, str) and isinstance(item, str):
+            safe[key] = item
+    return safe
+
+
+def _safe_temporary_whitelist(value):
+    if not isinstance(value, dict):
+        return {}
+
+    safe = {}
+    for pattern, config in value.items():
+        if not isinstance(pattern, str) or not isinstance(config, dict):
+            continue
+
+        entry = {}
+        reason = config.get("reason")
+        expires = config.get("expires")
+        if isinstance(reason, str):
+            entry["reason"] = reason
+        if isinstance(expires, str):
+            entry["expires"] = expires
+        safe[pattern] = entry
+    return safe
+
+
+def _safe_overrides(value):
+    if not isinstance(value, dict):
+        return {}
+
+    safe = {}
+    for path_pattern, rules in value.items():
+        if not isinstance(path_pattern, str) or not isinstance(rules, dict):
+            continue
+
+        safe_rules = {}
+        whitelist = _safe_string_list(rules.get("whitelist"), [])
+        if whitelist:
+            safe_rules["whitelist"] = whitelist
+        if safe_rules:
+            safe[path_pattern] = safe_rules
+    return safe
 
 
 def _safe_dict_list(value, default):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -300,6 +300,76 @@ whitelist = ["special_*"]
         self.assertIn("src/*.py", config["overrides"])
         self.assertEqual(config["overrides"]["src/*.py"]["whitelist"], ["special_*"])
 
+    def test_load_config_rejects_scalar_temporary_whitelist_entries(self):
+        toml_path = self.root / "pyproject.toml"
+        toml_path.write_text(
+            """
+[tool.skylos.whitelist.temporary]
+"*" = "boom"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = load_config(self.root)
+        ok, reason, penalty = is_whitelisted("any_definition", "app.py", config)
+        expired = get_expired_whitelists(config)
+
+        self.assertEqual(config["whitelist_temporary"], {})
+        self.assertFalse(ok)
+        self.assertIsNone(reason)
+        self.assertEqual(penalty, 0)
+        self.assertEqual(expired, [])
+
+    def test_load_config_rejects_scalar_override_entries(self):
+        toml_path = self.root / "pyproject.toml"
+        toml_path.write_text(
+            """
+[tool.skylos.overrides]
+"src/*.py" = "boom"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = load_config(self.root)
+        ok, reason, penalty = is_whitelisted("special_case", "src/a.py", config)
+
+        self.assertEqual(config["overrides"], {})
+        self.assertFalse(ok)
+        self.assertIsNone(reason)
+        self.assertEqual(penalty, 0)
+
+    def test_load_config_rejects_malformed_whitelist_lists_and_maps(self):
+        toml_path = self.root / "pyproject.toml"
+        toml_path.write_text(
+            """
+[tool.skylos.whitelist]
+names = ["safe_*", 123]
+lower_confidence = "boom"
+
+[tool.skylos.whitelist.documented]
+"doc_*" = 123
+"kept_*" = "reason"
+
+[tool.skylos.whitelist.temporary]
+"legacy_*" = { reason = 123, expires = 456 }
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = load_config(self.root)
+        ok, reason, penalty = is_whitelisted("kept_name", None, config)
+        legacy_ok, legacy_reason, _ = is_whitelisted("legacy_name", None, config)
+
+        self.assertEqual(config["whitelist"], ["safe_*"])
+        self.assertEqual(config["lower_confidence"], [])
+        self.assertEqual(config["whitelist_documented"], {"kept_*": "reason"})
+        self.assertEqual(config["whitelist_temporary"], {"legacy_*": {}})
+        self.assertTrue(ok)
+        self.assertEqual(reason, "reason")
+        self.assertEqual(penalty, 0)
+        self.assertTrue(legacy_ok)
+        self.assertIn("temporary whitelist", legacy_reason)
+
     def test_is_path_excluded_glob_path_match(self):
         cfg = {"exclude": ["src/**/gen_*.py"]}
         self.assertTrue(is_path_excluded("src/a/gen_file.py", cfg))


### PR DESCRIPTION
  ## Summary
  - Validate whitelist config values before they reach whitelist checks.
  - Drop malformed scalar `whitelist.temporary` entries, malformed override entries, and non-string whitelist/documented/lower-confidence values.


  ## Validation
  - `pytest test/test_config.py -k "whitelist or overrides"`