### PR TITLE
feat(quality): add opaque identifier readability rule

### DIFF
--- a/benchmarks/quality/fixtures/opaque_identifier/module.py
+++ b/benchmarks/quality/fixtures/opaque_identifier/module.py
@@ -1,0 +1,28 @@
+def load_account_snapshot(request, repository, audit_log):
+    x = request.args.get("account_id")
+    if not x:
+        audit_log.warning("missing account")
+        return {"status": "missing", "account_id": ""}
+
+    audit_log.info("loading account snapshot")
+    account = repository.fetch_account(x)
+    if account is None:
+        return {"status": "missing", "account_id": x}
+
+    owner = repository.fetch_owner(account.owner_id)
+    return {
+        "status": "active",
+        "account_id": x,
+        "owner": owner.email,
+    }
+
+
+def coordinate_area(point):
+    x = point.get("x", 0)
+    y = point.get("y", 0)
+    return x * y
+
+
+def normalize(raw):
+    tmp = raw.strip()
+    return tmp

--- a/benchmarks/quality/manifest.json
+++ b/benchmarks/quality/manifest.json
@@ -159,6 +159,29 @@
       }
     },
     {
+      "id": "opaque-identifier",
+      "path": "fixtures/opaque_identifier",
+      "description": "Long-lived short or vague variables should be reported only when RHS semantics provide a clearly better name.",
+      "taxonomy": ["readability", "maintainability", "precision_guard"],
+      "importance": "high",
+      "source": {
+        "repo": "https://github.com/google/styleguide",
+        "license": "CC-BY-3.0",
+        "notes": "Distilled from identifier guidance around descriptive names proportional to scope."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "quality": ["SKY-Q806", "x", "account_id"]
+        },
+        "absent": {
+          "quality": ["coordinate_area", "tmp"]
+        }
+      }
+    },
+    {
       "id": "repo-policy-missing-typechecker",
       "path": "fixtures/repo_policy_missing_typechecker",
       "description": "Repository policy checks should report Python projects without mypy or pyright configuration.",
@@ -198,7 +221,7 @@
       "expect": {
         "present": {},
         "absent": {
-          "quality": ["SKY-Q301", "SKY-C303", "SKY-C304", "SKY-L006", "SKY-L007", "SKY-UC001"]
+          "quality": ["SKY-Q301", "SKY-C303", "SKY-C304", "SKY-L006", "SKY-L007", "SKY-UC001", "SKY-Q806"]
         }
       }
     }

