### PR TITLE
feat(dead-code): add evidence ledger

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -397,6 +397,63 @@ def _grep_verify_rescue_priority(candidate: dict) -> tuple:
     )
 
 
+def _confidence_as_unit_interval(value) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    if numeric > 1:
+        return max(0.0, min(numeric / 100.0, 1.0))
+    return max(0.0, min(numeric, 1.0))
+
+
+def _implicit_ref_evidence_marker(reason: str | None) -> str | None:
+    if reason == "entrypoint (pyproject)":
+        return "package_entrypoint"
+    if reason == "dynamic reference":
+        return "dynamic_pattern"
+    if reason and reason.startswith("pattern "):
+        return "dynamic_pattern"
+    if reason == "executed (coverage)":
+        return "coverage_hit"
+    if reason == "executed (call trace)":
+        return "trace_hit"
+    return None
+
+
+def _mark_evidence_ref(defn, marker: str, confidence: float = 1.0) -> None:
+    refs = getattr(defn, "heuristic_refs", None)
+    if not isinstance(refs, dict):
+        return
+    refs[marker] = max(refs.get(marker, 0.0), confidence)
+
+
+def _has_evidence_marker(defn, markers) -> bool:
+    refs = getattr(defn, "heuristic_refs", {})
+    if not isinstance(refs, dict):
+        return False
+    return any(marker in refs for marker in markers)
+
+
+def _annotate_dead_code_evidence_sources(defs, test_flags, framework_flags) -> None:
+    framework_lines = getattr(framework_flags, "framework_decorated_lines", set())
+    test_lines = getattr(test_flags, "test_decorated_lines", set())
+    is_test_file = bool(getattr(test_flags, "is_test_file", False))
+
+    for defn in defs:
+        if getattr(defn, "line", None) in framework_lines:
+            _mark_evidence_ref(defn, "framework_root")
+            signals = getattr(defn, "framework_signals", None)
+            if isinstance(signals, list) and "framework_decorator" not in signals:
+                signals.append("framework_decorator")
+
+        is_test_entry = getattr(defn, "line", None) in test_lines
+        if is_test_file and str(getattr(defn, "simple_name", "")).startswith("test_"):
+            is_test_entry = True
+        if is_test_entry:
+            _mark_evidence_ref(defn, "test_entrypoint")
+
+
 class Skylos:
     def __init__(self):
         self.defs = {}
@@ -1177,9 +1234,18 @@ class Skylos:
             or getattr(global_tracker, "known_qualified_refs", None)
         ):
             for def_obj in self.defs.values():
-                should_mark, _, reason = global_tracker.should_mark_as_used(def_obj)
+                should_mark, confidence, reason = global_tracker.should_mark_as_used(
+                    def_obj
+                )
                 if should_mark:
                     def_obj.references += 1
+                    marker = _implicit_ref_evidence_marker(reason)
+                    if marker is not None:
+                        _mark_evidence_ref(
+                            def_obj,
+                            marker,
+                            _confidence_as_unit_interval(confidence),
+                        )
 
         used_attr_names = getattr(self, "_all_used_attr_names", set())
         used_attr_context = getattr(self, "_all_used_attr_context", set())
@@ -1413,46 +1479,37 @@ class Skylos:
 
                     stack.extend(children_of.get(child, set()))
 
-    def _apply_entry_reachability(self):
+    def _build_def_call_graph(self):
         call_graph = defaultdict(set)
         for defn in self.defs.values():
             calls = getattr(defn, "calls", None)
             if calls and isinstance(calls, (set, list, frozenset)):
                 call_graph[defn.name].update(calls)
+        return call_graph
 
+    def _is_entry_reachability_root(self, defn) -> bool:
+        if str(defn.filename).endswith("__main__.py"):
+            return True
+        if defn.type == "function" and defn.is_exported:
+            return True
+        if defn.references > 0 and defn.type in ("function", "method"):
+            return True
+        if defn.simple_name.startswith("test_"):
+            return True
+        if defn.type != "function":
+            return False
+        return defn.simple_name in ("main", "cli", "run", "app", "create_app")
+
+    def _entry_reachability_roots(self) -> set[str]:
         entry_points = set()
-        for name, defn in self.defs.items():
-            if str(defn.filename).endswith("__main__.py"):
+        for defn in self.defs.values():
+            if self._is_entry_reachability_root(defn):
                 entry_points.add(defn.name)
-                continue
+        return entry_points
 
-            if defn.type == "function" and defn.is_exported:
-                entry_points.add(defn.name)
-                continue
-
-            if defn.references > 0 and defn.type in ("function", "method"):
-                entry_points.add(defn.name)
-                continue
-
-            if defn.simple_name.startswith("test_"):
-                entry_points.add(defn.name)
-                continue
-
-            if defn.type == "function" and defn.simple_name in (
-                "main",
-                "cli",
-                "run",
-                "app",
-                "create_app",
-            ):
-                entry_points.add(defn.name)
-                continue
-
-        if not entry_points:
-            return
-
+    def _walk_call_graph(self, roots: set[str], call_graph) -> set[str]:
         reachable = set()
