### PR TITLE
fix(scanner): bound language assignment scans

### DIFF
--- a/skylos/visitors/languages/java/danger.py
+++ b/skylos/visitors/languages/java/danger.py
@@ -12,6 +12,7 @@ from skylos.constants import (
     MIN_SECRET_LENGTH,
     get_non_library_dir_kind,
 )
+from skylos.visitors.languages.statement_scan import iter_semicolon_assignments
 from skylos.visitors.languages.java.flow import scan_java_security_flows
 
 try:
@@ -94,10 +95,6 @@ _ARCHIVE_GUARD_HINTS = (
     "toRealPath(",
     "getCanonicalPath(",
     "getCanonicalFile(",
-)
-
-_LOCAL_ALIAS_PATTERN = re.compile(
-    r"(?ms)^\s*(?:(?:final)\s+)*(?:[\w<>\[\],.?]+\s+)?(?P<var>[A-Za-z_]\w*)\s*=\s*(?P<expr>.*?);",
 )
 
 _REQUEST_SOURCE_PATTERNS = (
@@ -350,11 +347,10 @@ def _collect_canonical_string_vars(lines: list[str]) -> tuple[set[str], set[str]
     slash_terminated_vars: set[str] = set()
 
     for line in lines:
-        match = _LOCAL_ALIAS_PATTERN.match(line)
-        if not match:
+        assignments = iter_semicolon_assignments(line)
+        if not assignments:
             continue
-        var = match.group("var")
-        expr = match.group("expr")
+        _, var, expr = assignments[0]
         if "getCanonicalPath(" not in expr:
             continue
         canonical_vars.add(var)
@@ -484,10 +480,7 @@ def _extract_call_args(line: str, token: str) -> list[str]:
 
 
 def _iter_assignment_events(text: str) -> list[tuple[int, str, str]]:
-    return [
-        (text[: match.start()].count("\n"), match.group("var"), match.group("expr"))
-        for match in _LOCAL_ALIAS_PATTERN.finditer(text)
-    ]
+    return iter_semicolon_assignments(text)
 
 
 def _iter_sink_calls(

--- a/skylos/visitors/languages/statement_scan.py
+++ b/skylos/visitors/languages/statement_scan.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import re
+
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
+_CONTROL_KEYWORDS = frozenset(
+    {
+        "case",
+        "catch",
+        "do",
+        "else",
+        "for",
+        "if",
+        "return",
+        "switch",
+        "throw",
+        "try",
+        "while",
+    }
+)
+_DECLARATION_KEYWORDS = frozenset(
+    {
+        "const",
+        "final",
+        "let",
+        "var",
+    }
+)
+_MAX_CONTINUATION_LINES = 8
+_MAX_EXPR_CHARS = 4096
+
+
+def _assignment_index(statement: str) -> int:
+    in_string: str | None = None
+    escaped = False
+    index = 0
+
+    while index < len(statement):
+        char = statement[index]
+
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == in_string:
+                in_string = None
+            index += 1
+            continue
+
+        if char in {'"', "'", "`"}:
+            in_string = char
+            index += 1
+            continue
+
+        if char == "=":
+            prev_char = statement[index - 1] if index > 0 else ""
+            next_char = statement[index + 1] if index + 1 < len(statement) else ""
+            if prev_char not in {"=", "!", "<", ">"} and next_char not in {
+                "=",
+                ">",
+            }:
+                return index
+
+        index += 1
+
+    return -1
+
+
+def _assignment_alias(lhs: str) -> str | None:
+    lhs = lhs.strip()
+    if not lhs:
+        return None
+
+    first = lhs.split(None, 1)[0].rstrip("(")
+    if first in _CONTROL_KEYWORDS:
+        return None
+    if "(" in lhs or ")" in lhs or "{" in lhs or "}" in lhs:
+        return None
+
+    remainder = lhs
+    for keyword in _DECLARATION_KEYWORDS:
+        prefix = f"{keyword} "
+        if remainder.startswith(prefix):
+            remainder = remainder[len(prefix) :].strip()
+            break
+
+    if remainder.startswith(("{", "[")):
+        return None
+    if ":" in remainder:
+        remainder = remainder.split(":", 1)[0].strip()
+
+    names = _IDENTIFIER_RE.findall(remainder)
+    if not names:
+        return None
+
+    alias = names[-1]
+    if alias in _CONTROL_KEYWORDS or alias in _DECLARATION_KEYWORDS:
+        return None
+    return alias
+
+
+def _parse_assignment_statement(statement: str) -> tuple[str, str] | None:
+    stripped = statement.strip()
+    if not stripped:
+        return None
+
+    index = _assignment_index(stripped)
+    if index < 0:
+        return None
+
+    alias = _assignment_alias(stripped[:index])
+    if not alias:
+        return None
+
+    expr = stripped[index + 1 :].strip()
+    if not expr:
+        return None
+
+    return alias, expr
+
+
+def _trim_expr(expr: str) -> str:
+    if ";" in expr:
+        return expr.split(";", 1)[0].strip()
+    return expr.strip()
+
+
+def _complete_expr(lines: list[str], line_index: int, expr: str) -> str:
+    parts = [_trim_expr(expr)]
+    if ";" in expr:
+        return parts[0]
+
+    for offset in range(1, _MAX_CONTINUATION_LINES + 1):
+        next_index = line_index + offset
+        if next_index >= len(lines):
+            break
+        next_line = lines[next_index]
+        parts.append(_trim_expr(next_line))
+        if ";" in next_line:
+            break
+        if sum(len(part) for part in parts) >= _MAX_EXPR_CHARS:
+            break
+
+    joined = " ".join(part for part in parts if part)
+    if len(joined) > _MAX_EXPR_CHARS:
+        return joined[:_MAX_EXPR_CHARS]
+    return joined
+
+
+def iter_semicolon_assignments(text: str) -> list[tuple[int, str, str]]:
+    assignments: list[tuple[int, str, str]] = []
+    lines = text.splitlines()
+
+    for line_index, line in enumerate(lines):
+        parsed = _parse_assignment_statement(line)
+        if not parsed:
+            continue
+        alias, expr = parsed
+        assignments.append((line_index, alias, _complete_expr(lines, line_index, expr)))
+
+    return assignments

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -12,6 +12,7 @@ from skylos.constants import (
     MIN_SECRET_LENGTH,
     get_non_library_dir_kind,
 )
+from skylos.visitors.languages.statement_scan import iter_semicolon_assignments
 
 try:
     TS_LANG: Language | None = Language(tsts.language_typescript())
@@ -929,10 +930,6 @@ _ARCHIVE_ENTRY_PROPERTY_PATTERN = re.compile(
     r"\b(?:(?:entry|header|[A-Za-z_$][A-Za-z0-9_$]*Entry)\.(?:path|fileName|name))\b"
 )
 
-_ARCHIVE_ALIAS_PATTERN = re.compile(
-    r"(?ms)^\s*(?:(?:const|let|var)\s+)?(?P<alias>[A-Za-z_$][A-Za-z0-9_$]*)(?:\s*:\s*[^=;]+)?\s*=\s*(?P<expr>.*?);"
-)
-
 _ARCHIVE_SINK_ARGS = {
     "fs.createWriteStream(": (0,),
     "createWriteStream(": (0,),
@@ -1157,12 +1154,8 @@ def _check_archive_extraction_path_traversal(
         latest_assignment: dict[str, int] = {}
         events: list[tuple[int, int, object]] = []
         events.extend(
-            (
-                scope_text[: match.start()].count("\n"),
-                0,
-                (match.group("alias"), match.group("expr")),
-            )
-            for match in _ARCHIVE_ALIAS_PATTERN.finditer(scope_text)
+            (line_offset, 0, (alias, expr))
+            for line_offset, alias, expr in iter_semicolon_assignments(scope_text)
         )
         events.extend(
             (line_offset, 1, args)

--- a/test/test_statement_scan.py
+++ b/test/test_statement_scan.py
@@ -1,0 +1,34 @@
+from time import perf_counter
+
+from skylos.visitors.languages.statement_scan import iter_semicolon_assignments
+
+
+def test_iter_semicolon_assignments_extracts_java_and_typescript_aliases():
+    source = """
+    final String name = entry.getName();
+    const fileName: string = entry.fileName;
+    outputPath = path.join(
+      "/tmp/out",
+      fileName
+    );
+    """
+
+    events = iter_semicolon_assignments(source)
+
+    assert events[0][1:] == ("name", "entry.getName()")
+    assert events[1][1:] == ("fileName", "entry.fileName")
+    assert events[2][1] == "outputPath"
+    assert "fileName" in events[2][2]
+
+
+def test_iter_semicolon_assignments_handles_semicolonless_alias_storm_quickly():
+    source = "\n".join(
+        f"const alias{index} = entry.path" for index in range(5000)
+    )
+
+    started = perf_counter()
+    events = iter_semicolon_assignments(source)
+    elapsed = perf_counter() - started
+
+    assert len(events) == 5000
+    assert elapsed < 2.0

--- a/test/test_typescript_archive_security.py
+++ b/test/test_typescript_archive_security.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from time import perf_counter
 
 from skylos.visitors.languages.typescript import scan_typescript_file
 
@@ -408,3 +409,25 @@ function extract(entry: { fileName: string }) {
 """,
     )
     assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_semicolonless_archive_alias_storm_does_not_dos_scan(tmp_path):
+    aliases = "\n".join(
+        f"    const alias{index} = entry.path" for index in range(1500)
+    )
+    started = perf_counter()
+
+    findings = _scan_ts_file(
+        tmp_path,
+        "archive.js",
+        f"""const unzipper = require("unzipper");
+
+function extract(entry) {{
+{aliases}
+}}
+""",
+    )
+    elapsed = perf_counter() - started
+
+    assert "SKY-D215" not in _rule_ids(findings)
+    assert elapsed < 2.0


### PR DESCRIPTION
## Summary

  - Replace Java and TypeScript regex-based assignment extraction with a bounded linear scanner
  - Remove the unbounded `_LOCAL_ALIAS_PATTERN` and `_ARCHIVE_ALIAS_PATTERN` paths

## Tests
  - `pytest test/test_statement_scan.py`
  - `pytest test/test_typescript_archive_security.py`
  - `pytest test/test_java_security.py`
  - `pytest test/test_typescript_expanded.py test/test_typescript_archive_security.py`
  - `pytest test/test_webhook_signature.py`