### PR TITLE
feat(docs): document repo map entrypoints

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -520,7 +520,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 16</span>
           <span class="pill"><strong>symbols</strong> 119</span>
-          <span class="pill"><strong>lines</strong> 3936</span>
+          <span class="pill"><strong>lines</strong> 4405</span>
         </div>
       </div>
       <p>Repository maintenance, benchmark, parity, and regression scripts.</p>
@@ -534,8 +534,8 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../scripts/build_repo_map.py">scripts/build_repo_map.py</a> <span>902 lines</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">scripts/repo_map_renderer.py</a> <span>474 lines</span></li>
+        <ul><li><a href="../../scripts/build_repo_map.py">scripts/build_repo_map.py</a> <span>1186 lines</span></li>
+<li><a href="../../scripts/repo_map_renderer.py">scripts/repo_map_renderer.py</a> <span>659 lines</span></li>
 <li><a href="../../scripts/regression_delta.py">scripts/regression_delta.py</a> <span>353 lines</span></li>
 <li><a href="../../scripts/compare_codex_skylos_quality.py">scripts/compare_codex_skylos_quality.py</a> <span>420 lines</span></li>
 <li><a href="../../scripts/compare_codex_skylos_agent_review.py">scripts/compare_codex_skylos_agent_review.py</a> <span>424 lines</span></li>
@@ -545,16 +545,16 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../scripts/build_repo_map.py">SymbolInfo:513</a> <span>class</span></li>
-<li><a href="../../scripts/build_repo_map.py">ModuleInfo:521</a> <span>class</span></li>
-<li><a href="../../scripts/build_repo_map.py">collect_repo_map:674</a> <span>def</span></li>
-<li><a href="../../scripts/build_repo_map.py">write_repo_map:850</a> <span>def</span></li>
-<li><a href="../../scripts/build_repo_map.py">main:858</a> <span>def</span></li>
+        <ul><li><a href="../../scripts/build_repo_map.py">SymbolInfo:535</a> <span>class</span></li>
+<li><a href="../../scripts/build_repo_map.py">ModuleInfo:558</a> <span>class</span></li>
+<li><a href="../../scripts/build_repo_map.py">collect_repo_map:806</a> <span>def</span></li>
+<li><a href="../../scripts/build_repo_map.py">write_repo_map:1094</a> <span>def</span></li>
+<li><a href="../../scripts/build_repo_map.py">main:1120</a> <span>def</span></li>
 <li><a href="../../scripts/repo_map_renderer.py">render_personas:30</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_workflows:55</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_first_steps:80</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_sharp_edges:99</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_architecture_layers:115</a> <span>def</span></li>
+<li><a href="../../scripts/repo_map_renderer.py">render_workflows:71</a> <span>def</span></li>
+<li><a href="../../scripts/repo_map_renderer.py">render_first_steps:113</a> <span>def</span></li>
+<li><a href="../../scripts/repo_map_renderer.py">render_sharp_edges:132</a> <span>def</span></li>
+<li><a href="../../scripts/repo_map_renderer.py">render_architecture_layers:148</a> <span>def</span></li>
 <li><a href="../../scripts/regression_delta.py">compare_corpus:177</a> <span>def</span></li>
 <li><a href="../../scripts/regression_delta.py">compare_agent_review:210</a> <span>def</span></li>
 <li><a href="../../scripts/regression_delta.py">compare_quality:267</a> <span>def</span></li>
@@ -3912,7 +3912,7 @@
             
 
             <tr class="searchable" data-search="symbolinfo class scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">SymbolInfo:513</a></td>
+              <td><a href="../../scripts/build_repo_map.py">SymbolInfo:535</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3920,7 +3920,7 @@
             
 
             <tr class="searchable" data-search="moduleinfo class scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">ModuleInfo:521</a></td>