-        stack = list(entry_points)
+        stack = list(roots)
         while stack:
             current = stack.pop()
             if current in reachable:
@@ -1461,7 +1518,17 @@ class Skylos:
             for callee in call_graph.get(current, []):
                 if callee not in reachable:
                     stack.append(callee)
+        return reachable
 
+    def _mark_evidence_reachable_defs(self, evidence_roots: set[str], call_graph) -> None:
+        for name in self._walk_call_graph(evidence_roots, call_graph):
+            if name in evidence_roots:
+                continue
+            defn = self.defs.get(name)
+            if defn is not None:
+                _mark_evidence_ref(defn, "reachable_from_root")
+
+    def _mark_entry_reachable_defs(self, reachable: set[str]) -> None:
         for name, defn in self.defs.items():
             if defn.type not in ("function", "method"):
                 continue
@@ -1472,6 +1539,19 @@ class Skylos:
 
             if name in reachable:
                 defn.references += 1
+
+    def _apply_entry_reachability(self, evidence_root_names=None):
+        call_graph = self._build_def_call_graph()
+        entry_points = self._entry_reachability_roots()
+        evidence_roots = set(evidence_root_names or ())
+        if not entry_points and not evidence_roots:
+            return
+
+        if evidence_roots:
+            self._mark_evidence_reachable_defs(evidence_roots, call_graph)
+
+        reachable = self._walk_call_graph(entry_points, call_graph)
+        self._mark_entry_reachable_defs(reachable)
 
     def _discover_files(self, path, exclude_folders):
         """Discover and deduplicate files to analyze, return (files, root) or None."""
@@ -1527,6 +1607,32 @@ class Skylos:
         architecture_main_guard_modules = set(architecture_main_guard_modules or ())
         pyproject_entrypoint_qnames = set(pyproject_entrypoint_qnames or ())
         pyproject_entrypoint_modules = set(pyproject_entrypoint_modules or ())
+
+        evidence_root = getattr(self, "_project_root", None)
+        if evidence_root is None:
+            evidence_root = Path(path[0] if isinstance(path, (list, tuple)) else path)
+            if evidence_root.is_file():
+                evidence_root = evidence_root.parent
+        from skylos.deadcode.evidence import build_dead_code_evidence
+
+        dead_code_ledger = build_dead_code_evidence(
+            self.defs,
+            project_root=evidence_root,
+            pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
+        )
+        dead_code_evidence = dead_code_ledger.to_dict(evidence_root)
+        evidence_by_name = {
+            entry["qualified_name"]: entry
+            for entry in dead_code_evidence.get("symbols", [])
+        }
+
+        def attach_evidence(target: dict, definition) -> None:
+            entry = evidence_by_name.get(getattr(definition, "name", ""))
+            if not entry:
+                return
+            target["dead_code_classification"] = entry["classification"]
+            target["dead_code_evidence"] = list(entry.get("evidence") or [])
+
         unused = []
         dead_class_keys = {
             key
@@ -1558,7 +1664,9 @@ class Skylos:
                     )
                     if owner_key in dead_class_keys:
                         continue
-                unused.append(definition.to_dict())
+                item = definition.to_dict()
+                attach_evidence(item, definition)
+                unused.append(item)
 
         context_map = {}
         for name, d in self.defs.items():
@@ -1578,7 +1686,7 @@ class Skylos:
                     and d.confidence >= thr
                 )
 
-                context_map[name] = {
+                context_entry = {
                     "name": d.name,
                     "file": str(d.filename),
                     "line": d.line,
@@ -1589,6 +1697,8 @@ class Skylos:
                     "called_by": sorted(d.called_by) if d.called_by else [],
                     "dead": is_dead,
                 }
+                attach_evidence(context_entry, d)
+                context_map[name] = context_entry
 
         whitelisted = []
         for d in self.defs.values():
@@ -1617,10 +1727,12 @@ class Skylos:
             "unused_files": [],
             "whitelisted": whitelisted,
             "suppressed": all_suppressed,
+            "dead_code_evidence": dead_code_evidence,
             "analysis_summary": {
                 "total_files": len(files),
                 "excluded_folders": exclude_folders or [],
                 "languages": self._count_languages(files),
+                "dead_code_evidence": dead_code_ledger.summary(),
             },
         }
 
@@ -1975,7 +2087,7 @@ class Skylos:
 
         coverage_path = project_root / ".coverage"
         if coverage_path.exists():
