### PR TITLE
fix(ci): harden generated workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -166,8 +166,9 @@ runs:
 
     - name: Upload Report Artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: skylos-report
         path: skylos-report.json
+        if-no-files-found: error
         retention-days: 30

--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -16,6 +16,11 @@ ANALYSIS_FLAG_MAP: dict[str, str] = {
 }
 
 SKYLOS_DEFENSE_RESULTS_SHELL_PATH = '"$RUNNER_TEMP/defense-results.json"'
+PINNED_ACTIONS_CHECKOUT = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+PINNED_ACTIONS_SETUP_PYTHON = "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
+PINNED_ACTIONS_UPLOAD_ARTIFACT = "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+PINNED_ACTIONS_DOWNLOAD_ARTIFACT = "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
+PINNED_CLAUDE_CODE_ACTION = "anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84"
 
 
 def _installed_skylos_version() -> str | None:
@@ -154,14 +159,10 @@ def generate_workflow(
             f"          {review_command}",
         ]
     )
+    skylos_environment = "\n    environment: skylos-security" if use_llm else ""
 
     permissions_block = """permissions:
-  contents: read
-  pull-requests: write
-  checks: write
-  id-token: write"""
-    if use_claude_security:
-        permissions_block += "\n  security-events: write"
+  contents: read"""
 
     sync_step = """
       - name: Pull Skylos Cloud Policy
@@ -179,14 +180,21 @@ jobs:
   skylos:
     name: Skylos Quality Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+{skylos_environment}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: {PINNED_ACTIONS_CHECKOUT}
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: {PINNED_ACTIONS_SETUP_PYTHON}
         with:
           python-version: '{python_version}'
 
@@ -218,10 +226,11 @@ jobs:
         else '''
       - name: Upload Skylos Results for Cross-Reference
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: {PINNED_ACTIONS_UPLOAD_ARTIFACT}
         with:
           name: skylos-results
           path: skylos-results.json
+          if-no-files-found: error
 '''
     }"""
 
@@ -235,24 +244,27 @@ def _build_claude_security_jobs(python_version: str, install_command: str) -> st
     return f"""
   claude-security:
     runs-on: ubuntu-latest
+    environment: skylos-security
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: {PINNED_ACTIONS_CHECKOUT}
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Claude Code Security Review
-        uses: anthropics/claude-code-action@main
+        uses: {PINNED_CLAUDE_CODE_ACTION}
         with:
           anthropic_api_key: ${{{{ secrets.ANTHROPIC_API_KEY }}}}
           direct_prompt: "/review --output-file claude-security-results.json"
 
       - name: Upload Claude Security Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: {PINNED_ACTIONS_UPLOAD_ARTIFACT}
         with:
           name: claude-security-results
           path: claude-security-results.json
+          if-no-files-found: error
 
   upload-claude-findings:
     if: always()
@@ -260,10 +272,12 @@ def _build_claude_security_jobs(python_version: str, install_command: str) -> st
     needs: [skylos, claude-security]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: {PINNED_ACTIONS_CHECKOUT}
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: {PINNED_ACTIONS_SETUP_PYTHON}
         with:
           python-version: '{python_version}'
 
@@ -271,12 +285,12 @@ def _build_claude_security_jobs(python_version: str, install_command: str) -> st
         run: {install_command}
 
       - name: Download Claude Security Results
-        uses: actions/download-artifact@v4
+        uses: {PINNED_ACTIONS_DOWNLOAD_ARTIFACT}
         with:
           name: claude-security-results
 
       - name: Download Skylos Results
-        uses: actions/download-artifact@v4
+        uses: {PINNED_ACTIONS_DOWNLOAD_ARTIFACT}
         with:
           name: skylos-results
 

--- a/test/test_cicd_workflow.py
+++ b/test/test_cicd_workflow.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from skylos.cicd.workflow import generate_workflow
+from skylos.rules.config.cicd.github_actions import scan_github_actions
 
 
 def test_default_workflow_valid_yaml():
@@ -106,10 +107,39 @@ def test_workflow_non_claude_model_no_anthropic_key():
 def test_workflow_permissions():
     content = generate_workflow()
     parsed = yaml.safe_load(content)
