### PR TITLE
fix(ui): guard nudge config reads

### DIFF
--- a/skylos/ui/nudge.py
+++ b/skylos/ui/nudge.py
@@ -1,5 +1,8 @@
 import os
 from pathlib import Path
+import stat
+
+NUDGE_PYPROJECT_MAX_BYTES = 512 * 1024
 
 
 def _is_ci():
@@ -22,11 +25,11 @@ def _nudges_enabled(project_root=None):
     if project_root is None:
         project_root = Path.cwd()
 
-    toml_path = Path(project_root) / "pyproject.toml"
-    if not toml_path.exists():
-        return True
-
     try:
+        toml_path = _safe_pyproject_path(project_root)
+        if toml_path is None:
+            return True
+
         try:
             import tomllib
         except ImportError:
@@ -35,12 +38,62 @@ def _nudges_enabled(project_root=None):
             except ImportError:
                 return True
 
-        with open(toml_path, "rb") as f:
-            data = tomllib.load(f)
+        data = tomllib.loads(_read_pyproject_text(toml_path))
 
         return data.get("tool", {}).get("skylos", {}).get("nudges", True)
     except Exception:
         return True
+
+
+def _safe_pyproject_path(project_root=None) -> Path | None:
+    root = Path(project_root or Path.cwd()).resolve()
+    toml_path = root / "pyproject.toml"
+    try:
+        path_stat = toml_path.lstat()
+    except FileNotFoundError:
+        return None
+
+    if stat.S_ISLNK(path_stat.st_mode):
+        raise ValueError(f"{toml_path}: pyproject.toml must not be a symlink")
+    if not stat.S_ISREG(path_stat.st_mode):
+        raise ValueError(f"{toml_path}: pyproject.toml must be a regular file")
+
+    resolved = toml_path.resolve(strict=True)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"{toml_path}: pyproject.toml must stay inside project root"
+        ) from exc
+
+    return toml_path
+
+
+def _read_pyproject_text(toml_path: Path) -> str:
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+
+    fd = os.open(  # skylos: ignore[SKY-D215] validated nudge config path with no-follow checks
+        toml_path, flags
+    )
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError(f"{toml_path}: pyproject.toml must be a regular file")
+        if file_stat.st_size > NUDGE_PYPROJECT_MAX_BYTES:
+            raise ValueError(f"{toml_path}: pyproject.toml is too large")
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            data = handle.read(NUDGE_PYPROJECT_MAX_BYTES + 1)
+        if len(data) > NUDGE_PYPROJECT_MAX_BYTES:
+            raise ValueError(f"{toml_path}: pyproject.toml is too large")
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+    return data.decode("utf-8")
 
 
 def pick_nudge(result, args, project_root=None):

--- a/test/test_nudge.py
+++ b/test/test_nudge.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+import pytest
+
+from skylos.ui import nudge
+
+
+def _scan_args(**overrides):
+    values = {
+        "json": False,
+        "quiet": False,
+        "all_checks": False,
+        "danger": False,
+        "secrets": False,
+        "quality": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_nudges_enabled_reads_regular_pyproject(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.skylos]\nnudges = false\n",
+        encoding="utf-8",
+    )
+
+    assert nudge._nudges_enabled(tmp_path) is False
+
+
+def test_nudge_ignores_symlinked_pyproject(tmp_path, monkeypatch):
+    outside = tmp_path / "outside.toml"
+    outside.write_text("[tool.skylos]\nnudges = false\n", encoding="utf-8")
+    pyproject = tmp_path / "pyproject.toml"
+    try:
+        pyproject.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    monkeypatch.setattr(nudge, "_is_ci", lambda: False)
+
+    result = {"danger": [{"rule_id": "SKY-D201"}]}
+
+    assert (
+        nudge.pick_nudge(result, _scan_args(), tmp_path)
+        == "[dim]Check LLM defenses:[/dim] [bold]skylos defend .[/bold]"
+    )
+
+
+def test_safe_pyproject_path_rejects_symlink(tmp_path):
+    outside = tmp_path / "outside.toml"
+    outside.write_text("[tool.skylos]\nnudges = false\n", encoding="utf-8")
+    pyproject = tmp_path / "pyproject.toml"
+    try:
+        pyproject.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="symlink"):
+        nudge._safe_pyproject_path(tmp_path)
+
+
+def test_safe_pyproject_path_rejects_non_regular_file(tmp_path):
+    (tmp_path / "pyproject.toml").mkdir()
+
+    with pytest.raises(ValueError, match="regular file"):
+        nudge._safe_pyproject_path(tmp_path)
+
+
+def test_nudges_enabled_defaults_true_for_oversized_pyproject(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.skylos]\nnudges = false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(nudge, "NUDGE_PYPROJECT_MAX_BYTES", 4)
+
+    assert nudge._nudges_enabled(tmp_path) is True


### PR DESCRIPTION
## Summary

  - Reject symlinked `pyproject.toml` files in the nudge config path.
  - Require `pyproject.toml` to be a regular file inside the project root.
  - Add a 512 KiB max read before TOML parsing.
  - Open with no-follow support when available.
  - Added regression tests for regular config, symlinked config, non-regular paths, and oversized files.

## Tests

  - `pytest test/test_nudge.py`
  - `pytest test/test_cli_refactor_guardrails.py test/test_cli.py`