### PR TITLE
fix(security): preserve synced policy precedence

### DIFF
--- a/skylos/config.py
+++ b/skylos/config.py
@@ -41,6 +41,9 @@ DEFAULTS = {
         "security_audit": None,
         "review": None,
     },
+    "security_enabled": False,
+    "secrets_enabled": False,
+    "quality_enabled": False,
     "vibe": {
         "extra_phantom_names": [],
         "extra_phantom_decorators": [],
@@ -79,6 +82,22 @@ _DICT_CONFIG_KEYS = {
 _BOOL_CONFIG_KEYS = {
     "nudges",
     "check_circular",
+    "security_enabled",
+    "secrets_enabled",
+    "quality_enabled",
+}
+_SYNCED_SECURITY_POLICY_KEYS = {
+    "security_contracts",
+    "security_enabled",
+    "secrets_enabled",
+    "quality_enabled",
+}
+_SYNCED_POLICY_OVERRIDE_KEYS = _SYNCED_SECURITY_POLICY_KEYS | {
+    "gate",
+}
+_REPO_POLICY_WEAKENING_KEYS = {
+    "ignore",
+    "exclude",
 }
 
 
@@ -89,17 +108,52 @@ def load_config(start_path) -> dict:
 
     root_config, sync_config = _find_config_paths(current)
     final_cfg = copy.deepcopy(DEFAULTS)
+    synced_cfg = _load_synced_config(sync_config) if sync_config else {}
 
-    if sync_config:
-        final_cfg = _merge_user_config(final_cfg, _load_synced_config(sync_config))
+    if synced_cfg:
+        final_cfg = _merge_user_config(final_cfg, synced_cfg)
 
     if not root_config:
         return final_cfg
 
     try:
-        return _merge_user_config(final_cfg, _load_pyproject_user_config(root_config))
+        final_cfg = _merge_user_config(
+            final_cfg, _load_pyproject_user_config(root_config)
+        )
     except Exception:
         return final_cfg
+    return _restore_synced_policy_precedence(final_cfg, synced_cfg)
+
+
+def _restore_synced_policy_precedence(final_cfg: dict, synced_cfg: dict) -> dict:
+    if not isinstance(synced_cfg, dict) or not synced_cfg:
+        return final_cfg
+
+    protected = {
+        key
+        for key in (_SYNCED_POLICY_OVERRIDE_KEYS | _REPO_POLICY_WEAKENING_KEYS)
+        if key in synced_cfg
+    }
+    synced_security_policy = _has_synced_security_policy(synced_cfg)
+    if synced_security_policy:
+        protected.update(_REPO_POLICY_WEAKENING_KEYS)
+
+    if not protected:
+        return final_cfg
+
+    cloud_cfg = _merge_user_config(copy.deepcopy(DEFAULTS), synced_cfg)
+    restored = copy.deepcopy(final_cfg)
+    for key in protected:
+        restored[key] = copy.deepcopy(cloud_cfg.get(key, DEFAULTS.get(key)))
+    if synced_security_policy:
+        restored["ignore"] = [
+            rule_id for rule_id in restored.get("ignore", []) if rule_id != "SKY-SC001"
+        ]
+    return _sanitize_config(restored)
+
+
+def _has_synced_security_policy(synced_cfg: dict) -> bool:
+    return any(bool(synced_cfg.get(key)) for key in _SYNCED_SECURITY_POLICY_KEYS)
 
 
 def _is_safe_config_file(config_path: Path, expected_name: str) -> bool:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -74,7 +74,7 @@ security_contracts:
         self.assertEqual(len(config["security_contracts"]), 1)
         self.assertEqual(config["security_contracts"][0]["handler"], "list_users")
 
-    def test_load_config_local_pyproject_overrides_synced_yaml(self):
+    def test_load_config_local_pyproject_cannot_override_synced_security_policy(self):
         skylos_dir = self.root / ".skylos"
         skylos_dir.mkdir()
         (skylos_dir / "config.yaml").write_text(
@@ -96,12 +96,8 @@ security_contracts:
 [tool.skylos]
 complexity = 99
 exclude = ["local/**"]
-
-[[tool.skylos.security_contracts]]
-framework = "fastapi"
-file = "app/api/admin.py"
-handler = "admin_panel"
-guards = ["require_staff"]
+ignore = ["SKY-SC001"]
+security_contracts = []
 """.strip(),
             encoding="utf-8",
         )
@@ -109,9 +105,40 @@ guards = ["require_staff"]
         config = load_config(self.root)
 
         self.assertEqual(config["complexity"], 99)
-        self.assertEqual(config["exclude"], ["local/**"])
+        self.assertEqual(config["exclude"], ["generated/**"])
+        self.assertNotIn("SKY-SC001", config["ignore"])
         self.assertEqual(len(config["security_contracts"]), 1)
-        self.assertEqual(config["security_contracts"][0]["handler"], "admin_panel")
+        self.assertEqual(config["security_contracts"][0]["handler"], "list_users")
+
+    def test_load_config_synced_security_policy_rejects_repo_ignore_and_exclude(self):
+        skylos_dir = self.root / ".skylos"
+        skylos_dir.mkdir()
+        (skylos_dir / "config.yaml").write_text(
+            """
+security_contracts:
+  - framework: fastapi
+    file: app/routes/admin.py
+    handler: list_users
+    guards:
+      - require_admin
+""".strip(),
+            encoding="utf-8",
+        )
+        (self.root / "pyproject.toml").write_text(
+            """
+[tool.skylos]
+ignore = ["SKY-SC001", "SKY-D000"]
+exclude = ["app/**"]
+security_enabled = false
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = load_config(self.root)
+
+        self.assertEqual(config["exclude"], [])
+        self.assertEqual(config["ignore"], [])
+        self.assertEqual(config["security_contracts"][0]["handler"], "list_users")
 
     def test_load_config_with_gate_logic(self):
         toml_path = self.root / "pyproject.toml"

--- a/test/test_security_contracts.py
+++ b/test/test_security_contracts.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from skylos.config import load_config
 from skylos.security.contracts import (
     detect_security_contract_regressions,
     load_security_contracts,
@@ -69,6 +70,79 @@ def test_load_security_contracts_normalizes_invalid_severity(tmp_path):
 
     assert len(contracts) == 1
     assert contracts[0].severity == "HIGH"
+
+
+def test_synced_security_contract_survives_repo_config_bypass(tmp_path, monkeypatch):
+    before_source = """
+from fastapi import APIRouter, Depends
+
+router = APIRouter()
+
+def require_admin():
+    return True
+
+@router.get("/admin/users")
+def list_users(user=Depends(require_admin)):
+    return {"ok": True}
+""".strip()
+    after_source = """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/admin/users")
+def list_users():
+    return {"ok": True}
+""".strip()
+
+    target = tmp_path / "app" / "routes"
+    target.mkdir(parents=True)
+    file_path = target / "admin.py"
+    file_path.write_text(after_source, encoding="utf-8")
+    skylos_dir = tmp_path / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "config.yaml").write_text(
+        """
+security_contracts:
+  - framework: fastapi
+    file: app/routes/admin.py
+    handler: list_users
+    guards:
+      - require_admin
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.skylos]
+security_contracts = []
+ignore = ["SKY-SC001"]
+exclude = ["app/**"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd, capture_output, text, cwd):
+        class Result:
+            returncode = 0
+            stdout = before_source
+
+        return Result()
+
+    monkeypatch.setattr("skylos.security.contracts.subprocess.run", fake_run)
+
+    config = load_config(tmp_path)
+    findings = detect_security_contract_regressions(
+        tmp_path,
+        config,
+        changed_files={str(file_path.resolve())},
+    )
+
+    assert "SKY-SC001" not in config["ignore"]
+    assert config["exclude"] == []
+    assert len(config["security_contracts"]) == 1
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-SC001"
 
 
 def test_detect_security_contract_regression_for_removed_depends_guard(


### PR DESCRIPTION
## Summary
  - Preserve synced Skylos Cloud policy precedence over repo-local `pyproject.toml` for security enforcement.
  - Prevent PR-controlled config from disabling synced `security_contracts`.
  - Prevent repo config from ignoring `SKY-SC001` or excluding protected contract paths when synced security policy is present.
 
  ## Tests
  - `pytest test/test_config.py test/test_security_contracts.py test/test_sync.py`
  - `pytest test/test_cli.py -k "policy or config or security_contracts"`