### PR TITLE
docs(entrypoints): add more call maps

### DIFF
--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -65,6 +65,16 @@ def generate_workflow(
     scan_path: str = ".",
     skylos_version: str | None = None,
 ) -> str:
+    """
+    Generate the GitHub Actions workflow YAML for Skylos scans.
+
+    Calls: skylos/cicd/workflow.py _build_trigger_block;
+        skylos/cicd/workflow.py _skylos_install_command;
+        skylos/cicd/workflow.py _shell_path;
+        skylos/cicd/workflow.py _build_claude_security_jobs.
+
+    Called from: skylos/commands/cicd_cmd.py run_cicd_command.
+    """
     triggers = triggers or ["pull_request", "push"]
     analysis_types = analysis_types or ["dead-code", "security", "quality", "secrets"]
 

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -124,6 +124,15 @@ def run_cicd_command(
     run_gate_interaction_func,
     emit_github_annotations_func,
 ) -> int:
+    """
+    Run the CI/CD subcommands for workflow generation, gates, annotations, and reviews.
+
+    Calls: skylos/cicd/workflow.py generate_workflow;
+        skylos/core/gatekeeper.py run_gate_interaction;
+        skylos/cicd/review.py run_pr_review.
+
+    Called from: skylos/cli.py run_cicd_command.
+    """
     cicd_parser = argparse.ArgumentParser(
         prog="skylos cicd", description="CI/CD integration for Skylos"
     )

--- a/skylos/commands/debt_cmd.py
+++ b/skylos/commands/debt_cmd.py
@@ -76,6 +76,15 @@ def run_debt_command(
     load_config_func,
     upload_debt_report_func,
 ) -> int:
+    """
+    Run the technical debt command and render, gate, history, or upload results.
+
+    Calls: skylos/debt/__init__.py run_debt_analysis;
+        skylos/debt/__init__.py load_history; skylos/debt/__init__.py append_history;
+        skylos/api.py upload_debt_report.
+
+    Called from: skylos/cli.py run_debt_command.
+    """
     debt_parser = argparse.ArgumentParser(
         prog="skylos debt",
         description="Analyze technical debt hotspots in a codebase",

--- a/skylos/commands/defend_cmd.py
+++ b/skylos/commands/defend_cmd.py
@@ -392,6 +392,16 @@ def run_defend_command(
     console_factory,
     progress_factory,
 ) -> int:
+    """
+    Run the AI defense command and render or upload defense findings.
+
+    Calls: skylos/commands/defend_cmd.py _discover_defend_inputs;
+        skylos/defend/engine.py run_defense_checks;
+        skylos/commands/defend_cmd.py _format_defend_output;
+        skylos/commands/defend_cmd.py _upload_defend_output.
+
+    Called from: skylos/cli.py run_defend_command.
+    """
     parser = _build_defend_parser()
     args = parser.parse_args(argv)
     console = console_factory()

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -5,6 +5,14 @@ from typing import Sequence
 
 
 def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
+    """
+    Run the main scan command after top-level CLI dispatch.
+
+    Calls: skylos/analyzer.py analyze; skylos/core/gatekeeper.py run_gate_interaction;
+        skylos/api.py upload_report; skylos/ui/nudge.py pick_nudge.
+
+    Called from: skylos/cli.py _run_scan_command.
+    """
     INTERACTIVE_AVAILABLE = cli_module.INTERACTIVE_AVAILABLE
     Panel = cli_module.Panel
     Progress = cli_module.Progress

--- a/skylos/debt/engine.py
+++ b/skylos/debt/engine.py
@@ -288,6 +288,13 @@ def run_debt_analysis(
     changed_files: list[str] | list[Path] | None = None,
     conf: int = 80,
 ) -> DebtSnapshot:
+    """
+    Run a quality-focused static scan and convert it into a debt snapshot.
+
+    Calls: skylos/analyzer.py analyze; skylos/debt/engine.py build_debt_snapshot.
+
+    Called from: skylos/debt/__init__.py run_debt_analysis.
+    """
     target = Path(path).resolve()
     project_root = _project_root(target)
 


### PR DESCRIPTION
## Summary

  Adds call-map docstrings to more central Skylos entrypoints.

## Covered

  - `skylos/commands/scan_cmd.py::run_scan_command`
  - `skylos/commands/debt_cmd.py::run_debt_command`
  - `skylos/commands/cicd_cmd.py::run_cicd_command`
  - `skylos/commands/defend_cmd.py::run_defend_command`
  - `skylos/cicd/workflow.py::generate_workflow`
  - `skylos/debt/engine.py::run_debt_analysis`

## Tests
N/A