### PR TITLE
fix(typescript): constrain glob expansion

### DIFF
--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import fnmatch
-import glob
 import json
 import os
 import shlex
@@ -26,6 +25,7 @@ from .resolve import (
     _parse_tsconfig_references,
     _resolve_path_target,
 )
+from .safe_glob import resolve_bounded_base, safe_glob_paths
 
 _NEXTJS_CONVENTION_EXPORTS = NEXTJS_CONVENTION_EXPORTS
 _NEXTJS_CONVENTION_FILES = NEXTJS_CONVENTION_FILES
@@ -672,8 +672,11 @@ def _expand_relative_entry_glob(
     base_dir: str, pattern: str, ts_files: set[str]
 ) -> set[str]:
     matches: set[str] = set()
-    for candidate in glob.glob(os.path.join(base_dir, pattern), recursive=True):
-        real_path = os.path.realpath(candidate)
+    for real_path in safe_glob_paths(
+        base_dir,
+        pattern,
+        allowed_suffixes=set(_ENTRY_FILE_SUFFIXES),
+    ):
         if real_path in ts_files:
             matches.add(real_path)
     return matches
@@ -685,10 +688,11 @@ def _resolve_config_root_base(
     root_values = _find_object_path_values(source, objects, ("root",))
     for node in root_values:
         for value in _collect_string_literals(source, node):
-            if os.path.isabs(value):
-                return os.path.normpath(value)
-            return os.path.normpath(os.path.join(default_base_dir, value))
-    return default_base_dir
+            bounded = resolve_bounded_base(default_base_dir, value)
+            if bounded:
+                return bounded
+            return os.path.realpath(default_base_dir)
+    return os.path.realpath(default_base_dir)
 
 
 def _literal_entries_from_nodes(

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import glob
 import os
 from pathlib import Path
 
 from tree_sitter import Language, Parser, Query, QueryCursor
 import tree_sitter_typescript as tsts
 from skylos.visitors.base import Definition
+from skylos.visitors.languages.typescript.safe_glob import safe_glob_paths
 
 try:
     TS_LANG: Language | None = Language(tsts.language_typescript())
@@ -602,15 +602,12 @@ class TypeScriptCore:
         for pattern in self._string_sources_from_node(node):
             if not pattern:
                 continue
-            if os.path.isabs(pattern):
-                full_pattern = pattern
-            else:
-                full_pattern = os.path.join(os.path.dirname(self.file_path), pattern)
-            for matched in glob.glob(full_pattern, recursive=True):
-                if not os.path.isfile(matched):
-                    continue
-                if Path(matched).suffix.lower() not in _RAW_IMPORT_FILE_EXTENSIONS:
-                    continue
+            base_dir = os.path.dirname(self.file_path)
+            for matched in safe_glob_paths(
+                base_dir,
+                pattern,
+                allowed_suffixes=_RAW_IMPORT_FILE_EXTENSIONS,
+            ):
                 matches.append(
                     self._relative_source_for_match(os.path.realpath(matched))
                 )

--- a/skylos/visitors/languages/typescript/safe_glob.py
+++ b/skylos/visitors/languages/typescript/safe_glob.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import glob
+import os
+from pathlib import Path
+
+MAX_TYPESCRIPT_GLOB_MATCHES = 512
+
+
+def _is_inside_root(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath([os.path.realpath(path), root]) == root
+    except ValueError:
+        return False
+
+
+def _absolute_pattern(base_dir: str, pattern: str) -> str:
+    if os.path.isabs(pattern):
+        return os.path.normpath(pattern)
+    return os.path.normpath(os.path.join(os.path.abspath(base_dir), pattern))
+
+
+def _static_glob_prefix(pattern: str) -> str:
+    normalized = os.path.abspath(os.path.normpath(pattern))
+    drive, tail = os.path.splitdrive(normalized)
+    prefix_parts: list[str] = []
+
+    for part in tail.split(os.sep):
+        if not part:
+            continue
+        if glob.has_magic(part):
+            break
+        prefix_parts.append(part)
+
+    if drive:
+        root = drive + os.sep
+    elif normalized.startswith(os.sep):
+        root = os.sep
+    else:
+        root = os.curdir
+
+    if not prefix_parts:
+        return root
+    return os.path.join(root, *prefix_parts)
+
+
+def resolve_bounded_base(base_dir: str, candidate: str) -> str | None:
+    root = os.path.realpath(base_dir)
+    resolved = _absolute_pattern(root, candidate)
+    if not _is_inside_root(resolved, root):
+        return None
+    return os.path.normpath(resolved)
+
+
+def safe_glob_paths(
+    base_dir: str,
+    pattern: str,
+    *,
+    allowed_suffixes: frozenset[str] | set[str] | None = None,
+    max_matches: int = MAX_TYPESCRIPT_GLOB_MATCHES,
+) -> list[str]:
+    root = os.path.realpath(base_dir)
+    full_pattern = _absolute_pattern(root, pattern)
+    search_base = _static_glob_prefix(full_pattern)
+
+    if not _is_inside_root(search_base, root):
+        return []
+
+    matches: list[str] = []
+    for candidate in glob.iglob(full_pattern, recursive=True):
+        real_path = os.path.realpath(candidate)
+        if not _is_inside_root(real_path, root):
+            continue
+        if not os.path.isfile(real_path):
+            continue
+        if allowed_suffixes and Path(real_path).suffix.lower() not in allowed_suffixes:
+            continue
+
+        matches.append(real_path)
+        if len(matches) >= max_matches:
+            break
+
+    return matches

--- a/test/test_ts_exports.py
+++ b/test/test_ts_exports.py
@@ -15,6 +15,7 @@ from skylos.visitors.languages.typescript.analysis import (
     find_dead_ts_files,
     _is_nextjs_convention_file,
     _NEXTJS_CONVENTION_EXPORTS,
+    _discover_vitest_config_entries,
 )
 
 
@@ -730,6 +731,68 @@ export default defineConfig({
         )
 
         assert dead_files == []
+
+    def test_import_meta_glob_ignores_absolute_outside_file_root(self, tmp_path):
+        app_file = tmp_path / "src" / "main.ts"
+        outside_file = tmp_path / "outside" / "leak.ts"
+
+        app_file.parent.mkdir(parents=True, exist_ok=True)
+        outside_file.parent.mkdir(parents=True, exist_ok=True)
+        outside_file.write_text("export const leak = true;\n", encoding="utf-8")
+        app_file.write_text(
+            f"const routes = import.meta.glob('{outside_file.parent}/**/*.ts');\n",
+            encoding="utf-8",
+        )
+
+        raw_imports = scan_typescript_file(str(app_file))[12]
+
+        assert raw_imports == []
+
+    def test_import_meta_glob_ignores_parent_traversal(self, tmp_path):
+        app_file = tmp_path / "src" / "main.ts"
+        outside_file = tmp_path / "outside" / "leak.ts"
+
+        app_file.parent.mkdir(parents=True, exist_ok=True)
+        outside_file.parent.mkdir(parents=True, exist_ok=True)
+        outside_file.write_text("export const leak = true;\n", encoding="utf-8")
+        app_file.write_text(
+            "const routes = import.meta.glob('../outside/**/*.ts');\n",
+            encoding="utf-8",
+        )
+
+        raw_imports = scan_typescript_file(str(app_file))[12]
+
+        assert raw_imports == []
+
+    def test_vitest_config_root_cannot_escape_project_root(self, tmp_path):
+        project_root = tmp_path / "project"
+        outside_file = tmp_path / "outside" / "checks" / "login.ts"
+        vitest_config = project_root / "vitest.config.ts"
+
+        project_root.mkdir(parents=True, exist_ok=True)
+        outside_file.parent.mkdir(parents=True, exist_ok=True)
+        outside_file.write_text("export const leak = true;\n", encoding="utf-8")
+        vitest_config.write_text(
+            f"""
+import {{ defineConfig }} from "vitest/config";
+
+export default defineConfig({{
+  root: "{outside_file.parent.parent}",
+  test: {{
+    include: ["**/*.ts"],
+  }},
+}});
+""",
+            encoding="utf-8",
+        )
+
+        entries = _discover_vitest_config_entries(
+            str(vitest_config),
+            {str(outside_file.resolve())},
+            str(project_root),
+        )
+
+        assert entries == set()
 
 
 class TestTypeScriptUnusedExports:

--- a/test/test_typescript_safe_glob.py
+++ b/test/test_typescript_safe_glob.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from skylos.visitors.languages.typescript.safe_glob import safe_glob_paths
+
+
+def test_safe_glob_rejects_parent_traversal(tmp_path):
+    root = tmp_path / "project"
+    outside = tmp_path / "outside" / "leak.ts"
+
+    root.mkdir()
+    outside.parent.mkdir()
+    outside.write_text("export const leak = true;\n", encoding="utf-8")
+
+    matches = safe_glob_paths(
+        str(root),
+        "../outside/**/*.ts",
+        allowed_suffixes={".ts"},
+    )
+
+    assert matches == []
+
+
+def test_safe_glob_caps_matches(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    for index in range(8):
+        path = root / f"entry_{index}.ts"
+        path.write_text("export const value = true;\n", encoding="utf-8")
+
+    matches = safe_glob_paths(
+        str(root),
+        "*.ts",
+        allowed_suffixes={".ts"},
+        max_matches=3,
+    )
+
+    assert len(matches) == 3
+    assert all(Path(match).suffix == ".ts" for match in matches)


### PR DESCRIPTION
## Summary

  - Add bounded TypeScript glob expansion helper with root containment and match caps
  - Use it for `import.meta.glob()` source expansion
  - Use it for Vite/Vitest config-derived entry discovery

## Why

  Untrusted JS/TS source and config literals could trigger recursive glob expansion outside the scan root before filtering.

## Tests

  - `pytest test/test_ts_exports.py`
  - `pytest test/test_typescript_resolve.py`
  - `pytest test/test_typescript.py test/test_typescript_expanded.py`
  - `pytest test/test_typescript_safe_glob.py`