--- a/docs/opaque-identifier-plan.md
+++ b/docs/opaque-identifier-plan.md
@@ -1,0 +1,55 @@
+# Opaque Identifier Readability Plan
+
+## Goal
+
+Add a low-noise quality rule that catches names like `x = request.args.get("user_id")` when the short or vague name hides useful meaning from the right-hand side and the variable lives long enough to hurt reviewability.
+
+## Rule Shape
+
+- Rule ID: `SKY-Q806`
+- Category: `quality`
+- Kind: `readability`
+- Default severity: `LOW`
+- No new feature flag. The rule is enabled with existing `--quality` analysis and can only be disabled through the normal rule ignore list.
+
+## Precision Constraints
+
+The rule must not flag short names by length alone. It should require all of these signals:
+
+- The assigned name is genuinely opaque, such as a one-letter non-counter name or a generic placeholder like `tmp`, `value`, `obj`, or `result`.
+- The RHS has recoverable key or subscript evidence, such as `.get("user_id")` or `request.headers["Authorization"]`. Call names can add context, but they are not enough by themselves for default-quality findings.
+- The variable has meaningful lifetime or usage, such as being used several lines later, passed onward, returned, or used in a branch.
+
+The rule must skip common acceptable short-name cases:
+
+- loop counters and compact iteration names such as `i`, `j`, `k`, `n`, and `m`
+- exception variables like `e`
+- file handles like `f`, `fp`, `fd`, and `fh`
+- throwaway names beginning with `_`
+- `x`, `y`, and `z` when the RHS already names the same coordinate or is clearly numeric/math-shaped
+- test files and small throwaway scopes
+
+## Implementation Steps
+
+- Add `skylos/rules/quality/_readability.py` with a module-scoped AST rule.
+- Register `SKY-Q806` in the analyzer, rule catalog, CWE/standard metadata, and quality node dispatch table.
+- Add unit tests for positive, negative, coordinate, short-scope, and test-file behavior.
+- Add a quality benchmark fixture that includes one hard positive and multiple clean counterexamples.
+- Run focused tests and the quality benchmark. Keep the rule only if the benchmark stays at 100 and the clean fixture remains clean for `SKY-Q806`.
+
+## Acceptance Criteria
+
+- `SKY-Q806` fires on an opaque long-lived variable whose RHS clearly exposes a better name.
+- `SKY-Q806` does not fire on coordinate/math short names, loop counters, exception variables, file handles, small temporary values, or test files.
+- Checked-in quality benchmark passes with no new failures.
+
+## Execution Result
+
+- Implemented `SKY-Q806` as default `--quality` behavior with no new feature flag.
+- Tightened the rule after self-scan evidence showed call-name-only matching was too noisy.
+- Final rule requires direct key/subscript evidence and at least a five-line usage span.
+- Validation:
+  - `test/test_good_practices_rules.py test/test_quality_benchmark.py test/test_quality_standards.py test/test_debt.py`: `100 passed`
+  - `test/test_architecture.py test/test_rules_cmd.py`: `48 passed`
+  - `benchmarks/quality/manifest.json`: `100.0/100`, `0` failures
+  - Skylos source-tree FP probe: `0` `SKY-Q806` findings

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -88,6 +88,7 @@ from skylos.rules.quality.practices import (
     FrameworkPracticeRule,
     TypeAnnotationPracticeRule,
 )
+from skylos.rules.quality._readability import OpaqueIdentifierRule
 from skylos.rules.quality.policy import analyze_repo_policy
 from skylos.rules.quality.phantom_refs import scan_repo_phantom_security_references
 from skylos.rules.vibe_dictionary import build_vibe_dictionary
@@ -285,6 +286,7 @@ _LINTER_RULE_NODE_TYPES = {
     PerformanceRule: (ast.Call, ast.For),
     TypeAnnotationPracticeRule: (ast.Module,),
     FrameworkPracticeRule: (ast.Module,),
+    OpaqueIdentifierRule: (ast.Module,),
     DangerousCallsRule: (ast.Module, ast.Import, ast.ImportFrom, ast.Assign, ast.Call),
 }
 