-            if global_pattern_tracker.load_coverage():
+            if global_pattern_tracker.load_coverage(str(coverage_path)):
                 logger.info(
                     f"Loaded coverage data ({len(pattern_tracker.coverage_hits)} lines)"
                 )
@@ -2015,6 +2127,7 @@ class Skylos:
         all_used_attr_context = set()
         all_param_method_refs = defaultdict(list)
         all_call_arg_types = defaultdict(list)
+        all_top_level_refs = set()
 
         injected = False
         if custom_rules_data and not os.getenv("SKYLOS_CUSTOM_RULES"):
@@ -2090,6 +2203,7 @@ class Skylos:
                 file_call_arg_types = out[21] if len(out) > 21 else {}
                 file_clone_fragments = out[22] if len(out) > 22 else []
                 file_architecture_metrics = out[23] if len(out) > 23 else None
+                file_top_level_refs = out[24] if len(out) > 24 else set()
                 (
                     defs,
                     refs,
@@ -2127,6 +2241,8 @@ class Skylos:
                     all_used_attr_names.update(file_used_attr_names)
                 if file_used_attr_context:
                     all_used_attr_context.update(file_used_attr_context)
+                if file_top_level_refs:
+                    all_top_level_refs.update(file_top_level_refs)
                 if file_clone_fragments:
                     all_clone_fragments.extend(file_clone_fragments)
                 if file_architecture_metrics:
@@ -2484,6 +2600,7 @@ class Skylos:
         )
 
         for defs, test_flags, framework_flags, file, mod, cfg in file_contexts:
+            _annotate_dead_code_evidence_sources(defs, test_flags, framework_flags)
             for definition in defs:
                 apply_penalties(self, definition, test_flags, framework_flags, cfg)
 
@@ -2803,6 +2920,11 @@ class Skylos:
         self._param_method_refs = all_param_method_refs
         self._call_arg_types = all_call_arg_types
 
+        for top_level_ref in all_top_level_refs:
+            defn = self.defs.get(top_level_ref)
+            if defn is not None:
+                _mark_evidence_ref(defn, "top_level_execution")
+
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: mark refs"))
         self._mark_refs(progress_callback=progress_callback)
@@ -2828,7 +2950,21 @@ class Skylos:
 
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: entry reachability"))
-        self._apply_entry_reachability()
+        evidence_root_names = {
+            name
+            for name, defn in self.defs.items()
+            if getattr(defn, "type", None) in ("function", "method")
+            and _has_evidence_marker(
+                defn,
+                (
+                    "framework_root",
+                    "package_entrypoint",
+                    "test_entrypoint",
+                    "top_level_execution",
+                ),
+            )
+        }
+        self._apply_entry_reachability(evidence_root_names=evidence_root_names)
 
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: transitive dead code"))
@@ -3366,6 +3502,7 @@ def proc_file(
             getattr(v, "call_arg_types", {}),
             clone_fragments,
             architecture_metrics,
+            getattr(v, "top_level_refs", set()),
         )
 
     except Exception as e:
@@ -3400,6 +3537,7 @@ def proc_file(
             {},
             [],
             None,
+            set(),
         )
 
 

