### PR TITLE
fix(scan): fail concise on reported findings

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2818,12 +2818,32 @@ def _concise_scan_exit_code(
         )
 
     if not bool(getattr(args, "force", False)):
-        from skylos.core.gatekeeper import check_gate
-
-        passed, _reasons = check_gate(result, {}, strict=True)
-        return 0 if passed else 1
+        return 1 if _has_concise_findings(result) else 0
 
     return 0
+
+
+CONCISE_FINDING_CATEGORIES = (
+    ("unused_functions", "unused function"),
+    ("unused_imports", "unused import"),
+    ("unused_classes", "unused class"),
+    ("unused_variables", "unused variable"),
+    ("unused_parameters", "unused parameter"),
+    ("unused_files", "unused file"),
+    ("unused_fixtures", "unused fixture"),
+    ("danger", "security issue"),
+    ("quality", "quality issue"),
+    ("secrets", "secret"),
+    ("custom_rules", "custom rule"),
+    ("dependency_vulnerabilities", "dependency vulnerability"),
+)
+
+
+def _has_concise_findings(result: dict) -> bool:
+    for category, _label in CONCISE_FINDING_CATEGORIES:
+        if result.get(category):
+            return True
+    return False
 
 
 def _concise_line(item: dict, label: str, root_path=None) -> str:
@@ -2838,22 +2858,8 @@ def _concise_line(item: dict, label: str, root_path=None) -> str:
 
 def _format_concise_results(result: dict, *, root_path=None, limit=None) -> str:
     lines: list[str] = []
-    categories = (
-        ("unused_functions", "unused function"),
-        ("unused_imports", "unused import"),
-        ("unused_classes", "unused class"),
-        ("unused_variables", "unused variable"),
-        ("unused_parameters", "unused parameter"),
-        ("unused_files", "unused file"),
-        ("unused_fixtures", "unused fixture"),
-        ("danger", "security issue"),
-        ("quality", "quality issue"),
-        ("secrets", "secret"),
-        ("custom_rules", "custom rule"),
-        ("dependency_vulnerabilities", "dependency vulnerability"),
-    )
 
-    for category, fallback_label in categories:
+    for category, fallback_label in CONCISE_FINDING_CATEGORIES:
         items = list(result.get(category, []) or [])
         if limit is not None:
             items = items[:limit]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1148,6 +1148,79 @@ def test_main_concise_outputs_clickable_dead_code_and_exits_nonzero(monkeypatch)
     print_badge.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("category", "finding", "expected_line"),
+    [
+        (
+            "dependency_vulnerabilities",
+            {
+                "package": "badpkg",
+                "file": "requirements.txt",
+                "line": 1,
+                "message": "CVE-TEST vulnerable dependency",
+            },
+            "requirements.txt:1  CVE-TEST vulnerable dependency\n",
+        ),
+        (
+            "custom_rules",
+            {
+                "rule_id": "CUSTOM-001",
+                "file": "src/test.py",
+                "line": 3,
+                "message": "custom rule hit",
+            },
+            "src/test.py:3  custom rule hit\n",
+        ),
+    ],
+)
+def test_main_concise_exits_nonzero_for_reported_extra_categories(
+    monkeypatch, category, finding, expected_line
+):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "unused_files": [],
+        "unused_fixtures": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+        "custom_rules": [],
+        "dependency_vulnerabilities": [],
+    }
+    result[category] = [finding]
+
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", "--format", "concise", "--no-provenance", "--sca", "src/test.py"],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress") as progress,
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.render_results") as render_results,
+        patch("skylos.cli.print_badge") as print_badge,
+        patch("builtins.print") as mock_print,
+    ):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+
+    assert e.value.code == 1
+    mock_print.assert_called_once_with(expected_line, end="")
+    progress.assert_not_called()
+    render_results.assert_not_called()
+    print_badge.assert_not_called()
+
+
 def test_main_concise_clean_output_prints_nothing(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},


### PR DESCRIPTION
## Summary

  - Added one shared concise finding category list used by both formatting and exit-code checks.
  - Updated concise mode to exit non-zero when any reported concise category has findings.
  - Preserved existing `--gate` behavior and `--force` bypass behavior.

## Tests

  - `pytest test/test_cli.py -q`
  - `pytest test/test_cli_refactor_guardrails.py test/test_gatekeeper.py test/test_gate_kwargs.py -q`
  - `pre-commit run skylos-gate --files skylos/cli.py test/test_cli.py`