+              <td><a href="../../scripts/build_repo_map.py">ModuleInfo:558</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3928,7 +3928,7 @@
             
 
             <tr class="searchable" data-search="collect_repo_map def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">collect_repo_map:674</a></td>
+              <td><a href="../../scripts/build_repo_map.py">collect_repo_map:806</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3936,7 +3936,7 @@
             
 
             <tr class="searchable" data-search="write_repo_map def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">write_repo_map:850</a></td>
+              <td><a href="../../scripts/build_repo_map.py">write_repo_map:1094</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3944,7 +3944,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">main:858</a></td>
+              <td><a href="../../scripts/build_repo_map.py">main:1120</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -4064,7 +4064,7 @@
             
 
             <tr class="searchable" data-search="render_workflows def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_workflows:55</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_workflows:71</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4072,7 +4072,7 @@
             
 
             <tr class="searchable" data-search="render_first_steps def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_first_steps:80</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_first_steps:113</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4080,7 +4080,7 @@
             
 
             <tr class="searchable" data-search="render_sharp_edges def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_sharp_edges:99</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_sharp_edges:132</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4088,7 +4088,7 @@
             
 
             <tr class="searchable" data-search="render_architecture_layers def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_architecture_layers:115</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_architecture_layers:148</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4096,7 +4096,7 @@
             
 
             <tr class="searchable" data-search="render_docstring_guide def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_docstring_guide:144</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_docstring_guide:197</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4104,7 +4104,7 @@
             
 
             <tr class="searchable" data-search="render_flow def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_flow:159</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_flow:224</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4112,7 +4112,7 @@
             
 
             <tr class="searchable" data-search="render_folder_cards def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_folder_cards:183</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_folder_cards:259</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4120,7 +4120,7 @@
             
 
             <tr class="searchable" data-search="render_folder_card def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_folder_card:187</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_folder_card:276</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4128,7 +4128,7 @@
             
 
             <tr class="searchable" data-search="render_hot_modules def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_hot_modules:253</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_hot_modules:360</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4136,7 +4136,7 @@
             
 
             <tr class="searchable" data-search="render_symbol_index def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_symbol_index:284</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_symbol_index:407</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4144,7 +4144,7 @@
             
 
             <tr class="searchable" data-search="render_glossary def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_glossary:302</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_glossary:436</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4152,7 +4152,7 @@
             
 
             <tr class="searchable" data-search="render_html def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_html:314</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_html:448</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4160,7 +4160,7 @@
             
 
             <tr class="searchable" data-search="render_snapshot def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_snapshot:332</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_snapshot:491</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4168,7 +4168,7 @@
             
 
             <tr class="searchable" data-search="section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">section:351</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">section:521</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4176,7 +4176,7 @@
             
 
             <tr class="searchable" data-search="render_flow_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_flow_section:367</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_flow_section:552</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4184,7 +4184,7 @@
             
 
             <tr class="searchable" data-search="render_folder_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_folder_section:378</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_folder_section:563</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4192,7 +4192,7 @@
             
 
             <tr class="searchable" data-search="render_hot_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_hot_section:389</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_hot_section:574</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4200,7 +4200,7 @@
             
 
             <tr class="searchable" data-search="render_symbol_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_symbol_section:404</a></td>
+              <td><a href="../../scripts/repo_map_renderer.py">render_symbol_section:589</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>

--- a/scripts/build_repo_map.py
+++ b/scripts/build_repo_map.py
@@ -15,6 +15,28 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_renderer():
+    """
+    Load the repo-map HTML renderer from the local scripts directory.
+
+    Args:
+        None.
+
+    Returns:
+        The renderer module's `render_html` callable.
+
+    Trust boundary:
+        The renderer path is fixed relative to this repository, not supplied by
+        a scanned project. Loading by file path avoids treating
+        `repo_map_renderer` as an external package dependency.
+
+    Failure mode:
+        Raises RuntimeError if the renderer module cannot be loaded.
+
+    Calls: importlib.util.spec_from_file_location;
+        importlib.util.module_from_spec.
+
+    Called from: scripts/build_repo_map.py module import.
+    """
     renderer_path = REPO_ROOT / "scripts" / "repo_map_renderer.py"
     spec = importlib.util.spec_from_file_location("skylos_repo_map_renderer", renderer_path)
     if spec is None or spec.loader is None:
