### PR TITLE
fix(typescript): bound duplicate condition scan

### DIFF
--- a/skylos/visitors/languages/typescript/quality.py
+++ b/skylos/visitors/languages/typescript/quality.py
@@ -58,6 +58,7 @@ _FUNC_PATTERN = """
 """
 
 _AWAIT_PATTERN = "(await_expression) @await_expr"
+_CONDITION_PREVIEW_LIMIT = 120
 
 
 def _get_query(lang: Language, key: str, pattern: str) -> Query | None:
@@ -243,12 +244,14 @@ def _check_duplicate_conditions(
 ) -> None:
     """SKY-Q305: Detect identical condition expressions in if-else-if chains."""
     stack = [root_node]
+    processed_chain_nodes: set[int] = set()
     while stack:
         node = stack.pop()
-        if node.type == "if_statement":
+        if node.type == "if_statement" and node.id not in processed_chain_nodes:
             conditions: list[tuple[str, int]] = []
             current = node
             while current and current.type == "if_statement":
+                processed_chain_nodes.add(current.id)
                 cond = current.child_by_field_name("condition")
                 if cond:
                     cond_text = _get_text(source, cond)
@@ -268,11 +271,12 @@ def _check_duplicate_conditions(
                 seen: dict[str, int] = {}
                 for cond_text, cond_line in conditions:
                     if cond_text in seen:
+                        preview = _condition_preview(cond_text)
                         findings.append(
                             {
                                 "rule_id": "SKY-Q305",
                                 "severity": "MEDIUM",
-                                "message": f"Duplicate condition '{cond_text}' in if-else chain (first seen at line {seen[cond_text]})",
+                                "message": f"Duplicate condition '{preview}' in if-else chain (first seen at line {seen[cond_text]})",
                                 "file": str(file_path),
                                 "line": cond_line,
                                 "col": 0,
@@ -283,6 +287,13 @@ def _check_duplicate_conditions(
 
         for child in node.children:
             stack.append(child)
+
+
+def _condition_preview(cond_text: str) -> str:
+    if len(cond_text) <= _CONDITION_PREVIEW_LIMIT:
+        return cond_text
+
+    return cond_text[: _CONDITION_PREVIEW_LIMIT - 3] + "..."
 
 
 def _check_await_in_loop(

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -1208,6 +1208,47 @@ class TestNewQualityRules:
         ids = {f["rule_id"] for f in quality}
         assert "SKY-Q305" in ids
 
+    def test_duplicate_condition_else_if_chain_scanned_once(self, tmp_path):
+        chain_length = 8
+        lines = [
+            "function check(x: number) {",
+            "    if (x === 1) { return 0; }",
+        ]
+        for index in range(1, chain_length):
+            lines.append(f"    else if (x === 1) {{ return {index}; }}")
+        lines.append("    return -1;")
+        lines.append("}")
+        code = "\n".join(lines)
+
+        _, _, quality, _ = _scan_ts(tmp_path, code)
+        q305 = []
+        for finding in quality:
+            if finding["rule_id"] == "SKY-Q305":
+                q305.append(finding)
+
+        assert len(q305) == chain_length - 1
+
+    def test_duplicate_condition_message_truncates_long_condition(self, tmp_path):
+        long_value = "a" * 200
+        condition = f"x === '{long_value}'"
+        code = (
+            "function check(x: string) {\n"
+            f"    if ({condition}) {{ return 1; }}\n"
+            f"    else if ({condition}) {{ return 2; }}\n"
+            "    return 0;\n"
+            "}\n"
+        )
+
+        _, _, quality, _ = _scan_ts(tmp_path, code)
+        q305 = []
+        for finding in quality:
+            if finding["rule_id"] == "SKY-Q305":
+                q305.append(finding)
+
+        assert len(q305) == 1
+        assert "..." in q305[0]["message"]
+        assert long_value not in q305[0]["message"]
+
     def test_no_duplicate_condition(self, tmp_path):
         """No duplicate conditions should not trigger SKY-Q305."""
         code = (


### PR DESCRIPTION
## Summary

  - Checker now scans each `if` / `else if` chain once instead of reprocessing every inner
  `else if` as another chain head. 
  - Avoid duplicate suffix rescans that caused quadratic finding growth.
  - Truncate long duplicate-condition previews in Q305 messages.

## Tests

  - `pytest test/test_typescript_expanded.py`