-    perms = parsed["permissions"]
-    assert perms["contents"] == "read"
-    assert perms["pull-requests"] == "write"
-    assert perms["id-token"] == "write"
+    assert parsed["permissions"] == {"contents": "read"}
+    job = parsed["jobs"]["skylos"]
+    assert job["permissions"] == {
+        "contents": "read",
+        "pull-requests": "write",
+        "id-token": "write",
+    }
+    assert job["timeout-minutes"] == 15
+
+
+def test_generated_workflow_passes_skylos_actions_audit(tmp_path):
+    workflow = tmp_path / ".github" / "workflows" / "skylos.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(generate_workflow(), encoding="utf-8")
+
+    assert scan_github_actions(tmp_path) == []
+
+
+def test_generated_claude_workflow_passes_skylos_actions_audit(tmp_path):
+    workflow = tmp_path / ".github" / "workflows" / "skylos.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        generate_workflow(
+            use_upload=True,
+            use_llm=True,
+            use_defend=True,
+            use_claude_security=True,
+            model="gpt-4.1",
+        ),
+        encoding="utf-8",
+    )
+
+    assert scan_github_actions(tmp_path) == []
 
 
 def test_workflow_schedule_trigger():

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -5,7 +5,10 @@ import yaml
 
 from skylos.analyzer import analyze
 from skylos.rules.config import scan_config_files
-from skylos.rules.config.cicd.github_actions import scan_github_actions
+from skylos.rules.config.cicd.github_actions import (
+    scan_github_actions,
+    scan_github_actions_file,
+)
 
 
 def _rule_ids(findings):
@@ -421,6 +424,10 @@ def test_composite_action_validates_and_quotes_max_comments_input():
     assert "${{ inputs.max-comments }}" not in run
     assert '"$SKYLOS_MAX_COMMENTS"' in run
     assert "=~ ^[0-9]+$" in run
+
+
+def test_composite_action_passes_skylos_actions_audit():
+    assert scan_github_actions_file("action.yml", root=".") == []
 
 
 def test_analyzer_reports_github_actions_dangers_without_source_files(tmp_path):

--- a/test/test_ingest.py
+++ b/test/test_ingest.py
@@ -293,12 +293,15 @@ class TestWorkflowClaudeSecurity:
         assert "upload-claude-findings" not in yaml
 
     def test_with_flag(self):
-        from skylos.cicd.workflow import generate_workflow
+        from skylos.cicd.workflow import (
+            PINNED_CLAUDE_CODE_ACTION,
+            generate_workflow,
+        )
 
         yaml = generate_workflow(use_claude_security=True)
         assert "claude-security:" in yaml
         assert "upload-claude-findings:" in yaml
-        assert "anthropics/claude-code-action@main" in yaml
+        assert PINNED_CLAUDE_CODE_ACTION in yaml
         assert "skylos ingest claude-security" in yaml
         assert "SKYLOS_TOKEN" not in yaml
         assert "ANTHROPIC_API_KEY" in yaml
@@ -309,11 +312,12 @@ class TestWorkflowClaudeSecurity:
         yaml = generate_workflow(use_claude_security=True)
         assert "needs: [skylos, claude-security]" in yaml
 
-    def test_security_events_permission(self):
+    def test_claude_security_uses_dedicated_environment_without_broad_permission(self):
         from skylos.cicd.workflow import generate_workflow
 
         yaml = generate_workflow(use_claude_security=True)
-        assert "security-events: write" in yaml
+        assert "environment: skylos-security" in yaml
+        assert "security-events: write" not in yaml
 
     def test_no_security_events_without_flag(self):
         from skylos.cicd.workflow import generate_workflow


### PR DESCRIPTION
## Summary

  - harden generated gh action workflows
  - pin gh action references to full commit SHAs
  - move broad token permissions from workflow level to job level
  - add bounded job timeout and checkout `persist-credentials: false`
  - apply same hardening to `action.yml`

  ## Tests

  - `pytest test/test_cicd_workflow.py`
  - `pytest test/test_github_actions_security.py`
  - `pytest test/test_ingest.py test/test_cicd_review.py test/test_cicd_evidence.py test/test_sync.py test/test_cli_refactor_guardrails.py`