### PR TITLE
fix(ci): guard defense sidecar reads

### DIFF
--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -15,6 +15,8 @@ ANALYSIS_FLAG_MAP: dict[str, str] = {
     "secrets": "--secrets",
 }
 
+SKYLOS_DEFENSE_RESULTS_SHELL_PATH = '"$RUNNER_TEMP/defense-results.json"'
+
 
 def _installed_skylos_version() -> str | None:
     try:
@@ -123,7 +125,7 @@ def generate_workflow(
         defend_parts = [
             "",
             "      - name: AI Defense Check",
-            f"        run: skylos defend {scan_target} --fail-on critical --min-score 70 --json -o defense-results.json{' --upload' if use_upload else ''}",
+            f"        run: skylos defend {scan_target} --fail-on critical --min-score 70 --json -o {SKYLOS_DEFENSE_RESULTS_SHELL_PATH}{' --upload' if use_upload else ''}",
         ]
         if use_upload:
             defend_parts.append(_upload_env_block())
@@ -133,7 +135,7 @@ def generate_workflow(
     if use_llm:
         review_args.append("--llm-input skylos-llm-results.json")
     if use_defend:
-        review_args.append("--defense-input defense-results.json")
+        review_args.append(f"--defense-input {SKYLOS_DEFENSE_RESULTS_SHELL_PATH}")
     review_args.extend(['--diff-base "$pr_base_ref"', "--evidence-cards"])
     review_command = "skylos cicd review " + " ".join(review_args)
     review_run = "\n".join(

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -2,7 +2,10 @@ import argparse
 import json
 import os
 from pathlib import Path
+import stat
 import subprocess
+
+REVIEW_SIDECAR_MAX_BYTES = 2 * 1024 * 1024
 
 
 def _cicd_load_results(args, *, console_factory):
@@ -54,10 +57,63 @@ def _default_workflow_output() -> str:
 
 
 def _read_review_sidecar_json(raw_path: str, *, label: str) -> dict | list:
-    safe_name = Path(raw_path).name
-    if not safe_name or safe_name != str(raw_path):
+    path = _review_sidecar_path(raw_path, label=label)
+    mode = path.lstat().st_mode
+    if stat.S_ISLNK(mode):
+        raise ValueError(f"{label} must not be a symlink")
+    if not stat.S_ISREG(mode):
+        raise ValueError(f"{label} must be a regular file")
+
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+
+    fd = os.open(  # skylos: ignore[SKY-D215] bounded sidecar path with no-follow checks
+        path, flags
+    )
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise ValueError(f"{label} must be a regular file")
+        if st.st_size > REVIEW_SIDECAR_MAX_BYTES:
+            raise ValueError(f"{label} is too large")
+        with os.fdopen(fd, "rb") as fh:
+            fd = -1
+            data = fh.read(REVIEW_SIDECAR_MAX_BYTES + 1)
+        if len(data) > REVIEW_SIDECAR_MAX_BYTES:
+            raise ValueError(f"{label} is too large")
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+    return json.loads(data.decode("utf-8"))
+
+
+def _review_sidecar_path(raw_path: str, *, label: str) -> Path:
+    raw = str(raw_path or "")
+    if not raw or any(ord(ch) < 32 or ord(ch) == 127 for ch in raw):
+        raise ValueError(f"{label} must be a valid sidecar path")
+
+    path = Path(raw)
+    if not path.is_absolute():
+        if path.name != raw:
+            raise ValueError(
+                f"{label} must be a filename in the current directory"
+            )
+        return path
+
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if not runner_temp:
         raise ValueError(f"{label} must be a filename in the current directory")
-    return json.loads(Path(safe_name).read_text(encoding="utf-8"))
+
+    runner_root = Path(runner_temp).resolve()
+    resolved = path.resolve(strict=False)
+    try:
+        resolved.relative_to(runner_root)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be inside RUNNER_TEMP") from exc
+    return path
 
 
 def run_cicd_command(
@@ -168,8 +224,8 @@ def run_cicd_command(
     p_ci_rev.add_argument(
         "--defense-input",
         help=(
-            "AI defense sidecar JSON filename from `skylos defend` "
-            "(for example: defense-results.json)"
+            "AI defense sidecar JSON from `skylos defend` "
+            "(filename in the current directory or path under RUNNER_TEMP)"
         ),
     )
     p_ci_rev.add_argument(

--- a/test/test_cicd_workflow.py
+++ b/test/test_cicd_workflow.py
@@ -156,7 +156,9 @@ def test_workflow_scan_path_is_monorepo_aware():
     content = generate_workflow(scan_path="apps/api", use_upload=True, use_defend=True)
     assert "skylos apps/api" in content
     assert "skylos defend apps/api" in content
-    assert "--defense-input defense-results.json" in content
+    assert '--json -o "$RUNNER_TEMP/defense-results.json"' in content
+    assert '--defense-input "$RUNNER_TEMP/defense-results.json"' in content
+    assert "--defense-input defense-results.json" not in content
 
 
 def test_workflow_prefixes_leading_dash_scan_path():

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -1113,6 +1113,71 @@ def test_cicd_review_command_passes_evidence_cards_flag(tmp_path, monkeypatch):
     assert mock_review.call_args.kwargs["pr_number"] == 12
 
 
+def test_cicd_review_rejects_symlink_defense_sidecar(tmp_path, monkeypatch):
+    results_path = tmp_path / "results.json"
+    results_path.write_text(json.dumps({"project_root": str(tmp_path), "danger": []}))
+    target = tmp_path / "outside.json"
+    target.write_text(json.dumps({"findings": ["outside"]}))
+    defense_path = tmp_path / "defense.json"
+    try:
+        defense_path.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    monkeypatch.chdir(tmp_path)
+    from skylos.commands.cicd_cmd import run_cicd_command
+
+    console = Mock()
+    with patch("skylos.cicd.review.run_pr_review") as mock_review:
+        exit_code = run_cicd_command(
+            [
+                "review",
+                "--input",
+                str(results_path),
+                "--pr",
+                "12",
+                "--repo",
+                "owner/repo",
+                "--defense-input",
+                defense_path.name,
+            ],
+            console_factory=lambda: console,
+            load_config_func=lambda path: {},
+            run_gate_interaction_func=Mock(),
+            emit_github_annotations_func=Mock(),
+        )
+
+    assert exit_code == 0
+    assert mock_review.call_args.kwargs["defense_report"] is None
+    assert "Could not read defense results" in console.print.call_args.args[0]
+
+
+def test_cicd_review_sidecar_accepts_runner_temp_path(tmp_path, monkeypatch):
+    defense_path = tmp_path / "defense.json"
+    defense_path.write_text(json.dumps({"findings": []}))
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    from skylos.commands.cicd_cmd import _read_review_sidecar_json
+
+    assert _read_review_sidecar_json(
+        str(defense_path),
+        label="--defense-input",
+    ) == {"findings": []}
+
+
+def test_cicd_review_sidecar_rejects_oversized_file(tmp_path, monkeypatch):
+    defense_path = tmp_path / "defense.json"
+    defense_path.write_text("[]" * 10, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    from skylos.commands import cicd_cmd
+
+    monkeypatch.setattr(cicd_cmd, "REVIEW_SIDECAR_MAX_BYTES", 4)
+
+    with pytest.raises(ValueError, match="too large"):
+        cicd_cmd._read_review_sidecar_json(
+            defense_path.name,
+            label="--defense-input",
+        )
+
+
 def test_cli_guardrail_static_json_output_passthrough(monkeypatch):
     result = {
         "unused_functions": [{"name": "unused_func", "file": "test.py", "line": 10}],


### PR DESCRIPTION
## Summary

  - Hardened `_read_review_sidecar_json()` to:
    - reject symlinks
    - require a regular file
    - open with no-follow support when available
    - enforce a 2 MiB sidecar size limit before JSON parsing
 
## Tests

  - `pytest test/test_cli_refactor_guardrails.py test/test_cicd_workflow.py`