### PR TITLE
fix(danger): track SQL and SSRF receiver aliases

### DIFF
--- a/skylos/rules/danger/danger_net/ssrf_flow.py
+++ b/skylos/rules/danger/danger_net/ssrf_flow.py
@@ -76,6 +76,19 @@ def _receiver_name(node: ast.Call) -> str | None:
     return None
 
 
+def _qualified_name_from_expr(node: ast.AST) -> str | None:
+    parts = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        parts.reverse()
+        return ".".join(parts)
+    return None
+
+
 def _has_safe_base_url(node):
     if not node.values:
         return True
@@ -282,6 +295,52 @@ class _SSRFFlowChecker(TaintVisitor):
     def __init__(self, file_path, findings, sanitizers=None):
         super().__init__(file_path, findings, sanitizers=sanitizers)
         self.http_names: set[str] = set()
+        self.http_receiver_alias_stack: list[set[str]] = [set()]
+
+    def _push(self):
+        super()._push()
+        self.http_receiver_alias_stack.append(set())
+
+    def _pop(self):
+        if len(self.http_receiver_alias_stack) > 1:
+            self.http_receiver_alias_stack.pop()
+        super()._pop()
+
+    def _mark_http_receiver_alias(self, name: str) -> None:
+        if not self.http_receiver_alias_stack:
+            self.http_receiver_alias_stack.append(set())
+        self.http_receiver_alias_stack[-1].add(name)
+
+    def _is_known_http_receiver_name(self, name: str) -> bool:
+        if name in self.http_names:
+            return True
+        return any(name in scope for scope in reversed(self.http_receiver_alias_stack))
+
+    def _is_http_reference(self, node: ast.AST) -> bool:
+        if isinstance(node, ast.Call):
+            return self._is_http_reference(node.func)
+
+        if isinstance(node, ast.Name):
+            return self._is_known_http_receiver_name(node.id)
+
+        qual_name = _qualified_name_from_expr(node)
+        if not qual_name:
+            return False
+
+        root = qual_name.split(".", 1)[0]
+        if root in HTTP_MODULES:
+            return True
+        return self._is_known_http_receiver_name(root)
+
+    def _track_http_receiver_aliases(self, targets, value: ast.AST | None) -> None:
+        if value is None or not self._is_http_reference(value):
+            return
+
+        for target in targets:
+            if isinstance(target, ast.Name):
+                self._mark_http_receiver_alias(target.id)
+            elif isinstance(target, ast.Attribute):
+                self._mark_http_receiver_alias(target.attr)
 
     def is_tainted(self, node):
         if isinstance(node, ast.JoinedStr) and _has_safe_base_url(node):
@@ -305,16 +364,24 @@ class _SSRFFlowChecker(TaintVisitor):
                     self.http_names.add(alias.asname or alias.name)
         self.generic_visit(node)
 
+    def visit_Assign(self, node):
+        self._track_http_receiver_aliases(node.targets, node.value)
+        super().visit_Assign(node)
+
+    def visit_AnnAssign(self, node):
+        self._track_http_receiver_aliases([node.target], node.value)
+        super().visit_AnnAssign(node)
+
     def _is_likely_http_receiver(self, node: ast.Call) -> bool:
         name = _receiver_name(node)
         if name is None:
             return False
 
+        if self._is_known_http_receiver_name(name):
+            return True
+
         if name.lower() in NON_HTTP_RECEIVER_NAMES:
             return False
-
-        if name in self.http_names:
-            return True
 
         if name.lower() in HTTP_RECEIVER_NAMES:
             return True

--- a/skylos/rules/danger/danger_sql/sql_flow.py
+++ b/skylos/rules/danger/danger_sql/sql_flow.py
@@ -147,6 +147,19 @@ def _receiver_name(node: ast.Call) -> str | None:
     return None
 
 
+def _qualified_name_from_expr(node: ast.AST) -> str | None:
+    parts = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        parts.reverse()
+        return ".".join(parts)
+    return None
+
+
 def get_query_expression(call: ast.Call, names=("sql", "query", "statement")):
     expression = None
     if call.args and len(call.args) > 0:
@@ -197,14 +210,18 @@ class _SQLFlowChecker(TaintVisitor):
         self.passthrough_functions: set[str] = set()
         self.db_names: set[str] = set()
         self.static_string_stack: list[dict[str, bool]] = [{}]
+        self.db_receiver_alias_stack: list[set[str]] = [set()]
 
     def _push(self):
         super()._push()
         self.static_string_stack.append({})
+        self.db_receiver_alias_stack.append(set())
 
     def _pop(self):
         if len(self.static_string_stack) > 1:
             self.static_string_stack.pop()