@@ -511,6 +533,21 @@ GLOSSARY = [
 
 @dataclass(frozen=True)
 class SymbolInfo:
+    """
+    Top-level class or function discovered in one Python source file.
+
+    Attributes:
+        name: Symbol name exactly as it appears in source.
+        kind: Human-readable symbol type, such as `class`, `def`, or
+            `async def`.
+        line: 1-based source line for the symbol definition.
+        private: Whether the symbol name starts with `_`.
+
+    Used by:
+        scripts/build_repo_map.py _extract_symbols;
+        scripts/build_repo_map.py _key_symbols;
+        scripts/repo_map_renderer.py render_symbol_index.
+    """
     name: str
     kind: str
     line: int
@@ -519,6 +556,20 @@ class SymbolInfo:
 
 @dataclass(frozen=True)
 class ModuleInfo:
+    """
+    Parsed facts for one Python module shown in the repo map.
+
+    Attributes:
+        path: Repository-relative POSIX path.
+        lines: Approximate source line count.
+        summary: Module docstring summary or curated folder fallback.
+        symbols: Top-level symbols extracted from the module AST.
+        imports: Top-level import roots used by the module.
+
+    Used by:
+        scripts/build_repo_map.py collect_repo_map;
+        scripts/repo_map_renderer.py render_hot_modules.
+    """
     path: str
     lines: int
     summary: str
@@ -531,6 +582,25 @@ def _rel(path: Path, root: Path) -> str:
 
 
 def _iter_source_files(root: Path) -> list[Path]:
+    """
+    Walk the repository roots that feed the generated map.
+
+    Args:
+        root: Repository root to scan.
+
+    Returns:
+        Sorted source/config/doc files under SOURCE_ROOTS that are regular,
+        non-symlink files under the size cap.
+
+    Trust boundary:
+        Source paths may come from the repository being documented. Directory
+        symlinks and oversized files are skipped before read/parsing.
+
+    Calls: scripts/build_repo_map.py _include_directory;
+        scripts/build_repo_map.py _safe_source_file.
+
+    Called from: scripts/build_repo_map.py collect_repo_map.
+    """
     files: list[Path] = []
     for root_name in SOURCE_ROOTS:
         base = root / root_name
@@ -559,6 +629,25 @@ def _include_directory(path: Path) -> bool:
 
 
 def _safe_source_file(path: Path) -> bool:
+    """
+    Decide whether a path is safe for the repo-map generator to read.
+
+    Args:
+        path: Candidate file path.
+
+    Returns:
+        True only for regular non-symlink files no larger than
+        MAX_SOURCE_BYTES.
+
+    Invariants:
+        Do not follow symlinks. Do not read unbounded file content.
+
+    Calls: pathlib.Path.stat.
+
+    Called from: scripts/build_repo_map.py _iter_source_files;
+        scripts/build_repo_map.py _read_text;
+        scripts/build_repo_map.py main.
+    """
     try:
         file_stat = path.stat(follow_symlinks=False)
         return (
@@ -581,6 +670,29 @@ def _first_sentence(text: str) -> str:
 
 
 def _read_text(path: Path) -> str:
+    """
+    Read a validated source file with symlink and size defenses.
+
+    Args:
+        path: Regular source file already expected to be inside the repo walk.
+
+    Returns:
+        UTF-8 text, replacing undecodable bytes.
+
+    Trust boundary:
+        Files are repository content and may be attacker-controlled in forks or
+        PRs. Reads are guarded by _safe_source_file and O_NOFOLLOW where the OS
+        supports it.
+
+    Failure mode:
+        Raises ValueError for unsafe paths. IO errors are allowed to propagate
+        because a broken repo-map generation should fail loudly.
+
+    Calls: scripts/build_repo_map.py _safe_source_file; os.open; os.fdopen.
+
+    Called from: scripts/build_repo_map.py _parse_python_module;
+        scripts/build_repo_map.py main.
+    """
     if not _safe_source_file(path):
         raise ValueError(f"Refusing to read unsafe or oversized source file: {path}")
     flags = os.O_RDONLY
@@ -630,6 +742,26 @@ def _fallback_summary(relpath: str) -> str:
 
 
 def _parse_python_module(path: Path, root: Path) -> ModuleInfo:
+    """
+    Parse one Python file into the module facts shown by the map.
+
+    Args:
+        path: Python source file to parse.
+        root: Repository root used to compute display paths.
+
+    Returns:
+        ModuleInfo containing path, line count, summary, imports, and top-level
+        symbols. Syntax errors produce an empty-symbol ModuleInfo instead of
+        aborting the whole map.
+
+    Calls: scripts/build_repo_map.py _rel;
+        scripts/build_repo_map.py _read_text;
+        scripts/build_repo_map.py _first_sentence;
+        scripts/build_repo_map.py _extract_symbols;
+        scripts/build_repo_map.py _extract_imports.
+
+    Called from: scripts/build_repo_map.py collect_repo_map.
+    """
     relpath = _rel(path, root)
     source = _read_text(path)
     lines = source.count("\n") + (1 if source else 0)
@@ -675,8 +807,26 @@ def collect_repo_map(root: Path) -> dict[str, Any]:
     """
     Build deterministic repo-map data from code and a small curated folder map.
 
+    Args:
+        root: Repository root to scan.
+
+    Returns:
+        Dictionary consumed by `scripts.repo_map_renderer.render_html`. It
+        includes persona cards, architecture layers, docstring guidance,
+        folder cards, hot modules, symbol index, and repo-level counts.
+
+    Invariants:
+        Generated data must be deterministic for the same tree. This keeps
+        `scripts/build_repo_map.py --check` useful in CI and avoids noisy PRs.
+
+    Performance shape:
+        Walks selected repository roots once, then parses Python files with
+        `ast`. The scan is intentionally local-only and uses a per-file size cap.
+
     Calls: scripts/build_repo_map.py _iter_source_files;
-        scripts/build_repo_map.py _parse_python_module.
+        scripts/build_repo_map.py _parse_python_module;
+        scripts/build_repo_map.py _sanitize_path_groups;
+        scripts/build_repo_map.py _sanitize_workflows.
 
     Called from: scripts/build_repo_map.py write_repo_map;
         scripts/build_repo_map.py main.
@@ -758,6 +908,21 @@ def collect_repo_map(root: Path) -> dict[str, Any]:
 
 
 def _sanitize_path_groups(root: Path, groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Remove stale links from curated card groups before rendering.
+
+    Args:
+        root: Repository root used to check whether paths still exist.
+        groups: Curated persona, first-step, or architecture cards.
+
+    Returns:
+        Shallow-copied card dictionaries with `paths` filtered to existing
+        files/directories or approved generated paths.
+
+    Calls: scripts/build_repo_map.py _path_exists_or_directory.
+
+    Called from: scripts/build_repo_map.py collect_repo_map.
+    """
     sanitized: list[dict[str, Any]] = []
     for group in groups:
         copy = dict(group)
@@ -767,6 +932,19 @@ def _sanitize_path_groups(root: Path, groups: list[dict[str, Any]]) -> list[dict
 
 
 def _sanitize_workflows(root: Path) -> list[dict[str, Any]]:
+    """
+    Remove stale file and test links from workflow cards.
+
+    Args:
+        root: Repository root used for path existence checks.
+
+    Returns:
+        Workflow dictionaries with non-existent `paths` and `tests` removed.
+
+    Calls: scripts/build_repo_map.py _path_exists_or_directory.
+
+    Called from: scripts/build_repo_map.py collect_repo_map.
+    """
     workflows: list[dict[str, Any]] = []
     for workflow in WORKFLOWS:
         copy = dict(workflow)
@@ -785,6 +963,18 @@ def _path_exists_or_directory(root: Path, relpath: str) -> bool:
 
 
 def _key_symbols(modules: list[ModuleInfo]) -> list[dict[str, Any]]:
+    """
+    Select a compact symbol sample for one folder card.
+
+    Args:
+        modules: ModuleInfo objects already sorted by local importance.
+
+    Returns:
+        Up to 14 dictionaries containing symbol name, kind, file path, and
+        source line. Public symbols are preferred before private helpers.
+
+    Called from: scripts/build_repo_map.py collect_repo_map.
+    """
     items: list[dict[str, Any]] = []
     for module in modules:
         public = [symbol for symbol in module.symbols if not symbol.private]
@@ -804,6 +994,21 @@ def _key_symbols(modules: list[ModuleInfo]) -> list[dict[str, Any]]:
 
 
 def _symbol_index(modules: list[ModuleInfo]) -> list[dict[str, Any]]:
+    """
+    Build the searchable symbol table shown near the bottom of the map.
+
+    Args:
+        modules: Parsed Python module facts.
+
+    Returns:
+        Up to 900 symbol dictionaries sorted by file and line. Private helpers
+        are hidden except in the major shared entrypoint files.
+
+    Invariants:
+        Keep this bounded so the generated page stays usable and predictable.
+
+    Called from: scripts/build_repo_map.py collect_repo_map.
+    """
     symbols: list[dict[str, Any]] = []
     for module in sorted(modules, key=lambda item: item.path):
         for symbol in module.symbols:
@@ -823,6 +1028,26 @@ def _symbol_index(modules: list[ModuleInfo]) -> list[dict[str, Any]]:
 
 
 def _resolve_output_path(root: Path, output: Path) -> Path:
+    """
+    Resolve and validate the generated HTML output path.
+
+    Args:
+        root: Repository root that must contain the output parent.
+        output: Absolute or root-relative output path requested by the caller.
+
+    Returns:
+        Absolute output path under `root`.
+
+    Trust boundary:
+        Output paths can be supplied from CLI args. The generator refuses
+        symlink parents, symlink targets, and paths outside the repository.
+
+    Failure mode:
+        Raises ValueError when the output path is unsafe.
+
+    Called from: scripts/build_repo_map.py write_repo_map;
+        scripts/build_repo_map.py main.
+    """
     candidate = output if output.is_absolute() else root / output
     candidate_parent = candidate.parent
     candidate_parent.mkdir(parents=True, exist_ok=True)
@@ -837,6 +1062,25 @@ def _resolve_output_path(root: Path, output: Path) -> Path:
 
 
 def _write_text_safely(path: Path, content: str) -> None:
+    """
+    Write generated repo-map HTML without following symlink targets.
+
+    Args:
+        path: Validated output file path.
+        content: Full HTML document to write.
+
+    Returns:
+        None.
+
+    Trust boundary:
+        This protects local and CI runs from writing generated content through
+        an attacker-controlled symlink in a checked-out repository.
+
+    Calls: os.open; os.fdopen.
+
+    Called from: scripts/build_repo_map.py write_repo_map;
+        scripts/build_repo_map.py main.
+    """
     if path.is_symlink():
         raise ValueError(f"Refusing to write repo map through symlink: {path}")
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
@@ -848,6 +1092,24 @@ def _write_text_safely(path: Path, content: str) -> None:
 
 
 def write_repo_map(root: Path, output: Path) -> str:
+    """
+    Generate and write the repo-map HTML page.
+
+    Args:
+        root: Repository root to scan.
+        output: HTML output path.
+
+    Returns:
+        The generated HTML string after it has been written to disk.
+
+    Calls: scripts/build_repo_map.py _resolve_output_path;
+        scripts/build_repo_map.py collect_repo_map;
+        scripts.repo_map_renderer.render_html;
+        scripts/build_repo_map.py _write_text_safely.
+
+    Called from: tests and by callers that want generation without invoking
+        the CLI parser.
+    """
     output = _resolve_output_path(root.resolve(), output)
     data = collect_repo_map(root)
     page = render_html(data)
@@ -856,6 +1118,28 @@ def write_repo_map(root: Path, output: Path) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """
+    Command-line entrypoint for building or checking the repo map.
+
+    Args:
+        argv: Optional argument list. When None, argparse reads sys.argv.
+
+    Returns:
+        Process-style exit code: 0 for success, 1 when `--check` finds a
+        missing or stale generated page.
+
+    Behavior:
+        Without `--check`, writes `docs/repo-map/index.html`. With `--check`,
+        renders in memory and compares against the checked-in generated file.
+
+    Calls: scripts/build_repo_map.py collect_repo_map;
+        scripts.repo_map_renderer.render_html;
+        scripts/build_repo_map.py _resolve_output_path;
+        scripts/build_repo_map.py _read_text;
+        scripts/build_repo_map.py _write_text_safely.
+
+    Called from: shell, GitHub Pages workflow, and test/test_repo_map.py.
+    """
     parser = argparse.ArgumentParser(description="Build Skylos' static repo navigator.")
     parser.add_argument(
         "--root",

--- a/scripts/repo_map_renderer.py
+++ b/scripts/repo_map_renderer.py
@@ -28,6 +28,22 @@ def _persona_attr(item: dict[str, Any]) -> str:
 
 
 def render_personas(personas: list[dict[str, Any]]) -> str:
+    """
+    Render persona filter cards for the top of the repo map.
+
+    Args:
+        personas: Curated persona dictionaries with id, title, summary, search
+            text, and paths.
+
+    Returns:
+        HTML button cards. Each card carries `data-mode` for client-side
+        filtering and escaped search text.
+
+    Calls: scripts/repo_map_renderer.py _esc;
+        scripts/repo_map_renderer.py _link.
+
+    Called from: scripts/repo_map_renderer.py render_html.
+    """
     cards = [
         """
         <button class="persona-card active" type="button" data-mode="all" data-search="all everything full map reset">
@@ -53,6 +69,23 @@ def render_personas(personas: list[dict[str, Any]]) -> str:
 
 
 def render_workflows(workflows: list[dict[str, Any]]) -> str:
+    """
+    Render task-oriented route cards.
+
+    Args:
+        workflows: Curated workflow dictionaries with title, goal, persona
+            tags, paths, tests, and ordered steps.
+
+    Returns:
+        HTML article cards showing what to read, what to test, and what action
+        to take next.
+
+    Calls: scripts/repo_map_renderer.py _link;
+        scripts/repo_map_renderer.py _esc;
+        scripts/repo_map_renderer.py _persona_attr.
+
+    Called from: scripts/repo_map_renderer.py render_html.
+    """
     cards = []
     for workflow in workflows:
         path_links = " ".join(_link(path) for path in workflow["paths"])
@@ -113,6 +146,26 @@ def render_sharp_edges(groups: list[dict[str, Any]]) -> str:
 
 
 def render_architecture_layers(layers: list[dict[str, Any]]) -> str:
+    """
+    Render the architecture-at-a-glance section.
+
+    Args:
+        layers: Curated layer dictionaries with purpose, dependency direction,
+            guardrail, persona tags, and representative paths.
+
+    Returns:
+        HTML cards that explain ownership boundaries before users open files.
+
+    Invariants:
+        Keep this conceptual and small. The page should guide navigation, not
+        become a giant dependency graph.
+
+    Calls: scripts/repo_map_renderer.py _link;
+        scripts/repo_map_renderer.py _esc;
+        scripts/repo_map_renderer.py _persona_attr.
+
+    Called from: scripts/repo_map_renderer.py render_html.
+    """
     cards = []
     for layer in layers:
         links = " ".join(_link(path) for path in layer["paths"])
@@ -142,6 +195,18 @@ def render_architecture_layers(layers: list[dict[str, Any]]) -> str:
 
 
 def render_docstring_guide(items: list[dict[str, str]]) -> str:
+    """
+    Render the guidance for future key-function docstrings.
+
+    Args:
+        items: Curated docstring guidance items with title and body text.
+
+    Returns:
+        HTML cards describing what maintainers should document for important
+        functions and classes.
+
+    Called from: scripts/repo_map_renderer.py render_html.
+    """
     cards = []
     for item in items:
         search_text = f"{item['title']} {item['body']}"
@@ -157,6 +222,17 @@ def render_docstring_guide(items: list[dict[str, str]]) -> str:
 
 
 def render_flow() -> str:
+    """
+    Render the main scan-flow pipeline.
+
+    Args:
+        None.
+
+    Returns:
+        HTML cards for the fixed high-level flow from input to output.
+
+    Called from: scripts/repo_map_renderer.py render_flow_section.
+    """
     steps = [
         ("Input", "CLI args, changed files, config", ["skylos/cli.py", "skylos/config.py"]),
         ("Discovery", "Select source files and language paths", ["skylos/discover/", "skylos/pipeline.py"]),
@@ -181,10 +257,41 @@ def render_flow() -> str:
 
 
 def render_folder_cards(cards: list[dict[str, Any]]) -> str:
+    """
+    Render all folder ownership cards.
+
+    Args:
+        cards: Folder card dictionaries produced by collect_repo_map.
+
+    Returns:
+        Concatenated HTML for each folder card.
+
+    Calls: scripts/repo_map_renderer.py render_folder_card.
+
+    Called from: scripts/repo_map_renderer.py render_folder_section.
+    """
     return "\n".join(render_folder_card(card) for card in cards)
 
 
 def render_folder_card(card: dict[str, Any]) -> str:
+    """
+    Render one folder ownership card.
+
+    Args:
+        card: Folder metadata and generated facts. Expected keys include path,
+            purpose, touch, entrypoints, tests, modules, and key_symbols.
+
+    Returns:
+        HTML article with folder purpose, touch guidance, entrypoints, nearby
+        tests, important files, and key symbols.
+
+    Calls: scripts/repo_map_renderer.py _link;
+        scripts/repo_map_renderer.py _pill;
+        scripts/repo_map_renderer.py _folder_detail_lists;
+        scripts/repo_map_renderer.py _folder_search_text.
+
+    Called from: scripts/repo_map_renderer.py render_folder_cards.
+    """
     modules = "\n".join(
         f"<li>{_link(module.path)} <span>{_esc(module.lines)} lines</span></li>"
         for module in card["modules"]
@@ -251,6 +358,22 @@ def _folder_detail_lists(modules: str, symbols: str) -> str:
 
 
 def render_hot_modules(modules: list[Any]) -> str:
+    """
+    Render high-risk or high-traffic modules.
+
+    Args:
+        modules: ModuleInfo-like objects sorted by size and symbol count.
+
+    Returns:
+        Table rows with path, line count, public/all symbol count, risk labels,
+        and summary.
+
+    Calls: scripts/repo_map_renderer.py _hot_module_labels;
+        scripts/repo_map_renderer.py _link;
+        scripts/repo_map_renderer.py _esc.
+
+    Called from: scripts/repo_map_renderer.py render_hot_section.
+    """
     rows = []
     for module in modules:
         public_symbols = sum(1 for symbol in module.symbols if not symbol.private)
@@ -282,6 +405,17 @@ def _hot_module_labels(module: Any) -> list[str]:
 
 
 def render_symbol_index(symbols: list[dict[str, Any]]) -> str:
+    """
+    Render the searchable symbol index.
+
+    Args:
+        symbols: Bounded symbol dictionaries from collect_repo_map.
+
+    Returns:
+        HTML table rows for symbol name, kind, surface, and file path.
+
+    Called from: scripts/repo_map_renderer.py render_symbol_section.
+    """
     rows = []
     for item in symbols:
         badge = '<span class="muted">private</span>' if item["private"] else '<span class="ok">public</span>'
@@ -312,6 +446,31 @@ def render_glossary(items: list[tuple[str, str]]) -> str:
 
 
 def render_html(data: dict[str, Any]) -> str:
+    """
+    Render the full repo-map HTML document.
+
+    Args:
+        data: Deterministic map data from scripts/build_repo_map.py
+            collect_repo_map.
+
+    Returns:
+        Full HTML page string. CSS and JS are external files under
+        docs/repo-map/.
+
+    Trust boundary:
+        Dynamic values come from repository metadata and are escaped by the
+        lower-level render helpers before interpolation.
+
+    Calls: scripts/repo_map_renderer.py render_snapshot;
+        scripts/repo_map_renderer.py section;
+        scripts/repo_map_renderer.py render_flow_section;
+        scripts/repo_map_renderer.py render_folder_section;
+        scripts/repo_map_renderer.py render_hot_section;
+        scripts/repo_map_renderer.py render_symbol_section.
+
+    Called from: scripts/build_repo_map.py write_repo_map;
+        scripts/build_repo_map.py main.
+    """
     sections = [
         render_snapshot(data),
         section("personas", "Choose A Mode", render_personas(data["personas"]), PERSONA_COPY, "persona-grid"),
@@ -330,6 +489,17 @@ def render_html(data: dict[str, Any]) -> str:
 
 
 def render_snapshot(data: dict[str, Any]) -> str:
+    """
+    Render repository-level counts and the comprehension-debt framing note.
+
+    Args:
+        data: Full map data dictionary.
+
+    Returns:
+        HTML section for top-level metrics and context.
+
+    Called from: scripts/repo_map_renderer.py render_html.
+    """
     guided_routes = len(data["workflows"]) + len(data["first_steps"])
     return (  # skylos: ignore escaped static repo-map HTML fragments
         f"""
@@ -349,6 +519,21 @@ def render_snapshot(data: dict[str, Any]) -> str:
 
 
 def section(section_id: str, title: str, body: str, lede: str = "", grid_class: str | None = None) -> str:
+    """
+    Wrap rendered cards in a named page section.
+
+    Args:
+        section_id: HTML id and sidebar anchor target.
+        title: Section heading text.
+        body: Already-rendered safe HTML card content.
+        lede: Optional introductory sentence.
+        grid_class: Optional CSS grid class override.
+
+    Returns:
+        HTML section wrapper.
+
+    Called from: scripts/repo_map_renderer.py render_html.
+    """
     lede_html = f'<p class="lede">{_esc(lede)}</p>' if lede else ""
     resolved_grid = grid_class or ("guide-grid" if section_id in {"first-steps", "sharp-edges"} else "route-grid")
     return (  # skylos: ignore escaped static repo-map HTML fragments


### PR DESCRIPTION
## Summary
- add structured docstrings to key repo-map generator and renderer entrypoints
- document args, returns, calls, callers, trust boundaries, invariants, failure modes, and performance shape where relevant
- regenerate the repo map so the new summaries remain current

## Validation
- `pytest test/test_repo_map.py`
- `.venv/bin/python scripts/build_repo_map.py --check`
- `.venv/bin/python -m py_compile scripts/build_repo_map.py scripts/repo_map_renderer.py test/test_repo_map.py`
- `.venv/bin/skylos agent pre-commit .`