@@ -3299,6 +3301,8 @@ def proc_file(
                 q_rules.append(TypeAnnotationPracticeRule())
             if "SKY-F101" not in cfg["ignore"] or "SKY-F102" not in cfg["ignore"]:
                 q_rules.append(FrameworkPracticeRule())
+            if "SKY-Q806" not in cfg["ignore"]:
+                q_rules.append(OpaqueIdentifierRule())
 
             if "SKY-U001" not in cfg["ignore"]:
                 q_rules.append(UnreachableCodeRule())

--- a/skylos/benchmarks/quality.py
+++ b/skylos/benchmarks/quality.py
@@ -18,6 +18,7 @@ QUALITY_TAXONOMY: dict[str, str] = {
     "framework": "Framework-specific route and handler practices.",
     "maintainability": "Long functions and patterns that become hard to review or change.",
     "precision_guard": "Clean cases that should stay free of noisy quality findings.",
+    "readability": "Identifier clarity and naming choices that affect code review.",
     "repo_policy": "Repository-level lint, type-check, gate, and hook policy.",
     "security_practice": "Security-oriented coding practices that support safe defaults.",
     "typing": "Type annotation coverage and type-check policy.",

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -46,6 +46,7 @@ _RULES = (
     RuleCatalogEntry("SKY-Q803", "Architecture zone warning", "quality"),
     RuleCatalogEntry("SKY-Q804", "Dependency inversion violation", "quality"),
     RuleCatalogEntry("SKY-Q805", "Architecture layer policy violation", "quality"),
+    RuleCatalogEntry("SKY-Q806", "Opaque identifier", "quality", "LOW"),
     RuleCatalogEntry("SKY-L001", "Mutable default argument", "quality"),
     RuleCatalogEntry("SKY-L002", "Bare except block", "quality"),
     RuleCatalogEntry("SKY-L003", "Dangerous comparison", "quality"),

--- a/skylos/rules/quality/_readability.py
+++ b/skylos/rules/quality/_readability.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from skylos.rules.base import SkylosRule
+
+
+_IDENT_SPLIT_RE = re.compile(r"[^A-Za-z0-9]+")
+_CAMEL_BOUNDARY_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+_ACCEPTED_SHORT_NAMES = {
+    "i",
+    "j",
+    "k",
+    "n",
+    "m",
+    "e",
+    "f",
+    "fp",
+    "fd",
+    "fh",
+    "db",
+    "id",
+    "pk",
+    "q",
+}
+
+_STRONG_OPAQUE_NAMES = {
+    "tmp",
+    "temp",
+    "var",
+    "val",
+    "obj",
+    "thing",
+    "stuff",
+    "out",
+    "ret",
+}
+
+_WEAK_OPAQUE_NAMES = {
+    "data",
+    "result",
+    "results",
+    "value",
+    "item",
+    "items",
+    "info",
+}
+
+_STOP_TOKENS = {
+    "a",
+    "an",
+    "and",
+    "api",
+    "arg",
+    "args",
+    "as",
+    "bool",
+    "build",
+    "by",
+    "call",
+    "client",
+    "cls",
+    "create",
+    "dict",
+    "do",
+    "fetch",
+    "for",
+    "format",
+    "from",
+    "get",
+    "handle",
+    "helper",
+    "http",
+    "https",
+    "int",
+    "json",
+    "kwargs",
+    "list",
+    "load",
+    "make",
+    "manager",
+    "none",
+    "object",
+    "of",
+    "parse",
+    "process",
+    "read",
+    "repo",
+    "repository",
+    "request",
+    "run",
+    "self",
+    "service",
+    "set",
+    "str",
+    "to",
+    "util",
+    "utils",
+    "with",
+    "write",
+}
+
+_DOMAIN_TOKENS = {
+    "account",
+    "admin",
+    "auth",
+    "authorization",
+    "bucket",
+    "cmd",
+    "command",
+    "config",
+    "cookie",
+    "email",
+    "file",
+    "filename",
+    "header",
+    "headers",
+    "host",
+    "invoice",
+    "order",
+    "org",
+    "password",
+    "path",
+    "payment",
+    "permission",
+    "project",
+    "query",
+    "role",
+    "secret",
+    "session",
+    "sql",
+    "tenant",
+    "token",
+    "url",
+    "user",
+}
+
+_MATH_TOKENS = {
+    "abs",
+    "acos",
+    "asin",
+    "atan",
+    "ceil",
+    "cos",
+    "floor",
+    "height",
+    "hypot",
+    "len",
+    "log",
+    "max",
+    "min",
+    "pow",
+    "sin",
+    "sqrt",
+    "tan",
+    "vector",
+    "width",
+}
+
+_COORD_NAMES = {"x", "y", "z"}
+
+
+@dataclass(frozen=True)
+class _AssignmentCandidate:
+    name: str
+    line: int
+    col: int
+    rhs: ast.AST
+
+
+@dataclass(frozen=True)
+class _UsageProfile:
+    use_count: int
+    span: int
+    contexts: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _RhsEvidence:
+    tokens: tuple[str, ...]
+    key_tokens: tuple[str, ...]
+    semantic_tokens: tuple[str, ...]
+    suggested_name: str
+    score: int
+    has_domain_token: bool
+
+
+def _basename(filename: str | None) -> str:
+    return Path(filename or "").name
+
+
+def _is_non_production_path(filename: str | None) -> bool:
+    normalized = str(filename or "").replace("\\", "/").lower()
+    parts = set(normalized.split("/"))
+    base = Path(normalized).name
+    return (
+        "test" in parts
+        or "tests" in parts
+        or "corpus" in parts
+        or base.startswith("test_")
+        or base.endswith("_test.py")
+    )
+
+
+def _split_identifier(value: str) -> list[str]:
+    spaced = _CAMEL_BOUNDARY_RE.sub("_", str(value))
+    tokens: list[str] = []
+    for part in _IDENT_SPLIT_RE.split(spaced):
+        part = part.strip("_").lower()
+        if not part:
+            continue
+        tokens.append(part)
+    return tokens
+
+
+def _ordered_unique(tokens: Iterable[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for token in tokens:
+        if token and token not in seen:
+            seen.add(token)
+            ordered.append(token)
+    return tuple(ordered)
+
+
+def _dotted_name(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Call):
+        return _dotted_name(node.func)
+    if isinstance(node, ast.Subscript):
+        return _dotted_name(node.value)
+    return ""
+
+
+def _string_constant(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _subscript_key(node: ast.Subscript) -> str | None:
+    key = node.slice
+    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+        return key.value
+    return None
+
+
+def _semantic_subset(tokens: Iterable[str]) -> tuple[str, ...]:
+    return _ordered_unique(
+        token for token in tokens if len(token) > 1 and token not in _STOP_TOKENS
+    )
+
+
+def _direct_key_tokens(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Call):
+        call_name = _dotted_name(node.func)
+        if call_name.rsplit(".", 1)[-1] == "get" and node.args:
+            key_value = _string_constant(node.args[0])
+            if key_value:
+                return _split_identifier(key_value)
+        if isinstance(node.func, ast.Attribute):
+            return _direct_key_tokens(node.func.value)
+        return []
+    if isinstance(node, ast.Attribute):
+        return _direct_key_tokens(node.value)
+    if isinstance(node, ast.Subscript):
+        tokens: list[str] = []
+        key_value = _subscript_key(node)
+        if key_value:
+            tokens.extend(_split_identifier(key_value))
+        tokens.extend(_direct_key_tokens(node.value))
+        return tokens
+    return []
+
+
+def _rhs_evidence(node: ast.AST) -> _RhsEvidence:
+    raw_tokens: list[str] = []
+    key_tokens = _direct_key_tokens(node)
+    has_structural_hint = bool(key_tokens)
+
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            call_name = _dotted_name(child.func)
+            raw_tokens.extend(_split_identifier(call_name))
+        elif isinstance(child, ast.Subscript):
+            raw_tokens.extend(_split_identifier(_dotted_name(child.value)))
+        elif isinstance(child, ast.Attribute):
+            raw_tokens.extend(_split_identifier(child.attr))
+        elif isinstance(child, ast.Name):
+            raw_tokens.extend(_split_identifier(child.id))
+
+    key_semantics = _semantic_subset(key_tokens)
+    all_semantics = _semantic_subset([*key_tokens, *raw_tokens])
+    suggested_tokens = key_semantics or all_semantics[:3]
+    suggested_name = "_".join(suggested_tokens[:3])
+
+    has_domain_token = bool(set(all_semantics) & _DOMAIN_TOKENS)
+    score = 0
+    if key_semantics:
+        score += 2
+    if all_semantics:
+        score += 1
+    if has_domain_token:
+        score += 1
+    if has_structural_hint:
+        score += 1
+
+    return _RhsEvidence(
+        tokens=_ordered_unique(raw_tokens),
+        key_tokens=key_semantics,
+        semantic_tokens=all_semantics,
+        suggested_name=suggested_name,
+        score=score,
+        has_domain_token=has_domain_token,
+    )
+
+
+def _name_opacity_strength(name: str) -> int:
+    normalized = name.lower()
+    if not normalized or normalized.startswith("_") or normalized.isupper():
+        return 0
+    if normalized in _ACCEPTED_SHORT_NAMES:
+        return 0
+    if len(normalized) == 1 and normalized.isalpha():
+        return 2
+    if normalized in _STRONG_OPAQUE_NAMES:
+        return 2
+    if normalized in _WEAK_OPAQUE_NAMES:
+        return 1
+    return 0
+
+
+def _is_numeric_or_math_shape(node: ast.AST, evidence: _RhsEvidence) -> bool:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float, complex)):
+        return True
+    if isinstance(node, ast.UnaryOp):
+        return _is_numeric_or_math_shape(node.operand, evidence)
+    if isinstance(node, ast.BinOp):
+        return _is_numeric_or_math_shape(node.left, evidence) or _is_numeric_or_math_shape(
+            node.right, evidence
+        )
+    if isinstance(node, ast.Call):
+        return bool(set(evidence.semantic_tokens) & _MATH_TOKENS)
+    return False
+
+
+def _rhs_already_names_target(name: str, evidence: _RhsEvidence) -> bool:
+    normalized = name.lower()
+    if evidence.suggested_name == normalized:
+        return True
+    return normalized in evidence.key_tokens and len(evidence.key_tokens) <= 2
+
+
+def _names_loaded_in(node: ast.AST | None) -> set[str]:
+    if node is None:
+        return set()
+    return {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+    }
+
+
+class _ScopeFactCollector(ast.NodeVisitor):
+    def __init__(self, root: ast.FunctionDef | ast.AsyncFunctionDef):
+        self.root = root
+        self.assignments: list[_AssignmentCandidate] = []
+        self.uses: dict[str, list[int]] = defaultdict(list)
+        self.contexts: dict[str, list[tuple[int, str]]] = defaultdict(list)
+
+    def collect(self) -> None:
+        for stmt in self.root.body:
+            self.visit(stmt)
+
+    def _visit_children(self, node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            self.visit(child)
+
+    def generic_visit(self, node: ast.AST) -> None:
+        self._visit_children(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if node is self.root:
+            self._visit_children(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        if node is self.root:
+            self._visit_children(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        return None
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return None
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                self.assignments.append(
+                    _AssignmentCandidate(
+                        name=target.id,
+                        line=getattr(target, "lineno", node.lineno),
+                        col=getattr(target, "col_offset", node.col_offset),
+                        rhs=node.value,
+                    )
+                )
+        self.visit(node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if isinstance(node.target, ast.Name) and node.value is not None:
+            self.assignments.append(
+                _AssignmentCandidate(
+                    name=node.target.id,
+                    line=getattr(node.target, "lineno", node.lineno),
+                    col=getattr(node.target, "col_offset", node.col_offset),
+                    rhs=node.value,
+                )
+            )
+        if node.value is not None:
+            self.visit(node.value)
+
+    def visit_If(self, node: ast.If) -> None:
+        for name in _names_loaded_in(node.test):
+            self.contexts[name].append((node.lineno, "branch"))
+        self._visit_children(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        for name in _names_loaded_in(node.test):
+            self.contexts[name].append((node.lineno, "branch"))
+        self._visit_children(node)
+
+    def visit_Return(self, node: ast.Return) -> None:
+        for name in _names_loaded_in(node.value):
+            self.contexts[name].append((node.lineno, "returned"))
+        self._visit_children(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        for arg in node.args:
+            for name in _names_loaded_in(arg):
+                self.contexts[name].append((node.lineno, "passed"))
+        for keyword in node.keywords:
+            for name in _names_loaded_in(keyword.value):
+                self.contexts[name].append((node.lineno, "passed"))
+        self._visit_children(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Load):
+            self.uses[node.id].append(node.lineno)
+
+
+def _iter_function_scopes(module: ast.Module):
+    for node in ast.walk(module):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _usage_profile(
+    assignment: _AssignmentCandidate,
+    assignments: list[_AssignmentCandidate],
+    uses: dict[str, list[int]],
+    contexts: dict[str, list[tuple[int, str]]],
+) -> _UsageProfile:
+    next_assignment_line = min(
+        (
+            other.line
+            for other in assignments
+            if other.name == assignment.name and other.line > assignment.line
+        ),
+        default=None,
+    )
+
+    def in_assignment_window(line: int) -> bool:
+        return line > assignment.line and (
+            next_assignment_line is None or line < next_assignment_line
+        )
+
+    use_lines = [line for line in uses.get(assignment.name, []) if in_assignment_window(line)]
+    context_values = {
+        context
+        for line, context in contexts.get(assignment.name, [])
+        if in_assignment_window(line)
+    }
+    span = max(use_lines) - assignment.line if use_lines else 0
+    return _UsageProfile(
+        use_count=len(use_lines),
+        span=span,
+        contexts=frozenset(context_values),
+    )
+
+
+def _usage_score(profile: _UsageProfile) -> int:
+    score = 0
+    if profile.span >= 8:
+        score += 2
+    elif profile.span >= 5:
+        score += 1
+    if profile.use_count >= 3:
+        score += 1
+    if profile.contexts & {"branch", "passed", "returned"}:
+        score += 1
+    return score
+
+
+def _should_report(
+    assignment: _AssignmentCandidate,
+    profile: _UsageProfile,
+    evidence: _RhsEvidence,
+) -> bool:
+    strength = _name_opacity_strength(assignment.name)
+    if strength == 0 or profile.use_count == 0:
+        return False
+    if not evidence.key_tokens:
+        return False
+    if evidence.score < 2 or not evidence.suggested_name:
+        return False
+    if _rhs_already_names_target(assignment.name, evidence):
+        return False
+    if assignment.name.lower() in _COORD_NAMES and _is_numeric_or_math_shape(
+        assignment.rhs, evidence
+    ):
+        return False
+    if profile.span < 5:
+        return False
+
+    total_score = strength + evidence.score + _usage_score(profile)
+    threshold = 7 if strength == 1 else 6
+    return total_score >= threshold
+
+
+class OpaqueIdentifierRule(SkylosRule):
+    rule_id = "SKY-Q806"
+    name = "Opaque Identifier"
+
+    def visit_node(self, node, context):
+        if not isinstance(node, ast.Module):
+            return None
+
+        filename = context.get("filename")
+        if _is_non_production_path(filename):
+            return None
+
+        findings: list[dict] = []
+        reported: set[tuple[str, int, int]] = set()
+
+        for scope in _iter_function_scopes(node):
+            collector = _ScopeFactCollector(scope)
+            collector.collect()
+
+            for assignment in collector.assignments:
+                evidence = _rhs_evidence(assignment.rhs)
+                profile = _usage_profile(
+                    assignment,
+                    collector.assignments,
+                    collector.uses,
+                    collector.contexts,
+                )
+                if not _should_report(assignment, profile, evidence):
+                    continue
+
+                key = (assignment.name, assignment.line, assignment.col)
+                if key in reported:
+                    continue
+                reported.add(key)
+
+                findings.append(
+                    {
+                        "rule_id": self.rule_id,
+                        "kind": "readability",
+                        "severity": "LOW",
+                        "type": "variable",
+                        "name": assignment.name,
+                        "simple_name": assignment.name,
+                        "value": evidence.suggested_name,
+                        "threshold": 6,
+                        "metric": "identifier_opacity",
+                        "message": (
+                            f"Opaque variable '{assignment.name}' hides semantic "
+                            f"RHS evidence; consider a name like "
+                            f"'{evidence.suggested_name}'."
+                        ),
+                        "file": filename,
+                        "basename": _basename(filename),
+                        "line": assignment.line,
+                        "col": assignment.col,
+                        "span": profile.span,
+                        "use_count": profile.use_count,
+                    }
+                )
+
+        return findings or None

--- a/skylos/rules/quality/standards.py
+++ b/skylos/rules/quality/standards.py
@@ -115,6 +115,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     "SKY-Q802": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-Q803": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-Q804": [{"id": "CWE-704", "name": "Incorrect Type Conversion or Cast"}],
+    "SKY-Q806": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-C303": [
         {
             "id": "CWE-1064",
@@ -151,6 +152,10 @@ STANDARD_REFS: dict[str, list[str]] = {
     "SKY-Q701": ["CK Metrics: CBO (Coupling Between Objects)", "ISO/IEC 9126"],
     "SKY-Q702": ["CK Metrics: LCOM (Lack of Cohesion of Methods)", "ISO/IEC 9126"],
     "SKY-Q805": ["Architecture layer dependency policy"],
+    "SKY-Q806": [
+        "PEP 8 naming guidance",
+        "Google Python style: descriptive names proportional to scope",
+    ],
     "SKY-L032": ["Production data hygiene: mock and placeholder values"],
     "SKY-C303": ["ISO/IEC 5055:2021 §6.3.2"],
     "SKY-C304": ["ISO/IEC 5055:2021 §6.3.3"],

--- a/test/test_good_practices_rules.py
+++ b/test/test_good_practices_rules.py
@@ -8,6 +8,7 @@ from skylos.rules.quality.practices import (
     FrameworkPracticeRule,
     TypeAnnotationPracticeRule,
 )
+from skylos.rules.quality._readability import OpaqueIdentifierRule
 
 
 def _run_rule(rule, code: str, filename: str = "app.py") -> list[dict]:
@@ -143,6 +144,72 @@ def test_mutating_flask_route_accepts_login_required_guard():
         def create_user():
             return {}
         """,
+    )
+
+    assert findings == []
+
+
+def test_opaque_identifier_flags_long_lived_semantic_rhs():
+    findings = _run_rule(
+        OpaqueIdentifierRule(),
+        """
+        def load_profile(request, repository, audit_log):
+            x = request.args.get("user_id")
+            if not x:
+                audit_log.warning("missing user")
+                return None
+            audit_log.info("loading profile")
+            profile = repository.fetch_profile(x)
+            if profile.disabled:
+                return {"status": "disabled", "id": x}
+            return {"status": "active", "id": x}
+        """,
+    )
+
+    assert [finding["rule_id"] for finding in findings] == ["SKY-Q806"]
+    assert findings[0]["kind"] == "readability"
+    assert findings[0]["name"] == "x"
+    assert findings[0]["value"] == "user_id"
+
+
+def test_opaque_identifier_accepts_coordinate_names():
+    findings = _run_rule(
+        OpaqueIdentifierRule(),
+        """
+        def area(point):
+            x = point.get("x", 0)
+            y = point.get("y", 0)
+            return x * y
+        """,
+    )
+
+    assert findings == []
+
+
+def test_opaque_identifier_accepts_short_lived_temporary():
+    findings = _run_rule(
+        OpaqueIdentifierRule(),
+        """
+        def normalize(raw):
+            tmp = raw.strip()
+            return tmp
+        """,
+    )
+
+    assert findings == []
+
+
+def test_opaque_identifier_skips_test_files():
+    findings = _run_rule(
+        OpaqueIdentifierRule(),
+        """
+        def test_load_profile(request, repository):
+            x = request.args.get("user_id")
+            assert repository.fetch_profile(x)
+            assert x
+            assert x.startswith("user_")
+        """,
+        filename="tests/test_profiles.py",
     )
 
     assert findings == []

--- a/test/test_quality_benchmark.py
+++ b/test/test_quality_benchmark.py
@@ -29,6 +29,7 @@ def test_checked_in_quality_manifest_validates():
         "empty-error-handler",
         "type-annotation-gaps",
         "framework-route-policy",
+        "opaque-identifier",
         "repo-policy-missing-typechecker",
         "clean-module",
     }


### PR DESCRIPTION
## Summary
  - Add `SKY-Q806` for opaque identifier readability issues.
  - Flag only long-lived opaque variables when direct RHS key/subscript evidence suggests a clearer name, e.g. `x = request.args.get("account_id")`.
  - Add quality benchmark coverage and a repo plan documenting the precision constraints and validation result.

  ## Tests

    - `pytest test/test_good_practices_rules.py`
    - `pytest test/test_quality_benchmark.py`
    - `pytest test/test_quality_standards.py`
    - `pytest test/test_debt.py`
    - `pytest test/test_architecture.py`
    - `pytest test/test_rules_cmd.py`