+        if len(self.db_receiver_alias_stack) > 1:
+            self.db_receiver_alias_stack.pop()
         super()._pop()
 
     def _set_static_string(self, name: str, is_static: bool) -> None:
@@ -224,6 +241,42 @@ class _SQLFlowChecker(TaintVisitor):
         if isinstance(node, ast.Name):
             return self._is_static_string_name(node.id)
         return False
+
+    def _mark_db_receiver_alias(self, name: str) -> None:
+        if not self.db_receiver_alias_stack:
+            self.db_receiver_alias_stack.append(set())
+        self.db_receiver_alias_stack[-1].add(name)
+
+    def _is_known_db_receiver_name(self, name: str) -> bool:
+        if name in self.db_names:
+            return True
+        return any(name in scope for scope in reversed(self.db_receiver_alias_stack))
+
+    def _is_db_reference(self, node: ast.AST) -> bool:
+        if isinstance(node, ast.Call):
+            return self._is_db_reference(node.func)
+
+        if isinstance(node, ast.Name):
+            return self._is_known_db_receiver_name(node.id)
+
+        qual_name = _qualified_name_from_expr(node)
+        if not qual_name:
+            return False
+
+        root = qual_name.split(".", 1)[0]
+        if root in DB_MODULES:
+            return True
+        return self._is_known_db_receiver_name(root)
+
+    def _track_db_receiver_aliases(self, targets, value: ast.AST | None) -> None:
+        if value is None or not self._is_db_reference(value):
+            return
+
+        for target in targets:
+            if isinstance(target, ast.Name):
+                self._mark_db_receiver_alias(target.id)
+            elif isinstance(target, ast.Attribute):
+                self._mark_db_receiver_alias(target.attr)
 
     def visit_Import(self, node):
         for alias in node.names:
@@ -245,7 +298,7 @@ class _SQLFlowChecker(TaintVisitor):
         if name is None:
             return False
 
-        if name in self.db_names:
+        if self._is_known_db_receiver_name(name):
             return True
 
         if name.lower() in DB_RECEIVER_NAMES:
@@ -274,6 +327,7 @@ class _SQLFlowChecker(TaintVisitor):
         super().visit_AsyncFunctionDef(node)
 
     def visit_Assign(self, node):
+        self._track_db_receiver_aliases(node.targets, node.value)
         is_static = self._is_static_query_expr(node.value)
         for target in node.targets:
             if isinstance(target, ast.Name):
@@ -281,6 +335,7 @@ class _SQLFlowChecker(TaintVisitor):
         super().visit_Assign(node)
 
     def visit_AnnAssign(self, node):
+        self._track_db_receiver_aliases([node.target], node.value)
         if node.value and isinstance(node.target, ast.Name):
             self._set_static_string(
                 node.target.id,

--- a/skylos/web/server.py
+++ b/skylos/web/server.py
@@ -20,6 +20,19 @@ from skylos.web.frontend import render_frontend_html
 app = Flask(__name__)
 
 
+def _normalize_exclude_folders(exclude_folders=None):
+    if exclude_folders is None:
+        exclude_folders = DEFAULT_EXCLUDE_FOLDERS
+
+    if isinstance(exclude_folders, (set, frozenset)):
+        return sorted(str(item) for item in exclude_folders)
+
+    if isinstance(exclude_folders, (list, tuple)):
+        return [str(item) for item in exclude_folders]
+
+    return []
+
+
 def _get_server_port():
     raw = os.getenv("SKYLOS_PORT", "5090")
     try:
@@ -140,7 +153,9 @@ def analyze_project():
                 403,
             )
 
