### PR TITLE
fix(precommit): block high severity quality findings

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -565,6 +565,7 @@ def _filter_precommit_findings_to_changed_lines(
 
 
 LOCAL_PRECOMMIT_BLOCKING_QUALITY_RULE_IDS = {"SKY-L021"}
+LOCAL_PRECOMMIT_BLOCKING_QUALITY_SEVERITIES = {"CRITICAL", "HIGH"}
 
 
 def _precommit_blocks_finding(finding: dict) -> bool:
@@ -573,7 +574,13 @@ def _precommit_blocks_finding(finding: dict) -> bool:
         return True
     if category != "quality":
         return True
-    return str(finding.get("rule_id", "")) in LOCAL_PRECOMMIT_BLOCKING_QUALITY_RULE_IDS
+
+    rule_id = str(finding.get("rule_id", ""))
+    if rule_id in LOCAL_PRECOMMIT_BLOCKING_QUALITY_RULE_IDS:
+        return True
+
+    severity = str(finding.get("severity", "")).upper()
+    return severity in LOCAL_PRECOMMIT_BLOCKING_QUALITY_SEVERITIES
 
 
 def _apply_precommit_gate_policy(findings: list[dict]) -> tuple[list[dict], int]:

--- a/test/test_cli_precommit.py
+++ b/test/test_cli_precommit.py
@@ -768,3 +768,78 @@ def test_agent_pre_commit_suppresses_structural_quality_noise_locally(tmp_path):
     assert "non-blocking quality finding(s)" in printed
     assert "No staged security, secrets, or quality issues" in printed
     assert "Function is 54 lines long" not in printed
+
+
+def test_agent_pre_commit_blocks_high_severity_quality_findings(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("password = 'secret'\n", encoding="utf-8")
+
+    console = Mock()
+    staged = Mock(stdout="app.py\n", returncode=0)
+    cached_diff = Mock(
+        stdout=(
+            "diff --git a/app.py b/app.py\n"
+            "--- a/app.py\n"
+            "+++ b/app.py\n"
+            "@@ -1 +1 @@\n"
+        ),
+        returncode=0,
+    )
+    unstaged = Mock(stdout="", returncode=0)
+    result = {
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "danger": [],
+        "quality": [
+            {
+                "rule_id": "SKY-L014",
+                "file": "app.py",
+                "line": 1,
+                "severity": "HIGH",
+                "message": "Hardcoded credential in 'password'.",
+            },
+            {
+                "rule_id": "SKY-Q301",
+                "file": "app.py",
+                "line": 1,
+                "severity": "MEDIUM",
+                "message": "Function is 54 lines long (limit: 50).",
+            },
+        ],
+        "secrets": [],
+    }
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return unstaged
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+        patch("skylos.cli.find_project_root", return_value=repo),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.core.baseline.load_baseline", return_value=None),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 1
+    printed = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "1 issue(s) found in staged files" in printed
+    assert "1 quality" in printed
+    assert "Hardcoded credential" in printed
+    assert "Function is 54 lines long" not in printed


### PR DESCRIPTION
## Summary

  - Fixes local pre-commit suppression of security-sensitive quality findings.
  - Keep blocking all `security` and `secrets` findings.
  - Keep explicit blocking for `SKY-L021`.
  - Block `quality` findings when severity is `HIGH` or `CRITICAL`.
  
## Tests

  - `pytest test/test_cli_precommit.py`
