### PR TITLE
fix(debt): guard history reads

### DIFF
--- a/skylos/debt/baseline.py
+++ b/skylos/debt/baseline.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import stat
 
 from skylos.debt.result import DebtHotspot, DebtSnapshot
 from skylos.debt.scoring import refresh_hotspot_priority
@@ -10,6 +12,7 @@ BASELINE_DIR = ".skylos"
 BASELINE_FILE = "debt_baseline.json"
 HISTORY_FILE = "debt_history.jsonl"
 HISTORY_HOTSPOT_LIMIT = 5
+HISTORY_MAX_BYTES = 5 * 1024 * 1024
 
 
 def _baseline_path(project_root: str | Path) -> Path:
@@ -18,6 +21,55 @@ def _baseline_path(project_root: str | Path) -> Path:
 
 def _history_path(project_root: str | Path) -> Path:
     return Path(project_root) / BASELINE_DIR / HISTORY_FILE
+
+
+def _safe_history_path(project_root: str | Path) -> Path | None:
+    root = Path(project_root).resolve()
+    path = _history_path(root)
+    try:
+        path_stat = path.lstat()
+    except FileNotFoundError:
+        return None
+
+    if stat.S_ISLNK(path_stat.st_mode):
+        raise ValueError(f"{path}: history file must not be a symlink")
+    if not stat.S_ISREG(path_stat.st_mode):
+        raise ValueError(f"{path}: history file must be a regular file")
+
+    resolved = path.resolve(strict=True)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{path}: history file must stay inside project root") from exc
+
+    return path
+
+
+def _read_history_text(path: Path) -> str:
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+
+    fd = os.open(  # skylos: ignore[SKY-D215] validated debt history path with no-follow checks
+        path, flags
+    )
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError(f"{path}: history file must be a regular file")
+        if file_stat.st_size > HISTORY_MAX_BYTES:
+            raise ValueError(f"{path}: history file is too large")
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            data = handle.read(HISTORY_MAX_BYTES + 1)
+        if len(data) > HISTORY_MAX_BYTES:
+            raise ValueError(f"{path}: history file is too large")
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+    return data.decode("utf-8")
 
 
 def _summary_for_project_persistence(snapshot: DebtSnapshot) -> dict:
@@ -66,12 +118,12 @@ def load_baseline(project_root: str | Path) -> dict | None:
 
 
 def load_history(project_root: str | Path) -> list[dict]:
-    path = _history_path(project_root)
-    if not path.exists():
+    path = _safe_history_path(project_root)
+    if path is None:
         return []
 
     entries = []
-    lines = path.read_text(encoding="utf-8").splitlines()
+    lines = _read_history_text(path).splitlines()
     for line_number, line in enumerate(lines, 1):
         raw = line.strip()
         if not raw:

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -374,6 +374,58 @@ def test_load_history_returns_empty_for_missing_history(tmp_path):
     assert load_history(tmp_path) == []
 
 
+def test_load_history_rejects_symlinked_history_file(tmp_path):
+    history_dir = tmp_path / ".skylos"
+    history_dir.mkdir()
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text(
+        json.dumps({"token": "secret-outside-value"}) + "\n",
+        encoding="utf-8",
+    )
+    history_path = history_dir / "debt_history.jsonl"
+    try:
+        history_path.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="symlink"):
+        load_history(tmp_path)
+
+
+def test_load_history_rejects_history_resolved_outside_project(tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "debt_history.jsonl").write_text(
+        json.dumps({"token": "secret-outside-value"}) + "\n",
+        encoding="utf-8",
+    )
+    history_dir = project / ".skylos"
+    try:
+        history_dir.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="inside project root"):
+        load_history(project)
+
+
+def test_load_history_rejects_oversized_history_file(tmp_path, monkeypatch):
+    history_dir = tmp_path / ".skylos"
+    history_dir.mkdir()
+    (history_dir / "debt_history.jsonl").write_text(
+        json.dumps({"score": {"score_pct": 93}}) + "\n",
+        encoding="utf-8",
+    )
+    from skylos.debt import baseline
+
+    monkeypatch.setattr(baseline, "HISTORY_MAX_BYTES", 4)
+
+    with pytest.raises(ValueError, match="too large"):
+        load_history(tmp_path)
+
+
 def test_parse_policy_accepts_gate_and_report():
     policy = _parse_policy(
         {
@@ -1123,3 +1175,42 @@ def test_cli_debt_show_history_json_outputs_saved_entries(tmp_path, monkeypatch)
     mock_scan.assert_not_called()
     payload = json.loads(mock_print.call_args.args[0])
     assert payload["history"][0]["score"]["score_pct"] == 93
+
+
+def test_cli_debt_show_history_json_rejects_symlink_history(
+    tmp_path, monkeypatch
+):
+    history_dir = tmp_path / ".skylos"
+    history_dir.mkdir()
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text(
+        json.dumps({"token": "secret-outside-value"}) + "\n",
+        encoding="utf-8",
+    )
+    history_path = history_dir / "debt_history.jsonl"
+    try:
+        history_path.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "debt", str(tmp_path), "--show-history", "--json"],
+    )
+    mock_console = Mock()
+
+    with (
+        patch("skylos.debt.run_debt_analysis") as mock_scan,
+        patch("builtins.print") as mock_print,
+        patch("skylos.cli.Console", return_value=mock_console),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 1
+    mock_scan.assert_not_called()
+    mock_print.assert_not_called()
+    message = mock_console.print.call_args.args[0]
+    assert "Error reading debt history" in message
+    assert "symlink" in message
+    assert "secret-outside-value" not in message


### PR DESCRIPTION
## Summary

  - Reject symlinked debt history files.
  - Reject history paths that resolve outside the requested project root, including symlinked `.skylos` directories.
  - Require the history target to be a regular file.
  - Add a 5 MiB history file size limit before parsing.
  - Use a no-follow guarded open path when available.

## Tests

  - `pytest test/test_debt.py`