-        exclude_folders = app.config.get("EXCLUDE_FOLDERS", DEFAULT_EXCLUDE_FOLDERS)
+        exclude_folders = _normalize_exclude_folders(
+            app.config.get("EXCLUDE_FOLDERS", DEFAULT_EXCLUDE_FOLDERS)
+        )
 
         result_json = skylos.analyze(
             path, conf=confidence, exclude_folders=exclude_folders
@@ -154,11 +169,9 @@ def analyze_project():
 
 
 def start_server(exclude_folders=None):
-    if exclude_folders is None:
-        exclude_folders = DEFAULT_EXCLUDE_FOLDERS
     port = _get_server_port()
     local_url = f"http://localhost:{port}"
-    app.config["EXCLUDE_FOLDERS"] = exclude_folders
+    app.config["EXCLUDE_FOLDERS"] = _normalize_exclude_folders(exclude_folders)
     app.config["ALLOWED_SCAN_ROOTS"] = _get_allowed_scan_roots()
     app.config["WEB_API_TOKEN"] = os.getenv("SKYLOS_WEB_TOKEN") or secrets.token_hex(24)
 

--- a/test/test_dangerous.py
+++ b/test/test_dangerous.py
@@ -241,6 +241,28 @@ def f(cur, query, params):
     assert "SKY-D211" in _rule_ids(out)
 
 
+def test_sql_execute_neutral_connection_alias_flags(tmp_path):
+    code = """
+import sqlite3
+
+def f(name):
+    c = sqlite3.connect(":memory:")
+    c.execute(f"SELECT * FROM users WHERE name = '{name}'")
+"""
+    out = _scan_one(tmp_path, "sql_connection_alias.py", code)
+    assert "SKY-D211" in _rule_ids(out)
+
+
+def test_unrelated_execute_receiver_is_not_db(tmp_path):
+    code = """
+def f(name):
+    c = object()
+    c.execute(f"SELECT * FROM users WHERE name = '{name}'")
+"""
+    out = _scan_one(tmp_path, "sql_unrelated_execute.py", code)
+    assert "SKY-D211" not in _rule_ids(out)
+
+
 def test_sql_execute_query_mutated_after_static_assignment_flags(tmp_path):
     code = """
 def f(cur, request):

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -23,6 +23,7 @@ from skylos.web.server import (
     start_server,
     _get_server_port,
     _get_default_cors_origins,
+    _normalize_exclude_folders,
 )
 
 if _original_constants is not None:
@@ -111,6 +112,26 @@ class TestSkylosWebApp(unittest.TestCase):
         args, kwargs = mock_skylos_analyze.call_args
         self.assertEqual(args[0], "/real/path")
         self.assertEqual(kwargs["conf"], 80)
+        self.assertIsInstance(kwargs["exclude_folders"], list)
+
+    @patch("skylos.analyze")
+    @patch("os.path.exists")
+    def test_analyze_normalizes_set_excludes_before_analysis(
+        self, mock_exists, mock_skylos_analyze
+    ):
+        mock_exists.return_value = True
+        app.config["EXCLUDE_FOLDERS"] = {"node_modules", ".git"}
+        mock_skylos_analyze.return_value = json.dumps({"unused_functions": []})
+
+        response = self.app.post(
+            "/api/analyze",
+            data=json.dumps({"path": "/real/path"}),
+            headers=self.auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        _, kwargs = mock_skylos_analyze.call_args
+        self.assertEqual(kwargs["exclude_folders"], [".git", "node_modules"])
 
     @patch("skylos.analyze")
     @patch("os.path.exists")
@@ -139,6 +160,20 @@ class TestSkylosWebApp(unittest.TestCase):
                 debug=False, host="127.0.0.1", port=5090, use_reloader=False
             )
             mock_timer.assert_called()
+
+    @patch("skylos.web.server.webbrowser.open")
+    @patch("skylos.web.server.Timer")
+    @patch("skylos.web.server.app.run")
+    def test_start_server_normalizes_default_excludes(
+        self, mock_run, mock_timer, mock_browser
+    ):
+        start_server()
+
+        self.assertIsInstance(app.config["EXCLUDE_FOLDERS"], list)
+        self.assertEqual(
+            app.config["EXCLUDE_FOLDERS"],
+            _normalize_exclude_folders(app.config["EXCLUDE_FOLDERS"]),
+        )
 
     @patch.dict(os.environ, {"SKYLOS_PORT": "5111"}, clear=False)
     @patch("skylos.web.server.webbrowser.open")

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -48,6 +48,27 @@ def test_httpx_tainted_url_flags(tmp_path):
     assert "SKY-D216" in _rule_ids(out)
 
 
+def test_requests_neutral_assignment_alias_flags(tmp_path):
+    code = (
+        "import requests\n"
+        "api = requests\n"
+        "def f(url):\n"
+        "    api.get(url)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_requests_alias.py", code)
+    assert "SKY-D216" in _rule_ids(out)
+
+
+def test_unrelated_get_receiver_is_not_http(tmp_path):
+    code = (
+        "def f(url):\n"
+        "    cache = {}\n"
+        "    cache.get(url)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_unrelated_get.py", code)
+    assert "SKY-D216" not in _rule_ids(out)
+
+
 def test_urllib_urlopen_tainted_url_flags(tmp_path):
     code = "import urllib.request as u\ndef f(x):\n    u.urlopen(f'http://{x}')\n"
     out = _scan_one(tmp_path, "ssrf_urlopen.py", code)


### PR DESCRIPTION
## Summary
  - Track receiver aliases assigned from known HTTP clients in the SSRF flow rule
  - Track receiver aliases assigned from known DB modules in the SQL flow rule

## KIV
  This fix does not make every `.get()` or `.execute()` call suspicious. It only trusts aliases derived from known HTTP/DB imports or previously tracked receiver aliases.

  ## Validation
  - `pytest test/test_ssrf.py`
  - `pytest test/test_dangerous.py`
  - `pytest test/test_sanitizers.py`