### PR TITLE
fix(ci): enable repo map pages

### DIFF
--- a/.github/workflows/repo-map-pages.yml
+++ b/.github/workflows/repo-map-pages.yml
@@ -34,6 +34,8 @@ jobs:
         run: python scripts/build_repo_map.py --check
 
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:


### PR DESCRIPTION
## Summary
- enable GitHub Pages during the repo-map Pages workflow when the repository has no Pages site yet
- keep the generated repo-map deploy path otherwise unchanged

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/repo-map-pages.yml"); puts "workflow yaml ok"'`
- `.venv/bin/python scripts/build_repo_map.py --check`
- staged Skylos gate during commit
- push hook Rust/Python parity check: `32 passed, 27 deselected`