### PR TITLE
fix(gate): allow non-critical threshold tuning

### DIFF
--- a/skylos/core/gatekeeper.py
+++ b/skylos/core/gatekeeper.py
@@ -169,14 +169,15 @@ def _append_threshold_reason(reasons, *, count, limit, message_template):
     return True
 
 
-def _strictest_limit(value, baseline):
-    if baseline is None:
-        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-            return None
-        return value
+def _safe_gate_limit(value, default):
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        return baseline
-    return min(value, baseline)
+        return default
+    return value
+
+
+def _non_relaxable_gate_limit(value, baseline):
+    safe_value = _safe_gate_limit(value, baseline)
+    return min(safe_value, baseline)
 
 
 def _effective_gate_config(config):
@@ -186,15 +187,13 @@ def _effective_gate_config(config):
 
     effective = dict(gate_config)
     effective["fail_on_critical"] = True
-    for key in (
-        "max_critical",
-        "max_high",
-        "max_security",
-        "max_quality",
-        "max_secrets",
-        "max_dead_code",
-    ):
-        effective[key] = _strictest_limit(
+    for key in ("max_critical", "max_secrets"):
+        effective[key] = _non_relaxable_gate_limit(
+            gate_config.get(key),
+            BASELINE_GATE_CONFIG[key],
+        )
+    for key in ("max_high", "max_security", "max_quality", "max_dead_code"):
+        effective[key] = _safe_gate_limit(
             gate_config.get(key),
             BASELINE_GATE_CONFIG[key],
         )

--- a/skylos/core/gatekeeper.py
+++ b/skylos/core/gatekeeper.py
@@ -21,6 +21,15 @@ DEAD_CODE_RESULT_KEYS = (
     "unused_parameters",
 )
 AGENT_GATE_PREFIX = "Agent gate: "
+BASELINE_GATE_CONFIG = {
+    "fail_on_critical": True,
+    "max_critical": 0,
+    "max_high": 5,
+    "max_security": 10,
+    "max_quality": 10,
+    "max_secrets": 0,
+    "max_dead_code": None,
+}
 ADVISORY_QUALITY_RULE_IDS = {"SKY-Q802", "SKY-Q803"}
 
 
@@ -158,6 +167,38 @@ def _append_threshold_reason(reasons, *, count, limit, message_template):
         reasons.append(message_template.format(count=count, limit=limit))
         return False
     return True
+
+
+def _strictest_limit(value, baseline):
+    if baseline is None:
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            return None
+        return value
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return baseline
+    return min(value, baseline)
+
+
+def _effective_gate_config(config):
+    gate_config = config.get("gate", {}) if isinstance(config, dict) else {}
+    if not isinstance(gate_config, dict):
+        gate_config = {}
+
+    effective = dict(gate_config)
+    effective["fail_on_critical"] = True
+    for key in (
+        "max_critical",
+        "max_high",
+        "max_security",
+        "max_quality",
+        "max_secrets",
+        "max_dead_code",
+    ):
+        effective[key] = _strictest_limit(
+            gate_config.get(key),
+            BASELINE_GATE_CONFIG[key],
+        )
+    return effective
 
 
 def _agent_gate_reason(message):
@@ -410,7 +451,7 @@ def check_gate(results, config, strict=False, provenance=None):
     quality = results.get("quality", []) or []
     gate_quality = _gate_quality_findings(quality)
     secrets = results.get("secrets", []) or []
-    gate_config = config.get("gate", {}) if config else {}
+    gate_config = _effective_gate_config(config)
 
     if strict:
         return _check_strict_gate(

--- a/test/test_gatekeeper.py
+++ b/test/test_gatekeeper.py
@@ -141,6 +141,26 @@ def test_run_gate_interaction_legacy_typeerror_fallback(monkeypatch):
     assert calls == [({}, {})]
 
 
+def test_run_gate_interaction_relaxed_config_does_not_run_command(monkeypatch):
+    result = {
+        "danger": [{"severity": "critical", "file": "app.py"}],
+        "quality": [],
+        "secrets": [],
+    }
+    calls = []
+
+    monkeypatch.setattr(gk.subprocess, "run", lambda command: calls.append(command))
+
+    rc = gk.run_gate_interaction(
+        result=result,
+        config={"gate": {"fail_on_critical": False, "max_critical": 999}},
+        command_to_run=["deploy"],
+    )
+
+    assert rc == 1
+    assert calls == []
+
+
 class FakeProvenance:
     def __init__(self, agent_files):
         self.agent_files = agent_files
@@ -230,6 +250,54 @@ def test_check_gate_quality_threshold_ignores_advisory_iad_quality():
 
     assert passed is True
     assert reasons == []
+
+
+def test_check_gate_project_config_cannot_relax_builtin_thresholds():
+    danger = [{"severity": "critical", "file": "app.py"}]
+    for index in range(10):
+        danger.append({"severity": "medium", "file": f"app_{index}.py"})
+
+    quality = []
+    for index in range(11):
+        quality.append({"rule_id": f"SKY-Q{index}", "file": "app.py"})
+
+    results = {
+        "danger": danger,
+        "quality": quality,
+        "secrets": [{"rule_id": "SKY-S101", "file": "app.py"}],
+    }
+    config = {
+        "gate": {
+            "fail_on_critical": False,
+            "max_critical": 999,
+            "max_high": 999,
+            "max_security": 999,
+            "max_quality": 999,
+            "max_secrets": 999,
+        }
+    }
+
+    passed, reasons = gk.check_gate(results, config)
+
+    assert passed is False
+    assert "1 critical security issue(s)" in reasons
+    assert "11 total security issues (max: 10)" in reasons
+    assert "11 quality issues (max: 10)" in reasons
+    assert "1 secrets issues (max: 0)" in reasons
+
+
+def test_check_gate_project_config_can_make_thresholds_stricter():
+    results = {
+        "danger": [{"severity": "high", "file": "app.py"}],
+        "quality": [],
+        "secrets": [],
+    }
+    config = {"gate": {"max_high": 0}}
+
+    passed, reasons = gk.check_gate(results, config)
+
+    assert passed is False
+    assert reasons == ["1 high severity issues (max: 0)"]
 
 
 def test_check_gate_agent_stricter_threshold():
@@ -360,7 +428,8 @@ def test_check_gate_agent_no_agent_config_skips():
     config = {"gate": {"fail_on_critical": False, "max_critical": 10}}
     prov = FakeProvenance(agent_files=["ai.py"])
     passed, reasons = gk.check_gate(results, config, provenance=prov)
-    assert passed is True
+    assert passed is False
+    assert reasons == ["1 critical security issue(s)"]
 
 
 def test_check_gate_agent_no_agent_files_skips():

--- a/test/test_gatekeeper.py
+++ b/test/test_gatekeeper.py
@@ -252,7 +252,7 @@ def test_check_gate_quality_threshold_ignores_advisory_iad_quality():
     assert reasons == []
 
 
-def test_check_gate_project_config_cannot_relax_builtin_thresholds():
+def test_check_gate_project_config_cannot_relax_critical_or_secrets():
     danger = [{"severity": "critical", "file": "app.py"}]
     for index in range(10):
         danger.append({"severity": "medium", "file": f"app_{index}.py"})
@@ -280,10 +280,70 @@ def test_check_gate_project_config_cannot_relax_builtin_thresholds():
     passed, reasons = gk.check_gate(results, config)
 
     assert passed is False
-    assert "1 critical security issue(s)" in reasons
-    assert "11 total security issues (max: 10)" in reasons
-    assert "11 quality issues (max: 10)" in reasons
-    assert "1 secrets issues (max: 0)" in reasons
+    assert reasons == [
+        "1 critical security issue(s)",
+        "1 secrets issues (max: 0)",
+    ]
+
+
+def test_check_gate_project_config_can_relax_non_critical_thresholds():
+    danger = []
+    for index in range(6):
+        danger.append({"severity": "high", "file": f"app_{index}.py"})
+
+    quality = []
+    for index in range(11):
+        quality.append({"rule_id": f"SKY-Q{index}", "file": "app.py"})
+
+    results = {
+        "danger": danger,
+        "quality": quality,
+        "secrets": [],
+    }
+    config = {
+        "gate": {
+            "max_high": 999,
+            "max_security": 999,
+            "max_quality": 999,
+        }
+    }
+
+    passed, reasons = gk.check_gate(results, config)
+
+    assert passed is True
+    assert reasons == []
+
+
+def test_check_gate_invalid_project_threshold_types_use_defaults():
+    danger = []
+    for index in range(11):
+        danger.append({"severity": "medium", "file": f"app_{index}.py"})
+
+    quality = []
+    for index in range(11):
+        quality.append({"rule_id": f"SKY-Q{index}", "file": "app.py"})
+
+    results = {
+        "danger": danger,
+        "quality": quality,
+        "secrets": [{"rule_id": "SKY-S101", "file": "app.py"}],
+    }
+    config = {
+        "gate": {
+            "max_security": "999",
+            "max_quality": True,
+            "max_secrets": "999",
+        }
+    }
+
+    passed, reasons = gk.check_gate(results, config)
+
+    assert passed is False
+    assert reasons == [
+        "11 total security issues (max: 10)",
+        "11 quality issues (max: 10)",
+        "1 secrets issues (max: 0)",
+    ]
 
 
 def test_check_gate_project_config_can_make_thresholds_stricter():


### PR DESCRIPTION
## Summary

  Fixed the `--gate` without making gate policy super rigid.

## Changes

  - Prevent project config from relaxing:
    - `max_critical`
    - `max_secrets`
  - Keep these thresholds tunable:
    - `max_high`
    - `max_security`
    - `max_quality`
    - `max_dead_code`

## Tests

  - `pytest test/test_gatekeeper.py test/test_cicd_gate.py test/test_gate_kwargs.py`