### PR TITLE
fix(excludes): honor absolute scan-root paths

### DIFF
--- a/skylos/core/file_discovery.py
+++ b/skylos/core/file_discovery.py
@@ -7,6 +7,120 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 
+def _normalize_path_text(value: str) -> str:
+    return value.replace("\\", "/").rstrip("/")
+
+
+def _normalized_parts(value: str) -> tuple[str, ...]:
+    return tuple(part for part in value.split("/") if part and part != ".")
+
+
+def _dedupe_candidates(candidates: list[str]) -> list[str]:
+    seen = set()
+    deduped = []
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            deduped.append(candidate)
+    return deduped
+
+
+def _absolute_exclude_candidate(exclude_folder: str, root_path: Path) -> str | None:
+    exclude_path = Path(exclude_folder)
+    if not exclude_path.is_absolute():
+        return None
+
+    try:
+        rel = exclude_path.resolve(strict=False).relative_to(
+            root_path.resolve(strict=False)
+        )
+    except (OSError, ValueError):
+        return None
+
+    return _normalize_path_text(str(rel))
+
+
+def _root_prefixed_exclude_candidate(exclude_normalized: str, root_path: Path) -> str | None:
+    if "/" not in exclude_normalized:
+        return None
+
+    exclude_parts = _normalized_parts(exclude_normalized)
+    root_parts = tuple(
+        part
+        for part in root_path.resolve(strict=False).parts
+        if part not in {"", os.sep}
+    )
+    max_prefix = min(len(exclude_parts), len(root_parts))
+    for prefix_size in range(max_prefix, 0, -1):
+        if exclude_parts[:prefix_size] == root_parts[-prefix_size:]:
+            return "/".join(exclude_parts[prefix_size:]) or None
+    return None
+
+
+def _exclude_candidates(exclude_folder: str, root_path: Path) -> list[str]:
+    exclude_normalized = _normalize_path_text(exclude_folder)
+    candidates = [exclude_normalized]
+
+    if "*" not in exclude_normalized:
+        absolute_candidate = _absolute_exclude_candidate(exclude_folder, root_path)
+        prefixed_candidate = _root_prefixed_exclude_candidate(
+            exclude_normalized, root_path
+        )
+        if absolute_candidate:
+            candidates.append(absolute_candidate)
+        if prefixed_candidate:
+            candidates.append(prefixed_candidate)
+
+    return _dedupe_candidates(candidates)
+
+
+def _glob_patterns(exclude_normalized: str) -> set[str]:
+    patterns = {exclude_normalized}
+    if exclude_normalized.startswith("**/"):
+        patterns.add(exclude_normalized[3:])
+    if exclude_normalized.endswith("/**"):
+        patterns.add(exclude_normalized[:-3])
+    if exclude_normalized.startswith("**/") and exclude_normalized.endswith("/**"):
+        patterns.add(exclude_normalized[3:-3])
+    return patterns
+
+
+def _matches_glob_exclude(
+    rel_path_str: str, path_parts: tuple[str, ...], exclude_normalized: str
+) -> bool:
+    for pattern in _glob_patterns(exclude_normalized):
+        if rel_path_str == pattern or fnmatchcase(rel_path_str, pattern):
+            return True
+        if pattern.endswith("/**"):
+            directory = pattern[:-3]
+            if rel_path_str == directory or rel_path_str.startswith(directory + "/"):
+                return True
+
+    suffix = exclude_normalized.replace("*", "")
+    return any(part.endswith(suffix) for part in path_parts)
+
+
+def _matches_nested_exclude(rel_path_str: str, exclude_normalized: str) -> bool:
+    if rel_path_str == exclude_normalized:
+        return True
+    if rel_path_str.startswith(exclude_normalized + "/"):
+        return True
+    check = "/" + rel_path_str + "/"
+    return "/" + exclude_normalized + "/" in check
+
+
+def _path_matches_exclude(
+    rel_path_str: str, path_parts: tuple[str, ...], exclude_normalized: str
+) -> bool:
+    if "*" in exclude_normalized:
+        return _matches_glob_exclude(rel_path_str, path_parts, exclude_normalized)
+
+    if "/" in exclude_normalized:
+        return _matches_nested_exclude(rel_path_str, exclude_normalized)
+
+    return exclude_normalized in path_parts
+
+
 def should_exclude_path(
     file_path: Path,
     root_path: Path,
@@ -24,53 +138,8 @@ def should_exclude_path(
     rel_path_str = str(rel_path).replace("\\", "/")
 
     for exclude_folder in exclude_folders:
-        exclude_normalized = exclude_folder.replace("\\", "/").rstrip("/")
-
-        if "*" in exclude_normalized:
-            patterns = {exclude_normalized}
-            if exclude_normalized.startswith("**/"):
-                patterns.add(exclude_normalized[3:])
-            if exclude_normalized.endswith("/**"):
-                patterns.add(exclude_normalized[:-3])
-            if exclude_normalized.startswith("**/") and exclude_normalized.endswith(
-                "/**"
-            ):
-                patterns.add(exclude_normalized[3:-3])
-
-            for pattern in patterns:
-                if rel_path_str == pattern or fnmatchcase(rel_path_str, pattern):
-                    return True
-                if pattern.endswith("/**"):
-                    directory = pattern[:-3]
-                    if rel_path_str == directory or rel_path_str.startswith(
-                        directory + "/"
-                    ):
-                        return True
-
-            suffix = exclude_normalized.replace("*", "")
-            for part in path_parts:
-                if part.endswith(suffix):
-                    return True
-        elif "/" in exclude_normalized:
-            if rel_path_str == exclude_normalized:
-                return True
-            if rel_path_str.startswith(exclude_normalized + "/"):
-                return True
-            check = "/" + rel_path_str + "/"
-            if "/" + exclude_normalized + "/" in check:
-                return True
-
-            root_name = root_path.resolve().name
-            exclude_parts = exclude_normalized.split("/")
-            if exclude_parts[0] == root_name:
-                stripped = "/".join(exclude_parts[1:])
-                if stripped:
-                    if rel_path_str == stripped:
-                        return True
-                    if rel_path_str.startswith(stripped + "/"):
-                        return True
-        else:
-            if exclude_normalized in path_parts:
+        for exclude_normalized in _exclude_candidates(exclude_folder, root_path):
+            if _path_matches_exclude(rel_path_str, path_parts, exclude_normalized):
                 return True
 
     return False

--- a/test/test_exclusions.py
+++ b/test/test_exclusions.py
@@ -143,6 +143,71 @@ class TestPathExclusion(unittest.TestCase):
 
             shutil.rmtree(tmpdir, ignore_errors=True)
 
+    def test_absolute_exclude_under_scan_root(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            target_root = Path(tmpdir) / "app"
+            private_dir = target_root / "private"
+            private_dir.mkdir(parents=True)
+            secret_file = private_dir / "secret.py"
+            secret_file.touch()
+
+            excludes = [str(private_dir)]
+
+            self.assertTrue(
+                self.analyzer._should_exclude_file(secret_file, target_root, excludes),
+                "Absolute exclude under scan root did not match the relative file",
+            )
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_fuller_cwd_relative_exclude_under_scan_root(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            target_root = Path(tmpdir) / "services" / "app"
+            private_dir = target_root / "private"
+            private_dir.mkdir(parents=True)
+            secret_file = private_dir / "secret.py"
+            secret_file.touch()
+
+            excludes = ["services/app/private"]
+
+            self.assertTrue(
+                self.analyzer._should_exclude_file(secret_file, target_root, excludes),
+                "Fuller CWD-relative exclude did not match under the scan root",
+            )
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_get_python_files_filters_absolute_exclude(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            target_root = Path(tmpdir) / "app"
+            private_dir = target_root / "private"
+            public_dir = target_root / "public"
+            private_dir.mkdir(parents=True)
+            public_dir.mkdir(parents=True)
+            secret_file = private_dir / "secret.py"
+            public_file = public_dir / "visible.py"
+            secret_file.write_text("def secret():\n    pass\n", encoding="utf-8")
+            public_file.write_text("def visible():\n    pass\n", encoding="utf-8")
+
+            files, _root = self.analyzer._get_python_files(
+                target_root, exclude_folders=[str(private_dir)]
+            )
+
+            resolved_files = {path.resolve() for path in files}
+            self.assertIn(public_file.resolve(), resolved_files)
+            self.assertNotIn(secret_file.resolve(), resolved_files)
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
     def test_cwd_relative_exclude_with_trailing_slash(self):
         tmpdir = tempfile.mkdtemp()
         try:


### PR DESCRIPTION
## Summary

  - Normalize absolute exclude paths under the scan root to relative paths.
  - Support fuller CWD-relative excludes like `services/app/private` when scanning `services/app`.
  - Preserve existing root-prefixed excludes such as `app/alembic`.
  - Split exclude matching into smaller helpers to keep the gate clean.

## Tests

  - `pytest test/test_exclusions.py test/test_file_discovery.py test/test_analyzer.py`