### PR TITLE
fix(java): tie canonical guards to path sinks

### DIFF
--- a/skylos/visitors/languages/java/danger.py
+++ b/skylos/visitors/languages/java/danger.py
@@ -360,6 +360,24 @@ def _collect_canonical_string_vars(lines: list[str]) -> tuple[set[str], set[str]
     return canonical_vars, slash_terminated_vars
 
 
+def _collect_canonical_string_vars_for_names(
+    lines: list[str], names: set[str]
+) -> set[str]:
+    canonical_vars: set[str] = set()
+
+    for line in lines:
+        assignments = iter_semicolon_assignments(line)
+        if not assignments:
+            continue
+        _, var, expr = assignments[0]
+        if "getCanonicalPath(" not in expr:
+            continue
+        if _line_mentions_names(expr, names | canonical_vars):
+            canonical_vars.add(var)
+
+    return canonical_vars
+
+
 def _expr_is_slash_terminated_base(expr: str) -> bool:
     return any(
         token in expr
@@ -399,7 +417,7 @@ def _has_named_path_guard(
 ) -> bool:
     has_normalize = False
     canonical_vars, slash_terminated_vars = _collect_canonical_string_vars(lines)
-    known_guard_vars = canonical_vars | slash_terminated_vars
+    sink_canonical_vars = _collect_canonical_string_vars_for_names(lines, names)
 
     for idx, line in enumerate(lines):
         mentioned = _names_in_line(line, names)
@@ -407,7 +425,7 @@ def _has_named_path_guard(
         if not mentioned and not (
             has_normalize
             and startswith_line
-            and _line_mentions_names(line, known_guard_vars)
+            and _line_mentions_names(line, sink_canonical_vars)
         ):
             continue
         if any(hint in line for hint in hints):

--- a/test/test_java_security.py
+++ b/test/test_java_security.py
@@ -201,6 +201,32 @@ class App {
     assert "SKY-D215" not in _rule_ids(findings)
 
 
+def test_archive_extraction_unrelated_canonical_guard_still_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import java.util.zip.*;
+
+class App {
+  void unzip(ZipInputStream zis, File destDir) throws Exception {
+    ZipEntry entry;
+    while ((entry = zis.getNextEntry()) != null) {
+      File file = new File(destDir, entry.getName());
+      String targetPath = file.getCanonicalPath();
+      String otherPath = new File("/tmp/other").getCanonicalPath();
+      String otherBase = new File("/tmp/base").getCanonicalPath() + File.separator;
+      if (!otherPath.startsWith(otherBase)) {
+        throw new IOException("bad unrelated path");
+      }
+      FileOutputStream fos = new FileOutputStream(file);
+    }
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
 def test_archive_extraction_mixed_safe_and_unsafe_still_flags(tmp_path):
     findings = _scan_java(
         tmp_path,
@@ -368,6 +394,30 @@ class App {
 """,
     )
     assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_request_path_unrelated_canonical_guard_still_flags(tmp_path):
+    findings = _scan_java(
+        tmp_path,
+        """import java.io.*;
+import javax.servlet.http.HttpServletRequest;
+
+class App {
+  String read(HttpServletRequest request) throws Exception {
+    File base = new File("/srv/data");
+    File target = new File(base, request.getParameter("file"));
+    String targetPath = target.getCanonicalPath();
+    String otherPath = new File("/tmp/other").getCanonicalPath();
+    String otherBase = new File("/tmp/base").getCanonicalPath() + File.separator;
+    if (!otherPath.startsWith(otherBase)) {
+      throw new IllegalArgumentException("bad unrelated path");
+    }
+    return new BufferedReader(new FileReader(target)).readLine();
+  }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
 
 
 def test_request_path_normalize_and_startswith_noop_still_flags(tmp_path):


### PR DESCRIPTION
 ## Summary

  - Fixed Java path-traversal FN where unrelated canonical `startsWith` guards could suppress `SKY-D215`.
  - Track canonical string variables derived from the tainted sink names.
  - Require relaxed canonical `startsWith` guards to mention those sink-derived canonical variables.

  ## Validation

  - `pytest test/test_java_security.py`