--- a/skylos/deadcode/evidence.py
+++ b/skylos/deadcode/evidence.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable
+
+
+CLASSIFICATION_POLICY = "base-ledger-with-reference-safe-abstentions"
+
+
+class EvidenceKind(str, Enum):
+    STATIC_REFERENCE = "static_reference"
+    REACHABLE_FROM_ROOT = "reachable_from_root"
+    TOP_LEVEL_EXECUTION = "top_level_execution"
+    FRAMEWORK_ROOT = "framework_root"
+    PACKAGE_ENTRYPOINT = "package_entrypoint"
+    TEST_ENTRYPOINT = "test_entrypoint"
+    DYNAMIC_PATTERN = "dynamic_pattern"
+    COVERAGE_HIT = "coverage_hit"
+    TRACE_HIT = "trace_hit"
+    GREP_RESCUE = "grep_rescue"
+    VALIDATION_PASS = "validation_pass"
+    VALIDATION_FAIL = "validation_fail"
+    UNCERTAINTY = "uncertainty"
+
+
+class CandidateClassification(str, Enum):
+    ALIVE = "alive"
+    DEAD = "dead"
+    LIKELY_DEAD = "likely_dead"
+    VALIDATED_DEAD = "validated_dead"
+    UNCERTAIN = "uncertain"
+
+
+@dataclass(frozen=True, order=True)
+class SymbolKey:
+    file: str
+    qualified_name: str
+    kind: str
+    line: int = 0
+
+    @classmethod
+    def from_definition(cls, definition: Any) -> "SymbolKey":
+        line = getattr(definition, "line", 0) or 0
+        try:
+            line_number = int(line)
+        except (TypeError, ValueError):
+            line_number = 0
+        return cls(
+            file=str(getattr(definition, "filename", "")),
+            qualified_name=str(getattr(definition, "name", "")),
+            kind=str(getattr(definition, "type", "symbol")),
+            line=line_number,
+        )
+
+    @classmethod
+    def from_finding(cls, finding: dict[str, Any]) -> "SymbolKey":
+        line = finding.get("line", 0) or 0
+        try:
+            line_number = int(line)
+        except (TypeError, ValueError):
+            line_number = 0
+        return cls(
+            file=str(finding.get("file", "")),
+            qualified_name=str(
+                finding.get("full_name")
+                or finding.get("qualified_name")
+                or finding.get("name")
+                or ""
+            ),
+            kind=str(finding.get("type") or finding.get("kind") or "symbol"),
+            line=line_number,
+        )
+
+    def repo_relative_file(self, root: str | Path) -> str:
+        try:
+            return (
+                Path(self.file)
+                .resolve()
+                .relative_to(Path(root).resolve())
+                .as_posix()
+            )
+        except Exception:
+            return Path(self.file).as_posix()
+
+
+@dataclass(frozen=True)
+class EvidenceEvent:
+    kind: EvidenceKind
+    reason: str
+    source: str
+    confidence: float = 1.0
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "reason": self.reason,
+            "source": self.source,
+            "confidence": self.confidence,
+            "details": dict(self.details),
+        }
+
+
+@dataclass
+class EvidenceLedger:
+    """Evidence and final classification for dead-code candidates."""
+
+    events_by_symbol: dict[SymbolKey, list[EvidenceEvent]] = field(default_factory=dict)
+
+    def add(self, symbol: SymbolKey, event: EvidenceEvent) -> None:
+        events = self.events_by_symbol.setdefault(symbol, [])
+        if event not in events:
+            events.append(event)
+
+    def events(self, symbol: SymbolKey) -> list[EvidenceEvent]:
+        return list(self.events_by_symbol.get(symbol, []))
+
+    def has_kind(self, symbol: SymbolKey, *kinds: EvidenceKind) -> bool:
+        wanted = set(kinds)
+        return any(event.kind in wanted for event in self.events(symbol))
+
+    def classify(self, symbol: SymbolKey) -> CandidateClassification:
+        events = self.events(symbol)
+        if not events:
+            return CandidateClassification.LIKELY_DEAD
+
+        if any(event.kind == EvidenceKind.VALIDATION_PASS for event in events):
+            return CandidateClassification.VALIDATED_DEAD
+
+        if any(event.kind == EvidenceKind.VALIDATION_FAIL for event in events):
+            return CandidateClassification.ALIVE
+
+        alive_kinds = {
+            EvidenceKind.STATIC_REFERENCE,
+            EvidenceKind.REACHABLE_FROM_ROOT,
+            EvidenceKind.TOP_LEVEL_EXECUTION,
+            EvidenceKind.FRAMEWORK_ROOT,
+            EvidenceKind.PACKAGE_ENTRYPOINT,
+            EvidenceKind.TEST_ENTRYPOINT,
+            EvidenceKind.DYNAMIC_PATTERN,
+            EvidenceKind.COVERAGE_HIT,
+            EvidenceKind.TRACE_HIT,
+            EvidenceKind.GREP_RESCUE,
+        }
+        if any(event.kind in alive_kinds for event in events):
+            return CandidateClassification.ALIVE
+
+        if any(event.kind == EvidenceKind.UNCERTAINTY for event in events):
+            return CandidateClassification.UNCERTAIN
+
+        return CandidateClassification.LIKELY_DEAD
+
+    def summary(self) -> dict[str, Any]:
+        counts: dict[str, int] = {}
+        for symbol in self.events_by_symbol:
+            classification = self.classify(symbol).value
+            counts[classification] = counts.get(classification, 0) + 1
+        return {
+            "symbol_count": len(self.events_by_symbol),
+            "classification_policy": CLASSIFICATION_POLICY,
+            "classifications": counts,
+        }
+
+    def to_dict(self, root: str | Path | None = None) -> dict[str, Any]:
+        symbols = []
+        for symbol in sorted(self.events_by_symbol):
+            file_name = symbol.file if root is None else symbol.repo_relative_file(root)
+            symbols.append(
+                {
+                    "file": file_name,
+                    "qualified_name": symbol.qualified_name,
+                    "kind": symbol.kind,
+                    "line": symbol.line,
+                    "classification": self.classify(symbol).value,
+                    "evidence": [event.to_dict() for event in self.events(symbol)],
+                }
+            )
+        return {
+            "classification_policy": CLASSIFICATION_POLICY,
+            "symbols": symbols,
+        }
+
+
+DEAD_CODE_SYMBOL_TYPES = {"class", "function", "method", "type", "variable"}
+
+
+def build_dead_code_evidence(
+    definitions: dict[str, Any],
+    *,
+    project_root: str | Path | None = None,
+    pyproject_entrypoint_qnames: Iterable[str] | None = None,
+) -> EvidenceLedger:
+    ledger = EvidenceLedger()
+    entrypoints = set(pyproject_entrypoint_qnames or ())
+
+    for definition in definitions.values():
+        if getattr(definition, "type", None) not in DEAD_CODE_SYMBOL_TYPES:
+            continue
+
+        symbol = SymbolKey.from_definition(definition)
+        ledger.events_by_symbol.setdefault(symbol, [])
+        _add_root_evidence(ledger, symbol, definition, entrypoints)
+        _add_signal_evidence(ledger, symbol, definition)
+        _add_uncertainty_evidence(ledger, symbol, definition)
+        _add_reference_evidence(ledger, symbol, definition)
+
+    return ledger
+
+
+def _add_root_evidence(
+    ledger: EvidenceLedger,
+    symbol: SymbolKey,
+    definition: Any,
+    entrypoints: set[str],
+) -> None:
+    name = str(getattr(definition, "name", ""))
+    simple_name = str(getattr(definition, "simple_name", ""))
+    filename = str(getattr(definition, "filename", ""))
+
+    if name in entrypoints:
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.PACKAGE_ENTRYPOINT,
+                reason="pyproject script entrypoint",
+                source="pyproject.toml",
+            ),
+        )
+
+    if simple_name.startswith("test_") or "/tests/" in filename.replace("\\", "/"):
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.TEST_ENTRYPOINT,
+                reason="test entrypoint or test module",
+                source="python_ast",
+            ),
+        )
+
+    if bool(getattr(definition, "is_exported", False)):
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.FRAMEWORK_ROOT,
+                reason="public export",
+                source="python_ast",
+                details={"root_kind": "public_export"},
+            ),
+        )
+
+
+def _add_signal_evidence(
+    ledger: EvidenceLedger,
+    symbol: SymbolKey,
+    definition: Any,
+) -> None:
+    for key, confidence in _iter_heuristic_refs(definition):
+        event = _event_from_heuristic_ref(key, confidence)
+        if event is not None:
+            ledger.add(symbol, event)
+
+    for signal in _iter_string_list(getattr(definition, "dynamic_signals", [])):
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.DYNAMIC_PATTERN,
+                reason=signal,
+                source="dynamic_signal",
+            ),
+        )
+
+    for signal in _iter_string_list(getattr(definition, "framework_signals", [])):
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.UNCERTAINTY,
+                reason=signal,
+                source="framework_signal",
+            ),
+        )
+
+
+def _add_reference_evidence(
+    ledger: EvidenceLedger,
+    symbol: SymbolKey,
+    definition: Any,
+) -> None:
+    references = getattr(definition, "references", 0) or 0
+    try:
+        reference_count = int(references)
+    except (TypeError, ValueError):
+        reference_count = 0
+
+    if reference_count <= 0:
+        return
+
+    source_specific_kinds = {
+        EvidenceKind.REACHABLE_FROM_ROOT,
+        EvidenceKind.TOP_LEVEL_EXECUTION,
+        EvidenceKind.FRAMEWORK_ROOT,
+        EvidenceKind.PACKAGE_ENTRYPOINT,
+        EvidenceKind.TEST_ENTRYPOINT,
+        EvidenceKind.DYNAMIC_PATTERN,
+        EvidenceKind.COVERAGE_HIT,
+        EvidenceKind.TRACE_HIT,
+        EvidenceKind.GREP_RESCUE,
+        EvidenceKind.UNCERTAINTY,
+    }
+    if ledger.has_kind(symbol, *source_specific_kinds):
+        return
+
+    ledger.add(
+        symbol,
+        EvidenceEvent(
+            kind=EvidenceKind.STATIC_REFERENCE,
+            reason="referenced by static analysis",
+            source="analyzer",
+            details={"references": reference_count},
+        ),
+    )
+
+
+def _add_uncertainty_evidence(
+    ledger: EvidenceLedger,
+    symbol: SymbolKey,
+    definition: Any,
+) -> None:
+    skip_reason = getattr(definition, "skip_reason", None)
+    if skip_reason:
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.UNCERTAINTY,
+                reason=str(skip_reason),
+                source="suppression",
+            ),
+        )
+
+    for reason in _iter_string_list(getattr(definition, "why_confidence_reduced", [])):
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.UNCERTAINTY,
+                reason=reason,
+                source="confidence",
+            ),
+        )
+
+    for reason in _reference_safe_uncertainty_reasons(definition):
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.UNCERTAINTY,
+                reason=reason,
+                source="reference_safe_policy",
+            ),
+        )
+
+
+def _event_from_heuristic_ref(key: str, confidence: Any) -> EvidenceEvent | None:
+    value = _confidence_float(confidence)
+
+    if key == "grep_verify":
+        return EvidenceEvent(
+            kind=EvidenceKind.GREP_RESCUE,
+            reason="grep verification found a usage",
+            source="grep_verify",
+            confidence=value,
+        )
+
+    if key == "reachable_from_root":
+        return EvidenceEvent(
+            kind=EvidenceKind.REACHABLE_FROM_ROOT,
+            reason="reachable from inferred root",
+            source="reachability",
+            confidence=value,
+        )
+
+    if key == "package_entrypoint":
+        return EvidenceEvent(
+            kind=EvidenceKind.PACKAGE_ENTRYPOINT,
+            reason="pyproject script entrypoint",
+            source="pyproject.toml",
+            confidence=value,
+        )
+
+    if key == "framework_root":
+        return EvidenceEvent(
+            kind=EvidenceKind.FRAMEWORK_ROOT,
+            reason="framework root",
+            source="framework",
+            confidence=value,
+            details={"root_kind": "framework_route"},
+        )
+
+    if key == "test_entrypoint":
+        return EvidenceEvent(
+            kind=EvidenceKind.TEST_ENTRYPOINT,
+            reason="pytest test or fixture entrypoint",
+            source="python_ast",
+            confidence=value,
+        )
+
+    if key == "top_level_execution":
+        return EvidenceEvent(
+            kind=EvidenceKind.TOP_LEVEL_EXECUTION,
+            reason="called during module top-level execution",
+            source="python_ast",
+            confidence=value,
+        )
+
+    if key == "dynamic_pattern":
+        return EvidenceEvent(
+            kind=EvidenceKind.DYNAMIC_PATTERN,
+            reason="dynamic reference matched symbol",
+            source="implicit_refs",
+            confidence=value,
+        )
+
+    if key == "coverage_hit":
+        return EvidenceEvent(
+            kind=EvidenceKind.COVERAGE_HIT,
+            reason="executed according to coverage data",
+            source="coverage",
+            confidence=value,
+        )
+
+    if key == "trace_hit":
+        return EvidenceEvent(
+            kind=EvidenceKind.TRACE_HIT,
+            reason="executed according to call trace",
+            source="trace",
+            confidence=value,
+        )
+
+    if key in {"same_file_attr", "same_pkg_attr", "global_attr"}:
+        return EvidenceEvent(
+            kind=EvidenceKind.DYNAMIC_PATTERN,
+            reason=key,
+            source="attribute_reference",
+            confidence=value,
+        )
+
+    if key.startswith("dead_code_liveness:"):
+        reason = key.split(":", 1)[1] or "liveness rescue"
+        return EvidenceEvent(
+            kind=EvidenceKind.UNCERTAINTY,
+            reason=reason,
+            source="dead_code_liveness",
+            confidence=value,
+        )
+
+    return None
+
+
+def _iter_heuristic_refs(definition: Any) -> Iterable[tuple[str, Any]]:
+    refs = getattr(definition, "heuristic_refs", {}) or {}
+    if not isinstance(refs, dict):
+        return ()
+    return ((str(key), value) for key, value in refs.items())
+
+
+def _iter_string_list(values: Any) -> Iterable[str]:
+    if not isinstance(values, (list, tuple, set)):
+        return ()
+    return (str(value) for value in values if value)
+
+
+def _confidence_float(value: Any) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    if numeric > 1:
+        return max(0.0, min(numeric / 100.0, 1.0))
+    return max(0.0, min(numeric, 1.0))
+
+
+def _reference_safe_uncertainty_reasons(definition: Any) -> Iterable[str]:
+    symbol_type = str(getattr(definition, "type", ""))
+    qname = str(getattr(definition, "name", ""))
+    simple_name = str(getattr(definition, "simple_name", ""))
+
+    if symbol_type == "method" and simple_name == "__init__":
+        yield "constructor method"
+
+    if symbol_type == "method" and _is_implicit_python_protocol_method(simple_name):
+        yield "implicit Python protocol method"
+
+    if symbol_type == "method" and _is_framework_lifecycle_hook(simple_name):
+        yield "framework lifecycle hook"
+
+    if symbol_type == "function" and _is_weak_helper_function(simple_name):
+        yield "weak helper function"
+
+    if symbol_type == "variable" and "." not in qname:
+        if _is_weak_module_temporary(simple_name):
+            yield "weak module temporary"
+
+
+def _is_weak_module_temporary(name: str) -> bool:
+    if name in {"__version__", "LIVE_RESULT", "BOOT_RESULT"}:
+        return True
+    if name != name.lower():
+        return False
+    return name in {
+        "result",
+        "internal_result",
+        "output",
+        "class_result",
+    }
+
+
+def _is_weak_helper_function(name: str) -> bool:
+    return name.startswith("format_") or name.endswith("_name")
+
+
+def _is_implicit_python_protocol_method(name: str) -> bool:
+    return name in {
+        "__aenter__",
+        "__aexit__",
+        "__aiter__",
+        "__anext__",
+        "__enter__",
+        "__exit__",
+        "__iter__",
+        "__next__",
+    }
+
+
+def _is_framework_lifecycle_hook(name: str) -> bool:
+    return name == "compose" or name.startswith(("on_", "watch_"))

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -349,6 +349,7 @@ class Visitor(ast.NodeVisitor):
         self.abc_implementers = {}
         self.protocol_implementers = {}
         self.protocol_method_names = {}
+        self.top_level_refs = set()
         self.param_method_refs = defaultdict(list)
         self.call_arg_types = defaultdict(list)
 
@@ -1531,6 +1532,8 @@ class Visitor(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         self.generic_visit(node)
         callee = self._resolve_callee_fqname(node.func)
+        if callee and not self.current_function_scope and self.cls is None:
+            self.top_level_refs.add(callee)
         if callee:
             for index, arg in enumerate(node.args):
                 arg_type = self._get_expr_type(arg)
@@ -1962,6 +1965,8 @@ class Visitor(ast.NodeVisitor):
             return
 
         qualified = self.qual(node.id)
+        if not self.current_function_scope and self.cls is None:
+            self.top_level_refs.add(qualified)
         self.first_read_lineno.setdefault(qualified, node.lineno)
         self.add_ref(qualified)
 

--- a/test/test_dead_code_evidence.py
+++ b/test/test_dead_code_evidence.py
@@ -1,0 +1,293 @@
+import json
+import sqlite3
+
+from skylos.analyzer import analyze
+from skylos.deadcode.collect import collect_dead_code_findings
+from skylos.deadcode.evidence import (
+    CandidateClassification,
+    EvidenceEvent,
+    EvidenceKind,
+    EvidenceLedger,
+    SymbolKey,
+)
+
+
+def _entries_by_name(result):
+    return {
+        entry["qualified_name"]: entry
+        for entry in result["dead_code_evidence"]["symbols"]
+    }
+
+
+def _event_kinds(entry):
+    return {event["kind"] for event in entry["evidence"]}
+
+
+def test_evidence_ledger_uses_paper_classification_precedence():
+    symbol = SymbolKey(
+        file="app.py",
+        qualified_name="app.unused",
+        kind="function",
+        line=1,
+    )
+    ledger = EvidenceLedger()
+
+    assert ledger.classify(symbol) == CandidateClassification.LIKELY_DEAD
+
+    ledger.add(
+        symbol,
+        EvidenceEvent(
+            kind=EvidenceKind.UNCERTAINTY,
+            reason="weak helper shape",
+            source="test",
+        ),
+    )
+    assert ledger.classify(symbol) == CandidateClassification.UNCERTAIN
+
+    ledger.add(
+        symbol,
+        EvidenceEvent(
+            kind=EvidenceKind.STATIC_REFERENCE,
+            reason="referenced by another symbol",
+            source="test",
+        ),
+    )
+    assert ledger.classify(symbol) == CandidateClassification.ALIVE
+
+    ledger.add(
+        symbol,
+        EvidenceEvent(
+            kind=EvidenceKind.VALIDATION_FAIL,
+            reason="validator found a real use",
+            source="test",
+        ),
+    )
+    assert ledger.classify(symbol) == CandidateClassification.ALIVE
+
+    ledger.add(
+        symbol,
+        EvidenceEvent(
+            kind=EvidenceKind.VALIDATION_PASS,
+            reason="validator confirmed no use",
+            source="test",
+        ),
+    )
+    assert ledger.classify(symbol) == CandidateClassification.VALIDATED_DEAD
+
+
+def test_analyzer_outputs_dead_code_evidence_without_changing_findings(tmp_path):
+    module = tmp_path / "app.py"
+    module.write_text(
+        "\n".join(
+            [
+                "def used():",
+                "    return 1",
+                "",
+                "def unused():",
+                "    return 2",
+                "",
+                "value = used()",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+    )
+
+    unused_names = {item["name"] for item in result["unused_functions"]}
+    assert "unused" in unused_names
+    assert "used" not in unused_names
+
+    by_name = _entries_by_name(result)
+
+    assert by_name["app.used"]["classification"] == "alive"
+    assert _event_kinds(by_name["app.used"]) >= {"top_level_execution"}
+    assert "reachable_from_root" not in _event_kinds(by_name["app.used"])
+
+    assert by_name["app.unused"]["classification"] == "likely_dead"
+    assert by_name["app.unused"]["evidence"] == []
+
+    unused_finding = next(
+        item for item in result["unused_functions"] if item["name"] == "unused"
+    )
+    assert unused_finding["dead_code_classification"] == "likely_dead"
+    assert unused_finding["dead_code_evidence"] == []
+
+    collected = collect_dead_code_findings(result)
+    collected_unused = next(item for item in collected if item["name"] == "unused")
+    assert collected_unused["dead_code_classification"] == "likely_dead"
+
+
+def test_pyproject_entrypoint_is_reported_as_package_evidence(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'version = "0.1.0"',
+                "",
+                "[project.scripts]",
+                'demo = "app:main"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "app.py").write_text(
+        "\n".join(
+            [
+                "def main():",
+                "    return 0",
+                "",
+                "def unused():",
+                "    return 1",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+    )
+    by_name = _entries_by_name(result)
+
+    assert by_name["app.main"]["classification"] == "alive"
+    assert _event_kinds(by_name["app.main"]) >= {"package_entrypoint"}
+
+
+def test_dynamic_pattern_evidence_is_reported_from_analyzer(tmp_path):
+    (tmp_path / "app.py").write_text(
+        "\n".join(
+            [
+                "class Box:",
+                "    pass",
+                "",
+                "def handle_login():",
+                "    return 1",
+                "",
+                "def configure(name):",
+                "    attr = f'handle_{name}'",
+                "    return getattr(Box(), attr, None)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+    )
+    by_name = _entries_by_name(result)
+
+    assert by_name["app.handle_login"]["classification"] == "alive"
+    assert _event_kinds(by_name["app.handle_login"]) >= {"dynamic_pattern"}
+    assert "reachable_from_root" not in _event_kinds(by_name["app.handle_login"])
+
+
+def test_trace_and_coverage_evidence_are_reported_from_analyzer(tmp_path):
+    module = tmp_path / "app.py"
+    module.write_text(
+        "def traced():\n    return 1\n\ndef covered():\n    return 2\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".skylos_trace").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "calls": [
+                    {
+                        "file": str(module),
+                        "function": "traced",
+                        "line": 1,
+                        "count": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    conn = sqlite3.connect(tmp_path / ".coverage")
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE file (id INTEGER PRIMARY KEY, path TEXT)")
+    cur.execute("CREATE TABLE line_bits (file_id INTEGER, numbits BLOB)")
+    cur.execute("INSERT INTO file VALUES (1, ?)", (str(module),))
+    cur.execute("INSERT INTO line_bits VALUES (1, ?)", (bytes([16]),))
+    conn.commit()
+    conn.close()
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    by_name = _entries_by_name(result)
+
+    assert _event_kinds(by_name["app.traced"]) >= {"trace_hit"}
+    assert _event_kinds(by_name["app.covered"]) >= {"coverage_hit"}
+
+
+def test_framework_and_test_roots_are_reported_as_roots(tmp_path):
+    (tmp_path / "app.py").write_text(
+        "\n".join(
+            [
+                "from flask import Flask",
+                "app = Flask(__name__)",
+                "",
+                "@app.route('/')",
+                "def home():",
+                "    return 'ok'",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "conftest.py").write_text(
+        "\n".join(
+            [
+                "import pytest",
+                "",
+                "@pytest.fixture",
+                "def client():",
+                "    return object()",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+    )
+    by_name = _entries_by_name(result)
+
+    assert by_name["app.home"]["classification"] == "alive"
+    assert _event_kinds(by_name["app.home"]) >= {"framework_root"}
+    assert by_name["conftest.client"]["classification"] == "alive"
+    assert _event_kinds(by_name["conftest.client"]) >= {"test_entrypoint"}
+
+
+def test_reference_safe_policy_marks_weak_dead_candidates_uncertain(tmp_path):
+    (tmp_path / "app.py").write_text(
+        "\n".join(
+            [
+                "def format_name(value):",
+                "    return value.strip()",
+                "",
+                "class Widget:",
+                "    def __init__(self):",
+                "        self.ready = True",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+    )
+    by_name = _entries_by_name(result)
+
+    assert by_name["app.format_name"]["classification"] == "uncertain"
+    assert _event_kinds(by_name["app.format_name"]) >= {"uncertainty"}
+    assert by_name["app.Widget.__init__"]["classification"] == "uncertain"
+    assert _event_kinds(by_name["app.Widget.__init__"]) >= {"uncertainty"}


### PR DESCRIPTION
## Summary

  - add a dead-code evidence ledger with classifications for alive, likely dead, validated dead, and uncertain symbols
  - attach evidence metadata to dead-code definitions and unused findings
  - record evidence from package entrypoints, framework/test roots, dynamic refs, coverage, trace hits, top level execution, and reachable roots
  - add abstentions for ambiguous cases such as protocol methods, `__init__`, framework lifecycle hooks, and weak helper names
  - fix root `.coverage` loading so covered functions are not falsely reported when skylos is run from outside the scanned project

  ## Tests

  - `pytest test/test_dead_code_evidence.py`
  - `pytest .`