### PR TITLE
fix(docs): repair repo map navigation

### DIFF
--- a/docs/repo-map/app.js
+++ b/docs/repo-map/app.js
@@ -2,7 +2,33 @@ const search = document.getElementById("repo-search");
 const emptyState = document.getElementById("empty-state");
 const items = Array.from(document.querySelectorAll(".searchable"));
 const personaButtons = Array.from(document.querySelectorAll(".persona-card[data-mode]"));
+const modePanel = document.getElementById("mode-panel");
+const activeModeTitle = document.getElementById("active-mode-title");
+const activeModeSummary = document.getElementById("active-mode-summary");
+const activeModePlan = document.getElementById("active-mode-plan");
+const modePlanTemplates = new Map(
+  Array.from(document.querySelectorAll("template[data-mode-plan]")).map((template) => [
+    template.dataset.modePlan,
+    template,
+  ]),
+);
 let activeMode = "all";
+
+function updateModePanel(button, { animate = false } = {}) {
+  activeModeTitle.textContent = button.dataset.modeTitle || button.textContent.trim();
+  activeModeSummary.textContent = button.dataset.modeSummary || "";
+
+  const template = modePlanTemplates.get(activeMode) || modePlanTemplates.get("all");
+  activeModePlan.replaceChildren();
+  if (template) {
+    activeModePlan.appendChild(template.content.cloneNode(true));
+  }
+
+  if (animate && modePanel) {
+    modePanel.classList.remove("mode-panel-updated");
+    window.requestAnimationFrame(() => modePanel.classList.add("mode-panel-updated"));
+  }
+}
 
 function applySearch() {
   const tokens = search.value.toLowerCase().trim().split(/\s+/).filter(Boolean);
@@ -30,7 +56,14 @@ for (const button of personaButtons) {
     activeMode = button.dataset.mode || "all";
     for (const option of personaButtons) {
       option.classList.toggle("active", option === button);
+      option.setAttribute("aria-pressed", option === button ? "true" : "false");
     }
+    updateModePanel(button, { animate: true });
     applySearch();
   });
+}
+
+const initialMode = personaButtons.find((button) => button.classList.contains("active")) || personaButtons[0];
+if (initialMode) {
+  updateModePanel(initialMode);
 }

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,9 +39,9 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>641</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5238</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>5243</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
-        <div class="metric"><strong>11</strong><span>guided routes</span></div>
+        <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
       <div class="note">Comprehension debt grows when the codebase changes faster than the team can maintain a shared mental model. This page keeps the first question simple: where should I start? Source framing: <a href="https://dev.to/javz/your-codebase-has-technical-debt-but-does-your-team-have-comprehension-debt-385f">DEV Community article</a>.</div>
     </section>
@@ -50,49 +50,126 @@
     <section id="personas">
       <h2>Choose A Mode</h2>
       <p class="lede">Choose the closest job-to-be-done. The page will hide unrelated cards while keeping search available.</p>
+      <div class="mode-stack">
+        
+      <div id="mode-panel" class="mode-panel" aria-live="polite">
+        <div>
+          <div class="mini-label">Current mode</div>
+          <h3 id="active-mode-title">Show everything</h3>
+          <p id="active-mode-summary">Everything is visible. Choose a mode to hide unrelated cards and rows.</p>
+        </div>
+        <div>
+          <div class="mini-label">First 10 minutes</div>
+          <div id="active-mode-plan"></div>
+        </div>
+      </div>
       <div class="persona-grid">
         
-        <button class="persona-card active" type="button" data-mode="all" data-search="all everything full map reset">
+        <button class="persona-card active" type="button" data-mode="all" data-mode-title="Show everything" data-mode-summary="Everything is visible. Choose a mode to hide unrelated cards and rows." data-search="all everything full map reset" aria-pressed="true">
           <span class="persona-title">Show everything</span>
           <span class="persona-summary">Use this when you already know what you are looking for.</span>
           <span class="link-row"><span class="muted">Full map</span></span>
         </button>
         
 
-            <button class="persona-card searchable" type="button" data-mode="user" data-search="i just want to use skylos start with install, commands, output, and rule meanings. skip internal ownership maps. install quick start cli output rules user docs readme.md docs/readme.md dictionary.md">
+            <button class="persona-card searchable" type="button" data-mode="user" data-mode-title="I just want to use Skylos" data-mode-summary="Start with install, commands, output, and rule meanings. Skip internal ownership maps." data-search="i just want to use skylos start with install, commands, output, and rule meanings. skip internal ownership maps. install quick start cli output rules user docs readme.md docs/readme.md dictionary.md" aria-pressed="false">
               <span class="persona-title">I just want to use Skylos</span>
               <span class="persona-summary">Start with install, commands, output, and rule meanings. Skip internal ownership maps.</span>
-              <span class="link-row"><a href="../../README.md">README.md</a> <a href="../../docs/README.md">docs/README.md</a> <a href="../../dictionary.md">dictionary.md</a></span>
+              <span class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/README.md" rel="noopener noreferrer">README.md</a> <a href="https://github.com/duriantaco/skylos/blob/main/docs/README.md" rel="noopener noreferrer">docs/README.md</a> <a href="https://github.com/duriantaco/skylos/blob/main/dictionary.md" rel="noopener noreferrer">dictionary.md</a></span>
             </button>
             
 
-            <button class="persona-card searchable" type="button" data-mode="contributor" data-search="i want to contribute pick a safe ownership area, find nearby tests, and keep the change narrow. contribute first pr tests safe change ownership contributing.md test/ scripts/">
+            <button class="persona-card searchable" type="button" data-mode="contributor" data-mode-title="I want to contribute" data-mode-summary="Pick a safe ownership area, find nearby tests, and keep the change narrow." data-search="i want to contribute pick a safe ownership area, find nearby tests, and keep the change narrow. contribute first pr tests safe change ownership contributing.md test/ scripts/" aria-pressed="false">
               <span class="persona-title">I want to contribute</span>
               <span class="persona-summary">Pick a safe ownership area, find nearby tests, and keep the change narrow.</span>
-              <span class="link-row"><a href="../../CONTRIBUTING.md">CONTRIBUTING.md</a> <a href="../../test">test</a> <a href="../../scripts">scripts</a></span>
+              <span class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/CONTRIBUTING.md" rel="noopener noreferrer">CONTRIBUTING.md</a> <a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a> <a href="https://github.com/duriantaco/skylos/tree/main/scripts" rel="noopener noreferrer">scripts</a></span>
             </button>
             
 
-            <button class="persona-card searchable" type="button" data-mode="debugger" data-search="i am debugging a bad finding reproduce the finding, locate the detector/evidence layer, and add a regression test. false positive false negative detector evidence regression skylos/analyzer.py skylos/rules/ skylos/analysis/ test/">
+            <button class="persona-card searchable" type="button" data-mode="debugger" data-mode-title="I am debugging a bad finding" data-mode-summary="Reproduce the finding, locate the detector/evidence layer, and add a regression test." data-search="i am debugging a bad finding reproduce the finding, locate the detector/evidence layer, and add a regression test. false positive false negative detector evidence regression skylos/analyzer.py skylos/rules/ skylos/analysis/ test/" aria-pressed="false">
               <span class="persona-title">I am debugging a bad finding</span>
               <span class="persona-summary">Reproduce the finding, locate the detector/evidence layer, and add a regression test.</span>
-              <span class="link-row"><a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../skylos/rules">skylos/rules</a> <a href="../../skylos/analysis">skylos/analysis</a> <a href="../../test">test</a></span>
+              <span class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/analysis" rel="noopener noreferrer">skylos/analysis</a> <a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a></span>
             </button>
             
 
-            <button class="persona-card searchable" type="button" data-mode="security" data-search="i am reviewing security or llm behavior follow trust boundaries: config policy, llm evidence filters, ci, and cloud sync. security llm policy cloud ci evidence bypass skylos/config.py skylos/llm/ skylos/security/ skylos/cloud/ skylos/cicd/">
+            <button class="persona-card searchable" type="button" data-mode="security" data-mode-title="I am reviewing security or LLM behavior" data-mode-summary="Follow trust boundaries: config policy, LLM evidence filters, CI, and cloud sync." data-search="i am reviewing security or llm behavior follow trust boundaries: config policy, llm evidence filters, ci, and cloud sync. security llm policy cloud ci evidence bypass skylos/config.py skylos/llm/ skylos/security/ skylos/cloud/ skylos/cicd/" aria-pressed="false">
               <span class="persona-title">I am reviewing security or LLM behavior</span>
               <span class="persona-summary">Follow trust boundaries: config policy, LLM evidence filters, CI, and cloud sync.</span>
-              <span class="link-row"><a href="../../skylos/config.py">skylos/config.py</a> <a href="../../skylos/llm">skylos/llm</a> <a href="../../skylos/security">skylos/security</a> <a href="../../skylos/cloud">skylos/cloud</a> <a href="../../skylos/cicd">skylos/cicd</a></span>
+              <span class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/security" rel="noopener noreferrer">skylos/security</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cloud" rel="noopener noreferrer">skylos/cloud</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a></span>
             </button>
             
 
-            <button class="persona-card searchable" type="button" data-mode="maintainer" data-search="i need the architecture use the layer map, hot zones, and docstring guide before reshaping shared paths. architecture maintainer hot zones boundaries main sequence skylos/pipeline.py skylos/analyzer.py skylos/cli.py skylos/config.py">
+            <button class="persona-card searchable" type="button" data-mode="maintainer" data-mode-title="I need the architecture" data-mode-summary="Use the layer map, hot zones, and docstring guide before reshaping shared paths." data-search="i need the architecture use the layer map, hot zones, and docstring guide before reshaping shared paths. architecture maintainer hot zones boundaries main sequence skylos/pipeline.py skylos/analyzer.py skylos/cli.py skylos/config.py" aria-pressed="false">
               <span class="persona-title">I need the architecture</span>
               <span class="persona-summary">Use the layer map, hot zones, and docstring guide before reshaping shared paths.</span>
-              <span class="link-row"><a href="../../skylos/pipeline.py">skylos/pipeline.py</a> <a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../skylos/cli.py">skylos/cli.py</a> <a href="../../skylos/config.py">skylos/config.py</a></span>
+              <span class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></span>
             </button>
             
+      </div>
+      <div id="mode-plan-templates" hidden>
+        
+      <template data-mode-plan="all">
+        <div class="guide-time">10 minutes</div>
+        <h3>Use the full map</h3>
+        <ol class="step-list"><li>Use search when you already know a path, symbol, or rule id.</li>
+<li>Pick a mode when you want unrelated sections hidden.</li>
+<li>Start from route cards before opening folder or symbol indexes.</li></ol>
+        
+      </template>
+    
+
+      <template data-mode-plan="user">
+        <div class="guide-time">10 minutes</div>
+        <h3>I am completely new</h3>
+        <ol class="step-list"><li>Open README.md to understand what Skylos does.</li>
+<li>Open this map and pick exactly one route card.</li>
+<li>Read only the first two files in that route before browsing deeper.</li></ol>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/README.md" rel="noopener noreferrer">README.md</a> <a href="https://github.com/duriantaco/skylos/blob/main/docs/repo-map/index.html" rel="noopener noreferrer">docs/repo-map/index.html</a></div>
+      </template>
+    
+
+      <template data-mode-plan="contributor">
+        <div class="guide-time">15 minutes</div>
+        <h3>I need to make a small change</h3>
+        <ol class="step-list"><li>Search this page for the thing you want to change.</li>
+<li>Open the matching folder card and check the nearby tests.</li>
+<li>Change one ownership area first; avoid drive-by refactors.</li></ol>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a> <a href="https://github.com/duriantaco/skylos/tree/main/scripts" rel="noopener noreferrer">scripts</a></div>
+      </template>
+    
+
+      <template data-mode-plan="debugger">
+        <div class="guide-time">20 minutes</div>
+        <h3>I am debugging a bad result</h3>
+        <ol class="step-list"><li>Find the rule or finding category in the route cards.</li>
+<li>Build the smallest fixture that reproduces the bad result.</li>
+<li>Patch the detector and keep the fixture as a regression test.</li></ol>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a></div>
+      </template>
+    
+
+      <template data-mode-plan="security">
+        <div class="guide-time">20 minutes</div>
+        <h3>I am reviewing a risky PR</h3>
+        <ol class="step-list"><li>Check whether the PR touches a hot zone.</li>
+<li>Follow the scan flow to see downstream output impact.</li>
+<li>Ask for benchmark or regression evidence before merging scanner semantics.</li></ol>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/security" rel="noopener noreferrer">skylos/security</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cloud" rel="noopener noreferrer">skylos/cloud</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a></div>
+      </template>
+    
+
+      <template data-mode-plan="maintainer">
+        <div class="guide-time">15 minutes</div>
+        <h3>I need the architecture</h3>
+        <ol class="step-list"><li>Read the Architecture section before opening shared core files.</li>
+<li>Check hot zones for files that can change many workflows.</li>
+<li>Use the docstring standard before reshaping public entrypoints.</li></ol>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></div>
+      </template>
+    
+      </div>
+    
       </div>
     </section>
     
@@ -108,7 +185,7 @@
               <ol class="step-list"><li>Open README.md to understand what Skylos does.</li>
 <li>Open this map and pick exactly one route card.</li>
 <li>Read only the first two files in that route before browsing deeper.</li></ol>
-              <div class="link-row"><a href="../../README.md">README.md</a> <a href="../../docs/repo-map/index.html">docs/repo-map/index.html</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/README.md" rel="noopener noreferrer">README.md</a> <a href="https://github.com/duriantaco/skylos/blob/main/docs/repo-map/index.html" rel="noopener noreferrer">docs/repo-map/index.html</a></div>
             </article>
             
 
@@ -118,7 +195,7 @@
               <ol class="step-list"><li>Search this page for the thing you want to change.</li>
 <li>Open the matching folder card and check the nearby tests.</li>
 <li>Change one ownership area first; avoid drive-by refactors.</li></ol>
-              <div class="link-row"><a href="../../test">test</a> <a href="../../scripts">scripts</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a> <a href="https://github.com/duriantaco/skylos/tree/main/scripts" rel="noopener noreferrer">scripts</a></div>
             </article>
             
 
@@ -128,7 +205,7 @@
               <ol class="step-list"><li>Find the rule or finding category in the route cards.</li>
 <li>Build the smallest fixture that reproduces the bad result.</li>
 <li>Patch the detector and keep the fixture as a regression test.</li></ol>
-              <div class="link-row"><a href="../../skylos/rules">skylos/rules</a> <a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../test">test</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a></div>
             </article>
             
 
@@ -138,7 +215,17 @@
               <ol class="step-list"><li>Check whether the PR touches a hot zone.</li>
 <li>Follow the scan flow to see downstream output impact.</li>
 <li>Ask for benchmark or regression evidence before merging scanner semantics.</li></ol>
-              <div class="link-row"><a href="../../skylos/llm">skylos/llm</a> <a href="../../skylos/security">skylos/security</a> <a href="../../skylos/cloud">skylos/cloud</a> <a href="../../skylos/cicd">skylos/cicd</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/security" rel="noopener noreferrer">skylos/security</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cloud" rel="noopener noreferrer">skylos/cloud</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a></div>
+            </article>
+            
+
+            <article class="guide-card searchable persona-target" data-personas="maintainer" data-search="i need the architecture 15 minutes read the architecture section before opening shared core files. check hot zones for files that can change many workflows. use the docstring standard before reshaping public entrypoints. skylos/pipeline.py skylos/analyzer.py skylos/cli.py skylos/config.py">
+              <div class="guide-time">15 minutes</div>
+              <h3>I need the architecture</h3>
+              <ol class="step-list"><li>Read the Architecture section before opening shared core files.</li>
+<li>Check hot zones for files that can change many workflows.</li>
+<li>Use the docstring standard before reshaping public entrypoints.</li></ol>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></div>
             </article>
             
       </div>
@@ -157,9 +244,9 @@
 <li>Follow the handoff into pipeline/analyzer only after the inputs make sense.</li>
 <li>Verify with CLI and analyzer tests before trusting a behavior change.</li></ol>
               <div class="mini-label">Start with</div>
-              <div class="link-row"><a href="../../skylos/cli.py">skylos/cli.py</a> <a href="../../skylos/config.py">skylos/config.py</a> <a href="../../skylos/pipeline.py">skylos/pipeline.py</a> <a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../skylos/reporting">skylos/reporting</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a></div>
               <div class="mini-label">Tests / proof</div>
-              <div class="link-row"><a href="../../test/test_cli.py">test/test_cli.py</a> <a href="../../test/test_analyzer.py">test/test_analyzer.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a></div>
             </article>
             
 
@@ -170,9 +257,9 @@
 <li>Find whether the bug is rule logic, liveness evidence, framework handling, or output filtering.</li>
 <li>Add a regression test that fails before the fix and passes after it.</li></ol>
               <div class="mini-label">Start with</div>
-              <div class="link-row"><a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../skylos/analysis">skylos/analysis</a> <a href="../../skylos/deadcode">skylos/deadcode</a> <a href="../../skylos/visitors">skylos/visitors</a> <a href="../../test">test</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/analysis" rel="noopener noreferrer">skylos/analysis</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a> <a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a></div>
               <div class="mini-label">Tests / proof</div>
-              <div class="link-row"><a href="../../test/test_analyzer.py">test/test_analyzer.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a></div>
             </article>
             
 
@@ -183,9 +270,9 @@
 <li>Keep the catalog, implementation, tests, and docs parity together.</li>
 <li>Run parity checks so users do not see undocumented or mismatched rule IDs.</li></ol>
               <div class="mini-label">Start with</div>
-              <div class="link-row"><a href="../../skylos/rules/catalog.py">skylos/rules/catalog.py</a> <a href="../../skylos/rules/danger">skylos/rules/danger</a> <a href="../../skylos/rules/quality">skylos/rules/quality</a> <a href="../../dictionary.md">dictionary.md</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/catalog.py" rel="noopener noreferrer">skylos/rules/catalog.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/rules/danger" rel="noopener noreferrer">skylos/rules/danger</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/rules/quality" rel="noopener noreferrer">skylos/rules/quality</a> <a href="https://github.com/duriantaco/skylos/blob/main/dictionary.md" rel="noopener noreferrer">dictionary.md</a></div>
               <div class="mini-label">Tests / proof</div>
-              <div class="link-row"><a href="../../scripts/check_rule_docs_parity.py">scripts/check_rule_docs_parity.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/scripts/check_rule_docs_parity.py" rel="noopener noreferrer">scripts/check_rule_docs_parity.py</a></div>
             </article>
             
 
@@ -196,9 +283,9 @@
 <li>Change prompts/runtime separately from evidence filters when possible.</li>
 <li>Benchmark against hard false-positive and false-negative fixtures.</li></ol>
               <div class="mini-label">Start with</div>
-              <div class="link-row"><a href="../../skylos/llm/analyzer.py">skylos/llm/analyzer.py</a> <a href="../../skylos/llm/finding_evidence.py">skylos/llm/finding_evidence.py</a> <a href="../../skylos/adapters">skylos/adapters</a> <a href="../../skylos/agents">skylos/agents</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py" rel="noopener noreferrer">skylos/llm/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/adapters" rel="noopener noreferrer">skylos/adapters</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/agents" rel="noopener noreferrer">skylos/agents</a></div>
               <div class="mini-label">Tests / proof</div>
-              <div class="link-row"><a href="../../test/test_llm_finding_evidence.py">test/test_llm_finding_evidence.py</a> <a href="../../test/test_agent_service.py">test/test_agent_service.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_llm_finding_evidence.py" rel="noopener noreferrer">test/test_llm_finding_evidence.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_agent_service.py" rel="noopener noreferrer">test/test_agent_service.py</a></div>
             </article>
             
 
@@ -209,9 +296,9 @@
 <li>Check merge precedence before changing analyzer behavior.</li>
 <li>Test the bypass case, not only the normal happy path.</li></ol>
               <div class="mini-label">Start with</div>
-              <div class="link-row"><a href="../../skylos/config.py">skylos/config.py</a> <a href="../../skylos/cloud/sync.py">skylos/cloud/sync.py</a> <a href="../../skylos/cicd/workflow.py">skylos/cicd/workflow.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">skylos/cloud/sync.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">skylos/cicd/workflow.py</a></div>
               <div class="mini-label">Tests / proof</div>
-              <div class="link-row"><a href="../../test/test_config.py">test/test_config.py</a> <a href="../../test/test_security_contracts.py">test/test_security_contracts.py</a> <a href="../../test/test_cicd_workflow.py">test/test_cicd_workflow.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_config.py" rel="noopener noreferrer">test/test_config.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_security_contracts.py" rel="noopener noreferrer">test/test_security_contracts.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_cicd_workflow.py" rel="noopener noreferrer">test/test_cicd_workflow.py</a></div>
             </article>
             
 
@@ -222,9 +309,9 @@
 <li>Record before/after scores and timing.</li>
 <li>Keep hard fixtures in the benchmark suite when they guard real regressions.</li></ol>
               <div class="mini-label">Start with</div>
-              <div class="link-row"><a href="../../scripts/security_benchmark.py">scripts/security_benchmark.py</a> <a href="../../scripts/quality_benchmark.py">scripts/quality_benchmark.py</a> <a href="../../scripts/dead_code_benchmark.py">scripts/dead_code_benchmark.py</a> <a href="../../skylos/benchmarks">skylos/benchmarks</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_benchmark.py" rel="noopener noreferrer">scripts/security_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/scripts/quality_benchmark.py" rel="noopener noreferrer">scripts/quality_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_benchmark.py" rel="noopener noreferrer">scripts/dead_code_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/benchmarks" rel="noopener noreferrer">skylos/benchmarks</a></div>
               <div class="mini-label">Tests / proof</div>
-              <div class="link-row"><a href="../../test/test_security_benchmark.py">test/test_security_benchmark.py</a> <a href="../../test/test_quality_benchmark.py">test/test_quality_benchmark.py</a> <a href="../../test/test_dead_code_benchmark.py">test/test_dead_code_benchmark.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_security_benchmark.py" rel="noopener noreferrer">test/test_security_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_quality_benchmark.py" rel="noopener noreferrer">test/test_quality_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dead_code_benchmark.py" rel="noopener noreferrer">test/test_dead_code_benchmark.py</a></div>
             </article>
             
 
@@ -235,9 +322,9 @@
 <li>Check payload shape helpers before creating a new response format.</li>
 <li>Preserve public facade behavior even when private helpers move.</li></ol>
               <div class="mini-label">Start with</div>
-              <div class="link-row"><a href="../../skylos/api/__init__.py">skylos/api/__init__.py</a> <a href="../../skylos/api/_findings.py">skylos/api/_findings.py</a> <a href="../../skylos/api/_payloads.py">skylos/api/_payloads.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_findings.py" rel="noopener noreferrer">skylos/api/_findings.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">skylos/api/_payloads.py</a></div>
               <div class="mini-label">Tests / proof</div>
-              <div class="link-row"><a href="../../test/test_api.py">test/test_api.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_api.py" rel="noopener noreferrer">test/test_api.py</a></div>
             </article>
             
       </div>
@@ -291,7 +378,7 @@
               <p class="compact">Policy, discovery, analysis, reporting</p>
               <div class="mini-label">Guardrail</div>
               <p class="compact">Keep interface code thin; move command-specific logic into focused modules.</p>
-              <div class="link-row"><a href="../../skylos/cli.py">skylos/cli.py</a> <a href="../../skylos/api">skylos/api</a> <a href="../../skylos/commands">skylos/commands</a> <a href="../../skylos/cicd">skylos/cicd</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/api" rel="noopener noreferrer">skylos/api</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/commands" rel="noopener noreferrer">skylos/commands</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a></div>
             </article>
             
 
@@ -302,7 +389,7 @@
               <p class="compact">Interfaces and analyzer output</p>
               <div class="mini-label">Guardrail</div>
               <p class="compact">Treat merge precedence and attacker-controlled repo config as security-sensitive.</p>
-              <div class="link-row"><a href="../../skylos/config.py">skylos/config.py</a> <a href="../../skylos/cloud/sync.py">skylos/cloud/sync.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">skylos/cloud/sync.py</a></div>
             </article>
             
 
@@ -313,7 +400,7 @@
               <p class="compact">Config and filesystem state</p>
               <div class="mini-label">Guardrail</div>
               <p class="compact">Too broad creates noise; too narrow creates false negatives.</p>
-              <div class="link-row"><a href="../../skylos/discover">skylos/discover</a> <a href="../../skylos/pipeline.py">skylos/pipeline.py</a> <a href="../../skylos/engines">skylos/engines</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/discover" rel="noopener noreferrer">skylos/discover</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/engines" rel="noopener noreferrer">skylos/engines</a></div>
             </article>
             
 
@@ -324,7 +411,7 @@
               <p class="compact">Discovery, config, language engines</p>
               <div class="mini-label">Guardrail</div>
               <p class="compact">Every semantic change needs a small fixture and a regression test.</p>
-              <div class="link-row"><a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../skylos/analysis">skylos/analysis</a> <a href="../../skylos/rules">skylos/rules</a> <a href="../../skylos/visitors">skylos/visitors</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/analysis" rel="noopener noreferrer">skylos/analysis</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></div>
             </article>
             
 
@@ -335,7 +422,7 @@
               <p class="compact">Static analysis output and provider adapters</p>
               <div class="mini-label">Guardrail</div>
               <p class="compact">Filters must prove safety; weak refutation creates scanner false negatives.</p>
-              <div class="link-row"><a href="../../skylos/llm">skylos/llm</a> <a href="../../skylos/agents">skylos/agents</a> <a href="../../skylos/adapters">skylos/adapters</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/agents" rel="noopener noreferrer">skylos/agents</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/adapters" rel="noopener noreferrer">skylos/adapters</a></div>
             </article>
             
 
@@ -346,7 +433,7 @@
               <p class="compact">Analyzer results and policy decisions</p>
               <div class="mini-label">Guardrail</div>
               <p class="compact">Output changes should preserve machine-readable compatibility.</p>
-              <div class="link-row"><a href="../../skylos/reporting">skylos/reporting</a> <a href="../../skylos/cloud">skylos/cloud</a> <a href="../../skylos/cicd">skylos/cicd</a> <a href="../../skylos/ui">skylos/ui</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cloud" rel="noopener noreferrer">skylos/cloud</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></div>
             </article>
             
 
@@ -357,7 +444,7 @@
               <p class="compact">All product layers</p>
               <div class="mini-label">Guardrail</div>
               <p class="compact">Benchmark updates should explain score, timing, and regression intent.</p>
-              <div class="link-row"><a href="../../test">test</a> <a href="../../benchmarks">benchmarks</a> <a href="../../scripts">scripts</a> <a href="../../skylos/benchmarks">skylos/benchmarks</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a> <a href="https://github.com/duriantaco/skylos/tree/main/benchmarks" rel="noopener noreferrer">benchmarks</a> <a href="https://github.com/duriantaco/skylos/tree/main/scripts" rel="noopener noreferrer">scripts</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/benchmarks" rel="noopener noreferrer">skylos/benchmarks</a></div>
             </article>
             
       </div>
@@ -426,35 +513,35 @@
             <div class="flow-step searchable" data-search="input cli args, changed files, config skylos/cli.py skylos/config.py">
               <div class="flow-title">Input</div>
               <p>CLI args, changed files, config</p>
-              <div class="link-row"><a href="../../skylos/cli.py">skylos/cli.py</a> <a href="../../skylos/config.py">skylos/config.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></div>
             </div>
             
 
             <div class="flow-step searchable" data-search="discovery select source files and language paths skylos/discover/ skylos/pipeline.py">
               <div class="flow-title">Discovery</div>
               <p>Select source files and language paths</p>
-              <div class="link-row"><a href="../../skylos/discover">skylos/discover</a> <a href="../../skylos/pipeline.py">skylos/pipeline.py</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/discover" rel="noopener noreferrer">skylos/discover</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a></div>
             </div>
             
 
             <div class="flow-step searchable" data-search="analysis static detectors, rules, liveness, evidence skylos/analyzer.py skylos/rules/ skylos/analysis/">
               <div class="flow-title">Analysis</div>
               <p>Static detectors, rules, liveness, evidence</p>
-              <div class="link-row"><a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../skylos/rules">skylos/rules</a> <a href="../../skylos/analysis">skylos/analysis</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/analysis" rel="noopener noreferrer">skylos/analysis</a></div>
             </div>
             
 
             <div class="flow-step searchable" data-search="review llm/agent review and evidence grounding where enabled skylos/llm/ skylos/agents/ skylos/adapters/">
               <div class="flow-title">Review</div>
               <p>LLM/agent review and evidence grounding where enabled</p>
-              <div class="link-row"><a href="../../skylos/llm">skylos/llm</a> <a href="../../skylos/agents">skylos/agents</a> <a href="../../skylos/adapters">skylos/adapters</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/agents" rel="noopener noreferrer">skylos/agents</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/adapters" rel="noopener noreferrer">skylos/adapters</a></div>
             </div>
             
 
             <div class="flow-step searchable" data-search="output pretty output, sarif, cloud upload, ci review skylos/reporting/ skylos/cloud/ skylos/cicd/">
               <div class="flow-title">Output</div>
               <p>Pretty output, SARIF, cloud upload, CI review</p>
-              <div class="link-row"><a href="../../skylos/reporting">skylos/reporting</a> <a href="../../skylos/cloud">skylos/cloud</a> <a href="../../skylos/cicd">skylos/cicd</a></div>
+              <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cloud" rel="noopener noreferrer">skylos/cloud</a> <a href="https://github.com/duriantaco/skylos/tree/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a></div>
             </div>
             </div>
     </section>
@@ -465,7 +552,7 @@
       <div class="folder-grid">
     <article class="folder-card searchable" data-search="benchmarks benchmark data and generated comparison artifacts. use this when storing benchmark fixtures or outputs that explain scanner quality. benchmarks/  benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py">
       <div class="card-head">
-        <h3><a href="../../benchmarks">benchmarks</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks" rel="noopener noreferrer">benchmarks</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 129</span>
           <span class="pill"><strong>symbols</strong> 225</span>
@@ -477,37 +564,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../benchmarks">benchmarks</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/benchmarks" rel="noopener noreferrer">benchmarks</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</a> <span>28 lines</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">benchmarks/dead_code/fixtures/pydantic_validators/app.py</a> <span>30 lines</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</a> <span>29 lines</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py">benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</a> <span>29 lines</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py">benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</a> <span>28 lines</span></li>
-<li><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py">benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</a> <span>27 lines</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py">benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</a> <span>27 lines</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py">benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</a> <span>27 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</a> <span>28 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/pydantic_validators/app.py</a> <span>30 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</a> <span>29 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</a> <span>29 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</a> <span>28 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</a> <span>27 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</a> <span>27 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</a> <span>27 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">register:4</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">handle_create:13</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">handle_update:18</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">dispatch:22</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">unused_handler:26</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">UserInput:4</a> <span>class</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">UnusedSchema:17</a> <span>class</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">build_user:21</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">unused_normalizer:25</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">UsedWorker:9</a> <span>class</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">UnusedWorker:14</a> <span>class</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">used_helper:19</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">unused_helper:24</a> <span>def</span></li>
-<li><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py">Base:5</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L4" rel="noopener noreferrer">register:4</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L13" rel="noopener noreferrer">handle_create:13</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L18" rel="noopener noreferrer">handle_update:18</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L22" rel="noopener noreferrer">dispatch:22</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L26" rel="noopener noreferrer">unused_handler:26</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L4" rel="noopener noreferrer">UserInput:4</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L17" rel="noopener noreferrer">UnusedSchema:17</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L21" rel="noopener noreferrer">build_user:21</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L25" rel="noopener noreferrer">unused_normalizer:25</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L9" rel="noopener noreferrer">UsedWorker:9</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L14" rel="noopener noreferrer">UnusedWorker:14</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L19" rel="noopener noreferrer">used_helper:19</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L24" rel="noopener noreferrer">unused_helper:24</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L5" rel="noopener noreferrer">Base:5</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -516,11 +603,11 @@
 
     <article class="folder-card searchable" data-search="scripts repository maintenance, benchmark, parity, and regression scripts. use this for repeatable evidence and local automation that should not live in runtime package code. scripts/security_benchmark.py scripts/quality_benchmark.py scripts/check_rule_docs_parity.py test/test_typescript_safe_glob.py scripts/build_repo_map.py scripts/repo_map_renderer.py scripts/regression_delta.py scripts/compare_codex_skylos_quality.py scripts/compare_codex_skylos_agent_review.py scripts/analyzer_speed_check.py scripts/compare_codex_skylos_demo_deadcode.py scripts/dead_code_compare_scanners.py">
       <div class="card-head">
-        <h3><a href="../../scripts">scripts</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/scripts" rel="noopener noreferrer">scripts</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 16</span>
-          <span class="pill"><strong>symbols</strong> 119</span>
-          <span class="pill"><strong>lines</strong> 4405</span>
+          <span class="pill"><strong>symbols</strong> 124</span>
+          <span class="pill"><strong>lines</strong> 4548</span>
         </div>
       </div>
       <p>Repository maintenance, benchmark, parity, and regression scripts.</p>
@@ -528,37 +615,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../scripts/security_benchmark.py">scripts/security_benchmark.py</a> <a href="../../scripts/quality_benchmark.py">scripts/quality_benchmark.py</a> <a href="../../scripts/check_rule_docs_parity.py">scripts/check_rule_docs_parity.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_benchmark.py" rel="noopener noreferrer">scripts/security_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/scripts/quality_benchmark.py" rel="noopener noreferrer">scripts/quality_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/scripts/check_rule_docs_parity.py" rel="noopener noreferrer">scripts/check_rule_docs_parity.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_typescript_safe_glob.py">test/test_typescript_safe_glob.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_typescript_safe_glob.py" rel="noopener noreferrer">test/test_typescript_safe_glob.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../scripts/build_repo_map.py">scripts/build_repo_map.py</a> <span>1186 lines</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">scripts/repo_map_renderer.py</a> <span>659 lines</span></li>
-<li><a href="../../scripts/regression_delta.py">scripts/regression_delta.py</a> <span>353 lines</span></li>
-<li><a href="../../scripts/compare_codex_skylos_quality.py">scripts/compare_codex_skylos_quality.py</a> <span>420 lines</span></li>
-<li><a href="../../scripts/compare_codex_skylos_agent_review.py">scripts/compare_codex_skylos_agent_review.py</a> <span>424 lines</span></li>
-<li><a href="../../scripts/analyzer_speed_check.py">scripts/analyzer_speed_check.py</a> <span>315 lines</span></li>
-<li><a href="../../scripts/compare_codex_skylos_demo_deadcode.py">scripts/compare_codex_skylos_demo_deadcode.py</a> <span>280 lines</span></li>
-<li><a href="../../scripts/dead_code_compare_scanners.py">scripts/dead_code_compare_scanners.py</a> <span>152 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">scripts/build_repo_map.py</a> <span>1197 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">scripts/repo_map_renderer.py</a> <span>791 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">scripts/regression_delta.py</a> <span>353 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_quality.py" rel="noopener noreferrer">scripts/compare_codex_skylos_quality.py</a> <span>420 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_agent_review.py" rel="noopener noreferrer">scripts/compare_codex_skylos_agent_review.py</a> <span>424 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">scripts/analyzer_speed_check.py</a> <span>315 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_demo_deadcode.py" rel="noopener noreferrer">scripts/compare_codex_skylos_demo_deadcode.py</a> <span>280 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_compare_scanners.py" rel="noopener noreferrer">scripts/dead_code_compare_scanners.py</a> <span>152 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../scripts/build_repo_map.py">SymbolInfo:535</a> <span>class</span></li>
-<li><a href="../../scripts/build_repo_map.py">ModuleInfo:558</a> <span>class</span></li>
-<li><a href="../../scripts/build_repo_map.py">collect_repo_map:806</a> <span>def</span></li>
-<li><a href="../../scripts/build_repo_map.py">write_repo_map:1094</a> <span>def</span></li>
-<li><a href="../../scripts/build_repo_map.py">main:1120</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_personas:30</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_workflows:71</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_first_steps:113</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_sharp_edges:132</a> <span>def</span></li>
-<li><a href="../../scripts/repo_map_renderer.py">render_architecture_layers:148</a> <span>def</span></li>
-<li><a href="../../scripts/regression_delta.py">compare_corpus:177</a> <span>def</span></li>
-<li><a href="../../scripts/regression_delta.py">compare_agent_review:210</a> <span>def</span></li>
-<li><a href="../../scripts/regression_delta.py">compare_quality:267</a> <span>def</span></li>
-<li><a href="../../scripts/regression_delta.py">compare:323</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L546" rel="noopener noreferrer">SymbolInfo:546</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L569" rel="noopener noreferrer">ModuleInfo:569</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L817" rel="noopener noreferrer">collect_repo_map:817</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1105" rel="noopener noreferrer">write_repo_map:1105</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1131" rel="noopener noreferrer">main:1131</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L75" rel="noopener noreferrer">render_mode_plan_templates:75</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L114" rel="noopener noreferrer">render_mode_selector:114</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L156" rel="noopener noreferrer">render_personas:156</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L197" rel="noopener noreferrer">render_workflows:197</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L239" rel="noopener noreferrer">render_first_steps:239</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L177" rel="noopener noreferrer">compare_corpus:177</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L210" rel="noopener noreferrer">compare_agent_review:210</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L267" rel="noopener noreferrer">compare_quality:267</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L323" rel="noopener noreferrer">compare:323</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -567,7 +654,7 @@
 
     <article class="folder-card searchable" data-search="skylos root entrypoints and shared scan orchestration. start here when cli behavior, scan flow, or global configuration changes. skylos/cli.py skylos/analyzer.py skylos/pipeline.py skylos/config.py test/test_skylos.py skylos/cli.py skylos/analyzer.py skylos/pipeline.py skylos/config.py skylos/constants.py skylos/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos">skylos</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 247</span>
@@ -579,35 +666,35 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/cli.py">skylos/cli.py</a> <a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <a href="../../skylos/pipeline.py">skylos/pipeline.py</a> <a href="../../skylos/config.py">skylos/config.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_skylos.py">test/test_skylos.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_skylos.py" rel="noopener noreferrer">test/test_skylos.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/cli.py">skylos/cli.py</a> <span>5462 lines</span></li>
-<li><a href="../../skylos/analyzer.py">skylos/analyzer.py</a> <span>3740 lines</span></li>
-<li><a href="../../skylos/pipeline.py">skylos/pipeline.py</a> <span>989 lines</span></li>
-<li><a href="../../skylos/config.py">skylos/config.py</a> <span>616 lines</span></li>
-<li><a href="../../skylos/constants.py">skylos/constants.py</a> <span>229 lines</span></li>
-<li><a href="../../skylos/__init__.py">skylos/__init__.py</a> <span>40 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <span>5462 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <span>3740 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <span>989 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <span>616 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">skylos/constants.py</a> <span>229 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py" rel="noopener noreferrer">skylos/__init__.py</a> <span>40 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/cli.py">remove_unused_import_cst:93</a> <span>def</span></li>
-<li><a href="../../skylos/cli.py">remove_unused_function_cst:97</a> <span>def</span></li>
-<li><a href="../../skylos/cli.py">comment_out_unused_import_cst:101</a> <span>def</span></li>
-<li><a href="../../skylos/cli.py">comment_out_unused_function_cst:105</a> <span>def</span></li>
-<li><a href="../../skylos/cli.py">run_analyze:109</a> <span>def</span></li>
-<li><a href="../../skylos/analyzer.py">Skylos:459</a> <span>class</span></li>
-<li><a href="../../skylos/analyzer.py">proc_file:3041</a> <span>def</span></li>
-<li><a href="../../skylos/analyzer.py">analyze:3548</a> <span>def</span></li>
-<li><a href="../../skylos/analyzer.py">_entrypoint_module_name:148</a> <span>def</span></li>
-<li><a href="../../skylos/analyzer.py">_architecture_iad_strict:155</a> <span>def</span></li>
-<li><a href="../../skylos/pipeline.py">run_static_on_files:306</a> <span>def</span></li>
-<li><a href="../../skylos/pipeline.py">run_pipeline:400</a> <span>def</span></li>
-<li><a href="../../skylos/pipeline.py">_enrich_with_llm_suggestions:77</a> <span>def</span></li>
-<li><a href="../../skylos/pipeline.py">_norm:169</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L93" rel="noopener noreferrer">remove_unused_import_cst:93</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L97" rel="noopener noreferrer">remove_unused_function_cst:97</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L101" rel="noopener noreferrer">comment_out_unused_import_cst:101</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L105" rel="noopener noreferrer">comment_out_unused_function_cst:105</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L109" rel="noopener noreferrer">run_analyze:109</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L459" rel="noopener noreferrer">Skylos:459</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3041" rel="noopener noreferrer">proc_file:3041</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3548" rel="noopener noreferrer">analyze:3548</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L148" rel="noopener noreferrer">_entrypoint_module_name:148</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L155" rel="noopener noreferrer">_architecture_iad_strict:155</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L306" rel="noopener noreferrer">run_static_on_files:306</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L400" rel="noopener noreferrer">run_pipeline:400</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L77" rel="noopener noreferrer">_enrich_with_llm_suggestions:77</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L169" rel="noopener noreferrer">_norm:169</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -616,7 +703,7 @@
 
     <article class="folder-card searchable" data-search="skylos/adapters provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor. change this when adding or hardening an llm provider boundary. skylos/adapters/base.py skylos/adapters/litellm_adapter.py  skylos/adapters/litellm_adapter.py skylos/adapters/base.py skylos/adapters/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/adapters">skylos/adapters</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters" rel="noopener noreferrer">skylos/adapters</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 3</span>
@@ -628,21 +715,21 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/adapters/base.py">skylos/adapters/base.py</a> <a href="../../skylos/adapters/litellm_adapter.py">skylos/adapters/litellm_adapter.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py" rel="noopener noreferrer">skylos/adapters/base.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py" rel="noopener noreferrer">skylos/adapters/litellm_adapter.py</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/adapters/litellm_adapter.py">skylos/adapters/litellm_adapter.py</a> <span>423 lines</span></li>
-<li><a href="../../skylos/adapters/base.py">skylos/adapters/base.py</a> <span>12 lines</span></li>
-<li><a href="../../skylos/adapters/__init__.py">skylos/adapters/__init__.py</a> <span>9 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py" rel="noopener noreferrer">skylos/adapters/litellm_adapter.py</a> <span>423 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py" rel="noopener noreferrer">skylos/adapters/base.py</a> <span>12 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py" rel="noopener noreferrer">skylos/adapters/__init__.py</a> <span>9 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/adapters/litellm_adapter.py">LiteLLMAdapter:7</a> <span>class</span></li>
-<li><a href="../../skylos/adapters/base.py">BaseAdapter:4</a> <span>class</span></li>
-<li><a href="../../skylos/adapters/__init__.py">get_adapter:7</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py#L7" rel="noopener noreferrer">LiteLLMAdapter:7</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py#L4" rel="noopener noreferrer">BaseAdapter:4</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py#L7" rel="noopener noreferrer">get_adapter:7</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -651,7 +738,7 @@
 
     <article class="folder-card searchable" data-search="skylos/agents agent-facing payloads, service helpers, and review triage learning. use this area for agent review workflows and normalized agent result handling. skylos/agents/service.py skylos/agents/payload.py test/test_agent_service.py test/test_agents.py skylos/agents/center.py skylos/agents/service.py skylos/agents/triage_learner.py skylos/agents/payload.py skylos/agents/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/agents">skylos/agents</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents" rel="noopener noreferrer">skylos/agents</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 5</span>
           <span class="pill"><strong>symbols</strong> 91</span>
@@ -663,34 +750,34 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/agents/service.py">skylos/agents/service.py</a> <a href="../../skylos/agents/payload.py">skylos/agents/payload.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">skylos/agents/service.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">skylos/agents/payload.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_agent_service.py">test/test_agent_service.py</a> <a href="../../test/test_agents.py">test/test_agents.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_agent_service.py" rel="noopener noreferrer">test/test_agent_service.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_agents.py" rel="noopener noreferrer">test/test_agents.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/agents/center.py">skylos/agents/center.py</a> <span>1068 lines</span></li>
-<li><a href="../../skylos/agents/service.py">skylos/agents/service.py</a> <span>539 lines</span></li>
-<li><a href="../../skylos/agents/triage_learner.py">skylos/agents/triage_learner.py</a> <span>327 lines</span></li>
-<li><a href="../../skylos/agents/payload.py">skylos/agents/payload.py</a> <span>243 lines</span></li>
-<li><a href="../../skylos/agents/__init__.py">skylos/agents/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">skylos/agents/center.py</a> <span>1068 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">skylos/agents/service.py</a> <span>539 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py" rel="noopener noreferrer">skylos/agents/triage_learner.py</a> <span>327 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">skylos/agents/payload.py</a> <span>243 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/__init__.py" rel="noopener noreferrer">skylos/agents/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/agents/center.py">run_analyze:52</a> <span>def</span></li>
-<li><a href="../../skylos/agents/center.py">collect_debt_signals:58</a> <span>def</span></li>
-<li><a href="../../skylos/agents/center.py">discover_source_files:64</a> <span>def</span></li>
-<li><a href="../../skylos/agents/center.py">resolve_project_root:72</a> <span>def</span></li>
-<li><a href="../../skylos/agents/center.py">resolve_state_path:87</a> <span>def</span></li>
-<li><a href="../../skylos/agents/service.py">AgentServiceController:83</a> <span>class</span></li>
-<li><a href="../../skylos/agents/service.py">AgentServiceHandler:296</a> <span>class</span></li>
-<li><a href="../../skylos/agents/service.py">SafeAgentServiceHandler:428</a> <span>class</span></li>
-<li><a href="../../skylos/agents/service.py">create_agent_service:467</a> <span>def</span></li>
-<li><a href="../../skylos/agents/service.py">serve_agent_service:508</a> <span>def</span></li>
-<li><a href="../../skylos/agents/triage_learner.py">TriagePattern:22</a> <span>class</span></li>
-<li><a href="../../skylos/agents/triage_learner.py">TriageLearner:143</a> <span>class</span></li>
-<li><a href="../../skylos/agents/triage_learner.py">_pattern_key:47</a> <span>def</span></li>
-<li><a href="../../skylos/agents/triage_learner.py">_make_pattern:53</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L52" rel="noopener noreferrer">run_analyze:52</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L58" rel="noopener noreferrer">collect_debt_signals:58</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L64" rel="noopener noreferrer">discover_source_files:64</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L72" rel="noopener noreferrer">resolve_project_root:72</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L87" rel="noopener noreferrer">resolve_state_path:87</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L83" rel="noopener noreferrer">AgentServiceController:83</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L296" rel="noopener noreferrer">AgentServiceHandler:296</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L428" rel="noopener noreferrer">SafeAgentServiceHandler:428</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L467" rel="noopener noreferrer">create_agent_service:467</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L508" rel="noopener noreferrer">serve_agent_service:508</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L22" rel="noopener noreferrer">TriagePattern:22</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L143" rel="noopener noreferrer">TriageLearner:143</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L47" rel="noopener noreferrer">_pattern_key:47</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L53" rel="noopener noreferrer">_make_pattern:53</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -699,7 +786,7 @@
 
     <article class="folder-card searchable" data-search="skylos/analysis reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references. change this when multiple scanners need the same code-understanding primitive. skylos/analysis/module_reachability.py skylos/analysis/control_flow.py  skylos/analysis/penalties.py skylos/analysis/architecture.py skylos/analysis/known_patterns.py skylos/analysis/circular_deps.py skylos/analysis/control_flow.py skylos/analysis/ast_mask.py skylos/analysis/architecture_findings.py skylos/analysis/module_reachability.py">
       <div class="card-head">
-        <h3><a href="../../skylos/analysis">skylos/analysis</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis" rel="noopener noreferrer">skylos/analysis</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 12</span>
           <span class="pill"><strong>symbols</strong> 83</span>
@@ -711,37 +798,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/analysis/module_reachability.py">skylos/analysis/module_reachability.py</a> <a href="../../skylos/analysis/control_flow.py">skylos/analysis/control_flow.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py" rel="noopener noreferrer">skylos/analysis/module_reachability.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">skylos/analysis/control_flow.py</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/analysis/penalties.py">skylos/analysis/penalties.py</a> <span>1146 lines</span></li>
-<li><a href="../../skylos/analysis/architecture.py">skylos/analysis/architecture.py</a> <span>594 lines</span></li>
-<li><a href="../../skylos/analysis/known_patterns.py">skylos/analysis/known_patterns.py</a> <span>619 lines</span></li>
-<li><a href="../../skylos/analysis/circular_deps.py">skylos/analysis/circular_deps.py</a> <span>390 lines</span></li>
-<li><a href="../../skylos/analysis/control_flow.py">skylos/analysis/control_flow.py</a> <span>219 lines</span></li>
-<li><a href="../../skylos/analysis/ast_mask.py">skylos/analysis/ast_mask.py</a> <span>162 lines</span></li>
-<li><a href="../../skylos/analysis/architecture_findings.py">skylos/analysis/architecture_findings.py</a> <span>206 lines</span></li>
-<li><a href="../../skylos/analysis/module_reachability.py">skylos/analysis/module_reachability.py</a> <span>250 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">skylos/analysis/penalties.py</a> <span>1146 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">skylos/analysis/architecture.py</a> <span>594 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py" rel="noopener noreferrer">skylos/analysis/known_patterns.py</a> <span>619 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">skylos/analysis/circular_deps.py</a> <span>390 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">skylos/analysis/control_flow.py</a> <span>219 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">skylos/analysis/ast_mask.py</a> <span>162 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_findings.py" rel="noopener noreferrer">skylos/analysis/architecture_findings.py</a> <span>206 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py" rel="noopener noreferrer">skylos/analysis/module_reachability.py</a> <span>250 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/analysis/penalties.py">apply_penalties:1038</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/penalties.py">_suppress:202</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/penalties.py">_class_base_names:213</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/penalties.py">_class_declares_attr:228</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/penalties.py">_name_parent_has_base:248</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/architecture.py">ModuleMetrics:22</a> <span>class</span></li>
-<li><a href="../../skylos/analysis/architecture.py">DIPViolation:45</a> <span>class</span></li>
-<li><a href="../../skylos/analysis/architecture.py">ArchitectureResult:54</a> <span>class</span></li>
-<li><a href="../../skylos/analysis/architecture.py">analyze_architecture:200</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/architecture.py">get_architecture_findings:428</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/known_patterns.py">matches_pattern:592</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/known_patterns.py">has_base_class:596</a> <span>def</span></li>
-<li><a href="../../skylos/analysis/circular_deps.py">ModuleDependency:57</a> <span>class</span></li>
-<li><a href="../../skylos/analysis/circular_deps.py">CircularDependency:66</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L1038" rel="noopener noreferrer">apply_penalties:1038</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L202" rel="noopener noreferrer">_suppress:202</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L213" rel="noopener noreferrer">_class_base_names:213</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L228" rel="noopener noreferrer">_class_declares_attr:228</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L248" rel="noopener noreferrer">_name_parent_has_base:248</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L22" rel="noopener noreferrer">ModuleMetrics:22</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L45" rel="noopener noreferrer">DIPViolation:45</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L54" rel="noopener noreferrer">ArchitectureResult:54</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L200" rel="noopener noreferrer">analyze_architecture:200</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L428" rel="noopener noreferrer">get_architecture_findings:428</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L592" rel="noopener noreferrer">matches_pattern:592</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L596" rel="noopener noreferrer">has_base_class:596</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L57" rel="noopener noreferrer">ModuleDependency:57</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L66" rel="noopener noreferrer">CircularDependency:66</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -750,7 +837,7 @@
 
     <article class="folder-card searchable" data-search="skylos/api public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata. keep compatibility in mind here; external users may import from skylos.api. skylos/api/__init__.py skylos/api/_findings.py skylos/api/_payloads.py test/test_api.py skylos/api/__init__.py skylos/api/_artifacts.py skylos/api/_payloads.py skylos/api/_findings.py skylos/api/_urls.py skylos/api/_ai_detection.py skylos/api/_snippets.py">
       <div class="card-head">
-        <h3><a href="../../skylos/api">skylos/api</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api" rel="noopener noreferrer">skylos/api</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 150</span>
@@ -762,36 +849,36 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/api/__init__.py">skylos/api/__init__.py</a> <a href="../../skylos/api/_findings.py">skylos/api/_findings.py</a> <a href="../../skylos/api/_payloads.py">skylos/api/_payloads.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_findings.py" rel="noopener noreferrer">skylos/api/_findings.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">skylos/api/_payloads.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_api.py">test/test_api.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_api.py" rel="noopener noreferrer">test/test_api.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/api/__init__.py">skylos/api/__init__.py</a> <span>1970 lines</span></li>
-<li><a href="../../skylos/api/_artifacts.py">skylos/api/_artifacts.py</a> <span>324 lines</span></li>
-<li><a href="../../skylos/api/_payloads.py">skylos/api/_payloads.py</a> <span>240 lines</span></li>
-<li><a href="../../skylos/api/_findings.py">skylos/api/_findings.py</a> <span>206 lines</span></li>
-<li><a href="../../skylos/api/_urls.py">skylos/api/_urls.py</a> <span>154 lines</span></li>
-<li><a href="../../skylos/api/_ai_detection.py">skylos/api/_ai_detection.py</a> <span>180 lines</span></li>
-<li><a href="../../skylos/api/_snippets.py">skylos/api/_snippets.py</a> <span>46 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a> <span>1970 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">skylos/api/_artifacts.py</a> <span>324 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">skylos/api/_payloads.py</a> <span>240 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_findings.py" rel="noopener noreferrer">skylos/api/_findings.py</a> <span>206 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_urls.py" rel="noopener noreferrer">skylos/api/_urls.py</a> <span>154 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_ai_detection.py" rel="noopener noreferrer">skylos/api/_ai_detection.py</a> <span>180 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_snippets.py" rel="noopener noreferrer">skylos/api/_snippets.py</a> <span>46 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/api/__init__.py">get_project_token:338</a> <span>def</span></li>
-<li><a href="../../skylos/api/__init__.py">get_project_info:368</a> <span>def</span></li>
-<li><a href="../../skylos/api/__init__.py">get_credit_balance:386</a> <span>def</span></li>
-<li><a href="../../skylos/api/__init__.py">print_credit_status:404</a> <span>def</span></li>
-<li><a href="../../skylos/api/__init__.py">get_git_root:422</a> <span>def</span></li>
-<li><a href="../../skylos/api/_artifacts.py">UploadArtifact:39</a> <span>class</span></li>
-<li><a href="../../skylos/api/_artifacts.py">PreparedReportUpload:65</a> <span>class</span></li>
-<li><a href="../../skylos/api/_artifacts.py">upload_artifact:162</a> <span>def</span></li>
-<li><a href="../../skylos/api/_artifacts.py">_sha256_file:77</a> <span>def</span></li>
-<li><a href="../../skylos/api/_artifacts.py">_write_gzip_json_artifact:85</a> <span>def</span></li>
-<li><a href="../../skylos/api/_payloads.py">_json_size_bytes:20</a> <span>def</span></li>
-<li><a href="../../skylos/api/_payloads.py">_coerce_debt_snapshot_dict:24</a> <span>def</span></li>
-<li><a href="../../skylos/api/_payloads.py">_infer_upload_project_root:35</a> <span>def</span></li>
-<li><a href="../../skylos/api/_payloads.py">_extract_workspace_upload_metadata:71</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L338" rel="noopener noreferrer">get_project_token:338</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L368" rel="noopener noreferrer">get_project_info:368</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L386" rel="noopener noreferrer">get_credit_balance:386</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L404" rel="noopener noreferrer">print_credit_status:404</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L422" rel="noopener noreferrer">get_git_root:422</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L39" rel="noopener noreferrer">UploadArtifact:39</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L65" rel="noopener noreferrer">PreparedReportUpload:65</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L162" rel="noopener noreferrer">upload_artifact:162</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L77" rel="noopener noreferrer">_sha256_file:77</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L85" rel="noopener noreferrer">_write_gzip_json_artifact:85</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L20" rel="noopener noreferrer">_json_size_bytes:20</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L24" rel="noopener noreferrer">_coerce_debt_snapshot_dict:24</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L35" rel="noopener noreferrer">_infer_upload_project_root:35</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L71" rel="noopener noreferrer">_extract_workspace_upload_metadata:71</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -800,7 +887,7 @@
 
     <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/candidates.py skylos/audit/processor.py skylos/audit/types.py skylos/audit/revalidator.py skylos/audit/polyglot.py skylos/audit/store.py skylos/audit/ci.py">
       <div class="card-head">
-        <h3><a href="../../skylos/audit">skylos/audit</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit" rel="noopener noreferrer">skylos/audit</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 10</span>
           <span class="pill"><strong>symbols</strong> 96</span>
@@ -812,37 +899,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/audit/processor.py">skylos/audit/processor.py</a> <a href="../../skylos/audit/candidates.py">skylos/audit/candidates.py</a> <a href="../../skylos/audit/revalidator.py">skylos/audit/revalidator.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">skylos/audit/processor.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">skylos/audit/revalidator.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_audit_candidates.py">test/test_audit_candidates.py</a> <a href="../../test/test_audit_ci.py">test/test_audit_ci.py</a> <a href="../../test/test_audit_cli.py">test/test_audit_cli.py</a> <a href="../../test/test_audit_export.py">test/test_audit_export.py</a> <a href="../../test/test_audit_processor.py">test/test_audit_processor.py</a> <a href="../../test/test_audit_revalidator.py">test/test_audit_revalidator.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_candidates.py" rel="noopener noreferrer">test/test_audit_candidates.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_ci.py" rel="noopener noreferrer">test/test_audit_ci.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_cli.py" rel="noopener noreferrer">test/test_audit_cli.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_export.py" rel="noopener noreferrer">test/test_audit_export.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_processor.py" rel="noopener noreferrer">test/test_audit_processor.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_revalidator.py" rel="noopener noreferrer">test/test_audit_revalidator.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/audit/export.py">skylos/audit/export.py</a> <span>559 lines</span></li>
-<li><a href="../../skylos/audit/candidates.py">skylos/audit/candidates.py</a> <span>635 lines</span></li>
-<li><a href="../../skylos/audit/processor.py">skylos/audit/processor.py</a> <span>477 lines</span></li>
-<li><a href="../../skylos/audit/types.py">skylos/audit/types.py</a> <span>404 lines</span></li>
-<li><a href="../../skylos/audit/revalidator.py">skylos/audit/revalidator.py</a> <span>294 lines</span></li>
-<li><a href="../../skylos/audit/polyglot.py">skylos/audit/polyglot.py</a> <span>388 lines</span></li>
-<li><a href="../../skylos/audit/store.py">skylos/audit/store.py</a> <span>383 lines</span></li>
-<li><a href="../../skylos/audit/ci.py">skylos/audit/ci.py</a> <span>174 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">skylos/audit/export.py</a> <span>559 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a> <span>635 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">skylos/audit/processor.py</a> <span>477 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">skylos/audit/types.py</a> <span>404 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">skylos/audit/revalidator.py</a> <span>294 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py" rel="noopener noreferrer">skylos/audit/polyglot.py</a> <span>388 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/store.py" rel="noopener noreferrer">skylos/audit/store.py</a> <span>383 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py" rel="noopener noreferrer">skylos/audit/ci.py</a> <span>174 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/audit/export.py">build_deep_audit_export:49</a> <span>def</span></li>
-<li><a href="../../skylos/audit/export.py">render_deep_audit_export:102</a> <span>def</span></li>
-<li><a href="../../skylos/audit/export.py">write_deep_audit_export:116</a> <span>def</span></li>
-<li><a href="../../skylos/audit/export.py">_resolve_deep_audit_export_path:131</a> <span>def</span></li>
-<li><a href="../../skylos/audit/export.py">_normalized_allowed_files:140</a> <span>def</span></li>
-<li><a href="../../skylos/audit/candidates.py">scan_deep_audit_candidates:82</a> <span>def</span></li>
-<li><a href="../../skylos/audit/candidates.py">_project_root:217</a> <span>def</span></li>
-<li><a href="../../skylos/audit/candidates.py">_resolve_audit_file:222</a> <span>def</span></li>
-<li><a href="../../skylos/audit/candidates.py">_discover_audit_files:239</a> <span>def</span></li>
-<li><a href="../../skylos/audit/candidates.py">_is_audit_file:299</a> <span>def</span></li>
-<li><a href="../../skylos/audit/processor.py">process_deep_audit_records:29</a> <span>def</span></li>
-<li><a href="../../skylos/audit/processor.py">_record_sort_key:184</a> <span>def</span></li>
-<li><a href="../../skylos/audit/processor.py">_normalized_allowed_files:191</a> <span>def</span></li>
-<li><a href="../../skylos/audit/processor.py">_is_active_record:208</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L49" rel="noopener noreferrer">build_deep_audit_export:49</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L102" rel="noopener noreferrer">render_deep_audit_export:102</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L116" rel="noopener noreferrer">write_deep_audit_export:116</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L131" rel="noopener noreferrer">_resolve_deep_audit_export_path:131</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L140" rel="noopener noreferrer">_normalized_allowed_files:140</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L82" rel="noopener noreferrer">scan_deep_audit_candidates:82</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L217" rel="noopener noreferrer">_project_root:217</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L222" rel="noopener noreferrer">_resolve_audit_file:222</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L239" rel="noopener noreferrer">_discover_audit_files:239</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L299" rel="noopener noreferrer">_is_audit_file:299</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L29" rel="noopener noreferrer">process_deep_audit_records:29</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L184" rel="noopener noreferrer">_record_sort_key:184</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L191" rel="noopener noreferrer">_normalized_allowed_files:191</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L208" rel="noopener noreferrer">_is_active_record:208</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -851,7 +938,7 @@
 
     <article class="folder-card searchable" data-search="skylos/benchmarks benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons. change this when proving scanner quality changed, not just when code still passes tests. skylos/benchmarks/security.py skylos/benchmarks/quality.py skylos/benchmarks/agent_review.py  skylos/benchmarks/dead_code.py skylos/benchmarks/security.py skylos/benchmarks/agent_review.py skylos/benchmarks/quality.py skylos/benchmarks/corpus_ci.py skylos/benchmarks/demo_deadcode.py skylos/benchmarks/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/benchmarks">skylos/benchmarks</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks" rel="noopener noreferrer">skylos/benchmarks</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 88</span>
@@ -863,36 +950,36 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/benchmarks/security.py">skylos/benchmarks/security.py</a> <a href="../../skylos/benchmarks/quality.py">skylos/benchmarks/quality.py</a> <a href="../../skylos/benchmarks/agent_review.py">skylos/benchmarks/agent_review.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/benchmarks/dead_code.py">skylos/benchmarks/dead_code.py</a> <span>1083 lines</span></li>
-<li><a href="../../skylos/benchmarks/security.py">skylos/benchmarks/security.py</a> <span>725 lines</span></li>
-<li><a href="../../skylos/benchmarks/agent_review.py">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
-<li><a href="../../skylos/benchmarks/quality.py">skylos/benchmarks/quality.py</a> <span>507 lines</span></li>
-<li><a href="../../skylos/benchmarks/corpus_ci.py">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
-<li><a href="../../skylos/benchmarks/demo_deadcode.py">skylos/benchmarks/demo_deadcode.py</a> <span>172 lines</span></li>
-<li><a href="../../skylos/benchmarks/__init__.py">skylos/benchmarks/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1083 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>725 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>507 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">skylos/benchmarks/demo_deadcode.py</a> <span>172 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/__init__.py" rel="noopener noreferrer">skylos/benchmarks/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/benchmarks/dead_code.py">DeadCodeKey:102</a> <span>class</span></li>
-<li><a href="../../skylos/benchmarks/dead_code.py">DeadCodeBenchmarkFailure:112</a> <span>class</span></li>
-<li><a href="../../skylos/benchmarks/dead_code.py">load_manifest:129</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/dead_code.py">load_external_targets:133</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/dead_code.py">validate_manifest:305</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/security.py">SecurityBenchmarkFailure:78</a> <span>class</span></li>
-<li><a href="../../skylos/benchmarks/security.py">load_manifest:97</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/security.py">validate_manifest:101</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/security.py">run_case:488</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/security.py">run_manifest:575</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/agent_review.py">AgentReviewBenchmarkFailure:55</a> <span>class</span></li>
-<li><a href="../../skylos/benchmarks/agent_review.py">load_manifest:72</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/agent_review.py">validate_manifest:76</a> <span>def</span></li>
-<li><a href="../../skylos/benchmarks/agent_review.py">prepare_case_scan:243</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L102" rel="noopener noreferrer">DeadCodeKey:102</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L112" rel="noopener noreferrer">DeadCodeBenchmarkFailure:112</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L129" rel="noopener noreferrer">load_manifest:129</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L133" rel="noopener noreferrer">load_external_targets:133</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L305" rel="noopener noreferrer">validate_manifest:305</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L78" rel="noopener noreferrer">SecurityBenchmarkFailure:78</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L97" rel="noopener noreferrer">load_manifest:97</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L101" rel="noopener noreferrer">validate_manifest:101</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L488" rel="noopener noreferrer">run_case:488</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L575" rel="noopener noreferrer">run_manifest:575</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L243" rel="noopener noreferrer">prepare_case_scan:243</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -901,7 +988,7 @@
 
     <article class="folder-card searchable" data-search="skylos/cicd ci workflow generation, annotations, review comments, evidence, and risk passport output. use this when changing github/gitlab integration behavior or ci gate messaging. skylos/cicd/workflow.py skylos/cicd/review.py skylos/cicd/evidence.py test/test_cicd_annotate.py test/test_cicd_evidence.py test/test_cicd_gate.py test/test_cicd_review.py test/test_cicd_risk_passport.py test/test_cicd_workflow.py skylos/cicd/review.py skylos/cicd/evidence.py skylos/cicd/risk_passport.py skylos/cicd/workflow.py skylos/cicd/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/cicd">skylos/cicd</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 5</span>
           <span class="pill"><strong>symbols</strong> 61</span>
@@ -913,34 +1000,34 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/cicd/workflow.py">skylos/cicd/workflow.py</a> <a href="../../skylos/cicd/review.py">skylos/cicd/review.py</a> <a href="../../skylos/cicd/evidence.py">skylos/cicd/evidence.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">skylos/cicd/workflow.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">skylos/cicd/review.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">skylos/cicd/evidence.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_cicd_annotate.py">test/test_cicd_annotate.py</a> <a href="../../test/test_cicd_evidence.py">test/test_cicd_evidence.py</a> <a href="../../test/test_cicd_gate.py">test/test_cicd_gate.py</a> <a href="../../test/test_cicd_review.py">test/test_cicd_review.py</a> <a href="../../test/test_cicd_risk_passport.py">test/test_cicd_risk_passport.py</a> <a href="../../test/test_cicd_workflow.py">test/test_cicd_workflow.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cicd_annotate.py" rel="noopener noreferrer">test/test_cicd_annotate.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_cicd_evidence.py" rel="noopener noreferrer">test/test_cicd_evidence.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_cicd_gate.py" rel="noopener noreferrer">test/test_cicd_gate.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_cicd_review.py" rel="noopener noreferrer">test/test_cicd_review.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_cicd_risk_passport.py" rel="noopener noreferrer">test/test_cicd_risk_passport.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_cicd_workflow.py" rel="noopener noreferrer">test/test_cicd_workflow.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/cicd/review.py">skylos/cicd/review.py</a> <span>858 lines</span></li>
-<li><a href="../../skylos/cicd/evidence.py">skylos/cicd/evidence.py</a> <span>377 lines</span></li>
-<li><a href="../../skylos/cicd/risk_passport.py">skylos/cicd/risk_passport.py</a> <span>305 lines</span></li>
-<li><a href="../../skylos/cicd/workflow.py">skylos/cicd/workflow.py</a> <span>331 lines</span></li>
-<li><a href="../../skylos/cicd/__init__.py">skylos/cicd/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">skylos/cicd/review.py</a> <span>858 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">skylos/cicd/evidence.py</a> <span>377 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">skylos/cicd/risk_passport.py</a> <span>305 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">skylos/cicd/workflow.py</a> <span>331 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/__init__.py" rel="noopener noreferrer">skylos/cicd/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/cicd/review.py">run_pr_review:30</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/review.py">get_changed_line_ranges:130</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/review.py">filter_findings_to_diff:229</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/review.py">_resolve_review_provenance:115</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/review.py">_parse_unified_diff:145</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/evidence.py">EvidenceCard:19</a> <span>class</span></li>
-<li><a href="../../skylos/cicd/evidence.py">build_evidence_cards:112</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/evidence.py">build_evidence_card:116</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/evidence.py">evidence_counts:139</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/evidence.py">evidence_label_title:150</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/risk_passport.py">build_risk_passport:19</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/risk_passport.py">format_risk_passport_markdown:116</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/risk_passport.py">_defense_risk:159</a> <span>def</span></li>
-<li><a href="../../skylos/cicd/risk_passport.py">_is_ai_authored_finding:196</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L30" rel="noopener noreferrer">run_pr_review:30</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L130" rel="noopener noreferrer">get_changed_line_ranges:130</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L229" rel="noopener noreferrer">filter_findings_to_diff:229</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L115" rel="noopener noreferrer">_resolve_review_provenance:115</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L145" rel="noopener noreferrer">_parse_unified_diff:145</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L19" rel="noopener noreferrer">EvidenceCard:19</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L112" rel="noopener noreferrer">build_evidence_cards:112</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L116" rel="noopener noreferrer">build_evidence_card:116</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L139" rel="noopener noreferrer">evidence_counts:139</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L150" rel="noopener noreferrer">evidence_label_title:150</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L19" rel="noopener noreferrer">build_risk_passport:19</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L116" rel="noopener noreferrer">format_risk_passport_markdown:116</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L159" rel="noopener noreferrer">_defense_risk:159</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L196" rel="noopener noreferrer">_is_ai_authored_finding:196</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -949,7 +1036,7 @@
 
     <article class="folder-card searchable" data-search="skylos/cli_core smaller cli parser and dispatch pieces peeled away from the main cli module. prefer this for new command wiring when it fits the newer cli split. skylos/cli_core/main_parser.py skylos/cli_core/dispatch.py  skylos/cli_core/main_parser.py skylos/cli_core/dispatch.py skylos/cli_core/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/cli_core">skylos/cli_core</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core" rel="noopener noreferrer">skylos/cli_core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 6</span>
@@ -961,24 +1048,24 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/cli_core/main_parser.py">skylos/cli_core/main_parser.py</a> <a href="../../skylos/cli_core/dispatch.py">skylos/cli_core/dispatch.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">skylos/cli_core/main_parser.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">skylos/cli_core/dispatch.py</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/cli_core/main_parser.py">skylos/cli_core/main_parser.py</a> <span>362 lines</span></li>
-<li><a href="../../skylos/cli_core/dispatch.py">skylos/cli_core/dispatch.py</a> <span>89 lines</span></li>
-<li><a href="../../skylos/cli_core/__init__.py">skylos/cli_core/__init__.py</a> <span>0 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">skylos/cli_core/main_parser.py</a> <span>362 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">skylos/cli_core/dispatch.py</a> <span>89 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/__init__.py" rel="noopener noreferrer">skylos/cli_core/__init__.py</a> <span>0 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/cli_core/main_parser.py">build_main_parser:7</a> <span>def</span></li>
-<li><a href="../../skylos/cli_core/main_parser.py">apply_main_output_format:305</a> <span>def</span></li>
-<li><a href="../../skylos/cli_core/main_parser.py">parse_main_cli_args:335</a> <span>def</span></li>
-<li><a href="../../skylos/cli_core/dispatch.py">is_first_level_help_request:37</a> <span>def</span></li>
-<li><a href="../../skylos/cli_core/dispatch.py">run_early_command_help:41</a> <span>def</span></li>
-<li><a href="../../skylos/cli_core/dispatch.py">dispatch_early_command:71</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L7" rel="noopener noreferrer">build_main_parser:7</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L305" rel="noopener noreferrer">apply_main_output_format:305</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L335" rel="noopener noreferrer">parse_main_cli_args:335</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L37" rel="noopener noreferrer">is_first_level_help_request:37</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L41" rel="noopener noreferrer">run_early_command_help:41</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L71" rel="noopener noreferrer">dispatch_early_command:71</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -987,7 +1074,7 @@
 
     <article class="folder-card searchable" data-search="skylos/cloud skylos cloud login, credentials, policy sync, project context, and upload manifest support. treat this as security-sensitive because local repo state and cloud policy meet here. skylos/cloud/sync.py skylos/cloud/credentials.py skylos/cloud/project_context.py  skylos/cloud/sync.py skylos/cloud/login.py skylos/cloud/upload_manifest.py skylos/cloud/credentials.py skylos/cloud/project_context.py skylos/cloud/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/cloud">skylos/cloud</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud" rel="noopener noreferrer">skylos/cloud</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 74</span>
@@ -999,35 +1086,35 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/cloud/sync.py">skylos/cloud/sync.py</a> <a href="../../skylos/cloud/credentials.py">skylos/cloud/credentials.py</a> <a href="../../skylos/cloud/project_context.py">skylos/cloud/project_context.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">skylos/cloud/sync.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py" rel="noopener noreferrer">skylos/cloud/credentials.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py" rel="noopener noreferrer">skylos/cloud/project_context.py</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/cloud/sync.py">skylos/cloud/sync.py</a> <span>1197 lines</span></li>
-<li><a href="../../skylos/cloud/login.py">skylos/cloud/login.py</a> <span>489 lines</span></li>
-<li><a href="../../skylos/cloud/upload_manifest.py">skylos/cloud/upload_manifest.py</a> <span>129 lines</span></li>
-<li><a href="../../skylos/cloud/credentials.py">skylos/cloud/credentials.py</a> <span>67 lines</span></li>
-<li><a href="../../skylos/cloud/project_context.py">skylos/cloud/project_context.py</a> <span>55 lines</span></li>
-<li><a href="../../skylos/cloud/__init__.py">skylos/cloud/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">skylos/cloud/sync.py</a> <span>1197 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">skylos/cloud/login.py</a> <span>489 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">skylos/cloud/upload_manifest.py</a> <span>129 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py" rel="noopener noreferrer">skylos/cloud/credentials.py</a> <span>67 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py" rel="noopener noreferrer">skylos/cloud/project_context.py</a> <span>55 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/__init__.py" rel="noopener noreferrer">skylos/cloud/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/cloud/sync.py">get_api_url:267</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/sync.py">get_token:315</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/sync.py">save_token:342</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/sync.py">clear_token:379</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/sync.py">mask_token:386</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/login.py">LoginResult:18</a> <span>class</span></li>
-<li><a href="../../skylos/cloud/login.py">browser_login:149</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/login.py">manual_token_fallback:228</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/login.py">get_current_connection:299</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/login.py">run_login:350</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/upload_manifest.py">UploadFamilyManifest:7</a> <span>class</span></li>
-<li><a href="../../skylos/cloud/upload_manifest.py">build_code_scan_manifest:24</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/upload_manifest.py">build_defense_manifest:48</a> <span>def</span></li>
-<li><a href="../../skylos/cloud/upload_manifest.py">build_debt_manifest:63</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L267" rel="noopener noreferrer">get_api_url:267</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L315" rel="noopener noreferrer">get_token:315</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L342" rel="noopener noreferrer">save_token:342</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L379" rel="noopener noreferrer">clear_token:379</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L386" rel="noopener noreferrer">mask_token:386</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L18" rel="noopener noreferrer">LoginResult:18</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L149" rel="noopener noreferrer">browser_login:149</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L228" rel="noopener noreferrer">manual_token_fallback:228</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L299" rel="noopener noreferrer">get_current_connection:299</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L350" rel="noopener noreferrer">run_login:350</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L7" rel="noopener noreferrer">UploadFamilyManifest:7</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L24" rel="noopener noreferrer">build_code_scan_manifest:24</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L48" rel="noopener noreferrer">build_defense_manifest:48</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L63" rel="noopener noreferrer">build_debt_manifest:63</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1036,7 +1123,7 @@
 
     <article class="folder-card searchable" data-search="skylos/commands command modules used by the cli for focused command behavior. put command-specific behavior here instead of growing skylos/cli.py. skylos/commands/run_cmd.py skylos/commands/cicd_cmd.py skylos/commands/sync_cmd.py  skylos/commands/scan_cmd.py skylos/commands/suite_cmd.py skylos/commands/rules_cmd.py skylos/commands/defend_cmd.py skylos/commands/debt_cmd.py skylos/commands/cicd_cmd.py skylos/commands/key_cmd.py skylos/commands/clean_cmd.py">
       <div class="card-head">
-        <h3><a href="../../skylos/commands">skylos/commands</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands" rel="noopener noreferrer">skylos/commands</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 25</span>
           <span class="pill"><strong>symbols</strong> 97</span>
@@ -1048,37 +1135,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/commands/run_cmd.py">skylos/commands/run_cmd.py</a> <a href="../../skylos/commands/cicd_cmd.py">skylos/commands/cicd_cmd.py</a> <a href="../../skylos/commands/sync_cmd.py">skylos/commands/sync_cmd.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/run_cmd.py" rel="noopener noreferrer">skylos/commands/run_cmd.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py" rel="noopener noreferrer">skylos/commands/cicd_cmd.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/sync_cmd.py" rel="noopener noreferrer">skylos/commands/sync_cmd.py</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/commands/scan_cmd.py">skylos/commands/scan_cmd.py</a> <span>961 lines</span></li>
-<li><a href="../../skylos/commands/suite_cmd.py">skylos/commands/suite_cmd.py</a> <span>506 lines</span></li>
-<li><a href="../../skylos/commands/rules_cmd.py">skylos/commands/rules_cmd.py</a> <span>516 lines</span></li>
-<li><a href="../../skylos/commands/defend_cmd.py">skylos/commands/defend_cmd.py</a> <span>496 lines</span></li>
-<li><a href="../../skylos/commands/debt_cmd.py">skylos/commands/debt_cmd.py</a> <span>428 lines</span></li>
-<li><a href="../../skylos/commands/cicd_cmd.py">skylos/commands/cicd_cmd.py</a> <span>361 lines</span></li>
-<li><a href="../../skylos/commands/key_cmd.py">skylos/commands/key_cmd.py</a> <span>223 lines</span></li>
-<li><a href="../../skylos/commands/clean_cmd.py">skylos/commands/clean_cmd.py</a> <span>201 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/scan_cmd.py" rel="noopener noreferrer">skylos/commands/scan_cmd.py</a> <span>961 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">skylos/commands/suite_cmd.py</a> <span>506 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">skylos/commands/rules_cmd.py</a> <span>516 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">skylos/commands/defend_cmd.py</a> <span>496 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/debt_cmd.py" rel="noopener noreferrer">skylos/commands/debt_cmd.py</a> <span>428 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py" rel="noopener noreferrer">skylos/commands/cicd_cmd.py</a> <span>361 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py" rel="noopener noreferrer">skylos/commands/key_cmd.py</a> <span>223 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">skylos/commands/clean_cmd.py</a> <span>201 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/commands/scan_cmd.py">run_scan_command:7</a> <span>def</span></li>
-<li><a href="../../skylos/commands/suite_cmd.py">run_suite_command:446</a> <span>def</span></li>
-<li><a href="../../skylos/commands/suite_cmd.py">_parse_csv_selection:20</a> <span>def</span></li>
-<li><a href="../../skylos/commands/suite_cmd.py">_build_static_upload_result:42</a> <span>def</span></li>
-<li><a href="../../skylos/commands/suite_cmd.py">_static_upload_failed_quality_gate:83</a> <span>def</span></li>
-<li><a href="../../skylos/commands/suite_cmd.py">_build_suite_parser:90</a> <span>def</span></li>
-<li><a href="../../skylos/commands/rules_cmd.py">run_rules_command:17</a> <span>def</span></li>
-<li><a href="../../skylos/commands/rules_cmd.py">init_rules:109</a> <span>def</span></li>
-<li><a href="../../skylos/commands/rules_cmd.py">install_rules:170</a> <span>def</span></li>
-<li><a href="../../skylos/commands/rules_cmd.py">list_rules:220</a> <span>def</span></li>
-<li><a href="../../skylos/commands/rules_cmd.py">list_rule_packs:252</a> <span>def</span></li>
-<li><a href="../../skylos/commands/defend_cmd.py">run_defend_command:389</a> <span>def</span></li>
-<li><a href="../../skylos/commands/defend_cmd.py">_build_empty_defense_json:41</a> <span>def</span></li>
-<li><a href="../../skylos/commands/defend_cmd.py">_build_defend_parser:80</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/scan_cmd.py#L7" rel="noopener noreferrer">run_scan_command:7</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L446" rel="noopener noreferrer">run_suite_command:446</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L20" rel="noopener noreferrer">_parse_csv_selection:20</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L42" rel="noopener noreferrer">_build_static_upload_result:42</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L83" rel="noopener noreferrer">_static_upload_failed_quality_gate:83</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L90" rel="noopener noreferrer">_build_suite_parser:90</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L17" rel="noopener noreferrer">run_rules_command:17</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L109" rel="noopener noreferrer">init_rules:109</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L170" rel="noopener noreferrer">install_rules:170</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L220" rel="noopener noreferrer">list_rules:220</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L252" rel="noopener noreferrer">list_rule_packs:252</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L389" rel="noopener noreferrer">run_defend_command:389</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L41" rel="noopener noreferrer">_build_empty_defense_json:41</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L80" rel="noopener noreferrer">_build_defend_parser:80</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1087,7 +1174,7 @@
 
     <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/gatekeeper.py skylos/core/result_cache.py skylos/core/grep_verify_common.py skylos/core/file_discovery.py skylos/core/grep_verify.py skylos/core/grep_verify_language_strategies.py skylos/core/suite.py skylos/core/grep_verify_python_strategy.py">
       <div class="card-head">
-        <h3><a href="../../skylos/core">skylos/core</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 17</span>
           <span class="pill"><strong>symbols</strong> 144</span>
@@ -1105,31 +1192,31 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/core/gatekeeper.py">skylos/core/gatekeeper.py</a> <span>674 lines</span></li>
-<li><a href="../../skylos/core/result_cache.py">skylos/core/result_cache.py</a> <span>580 lines</span></li>
-<li><a href="../../skylos/core/grep_verify_common.py">skylos/core/grep_verify_common.py</a> <span>500 lines</span></li>
-<li><a href="../../skylos/core/file_discovery.py">skylos/core/file_discovery.py</a> <span>407 lines</span></li>
-<li><a href="../../skylos/core/grep_verify.py">skylos/core/grep_verify.py</a> <span>372 lines</span></li>
-<li><a href="../../skylos/core/grep_verify_language_strategies.py">skylos/core/grep_verify_language_strategies.py</a> <span>391 lines</span></li>
-<li><a href="../../skylos/core/suite.py">skylos/core/suite.py</a> <span>388 lines</span></li>
-<li><a href="../../skylos/core/grep_verify_python_strategy.py">skylos/core/grep_verify_python_strategy.py</a> <span>418 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">skylos/core/gatekeeper.py</a> <span>674 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">skylos/core/result_cache.py</a> <span>580 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a> <span>500 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">skylos/core/file_discovery.py</a> <span>407 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a> <span>372 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_language_strategies.py" rel="noopener noreferrer">skylos/core/grep_verify_language_strategies.py</a> <span>391 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">skylos/core/suite.py</a> <span>388 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_python_strategy.py" rel="noopener noreferrer">skylos/core/grep_verify_python_strategy.py</a> <span>418 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/core/gatekeeper.py">run_cmd:36</a> <span>def</span></li>
-<li><a href="../../skylos/core/gatekeeper.py">get_git_status:45</a> <span>def</span></li>
-<li><a href="../../skylos/core/gatekeeper.py">run_push:59</a> <span>def</span></li>
-<li><a href="../../skylos/core/gatekeeper.py">start_deployment_wizard:70</a> <span>def</span></li>
-<li><a href="../../skylos/core/gatekeeper.py">check_gate:431</a> <span>def</span></li>
-<li><a href="../../skylos/core/result_cache.py">build_trace_cache_key:117</a> <span>def</span></li>
-<li><a href="../../skylos/core/result_cache.py">load_trace_cache:153</a> <span>def</span></li>
-<li><a href="../../skylos/core/result_cache.py">save_trace_cache:181</a> <span>def</span></li>
-<li><a href="../../skylos/core/result_cache.py">clear_run_cache:209</a> <span>def</span></li>
-<li><a href="../../skylos/core/result_cache.py">run_cache_stats:226</a> <span>def</span></li>
-<li><a href="../../skylos/core/grep_verify_common.py">detect_language:82</a> <span>def</span></li>
-<li><a href="../../skylos/core/grep_verify_common.py">source_globs_for_language:101</a> <span>def</span></li>
-<li><a href="../../skylos/core/grep_verify_common.py">repo_relative_path:178</a> <span>def</span></li>
-<li><a href="../../skylos/core/grep_verify_common.py">module_candidates:192</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L36" rel="noopener noreferrer">run_cmd:36</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L45" rel="noopener noreferrer">get_git_status:45</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L59" rel="noopener noreferrer">run_push:59</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L70" rel="noopener noreferrer">start_deployment_wizard:70</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L431" rel="noopener noreferrer">check_gate:431</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L117" rel="noopener noreferrer">build_trace_cache_key:117</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L153" rel="noopener noreferrer">load_trace_cache:153</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L181" rel="noopener noreferrer">save_trace_cache:181</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L209" rel="noopener noreferrer">clear_run_cache:209</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L226" rel="noopener noreferrer">run_cache_stats:226</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L82" rel="noopener noreferrer">detect_language:82</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L101" rel="noopener noreferrer">source_globs_for_language:101</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L178" rel="noopener noreferrer">repo_relative_path:178</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L192" rel="noopener noreferrer">module_candidates:192</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1138,7 +1225,7 @@
 
     <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/collect.py skylos/deadcode/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/deadcode">skylos/deadcode</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 40</span>
@@ -1150,30 +1237,30 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/deadcode/evidence.py">skylos/deadcode/evidence.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">skylos/deadcode/evidence.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_dead_code.py">test/test_dead_code.py</a> <a href="../../test/test_dead_code_benchmark.py">test/test_dead_code_benchmark.py</a> <a href="../../test/test_dead_code_evidence.py">test/test_dead_code_evidence.py</a> <a href="../../test/test_dead_code_liveness.py">test/test_dead_code_liveness.py</a> <a href="../../test/test_demo_deadcode_benchmark.py">test/test_demo_deadcode_benchmark.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_dead_code.py" rel="noopener noreferrer">test/test_dead_code.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dead_code_benchmark.py" rel="noopener noreferrer">test/test_dead_code_benchmark.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dead_code_evidence.py" rel="noopener noreferrer">test/test_dead_code_evidence.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dead_code_liveness.py" rel="noopener noreferrer">test/test_dead_code_liveness.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_demo_deadcode_benchmark.py" rel="noopener noreferrer">test/test_demo_deadcode_benchmark.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/deadcode/evidence.py">skylos/deadcode/evidence.py</a> <span>535 lines</span></li>
-<li><a href="../../skylos/deadcode/liveness.py">skylos/deadcode/liveness.py</a> <span>437 lines</span></li>
-<li><a href="../../skylos/deadcode/collect.py">skylos/deadcode/collect.py</a> <span>20 lines</span></li>
-<li><a href="../../skylos/deadcode/__init__.py">skylos/deadcode/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">skylos/deadcode/evidence.py</a> <span>535 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">skylos/deadcode/liveness.py</a> <span>437 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py" rel="noopener noreferrer">skylos/deadcode/collect.py</a> <span>20 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/__init__.py" rel="noopener noreferrer">skylos/deadcode/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/deadcode/evidence.py">EvidenceKind:12</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/evidence.py">CandidateClassification:28</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/evidence.py">SymbolKey:37</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/evidence.py">EvidenceEvent:89</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/evidence.py">EvidenceLedger:107</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/liveness.py">LivenessRescue:61</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/liveness.py">LivenessReport:69</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/liveness.py">apply_dead_code_liveness:95</a> <span>def</span></li>
-<li><a href="../../skylos/deadcode/liveness.py">_AttrCall:88</a> <span>class</span></li>
-<li><a href="../../skylos/deadcode/liveness.py">_mark:129</a> <span>def</span></li>
-<li><a href="../../skylos/deadcode/collect.py">collect_dead_code_findings:14</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L12" rel="noopener noreferrer">EvidenceKind:12</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L28" rel="noopener noreferrer">CandidateClassification:28</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L37" rel="noopener noreferrer">SymbolKey:37</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L89" rel="noopener noreferrer">EvidenceEvent:89</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L107" rel="noopener noreferrer">EvidenceLedger:107</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L61" rel="noopener noreferrer">LivenessRescue:61</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L69" rel="noopener noreferrer">LivenessReport:69</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L95" rel="noopener noreferrer">apply_dead_code_liveness:95</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L88" rel="noopener noreferrer">_AttrCall:88</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L129" rel="noopener noreferrer">_mark:129</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py#L14" rel="noopener noreferrer">collect_dead_code_findings:14</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1182,7 +1269,7 @@
 
     <article class="folder-card searchable" data-search="skylos/debt technical-debt detection and reporting helpers. use this for code-health signals that are not direct security findings. skylos/debt/ test/test_debt.py skylos/debt/report.py skylos/debt/engine.py skylos/debt/advisor.py skylos/debt/scoring.py skylos/debt/baseline.py skylos/debt/result.py skylos/debt/policy.py skylos/debt/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/debt">skylos/debt</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt" rel="noopener noreferrer">skylos/debt</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 8</span>
           <span class="pill"><strong>symbols</strong> 90</span>
@@ -1194,37 +1281,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/debt">skylos/debt</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/debt" rel="noopener noreferrer">skylos/debt</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_debt.py">test/test_debt.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/debt/report.py">skylos/debt/report.py</a> <span>390 lines</span></li>
-<li><a href="../../skylos/debt/engine.py">skylos/debt/engine.py</a> <span>316 lines</span></li>
-<li><a href="../../skylos/debt/advisor.py">skylos/debt/advisor.py</a> <span>292 lines</span></li>
-<li><a href="../../skylos/debt/scoring.py">skylos/debt/scoring.py</a> <span>301 lines</span></li>
-<li><a href="../../skylos/debt/baseline.py">skylos/debt/baseline.py</a> <span>236 lines</span></li>
-<li><a href="../../skylos/debt/result.py">skylos/debt/result.py</a> <span>138 lines</span></li>
-<li><a href="../../skylos/debt/policy.py">skylos/debt/policy.py</a> <span>116 lines</span></li>
-<li><a href="../../skylos/debt/__init__.py">skylos/debt/__init__.py</a> <span>74 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">skylos/debt/report.py</a> <span>390 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py" rel="noopener noreferrer">skylos/debt/engine.py</a> <span>316 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">skylos/debt/advisor.py</a> <span>292 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">skylos/debt/scoring.py</a> <span>301 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">skylos/debt/baseline.py</a> <span>236 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">skylos/debt/result.py</a> <span>138 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py" rel="noopener noreferrer">skylos/debt/policy.py</a> <span>116 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py" rel="noopener noreferrer">skylos/debt/__init__.py</a> <span>74 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/debt/report.py">format_debt_table:244</a> <span>def</span></li>
-<li><a href="../../skylos/debt/report.py">format_debt_json:280</a> <span>def</span></li>
-<li><a href="../../skylos/debt/report.py">format_debt_history_table:357</a> <span>def</span></li>
-<li><a href="../../skylos/debt/report.py">format_debt_history_json:388</a> <span>def</span></li>
-<li><a href="../../skylos/debt/report.py">_ordered_hotspots:9</a> <span>def</span></li>
-<li><a href="../../skylos/debt/engine.py">run_analyze:43</a> <span>def</span></li>
-<li><a href="../../skylos/debt/engine.py">collect_debt_signals:186</a> <span>def</span></li>
-<li><a href="../../skylos/debt/engine.py">build_debt_snapshot:223</a> <span>def</span></li>
-<li><a href="../../skylos/debt/engine.py">run_debt_analysis:284</a> <span>def</span></li>
-<li><a href="../../skylos/debt/engine.py">_project_root:49</a> <span>def</span></li>
-<li><a href="../../skylos/debt/advisor.py">DebtAdvisor:226</a> <span>class</span></li>
-<li><a href="../../skylos/debt/advisor.py">augment_hotspots_with_advisories:263</a> <span>def</span></li>
-<li><a href="../../skylos/debt/advisor.py">_system_prompt:49</a> <span>def</span></li>
-<li><a href="../../skylos/debt/advisor.py">_safe_excerpt:64</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L244" rel="noopener noreferrer">format_debt_table:244</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L280" rel="noopener noreferrer">format_debt_json:280</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L357" rel="noopener noreferrer">format_debt_history_table:357</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L388" rel="noopener noreferrer">format_debt_history_json:388</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L9" rel="noopener noreferrer">_ordered_hotspots:9</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L43" rel="noopener noreferrer">run_analyze:43</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L186" rel="noopener noreferrer">collect_debt_signals:186</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L223" rel="noopener noreferrer">build_debt_snapshot:223</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L284" rel="noopener noreferrer">run_debt_analysis:284</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L49" rel="noopener noreferrer">_project_root:49</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L226" rel="noopener noreferrer">DebtAdvisor:226</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L263" rel="noopener noreferrer">augment_hotspots_with_advisories:263</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L49" rel="noopener noreferrer">_system_prompt:49</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L64" rel="noopener noreferrer">_safe_excerpt:64</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1233,7 +1320,7 @@
 
     <article class="folder-card searchable" data-search="skylos/defend defensive scanning plugins and checks for suspicious package or code patterns. use this for supply-chain or malicious-code detection extensions. skylos/defend/ test/test_defend.py test/test_defend_typescript.py skylos/defend/owasp.py skylos/defend/report.py skylos/defend/policy.py skylos/defend/scoring.py skylos/defend/result.py skylos/defend/engine.py skylos/defend/plugin.py skylos/defend/plugins/untrusted_input_to_prompt.py">
       <div class="card-head">
-        <h3><a href="../../skylos/defend">skylos/defend</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend" rel="noopener noreferrer">skylos/defend</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 22</span>
           <span class="pill"><strong>symbols</strong> 36</span>
@@ -1245,37 +1332,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/defend">skylos/defend</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/defend" rel="noopener noreferrer">skylos/defend</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_defend.py">test/test_defend.py</a> <a href="../../test/test_defend_typescript.py">test/test_defend_typescript.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_defend.py" rel="noopener noreferrer">test/test_defend.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_defend_typescript.py" rel="noopener noreferrer">test/test_defend_typescript.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/defend/owasp.py">skylos/defend/owasp.py</a> <span>319 lines</span></li>
-<li><a href="../../skylos/defend/report.py">skylos/defend/report.py</a> <span>198 lines</span></li>
-<li><a href="../../skylos/defend/policy.py">skylos/defend/policy.py</a> <span>150 lines</span></li>
-<li><a href="../../skylos/defend/scoring.py">skylos/defend/scoring.py</a> <span>100 lines</span></li>
-<li><a href="../../skylos/defend/result.py">skylos/defend/result.py</a> <span>69 lines</span></li>
-<li><a href="../../skylos/defend/engine.py">skylos/defend/engine.py</a> <span>80 lines</span></li>
-<li><a href="../../skylos/defend/plugin.py">skylos/defend/plugin.py</a> <span>65 lines</span></li>
-<li><a href="../../skylos/defend/plugins/untrusted_input_to_prompt.py">skylos/defend/plugins/untrusted_input_to_prompt.py</a> <span>44 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">skylos/defend/owasp.py</a> <span>319 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py" rel="noopener noreferrer">skylos/defend/report.py</a> <span>198 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">skylos/defend/policy.py</a> <span>150 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">skylos/defend/scoring.py</a> <span>100 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">skylos/defend/result.py</a> <span>69 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/engine.py" rel="noopener noreferrer">skylos/defend/engine.py</a> <span>80 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugin.py" rel="noopener noreferrer">skylos/defend/plugin.py</a> <span>65 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/untrusted_input_to_prompt.py" rel="noopener noreferrer">skylos/defend/plugins/untrusted_input_to_prompt.py</a> <span>44 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/defend/owasp.py">supported_owasp_frameworks:189</a> <span>def</span></li>
-<li><a href="../../skylos/defend/owasp.py">supported_owasp_versions:193</a> <span>def</span></li>
-<li><a href="../../skylos/defend/owasp.py">normalize_owasp_framework:200</a> <span>def</span></li>
-<li><a href="../../skylos/defend/owasp.py">normalize_owasp_selection:209</a> <span>def</span></li>
-<li><a href="../../skylos/defend/owasp.py">get_owasp_mapping:232</a> <span>def</span></li>
-<li><a href="../../skylos/defend/report.py">format_defense_table:17</a> <span>def</span></li>
-<li><a href="../../skylos/defend/report.py">format_defense_json:102</a> <span>def</span></li>
-<li><a href="../../skylos/defend/policy.py">DefensePolicy:51</a> <span>class</span></li>
-<li><a href="../../skylos/defend/policy.py">load_policy:66</a> <span>def</span></li>
-<li><a href="../../skylos/defend/policy.py">_parse_policy:89</a> <span>def</span></li>
-<li><a href="../../skylos/defend/scoring.py">compute_defense_score:19</a> <span>def</span></li>
-<li><a href="../../skylos/defend/scoring.py">compute_ops_score:70</a> <span>def</span></li>
-<li><a href="../../skylos/defend/scoring.py">_score_pct:13</a> <span>def</span></li>
-<li><a href="../../skylos/defend/result.py">DefenseResult:8</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L189" rel="noopener noreferrer">supported_owasp_frameworks:189</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L193" rel="noopener noreferrer">supported_owasp_versions:193</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L200" rel="noopener noreferrer">normalize_owasp_framework:200</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L209" rel="noopener noreferrer">normalize_owasp_selection:209</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L232" rel="noopener noreferrer">get_owasp_mapping:232</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L17" rel="noopener noreferrer">format_defense_table:17</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L102" rel="noopener noreferrer">format_defense_json:102</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L51" rel="noopener noreferrer">DefensePolicy:51</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L66" rel="noopener noreferrer">load_policy:66</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L89" rel="noopener noreferrer">_parse_policy:89</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L19" rel="noopener noreferrer">compute_defense_score:19</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L70" rel="noopener noreferrer">compute_ops_score:70</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L13" rel="noopener noreferrer">_score_pct:13</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L8" rel="noopener noreferrer">DefenseResult:8</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -1284,7 +1371,7 @@
 
     <article class="folder-card searchable" data-search="skylos/discover source discovery and language/workspace detection. change this when skylos misses files or scans too much.  test/test_discover.py test/test_discover_typescript.py test/test_file_discovery.py skylos/discover/detector.py skylos/discover/detector_typescript.py skylos/discover/taint.py skylos/discover/graph.py skylos/discover/integration.py skylos/discover/report.py skylos/discover/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/discover">skylos/discover</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover" rel="noopener noreferrer">skylos/discover</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 45</span>
@@ -1298,34 +1385,34 @@
         <div class="mini-label">Entrypoints</div>
         <div class="link-row"><span class="muted">Generated only</span></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_discover.py">test/test_discover.py</a> <a href="../../test/test_discover_typescript.py">test/test_discover_typescript.py</a> <a href="../../test/test_file_discovery.py">test/test_file_discovery.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_discover.py" rel="noopener noreferrer">test/test_discover.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_discover_typescript.py" rel="noopener noreferrer">test/test_discover_typescript.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_file_discovery.py" rel="noopener noreferrer">test/test_file_discovery.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/discover/detector.py">skylos/discover/detector.py</a> <span>1308 lines</span></li>
-<li><a href="../../skylos/discover/detector_typescript.py">skylos/discover/detector_typescript.py</a> <span>626 lines</span></li>
-<li><a href="../../skylos/discover/taint.py">skylos/discover/taint.py</a> <span>210 lines</span></li>
-<li><a href="../../skylos/discover/graph.py">skylos/discover/graph.py</a> <span>98 lines</span></li>
-<li><a href="../../skylos/discover/integration.py">skylos/discover/integration.py</a> <span>68 lines</span></li>
-<li><a href="../../skylos/discover/report.py">skylos/discover/report.py</a> <span>67 lines</span></li>
-<li><a href="../../skylos/discover/__init__.py">skylos/discover/__init__.py</a> <span>16 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">skylos/discover/detector.py</a> <span>1308 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">skylos/discover/detector_typescript.py</a> <span>626 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">skylos/discover/taint.py</a> <span>210 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">skylos/discover/graph.py</a> <span>98 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py" rel="noopener noreferrer">skylos/discover/integration.py</a> <span>68 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py" rel="noopener noreferrer">skylos/discover/report.py</a> <span>67 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/__init__.py" rel="noopener noreferrer">skylos/discover/__init__.py</a> <span>16 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/discover/detector.py">detect_integrations:1049</a> <span>def</span></li>
-<li><a href="../../skylos/discover/detector.py">_LLMDetectorVisitor:233</a> <span>class</span></li>
-<li><a href="../../skylos/discover/detector.py">_default_exclude_folders:1082</a> <span>def</span></li>
-<li><a href="../../skylos/discover/detector.py">_scan_python_file:1102</a> <span>def</span></li>
-<li><a href="../../skylos/discover/detector.py">_collect_python_files:1118</a> <span>def</span></li>
-<li><a href="../../skylos/discover/detector_typescript.py">JSImport:173</a> <span>class</span></li>
-<li><a href="../../skylos/discover/detector_typescript.py">TSClient:180</a> <span>class</span></li>
-<li><a href="../../skylos/discover/detector_typescript.py">collect_typescript_files:187</a> <span>def</span></li>
-<li><a href="../../skylos/discover/detector_typescript.py">scan_typescript_file:200</a> <span>def</span></li>
-<li><a href="../../skylos/discover/detector_typescript.py">_should_skip_typescript_file:290</a> <span>def</span></li>
-<li><a href="../../skylos/discover/taint.py">TaintFlow:9</a> <span>class</span></li>
-<li><a href="../../skylos/discover/taint.py">analyze_taint_flows:201</a> <span>def</span></li>
-<li><a href="../../skylos/discover/taint.py">_TaintVisitor:26</a> <span>class</span></li>
-<li><a href="../../skylos/discover/graph.py">NodeType:8</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1049" rel="noopener noreferrer">detect_integrations:1049</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L233" rel="noopener noreferrer">_LLMDetectorVisitor:233</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1082" rel="noopener noreferrer">_default_exclude_folders:1082</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1102" rel="noopener noreferrer">_scan_python_file:1102</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1118" rel="noopener noreferrer">_collect_python_files:1118</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L173" rel="noopener noreferrer">JSImport:173</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L180" rel="noopener noreferrer">TSClient:180</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L187" rel="noopener noreferrer">collect_typescript_files:187</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L200" rel="noopener noreferrer">scan_typescript_file:200</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L290" rel="noopener noreferrer">_should_skip_typescript_file:290</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L9" rel="noopener noreferrer">TaintFlow:9</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L201" rel="noopener noreferrer">analyze_taint_flows:201</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L26" rel="noopener noreferrer">_TaintVisitor:26</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L8" rel="noopener noreferrer">NodeType:8</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -1334,7 +1421,7 @@
 
     <article class="folder-card searchable" data-search="skylos/engines language-specific engines and parsers beyond the python ast path. use this when adding or fixing non-python language analysis. skylos/engines/  skylos/engines/go_runner.py skylos/engines/go_contract.py skylos/engines/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/engines">skylos/engines</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines" rel="noopener noreferrer">skylos/engines</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 7</span>
@@ -1346,25 +1433,25 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/engines">skylos/engines</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/engines" rel="noopener noreferrer">skylos/engines</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/engines/go_runner.py">skylos/engines/go_runner.py</a> <span>147 lines</span></li>
-<li><a href="../../skylos/engines/go_contract.py">skylos/engines/go_contract.py</a> <span>48 lines</span></li>
-<li><a href="../../skylos/engines/__init__.py">skylos/engines/__init__.py</a> <span>0 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">skylos/engines/go_runner.py</a> <span>147 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">skylos/engines/go_contract.py</a> <span>48 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/__init__.py" rel="noopener noreferrer">skylos/engines/__init__.py</a> <span>0 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/engines/go_runner.py">GoEngineError:15</a> <span>class</span></li>
-<li><a href="../../skylos/engines/go_runner.py">discover_go_modules:34</a> <span>def</span></li>
-<li><a href="../../skylos/engines/go_runner.py">resolve_go_engine_bin:67</a> <span>def</span></li>
-<li><a href="../../skylos/engines/go_runner.py">run_go_engine_for_module:96</a> <span>def</span></li>
-<li><a href="../../skylos/engines/go_runner.py">_is_runnable_go_engine:19</a> <span>def</span></li>
-<li><a href="../../skylos/engines/go_contract.py">build_go_engine_args:4</a> <span>def</span></li>
-<li><a href="../../skylos/engines/go_contract.py">validate_go_engine_output:17</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L15" rel="noopener noreferrer">GoEngineError:15</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L34" rel="noopener noreferrer">discover_go_modules:34</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L67" rel="noopener noreferrer">resolve_go_engine_bin:67</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L96" rel="noopener noreferrer">run_go_engine_for_module:96</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L19" rel="noopener noreferrer">_is_runnable_go_engine:19</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L4" rel="noopener noreferrer">build_go_engine_args:4</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L17" rel="noopener noreferrer">validate_go_engine_output:17</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1373,7 +1460,7 @@
 
     <article class="folder-card searchable" data-search="skylos/integrations external-service integration helpers. keep external contracts small and well-tested here. skylos/integrations/  skylos/integrations/ingest.py skylos/integrations/sonar.py skylos/integrations/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/integrations">skylos/integrations</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations" rel="noopener noreferrer">skylos/integrations</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 16</span>
@@ -1385,28 +1472,28 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/integrations">skylos/integrations</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/integrations" rel="noopener noreferrer">skylos/integrations</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/integrations/ingest.py">skylos/integrations/ingest.py</a> <span>344 lines</span></li>
-<li><a href="../../skylos/integrations/sonar.py">skylos/integrations/sonar.py</a> <span>156 lines</span></li>
-<li><a href="../../skylos/integrations/__init__.py">skylos/integrations/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">skylos/integrations/ingest.py</a> <span>344 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">skylos/integrations/sonar.py</a> <span>156 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/__init__.py" rel="noopener noreferrer">skylos/integrations/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/integrations/ingest.py">is_claude_security_report:27</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/ingest.py">normalize_claude_security:56</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/ingest.py">cross_reference:165</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/ingest.py">print_cross_reference_report:223</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/ingest.py">ingest_claude_security:265</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/sonar.py">parse_sonar_properties:16</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/sonar.py">split_sonar_list:86</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/sonar.py">build_sonar_migration_plan:92</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/sonar.py">write_skylos_yaml_config:139</a> <span>def</span></li>
-<li><a href="../../skylos/integrations/sonar.py">format_migration_plan_json:154</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L27" rel="noopener noreferrer">is_claude_security_report:27</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L56" rel="noopener noreferrer">normalize_claude_security:56</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L165" rel="noopener noreferrer">cross_reference:165</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L223" rel="noopener noreferrer">print_cross_reference_report:223</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L265" rel="noopener noreferrer">ingest_claude_security:265</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L16" rel="noopener noreferrer">parse_sonar_properties:16</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L86" rel="noopener noreferrer">split_sonar_list:86</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L92" rel="noopener noreferrer">build_sonar_migration_plan:92</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L139" rel="noopener noreferrer">write_skylos_yaml_config:139</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L154" rel="noopener noreferrer">format_migration_plan_json:154</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1415,7 +1502,7 @@
 
     <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_context.py test/test_llm_finding_evidence.py test/test_llm_graph.py skylos/llm/verify_orchestrator.py skylos/llm/security_taskflow.py skylos/llm/analyzer.py skylos/llm/agents.py skylos/llm/_grounding.py skylos/llm/context.py skylos/llm/finding_evidence.py skylos/llm/prompts.py">
       <div class="card-head">
-        <h3><a href="../../skylos/llm">skylos/llm</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 28</span>
           <span class="pill"><strong>symbols</strong> 346</span>
@@ -1427,37 +1514,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/llm/analyzer.py">skylos/llm/analyzer.py</a> <a href="../../skylos/llm/finding_evidence.py">skylos/llm/finding_evidence.py</a> <a href="../../skylos/llm/runtime.py">skylos/llm/runtime.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py" rel="noopener noreferrer">skylos/llm/analyzer.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/runtime.py" rel="noopener noreferrer">skylos/llm/runtime.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_cli_llm_provider.py">test/test_cli_llm_provider.py</a> <a href="../../test/test_litellm_adapter.py">test/test_litellm_adapter.py</a> <a href="../../test/test_llm_analyzer.py">test/test_llm_analyzer.py</a> <a href="../../test/test_llm_context.py">test/test_llm_context.py</a> <a href="../../test/test_llm_finding_evidence.py">test/test_llm_finding_evidence.py</a> <a href="../../test/test_llm_graph.py">test/test_llm_graph.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_llm_provider.py" rel="noopener noreferrer">test/test_cli_llm_provider.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_litellm_adapter.py" rel="noopener noreferrer">test/test_litellm_adapter.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_llm_analyzer.py" rel="noopener noreferrer">test/test_llm_analyzer.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_llm_context.py" rel="noopener noreferrer">test/test_llm_context.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_llm_finding_evidence.py" rel="noopener noreferrer">test/test_llm_finding_evidence.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_llm_graph.py" rel="noopener noreferrer">test/test_llm_graph.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/llm/verify_orchestrator.py">skylos/llm/verify_orchestrator.py</a> <span>3110 lines</span></li>
-<li><a href="../../skylos/llm/security_taskflow.py">skylos/llm/security_taskflow.py</a> <span>940 lines</span></li>
-<li><a href="../../skylos/llm/analyzer.py">skylos/llm/analyzer.py</a> <span>882 lines</span></li>
-<li><a href="../../skylos/llm/agents.py">skylos/llm/agents.py</a> <span>754 lines</span></li>
-<li><a href="../../skylos/llm/_grounding.py">skylos/llm/_grounding.py</a> <span>466 lines</span></li>
-<li><a href="../../skylos/llm/context.py">skylos/llm/context.py</a> <span>749 lines</span></li>
-<li><a href="../../skylos/llm/finding_evidence.py">skylos/llm/finding_evidence.py</a> <span>344 lines</span></li>
-<li><a href="../../skylos/llm/prompts.py">skylos/llm/prompts.py</a> <span>460 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a> <span>3110 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">skylos/llm/security_taskflow.py</a> <span>940 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py" rel="noopener noreferrer">skylos/llm/analyzer.py</a> <span>882 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/agents.py" rel="noopener noreferrer">skylos/llm/agents.py</a> <span>754 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">skylos/llm/_grounding.py</a> <span>466 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/context.py" rel="noopener noreferrer">skylos/llm/context.py</a> <span>749 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a> <span>344 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/prompts.py" rel="noopener noreferrer">skylos/llm/prompts.py</a> <span>460 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/llm/verify_orchestrator.py">discover_entry_points:292</a> <span>def</span></li>
-<li><a href="../../skylos/llm/verify_orchestrator.py">verify_with_graph_context:1457</a> <span>def</span></li>
-<li><a href="../../skylos/llm/verify_orchestrator.py">audit_suppressed_finding:1551</a> <span>def</span></li>
-<li><a href="../../skylos/llm/verify_orchestrator.py">run_verification:2480</a> <span>def</span></li>
-<li><a href="../../skylos/llm/verify_orchestrator.py">_gather_config_files:72</a> <span>def</span></li>
-<li><a href="../../skylos/llm/security_taskflow.py">SecurityTaskStage:50</a> <span>class</span></li>
-<li><a href="../../skylos/llm/security_taskflow.py">SecurityRepoNode:57</a> <span>class</span></li>
-<li><a href="../../skylos/llm/security_taskflow.py">SecurityEntrypoint:71</a> <span>class</span></li>
-<li><a href="../../skylos/llm/security_taskflow.py">SecurityTrustBoundary:77</a> <span>class</span></li>
-<li><a href="../../skylos/llm/security_taskflow.py">SecurityFileFacts:83</a> <span>class</span></li>
-<li><a href="../../skylos/llm/analyzer.py">AnalyzerConfig:39</a> <span>class</span></li>
-<li><a href="../../skylos/llm/analyzer.py">SkylosLLM:102</a> <span>class</span></li>
-<li><a href="../../skylos/llm/analyzer.py">analyze:862</a> <span>def</span></li>
-<li><a href="../../skylos/llm/analyzer.py">audit:874</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L292" rel="noopener noreferrer">discover_entry_points:292</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L1457" rel="noopener noreferrer">verify_with_graph_context:1457</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L1551" rel="noopener noreferrer">audit_suppressed_finding:1551</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L2480" rel="noopener noreferrer">run_verification:2480</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L72" rel="noopener noreferrer">_gather_config_files:72</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L50" rel="noopener noreferrer">SecurityTaskStage:50</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L57" rel="noopener noreferrer">SecurityRepoNode:57</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L71" rel="noopener noreferrer">SecurityEntrypoint:71</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L77" rel="noopener noreferrer">SecurityTrustBoundary:77</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L83" rel="noopener noreferrer">SecurityFileFacts:83</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L39" rel="noopener noreferrer">AnalyzerConfig:39</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L102" rel="noopener noreferrer">SkylosLLM:102</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L862" rel="noopener noreferrer">analyze:862</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L874" rel="noopener noreferrer">audit:874</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1466,7 +1553,7 @@
 
     <article class="folder-card searchable" data-search="skylos/misc generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.   skylos/misc/update_mapping.py">
       <div class="card-head">
-        <h3><a href="../../skylos/misc">skylos/misc</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc" rel="noopener noreferrer">skylos/misc</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 1</span>
           <span class="pill"><strong>symbols</strong> 7</span>
@@ -1484,15 +1571,15 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/misc/update_mapping.py">skylos/misc/update_mapping.py</a> <span>309 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">skylos/misc/update_mapping.py</a> <span>309 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/misc/update_mapping.py">load_existing:17</a> <span>def</span></li>
-<li><a href="../../skylos/misc/update_mapping.py">bootstrap_from_pipreqs:32</a> <span>def</span></li>
-<li><a href="../../skylos/misc/update_mapping.py">get_stdlib:98</a> <span>def</span></li>
-<li><a href="../../skylos/misc/update_mapping.py">scan:190</a> <span>def</span></li>
-<li><a href="../../skylos/misc/update_mapping.py">main:268</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L17" rel="noopener noreferrer">load_existing:17</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L32" rel="noopener noreferrer">bootstrap_from_pipreqs:32</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L98" rel="noopener noreferrer">get_stdlib:98</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L190" rel="noopener noreferrer">scan:190</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L268" rel="noopener noreferrer">main:268</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1501,7 +1588,7 @@
 
     <article class="folder-card searchable" data-search="skylos/plugins plugin interfaces and loading support. use this when adding extension points without coupling them to core scan flow. skylos/plugins/  skylos/plugins/pytest_unused_fixtures.py skylos/plugins/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/plugins">skylos/plugins</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins" rel="noopener noreferrer">skylos/plugins</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 2</span>
           <span class="pill"><strong>symbols</strong> 4</span>
@@ -1513,21 +1600,21 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/plugins">skylos/plugins</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/plugins" rel="noopener noreferrer">skylos/plugins</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/plugins/pytest_unused_fixtures.py">skylos/plugins/pytest_unused_fixtures.py</a> <span>189 lines</span></li>
-<li><a href="../../skylos/plugins/__init__.py">skylos/plugins/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py" rel="noopener noreferrer">skylos/plugins/pytest_unused_fixtures.py</a> <span>189 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/__init__.py" rel="noopener noreferrer">skylos/plugins/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/plugins/pytest_unused_fixtures.py">UnsafeFixtureReportPath:9</a> <span>class</span></li>
-<li><a href="../../skylos/plugins/pytest_unused_fixtures.py">FixtureInfo:13</a> <span>class</span></li>
-<li><a href="../../skylos/plugins/pytest_unused_fixtures.py">UnusedFixturesPlugin:21</a> <span>class</span></li>
-<li><a href="../../skylos/plugins/pytest_unused_fixtures.py">pytest_configure:185</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L9" rel="noopener noreferrer">UnsafeFixtureReportPath:9</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L13" rel="noopener noreferrer">FixtureInfo:13</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L21" rel="noopener noreferrer">UnusedFixturesPlugin:21</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L185" rel="noopener noreferrer">pytest_configure:185</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1536,7 +1623,7 @@
 
     <article class="folder-card searchable" data-search="skylos/remediation autofix and cleanup support for selected findings. use this only when a finding has a safe, narrow, testable edit path. skylos/remediation/  skylos/remediation/fixgen.py skylos/remediation/codemods.py skylos/remediation/safety.py skylos/remediation/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/remediation">skylos/remediation</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation" rel="noopener noreferrer">skylos/remediation</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 42</span>
@@ -1548,30 +1635,30 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/remediation">skylos/remediation</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/remediation" rel="noopener noreferrer">skylos/remediation</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/remediation/fixgen.py">skylos/remediation/fixgen.py</a> <span>590 lines</span></li>
-<li><a href="../../skylos/remediation/codemods.py">skylos/remediation/codemods.py</a> <span>390 lines</span></li>
-<li><a href="../../skylos/remediation/safety.py">skylos/remediation/safety.py</a> <span>36 lines</span></li>
-<li><a href="../../skylos/remediation/__init__.py">skylos/remediation/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">skylos/remediation/fixgen.py</a> <span>590 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">skylos/remediation/codemods.py</a> <span>390 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/safety.py" rel="noopener noreferrer">skylos/remediation/safety.py</a> <span>36 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/__init__.py" rel="noopener noreferrer">skylos/remediation/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/remediation/fixgen.py">RemovalPatch:186</a> <span>class</span></li>
-<li><a href="../../skylos/remediation/fixgen.py">generate_removal_plan:428</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/fixgen.py">generate_unified_diff:463</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/fixgen.py">apply_patches:514</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/fixgen.py">validate_patches:558</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/codemods.py">comment_out_unused_function_cst:203</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/codemods.py">comment_out_unused_import_cst:212</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/codemods.py">remove_unused_import_cst:316</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/codemods.py">remove_unused_function_cst:323</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/codemods.py">remove_unused_class_cst:376</a> <span>def</span></li>
-<li><a href="../../skylos/remediation/safety.py">resolve_remediation_path:6</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L186" rel="noopener noreferrer">RemovalPatch:186</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L428" rel="noopener noreferrer">generate_removal_plan:428</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L463" rel="noopener noreferrer">generate_unified_diff:463</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L514" rel="noopener noreferrer">apply_patches:514</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L558" rel="noopener noreferrer">validate_patches:558</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L203" rel="noopener noreferrer">comment_out_unused_function_cst:203</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L212" rel="noopener noreferrer">comment_out_unused_import_cst:212</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L316" rel="noopener noreferrer">remove_unused_import_cst:316</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L323" rel="noopener noreferrer">remove_unused_function_cst:323</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L376" rel="noopener noreferrer">remove_unused_class_cst:376</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/safety.py#L6" rel="noopener noreferrer">resolve_remediation_path:6</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1580,7 +1667,7 @@
 
     <article class="folder-card searchable" data-search="skylos/reporting output formatters and exports such as sarif, compact json, and human-readable reports. use this when scan results are right but the output is wrong or hard to consume. skylos/reporting/  skylos/reporting/provenance.py skylos/reporting/grader.py skylos/reporting/sarif.py skylos/reporting/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/reporting">skylos/reporting</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 30</span>
@@ -1592,32 +1679,32 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/reporting">skylos/reporting</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/reporting/provenance.py">skylos/reporting/provenance.py</a> <span>529 lines</span></li>
-<li><a href="../../skylos/reporting/grader.py">skylos/reporting/grader.py</a> <span>346 lines</span></li>
-<li><a href="../../skylos/reporting/sarif.py">skylos/reporting/sarif.py</a> <span>196 lines</span></li>
-<li><a href="../../skylos/reporting/__init__.py">skylos/reporting/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">skylos/reporting/provenance.py</a> <span>529 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">skylos/reporting/grader.py</a> <span>346 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py" rel="noopener noreferrer">skylos/reporting/sarif.py</a> <span>196 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/__init__.py" rel="noopener noreferrer">skylos/reporting/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/reporting/provenance.py">FileProvenance:59</a> <span>class</span></li>
-<li><a href="../../skylos/reporting/provenance.py">ProvenanceReport:68</a> <span>class</span></li>
-<li><a href="../../skylos/reporting/provenance.py">analyze_provenance:151</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/provenance.py">annotate_findings_with_provenance:356</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/provenance.py">compute_ai_security_stats:395</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/grader.py">score_to_letter:72</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/grader.py">count_lines_of_code:80</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/grader.py">score_security:144</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/grader.py">score_quality:148</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/grader.py">score_dead_code:167</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/sarif.py">severity_to_sarif_level:5</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/sarif.py">normalize_file_path_for_sarif:14</a> <span>def</span></li>
-<li><a href="../../skylos/reporting/sarif.py">SarifExporter:32</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L59" rel="noopener noreferrer">FileProvenance:59</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L68" rel="noopener noreferrer">ProvenanceReport:68</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L151" rel="noopener noreferrer">analyze_provenance:151</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L356" rel="noopener noreferrer">annotate_findings_with_provenance:356</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L395" rel="noopener noreferrer">compute_ai_security_stats:395</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L72" rel="noopener noreferrer">score_to_letter:72</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L80" rel="noopener noreferrer">count_lines_of_code:80</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L144" rel="noopener noreferrer">score_security:144</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L148" rel="noopener noreferrer">score_quality:148</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L167" rel="noopener noreferrer">score_dead_code:167</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py#L5" rel="noopener noreferrer">severity_to_sarif_level:5</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py#L14" rel="noopener noreferrer">normalize_file_path_for_sarif:14</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py#L32" rel="noopener noreferrer">SarifExporter:32</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -1626,7 +1713,7 @@
 
     <article class="folder-card searchable" data-search="skylos/rules rule catalog and concrete rule implementations for quality, security, config, and sca findings. start here when adding rule ids, tuning scanner semantics, or changing rule docs parity. skylos/rules/catalog.py skylos/rules/danger skylos/rules/quality test/test_community_rules.py test/test_good_practices_rules.py test/test_mcp_rules.py test/test_quality_new_rules.py test/test_quality_rules.py test/test_rules_cmd.py skylos/rules/config/cicd/github_actions.py skylos/rules/quality/logic_security.py skylos/rules/config/cicd/gitlab_ci.py skylos/rules/quality/logic_foundation.py skylos/rules/danger/danger_hallucination/dependency_hallucination.py skylos/rules/quality/_readability.py skylos/rules/quality/clones.py skylos/rules/quality/phantom_refs.py">
       <div class="card-head">
-        <h3><a href="../../skylos/rules">skylos/rules</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 67</span>
           <span class="pill"><strong>symbols</strong> 489</span>
@@ -1638,37 +1725,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/rules/catalog.py">skylos/rules/catalog.py</a> <a href="../../skylos/rules/danger">skylos/rules/danger</a> <a href="../../skylos/rules/quality">skylos/rules/quality</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/catalog.py" rel="noopener noreferrer">skylos/rules/catalog.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/danger" rel="noopener noreferrer">skylos/rules/danger</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality" rel="noopener noreferrer">skylos/rules/quality</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_community_rules.py">test/test_community_rules.py</a> <a href="../../test/test_good_practices_rules.py">test/test_good_practices_rules.py</a> <a href="../../test/test_mcp_rules.py">test/test_mcp_rules.py</a> <a href="../../test/test_quality_new_rules.py">test/test_quality_new_rules.py</a> <a href="../../test/test_quality_rules.py">test/test_quality_rules.py</a> <a href="../../test/test_rules_cmd.py">test/test_rules_cmd.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_community_rules.py" rel="noopener noreferrer">test/test_community_rules.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_good_practices_rules.py" rel="noopener noreferrer">test/test_good_practices_rules.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_mcp_rules.py" rel="noopener noreferrer">test/test_mcp_rules.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_quality_new_rules.py" rel="noopener noreferrer">test/test_quality_new_rules.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_quality_rules.py" rel="noopener noreferrer">test/test_quality_rules.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_rules_cmd.py" rel="noopener noreferrer">test/test_rules_cmd.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/rules/config/cicd/github_actions.py">skylos/rules/config/cicd/github_actions.py</a> <span>1963 lines</span></li>
-<li><a href="../../skylos/rules/quality/logic_security.py">skylos/rules/quality/logic_security.py</a> <span>1720 lines</span></li>
-<li><a href="../../skylos/rules/config/cicd/gitlab_ci.py">skylos/rules/config/cicd/gitlab_ci.py</a> <span>946 lines</span></li>
-<li><a href="../../skylos/rules/quality/logic_foundation.py">skylos/rules/quality/logic_foundation.py</a> <span>1024 lines</span></li>
-<li><a href="../../skylos/rules/danger/danger_hallucination/dependency_hallucination.py">skylos/rules/danger/danger_hallucination/dependency_hallucination.py</a> <span>895 lines</span></li>
-<li><a href="../../skylos/rules/quality/_readability.py">skylos/rules/quality/_readability.py</a> <span>603 lines</span></li>
-<li><a href="../../skylos/rules/quality/clones.py">skylos/rules/quality/clones.py</a> <span>543 lines</span></li>
-<li><a href="../../skylos/rules/quality/phantom_refs.py">skylos/rules/quality/phantom_refs.py</a> <span>565 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">skylos/rules/config/cicd/github_actions.py</a> <span>1963 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py" rel="noopener noreferrer">skylos/rules/quality/logic_security.py</a> <span>1720 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">skylos/rules/config/cicd/gitlab_ci.py</a> <span>946 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">skylos/rules/quality/logic_foundation.py</a> <span>1024 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/danger/danger_hallucination/dependency_hallucination.py" rel="noopener noreferrer">skylos/rules/danger/danger_hallucination/dependency_hallucination.py</a> <span>895 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/_readability.py" rel="noopener noreferrer">skylos/rules/quality/_readability.py</a> <span>603 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/clones.py" rel="noopener noreferrer">skylos/rules/quality/clones.py</a> <span>543 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/phantom_refs.py" rel="noopener noreferrer">skylos/rules/quality/phantom_refs.py</a> <span>565 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/rules/config/cicd/github_actions.py">scan_github_actions_file:1889</a> <span>def</span></li>
-<li><a href="../../skylos/rules/config/cicd/github_actions.py">scan_github_actions:1950</a> <span>def</span></li>
-<li><a href="../../skylos/rules/config/cicd/github_actions.py">_finding:165</a> <span>def</span></li>
-<li><a href="../../skylos/rules/config/cicd/github_actions.py">_is_workflow_file:189</a> <span>def</span></li>
-<li><a href="../../skylos/rules/config/cicd/github_actions.py">_is_action_file:199</a> <span>def</span></li>
-<li><a href="../../skylos/rules/quality/logic_security.py">DebugLeftoverRule:49</a> <span>class</span></li>
-<li><a href="../../skylos/rules/quality/logic_security.py">SecurityTodoRule:143</a> <span>class</span></li>
-<li><a href="../../skylos/rules/quality/logic_security.py">DisabledSecurityRule:195</a> <span>class</span></li>
-<li><a href="../../skylos/rules/quality/logic_security.py">PhantomCallRule:350</a> <span>class</span></li>
-<li><a href="../../skylos/rules/quality/logic_security.py">PhantomDecoratorRule:438</a> <span>class</span></li>
-<li><a href="../../skylos/rules/config/cicd/gitlab_ci.py">scan_gitlab_ci_file:901</a> <span>def</span></li>
-<li><a href="../../skylos/rules/config/cicd/gitlab_ci.py">scan_gitlab_ci:935</a> <span>def</span></li>
-<li><a href="../../skylos/rules/config/cicd/gitlab_ci.py">_finding:110</a> <span>def</span></li>
-<li><a href="../../skylos/rules/config/cicd/gitlab_ci.py">_is_gitlab_ci_file:134</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L1889" rel="noopener noreferrer">scan_github_actions_file:1889</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L1950" rel="noopener noreferrer">scan_github_actions:1950</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L165" rel="noopener noreferrer">_finding:165</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L189" rel="noopener noreferrer">_is_workflow_file:189</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L199" rel="noopener noreferrer">_is_action_file:199</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L49" rel="noopener noreferrer">DebugLeftoverRule:49</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L143" rel="noopener noreferrer">SecurityTodoRule:143</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L195" rel="noopener noreferrer">DisabledSecurityRule:195</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L350" rel="noopener noreferrer">PhantomCallRule:350</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L438" rel="noopener noreferrer">PhantomDecoratorRule:438</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L901" rel="noopener noreferrer">scan_gitlab_ci_file:901</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L935" rel="noopener noreferrer">scan_gitlab_ci:935</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L110" rel="noopener noreferrer">_finding:110</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L134" rel="noopener noreferrer">_is_gitlab_ci_file:134</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1677,7 +1764,7 @@
 
     <article class="folder-card searchable" data-search="skylos/scale scale and performance helpers for larger repositories. use this when scan runtime, batching, or large-repo behavior changes. skylos/scale/  skylos/scale/parallel_static.py skylos/scale/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/scale">skylos/scale</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale" rel="noopener noreferrer">skylos/scale</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 2</span>
           <span class="pill"><strong>symbols</strong> 2</span>
@@ -1689,19 +1776,19 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/scale">skylos/scale</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/scale" rel="noopener noreferrer">skylos/scale</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/scale/parallel_static.py">skylos/scale/parallel_static.py</a> <span>125 lines</span></li>
-<li><a href="../../skylos/scale/__init__.py">skylos/scale/__init__.py</a> <span>0 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py" rel="noopener noreferrer">skylos/scale/parallel_static.py</a> <span>125 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/__init__.py" rel="noopener noreferrer">skylos/scale/__init__.py</a> <span>0 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/scale/parallel_static.py">run_proc_file_parallel:31</a> <span>def</span></li>
-<li><a href="../../skylos/scale/parallel_static.py">_worker:4</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L31" rel="noopener noreferrer">run_proc_file_parallel:31</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L4" rel="noopener noreferrer">_worker:4</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1710,7 +1797,7 @@
 
     <article class="folder-card searchable" data-search="skylos/security security contract detection, secret handling, and security-specific analysis helpers. treat this as gate-sensitive; regressions here can hide vulnerabilities. skylos/security/ test/test_dart_security.py test/test_github_actions_security.py test/test_gitlab_ci_security.py test/test_go_security.py test/test_java_security.py test/test_mcp_security.py skylos/security/contracts.py skylos/security/injection_scanner.py skylos/security/canonicalize.py skylos/security/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/security">skylos/security</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security" rel="noopener noreferrer">skylos/security</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 35</span>
@@ -1722,33 +1809,33 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/security">skylos/security</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/security" rel="noopener noreferrer">skylos/security</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_dart_security.py">test/test_dart_security.py</a> <a href="../../test/test_github_actions_security.py">test/test_github_actions_security.py</a> <a href="../../test/test_gitlab_ci_security.py">test/test_gitlab_ci_security.py</a> <a href="../../test/test_go_security.py">test/test_go_security.py</a> <a href="../../test/test_java_security.py">test/test_java_security.py</a> <a href="../../test/test_mcp_security.py">test/test_mcp_security.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_dart_security.py" rel="noopener noreferrer">test/test_dart_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_github_actions_security.py" rel="noopener noreferrer">test/test_github_actions_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_gitlab_ci_security.py" rel="noopener noreferrer">test/test_gitlab_ci_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_go_security.py" rel="noopener noreferrer">test/test_go_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_mcp_security.py" rel="noopener noreferrer">test/test_mcp_security.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/security/contracts.py">skylos/security/contracts.py</a> <span>471 lines</span></li>
-<li><a href="../../skylos/security/injection_scanner.py">skylos/security/injection_scanner.py</a> <span>462 lines</span></li>
-<li><a href="../../skylos/security/canonicalize.py">skylos/security/canonicalize.py</a> <span>167 lines</span></li>
-<li><a href="../../skylos/security/__init__.py">skylos/security/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">skylos/security/contracts.py</a> <span>471 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">skylos/security/injection_scanner.py</a> <span>462 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">skylos/security/canonicalize.py</a> <span>167 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/__init__.py" rel="noopener noreferrer">skylos/security/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/security/contracts.py">SecurityContract:26</a> <span>class</span></li>
-<li><a href="../../skylos/security/contracts.py">RouteSnapshot:37</a> <span>class</span></li>
-<li><a href="../../skylos/security/contracts.py">load_security_contracts:46</a> <span>def</span></li>
-<li><a href="../../skylos/security/contracts.py">resolve_diff_base_ref:101</a> <span>def</span></li>
-<li><a href="../../skylos/security/contracts.py">detect_security_contract_regressions:117</a> <span>def</span></li>
-<li><a href="../../skylos/security/injection_scanner.py">scan_file:105</a> <span>def</span></li>
-<li><a href="../../skylos/security/injection_scanner.py">scan_directory:228</a> <span>def</span></li>
-<li><a href="../../skylos/security/injection_scanner.py">_extract_segments:256</a> <span>def</span></li>
-<li><a href="../../skylos/security/injection_scanner.py">_markdown_fence_marker:327</a> <span>def</span></li>
-<li><a href="../../skylos/security/injection_scanner.py">_matched_fenced_block_lines:345</a> <span>def</span></li>
-<li><a href="../../skylos/security/canonicalize.py">normalize:80</a> <span>def</span></li>
-<li><a href="../../skylos/security/canonicalize.py">strip_zero_width:86</a> <span>def</span></li>
-<li><a href="../../skylos/security/canonicalize.py">decode_base64_blobs:105</a> <span>def</span></li>
-<li><a href="../../skylos/security/canonicalize.py">detect_homoglyphs:149</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L26" rel="noopener noreferrer">SecurityContract:26</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L37" rel="noopener noreferrer">RouteSnapshot:37</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L46" rel="noopener noreferrer">load_security_contracts:46</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L101" rel="noopener noreferrer">resolve_diff_base_ref:101</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L117" rel="noopener noreferrer">detect_security_contract_regressions:117</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L105" rel="noopener noreferrer">scan_file:105</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L228" rel="noopener noreferrer">scan_directory:228</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L256" rel="noopener noreferrer">_extract_segments:256</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L327" rel="noopener noreferrer">_markdown_fence_marker:327</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L345" rel="noopener noreferrer">_matched_fenced_block_lines:345</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L80" rel="noopener noreferrer">normalize:80</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L86" rel="noopener noreferrer">strip_zero_width:86</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L105" rel="noopener noreferrer">decode_base64_blobs:105</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L149" rel="noopener noreferrer">detect_homoglyphs:149</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1757,7 +1844,7 @@
 
     <article class="folder-card searchable" data-search="skylos/ui terminal ui and presentation helpers. use this when the scan is correct but terminal interaction is confusing. skylos/ui/ test/test_suite.py test/test_tui.py skylos/ui/tui.py skylos/ui/terminal_report.py skylos/ui/help.py skylos/ui/nudge.py skylos/ui/tour.py skylos/ui/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/ui">skylos/ui</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 40</span>
@@ -1769,35 +1856,35 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/ui">skylos/ui</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_suite.py">test/test_suite.py</a> <a href="../../test/test_tui.py">test/test_tui.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_suite.py" rel="noopener noreferrer">test/test_suite.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_tui.py" rel="noopener noreferrer">test/test_tui.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/ui/tui.py">skylos/ui/tui.py</a> <span>802 lines</span></li>
-<li><a href="../../skylos/ui/terminal_report.py">skylos/ui/terminal_report.py</a> <span>477 lines</span></li>
-<li><a href="../../skylos/ui/help.py">skylos/ui/help.py</a> <span>236 lines</span></li>
-<li><a href="../../skylos/ui/nudge.py">skylos/ui/nudge.py</a> <span>152 lines</span></li>
-<li><a href="../../skylos/ui/tour.py">skylos/ui/tour.py</a> <span>130 lines</span></li>
-<li><a href="../../skylos/ui/__init__.py">skylos/ui/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">skylos/ui/tui.py</a> <span>802 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">skylos/ui/terminal_report.py</a> <span>477 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py" rel="noopener noreferrer">skylos/ui/help.py</a> <span>236 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">skylos/ui/nudge.py</a> <span>152 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tour.py" rel="noopener noreferrer">skylos/ui/tour.py</a> <span>130 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/__init__.py" rel="noopener noreferrer">skylos/ui/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/ui/tui.py">prepare_category_data:68</a> <span>def</span></li>
-<li><a href="../../skylos/ui/tui.py">CategoryItem:179</a> <span>class</span></li>
-<li><a href="../../skylos/ui/tui.py">FindingItem:191</a> <span>class</span></li>
-<li><a href="../../skylos/ui/tui.py">OverviewPanel:274</a> <span>class</span></li>
-<li><a href="../../skylos/ui/tui.py">DetailPanel:355</a> <span>class</span></li>
-<li><a href="../../skylos/ui/terminal_report.py">PrettyFinding:71</a> <span>class</span></li>
-<li><a href="../../skylos/ui/terminal_report.py">render_pretty_results:84</a> <span>def</span></li>
-<li><a href="../../skylos/ui/terminal_report.py">collect_pretty_findings:139</a> <span>def</span></li>
-<li><a href="../../skylos/ui/terminal_report.py">_make_pretty_finding:169</a> <span>def</span></li>
-<li><a href="../../skylos/ui/terminal_report.py">_print_finding:203</a> <span>def</span></li>
-<li><a href="../../skylos/ui/help.py">print_command_overview:174</a> <span>def</span></li>
-<li><a href="../../skylos/ui/help.py">print_flat_commands:216</a> <span>def</span></li>
-<li><a href="../../skylos/ui/nudge.py">pick_nudge:99</a> <span>def</span></li>
-<li><a href="../../skylos/ui/nudge.py">_is_ci:8</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L68" rel="noopener noreferrer">prepare_category_data:68</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L179" rel="noopener noreferrer">CategoryItem:179</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L191" rel="noopener noreferrer">FindingItem:191</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L274" rel="noopener noreferrer">OverviewPanel:274</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L355" rel="noopener noreferrer">DetailPanel:355</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L71" rel="noopener noreferrer">PrettyFinding:71</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L84" rel="noopener noreferrer">render_pretty_results:84</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L139" rel="noopener noreferrer">collect_pretty_findings:139</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L169" rel="noopener noreferrer">_make_pretty_finding:169</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L203" rel="noopener noreferrer">_print_finding:203</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py#L174" rel="noopener noreferrer">print_command_overview:174</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py#L216" rel="noopener noreferrer">print_flat_commands:216</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py#L99" rel="noopener noreferrer">pick_nudge:99</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py#L8" rel="noopener noreferrer">_is_ci:8</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1806,7 +1893,7 @@
 
     <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/danger.py skylos/visitors/base.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/java/flow.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/typescript/resolve.py skylos/visitors/languages/typescript/core.py">
       <div class="card-head">
-        <h3><a href="../../skylos/visitors">skylos/visitors</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 33</span>
           <span class="pill"><strong>symbols</strong> 271</span>
@@ -1818,37 +1905,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/visitors">skylos/visitors</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></div>
         <div class="mini-label">Nearby tests</div>
         <div class="link-row"><span class="muted">No obvious matching test file</span></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/visitors/languages/java/danger.py">skylos/visitors/languages/java/danger.py</a> <span>1846 lines</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/danger.py">skylos/visitors/languages/typescript/danger.py</a> <span>1590 lines</span></li>
-<li><a href="../../skylos/visitors/base.py">skylos/visitors/base.py</a> <span>2316 lines</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/analysis.py">skylos/visitors/languages/typescript/analysis.py</a> <span>1377 lines</span></li>
-<li><a href="../../skylos/visitors/languages/java/flow.py">skylos/visitors/languages/java/flow.py</a> <span>1997 lines</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/workspace.py">skylos/visitors/languages/typescript/workspace.py</a> <span>563 lines</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/resolve.py">skylos/visitors/languages/typescript/resolve.py</a> <span>623 lines</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/core.py">skylos/visitors/languages/typescript/core.py</a> <span>742 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a> <span>1846 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a> <span>1590 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py" rel="noopener noreferrer">skylos/visitors/base.py</a> <span>2316 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a> <span>1377 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/flow.py" rel="noopener noreferrer">skylos/visitors/languages/java/flow.py</a> <span>1997 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/workspace.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/workspace.py</a> <span>563 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/resolve.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/resolve.py</a> <span>623 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/core.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/core.py</a> <span>742 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/visitors/languages/java/danger.py">scan_danger:1692</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/java/danger.py">_shannon_entropy:261</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/java/danger.py">_get_query:271</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/java/danger.py">_get_text:281</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/java/danger.py">_run_batch:285</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/danger.py">scan_danger:490</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/danger.py">_shannon_entropy:255</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/danger.py">_get_query:265</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/danger.py">_get_text:275</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/danger.py">_is_sensitive_name:279</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/base.py">Definition:182</a> <span>class</span></li>
-<li><a href="../../skylos/visitors/base.py">Visitor:313</a> <span>class</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/analysis.py">resolve_ts_module:96</a> <span>def</span></li>
-<li><a href="../../skylos/visitors/languages/typescript/analysis.py">build_ts_import_graph:148</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L1692" rel="noopener noreferrer">scan_danger:1692</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L261" rel="noopener noreferrer">_shannon_entropy:261</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L271" rel="noopener noreferrer">_get_query:271</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L281" rel="noopener noreferrer">_get_text:281</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L285" rel="noopener noreferrer">_run_batch:285</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L490" rel="noopener noreferrer">scan_danger:490</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L255" rel="noopener noreferrer">_shannon_entropy:255</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L265" rel="noopener noreferrer">_get_query:265</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L275" rel="noopener noreferrer">_get_text:275</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L279" rel="noopener noreferrer">_is_sensitive_name:279</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py#L182" rel="noopener noreferrer">Definition:182</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py#L313" rel="noopener noreferrer">Visitor:313</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py#L96" rel="noopener noreferrer">resolve_ts_module:96</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py#L148" rel="noopener noreferrer">build_ts_import_graph:148</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1857,7 +1944,7 @@
 
     <article class="folder-card searchable" data-search="skylos/web optional web server helpers. keep this separate from core cli scanning. skylos/web/ test/test_webhook_signature.py skylos/web/frontend.py skylos/web/server.py skylos/web/__init__.py">
       <div class="card-head">
-        <h3><a href="../../skylos/web">skylos/web</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web" rel="noopener noreferrer">skylos/web</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 10</span>
@@ -1869,24 +1956,24 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../skylos/web">skylos/web</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/web" rel="noopener noreferrer">skylos/web</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/test_webhook_signature.py">test/test_webhook_signature.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_webhook_signature.py" rel="noopener noreferrer">test/test_webhook_signature.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../skylos/web/frontend.py">skylos/web/frontend.py</a> <span>544 lines</span></li>
-<li><a href="../../skylos/web/server.py">skylos/web/server.py</a> <span>192 lines</span></li>
-<li><a href="../../skylos/web/__init__.py">skylos/web/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/frontend.py" rel="noopener noreferrer">skylos/web/frontend.py</a> <span>544 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">skylos/web/server.py</a> <span>192 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/__init__.py" rel="noopener noreferrer">skylos/web/__init__.py</a> <span>2 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../skylos/web/frontend.py">render_frontend_html:540</a> <span>def</span></li>
-<li><a href="../../skylos/web/server.py">serve_frontend:111</a> <span>def</span></li>
-<li><a href="../../skylos/web/server.py">analyze_project:116</a> <span>def</span></li>
-<li><a href="../../skylos/web/server.py">start_server:171</a> <span>def</span></li>
-<li><a href="../../skylos/web/server.py">_normalize_exclude_folders:23</a> <span>def</span></li>
-<li><a href="../../skylos/web/server.py">_get_server_port:36</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/frontend.py#L540" rel="noopener noreferrer">render_frontend_html:540</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L111" rel="noopener noreferrer">serve_frontend:111</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L116" rel="noopener noreferrer">analyze_project:116</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L171" rel="noopener noreferrer">start_server:171</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L23" rel="noopener noreferrer">_normalize_exclude_folders:23</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L36" rel="noopener noreferrer">_get_server_port:36</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1895,11 +1982,11 @@
 
     <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_center.py test/test_agent_integration.py test/test_agent_remediate.py test/test_agent_review_benchmark.py test/test_verify_orchestrator.py test/test_java_security.py test/test_analyzer.py test/test_cli.py test/test_vibe_rules.py test/test_defend.py test/test_cli_refactor_guardrails.py test/test_debt.py">
       <div class="card-head">
-        <h3><a href="../../test">test</a></h3>
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 189</span>
           <span class="pill"><strong>symbols</strong> 2244</span>
-          <span class="pill"><strong>lines</strong> 77033</span>
+          <span class="pill"><strong>lines</strong> 77040</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -1907,37 +1994,37 @@
       <details>
         <summary>Entrypoints, tests, and key symbols</summary>
         <div class="mini-label">Entrypoints</div>
-        <div class="link-row"><a href="../../test">test</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/test" rel="noopener noreferrer">test</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="../../test/__init__.py">test/__init__.py</a> <a href="../../test/conftest.py">test/conftest.py</a> <a href="../../test/test_agent_center.py">test/test_agent_center.py</a> <a href="../../test/test_agent_integration.py">test/test_agent_integration.py</a> <a href="../../test/test_agent_remediate.py">test/test_agent_remediate.py</a> <a href="../../test/test_agent_review_benchmark.py">test/test_agent_review_benchmark.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/__init__.py" rel="noopener noreferrer">test/__init__.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/conftest.py" rel="noopener noreferrer">test/conftest.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_agent_center.py" rel="noopener noreferrer">test/test_agent_center.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_agent_integration.py" rel="noopener noreferrer">test/test_agent_integration.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_agent_remediate.py" rel="noopener noreferrer">test/test_agent_remediate.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_agent_review_benchmark.py" rel="noopener noreferrer">test/test_agent_review_benchmark.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="../../test/test_verify_orchestrator.py">test/test_verify_orchestrator.py</a> <span>2542 lines</span></li>
-<li><a href="../../test/test_java_security.py">test/test_java_security.py</a> <span>1901 lines</span></li>
-<li><a href="../../test/test_analyzer.py">test/test_analyzer.py</a> <span>3105 lines</span></li>
-<li><a href="../../test/test_cli.py">test/test_cli.py</a> <span>1878 lines</span></li>
-<li><a href="../../test/test_vibe_rules.py">test/test_vibe_rules.py</a> <span>2201 lines</span></li>
-<li><a href="../../test/test_defend.py">test/test_defend.py</a> <span>2132 lines</span></li>
-<li><a href="../../test/test_cli_refactor_guardrails.py">test/test_cli_refactor_guardrails.py</a> <span>1310 lines</span></li>
-<li><a href="../../test/test_debt.py">test/test_debt.py</a> <span>1217 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a> <span>2542 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a> <span>1901 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a> <span>3105 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a> <span>1878 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_vibe_rules.py" rel="noopener noreferrer">test/test_vibe_rules.py</a> <span>2201 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_defend.py" rel="noopener noreferrer">test/test_defend.py</a> <span>2132 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a> <span>1310 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a> <span>1217 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="../../test/test_verify_orchestrator.py">sample_finding:40</a> <span>def</span></li>
-<li><a href="../../test/test_verify_orchestrator.py">sample_finding_with_callers:62</a> <span>def</span></li>
-<li><a href="../../test/test_verify_orchestrator.py">sample_defs_map:84</a> <span>def</span></li>
-<li><a href="../../test/test_verify_orchestrator.py">sample_source_cache:108</a> <span>def</span></li>
-<li><a href="../../test/test_verify_orchestrator.py">survivor_with_heuristic:134</a> <span>def</span></li>
-<li><a href="../../test/test_java_security.py">test_java_constant_folding_caps_string_concatenation:39</a> <span>def</span></li>
-<li><a href="../../test/test_java_security.py">test_java_constant_store_has_total_string_budget:49</a> <span>def</span></li>
-<li><a href="../../test/test_java_security.py">test_object_input_stream_flags:69</a> <span>def</span></li>
-<li><a href="../../test/test_java_security.py">test_zip_slip_style_archive_extraction_flags:85</a> <span>def</span></li>
-<li><a href="../../test/test_java_security.py">test_archive_extraction_with_normalize_guard_is_safe:105</a> <span>def</span></li>
-<li><a href="../../test/test_analyzer.py">mock_definition:23</a> <span>def</span></li>
-<li><a href="../../test/test_analyzer.py">mock_test_aware_visitor:63</a> <span>def</span></li>
-<li><a href="../../test/test_analyzer.py">mock_framework_aware_visitor:71</a> <span>def</span></li>
-<li><a href="../../test/test_analyzer.py">temp_python_project:78</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L40" rel="noopener noreferrer">sample_finding:40</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L62" rel="noopener noreferrer">sample_finding_with_callers:62</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L84" rel="noopener noreferrer">sample_defs_map:84</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L108" rel="noopener noreferrer">sample_source_cache:108</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L134" rel="noopener noreferrer">survivor_with_heuristic:134</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L39" rel="noopener noreferrer">test_java_constant_folding_caps_string_concatenation:39</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L49" rel="noopener noreferrer">test_java_constant_store_has_total_string_budget:49</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L69" rel="noopener noreferrer">test_object_input_stream_flags:69</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L85" rel="noopener noreferrer">test_zip_slip_style_archive_extraction_flags:85</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L105" rel="noopener noreferrer">test_archive_extraction_with_normalize_guard_is_safe:105</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L23" rel="noopener noreferrer">mock_definition:23</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L63" rel="noopener noreferrer">mock_test_aware_visitor:63</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L71" rel="noopener noreferrer">mock_framework_aware_visitor:71</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L78" rel="noopener noreferrer">temp_python_project:78</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1953,7 +2040,7 @@
         <thead><tr><th>File</th><th>Lines</th><th>Public / all symbols</th><th>Signal</th><th>What it seems to own</th></tr></thead>
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">skylos/cli.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
               <td>5462</td>
               <td>35 / 180</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span> <span class="warn">shared path</span></td>
@@ -1962,7 +2049,7 @@
             
 
             <tr class="searchable" data-search="test/test_verify_orchestrator.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="../../test/test_verify_orchestrator.py">test/test_verify_orchestrator.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a></td>
               <td>2542</td>
               <td>79 / 79</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -1971,7 +2058,7 @@
             
 
             <tr class="searchable" data-search="skylos/llm/verify_orchestrator.py llm security analysis, evidence grounding, provider runtime resolution, and prompt templates.">
-              <td><a href="../../skylos/llm/verify_orchestrator.py">skylos/llm/verify_orchestrator.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a></td>
               <td>3110</td>
               <td>4 / 56</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -1980,7 +2067,7 @@
             
 
             <tr class="searchable" data-search="skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">skylos/api/__init__.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a></td>
               <td>1970</td>
               <td>15 / 93</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -1989,7 +2076,7 @@
             
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">skylos/analyzer.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
               <td>3740</td>
               <td>3 / 19</td>
               <td><span class="warn">large</span> <span class="warn">shared path</span></td>
@@ -1998,7 +2085,7 @@
             
 
             <tr class="searchable" data-search="test/test_java_security.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="../../test/test_java_security.py">test/test_java_security.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a></td>
               <td>1901</td>
               <td>85 / 89</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -2007,7 +2094,7 @@
             
 
             <tr class="searchable" data-search="skylos/rules/config/cicd/github_actions.py rule catalog and concrete rule implementations for quality, security, config, and sca findings.">
-              <td><a href="../../skylos/rules/config/cicd/github_actions.py">skylos/rules/config/cicd/github_actions.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">skylos/rules/config/cicd/github_actions.py</a></td>
               <td>1963</td>
               <td>2 / 63</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -2016,7 +2103,7 @@
             
 
             <tr class="searchable" data-search="test/test_analyzer.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="../../test/test_analyzer.py">test/test_analyzer.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a></td>
               <td>3105</td>
               <td>15 / 15</td>
               <td><span class="warn">large</span></td>
@@ -2025,7 +2112,7 @@
             
 
             <tr class="searchable" data-search="test/test_cli.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="../../test/test_cli.py">test/test_cli.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></td>
               <td>1878</td>
               <td>43 / 44</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -2034,7 +2121,7 @@
             
 
             <tr class="searchable" data-search="skylos/visitors/languages/java/danger.py ast/tree visitors that collect findings and semantic evidence.">
-              <td><a href="../../skylos/visitors/languages/java/danger.py">skylos/visitors/languages/java/danger.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></td>
               <td>1846</td>
               <td>1 / 45</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -2043,7 +2130,7 @@
             
 
             <tr class="searchable" data-search="test/test_vibe_rules.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="../../test/test_vibe_rules.py">test/test_vibe_rules.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_vibe_rules.py" rel="noopener noreferrer">test/test_vibe_rules.py</a></td>
               <td>2201</td>
               <td>26 / 27</td>
               <td><span class="warn">large</span></td>
@@ -2052,7 +2139,7 @@
             
 
             <tr class="searchable" data-search="test/test_defend.py tests for the ai defense engine (phase 1b, 1c, 2, 3).">
-              <td><a href="../../test/test_defend.py">test/test_defend.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_defend.py" rel="noopener noreferrer">test/test_defend.py</a></td>
               <td>2132</td>
               <td>23 / 25</td>
               <td><span class="warn">large</span></td>
@@ -2061,7 +2148,7 @@
             
 
             <tr class="searchable" data-search="skylos/visitors/languages/typescript/danger.py ast/tree visitors that collect findings and semantic evidence.">
-              <td><a href="../../skylos/visitors/languages/typescript/danger.py">skylos/visitors/languages/typescript/danger.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a></td>
               <td>1590</td>
               <td>1 / 44</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -2070,7 +2157,7 @@
             
 
             <tr class="searchable" data-search="test/test_cli_refactor_guardrails.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="../../test/test_cli_refactor_guardrails.py">test/test_cli_refactor_guardrails.py</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></td>
               <td>1310</td>
               <td>52 / 54</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
@@ -2088,7 +2175,7 @@
         <thead><tr><th>Symbol</th><th>Kind</th><th>Surface</th><th>File</th></tr></thead>
         <tbody>
             <tr class="searchable" data-search="fetch_profile async def benchmarks/agent_review/fixtures/async_blocking_handler/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/async_blocking_handler/app.py">fetch_profile:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/async_blocking_handler/app.py#L5" rel="noopener noreferrer">fetch_profile:5</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/async_blocking_handler/app.py</td>
@@ -2096,7 +2183,7 @@
             
 
             <tr class="searchable" data-search="fetch_health async def benchmarks/agent_review/fixtures/async_blocking_handler/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/async_blocking_handler/app.py">fetch_health:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/async_blocking_handler/app.py#L14" rel="noopener noreferrer">fetch_health:14</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/async_blocking_handler/app.py</td>
@@ -2104,7 +2191,7 @@
             
 
             <tr class="searchable" data-search="handle_search def benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py">handle_search:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py#L4" rel="noopener noreferrer">handle_search:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py</td>
@@ -2112,7 +2199,7 @@
             
 
             <tr class="searchable" data-search="handle_homepage def benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py">handle_homepage:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py#L8" rel="noopener noreferrer">handle_homepage:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py</td>
@@ -2120,7 +2207,7 @@
             
 
             <tr class="searchable" data-search="query_all def benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py</td>
@@ -2128,7 +2215,7 @@
             
 
             <tr class="searchable" data-search="search_users def benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py">search_users:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py#L4" rel="noopener noreferrer">search_users:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py</td>
@@ -2136,7 +2223,7 @@
             
 
             <tr class="searchable" data-search="list_recent_users def benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py">list_recent_users:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py#L13" rel="noopener noreferrer">list_recent_users:13</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py</td>
@@ -2144,7 +2231,7 @@
             
 
             <tr class="searchable" data-search="test_recent_users_query_shape def benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py">test_recent_users_query_shape:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py#L4" rel="noopener noreferrer">test_recent_users_query_shape:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py</td>
@@ -2152,7 +2239,7 @@
             
 
             <tr class="searchable" data-search="handle_dashboard def benchmarks/agent_review/fixtures/debt_hotspot_service/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/debt_hotspot_service/app.py">handle_dashboard:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/app.py#L4" rel="noopener noreferrer">handle_dashboard:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/app.py</td>
@@ -2160,7 +2247,7 @@
             
 
             <tr class="searchable" data-search="reconcile_account def benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py">reconcile_account:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py#L1" rel="noopener noreferrer">reconcile_account:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py</td>
@@ -2168,7 +2255,7 @@
             
 
             <tr class="searchable" data-search="summarize_account def benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py">summarize_account:41</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py#L41" rel="noopener noreferrer">summarize_account:41</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py</td>
@@ -2176,7 +2263,7 @@
             
 
             <tr class="searchable" data-search="test_dashboard_happy_path def benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py">test_dashboard_happy_path:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py#L4" rel="noopener noreferrer">test_dashboard_happy_path:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py</td>
@@ -2184,7 +2271,7 @@
             
 
             <tr class="searchable" data-search="process_nightly_account def benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py">process_nightly_account:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py#L4" rel="noopener noreferrer">process_nightly_account:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py</td>
@@ -2192,7 +2279,7 @@
             
 
             <tr class="searchable" data-search="route_request def benchmarks/agent_review/fixtures/duplicate_condition/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/duplicate_condition/module.py">route_request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/duplicate_condition/module.py#L1" rel="noopener noreferrer">route_request:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/duplicate_condition/module.py</td>
@@ -2200,7 +2287,7 @@
             
 
             <tr class="searchable" data-search="route_request_ok def benchmarks/agent_review/fixtures/duplicate_condition/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/duplicate_condition/module.py">route_request_ok:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/duplicate_condition/module.py#L9" rel="noopener noreferrer">route_request_ok:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/duplicate_condition/module.py</td>
@@ -2208,7 +2295,7 @@
             
 
             <tr class="searchable" data-search="dispatch_http def benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py">dispatch_http:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py#L5" rel="noopener noreferrer">dispatch_http:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py</td>
@@ -2216,7 +2303,7 @@
             
 
             <tr class="searchable" data-search="main def benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py">main:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py#L5" rel="noopener noreferrer">main:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py</td>
@@ -2224,7 +2311,7 @@
             
 
             <tr class="searchable" data-search="preview def benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py">preview:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py#L11" rel="noopener noreferrer">preview:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py</td>
@@ -2232,7 +2319,7 @@
             
 
             <tr class="searchable" data-search="dispatch_job def benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py">dispatch_job:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py#L4" rel="noopener noreferrer">dispatch_job:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py</td>
@@ -2240,7 +2327,7 @@
             
 
             <tr class="searchable" data-search="load_account def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py">load_account:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py#L5" rel="noopener noreferrer">load_account:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py</td>
@@ -2248,7 +2335,7 @@
             
 
             <tr class="searchable" data-search="archive_account def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py">archive_account:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py#L15" rel="noopener noreferrer">archive_account:15</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py</td>
@@ -2256,7 +2343,7 @@
             
 
             <tr class="searchable" data-search="dormant_report def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py">dormant_report:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py#L20" rel="noopener noreferrer">dormant_report:20</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py</td>
@@ -2264,7 +2351,7 @@
             
 
             <tr class="searchable" data-search="query_all def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py</td>
@@ -2272,7 +2359,7 @@
             
 
             <tr class="searchable" data-search="execute def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py">execute:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py#L5" rel="noopener noreferrer">execute:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py</td>
@@ -2280,7 +2367,7 @@
             
 
             <tr class="searchable" data-search="normalize_sort def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py">normalize_sort:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py#L4" rel="noopener noreferrer">normalize_sort:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py</td>
@@ -2288,7 +2375,7 @@
             
 
             <tr class="searchable" data-search="normalize_host def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py">normalize_host:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py#L10" rel="noopener noreferrer">normalize_host:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py</td>
@@ -2296,7 +2383,7 @@
             
 
             <tr class="searchable" data-search="run_dynamic_hook def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py">run_dynamic_hook:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L4" rel="noopener noreferrer">run_dynamic_hook:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -2304,7 +2391,7 @@
             
 
             <tr class="searchable" data-search="run_registered_hook def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py">run_registered_hook:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L9" rel="noopener noreferrer">run_registered_hook:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -2312,7 +2399,7 @@
             
 
             <tr class="searchable" data-search="run_mutable_runner def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py">run_mutable_runner:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L17" rel="noopener noreferrer">run_mutable_runner:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -2320,7 +2407,7 @@
             
 
             <tr class="searchable" data-search="run_sample def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py">run_sample:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L24" rel="noopener noreferrer">run_sample:24</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -2328,7 +2415,7 @@
             
 
             <tr class="searchable" data-search="fetch_partner def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py">fetch_partner:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py#L6" rel="noopener noreferrer">fetch_partner:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py</td>
@@ -2336,7 +2423,7 @@
             
 
             <tr class="searchable" data-search="fetch_internal_status def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py">fetch_internal_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py#L11" rel="noopener noreferrer">fetch_internal_status:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py</td>
@@ -2344,7 +2431,7 @@
             
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py">lab_fetch:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py#L15" rel="noopener noreferrer">lab_fetch:15</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py</td>
@@ -2352,7 +2439,7 @@
             
 
             <tr class="searchable" data-search="test_http_search_reaches_repository def benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py">test_http_search_reaches_repository:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py#L5" rel="noopener noreferrer">test_http_search_reaches_repository:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
@@ -2360,7 +2447,7 @@
             
 
             <tr class="searchable" data-search="test_registered_hook_is_list_based def benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py">test_registered_hook_is_list_based:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py#L10" rel="noopener noreferrer">test_registered_hook_is_list_based:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
@@ -2368,7 +2455,7 @@
             
 
             <tr class="searchable" data-search="dangerous_admin def benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py">dangerous_admin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py#L4" rel="noopener noreferrer">dangerous_admin:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py</td>
@@ -2376,7 +2463,7 @@
             
 
             <tr class="searchable" data-search="format_admin_status def benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py">format_admin_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py#L11" rel="noopener noreferrer">format_admin_status:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py</td>
@@ -2384,7 +2471,7 @@
             
 
             <tr class="searchable" data-search="request class benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py">Request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py#L1" rel="noopener noreferrer">Request:1</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py</td>
@@ -2392,7 +2479,7 @@
             
 
             <tr class="searchable" data-search="app class benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py">App:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py#L5" rel="noopener noreferrer">App:5</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py</td>
@@ -2400,7 +2487,7 @@
             
 
             <tr class="searchable" data-search="admin_query_route def benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py">admin_query_route:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py#L6" rel="noopener noreferrer">admin_query_route:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py</td>
@@ -2408,7 +2495,7 @@
             
 
             <tr class="searchable" data-search="health_route def benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py">health_route:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py#L14" rel="noopener noreferrer">health_route:14</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py</td>
@@ -2416,7 +2503,7 @@
             
 
             <tr class="searchable" data-search="mirror_url async def benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py">mirror_url:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py#L9" rel="noopener noreferrer">mirror_url:9</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py</td>
@@ -2424,7 +2511,7 @@
             
 
             <tr class="searchable" data-search="fetch_status async def benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py">fetch_status:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py#L15" rel="noopener noreferrer">fetch_status:15</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py</td>
@@ -2432,7 +2519,7 @@
             
 
             <tr class="searchable" data-search="extract_bundle def benchmarks/agent_review/fixtures/flask_archive_extraction/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_archive_extraction/app.py">extract_bundle:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_archive_extraction/app.py#L17" rel="noopener noreferrer">extract_bundle:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_archive_extraction/app.py</td>
@@ -2440,7 +2527,7 @@
             
 
             <tr class="searchable" data-search="extract_bundle_safe def benchmarks/agent_review/fixtures/flask_archive_extraction/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_archive_extraction/app.py">extract_bundle_safe:27</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_archive_extraction/app.py#L27" rel="noopener noreferrer">extract_bundle_safe:27</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_archive_extraction/app.py</td>
@@ -2448,7 +2535,7 @@
             
 
             <tr class="searchable" data-search="run_tool def benchmarks/agent_review/fixtures/flask_getter_shell/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_getter_shell/app.py">run_tool:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_getter_shell/app.py#L9" rel="noopener noreferrer">run_tool:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_getter_shell/app.py</td>
@@ -2456,7 +2543,7 @@
             
 
             <tr class="searchable" data-search="run_safe def benchmarks/agent_review/fixtures/flask_getter_shell/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_getter_shell/app.py">run_safe:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_getter_shell/app.py#L15" rel="noopener noreferrer">run_safe:15</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_getter_shell/app.py</td>
@@ -2464,7 +2551,7 @@
             
 
             <tr class="searchable" data-search="user def benchmarks/agent_review/fixtures/flask_handler_security/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_handler_security/app.py">user:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py#L10" rel="noopener noreferrer">user:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_handler_security/app.py</td>
@@ -2472,7 +2559,7 @@
             
 
             <tr class="searchable" data-search="ls def benchmarks/agent_review/fixtures/flask_handler_security/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_handler_security/app.py">ls:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py#L17" rel="noopener noreferrer">ls:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_handler_security/app.py</td>
@@ -2480,7 +2567,7 @@
             
 
             <tr class="searchable" data-search="safe def benchmarks/agent_review/fixtures/flask_handler_security/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_handler_security/app.py">safe:23</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py#L23" rel="noopener noreferrer">safe:23</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_handler_security/app.py</td>
@@ -2488,7 +2575,7 @@
             
 
             <tr class="searchable" data-search="bounce def benchmarks/agent_review/fixtures/flask_open_redirect/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_open_redirect/app.py">bounce:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_open_redirect/app.py#L10" rel="noopener noreferrer">bounce:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_open_redirect/app.py</td>
@@ -2496,7 +2583,7 @@
             
 
             <tr class="searchable" data-search="bounce_safe def benchmarks/agent_review/fixtures/flask_open_redirect/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_open_redirect/app.py">bounce_safe:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_open_redirect/app.py#L16" rel="noopener noreferrer">bounce_safe:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_open_redirect/app.py</td>
@@ -2504,7 +2591,7 @@
             
 
             <tr class="searchable" data-search="download_file def benchmarks/agent_review/fixtures/flask_path_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_path_traversal/app.py">download_file:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_path_traversal/app.py#L11" rel="noopener noreferrer">download_file:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_path_traversal/app.py</td>
@@ -2512,7 +2599,7 @@
             
 
             <tr class="searchable" data-search="read_help def benchmarks/agent_review/fixtures/flask_path_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_path_traversal/app.py">read_help:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_path_traversal/app.py#L19" rel="noopener noreferrer">read_help:19</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_path_traversal/app.py</td>
@@ -2520,7 +2607,7 @@
             
 
             <tr class="searchable" data-search="restore_session def benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py">restore_session:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py#L12" rel="noopener noreferrer">restore_session:12</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py</td>
@@ -2528,7 +2615,7 @@
             
 
             <tr class="searchable" data-search="restore_session_safe def benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py">restore_session_safe:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py#L20" rel="noopener noreferrer">restore_session_safe:20</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py</td>
@@ -2536,7 +2623,7 @@
             
 
             <tr class="searchable" data-search="profile def benchmarks/agent_review/fixtures/flask_reflected_xss/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_reflected_xss/app.py">profile:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_reflected_xss/app.py#L10" rel="noopener noreferrer">profile:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_reflected_xss/app.py</td>
@@ -2544,7 +2631,7 @@
             
 
             <tr class="searchable" data-search="safe_profile def benchmarks/agent_review/fixtures/flask_reflected_xss/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_reflected_xss/app.py">safe_profile:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_reflected_xss/app.py#L16" rel="noopener noreferrer">safe_profile:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_reflected_xss/app.py</td>
@@ -2552,7 +2639,7 @@
             
 
             <tr class="searchable" data-search="fetch_avatar def benchmarks/agent_review/fixtures/flask_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_ssrf/app.py">fetch_avatar:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_ssrf/app.py#L9" rel="noopener noreferrer">fetch_avatar:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_ssrf/app.py</td>
@@ -2560,7 +2647,7 @@
             
 
             <tr class="searchable" data-search="fetch_health def benchmarks/agent_review/fixtures/flask_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_ssrf/app.py">fetch_health:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_ssrf/app.py#L15" rel="noopener noreferrer">fetch_health:15</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_ssrf/app.py</td>
@@ -2568,7 +2655,7 @@
             
 
             <tr class="searchable" data-search="upload_file def benchmarks/agent_review/fixtures/flask_upload_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_upload_traversal/app.py">upload_file:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_upload_traversal/app.py#L12" rel="noopener noreferrer">upload_file:12</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_upload_traversal/app.py</td>
@@ -2576,7 +2663,7 @@
             
 
             <tr class="searchable" data-search="upload_safe def benchmarks/agent_review/fixtures/flask_upload_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/flask_upload_traversal/app.py">upload_safe:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_upload_traversal/app.py#L22" rel="noopener noreferrer">upload_safe:22</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_upload_traversal/app.py</td>
@@ -2584,7 +2671,7 @@
             
 
             <tr class="searchable" data-search="decode_session def benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py">decode_session:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py#L4" rel="noopener noreferrer">decode_session:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py</td>
@@ -2592,7 +2679,7 @@
             
 
             <tr class="searchable" data-search="decode_signed_session def benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py">decode_signed_session:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py#L8" rel="noopener noreferrer">decode_signed_session:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py</td>
@@ -2600,7 +2687,7 @@
             
 
             <tr class="searchable" data-search="fetch_user async def benchmarks/agent_review/fixtures/missing_await/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/missing_await/module.py">fetch_user:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py#L1" rel="noopener noreferrer">fetch_user:1</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/missing_await/module.py</td>
@@ -2608,7 +2695,7 @@
             
 
             <tr class="searchable" data-search="load_dashboard async def benchmarks/agent_review/fixtures/missing_await/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/missing_await/module.py">load_dashboard:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py#L5" rel="noopener noreferrer">load_dashboard:5</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/missing_await/module.py</td>
@@ -2616,7 +2703,7 @@
             
 
             <tr class="searchable" data-search="load_dashboard_ok async def benchmarks/agent_review/fixtures/missing_await/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/missing_await/module.py">load_dashboard_ok:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py#L10" rel="noopener noreferrer">load_dashboard_ok:10</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/missing_await/module.py</td>
@@ -2624,7 +2711,7 @@
             
 
             <tr class="searchable" data-search="append_tag def benchmarks/agent_review/fixtures/mutable_default_state/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/mutable_default_state/module.py">append_tag:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/mutable_default_state/module.py#L1" rel="noopener noreferrer">append_tag:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/mutable_default_state/module.py</td>
@@ -2632,7 +2719,7 @@
             
 
             <tr class="searchable" data-search="build_headers def benchmarks/agent_review/fixtures/mutable_default_state/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/mutable_default_state/module.py">build_headers:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/mutable_default_state/module.py#L6" rel="noopener noreferrer">build_headers:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/mutable_default_state/module.py</td>
@@ -2640,7 +2727,7 @@
             
 
             <tr class="searchable" data-search="handle_status def benchmarks/agent_review/fixtures/repo_clean_service/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/repo_clean_service/app.py">handle_status:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/app.py#L5" rel="noopener noreferrer">handle_status:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/app.py</td>
@@ -2648,7 +2735,7 @@
             
 
             <tr class="searchable" data-search="normalize_headers def benchmarks/agent_review/fixtures/repo_clean_service/formatter.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/repo_clean_service/formatter.py">normalize_headers:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/formatter.py#L1" rel="noopener noreferrer">normalize_headers:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/formatter.py</td>
@@ -2656,7 +2743,7 @@
             
 
             <tr class="searchable" data-search="fetch_status def benchmarks/agent_review/fixtures/repo_clean_service/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/repo_clean_service/service.py">fetch_status:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/service.py#L1" rel="noopener noreferrer">fetch_status:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/service.py</td>
@@ -2664,7 +2751,7 @@
             
 
             <tr class="searchable" data-search="list_checks def benchmarks/agent_review/fixtures/repo_clean_service/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/repo_clean_service/service.py">list_checks:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/service.py#L5" rel="noopener noreferrer">list_checks:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/service.py</td>
@@ -2672,7 +2759,7 @@
             
 
             <tr class="searchable" data-search="test_status_handler def benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py">test_status_handler:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py#L4" rel="noopener noreferrer">test_status_handler:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py</td>
@@ -2680,7 +2767,7 @@
             
 
             <tr class="searchable" data-search="load_first_line def benchmarks/agent_review/fixtures/resource_leak/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/resource_leak/module.py">load_first_line:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/resource_leak/module.py#L1" rel="noopener noreferrer">load_first_line:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/resource_leak/module.py</td>
@@ -2688,7 +2775,7 @@
             
 
             <tr class="searchable" data-search="safe_preview def benchmarks/agent_review/fixtures/resource_leak/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/resource_leak/module.py">safe_preview:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/resource_leak/module.py#L8" rel="noopener noreferrer">safe_preview:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/resource_leak/module.py</td>
@@ -2696,7 +2783,7 @@
             
 
             <tr class="searchable" data-search="sync_repository def benchmarks/agent_review/fixtures/shell_hook_runner/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/shell_hook_runner/cli.py">sync_repository:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/cli.py#L4" rel="noopener noreferrer">sync_repository:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/cli.py</td>
@@ -2704,7 +2791,7 @@
             
 
             <tr class="searchable" data-search="execute_custom_hook def benchmarks/agent_review/fixtures/shell_hook_runner/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/shell_hook_runner/cli.py">execute_custom_hook:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/cli.py#L8" rel="noopener noreferrer">execute_custom_hook:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/cli.py</td>
@@ -2712,7 +2799,7 @@
             
 
             <tr class="searchable" data-search="run_named_hook def benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py">run_named_hook:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py#L10" rel="noopener noreferrer">run_named_hook:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py</td>
@@ -2720,7 +2807,7 @@
             
 
             <tr class="searchable" data-search="run_builtin def benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py">run_builtin:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py#L15" rel="noopener noreferrer">run_builtin:15</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py</td>
@@ -2728,7 +2815,7 @@
             
 
             <tr class="searchable" data-search="test_builtin_hook_is_list_based def benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py">test_builtin_hook_is_list_based:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py#L4" rel="noopener noreferrer">test_builtin_hook_is_list_based:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py</td>
@@ -2736,7 +2823,7 @@
             
 
             <tr class="searchable" data-search="main def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py">main:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py#L4" rel="noopener noreferrer">main:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py</td>
@@ -2744,7 +2831,7 @@
             
 
             <tr class="searchable" data-search="dispatch_event def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py">dispatch_event:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py#L6" rel="noopener noreferrer">dispatch_event:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py</td>
@@ -2752,7 +2839,7 @@
             
 
             <tr class="searchable" data-search="ship_audit def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py">ship_audit:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L4" rel="noopener noreferrer">ship_audit:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
@@ -2760,7 +2847,7 @@
             
 
             <tr class="searchable" data-search="sample_shell def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py">sample_shell:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L10" rel="noopener noreferrer">sample_shell:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
@@ -2768,7 +2855,7 @@
             
 
             <tr class="searchable" data-search="query_all def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py</td>
@@ -2776,7 +2863,7 @@
             
 
             <tr class="searchable" data-search="fetch_url def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py">fetch_url:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py#L4" rel="noopener noreferrer">fetch_url:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
@@ -2784,7 +2871,7 @@
             
 
             <tr class="searchable" data-search="fetch_fixed_status def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py">fetch_fixed_status:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py#L9" rel="noopener noreferrer">fetch_fixed_status:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
@@ -2792,7 +2879,7 @@
             
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py">lab_fetch:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py#L13" rel="noopener noreferrer">lab_fetch:13</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
@@ -2800,7 +2887,7 @@
             
 
             <tr class="searchable" data-search="charge_card def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py">charge_card:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L4" rel="noopener noreferrer">charge_card:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
@@ -2808,7 +2895,7 @@
             
 
             <tr class="searchable" data-search="archived_invoice def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py">archived_invoice:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L11" rel="noopener noreferrer">archived_invoice:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
@@ -2816,7 +2903,7 @@
             
 
             <tr class="searchable" data-search="debug_query def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py">debug_query:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L16" rel="noopener noreferrer">debug_query:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
@@ -2824,7 +2911,7 @@
             
 
             <tr class="searchable" data-search="run_safe_builtin def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py">run_safe_builtin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L4" rel="noopener noreferrer">run_safe_builtin:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
@@ -2832,7 +2919,7 @@
             
 
             <tr class="searchable" data-search="run_mutable_registered def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py">run_mutable_registered:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L12" rel="noopener noreferrer">run_mutable_registered:12</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
@@ -2840,7 +2927,7 @@
             
 
             <tr class="searchable" data-search="test_pay_handler_dispatches_by_registry_string def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py">test_pay_handler_dispatches_by_registry_string:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py#L4" rel="noopener noreferrer">test_pay_handler_dispatches_by_registry_string:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py</td>
@@ -2848,7 +2935,7 @@
             
 
             <tr class="searchable" data-search="fetch_status async def benchmarks/agent_review/fixtures/tricky_clean/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/tricky_clean/module.py">fetch_status:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/tricky_clean/module.py#L1" rel="noopener noreferrer">fetch_status:1</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/tricky_clean/module.py</td>
@@ -2856,7 +2943,7 @@
             
 
             <tr class="searchable" data-search="normalize_headers def benchmarks/agent_review/fixtures/tricky_clean/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/agent_review/fixtures/tricky_clean/module.py">normalize_headers:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/tricky_clean/module.py#L9" rel="noopener noreferrer">normalize_headers:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/tricky_clean/module.py</td>
@@ -2864,7 +2951,7 @@
             
 
             <tr class="searchable" data-search="upgrade def benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py">upgrade:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L9" rel="noopener noreferrer">upgrade:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
@@ -2872,7 +2959,7 @@
             
 
             <tr class="searchable" data-search="downgrade def benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py">downgrade:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L17" rel="noopener noreferrer">downgrade:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
@@ -2880,7 +2967,7 @@
             
 
             <tr class="searchable" data-search="unused_migration_helper def benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py">unused_migration_helper:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L21" rel="noopener noreferrer">unused_migration_helper:21</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
@@ -2888,7 +2975,7 @@
             
 
             <tr class="searchable" data-search="unusedmigrationstate class benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py">UnusedMigrationState:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L25" rel="noopener noreferrer">UnusedMigrationState:25</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
@@ -2896,7 +2983,7 @@
             
 
             <tr class="searchable" data-search="usedworker class benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">UsedWorker:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L9" rel="noopener noreferrer">UsedWorker:9</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
@@ -2904,7 +2991,7 @@
             
 
             <tr class="searchable" data-search="unusedworker class benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">UnusedWorker:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L14" rel="noopener noreferrer">UnusedWorker:14</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
@@ -2912,7 +2999,7 @@
             
 
             <tr class="searchable" data-search="used_helper def benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">used_helper:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L19" rel="noopener noreferrer">used_helper:19</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
@@ -2920,7 +3007,7 @@
             
 
             <tr class="searchable" data-search="unused_helper def benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/basic_unused_symbols/app.py">unused_helper:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L24" rel="noopener noreferrer">unused_helper:24</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
@@ -2928,7 +3015,7 @@
             
 
             <tr class="searchable" data-search="send_receipt def benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/celery_tasks/app.py">send_receipt:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L8" rel="noopener noreferrer">send_receipt:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
@@ -2936,7 +3023,7 @@
             
 
             <tr class="searchable" data-search="rebuild_rollups def benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/celery_tasks/app.py">rebuild_rollups:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L13" rel="noopener noreferrer">rebuild_rollups:13</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
@@ -2944,7 +3031,7 @@
             
 
             <tr class="searchable" data-search="unused_task_helper def benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/celery_tasks/app.py">unused_task_helper:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L17" rel="noopener noreferrer">unused_task_helper:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
@@ -2952,7 +3039,7 @@
             
 
             <tr class="searchable" data-search="unusedtaskpayload class benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/celery_tasks/app.py">UnusedTaskPayload:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L21" rel="noopener noreferrer">UnusedTaskPayload:21</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
@@ -2960,7 +3047,7 @@
             
 
             <tr class="searchable" data-search="command class benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py">Command:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L4" rel="noopener noreferrer">Command:4</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
@@ -2968,7 +3055,7 @@
             
 
             <tr class="searchable" data-search="rebuild_index def benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py">rebuild_index:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L14" rel="noopener noreferrer">rebuild_index:14</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
@@ -2976,7 +3063,7 @@
             
 
             <tr class="searchable" data-search="unused_export_job def benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py">unused_export_job:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L18" rel="noopener noreferrer">unused_export_job:18</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
@@ -2984,7 +3071,7 @@
             
 
             <tr class="searchable" data-search="unusedcommandhelper class benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py">UnusedCommandHelper:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L22" rel="noopener noreferrer">UnusedCommandHelper:22</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
@@ -2992,7 +3079,7 @@
             
 
             <tr class="searchable" data-search="register def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">register:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L4" rel="noopener noreferrer">register:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
@@ -3000,7 +3087,7 @@
             
 
             <tr class="searchable" data-search="handle_create def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">handle_create:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L13" rel="noopener noreferrer">handle_create:13</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
@@ -3008,7 +3095,7 @@
             
 
             <tr class="searchable" data-search="handle_update def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">handle_update:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L18" rel="noopener noreferrer">handle_update:18</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
@@ -3016,7 +3103,7 @@
             
 
             <tr class="searchable" data-search="dispatch def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">dispatch:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L22" rel="noopener noreferrer">dispatch:22</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
@@ -3024,7 +3111,7 @@
             
 
             <tr class="searchable" data-search="unused_handler def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/dynamic_registry_used/app.py">unused_handler:26</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L26" rel="noopener noreferrer">unused_handler:26</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
@@ -3032,7 +3119,7 @@
             
 
             <tr class="searchable" data-search="dispatch_http def benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py">dispatch_http:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py#L5" rel="noopener noreferrer">dispatch_http:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py</td>
@@ -3040,7 +3127,7 @@
             
 
             <tr class="searchable" data-search="main def benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py">main:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py#L5" rel="noopener noreferrer">main:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py</td>
@@ -3048,7 +3135,7 @@
             
 
             <tr class="searchable" data-search="preview def benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py">preview:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py#L11" rel="noopener noreferrer">preview:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py</td>
@@ -3056,7 +3143,7 @@
             
 
             <tr class="searchable" data-search="dispatch_job def benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py">dispatch_job:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py#L4" rel="noopener noreferrer">dispatch_job:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py</td>
@@ -3064,7 +3151,7 @@
             
 
             <tr class="searchable" data-search="load_account def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py">load_account:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py#L5" rel="noopener noreferrer">load_account:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py</td>
@@ -3072,7 +3159,7 @@
             
 
             <tr class="searchable" data-search="archive_account def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py">archive_account:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py#L15" rel="noopener noreferrer">archive_account:15</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py</td>
@@ -3080,7 +3167,7 @@
             
 
             <tr class="searchable" data-search="dormant_report def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py">dormant_report:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py#L20" rel="noopener noreferrer">dormant_report:20</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py</td>
@@ -3088,7 +3175,7 @@
             
 
             <tr class="searchable" data-search="query_all def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py</td>
@@ -3096,7 +3183,7 @@
             
 
             <tr class="searchable" data-search="execute def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py">execute:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py#L5" rel="noopener noreferrer">execute:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py</td>
@@ -3104,7 +3191,7 @@
             
 
             <tr class="searchable" data-search="normalize_sort def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py">normalize_sort:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py#L4" rel="noopener noreferrer">normalize_sort:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py</td>
@@ -3112,7 +3199,7 @@
             
 
             <tr class="searchable" data-search="normalize_host def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py">normalize_host:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py#L10" rel="noopener noreferrer">normalize_host:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py</td>
@@ -3120,7 +3207,7 @@
             
 
             <tr class="searchable" data-search="run_dynamic_hook def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py">run_dynamic_hook:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L4" rel="noopener noreferrer">run_dynamic_hook:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -3128,7 +3215,7 @@
             
 
             <tr class="searchable" data-search="run_registered_hook def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py">run_registered_hook:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L9" rel="noopener noreferrer">run_registered_hook:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -3136,7 +3223,7 @@
             
 
             <tr class="searchable" data-search="run_mutable_runner def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py">run_mutable_runner:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L17" rel="noopener noreferrer">run_mutable_runner:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -3144,7 +3231,7 @@
             
 
             <tr class="searchable" data-search="run_sample def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py">run_sample:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L24" rel="noopener noreferrer">run_sample:24</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
@@ -3152,7 +3239,7 @@
             
 
             <tr class="searchable" data-search="fetch_partner def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py">fetch_partner:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py#L6" rel="noopener noreferrer">fetch_partner:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py</td>
@@ -3160,7 +3247,7 @@
             
 
             <tr class="searchable" data-search="fetch_internal_status def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py">fetch_internal_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py#L11" rel="noopener noreferrer">fetch_internal_status:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py</td>
@@ -3168,7 +3255,7 @@
             
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py">lab_fetch:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py#L15" rel="noopener noreferrer">lab_fetch:15</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py</td>
@@ -3176,7 +3263,7 @@
             
 
             <tr class="searchable" data-search="test_http_search_reaches_repository def benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py">test_http_search_reaches_repository:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py#L5" rel="noopener noreferrer">test_http_search_reaches_repository:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
@@ -3184,7 +3271,7 @@
             
 
             <tr class="searchable" data-search="test_registered_hook_is_list_based def benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py">test_registered_hook_is_list_based:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py#L10" rel="noopener noreferrer">test_registered_hook_is_list_based:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
@@ -3192,7 +3279,7 @@
             
 
             <tr class="searchable" data-search="dangerous_admin def benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py">dangerous_admin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py#L4" rel="noopener noreferrer">dangerous_admin:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py</td>
@@ -3200,7 +3287,7 @@
             
 
             <tr class="searchable" data-search="format_admin_status def benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py">format_admin_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py#L11" rel="noopener noreferrer">format_admin_status:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py</td>
@@ -3208,7 +3295,7 @@
             
 
             <tr class="searchable" data-search="request class benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py">Request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py#L1" rel="noopener noreferrer">Request:1</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py</td>
@@ -3216,7 +3303,7 @@
             
 
             <tr class="searchable" data-search="app class benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py">App:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py#L5" rel="noopener noreferrer">App:5</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py</td>
@@ -3224,7 +3311,7 @@
             
 
             <tr class="searchable" data-search="admin_query_route def benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py">admin_query_route:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py#L6" rel="noopener noreferrer">admin_query_route:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py</td>
@@ -3232,7 +3319,7 @@
             
 
             <tr class="searchable" data-search="health_route def benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py">health_route:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py#L14" rel="noopener noreferrer">health_route:14</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py</td>
@@ -3240,7 +3327,7 @@
             
 
             <tr class="searchable" data-search="get_current_user def benchmarks/dead_code/fixtures/fastapi_route_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/fastapi_route_used/app.py">get_current_user:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py#L7" rel="noopener noreferrer">get_current_user:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/fastapi_route_used/app.py</td>
@@ -3248,7 +3335,7 @@
             
 
             <tr class="searchable" data-search="read_profile def benchmarks/dead_code/fixtures/fastapi_route_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/fastapi_route_used/app.py">read_profile:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py#L12" rel="noopener noreferrer">read_profile:12</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/fastapi_route_used/app.py</td>
@@ -3256,7 +3343,7 @@
             
 
             <tr class="searchable" data-search="unused_helper def benchmarks/dead_code/fixtures/fastapi_route_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/fastapi_route_used/app.py">unused_helper:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py#L16" rel="noopener noreferrer">unused_helper:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/fastapi_route_used/app.py</td>
@@ -3264,7 +3351,7 @@
             
 
             <tr class="searchable" data-search="show_order def benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py">show_order:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L9" rel="noopener noreferrer">show_order:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
@@ -3272,7 +3359,7 @@
             
 
             <tr class="searchable" data-search="reindex_orders def benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py">reindex_orders:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L14" rel="noopener noreferrer">reindex_orders:14</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
@@ -3280,7 +3367,7 @@
             
 
             <tr class="searchable" data-search="unused_view_helper def benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py">unused_view_helper:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L18" rel="noopener noreferrer">unused_view_helper:18</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
@@ -3288,7 +3375,7 @@
             
 
             <tr class="searchable" data-search="unusedformatter class benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py">UnusedFormatter:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L22" rel="noopener noreferrer">UnusedFormatter:22</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
@@ -3296,7 +3383,7 @@
             
 
             <tr class="searchable" data-search="load_plugin def benchmarks/dead_code/fixtures/importlib_plugins/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/importlib_plugins/app.py">load_plugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py#L7" rel="noopener noreferrer">load_plugin:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/app.py</td>
@@ -3304,7 +3391,7 @@
             
 
             <tr class="searchable" data-search="run_notification def benchmarks/dead_code/fixtures/importlib_plugins/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/importlib_plugins/app.py">run_notification:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py#L12" rel="noopener noreferrer">run_notification:12</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/app.py</td>
@@ -3312,7 +3399,7 @@
             
 
             <tr class="searchable" data-search="unused_loader def benchmarks/dead_code/fixtures/importlib_plugins/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/importlib_plugins/app.py">unused_loader:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py#L17" rel="noopener noreferrer">unused_loader:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/app.py</td>
@@ -3320,7 +3407,7 @@
             
 
             <tr class="searchable" data-search="send_email def benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py">send_email:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py#L1" rel="noopener noreferrer">send_email:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py</td>
@@ -3328,7 +3415,7 @@
             
 
             <tr class="searchable" data-search="unused_plugin_hook def benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py">unused_plugin_hook:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py#L5" rel="noopener noreferrer">unused_plugin_hook:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py</td>
@@ -3336,7 +3423,7 @@
             
 
             <tr class="searchable" data-search="unusedplugin class benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py">UnusedPlugin:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py#L9" rel="noopener noreferrer">UnusedPlugin:9</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py</td>
@@ -3344,7 +3431,7 @@
             
 
             <tr class="searchable" data-search="main def benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py">main:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py#L1" rel="noopener noreferrer">main:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py</td>
@@ -3352,7 +3439,7 @@
             
 
             <tr class="searchable" data-search="format_status def benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py">format_status:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py#L5" rel="noopener noreferrer">format_status:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py</td>
@@ -3360,7 +3447,7 @@
             
 
             <tr class="searchable" data-search="run_checkout def benchmarks/dead_code/fixtures/package_service_layers/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/package_service_layers/app.py">run_checkout:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/app.py#L4" rel="noopener noreferrer">run_checkout:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/app.py</td>
@@ -3368,7 +3455,7 @@
             
 
             <tr class="searchable" data-search="invoicerepository class benchmarks/dead_code/fixtures/package_service_layers/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/package_service_layers/repository.py">InvoiceRepository:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/repository.py#L1" rel="noopener noreferrer">InvoiceRepository:1</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/repository.py</td>
@@ -3376,7 +3463,7 @@
             
 
             <tr class="searchable" data-search="unusedstrategy class benchmarks/dead_code/fixtures/package_service_layers/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/package_service_layers/service.py">UnusedStrategy:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/service.py#L11" rel="noopener noreferrer">UnusedStrategy:11</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/service.py</td>
@@ -3384,7 +3471,7 @@
             
 
             <tr class="searchable" data-search="create_invoice def benchmarks/dead_code/fixtures/package_service_layers/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/package_service_layers/service.py">create_invoice:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/service.py#L16" rel="noopener noreferrer">create_invoice:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/service.py</td>
@@ -3392,7 +3479,7 @@
             
 
             <tr class="searchable" data-search="userinput class benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">UserInput:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L4" rel="noopener noreferrer">UserInput:4</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
@@ -3400,7 +3487,7 @@
             
 
             <tr class="searchable" data-search="unusedschema class benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">UnusedSchema:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L17" rel="noopener noreferrer">UnusedSchema:17</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
@@ -3408,7 +3495,7 @@
             
 
             <tr class="searchable" data-search="build_user def benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">build_user:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L21" rel="noopener noreferrer">build_user:21</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
@@ -3416,7 +3503,7 @@
             
 
             <tr class="searchable" data-search="unused_normalizer def benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/pydantic_validators/app.py">unused_normalizer:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L25" rel="noopener noreferrer">unused_normalizer:25</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
@@ -3424,7 +3511,7 @@
             
 
             <tr class="searchable" data-search="api_client def benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py">api_client:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py#L5" rel="noopener noreferrer">api_client:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py</td>
@@ -3432,7 +3519,7 @@
             
 
             <tr class="searchable" data-search="payload_fixture def benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py">payload_fixture:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py#L10" rel="noopener noreferrer">payload_fixture:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py</td>
@@ -3440,7 +3527,7 @@
             
 
             <tr class="searchable" data-search="test_create_order def benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py">test_create_order:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py#L14" rel="noopener noreferrer">test_create_order:14</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py</td>
@@ -3448,7 +3535,7 @@
             
 
             <tr class="searchable" data-search="build_demo_note def benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py">build_demo_note:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py#L4" rel="noopener noreferrer">build_demo_note:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py</td>
@@ -3456,7 +3543,7 @@
             
 
             <tr class="searchable" data-search="base class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py">Base:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L5" rel="noopener noreferrer">Base:5</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
@@ -3464,7 +3551,7 @@
             
 
             <tr class="searchable" data-search="note class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py">Note:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L9" rel="noopener noreferrer">Note:9</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
@@ -3472,7 +3559,7 @@
             
 
             <tr class="searchable" data-search="auditlog class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py">AuditLog:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L17" rel="noopener noreferrer">AuditLog:17</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
@@ -3480,7 +3567,7 @@
             
 
             <tr class="searchable" data-search="tag class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py">Tag:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L24" rel="noopener noreferrer">Tag:24</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
@@ -3488,7 +3575,7 @@
             
 
             <tr class="searchable" data-search="create_note def benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py">create_note:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py#L4" rel="noopener noreferrer">create_note:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py</td>
@@ -3496,7 +3583,7 @@
             
 
             <tr class="searchable" data-search="main def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py">main:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py#L4" rel="noopener noreferrer">main:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py</td>
@@ -3504,7 +3591,7 @@
             
 
             <tr class="searchable" data-search="dispatch_event def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py">dispatch_event:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py#L6" rel="noopener noreferrer">dispatch_event:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py</td>
@@ -3512,7 +3599,7 @@
             
 
             <tr class="searchable" data-search="ship_audit def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py">ship_audit:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L4" rel="noopener noreferrer">ship_audit:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
@@ -3520,7 +3607,7 @@
             
 
             <tr class="searchable" data-search="sample_shell def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py">sample_shell:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L10" rel="noopener noreferrer">sample_shell:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
@@ -3528,7 +3615,7 @@
             
 
             <tr class="searchable" data-search="query_all def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py</td>
@@ -3536,7 +3623,7 @@
             
 
             <tr class="searchable" data-search="fetch_url def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py">fetch_url:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py#L4" rel="noopener noreferrer">fetch_url:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
@@ -3544,7 +3631,7 @@
             
 
             <tr class="searchable" data-search="fetch_fixed_status def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py">fetch_fixed_status:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py#L9" rel="noopener noreferrer">fetch_fixed_status:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
@@ -3552,7 +3639,7 @@
             
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py">lab_fetch:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py#L13" rel="noopener noreferrer">lab_fetch:13</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
@@ -3560,7 +3647,7 @@
             
 
             <tr class="searchable" data-search="charge_card def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py">charge_card:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L4" rel="noopener noreferrer">charge_card:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
@@ -3568,7 +3655,7 @@
             
 
             <tr class="searchable" data-search="archived_invoice def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py">archived_invoice:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L11" rel="noopener noreferrer">archived_invoice:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
@@ -3576,7 +3663,7 @@
             
 
             <tr class="searchable" data-search="debug_query def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py">debug_query:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L16" rel="noopener noreferrer">debug_query:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
@@ -3584,7 +3671,7 @@
             
 
             <tr class="searchable" data-search="run_safe_builtin def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py">run_safe_builtin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L4" rel="noopener noreferrer">run_safe_builtin:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
@@ -3592,7 +3679,7 @@
             
 
             <tr class="searchable" data-search="run_mutable_registered def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py">run_mutable_registered:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L12" rel="noopener noreferrer">run_mutable_registered:12</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
@@ -3600,7 +3687,7 @@
             
 
             <tr class="searchable" data-search="test_pay_handler_dispatches_by_registry_string def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py">test_pay_handler_dispatches_by_registry_string:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py#L4" rel="noopener noreferrer">test_pay_handler_dispatches_by_registry_string:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py</td>
@@ -3608,7 +3695,7 @@
             
 
             <tr class="searchable" data-search="build_request def benchmarks/quality/fixtures/argument_overload/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/argument_overload/service.py">build_request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/argument_overload/service.py#L1" rel="noopener noreferrer">build_request:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/argument_overload/service.py</td>
@@ -3616,7 +3703,7 @@
             
 
             <tr class="searchable" data-search="helper def benchmarks/quality/fixtures/argument_overload/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/argument_overload/service.py">helper:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/argument_overload/service.py#L11" rel="noopener noreferrer">helper:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/argument_overload/service.py</td>
@@ -3624,7 +3711,7 @@
             
 
             <tr class="searchable" data-search="normalize_name def benchmarks/quality/fixtures/clean_module/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/clean_module/module.py">normalize_name:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/clean_module/module.py#L1" rel="noopener noreferrer">normalize_name:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/clean_module/module.py</td>
@@ -3632,7 +3719,7 @@
             
 
             <tr class="searchable" data-search="join_parts def benchmarks/quality/fixtures/clean_module/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/clean_module/module.py">join_parts:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/clean_module/module.py#L7" rel="noopener noreferrer">join_parts:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/clean_module/module.py</td>
@@ -3640,7 +3727,7 @@
             
 
             <tr class="searchable" data-search="branchy_handler def benchmarks/quality/fixtures/complexity_hotspot/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/complexity_hotspot/app.py">branchy_handler:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/complexity_hotspot/app.py#L1" rel="noopener noreferrer">branchy_handler:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/complexity_hotspot/app.py</td>
@@ -3648,7 +3735,7 @@
             
 
             <tr class="searchable" data-search="simple_handler def benchmarks/quality/fixtures/complexity_hotspot/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/complexity_hotspot/app.py">simple_handler:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/complexity_hotspot/app.py#L11" rel="noopener noreferrer">simple_handler:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/complexity_hotspot/app.py</td>
@@ -3656,7 +3743,7 @@
             
 
             <tr class="searchable" data-search="parse_payload def benchmarks/quality/fixtures/empty_error_handler/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/empty_error_handler/module.py">parse_payload:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/empty_error_handler/module.py#L1" rel="noopener noreferrer">parse_payload:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/empty_error_handler/module.py</td>
@@ -3664,7 +3751,7 @@
             
 
             <tr class="searchable" data-search="require_admin def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/framework_route_policy/app.py">require_admin:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L6" rel="noopener noreferrer">require_admin:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
@@ -3672,7 +3759,7 @@
             
 
             <tr class="searchable" data-search="create_user def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/framework_route_policy/app.py">create_user:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L11" rel="noopener noreferrer">create_user:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
@@ -3680,7 +3767,7 @@
             
 
             <tr class="searchable" data-search="list_users def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/framework_route_policy/app.py">list_users:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L16" rel="noopener noreferrer">list_users:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
@@ -3688,7 +3775,7 @@
             
 
             <tr class="searchable" data-search="create_admin def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/framework_route_policy/app.py">create_admin:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L21" rel="noopener noreferrer">create_admin:21</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
@@ -3696,7 +3783,7 @@
             
 
             <tr class="searchable" data-search="resolve_user def benchmarks/quality/fixtures/inconsistent_return/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/inconsistent_return/module.py">resolve_user:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/inconsistent_return/module.py#L1" rel="noopener noreferrer">resolve_user:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/inconsistent_return/module.py</td>
@@ -3704,7 +3791,7 @@
             
 
             <tr class="searchable" data-search="render_report def benchmarks/quality/fixtures/long_function/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/long_function/module.py">render_report:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/long_function/module.py#L1" rel="noopener noreferrer">render_report:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/long_function/module.py</td>
@@ -3712,7 +3799,7 @@
             
 
             <tr class="searchable" data-search="tiny_helper def benchmarks/quality/fixtures/long_function/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/long_function/module.py">tiny_helper:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/long_function/module.py#L12" rel="noopener noreferrer">tiny_helper:12</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/long_function/module.py</td>
@@ -3720,7 +3807,7 @@
             
 
             <tr class="searchable" data-search="load_account_snapshot def benchmarks/quality/fixtures/opaque_identifier/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/opaque_identifier/module.py">load_account_snapshot:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py#L1" rel="noopener noreferrer">load_account_snapshot:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/opaque_identifier/module.py</td>
@@ -3728,7 +3815,7 @@
             
 
             <tr class="searchable" data-search="coordinate_area def benchmarks/quality/fixtures/opaque_identifier/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/opaque_identifier/module.py">coordinate_area:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py#L20" rel="noopener noreferrer">coordinate_area:20</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/opaque_identifier/module.py</td>
@@ -3736,7 +3823,7 @@
             
 
             <tr class="searchable" data-search="normalize def benchmarks/quality/fixtures/opaque_identifier/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/opaque_identifier/module.py">normalize:26</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py#L26" rel="noopener noreferrer">normalize:26</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/opaque_identifier/module.py</td>
@@ -3744,7 +3831,7 @@
             
 
             <tr class="searchable" data-search="configured_helper def benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py">configured_helper:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py#L1" rel="noopener noreferrer">configured_helper:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py</td>
@@ -3752,7 +3839,7 @@
             
 
             <tr class="searchable" data-search="load_user def benchmarks/quality/fixtures/type_annotation_gaps/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/type_annotation_gaps/module.py">load_user:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/type_annotation_gaps/module.py#L4" rel="noopener noreferrer">load_user:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/type_annotation_gaps/module.py</td>
@@ -3760,7 +3847,7 @@
             
 
             <tr class="searchable" data-search="typed_helper def benchmarks/quality/fixtures/type_annotation_gaps/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/quality/fixtures/type_annotation_gaps/module.py">typed_helper:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/type_annotation_gaps/module.py#L8" rel="noopener noreferrer">typed_helper:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/type_annotation_gaps/module.py</td>
@@ -3768,7 +3855,7 @@
             
 
             <tr class="searchable" data-search="decode_token def benchmarks/security/fixtures/jwt_verify_disabled/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/jwt_verify_disabled/app.py">decode_token:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/jwt_verify_disabled/app.py#L4" rel="noopener noreferrer">decode_token:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/jwt_verify_disabled/app.py</td>
@@ -3776,7 +3863,7 @@
             
 
             <tr class="searchable" data-search="login def benchmarks/security/fixtures/open_redirect_local_guard/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/open_redirect_local_guard/app.py">login:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/open_redirect_local_guard/app.py#L4" rel="noopener noreferrer">login:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/open_redirect_local_guard/app.py</td>
@@ -3784,7 +3871,7 @@
             
 
             <tr class="searchable" data-search="login def benchmarks/security/fixtures/open_redirect_tainted/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/open_redirect_tainted/app.py">login:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/open_redirect_tainted/app.py#L4" rel="noopener noreferrer">login:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/open_redirect_tainted/app.py</td>
@@ -3792,7 +3879,7 @@
             
 
             <tr class="searchable" data-search="read_upload def benchmarks/security/fixtures/path_traversal_basename/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/path_traversal_basename/app.py">read_upload:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/path_traversal_basename/app.py#L7" rel="noopener noreferrer">read_upload:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/path_traversal_basename/app.py</td>
@@ -3800,7 +3887,7 @@
             
 
             <tr class="searchable" data-search="read_upload def benchmarks/security/fixtures/path_traversal_tainted_join/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/path_traversal_tainted_join/app.py">read_upload:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/path_traversal_tainted_join/app.py#L7" rel="noopener noreferrer">read_upload:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/path_traversal_tainted_join/app.py</td>
@@ -3808,7 +3895,7 @@
             
 
             <tr class="searchable" data-search="load_users def benchmarks/security/fixtures/sql_constant_format/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/sql_constant_format/app.py">load_users:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/sql_constant_format/app.py#L1" rel="noopener noreferrer">load_users:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/sql_constant_format/app.py</td>
@@ -3816,7 +3903,7 @@
             
 
             <tr class="searchable" data-search="run_query def benchmarks/security/fixtures/sql_tainted_param/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/sql_tainted_param/app.py">run_query:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/sql_tainted_param/app.py#L1" rel="noopener noreferrer">run_query:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/sql_tainted_param/app.py</td>
@@ -3824,7 +3911,7 @@
             
 
             <tr class="searchable" data-search="fetch_user def benchmarks/security/fixtures/ssrf_fixed_host_path/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/ssrf_fixed_host_path/app.py">fetch_user:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/ssrf_fixed_host_path/app.py#L4" rel="noopener noreferrer">fetch_user:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/ssrf_fixed_host_path/app.py</td>
@@ -3832,7 +3919,7 @@
             
 
             <tr class="searchable" data-search="fetch_host def benchmarks/security/fixtures/ssrf_tainted_host/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/ssrf_tainted_host/app.py">fetch_host:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/ssrf_tainted_host/app.py#L4" rel="noopener noreferrer">fetch_host:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/ssrf_tainted_host/app.py</td>
@@ -3840,7 +3927,7 @@
             
 
             <tr class="searchable" data-search="list_files def benchmarks/security/fixtures/subprocess_alias_shell/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/subprocess_alias_shell/app.py">list_files:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/subprocess_alias_shell/app.py#L4" rel="noopener noreferrer">list_files:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/subprocess_alias_shell/app.py</td>
@@ -3848,7 +3935,7 @@
             
 
             <tr class="searchable" data-search="render_name def benchmarks/security/fixtures/xss_escape_safe/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/xss_escape_safe/app.py">render_name:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/xss_escape_safe/app.py#L6" rel="noopener noreferrer">render_name:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/xss_escape_safe/app.py</td>
@@ -3856,7 +3943,7 @@
             
 
             <tr class="searchable" data-search="render_name def benchmarks/security/fixtures/xss_mark_safe/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/xss_mark_safe/app.py">render_name:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/xss_mark_safe/app.py#L4" rel="noopener noreferrer">render_name:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/xss_mark_safe/app.py</td>
@@ -3864,7 +3951,7 @@
             
 
             <tr class="searchable" data-search="parse_config def benchmarks/security/fixtures/yaml_safeloader_positional/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="../../benchmarks/security/fixtures/yaml_safeloader_positional/app.py">parse_config:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/yaml_safeloader_positional/app.py#L4" rel="noopener noreferrer">parse_config:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/yaml_safeloader_positional/app.py</td>
@@ -3872,7 +3959,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/agent_review_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/agent_review_benchmark.py">main:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/agent_review_benchmark.py#L17" rel="noopener noreferrer">main:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/agent_review_benchmark.py</td>
@@ -3880,7 +3967,7 @@
             
 
             <tr class="searchable" data-search="build_fixture def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/analyzer_speed_check.py">build_fixture:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L21" rel="noopener noreferrer">build_fixture:21</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
@@ -3888,7 +3975,7 @@
             
 
             <tr class="searchable" data-search="run_once def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/analyzer_speed_check.py">run_once:192</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L192" rel="noopener noreferrer">run_once:192</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
@@ -3896,7 +3983,7 @@
             
 
             <tr class="searchable" data-search="run_speed_check def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/analyzer_speed_check.py">run_speed_check:205</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L205" rel="noopener noreferrer">run_speed_check:205</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
@@ -3904,7 +3991,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/analyzer_speed_check.py">main:249</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L249" rel="noopener noreferrer">main:249</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
@@ -3912,7 +3999,7 @@
             
 
             <tr class="searchable" data-search="symbolinfo class scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">SymbolInfo:535</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L546" rel="noopener noreferrer">SymbolInfo:546</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3920,7 +4007,7 @@
             
 
             <tr class="searchable" data-search="moduleinfo class scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">ModuleInfo:558</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L569" rel="noopener noreferrer">ModuleInfo:569</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3928,7 +4015,7 @@
             
 
             <tr class="searchable" data-search="collect_repo_map def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">collect_repo_map:806</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L817" rel="noopener noreferrer">collect_repo_map:817</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3936,7 +4023,7 @@
             
 
             <tr class="searchable" data-search="write_repo_map def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">write_repo_map:1094</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1105" rel="noopener noreferrer">write_repo_map:1105</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3944,7 +4031,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/build_repo_map.py">main:1120</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1131" rel="noopener noreferrer">main:1131</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
@@ -3952,7 +4039,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/check_rule_docs_parity.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/check_rule_docs_parity.py">main:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/check_rule_docs_parity.py#L14" rel="noopener noreferrer">main:14</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/check_rule_docs_parity.py</td>
@@ -3960,7 +4047,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/compare_codex_skylos_agent_review.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/compare_codex_skylos_agent_review.py">main:331</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_agent_review.py#L331" rel="noopener noreferrer">main:331</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/compare_codex_skylos_agent_review.py</td>
@@ -3968,7 +4055,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/compare_codex_skylos_demo_deadcode.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/compare_codex_skylos_demo_deadcode.py">main:216</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_demo_deadcode.py#L216" rel="noopener noreferrer">main:216</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/compare_codex_skylos_demo_deadcode.py</td>
@@ -3976,7 +4063,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/compare_codex_skylos_quality.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/compare_codex_skylos_quality.py">main:365</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_quality.py#L365" rel="noopener noreferrer">main:365</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/compare_codex_skylos_quality.py</td>
@@ -3984,7 +4071,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/corpus_ci.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/corpus_ci.py">main:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/corpus_ci.py#L16" rel="noopener noreferrer">main:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/corpus_ci.py</td>
@@ -3992,7 +4079,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/dead_code_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/dead_code_benchmark.py">main:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_benchmark.py#L20" rel="noopener noreferrer">main:20</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/dead_code_benchmark.py</td>
@@ -4000,7 +4087,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/dead_code_compare_scanners.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/dead_code_compare_scanners.py">main:74</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_compare_scanners.py#L74" rel="noopener noreferrer">main:74</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/dead_code_compare_scanners.py</td>
@@ -4008,7 +4095,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/quality_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/quality_benchmark.py">main:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/quality_benchmark.py#L16" rel="noopener noreferrer">main:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/quality_benchmark.py</td>
@@ -4016,7 +4103,7 @@
             
 
             <tr class="searchable" data-search="compare_corpus def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/regression_delta.py">compare_corpus:177</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L177" rel="noopener noreferrer">compare_corpus:177</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
@@ -4024,7 +4111,7 @@
             
 
             <tr class="searchable" data-search="compare_agent_review def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/regression_delta.py">compare_agent_review:210</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L210" rel="noopener noreferrer">compare_agent_review:210</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
@@ -4032,7 +4119,7 @@
             
 
             <tr class="searchable" data-search="compare_quality def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/regression_delta.py">compare_quality:267</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L267" rel="noopener noreferrer">compare_quality:267</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
@@ -4040,7 +4127,7 @@
             
 
             <tr class="searchable" data-search="compare def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/regression_delta.py">compare:323</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L323" rel="noopener noreferrer">compare:323</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
@@ -4048,15 +4135,31 @@
             
 
             <tr class="searchable" data-search="main def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/regression_delta.py">main:335</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L335" rel="noopener noreferrer">main:335</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
             </tr>
             
 
+            <tr class="searchable" data-search="render_mode_plan_templates def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L75" rel="noopener noreferrer">render_mode_plan_templates:75</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>scripts/repo_map_renderer.py</td>
+            </tr>
+            
+
+            <tr class="searchable" data-search="render_mode_selector def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L114" rel="noopener noreferrer">render_mode_selector:114</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>scripts/repo_map_renderer.py</td>
+            </tr>
+            
+
             <tr class="searchable" data-search="render_personas def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_personas:30</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L156" rel="noopener noreferrer">render_personas:156</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4064,7 +4167,7 @@
             
 
             <tr class="searchable" data-search="render_workflows def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_workflows:71</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L197" rel="noopener noreferrer">render_workflows:197</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4072,7 +4175,7 @@
             
 
             <tr class="searchable" data-search="render_first_steps def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_first_steps:113</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L239" rel="noopener noreferrer">render_first_steps:239</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4080,7 +4183,7 @@
             
 
             <tr class="searchable" data-search="render_sharp_edges def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_sharp_edges:132</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L258" rel="noopener noreferrer">render_sharp_edges:258</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4088,7 +4191,7 @@
             
 
             <tr class="searchable" data-search="render_architecture_layers def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_architecture_layers:148</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L274" rel="noopener noreferrer">render_architecture_layers:274</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4096,7 +4199,7 @@
             
 
             <tr class="searchable" data-search="render_docstring_guide def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_docstring_guide:197</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L323" rel="noopener noreferrer">render_docstring_guide:323</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4104,7 +4207,7 @@
             
 
             <tr class="searchable" data-search="render_flow def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_flow:224</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L350" rel="noopener noreferrer">render_flow:350</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4112,7 +4215,7 @@
             
 
             <tr class="searchable" data-search="render_folder_cards def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_folder_cards:259</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L385" rel="noopener noreferrer">render_folder_cards:385</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4120,7 +4223,7 @@
             
 
             <tr class="searchable" data-search="render_folder_card def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_folder_card:276</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L402" rel="noopener noreferrer">render_folder_card:402</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4128,7 +4231,7 @@
             
 
             <tr class="searchable" data-search="render_hot_modules def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_hot_modules:360</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L486" rel="noopener noreferrer">render_hot_modules:486</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4136,7 +4239,7 @@
             
 
             <tr class="searchable" data-search="render_symbol_index def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_symbol_index:407</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L533" rel="noopener noreferrer">render_symbol_index:533</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4144,7 +4247,7 @@
             
 
             <tr class="searchable" data-search="render_glossary def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_glossary:436</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L562" rel="noopener noreferrer">render_glossary:562</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4152,7 +4255,7 @@
             
 
             <tr class="searchable" data-search="render_html def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_html:448</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L574" rel="noopener noreferrer">render_html:574</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4160,7 +4263,7 @@
             
 
             <tr class="searchable" data-search="render_snapshot def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_snapshot:491</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L623" rel="noopener noreferrer">render_snapshot:623</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4168,7 +4271,7 @@
             
 
             <tr class="searchable" data-search="section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">section:521</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L653" rel="noopener noreferrer">section:653</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4176,7 +4279,7 @@
             
 
             <tr class="searchable" data-search="render_flow_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_flow_section:552</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L684" rel="noopener noreferrer">render_flow_section:684</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4184,7 +4287,7 @@
             
 
             <tr class="searchable" data-search="render_folder_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_folder_section:563</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L695" rel="noopener noreferrer">render_folder_section:695</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4192,7 +4295,7 @@
             
 
             <tr class="searchable" data-search="render_hot_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_hot_section:574</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L706" rel="noopener noreferrer">render_hot_section:706</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4200,7 +4303,7 @@
             
 
             <tr class="searchable" data-search="render_symbol_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/repo_map_renderer.py">render_symbol_section:589</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L721" rel="noopener noreferrer">render_symbol_section:721</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
@@ -4208,7 +4311,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/security_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/security_benchmark.py">main:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_benchmark.py#L16" rel="noopener noreferrer">main:16</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/security_benchmark.py</td>
@@ -4216,7 +4319,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/security_compare_scanners.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/security_compare_scanners.py">main:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_compare_scanners.py#L70" rel="noopener noreferrer">main:70</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/security_compare_scanners.py</td>
@@ -4224,7 +4327,7 @@
             
 
             <tr class="searchable" data-search="main def scripts/skylos_gate.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="../../scripts/skylos_gate.py">main:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/skylos_gate.py#L9" rel="noopener noreferrer">main:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/skylos_gate.py</td>
@@ -4232,7 +4335,7 @@
             
 
             <tr class="searchable" data-search="analyze def skylos/__init__.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/__init__.py">analyze:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py#L29" rel="noopener noreferrer">analyze:29</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/__init__.py</td>
@@ -4240,7 +4343,7 @@
             
 
             <tr class="searchable" data-search="debug_test def skylos/__init__.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/__init__.py">debug_test:35</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py#L35" rel="noopener noreferrer">debug_test:35</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/__init__.py</td>
@@ -4248,7 +4351,7 @@
             
 
             <tr class="searchable" data-search="get_adapter def skylos/adapters/__init__.py provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor.">
-              <td><a href="../../skylos/adapters/__init__.py">get_adapter:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py#L7" rel="noopener noreferrer">get_adapter:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/adapters/__init__.py</td>
@@ -4256,7 +4359,7 @@
             
 
             <tr class="searchable" data-search="baseadapter class skylos/adapters/base.py provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor.">
-              <td><a href="../../skylos/adapters/base.py">BaseAdapter:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py#L4" rel="noopener noreferrer">BaseAdapter:4</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/adapters/base.py</td>
@@ -4264,7 +4367,7 @@
             
 
             <tr class="searchable" data-search="litellmadapter class skylos/adapters/litellm_adapter.py provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor.">
-              <td><a href="../../skylos/adapters/litellm_adapter.py">LiteLLMAdapter:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py#L7" rel="noopener noreferrer">LiteLLMAdapter:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/adapters/litellm_adapter.py</td>
@@ -4272,7 +4375,7 @@
             
 
             <tr class="searchable" data-search="run_analyze def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">run_analyze:52</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L52" rel="noopener noreferrer">run_analyze:52</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4280,7 +4383,7 @@
             
 
             <tr class="searchable" data-search="collect_debt_signals def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">collect_debt_signals:58</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L58" rel="noopener noreferrer">collect_debt_signals:58</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4288,7 +4391,7 @@
             
 
             <tr class="searchable" data-search="discover_source_files def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">discover_source_files:64</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L64" rel="noopener noreferrer">discover_source_files:64</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4296,7 +4399,7 @@
             
 
             <tr class="searchable" data-search="resolve_project_root def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">resolve_project_root:72</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L72" rel="noopener noreferrer">resolve_project_root:72</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4304,7 +4407,7 @@
             
 
             <tr class="searchable" data-search="resolve_state_path def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">resolve_state_path:87</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L87" rel="noopener noreferrer">resolve_state_path:87</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4312,7 +4415,7 @@
             
 
             <tr class="searchable" data-search="load_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">load_agent_state:99</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L99" rel="noopener noreferrer">load_agent_state:99</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4320,7 +4423,7 @@
             
 
             <tr class="searchable" data-search="save_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">save_agent_state:112</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L112" rel="noopener noreferrer">save_agent_state:112</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4328,7 +4431,7 @@
             
 
             <tr class="searchable" data-search="snapshot_file_signatures def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">snapshot_file_signatures:123</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L123" rel="noopener noreferrer">snapshot_file_signatures:123</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4336,7 +4439,7 @@
             
 
             <tr class="searchable" data-search="detect_changed_files def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">detect_changed_files:153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L153" rel="noopener noreferrer">detect_changed_files:153</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4344,7 +4447,7 @@
             
 
             <tr class="searchable" data-search="normalize_triage_map def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">normalize_triage_map:170</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L170" rel="noopener noreferrer">normalize_triage_map:170</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4352,7 +4455,7 @@
             
 
             <tr class="searchable" data-search="apply_triage_to_findings def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">apply_triage_to_findings:192</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L192" rel="noopener noreferrer">apply_triage_to_findings:192</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4360,7 +4463,7 @@
             
 
             <tr class="searchable" data-search="compose_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">compose_agent_state:213</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L213" rel="noopener noreferrer">compose_agent_state:213</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4368,7 +4471,7 @@
             
 
             <tr class="searchable" data-search="rebuild_agent_state_from_existing def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">rebuild_agent_state_from_existing:276</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L276" rel="noopener noreferrer">rebuild_agent_state_from_existing:276</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4376,7 +4479,7 @@
             
 
             <tr class="searchable" data-search="update_action_triage def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">update_action_triage:302</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L302" rel="noopener noreferrer">update_action_triage:302</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4384,7 +4487,7 @@
             
 
             <tr class="searchable" data-search="clear_action_triage def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">clear_action_triage:339</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L339" rel="noopener noreferrer">clear_action_triage:339</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4392,7 +4495,7 @@
             
 
             <tr class="searchable" data-search="refresh_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">refresh_agent_state:507</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L507" rel="noopener noreferrer">refresh_agent_state:507</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4400,7 +4503,7 @@
             
 
             <tr class="searchable" data-search="watch_project def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">watch_project:653</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L653" rel="noopener noreferrer">watch_project:653</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4408,7 +4511,7 @@
             
 
             <tr class="searchable" data-search="normalize_findings def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">normalize_findings:703</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L703" rel="noopener noreferrer">normalize_findings:703</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4416,7 +4519,7 @@
             
 
             <tr class="searchable" data-search="build_ranked_actions def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">build_ranked_actions:760</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L760" rel="noopener noreferrer">build_ranked_actions:760</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4424,7 +4527,7 @@
             
 
             <tr class="searchable" data-search="build_summary def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">build_summary:766</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L766" rel="noopener noreferrer">build_summary:766</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4432,7 +4535,7 @@
             
 
             <tr class="searchable" data-search="build_headline def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">build_headline:783</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L783" rel="noopener noreferrer">build_headline:783</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4440,7 +4543,7 @@
             
 
             <tr class="searchable" data-search="render_status_table def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">render_status_table:802</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L802" rel="noopener noreferrer">render_status_table:802</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4448,7 +4551,7 @@
             
 
             <tr class="searchable" data-search="command_center_payload def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">command_center_payload:806</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L806" rel="noopener noreferrer">command_center_payload:806</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4456,7 +4559,7 @@
             
 
             <tr class="searchable" data-search="debt_hotspot_severity def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">debt_hotspot_severity:860</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L860" rel="noopener noreferrer">debt_hotspot_severity:860</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4464,7 +4567,7 @@
             
 
             <tr class="searchable" data-search="debt_hotspot_message def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">debt_hotspot_message:884</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L884" rel="noopener noreferrer">debt_hotspot_message:884</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4472,7 +4575,7 @@
             
 
             <tr class="searchable" data-search="dead_code_rule_id def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">dead_code_rule_id:985</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L985" rel="noopener noreferrer">dead_code_rule_id:985</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4480,7 +4583,7 @@
             
 
             <tr class="searchable" data-search="finding_fingerprint def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">finding_fingerprint:995</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L995" rel="noopener noreferrer">finding_fingerprint:995</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4488,7 +4591,7 @@
             
 
             <tr class="searchable" data-search="relative_path def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">relative_path:1001</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1001" rel="noopener noreferrer">relative_path:1001</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4496,7 +4599,7 @@
             
 
             <tr class="searchable" data-search="resolve_file_path def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">resolve_file_path:1010</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1010" rel="noopener noreferrer">resolve_file_path:1010</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4504,7 +4607,7 @@
             
 
             <tr class="searchable" data-search="normalize_severity def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">normalize_severity:1017</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1017" rel="noopener noreferrer">normalize_severity:1017</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4512,7 +4615,7 @@
             
 
             <tr class="searchable" data-search="severity_score def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">severity_score:1026</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1026" rel="noopener noreferrer">severity_score:1026</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4520,7 +4623,7 @@
             
 
             <tr class="searchable" data-search="build_action_title def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">build_action_title:1030</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1030" rel="noopener noreferrer">build_action_title:1030</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4528,7 +4631,7 @@
             
 
             <tr class="searchable" data-search="build_action_subtitle def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">build_action_subtitle:1034</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1034" rel="noopener noreferrer">build_action_subtitle:1034</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4536,7 +4639,7 @@
             
 
             <tr class="searchable" data-search="build_action_reason def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">build_action_reason:1038</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1038" rel="noopener noreferrer">build_action_reason:1038</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4544,7 +4647,7 @@
             
 
             <tr class="searchable" data-search="infer_action_type def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">infer_action_type:1042</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1042" rel="noopener noreferrer">infer_action_type:1042</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4552,7 +4655,7 @@
             
 
             <tr class="searchable" data-search="infer_safe_fix def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">infer_safe_fix:1046</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1046" rel="noopener noreferrer">infer_safe_fix:1046</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4560,7 +4663,7 @@
             
 
             <tr class="searchable" data-search="parse_utc_timestamp def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">parse_utc_timestamp:1050</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1050" rel="noopener noreferrer">parse_utc_timestamp:1050</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4568,7 +4671,7 @@
             
 
             <tr class="searchable" data-search="utc_now def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/center.py">utc_now:1066</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1066" rel="noopener noreferrer">utc_now:1066</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
@@ -4576,7 +4679,7 @@
             
 
             <tr class="searchable" data-search="severity_score def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">severity_score:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L6" rel="noopener noreferrer">severity_score:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4584,7 +4687,7 @@
             
 
             <tr class="searchable" data-search="build_action_title def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">build_action_title:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L19" rel="noopener noreferrer">build_action_title:19</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4592,7 +4695,7 @@
             
 
             <tr class="searchable" data-search="build_action_subtitle def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">build_action_subtitle:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L28" rel="noopener noreferrer">build_action_subtitle:28</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4600,7 +4703,7 @@
             
 
             <tr class="searchable" data-search="build_action_reason def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">build_action_reason:33</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L33" rel="noopener noreferrer">build_action_reason:33</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4608,7 +4711,7 @@
             
 
             <tr class="searchable" data-search="infer_action_type def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">infer_action_type:54</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L54" rel="noopener noreferrer">infer_action_type:54</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4616,7 +4719,7 @@
             
 
             <tr class="searchable" data-search="infer_safe_fix def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">infer_safe_fix:64</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L64" rel="noopener noreferrer">infer_safe_fix:64</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4624,7 +4727,7 @@
             
 
             <tr class="searchable" data-search="build_ranked_actions def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">build_ranked_actions:74</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L74" rel="noopener noreferrer">build_ranked_actions:74</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4632,7 +4735,7 @@
             
 
             <tr class="searchable" data-search="build_headline def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">build_headline:140</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L140" rel="noopener noreferrer">build_headline:140</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4640,7 +4743,7 @@
             
 
             <tr class="searchable" data-search="build_summary def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">build_summary:163</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L163" rel="noopener noreferrer">build_summary:163</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4648,7 +4751,7 @@
             
 
             <tr class="searchable" data-search="render_status_table def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">render_status_table:229</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L229" rel="noopener noreferrer">render_status_table:229</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4656,7 +4759,7 @@
             
 
             <tr class="searchable" data-search="command_center_payload def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/payload.py">command_center_payload:239</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L239" rel="noopener noreferrer">command_center_payload:239</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
@@ -4664,7 +4767,7 @@
             
 
             <tr class="searchable" data-search="agentservicecontroller class skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/service.py">AgentServiceController:83</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L83" rel="noopener noreferrer">AgentServiceController:83</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
@@ -4672,7 +4775,7 @@
             
 
             <tr class="searchable" data-search="agentservicehandler class skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/service.py">AgentServiceHandler:296</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L296" rel="noopener noreferrer">AgentServiceHandler:296</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
@@ -4680,7 +4783,7 @@
             
 
             <tr class="searchable" data-search="safeagentservicehandler class skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/service.py">SafeAgentServiceHandler:428</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L428" rel="noopener noreferrer">SafeAgentServiceHandler:428</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
@@ -4688,7 +4791,7 @@
             
 
             <tr class="searchable" data-search="create_agent_service def skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/service.py">create_agent_service:467</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L467" rel="noopener noreferrer">create_agent_service:467</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
@@ -4696,7 +4799,7 @@
             
 
             <tr class="searchable" data-search="serve_agent_service def skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/service.py">serve_agent_service:508</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L508" rel="noopener noreferrer">serve_agent_service:508</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
@@ -4704,7 +4807,7 @@
             
 
             <tr class="searchable" data-search="triagepattern class skylos/agents/triage_learner.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/triage_learner.py">TriagePattern:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L22" rel="noopener noreferrer">TriagePattern:22</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/triage_learner.py</td>
@@ -4712,7 +4815,7 @@
             
 
             <tr class="searchable" data-search="triagelearner class skylos/agents/triage_learner.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="../../skylos/agents/triage_learner.py">TriageLearner:143</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L143" rel="noopener noreferrer">TriageLearner:143</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/triage_learner.py</td>
@@ -4720,7 +4823,7 @@
             
 
             <tr class="searchable" data-search="modulemetrics class skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="../../skylos/analysis/architecture.py">ModuleMetrics:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L22" rel="noopener noreferrer">ModuleMetrics:22</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
@@ -4728,7 +4831,7 @@
             
 
             <tr class="searchable" data-search="dipviolation class skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="../../skylos/analysis/architecture.py">DIPViolation:45</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L45" rel="noopener noreferrer">DIPViolation:45</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
@@ -4736,7 +4839,7 @@
             
 
             <tr class="searchable" data-search="architectureresult class skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="../../skylos/analysis/architecture.py">ArchitectureResult:54</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L54" rel="noopener noreferrer">ArchitectureResult:54</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
@@ -4744,7 +4847,7 @@
             
 
             <tr class="searchable" data-search="analyze_architecture def skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="../../skylos/analysis/architecture.py">analyze_architecture:200</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L200" rel="noopener noreferrer">analyze_architecture:200</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
@@ -4752,7 +4855,7 @@
             
 
             <tr class="searchable" data-search="get_architecture_findings def skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="../../skylos/analysis/architecture.py">get_architecture_findings:428</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L428" rel="noopener noreferrer">get_architecture_findings:428</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
@@ -4760,7 +4863,7 @@
             
 
             <tr class="searchable" data-search="generate_architecture_findings def skylos/analysis/architecture_findings.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/architecture_findings.py">generate_architecture_findings:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_findings.py#L102" rel="noopener noreferrer">generate_architecture_findings:102</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture_findings.py</td>
@@ -4768,7 +4871,7 @@
             
 
             <tr class="searchable" data-search="get_layer_policy_findings def skylos/analysis/architecture_layers.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/architecture_layers.py">get_layer_policy_findings:117</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_layers.py#L117" rel="noopener noreferrer">get_layer_policy_findings:117</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture_layers.py</td>
@@ -4776,7 +4879,7 @@
             
 
             <tr class="searchable" data-search="maskspec class skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/ast_mask.py">MaskSpec:62</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L62" rel="noopener noreferrer">MaskSpec:62</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
@@ -4784,7 +4887,7 @@
             
 
             <tr class="searchable" data-search="bodymasker class skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/ast_mask.py">BodyMasker:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L70" rel="noopener noreferrer">BodyMasker:70</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
@@ -4792,7 +4895,7 @@
             
 
             <tr class="searchable" data-search="apply_body_mask def skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/ast_mask.py">apply_body_mask:140</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L140" rel="noopener noreferrer">apply_body_mask:140</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
@@ -4800,7 +4903,7 @@
             
 
             <tr class="searchable" data-search="default_mask_spec_from_config def skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/ast_mask.py">default_mask_spec_from_config:150</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L150" rel="noopener noreferrer">default_mask_spec_from_config:150</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
@@ -4808,7 +4911,7 @@
             
 
             <tr class="searchable" data-search="moduledependency class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/circular_deps.py">ModuleDependency:57</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L57" rel="noopener noreferrer">ModuleDependency:57</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
@@ -4816,7 +4919,7 @@
             
 
             <tr class="searchable" data-search="circulardependency class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/circular_deps.py">CircularDependency:66</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L66" rel="noopener noreferrer">CircularDependency:66</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
@@ -4824,7 +4927,7 @@
             
 
             <tr class="searchable" data-search="dependencygraphbuilder class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/circular_deps.py">DependencyGraphBuilder:84</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L84" rel="noopener noreferrer">DependencyGraphBuilder:84</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
@@ -4832,7 +4935,7 @@
             
 
             <tr class="searchable" data-search="circulardependencyanalyzer class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/circular_deps.py">CircularDependencyAnalyzer:152</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L152" rel="noopener noreferrer">CircularDependencyAnalyzer:152</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
@@ -4840,7 +4943,7 @@
             
 
             <tr class="searchable" data-search="circulardependencyrule class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/circular_deps.py">CircularDependencyRule:336</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L336" rel="noopener noreferrer">CircularDependencyRule:336</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
@@ -4848,7 +4951,7 @@
             
 
             <tr class="searchable" data-search="analyze_circular_dependencies def skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/circular_deps.py">analyze_circular_dependencies:381</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L381" rel="noopener noreferrer">analyze_circular_dependencies:381</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
@@ -4856,7 +4959,7 @@
             
 
             <tr class="searchable" data-search="evaluate_static_condition def skylos/analysis/control_flow.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/control_flow.py">evaluate_static_condition:143</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py#L143" rel="noopener noreferrer">evaluate_static_condition:143</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/control_flow.py</td>
@@ -4864,7 +4967,7 @@
             
 
             <tr class="searchable" data-search="extract_constant_string def skylos/analysis/control_flow.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/control_flow.py">extract_constant_string:215</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py#L215" rel="noopener noreferrer">extract_constant_string:215</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/control_flow.py</td>
@@ -4872,7 +4975,7 @@
             
 
             <tr class="searchable" data-search="implicitreftracker class skylos/analysis/implicit_refs.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/implicit_refs.py">ImplicitRefTracker:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/implicit_refs.py#L11" rel="noopener noreferrer">ImplicitRefTracker:11</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/implicit_refs.py</td>
@@ -4880,7 +4983,7 @@
             
 
             <tr class="searchable" data-search="matches_pattern def skylos/analysis/known_patterns.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/known_patterns.py">matches_pattern:592</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L592" rel="noopener noreferrer">matches_pattern:592</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/known_patterns.py</td>
@@ -4888,7 +4991,7 @@
             
 
             <tr class="searchable" data-search="has_base_class def skylos/analysis/known_patterns.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/known_patterns.py">has_base_class:596</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L596" rel="noopener noreferrer">has_base_class:596</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/known_patterns.py</td>
@@ -4896,7 +4999,7 @@
             
 
             <tr class="searchable" data-search="modulereachabilityanalyzer class skylos/analysis/module_reachability.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/module_reachability.py">ModuleReachabilityAnalyzer:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py#L28" rel="noopener noreferrer">ModuleReachabilityAnalyzer:28</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/module_reachability.py</td>
@@ -4904,7 +5007,7 @@
             
 
             <tr class="searchable" data-search="find_unreachable_modules def skylos/analysis/module_reachability.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/module_reachability.py">find_unreachable_modules:234</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py#L234" rel="noopener noreferrer">find_unreachable_modules:234</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/module_reachability.py</td>
@@ -4912,7 +5015,7 @@
             
 
             <tr class="searchable" data-search="apply_penalties def skylos/analysis/penalties.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/penalties.py">apply_penalties:1038</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L1038" rel="noopener noreferrer">apply_penalties:1038</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/penalties.py</td>
@@ -4920,7 +5023,7 @@
             
 
             <tr class="searchable" data-search="extract_entrypoints def skylos/analysis/pyproject_entrypoints.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="../../skylos/analysis/pyproject_entrypoints.py">extract_entrypoints:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/pyproject_entrypoints.py#L25" rel="noopener noreferrer">extract_entrypoints:25</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/pyproject_entrypoints.py</td>
@@ -4928,7 +5031,7 @@
             
 
             <tr class="searchable" data-search="_entrypoint_module_name def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_entrypoint_module_name:148</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L148" rel="noopener noreferrer">_entrypoint_module_name:148</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4936,7 +5039,7 @@
             
 
             <tr class="searchable" data-search="_architecture_iad_strict def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_architecture_iad_strict:155</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L155" rel="noopener noreferrer">_architecture_iad_strict:155</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4944,7 +5047,7 @@
             
 
             <tr class="searchable" data-search="_expand_reexported_entrypoint_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_expand_reexported_entrypoint_modules:164</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L164" rel="noopener noreferrer">_expand_reexported_entrypoint_modules:164</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4952,7 +5055,7 @@
             
 
             <tr class="searchable" data-search="_find_package_boundary_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_find_package_boundary_modules:194</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L194" rel="noopener noreferrer">_find_package_boundary_modules:194</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4960,7 +5063,7 @@
             
 
             <tr class="searchable" data-search="_set_linter_node_types def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_set_linter_node_types:294</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L294" rel="noopener noreferrer">_set_linter_node_types:294</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4968,7 +5071,7 @@
             
 
             <tr class="searchable" data-search="_is_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_is_secret_config_candidate:301</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L301" rel="noopener noreferrer">_is_secret_config_candidate:301</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4976,7 +5079,7 @@
             
 
             <tr class="searchable" data-search="_resolve_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_resolve_secret_config_candidate:308</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L308" rel="noopener noreferrer">_resolve_secret_config_candidate:308</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4984,7 +5087,7 @@
             
 
             <tr class="searchable" data-search="_definition_module_and_class def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_definition_module_and_class:344</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L344" rel="noopener noreferrer">_definition_module_and_class:344</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -4992,7 +5095,7 @@
             
 
             <tr class="searchable" data-search="_resolve_analysis_root def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_resolve_analysis_root:354</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L354" rel="noopener noreferrer">_resolve_analysis_root:354</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5000,7 +5103,7 @@
             
 
             <tr class="searchable" data-search="_grep_verify_rescue_priority def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_grep_verify_rescue_priority:391</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L391" rel="noopener noreferrer">_grep_verify_rescue_priority:391</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5008,7 +5111,7 @@
             
 
             <tr class="searchable" data-search="_confidence_as_unit_interval def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_confidence_as_unit_interval:402</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L402" rel="noopener noreferrer">_confidence_as_unit_interval:402</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5016,7 +5119,7 @@
             
 
             <tr class="searchable" data-search="_implicit_ref_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_implicit_ref_evidence_marker:412</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L412" rel="noopener noreferrer">_implicit_ref_evidence_marker:412</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5024,7 +5127,7 @@
             
 
             <tr class="searchable" data-search="_mark_evidence_ref def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_mark_evidence_ref:426</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L426" rel="noopener noreferrer">_mark_evidence_ref:426</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5032,7 +5135,7 @@
             
 
             <tr class="searchable" data-search="_has_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_has_evidence_marker:433</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L433" rel="noopener noreferrer">_has_evidence_marker:433</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5040,7 +5143,7 @@
             
 
             <tr class="searchable" data-search="_annotate_dead_code_evidence_sources def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_annotate_dead_code_evidence_sources:440</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L440" rel="noopener noreferrer">_annotate_dead_code_evidence_sources:440</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5048,7 +5151,7 @@
             
 
             <tr class="searchable" data-search="skylos class skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">Skylos:459</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L459" rel="noopener noreferrer">Skylos:459</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
@@ -5056,7 +5159,7 @@
             
 
             <tr class="searchable" data-search="_is_truly_empty_or_docstring_only def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">_is_truly_empty_or_docstring_only:3023</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3023" rel="noopener noreferrer">_is_truly_empty_or_docstring_only:3023</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5064,7 +5167,7 @@
             
 
             <tr class="searchable" data-search="proc_file def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">proc_file:3041</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3041" rel="noopener noreferrer">proc_file:3041</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
@@ -5072,7 +5175,7 @@
             
 
             <tr class="searchable" data-search="analyze def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/analyzer.py">analyze:3548</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3548" rel="noopener noreferrer">analyze:3548</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
@@ -5080,7 +5183,7 @@
             
 
             <tr class="searchable" data-search="get_project_token def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">get_project_token:338</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L338" rel="noopener noreferrer">get_project_token:338</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5088,7 +5191,7 @@
             
 
             <tr class="searchable" data-search="get_project_info def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">get_project_info:368</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L368" rel="noopener noreferrer">get_project_info:368</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5096,7 +5199,7 @@
             
 
             <tr class="searchable" data-search="get_credit_balance def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">get_credit_balance:386</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L386" rel="noopener noreferrer">get_credit_balance:386</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5104,7 +5207,7 @@
             
 
             <tr class="searchable" data-search="print_credit_status def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">print_credit_status:404</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L404" rel="noopener noreferrer">print_credit_status:404</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5112,7 +5215,7 @@
             
 
             <tr class="searchable" data-search="get_git_root def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">get_git_root:422</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L422" rel="noopener noreferrer">get_git_root:422</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5120,7 +5223,7 @@
             
 
             <tr class="searchable" data-search="get_git_info def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">get_git_info:486</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L486" rel="noopener noreferrer">get_git_info:486</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5128,7 +5231,7 @@
             
 
             <tr class="searchable" data-search="detect_ai_code def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">detect_ai_code:595</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L595" rel="noopener noreferrer">detect_ai_code:595</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5136,7 +5239,7 @@
             
 
             <tr class="searchable" data-search="upload_report_legacy def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">upload_report_legacy:1252</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1252" rel="noopener noreferrer">upload_report_legacy:1252</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5144,7 +5247,7 @@
             
 
             <tr class="searchable" data-search="upload_report_compatibility def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">upload_report_compatibility:1279</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1279" rel="noopener noreferrer">upload_report_compatibility:1279</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5152,7 +5255,7 @@
             
 
             <tr class="searchable" data-search="upload_report_v2 def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">upload_report_v2:1301</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1301" rel="noopener noreferrer">upload_report_v2:1301</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5160,7 +5263,7 @@
             
 
             <tr class="searchable" data-search="upload_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">upload_report:1514</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1514" rel="noopener noreferrer">upload_report:1514</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5168,7 +5271,7 @@
             
 
             <tr class="searchable" data-search="upload_debt_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">upload_debt_report:1577</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1577" rel="noopener noreferrer">upload_debt_report:1577</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5176,7 +5279,7 @@
             
 
             <tr class="searchable" data-search="upload_defense_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">upload_defense_report:1652</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1652" rel="noopener noreferrer">upload_defense_report:1652</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5184,7 +5287,7 @@
             
 
             <tr class="searchable" data-search="upload_agent_run def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">upload_agent_run:1782</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1782" rel="noopener noreferrer">upload_agent_run:1782</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5192,7 +5295,7 @@
             
 
             <tr class="searchable" data-search="verify_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/__init__.py">verify_report:1821</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1821" rel="noopener noreferrer">verify_report:1821</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
@@ -5200,7 +5303,7 @@
             
 
             <tr class="searchable" data-search="detect_ai_code def skylos/api/_ai_detection.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/_ai_detection.py">detect_ai_code:46</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_ai_detection.py#L46" rel="noopener noreferrer">detect_ai_code:46</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_ai_detection.py</td>
@@ -5208,7 +5311,7 @@
             
 
             <tr class="searchable" data-search="uploadartifact class skylos/api/_artifacts.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/_artifacts.py">UploadArtifact:39</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L39" rel="noopener noreferrer">UploadArtifact:39</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_artifacts.py</td>
@@ -5216,7 +5319,7 @@
             
 
             <tr class="searchable" data-search="preparedreportupload class skylos/api/_artifacts.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/_artifacts.py">PreparedReportUpload:65</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L65" rel="noopener noreferrer">PreparedReportUpload:65</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_artifacts.py</td>
@@ -5224,7 +5327,7 @@
             
 
             <tr class="searchable" data-search="upload_artifact def skylos/api/_artifacts.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/_artifacts.py">upload_artifact:162</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L162" rel="noopener noreferrer">upload_artifact:162</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_artifacts.py</td>
@@ -5232,7 +5335,7 @@
             
 
             <tr class="searchable" data-search="extract_snippet def skylos/api/_snippets.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="../../skylos/api/_snippets.py">extract_snippet:30</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_snippets.py#L30" rel="noopener noreferrer">extract_snippet:30</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_snippets.py</td>
@@ -5240,7 +5343,7 @@
             
 
             <tr class="searchable" data-search="scan_deep_audit_candidates def skylos/audit/candidates.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/candidates.py">scan_deep_audit_candidates:82</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L82" rel="noopener noreferrer">scan_deep_audit_candidates:82</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/candidates.py</td>
@@ -5248,7 +5351,7 @@
             
 
             <tr class="searchable" data-search="evaluate_deep_audit_ci_gate def skylos/audit/ci.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/ci.py">evaluate_deep_audit_ci_gate:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py#L29" rel="noopener noreferrer">evaluate_deep_audit_ci_gate:29</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/ci.py</td>
@@ -5256,7 +5359,7 @@
             
 
             <tr class="searchable" data-search="build_deep_audit_export def skylos/audit/export.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/export.py">build_deep_audit_export:49</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L49" rel="noopener noreferrer">build_deep_audit_export:49</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/export.py</td>
@@ -5264,7 +5367,7 @@
             
 
             <tr class="searchable" data-search="render_deep_audit_export def skylos/audit/export.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/export.py">render_deep_audit_export:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L102" rel="noopener noreferrer">render_deep_audit_export:102</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/export.py</td>
@@ -5272,7 +5375,7 @@
             
 
             <tr class="searchable" data-search="write_deep_audit_export def skylos/audit/export.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/export.py">write_deep_audit_export:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L116" rel="noopener noreferrer">write_deep_audit_export:116</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/export.py</td>
@@ -5280,7 +5383,7 @@
             
 
             <tr class="searchable" data-search="polyglotsignalrule class skylos/audit/polyglot.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/polyglot.py">PolyglotSignalRule:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py#L18" rel="noopener noreferrer">PolyglotSignalRule:18</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/polyglot.py</td>
@@ -5288,7 +5391,7 @@
             
 
             <tr class="searchable" data-search="build_polyglot_signal_candidates def skylos/audit/polyglot.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/polyglot.py">build_polyglot_signal_candidates:300</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py#L300" rel="noopener noreferrer">build_polyglot_signal_candidates:300</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/polyglot.py</td>
@@ -5296,7 +5399,7 @@
             
 
             <tr class="searchable" data-search="process_deep_audit_records def skylos/audit/processor.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/processor.py">process_deep_audit_records:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L29" rel="noopener noreferrer">process_deep_audit_records:29</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/processor.py</td>
@@ -5304,7 +5407,7 @@
             
 
             <tr class="searchable" data-search="redact_text def skylos/audit/redaction.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/redaction.py">redact_text:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/redaction.py#L43" rel="noopener noreferrer">redact_text:43</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/redaction.py</td>
@@ -5312,7 +5415,7 @@
             
 
             <tr class="searchable" data-search="sanitize_for_audit def skylos/audit/redaction.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/redaction.py">sanitize_for_audit:55</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/redaction.py#L55" rel="noopener noreferrer">sanitize_for_audit:55</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/redaction.py</td>
@@ -5320,7 +5423,7 @@
             
 
             <tr class="searchable" data-search="revalidate_deep_audit_findings def skylos/audit/revalidator.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/revalidator.py">revalidate_deep_audit_findings:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py#L22" rel="noopener noreferrer">revalidate_deep_audit_findings:22</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/revalidator.py</td>
@@ -5328,7 +5431,7 @@
             
 
             <tr class="searchable" data-search="auditstore class skylos/audit/store.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/store.py">AuditStore:30</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/store.py#L30" rel="noopener noreferrer">AuditStore:30</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/store.py</td>
@@ -5336,7 +5439,7 @@
             
 
             <tr class="searchable" data-search="utc_now def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">utc_now:35</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L35" rel="noopener noreferrer">utc_now:35</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5344,7 +5447,7 @@
             
 
             <tr class="searchable" data-search="sha256_text def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">sha256_text:39</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L39" rel="noopener noreferrer">sha256_text:39</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5352,7 +5455,7 @@
             
 
             <tr class="searchable" data-search="sha256_file def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">sha256_file:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L43" rel="noopener noreferrer">sha256_file:43</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5360,7 +5463,7 @@
             
 
             <tr class="searchable" data-search="stable_json_hash def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">stable_json_hash:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L51" rel="noopener noreferrer">stable_json_hash:51</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5368,7 +5471,7 @@
             
 
             <tr class="searchable" data-search="normalize_relative_path def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">normalize_relative_path:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L59" rel="noopener noreferrer">normalize_relative_path:59</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5376,7 +5479,7 @@
             
 
             <tr class="searchable" data-search="language_for_path def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">language_for_path:72</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L72" rel="noopener noreferrer">language_for_path:72</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5384,7 +5487,7 @@
             
 
             <tr class="searchable" data-search="code_region_hash def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">code_region_hash:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L101" rel="noopener noreferrer">code_region_hash:101</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5392,7 +5495,7 @@
             
 
             <tr class="searchable" data-search="auditcandidate class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">AuditCandidate:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L116" rel="noopener noreferrer">AuditCandidate:116</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5400,7 +5503,7 @@
             
 
             <tr class="searchable" data-search="auditfilerecord class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">AuditFileRecord:174</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L174" rel="noopener noreferrer">AuditFileRecord:174</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5408,7 +5511,7 @@
             
 
             <tr class="searchable" data-search="auditscansummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">AuditScanSummary:277</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L277" rel="noopener noreferrer">AuditScanSummary:277</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5416,7 +5519,7 @@
             
 
             <tr class="searchable" data-search="auditprocesssummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">AuditProcessSummary:309</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L309" rel="noopener noreferrer">AuditProcessSummary:309</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5424,7 +5527,7 @@
             
 
             <tr class="searchable" data-search="auditcigatesummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">AuditCIGateSummary:351</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L351" rel="noopener noreferrer">AuditCIGateSummary:351</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5432,7 +5535,7 @@
             
 
             <tr class="searchable" data-search="auditrevalidationsummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="../../skylos/audit/types.py">AuditRevalidationSummary:369</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L369" rel="noopener noreferrer">AuditRevalidationSummary:369</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5440,7 +5543,7 @@
             
 
             <tr class="searchable" data-search="agentreviewbenchmarkfailure class skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/agent_review.py">AgentReviewBenchmarkFailure:55</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
@@ -5448,7 +5551,7 @@
             
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/agent_review.py">load_manifest:72</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
@@ -5456,7 +5559,7 @@
             
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/agent_review.py">validate_manifest:76</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
@@ -5464,7 +5567,7 @@
             
 
             <tr class="searchable" data-search="prepare_case_scan def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/agent_review.py">prepare_case_scan:243</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L243" rel="noopener noreferrer">prepare_case_scan:243</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
@@ -5472,7 +5575,7 @@
             
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/agent_review.py">run_case:435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L435" rel="noopener noreferrer">run_case:435</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
@@ -5480,7 +5583,7 @@
             
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/agent_review.py">run_manifest:548</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L548" rel="noopener noreferrer">run_manifest:548</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
@@ -5488,7 +5591,7 @@
             
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/agent_review.py">format_summary:622</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L622" rel="noopener noreferrer">format_summary:622</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
@@ -5496,7 +5599,7 @@
             
 
             <tr class="searchable" data-search="corpusfailure class skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/corpus_ci.py">CorpusFailure:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L12" rel="noopener noreferrer">CorpusFailure:12</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
@@ -5504,7 +5607,7 @@
             
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/corpus_ci.py">load_manifest:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L29" rel="noopener noreferrer">load_manifest:29</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
@@ -5512,7 +5615,7 @@
             
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/corpus_ci.py">validate_manifest:34</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L34" rel="noopener noreferrer">validate_manifest:34</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
@@ -5520,7 +5623,7 @@
             
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/corpus_ci.py">run_case:126</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L126" rel="noopener noreferrer">run_case:126</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
@@ -5528,7 +5631,7 @@
             
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/corpus_ci.py">run_manifest:185</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L185" rel="noopener noreferrer">run_manifest:185</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
@@ -5536,7 +5639,7 @@
             
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/corpus_ci.py">format_summary:207</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L207" rel="noopener noreferrer">format_summary:207</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
@@ -5544,7 +5647,7 @@
             
 
             <tr class="searchable" data-search="deadcodekey class skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">DeadCodeKey:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L102" rel="noopener noreferrer">DeadCodeKey:102</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5552,7 +5655,7 @@
             
 
             <tr class="searchable" data-search="deadcodebenchmarkfailure class skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">DeadCodeBenchmarkFailure:112</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L112" rel="noopener noreferrer">DeadCodeBenchmarkFailure:112</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5560,7 +5663,7 @@
             
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">load_manifest:129</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L129" rel="noopener noreferrer">load_manifest:129</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5568,7 +5671,7 @@
             
 
             <tr class="searchable" data-search="load_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">load_external_targets:133</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L133" rel="noopener noreferrer">load_external_targets:133</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5576,7 +5679,7 @@
             
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">validate_manifest:305</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L305" rel="noopener noreferrer">validate_manifest:305</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5584,7 +5687,7 @@
             
 
             <tr class="searchable" data-search="validate_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">validate_external_targets:331</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L331" rel="noopener noreferrer">validate_external_targets:331</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5592,7 +5695,7 @@
             
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">run_case:688</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L688" rel="noopener noreferrer">run_case:688</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5600,7 +5703,7 @@
             
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">run_manifest:915</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L915" rel="noopener noreferrer">run_manifest:915</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5608,7 +5711,7 @@
             
 
             <tr class="searchable" data-search="run_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">run_external_targets:981</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L981" rel="noopener noreferrer">run_external_targets:981</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5616,7 +5719,7 @@
             
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/dead_code.py">format_summary:1019</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L1019" rel="noopener noreferrer">format_summary:1019</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5624,7 +5727,7 @@
             
 
             <tr class="searchable" data-search="demodeadcodecase class skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/demo_deadcode.py">DemoDeadCodeCase:54</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L54" rel="noopener noreferrer">DemoDeadCodeCase:54</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
@@ -5632,7 +5735,7 @@
             
 
             <tr class="searchable" data-search="case_key def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/demo_deadcode.py">case_key:65</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L65" rel="noopener noreferrer">case_key:65</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
@@ -5640,7 +5743,7 @@
             
 
             <tr class="searchable" data-search="hard_cases def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/demo_deadcode.py">hard_cases:69</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L69" rel="noopener noreferrer">hard_cases:69</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
@@ -5648,7 +5751,7 @@
             
 
             <tr class="searchable" data-search="hard_case_keys def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/demo_deadcode.py">hard_case_keys:92</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L92" rel="noopener noreferrer">hard_case_keys:92</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
@@ -5656,7 +5759,7 @@
             
 
             <tr class="searchable" data-search="load_corrected_ground_truth def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/demo_deadcode.py">load_corrected_ground_truth:96</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L96" rel="noopener noreferrer">load_corrected_ground_truth:96</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
@@ -5664,7 +5767,7 @@
             
 
             <tr class="searchable" data-search="normalize_skylos_symbol def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/demo_deadcode.py">normalize_skylos_symbol:123</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L123" rel="noopener noreferrer">normalize_skylos_symbol:123</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
@@ -5672,7 +5775,7 @@
             
 
             <tr class="searchable" data-search="score_case_predictions def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/demo_deadcode.py">score_case_predictions:138</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L138" rel="noopener noreferrer">score_case_predictions:138</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
@@ -5680,7 +5783,7 @@
             
 
             <tr class="searchable" data-search="qualitybenchmarkfailure class skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/quality.py">QualityBenchmarkFailure:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L43" rel="noopener noreferrer">QualityBenchmarkFailure:43</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
@@ -5688,7 +5791,7 @@
             
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/quality.py">load_manifest:62</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L62" rel="noopener noreferrer">load_manifest:62</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
@@ -5696,7 +5799,7 @@
             
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/quality.py">validate_manifest:67</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L67" rel="noopener noreferrer">validate_manifest:67</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
@@ -5704,7 +5807,7 @@
             
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/quality.py">run_case:322</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L322" rel="noopener noreferrer">run_case:322</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
@@ -5712,7 +5815,7 @@
             
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/quality.py">run_manifest:384</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L384" rel="noopener noreferrer">run_manifest:384</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
@@ -5720,7 +5823,7 @@
             
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/quality.py">format_summary:469</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L469" rel="noopener noreferrer">format_summary:469</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
@@ -5728,7 +5831,7 @@
             
 
             <tr class="searchable" data-search="securitybenchmarkfailure class skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/security.py">SecurityBenchmarkFailure:78</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L78" rel="noopener noreferrer">SecurityBenchmarkFailure:78</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5736,7 +5839,7 @@
             
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/security.py">load_manifest:97</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L97" rel="noopener noreferrer">load_manifest:97</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5744,7 +5847,7 @@
             
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/security.py">validate_manifest:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L101" rel="noopener noreferrer">validate_manifest:101</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5752,7 +5855,7 @@
             
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/security.py">run_case:488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L488" rel="noopener noreferrer">run_case:488</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5760,7 +5863,7 @@
             
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/security.py">run_manifest:575</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L575" rel="noopener noreferrer">run_manifest:575</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5768,7 +5871,7 @@
             
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="../../skylos/benchmarks/security.py">format_summary:667</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L667" rel="noopener noreferrer">format_summary:667</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5776,7 +5879,7 @@
             
 
             <tr class="searchable" data-search="evidencecard class skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/evidence.py">EvidenceCard:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L19" rel="noopener noreferrer">EvidenceCard:19</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
@@ -5784,7 +5887,7 @@
             
 
             <tr class="searchable" data-search="build_evidence_cards def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/evidence.py">build_evidence_cards:112</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L112" rel="noopener noreferrer">build_evidence_cards:112</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
@@ -5792,7 +5895,7 @@
             
 
             <tr class="searchable" data-search="build_evidence_card def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/evidence.py">build_evidence_card:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L116" rel="noopener noreferrer">build_evidence_card:116</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
@@ -5800,7 +5903,7 @@
             
 
             <tr class="searchable" data-search="evidence_counts def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/evidence.py">evidence_counts:139</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L139" rel="noopener noreferrer">evidence_counts:139</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
@@ -5808,7 +5911,7 @@
             
 
             <tr class="searchable" data-search="evidence_label_title def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/evidence.py">evidence_label_title:150</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L150" rel="noopener noreferrer">evidence_label_title:150</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
@@ -5816,7 +5919,7 @@
             
 
             <tr class="searchable" data-search="redact_sensitive_text def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/evidence.py">redact_sensitive_text:158</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L158" rel="noopener noreferrer">redact_sensitive_text:158</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
@@ -5824,7 +5927,7 @@
             
 
             <tr class="searchable" data-search="run_pr_review def skylos/cicd/review.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/review.py">run_pr_review:30</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L30" rel="noopener noreferrer">run_pr_review:30</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/review.py</td>
@@ -5832,7 +5935,7 @@
             
 
             <tr class="searchable" data-search="get_changed_line_ranges def skylos/cicd/review.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/review.py">get_changed_line_ranges:130</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L130" rel="noopener noreferrer">get_changed_line_ranges:130</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/review.py</td>
@@ -5840,7 +5943,7 @@
             
 
             <tr class="searchable" data-search="filter_findings_to_diff def skylos/cicd/review.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/review.py">filter_findings_to_diff:229</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L229" rel="noopener noreferrer">filter_findings_to_diff:229</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/review.py</td>
@@ -5848,7 +5951,7 @@
             
 
             <tr class="searchable" data-search="build_risk_passport def skylos/cicd/risk_passport.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/risk_passport.py">build_risk_passport:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L19" rel="noopener noreferrer">build_risk_passport:19</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/risk_passport.py</td>
@@ -5856,7 +5959,7 @@
             
 
             <tr class="searchable" data-search="format_risk_passport_markdown def skylos/cicd/risk_passport.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/risk_passport.py">format_risk_passport_markdown:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L116" rel="noopener noreferrer">format_risk_passport_markdown:116</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/risk_passport.py</td>
@@ -5864,7 +5967,7 @@
             
 
             <tr class="searchable" data-search="generate_workflow def skylos/cicd/workflow.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/workflow.py">generate_workflow:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py#L59" rel="noopener noreferrer">generate_workflow:59</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/workflow.py</td>
@@ -5872,7 +5975,7 @@
             
 
             <tr class="searchable" data-search="write_workflow def skylos/cicd/workflow.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="../../skylos/cicd/workflow.py">write_workflow:321</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py#L321" rel="noopener noreferrer">write_workflow:321</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/workflow.py</td>
@@ -5880,7 +5983,7 @@
             
 
             <tr class="searchable" data-search="_codemods_module def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_codemods_module:89</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L89" rel="noopener noreferrer">_codemods_module:89</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -5888,7 +5991,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">remove_unused_import_cst:93</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L93" rel="noopener noreferrer">remove_unused_import_cst:93</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5896,7 +5999,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">remove_unused_function_cst:97</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L97" rel="noopener noreferrer">remove_unused_function_cst:97</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5904,7 +6007,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">comment_out_unused_import_cst:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L101" rel="noopener noreferrer">comment_out_unused_import_cst:101</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5912,7 +6015,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">comment_out_unused_function_cst:105</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L105" rel="noopener noreferrer">comment_out_unused_function_cst:105</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5920,7 +6023,7 @@
             
 
             <tr class="searchable" data-search="run_analyze def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_analyze:109</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L109" rel="noopener noreferrer">run_analyze:109</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5928,7 +6031,7 @@
             
 
             <tr class="searchable" data-search="resolve_llm_runtime def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">resolve_llm_runtime:115</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L115" rel="noopener noreferrer">resolve_llm_runtime:115</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5936,7 +6039,7 @@
             
 
             <tr class="searchable" data-search="run_gate_interaction def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_gate_interaction:121</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L121" rel="noopener noreferrer">run_gate_interaction:121</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5944,7 +6047,7 @@
             
 
             <tr class="searchable" data-search="upload_report def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">upload_report:127</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">upload_report:127</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5952,7 +6055,7 @@
             
 
             <tr class="searchable" data-search="run_pipeline def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_pipeline:133</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L133" rel="noopener noreferrer">run_pipeline:133</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5960,7 +6063,7 @@
             
 
             <tr class="searchable" data-search="review_security_scan_result def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">review_security_scan_result:139</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L139" rel="noopener noreferrer">review_security_scan_result:139</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5968,7 +6071,7 @@
             
 
             <tr class="searchable" data-search="run_security_taskflow def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_security_taskflow:147</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L147" rel="noopener noreferrer">run_security_taskflow:147</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5976,7 +6079,7 @@
             
 
             <tr class="searchable" data-search="discover_source_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">discover_source_files:155</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L155" rel="noopener noreferrer">discover_source_files:155</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5984,7 +6087,7 @@
             
 
             <tr class="searchable" data-search="_read_staged_text def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_read_staged_text:163</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L163" rel="noopener noreferrer">_read_staged_text:163</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -5992,7 +6095,7 @@
             
 
             <tr class="searchable" data-search="_scan_staged_secret_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_scan_staged_secret_files:175</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L175" rel="noopener noreferrer">_scan_staged_secret_files:175</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6000,7 +6103,7 @@
             
 
             <tr class="searchable" data-search="_join_phrase def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_join_phrase:201</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L201" rel="noopener noreferrer">_join_phrase:201</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6008,7 +6111,7 @@
             
 
             <tr class="searchable" data-search="_list_dirty_relevant_paths def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_list_dirty_relevant_paths:211</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L211" rel="noopener noreferrer">_list_dirty_relevant_paths:211</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6016,7 +6119,7 @@
             
 
             <tr class="searchable" data-search="_deep_audit_output_exclude_paths def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_deep_audit_output_exclude_paths:239</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L239" rel="noopener noreferrer">_deep_audit_output_exclude_paths:239</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6024,7 +6127,7 @@
             
 
             <tr class="searchable" data-search="_deep_audit_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_deep_audit_project_root:259</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L259" rel="noopener noreferrer">_deep_audit_project_root:259</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6032,7 +6135,7 @@
             
 
             <tr class="searchable" data-search="_empty_changed_deep_audit_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_empty_changed_deep_audit_payload:264</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L264" rel="noopener noreferrer">_empty_changed_deep_audit_payload:264</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6040,7 +6143,7 @@
             
 
             <tr class="searchable" data-search="_write_deep_audit_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_write_deep_audit_payload:327</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L327" rel="noopener noreferrer">_write_deep_audit_payload:327</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6048,7 +6151,7 @@
             
 
             <tr class="searchable" data-search="_handle_empty_changed_deep_audit def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_handle_empty_changed_deep_audit:333</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L333" rel="noopener noreferrer">_handle_empty_changed_deep_audit:333</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6056,7 +6159,7 @@
             
 
             <tr class="searchable" data-search="_create_precommit_snapshot def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_create_precommit_snapshot:390</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L390" rel="noopener noreferrer">_create_precommit_snapshot:390</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6064,7 +6167,7 @@
             
 
             <tr class="searchable" data-search="_remap_precommit_result_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_remap_precommit_result_files:411</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L411" rel="noopener noreferrer">_remap_precommit_result_files:411</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6072,7 +6175,7 @@
             
 
             <tr class="searchable" data-search="_parse_unified_diff_ranges def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_parse_unified_diff_ranges:463</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L463" rel="noopener noreferrer">_parse_unified_diff_ranges:463</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6080,7 +6183,7 @@
             
 
             <tr class="searchable" data-search="_normalize_precommit_path def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_normalize_precommit_path:488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L488" rel="noopener noreferrer">_normalize_precommit_path:488</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6088,7 +6191,7 @@
             
 
             <tr class="searchable" data-search="_path_suffixes def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_path_suffixes:492</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L492" rel="noopener noreferrer">_path_suffixes:492</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6096,7 +6199,7 @@
             
 
             <tr class="searchable" data-search="_build_changed_range_index def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_build_changed_range_index:500</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L500" rel="noopener noreferrer">_build_changed_range_index:500</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6104,7 +6207,7 @@
             
 
             <tr class="searchable" data-search="_ranges_for_precommit_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_ranges_for_precommit_file:510</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L510" rel="noopener noreferrer">_ranges_for_precommit_file:510</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6112,7 +6215,7 @@
             
 
             <tr class="searchable" data-search="_finding_is_in_changed_lines def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_finding_is_in_changed_lines:520</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L520" rel="noopener noreferrer">_finding_is_in_changed_lines:520</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6120,7 +6223,7 @@
             
 
             <tr class="searchable" data-search="_get_cached_changed_line_ranges def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_get_cached_changed_line_ranges:536</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L536" rel="noopener noreferrer">_get_cached_changed_line_ranges:536</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6128,7 +6231,7 @@
             
 
             <tr class="searchable" data-search="_filter_precommit_findings_to_changed_lines def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_filter_precommit_findings_to_changed_lines:553</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L553" rel="noopener noreferrer">_filter_precommit_findings_to_changed_lines:553</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6136,7 +6239,7 @@
             
 
             <tr class="searchable" data-search="_precommit_blocks_finding def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_precommit_blocks_finding:571</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L571" rel="noopener noreferrer">_precommit_blocks_finding:571</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6144,7 +6247,7 @@
             
 
             <tr class="searchable" data-search="_apply_precommit_gate_policy def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_apply_precommit_gate_policy:586</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L586" rel="noopener noreferrer">_apply_precommit_gate_policy:586</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6152,7 +6255,7 @@
             
 
             <tr class="searchable" data-search="llm_estimate_cost def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">llm_estimate_cost:597</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L597" rel="noopener noreferrer">llm_estimate_cost:597</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6160,7 +6263,7 @@
             
 
             <tr class="searchable" data-search="_get_sarif_exporter_class def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_get_sarif_exporter_class:612</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L612" rel="noopener noreferrer">_get_sarif_exporter_class:612</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6168,7 +6271,7 @@
             
 
             <tr class="searchable" data-search="_ensure_llm_support def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_ensure_llm_support:623</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L623" rel="noopener noreferrer">_ensure_llm_support:623</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6176,7 +6279,7 @@
             
 
             <tr class="searchable" data-search="_build_analyzer_config def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_build_analyzer_config:645</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L645" rel="noopener noreferrer">_build_analyzer_config:645</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6184,7 +6287,7 @@
             
 
             <tr class="searchable" data-search="cleanformatter class skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">CleanFormatter:658</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L658" rel="noopener noreferrer">CleanFormatter:658</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6192,7 +6295,7 @@
             
 
             <tr class="searchable" data-search="_skylos_console_theme def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_skylos_console_theme:663</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L663" rel="noopener noreferrer">_skylos_console_theme:663</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6200,7 +6303,7 @@
             
 
             <tr class="searchable" data-search="setup_logger def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">setup_logger:675</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L675" rel="noopener noreferrer">setup_logger:675</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6208,7 +6311,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_import def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">remove_unused_import:699</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L699" rel="noopener noreferrer">remove_unused_import:699</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6216,7 +6319,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_function def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">remove_unused_function:714</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L714" rel="noopener noreferrer">remove_unused_function:714</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6224,7 +6327,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_import def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">comment_out_unused_import:731</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L731" rel="noopener noreferrer">comment_out_unused_import:731</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6232,7 +6335,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_function def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">comment_out_unused_function:752</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L752" rel="noopener noreferrer">comment_out_unused_function:752</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6240,7 +6343,7 @@
             
 
             <tr class="searchable" data-search="_shorten_path def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_shorten_path:773</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L773" rel="noopener noreferrer">_shorten_path:773</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6248,7 +6351,7 @@
             
 
             <tr class="searchable" data-search="find_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">find_project_root:790</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L790" rel="noopener noreferrer">find_project_root:790</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6256,7 +6359,7 @@
             
 
             <tr class="searchable" data-search="_rel_to_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_rel_to_project_root:815</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L815" rel="noopener noreferrer">_rel_to_project_root:815</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6264,7 +6367,7 @@
             
 
             <tr class="searchable" data-search="_normalize_agent_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_normalize_agent_findings:826</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L826" rel="noopener noreferrer">_normalize_agent_findings:826</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6272,7 +6375,7 @@
             
 
             <tr class="searchable" data-search="_agent_findings_to_result_json def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_agent_findings_to_result_json:847</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L847" rel="noopener noreferrer">_agent_findings_to_result_json:847</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6280,7 +6383,7 @@
             
 
             <tr class="searchable" data-search="_is_tty def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_is_tty:892</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L892" rel="noopener noreferrer">_is_tty:892</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6288,7 +6391,7 @@
             
 
             <tr class="searchable" data-search="_is_main_machine_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_is_main_machine_output:899</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L899" rel="noopener noreferrer">_is_main_machine_output:899</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6296,7 +6399,7 @@
             
 
             <tr class="searchable" data-search="_has_high_intent_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_has_high_intent_findings:908</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L908" rel="noopener noreferrer">_has_high_intent_findings:908</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6304,7 +6407,7 @@
             
 
             <tr class="searchable" data-search="_set_no_upload_prompt def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_set_no_upload_prompt:928</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L928" rel="noopener noreferrer">_set_no_upload_prompt:928</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6312,7 +6415,7 @@
             
 
             <tr class="searchable" data-search="_detect_link_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_detect_link_file:961</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L961" rel="noopener noreferrer">_detect_link_file:961</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6320,7 +6423,7 @@
             
 
             <tr class="searchable" data-search="_print_upload_destination def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_print_upload_destination:970</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L970" rel="noopener noreferrer">_print_upload_destination:970</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6328,7 +6431,7 @@
             
 
             <tr class="searchable" data-search="_selected_main_upload_static_categories def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_selected_main_upload_static_categories:989</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L989" rel="noopener noreferrer">_selected_main_upload_static_categories:989</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6336,7 +6439,7 @@
             
 
             <tr class="searchable" data-search="_print_main_upload_manifest def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_print_main_upload_manifest:1002</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1002" rel="noopener noreferrer">_print_main_upload_manifest:1002</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6344,7 +6447,7 @@
             
 
             <tr class="searchable" data-search="_render_upload_failure def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_upload_failure:1020</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1020" rel="noopener noreferrer">_render_upload_failure:1020</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6352,7 +6455,7 @@
             
 
             <tr class="searchable" data-search="_is_ci def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_is_ci:1038</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1038" rel="noopener noreferrer">_is_ci:1038</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6360,7 +6463,7 @@
             
 
             <tr class="searchable" data-search="_print_upload_cta def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_print_upload_cta:1055</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1055" rel="noopener noreferrer">_print_upload_cta:1055</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6368,7 +6471,7 @@
             
 
             <tr class="searchable" data-search="_print_feature_hints def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_print_feature_hints:1101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1101" rel="noopener noreferrer">_print_feature_hints:1101</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6376,7 +6479,7 @@
             
 
             <tr class="searchable" data-search="interactive_selection def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">interactive_selection:1153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1153" rel="noopener noreferrer">interactive_selection:1153</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6384,7 +6487,7 @@
             
 
             <tr class="searchable" data-search="print_badge def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">print_badge:1210</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1210" rel="noopener noreferrer">print_badge:1210</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6392,7 +6495,7 @@
             
 
             <tr class="searchable" data-search="_default_dead_code_llm_fields def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_default_dead_code_llm_fields:1272</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1272" rel="noopener noreferrer">_default_dead_code_llm_fields:1272</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6400,7 +6503,7 @@
             
 
             <tr class="searchable" data-search="_collect_llm_report_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_collect_llm_report_findings:1288</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1288" rel="noopener noreferrer">_collect_llm_report_findings:1288</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6408,7 +6511,7 @@
             
 
             <tr class="searchable" data-search="_llm_report_sort_key def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_llm_report_sort_key:1303</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1303" rel="noopener noreferrer">_llm_report_sort_key:1303</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6416,7 +6519,7 @@
             
 
             <tr class="searchable" data-search="_llm_report_code_block def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_llm_report_code_block:1308</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1308" rel="noopener noreferrer">_llm_report_code_block:1308</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6424,7 +6527,7 @@
             
 
             <tr class="searchable" data-search="_llm_report_secret_block def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_llm_report_secret_block:1352</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1352" rel="noopener noreferrer">_llm_report_secret_block:1352</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6432,7 +6535,7 @@
             
 
             <tr class="searchable" data-search="_format_llm_report_section def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_format_llm_report_section:1357</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1357" rel="noopener noreferrer">_format_llm_report_section:1357</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6440,7 +6543,7 @@
             
 
             <tr class="searchable" data-search="_generate_llm_report def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_generate_llm_report:1375</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1375" rel="noopener noreferrer">_generate_llm_report:1375</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6448,7 +6551,7 @@
             
 
             <tr class="searchable" data-search="_emit_github_grade_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_emit_github_grade_annotation:1426</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1426" rel="noopener noreferrer">_emit_github_grade_annotation:1426</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6456,7 +6559,7 @@
             
 
             <tr class="searchable" data-search="_github_finding_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_github_finding_annotation:1435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1435" rel="noopener noreferrer">_github_finding_annotation:1435</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6464,7 +6567,7 @@
             
 
             <tr class="searchable" data-search="_github_dead_code_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_github_dead_code_annotation:1456</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1456" rel="noopener noreferrer">_github_dead_code_annotation:1456</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6472,7 +6575,7 @@
             
 
             <tr class="searchable" data-search="_github_annotation_items def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_github_annotation_items:1469</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1469" rel="noopener noreferrer">_github_annotation_items:1469</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6480,7 +6583,7 @@
             
 
             <tr class="searchable" data-search="_filter_github_annotations_by_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_filter_github_annotations_by_severity:1481</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1481" rel="noopener noreferrer">_filter_github_annotations_by_severity:1481</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6488,7 +6591,7 @@
             
 
             <tr class="searchable" data-search="_github_annotation_sort_key def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_github_annotation_sort_key:1488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1488" rel="noopener noreferrer">_github_annotation_sort_key:1488</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6496,7 +6599,7 @@
             
 
             <tr class="searchable" data-search="_emit_github_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_emit_github_annotation:1492</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1492" rel="noopener noreferrer">_emit_github_annotation:1492</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6504,7 +6607,7 @@
             
 
             <tr class="searchable" data-search="_emit_github_annotations def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_emit_github_annotations:1500</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1500" rel="noopener noreferrer">_emit_github_annotations:1500</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6512,7 +6615,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_min_rank def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_filter_min_rank:1527</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1527" rel="noopener noreferrer">_display_filter_min_rank:1527</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6520,7 +6623,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_allowed_categories def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_filter_allowed_categories:1533</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1533" rel="noopener noreferrer">_display_filter_allowed_categories:1533</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6528,7 +6631,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_matches_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_filter_matches_file:1539</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1539" rel="noopener noreferrer">_display_filter_matches_file:1539</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6536,7 +6639,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_has_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_filter_has_severity:1545</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1545" rel="noopener noreferrer">_display_filter_has_severity:1545</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6544,7 +6647,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_passes_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_filter_passes_severity:1552</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1552" rel="noopener noreferrer">_display_filter_passes_severity:1552</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6552,7 +6655,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_items def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_filter_items:1557</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1557" rel="noopener noreferrer">_display_filter_items:1557</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6560,7 +6663,7 @@
             
 
             <tr class="searchable" data-search="_apply_display_filters def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_apply_display_filters:1572</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1572" rel="noopener noreferrer">_apply_display_filters:1572</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6568,7 +6671,7 @@
             
 
             <tr class="searchable" data-search="_results_pill def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_results_pill:1601</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1601" rel="noopener noreferrer">_results_pill:1601</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6576,7 +6679,7 @@
             
 
             <tr class="searchable" data-search="_grep_verify_pill def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_grep_verify_pill:1609</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1609" rel="noopener noreferrer">_grep_verify_pill:1609</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6584,7 +6687,7 @@
             
 
             <tr class="searchable" data-search="_display_cap def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_cap:1619</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1619" rel="noopener noreferrer">_display_cap:1619</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6592,7 +6695,7 @@
             
 
             <tr class="searchable" data-search="_score_style def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_score_style:1624</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1624" rel="noopener noreferrer">_score_style:1624</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6600,7 +6703,7 @@
             
 
             <tr class="searchable" data-search="_render_grade def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_grade:1634</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1634" rel="noopener noreferrer">_render_grade:1634</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6608,7 +6711,7 @@
             
 
             <tr class="searchable" data-search="_format_confidence def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_format_confidence:1715</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1715" rel="noopener noreferrer">_format_confidence:1715</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6616,7 +6719,7 @@
             
 
             <tr class="searchable" data-search="_render_unused def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_unused:1725</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1725" rel="noopener noreferrer">_render_unused:1725</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6624,7 +6727,7 @@
             
 
             <tr class="searchable" data-search="_render_unused_simple def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_unused_simple:1757</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1757" rel="noopener noreferrer">_render_unused_simple:1757</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6632,7 +6735,7 @@
             
 
             <tr class="searchable" data-search="_quality_detail def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_quality_detail:1785</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1785" rel="noopener noreferrer">_quality_detail:1785</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6640,7 +6743,7 @@
             
 
             <tr class="searchable" data-search="_render_quality def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_quality:1825</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1825" rel="noopener noreferrer">_render_quality:1825</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6648,7 +6751,7 @@
             
 
             <tr class="searchable" data-search="_render_circular_deps def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_circular_deps:1859</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1859" rel="noopener noreferrer">_render_circular_deps:1859</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6656,7 +6759,7 @@
             
 
             <tr class="searchable" data-search="_render_custom_rules def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_custom_rules:1893</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1893" rel="noopener noreferrer">_render_custom_rules:1893</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6664,7 +6767,7 @@
             
 
             <tr class="searchable" data-search="_render_secrets def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_secrets:1925</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1925" rel="noopener noreferrer">_render_secrets:1925</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6672,7 +6775,7 @@
             
 
             <tr class="searchable" data-search="_render_result_tree def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_result_tree:1972</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1972" rel="noopener noreferrer">_render_result_tree:1972</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6680,7 +6783,7 @@
             
 
             <tr class="searchable" data-search="_display_rule_name def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_display_rule_name:2036</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2036" rel="noopener noreferrer">_display_rule_name:2036</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6688,7 +6791,7 @@
             
 
             <tr class="searchable" data-search="_verification_proof def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_verification_proof:2042</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2042" rel="noopener noreferrer">_verification_proof:2042</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6696,7 +6799,7 @@
             
 
             <tr class="searchable" data-search="_verification_label def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_verification_label:2073</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2073" rel="noopener noreferrer">_verification_label:2073</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6704,7 +6807,7 @@
             
 
             <tr class="searchable" data-search="_render_danger def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_danger:2083</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2083" rel="noopener noreferrer">_render_danger:2083</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6712,7 +6815,7 @@
             
 
             <tr class="searchable" data-search="_render_sca def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_render_sca:2148</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2148" rel="noopener noreferrer">_render_sca:2148</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6720,7 +6823,7 @@
             
 
             <tr class="searchable" data-search="render_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">render_results:2194</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2194" rel="noopener noreferrer">render_results:2194</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6728,7 +6831,7 @@
             
 
             <tr class="searchable" data-search="render_pretty_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">render_pretty_results:2312</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2312" rel="noopener noreferrer">render_pretty_results:2312</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6736,7 +6839,7 @@
             
 
             <tr class="searchable" data-search="_write_rich_report_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_write_rich_report_output:2324</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2324" rel="noopener noreferrer">_write_rich_report_output:2324</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6744,7 +6847,7 @@
             
 
             <tr class="searchable" data-search="_write_pretty_report_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_write_pretty_report_output:2349</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2349" rel="noopener noreferrer">_write_pretty_report_output:2349</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6752,7 +6855,7 @@
             
 
             <tr class="searchable" data-search="run_init def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_init:2371</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2371" rel="noopener noreferrer">run_init:2371</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6760,7 +6863,7 @@
             
 
             <tr class="searchable" data-search="run_whitelist def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_whitelist:2377</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2377" rel="noopener noreferrer">run_whitelist:2377</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6768,7 +6871,7 @@
             
 
             <tr class="searchable" data-search="get_git_changed_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">get_git_changed_files:2383</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2383" rel="noopener noreferrer">get_git_changed_files:2383</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6776,7 +6879,7 @@
             
 
             <tr class="searchable" data-search="estimate_cost def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">estimate_cost:2402</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2402" rel="noopener noreferrer">estimate_cost:2402</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6784,7 +6887,7 @@
             
 
             <tr class="searchable" data-search="_run_clean_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_clean_command:2408</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2408" rel="noopener noreferrer">_run_clean_command:2408</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6792,7 +6895,7 @@
             
 
             <tr class="searchable" data-search="_run_cache_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_cache_command:2414</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2414" rel="noopener noreferrer">_run_cache_command:2414</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6800,7 +6903,7 @@
             
 
             <tr class="searchable" data-search="run_debt_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_debt_command:2420</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2420" rel="noopener noreferrer">run_debt_command:2420</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6808,7 +6911,7 @@
             
 
             <tr class="searchable" data-search="run_defend_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_defend_command:2435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2435" rel="noopener noreferrer">run_defend_command:2435</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6816,7 +6919,7 @@
             
 
             <tr class="searchable" data-search="run_suite_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_suite_command:2445</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2445" rel="noopener noreferrer">run_suite_command:2445</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6824,7 +6927,7 @@
             
 
             <tr class="searchable" data-search="run_ingest_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_ingest_command:2467</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2467" rel="noopener noreferrer">run_ingest_command:2467</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6832,7 +6935,7 @@
             
 
             <tr class="searchable" data-search="run_provenance_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_provenance_command:2476</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2476" rel="noopener noreferrer">run_provenance_command:2476</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6840,7 +6943,7 @@
             
 
             <tr class="searchable" data-search="run_cicd_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">run_cicd_command:2490</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2490" rel="noopener noreferrer">run_cicd_command:2490</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6848,7 +6951,7 @@
             
 
             <tr class="searchable" data-search="_load_addopts def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_load_addopts:2502</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2502" rel="noopener noreferrer">_load_addopts:2502</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6856,7 +6959,7 @@
             
 
             <tr class="searchable" data-search="_handle_rules_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_handle_rules_command:2508</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2508" rel="noopener noreferrer">_handle_rules_command:2508</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6864,7 +6967,7 @@
             
 
             <tr class="searchable" data-search="_rules_install def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_rules_install:2514</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2514" rel="noopener noreferrer">_rules_install:2514</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6872,7 +6975,7 @@
             
 
             <tr class="searchable" data-search="_rules_list def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_rules_list:2520</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2520" rel="noopener noreferrer">_rules_list:2520</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6880,7 +6983,7 @@
             
 
             <tr class="searchable" data-search="_rules_remove def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_rules_remove:2526</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2526" rel="noopener noreferrer">_rules_remove:2526</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6888,7 +6991,7 @@
             
 
             <tr class="searchable" data-search="_run_command_overview def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_command_overview:2535</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2535" rel="noopener noreferrer">_run_command_overview:2535</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6896,7 +6999,7 @@
             
 
             <tr class="searchable" data-search="_run_commands_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_commands_command:2542</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2542" rel="noopener noreferrer">_run_commands_command:2542</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6904,7 +7007,7 @@
             
 
             <tr class="searchable" data-search="_run_tour_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_tour_command:2549</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2549" rel="noopener noreferrer">_run_tour_command:2549</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6912,7 +7015,7 @@
             
 
             <tr class="searchable" data-search="_run_key_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_key_command:2556</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2556" rel="noopener noreferrer">_run_key_command:2556</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6920,7 +7023,7 @@
             
 
             <tr class="searchable" data-search="_run_credits_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_credits_command:2562</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2562" rel="noopener noreferrer">_run_credits_command:2562</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6928,7 +7031,7 @@
             
 
             <tr class="searchable" data-search="_run_init_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_init_command:2568</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2568" rel="noopener noreferrer">_run_init_command:2568</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6936,7 +7039,7 @@
             
 
             <tr class="searchable" data-search="_run_baseline_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_baseline_command:2572</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2572" rel="noopener noreferrer">_run_baseline_command:2572</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6944,7 +7047,7 @@
             
 
             <tr class="searchable" data-search="_run_badge_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_badge_command:2578</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2578" rel="noopener noreferrer">_run_badge_command:2578</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6952,7 +7055,7 @@
             
 
             <tr class="searchable" data-search="_run_whitelist_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_whitelist_command:2584</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2584" rel="noopener noreferrer">_run_whitelist_command:2584</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6960,7 +7063,7 @@
             
 
             <tr class="searchable" data-search="_run_doctor_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_doctor_command:2590</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2590" rel="noopener noreferrer">_run_doctor_command:2590</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6968,7 +7071,7 @@
             
 
             <tr class="searchable" data-search="_run_whoami_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_whoami_command:2596</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2596" rel="noopener noreferrer">_run_whoami_command:2596</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6976,7 +7079,7 @@
             
 
             <tr class="searchable" data-search="_run_login_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_login_command:2602</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2602" rel="noopener noreferrer">_run_login_command:2602</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6984,7 +7087,7 @@
             
 
             <tr class="searchable" data-search="_run_sync_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_sync_command:2608</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2608" rel="noopener noreferrer">_run_sync_command:2608</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6992,7 +7095,7 @@
             
 
             <tr class="searchable" data-search="_run_project_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_project_command:2614</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2614" rel="noopener noreferrer">_run_project_command:2614</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7000,7 +7103,7 @@
             
 
             <tr class="searchable" data-search="_run_sonar_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_sonar_command:2620</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2620" rel="noopener noreferrer">_run_sonar_command:2620</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7008,7 +7111,7 @@
             
 
             <tr class="searchable" data-search="_attach_upload_project_context def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_attach_upload_project_context:2626</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2626" rel="noopener noreferrer">_attach_upload_project_context:2626</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7016,7 +7119,7 @@
             
 
             <tr class="searchable" data-search="_upload_agent_run_best_effort def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_upload_agent_run_best_effort:2640</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2640" rel="noopener noreferrer">_upload_agent_run_best_effort:2640</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7024,7 +7127,7 @@
             
 
             <tr class="searchable" data-search="_run_removed_city_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_removed_city_command:2663</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2663" rel="noopener noreferrer">_run_removed_city_command:2663</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7032,7 +7135,7 @@
             
 
             <tr class="searchable" data-search="_run_discover_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_discover_command:2674</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2674" rel="noopener noreferrer">_run_discover_command:2674</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7040,7 +7143,7 @@
             
 
             <tr class="searchable" data-search="_run_web_server_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_web_server_command:2680</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2680" rel="noopener noreferrer">_run_web_server_command:2680</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7048,7 +7151,7 @@
             
 
             <tr class="searchable" data-search="_run_scan_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_scan_command:2691</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2691" rel="noopener noreferrer">_run_scan_command:2691</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7056,7 +7159,7 @@
             
 
             <tr class="searchable" data-search="_is_first_level_help_request def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_is_first_level_help_request:2697</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2697" rel="noopener noreferrer">_is_first_level_help_request:2697</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7064,7 +7167,7 @@
             
 
             <tr class="searchable" data-search="_run_early_command_help def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_early_command_help:2701</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2701" rel="noopener noreferrer">_run_early_command_help:2701</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7072,7 +7175,7 @@
             
 
             <tr class="searchable" data-search="_dispatch_early_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_dispatch_early_command:2705</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2705" rel="noopener noreferrer">_dispatch_early_command:2705</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7080,7 +7183,7 @@
             
 
             <tr class="searchable" data-search="_rules_validate def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_rules_validate:2709</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2709" rel="noopener noreferrer">_rules_validate:2709</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7088,7 +7191,7 @@
             
 
             <tr class="searchable" data-search="_build_main_parser def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_build_main_parser:2715</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2715" rel="noopener noreferrer">_build_main_parser:2715</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7096,7 +7199,7 @@
             
 
             <tr class="searchable" data-search="_apply_main_output_format def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_apply_main_output_format:2719</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2719" rel="noopener noreferrer">_apply_main_output_format:2719</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7104,7 +7207,7 @@
             
 
             <tr class="searchable" data-search="_parse_main_cli_args def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_parse_main_cli_args:2723</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2723" rel="noopener noreferrer">_parse_main_cli_args:2723</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7112,7 +7215,7 @@
             
 
             <tr class="searchable" data-search="_resolve_main_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_resolve_main_project_root:2727</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2727" rel="noopener noreferrer">_resolve_main_project_root:2727</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7120,7 +7223,7 @@
             
 
             <tr class="searchable" data-search="_print_default_excludes def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_print_default_excludes:2737</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2737" rel="noopener noreferrer">_print_default_excludes:2737</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7128,7 +7231,7 @@
             
 
             <tr class="searchable" data-search="_build_main_scan_context def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_build_main_scan_context:2746</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2746" rel="noopener noreferrer">_build_main_scan_context:2746</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7136,7 +7239,7 @@
             
 
             <tr class="searchable" data-search="_formatted_output_gate_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_formatted_output_gate_exit_code:2782</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2782" rel="noopener noreferrer">_formatted_output_gate_exit_code:2782</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7144,7 +7247,7 @@
             
 
             <tr class="searchable" data-search="_concise_scan_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_concise_scan_exit_code:2809</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2809" rel="noopener noreferrer">_concise_scan_exit_code:2809</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7152,7 +7255,7 @@
             
 
             <tr class="searchable" data-search="_has_concise_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_has_concise_findings:2842</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2842" rel="noopener noreferrer">_has_concise_findings:2842</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7160,7 +7263,7 @@
             
 
             <tr class="searchable" data-search="_concise_line def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_concise_line:2849</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2849" rel="noopener noreferrer">_concise_line:2849</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7168,7 +7271,7 @@
             
 
             <tr class="searchable" data-search="_format_concise_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_format_concise_results:2859</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2859" rel="noopener noreferrer">_format_concise_results:2859</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7176,7 +7279,7 @@
             
 
             <tr class="searchable" data-search="_strict_scan_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_strict_scan_exit_code:2882</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2882" rel="noopener noreferrer">_strict_scan_exit_code:2882</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7184,7 +7287,7 @@
             
 
             <tr class="searchable" data-search="_apply_config_driven_analysis_flags def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_apply_config_driven_analysis_flags:2895</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2895" rel="noopener noreferrer">_apply_config_driven_analysis_flags:2895</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7192,7 +7295,7 @@
             
 
             <tr class="searchable" data-search="_print_main_scan_banner def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_print_main_scan_banner:2934</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2934" rel="noopener noreferrer">_print_main_scan_banner:2934</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7200,7 +7303,7 @@
             
 
             <tr class="searchable" data-search="_trace_cache_requested def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_trace_cache_requested:2976</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2976" rel="noopener noreferrer">_trace_cache_requested:2976</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7208,7 +7311,7 @@
             
 
             <tr class="searchable" data-search="_trusted_module_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_trusted_module_file:2986</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2986" rel="noopener noreferrer">_trusted_module_file:2986</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7216,7 +7319,7 @@
             
 
             <tr class="searchable" data-search="_trace_subprocess_script def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_trace_subprocess_script:2994</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2994" rel="noopener noreferrer">_trace_subprocess_script:2994</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7224,7 +7327,7 @@
             
 
             <tr class="searchable" data-search="_trace_subprocess_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_trace_subprocess_command:3066</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3066" rel="noopener noreferrer">_trace_subprocess_command:3066</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7232,7 +7335,7 @@
             
 
             <tr class="searchable" data-search="_coverage_execution_allowed def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_coverage_execution_allowed:3091</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3091" rel="noopener noreferrer">_coverage_execution_allowed:3091</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7240,7 +7343,7 @@
             
 
             <tr class="searchable" data-search="_run_pre_analysis_steps def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_run_pre_analysis_steps:3095</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3095" rel="noopener noreferrer">_run_pre_analysis_steps:3095</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7248,7 +7351,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_model_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_add_agent_model_arg:3318</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3318" rel="noopener noreferrer">_add_agent_model_arg:3318</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7256,7 +7359,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_output_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_add_agent_output_arg:3322</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3322" rel="noopener noreferrer">_add_agent_output_arg:3322</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7264,7 +7367,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_quiet_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_add_agent_quiet_arg:3326</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3326" rel="noopener noreferrer">_add_agent_quiet_arg:3326</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7272,7 +7375,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_provider_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_add_agent_provider_arg:3330</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3330" rel="noopener noreferrer">_add_agent_provider_arg:3330</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7280,7 +7383,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_base_url_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_add_agent_base_url_arg:3339</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3339" rel="noopener noreferrer">_add_agent_base_url_arg:3339</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7288,7 +7391,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_prompt_template_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_add_agent_prompt_template_arg:3350</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3350" rel="noopener noreferrer">_add_agent_prompt_template_arg:3350</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7296,7 +7399,7 @@
             
 
             <tr class="searchable" data-search="_explicit_prompt_templates_from_args def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_explicit_prompt_templates_from_args:3363</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3363" rel="noopener noreferrer">_explicit_prompt_templates_from_args:3363</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7304,7 +7407,7 @@
             
 
             <tr class="searchable" data-search="_build_agent_parser def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">_build_agent_parser:3412</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3412" rel="noopener noreferrer">_build_agent_parser:3412</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7312,7 +7415,7 @@
             
 
             <tr class="searchable" data-search="main def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/cli.py">main:3855</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3855" rel="noopener noreferrer">main:3855</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -7320,7 +7423,7 @@
             
 
             <tr class="searchable" data-search="is_first_level_help_request def skylos/cli_core/dispatch.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="../../skylos/cli_core/dispatch.py">is_first_level_help_request:37</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L37" rel="noopener noreferrer">is_first_level_help_request:37</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/dispatch.py</td>
@@ -7328,7 +7431,7 @@
             
 
             <tr class="searchable" data-search="run_early_command_help def skylos/cli_core/dispatch.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="../../skylos/cli_core/dispatch.py">run_early_command_help:41</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L41" rel="noopener noreferrer">run_early_command_help:41</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/dispatch.py</td>
@@ -7336,7 +7439,7 @@
             
 
             <tr class="searchable" data-search="dispatch_early_command def skylos/cli_core/dispatch.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="../../skylos/cli_core/dispatch.py">dispatch_early_command:71</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L71" rel="noopener noreferrer">dispatch_early_command:71</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/dispatch.py</td>
@@ -7344,7 +7447,7 @@
             
 
             <tr class="searchable" data-search="build_main_parser def skylos/cli_core/main_parser.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="../../skylos/cli_core/main_parser.py">build_main_parser:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L7" rel="noopener noreferrer">build_main_parser:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/main_parser.py</td>
@@ -7352,7 +7455,7 @@
             
 
             <tr class="searchable" data-search="apply_main_output_format def skylos/cli_core/main_parser.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="../../skylos/cli_core/main_parser.py">apply_main_output_format:305</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L305" rel="noopener noreferrer">apply_main_output_format:305</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/main_parser.py</td>
@@ -7360,7 +7463,7 @@
             
 
             <tr class="searchable" data-search="parse_main_cli_args def skylos/cli_core/main_parser.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="../../skylos/cli_core/main_parser.py">parse_main_cli_args:335</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L335" rel="noopener noreferrer">parse_main_cli_args:335</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/main_parser.py</td>
@@ -7368,7 +7471,7 @@
             
 
             <tr class="searchable" data-search="save_key def skylos/cloud/credentials.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/credentials.py">save_key:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py#L24" rel="noopener noreferrer">save_key:24</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/credentials.py</td>
@@ -7376,7 +7479,7 @@
             
 
             <tr class="searchable" data-search="get_key def skylos/cloud/credentials.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/credentials.py">get_key:37</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py#L37" rel="noopener noreferrer">get_key:37</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/credentials.py</td>
@@ -7384,7 +7487,7 @@
             
 
             <tr class="searchable" data-search="delete_key def skylos/cloud/credentials.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/credentials.py">delete_key:53</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py#L53" rel="noopener noreferrer">delete_key:53</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/credentials.py</td>
@@ -7392,7 +7495,7 @@
             
 
             <tr class="searchable" data-search="loginresult class skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/login.py">LoginResult:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L18" rel="noopener noreferrer">LoginResult:18</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
@@ -7400,7 +7503,7 @@
             
 
             <tr class="searchable" data-search="browser_login def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/login.py">browser_login:149</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L149" rel="noopener noreferrer">browser_login:149</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
@@ -7408,7 +7511,7 @@
             
 
             <tr class="searchable" data-search="manual_token_fallback def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/login.py">manual_token_fallback:228</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L228" rel="noopener noreferrer">manual_token_fallback:228</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
@@ -7416,7 +7519,7 @@
             
 
             <tr class="searchable" data-search="get_current_connection def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/login.py">get_current_connection:299</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L299" rel="noopener noreferrer">get_current_connection:299</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
@@ -7424,7 +7527,7 @@
             
 
             <tr class="searchable" data-search="run_login def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/login.py">run_login:350</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L350" rel="noopener noreferrer">run_login:350</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
@@ -7432,7 +7535,7 @@
             
 
             <tr class="searchable" data-search="normalize_repo_subpath def skylos/cloud/project_context.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/project_context.py">normalize_repo_subpath:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py#L6" rel="noopener noreferrer">normalize_repo_subpath:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/project_context.py</td>
@@ -7440,7 +7543,7 @@
             
 
             <tr class="searchable" data-search="repo_subpath_for_project def skylos/cloud/project_context.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/project_context.py">repo_subpath_for_project:32</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py#L32" rel="noopener noreferrer">repo_subpath_for_project:32</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/project_context.py</td>
@@ -7448,7 +7551,7 @@
             
 
             <tr class="searchable" data-search="project_context_for_upload def skylos/cloud/project_context.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/project_context.py">project_context_for_upload:53</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py#L53" rel="noopener noreferrer">project_context_for_upload:53</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/project_context.py</td>
@@ -7456,7 +7559,7 @@
             
 
             <tr class="searchable" data-search="get_api_url def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">get_api_url:267</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L267" rel="noopener noreferrer">get_api_url:267</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7464,7 +7567,7 @@
             
 
             <tr class="searchable" data-search="get_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">get_token:315</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L315" rel="noopener noreferrer">get_token:315</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7472,7 +7575,7 @@
             
 
             <tr class="searchable" data-search="save_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">save_token:342</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L342" rel="noopener noreferrer">save_token:342</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7480,7 +7583,7 @@
             
 
             <tr class="searchable" data-search="clear_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">clear_token:379</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L379" rel="noopener noreferrer">clear_token:379</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7488,7 +7591,7 @@
             
 
             <tr class="searchable" data-search="mask_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">mask_token:386</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L386" rel="noopener noreferrer">mask_token:386</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7496,7 +7599,7 @@
             
 
             <tr class="searchable" data-search="autherror class skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">AuthError:392</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L392" rel="noopener noreferrer">AuthError:392</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7504,7 +7607,7 @@
             
 
             <tr class="searchable" data-search="api_get def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">api_get:405</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L405" rel="noopener noreferrer">api_get:405</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7512,7 +7615,7 @@
             
 
             <tr class="searchable" data-search="cmd_connect def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_connect:464</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L464" rel="noopener noreferrer">cmd_connect:464</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7520,7 +7623,7 @@
             
 
             <tr class="searchable" data-search="cmd_status def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_status:537</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L537" rel="noopener noreferrer">cmd_status:537</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7528,7 +7631,7 @@
             
 
             <tr class="searchable" data-search="cmd_disconnect def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_disconnect:566</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L566" rel="noopener noreferrer">cmd_disconnect:566</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7536,7 +7639,7 @@
             
 
             <tr class="searchable" data-search="cmd_project_status def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_project_status:593</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L593" rel="noopener noreferrer">cmd_project_status:593</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7544,7 +7647,7 @@
             
 
             <tr class="searchable" data-search="cmd_project_list def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_project_list:640</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L640" rel="noopener noreferrer">cmd_project_list:640</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7552,7 +7655,7 @@
             
 
             <tr class="searchable" data-search="cmd_project_use def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_project_use:662</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L662" rel="noopener noreferrer">cmd_project_use:662</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7560,7 +7663,7 @@
             
 
             <tr class="searchable" data-search="cmd_project_create def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_project_create:670</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L670" rel="noopener noreferrer">cmd_project_create:670</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7568,7 +7671,7 @@
             
 
             <tr class="searchable" data-search="cmd_project_unlink def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_project_unlink:676</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L676" rel="noopener noreferrer">cmd_project_unlink:676</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7576,7 +7679,7 @@
             
 
             <tr class="searchable" data-search="cmd_pull def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_pull:685</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L685" rel="noopener noreferrer">cmd_pull:685</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7584,7 +7687,7 @@
             
 
             <tr class="searchable" data-search="create_precommit_config def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">create_precommit_config:720</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L720" rel="noopener noreferrer">create_precommit_config:720</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7592,7 +7695,7 @@
             
 
             <tr class="searchable" data-search="cmd_setup def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_setup:793</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L793" rel="noopener noreferrer">cmd_setup:793</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7600,7 +7703,7 @@
             
 
             <tr class="searchable" data-search="cmd_upgrade def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">cmd_upgrade:1030</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1030" rel="noopener noreferrer">cmd_upgrade:1030</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7608,7 +7711,7 @@
             
 
             <tr class="searchable" data-search="main def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">main:1121</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1121" rel="noopener noreferrer">main:1121</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7616,7 +7719,7 @@
             
 
             <tr class="searchable" data-search="project_main def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">project_main:1153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1153" rel="noopener noreferrer">project_main:1153</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7624,7 +7727,7 @@
             
 
             <tr class="searchable" data-search="get_custom_rules def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/sync.py">get_custom_rules:1183</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1183" rel="noopener noreferrer">get_custom_rules:1183</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
@@ -7632,7 +7735,7 @@
             
 
             <tr class="searchable" data-search="uploadfamilymanifest class skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/upload_manifest.py">UploadFamilyManifest:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L7" rel="noopener noreferrer">UploadFamilyManifest:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
@@ -7640,7 +7743,7 @@
             
 
             <tr class="searchable" data-search="build_code_scan_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/upload_manifest.py">build_code_scan_manifest:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L24" rel="noopener noreferrer">build_code_scan_manifest:24</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
@@ -7648,7 +7751,7 @@
             
 
             <tr class="searchable" data-search="build_defense_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/upload_manifest.py">build_defense_manifest:48</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L48" rel="noopener noreferrer">build_defense_manifest:48</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
@@ -7656,7 +7759,7 @@
             
 
             <tr class="searchable" data-search="build_debt_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/upload_manifest.py">build_debt_manifest:63</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L63" rel="noopener noreferrer">build_debt_manifest:63</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
@@ -7664,7 +7767,7 @@
             
 
             <tr class="searchable" data-search="print_upload_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="../../skylos/cloud/upload_manifest.py">print_upload_manifest:77</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L77" rel="noopener noreferrer">print_upload_manifest:77</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
@@ -7672,7 +7775,7 @@
             
 
             <tr class="searchable" data-search="run_badge_command def skylos/commands/badge_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/badge_cmd.py">run_badge_command:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/badge_cmd.py#L8" rel="noopener noreferrer">run_badge_command:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/badge_cmd.py</td>
@@ -7680,7 +7783,7 @@
             
 
             <tr class="searchable" data-search="run_baseline_command def skylos/commands/baseline_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/baseline_cmd.py">run_baseline_command:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/baseline_cmd.py#L9" rel="noopener noreferrer">run_baseline_command:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/baseline_cmd.py</td>
@@ -7688,7 +7791,7 @@
             
 
             <tr class="searchable" data-search="run_cache_command def skylos/commands/cache_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/cache_cmd.py">run_cache_command:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cache_cmd.py#L13" rel="noopener noreferrer">run_cache_command:13</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/cache_cmd.py</td>
@@ -7696,7 +7799,7 @@
             
 
             <tr class="searchable" data-search="run_cicd_command def skylos/commands/cicd_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/cicd_cmd.py">run_cicd_command:119</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py#L119" rel="noopener noreferrer">run_cicd_command:119</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/cicd_cmd.py</td>
@@ -7704,7 +7807,7 @@
             
 
             <tr class="searchable" data-search="run_analyze def skylos/commands/clean_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/clean_cmd.py">run_analyze:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py#L19" rel="noopener noreferrer">run_analyze:19</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/clean_cmd.py</td>
@@ -7712,7 +7815,7 @@
             
 
             <tr class="searchable" data-search="run_clean_command def skylos/commands/clean_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/clean_cmd.py">run_clean_command:49</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py#L49" rel="noopener noreferrer">run_clean_command:49</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/clean_cmd.py</td>
@@ -7720,7 +7823,7 @@
             
 
             <tr class="searchable" data-search="run_credits_command def skylos/commands/credits_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/credits_cmd.py">run_credits_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/credits_cmd.py#L6" rel="noopener noreferrer">run_credits_command:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/credits_cmd.py</td>
@@ -7728,7 +7831,7 @@
             
 
             <tr class="searchable" data-search="run_debt_command def skylos/commands/debt_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/debt_cmd.py">run_debt_command:69</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/debt_cmd.py#L69" rel="noopener noreferrer">run_debt_command:69</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/debt_cmd.py</td>
@@ -7736,7 +7839,7 @@
             
 
             <tr class="searchable" data-search="run_defend_command def skylos/commands/defend_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/defend_cmd.py">run_defend_command:389</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L389" rel="noopener noreferrer">run_defend_command:389</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/defend_cmd.py</td>
@@ -7744,7 +7847,7 @@
             
 
             <tr class="searchable" data-search="run_discover_command def skylos/commands/discover_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/discover_cmd.py">run_discover_command:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/discover_cmd.py#L8" rel="noopener noreferrer">run_discover_command:8</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/discover_cmd.py</td>
@@ -7752,7 +7855,7 @@
             
 
             <tr class="searchable" data-search="run_doctor_command def skylos/commands/doctor_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/doctor_cmd.py">run_doctor_command:38</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/doctor_cmd.py#L38" rel="noopener noreferrer">run_doctor_command:38</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/doctor_cmd.py</td>
@@ -7760,7 +7863,7 @@
             
 
             <tr class="searchable" data-search="run_ingest_command def skylos/commands/ingest_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/ingest_cmd.py">run_ingest_command:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/ingest_cmd.py#L5" rel="noopener noreferrer">run_ingest_command:5</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/ingest_cmd.py</td>
@@ -7768,7 +7871,7 @@
             
 
             <tr class="searchable" data-search="run_init_command def skylos/commands/init_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/init_cmd.py">run_init_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/init_cmd.py#L6" rel="noopener noreferrer">run_init_command:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/init_cmd.py</td>
@@ -7776,7 +7879,7 @@
             
 
             <tr class="searchable" data-search="run_key_command def skylos/commands/key_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/key_cmd.py">run_key_command:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py#L11" rel="noopener noreferrer">run_key_command:11</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/key_cmd.py</td>
@@ -7784,7 +7887,7 @@
             
 
             <tr class="searchable" data-search="run_login_command def skylos/commands/login_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/login_cmd.py">run_login_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/login_cmd.py#L6" rel="noopener noreferrer">run_login_command:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/login_cmd.py</td>
@@ -7792,7 +7895,7 @@
             
 
             <tr class="searchable" data-search="run_project_command def skylos/commands/project_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/project_cmd.py">run_project_command:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/project_cmd.py#L1" rel="noopener noreferrer">run_project_command:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/project_cmd.py</td>
@@ -7800,7 +7903,7 @@
             
 
             <tr class="searchable" data-search="run_provenance_command def skylos/commands/provenance_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/provenance_cmd.py">run_provenance_command:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/provenance_cmd.py#L10" rel="noopener noreferrer">run_provenance_command:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/provenance_cmd.py</td>
@@ -7808,7 +7911,7 @@
             
 
             <tr class="searchable" data-search="run_rules_command def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/rules_cmd.py">run_rules_command:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L17" rel="noopener noreferrer">run_rules_command:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
@@ -7816,7 +7919,7 @@
             
 
             <tr class="searchable" data-search="init_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/rules_cmd.py">init_rules:109</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L109" rel="noopener noreferrer">init_rules:109</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
@@ -7824,7 +7927,7 @@
             
 
             <tr class="searchable" data-search="install_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/rules_cmd.py">install_rules:170</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L170" rel="noopener noreferrer">install_rules:170</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
@@ -7832,7 +7935,7 @@
             
 
             <tr class="searchable" data-search="list_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/rules_cmd.py">list_rules:220</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L220" rel="noopener noreferrer">list_rules:220</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
@@ -7840,7 +7943,7 @@
             
 
             <tr class="searchable" data-search="list_rule_packs def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/rules_cmd.py">list_rule_packs:252</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L252" rel="noopener noreferrer">list_rule_packs:252</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
@@ -7848,7 +7951,7 @@
             
 
             <tr class="searchable" data-search="remove_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/rules_cmd.py">remove_rules:414</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L414" rel="noopener noreferrer">remove_rules:414</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
@@ -7856,7 +7959,7 @@
             
 
             <tr class="searchable" data-search="validate_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/rules_cmd.py">validate_rules:425</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L425" rel="noopener noreferrer">validate_rules:425</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
@@ -7864,7 +7967,7 @@
             
 
             <tr class="searchable" data-search="run_run_command def skylos/commands/run_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/run_cmd.py">run_run_command:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/run_cmd.py#L20" rel="noopener noreferrer">run_run_command:20</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/run_cmd.py</td>
@@ -7872,7 +7975,7 @@
             
 
             <tr class="searchable" data-search="run_scan_command def skylos/commands/scan_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/scan_cmd.py">run_scan_command:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/scan_cmd.py#L7" rel="noopener noreferrer">run_scan_command:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/scan_cmd.py</td>
@@ -7880,7 +7983,7 @@
             
 
             <tr class="searchable" data-search="run_sonar_command def skylos/commands/sonar_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/sonar_cmd.py">run_sonar_command:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/sonar_cmd.py#L7" rel="noopener noreferrer">run_sonar_command:7</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/sonar_cmd.py</td>
@@ -7888,7 +7991,7 @@
             
 
             <tr class="searchable" data-search="run_suite_command def skylos/commands/suite_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/suite_cmd.py">run_suite_command:446</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L446" rel="noopener noreferrer">run_suite_command:446</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/suite_cmd.py</td>
@@ -7896,7 +7999,7 @@
             
 
             <tr class="searchable" data-search="run_sync_command def skylos/commands/sync_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/sync_cmd.py">run_sync_command:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/sync_cmd.py#L1" rel="noopener noreferrer">run_sync_command:1</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/sync_cmd.py</td>
@@ -7904,7 +8007,7 @@
             
 
             <tr class="searchable" data-search="run_whitelist def skylos/commands/whitelist_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/whitelist_cmd.py">run_whitelist:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whitelist_cmd.py#L9" rel="noopener noreferrer">run_whitelist:9</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/whitelist_cmd.py</td>
@@ -7912,7 +8015,7 @@
             
 
             <tr class="searchable" data-search="run_whitelist_command def skylos/commands/whitelist_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/whitelist_cmd.py">run_whitelist_command:89</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whitelist_cmd.py#L89" rel="noopener noreferrer">run_whitelist_command:89</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/whitelist_cmd.py</td>
@@ -7920,7 +8023,7 @@
             
 
             <tr class="searchable" data-search="run_whoami_command def skylos/commands/whoami_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="../../skylos/commands/whoami_cmd.py">run_whoami_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whoami_cmd.py#L6" rel="noopener noreferrer">run_whoami_command:6</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/whoami_cmd.py</td>
@@ -7928,7 +8031,7 @@
             
 
             <tr class="searchable" data-search="load_config def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/config.py">load_config:104</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L104" rel="noopener noreferrer">load_config:104</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7936,7 +8039,7 @@
             
 
             <tr class="searchable" data-search="is_path_excluded def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/config.py">is_path_excluded:466</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L466" rel="noopener noreferrer">is_path_excluded:466</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7944,7 +8047,7 @@
             
 
             <tr class="searchable" data-search="is_whitelisted def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/config.py">is_whitelisted:488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L488" rel="noopener noreferrer">is_whitelisted:488</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7952,7 +8055,7 @@
             
 
             <tr class="searchable" data-search="get_expired_whitelists def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/config.py">get_expired_whitelists:532</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L532" rel="noopener noreferrer">get_expired_whitelists:532</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7960,7 +8063,7 @@
             
 
             <tr class="searchable" data-search="get_all_ignore_lines def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/config.py">get_all_ignore_lines:553</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L553" rel="noopener noreferrer">get_all_ignore_lines:553</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7968,7 +8071,7 @@
             
 
             <tr class="searchable" data-search="suggest_pattern def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/config.py">suggest_pattern:598</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L598" rel="noopener noreferrer">suggest_pattern:598</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7976,7 +8079,7 @@
             
 
             <tr class="searchable" data-search="is_test_path def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/constants.py">is_test_path:130</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L130" rel="noopener noreferrer">is_test_path:130</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
@@ -7984,7 +8087,7 @@
             
 
             <tr class="searchable" data-search="is_framework_path def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/constants.py">is_framework_path:134</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L134" rel="noopener noreferrer">is_framework_path:134</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
@@ -7992,7 +8095,7 @@
             
 
             <tr class="searchable" data-search="get_non_library_dir_kind def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/constants.py">get_non_library_dir_kind:183</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L183" rel="noopener noreferrer">get_non_library_dir_kind:183</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
@@ -8000,7 +8103,7 @@
             
 
             <tr class="searchable" data-search="parse_exclude_folders def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="../../skylos/constants.py">parse_exclude_folders:207</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L207" rel="noopener noreferrer">parse_exclude_folders:207</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
@@ -8008,7 +8111,7 @@
             
 
             <tr class="searchable" data-search="save_baseline def skylos/core/baseline.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/baseline.py">save_baseline:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py#L13" rel="noopener noreferrer">save_baseline:13</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/baseline.py</td>
@@ -8016,7 +8119,7 @@
             
 
             <tr class="searchable" data-search="load_baseline def skylos/core/baseline.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/baseline.py">load_baseline:52</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py#L52" rel="noopener noreferrer">load_baseline:52</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/baseline.py</td>
@@ -8024,7 +8127,7 @@
             
 
             <tr class="searchable" data-search="filter_new_findings def skylos/core/baseline.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/baseline.py">filter_new_findings:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py#L59" rel="noopener noreferrer">filter_new_findings:59</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/baseline.py</td>
@@ -8032,7 +8135,7 @@
             
 
             <tr class="searchable" data-search="sanitize_addopts def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/cli_shared.py">sanitize_addopts:88</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L88" rel="noopener noreferrer">sanitize_addopts:88</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
@@ -8040,7 +8143,7 @@
             
 
             <tr class="searchable" data-search="get_git_changed_files def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/cli_shared.py">get_git_changed_files:129</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L129" rel="noopener noreferrer">get_git_changed_files:129</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
@@ -8048,7 +8151,7 @@
             
 
             <tr class="searchable" data-search="estimate_cost def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/cli_shared.py">estimate_cost:224</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L224" rel="noopener noreferrer">estimate_cost:224</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
@@ -8056,7 +8159,7 @@
             
 
             <tr class="searchable" data-search="load_addopts def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/cli_shared.py">load_addopts:237</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L237" rel="noopener noreferrer">load_addopts:237</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
@@ -8064,7 +8167,7 @@
             
 
             <tr class="searchable" data-search="should_exclude_path def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/file_discovery.py">should_exclude_path:124</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L124" rel="noopener noreferrer">should_exclude_path:124</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
@@ -8072,7 +8175,7 @@
             
 
             <tr class="searchable" data-search="should_include_path def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/file_discovery.py">should_include_path:148</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L148" rel="noopener noreferrer">should_include_path:148</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
@@ -8080,7 +8183,7 @@
             
 
             <tr class="searchable" data-search="find_git_root def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/file_discovery.py">find_git_root:156</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L156" rel="noopener noreferrer">find_git_root:156</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
@@ -8088,7 +8191,7 @@
             
 
             <tr class="searchable" data-search="list_git_visible_files def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/file_discovery.py">list_git_visible_files:174</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L174" rel="noopener noreferrer">list_git_visible_files:174</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
@@ -8096,7 +8199,7 @@
             
 
             <tr class="searchable" data-search="discover_source_files def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/file_discovery.py">discover_source_files:237</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L237" rel="noopener noreferrer">discover_source_files:237</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
@@ -8104,7 +8207,7 @@
             
 
             <tr class="searchable" data-search="run_cmd def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">run_cmd:36</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L36" rel="noopener noreferrer">run_cmd:36</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8112,7 +8215,7 @@
             
 
             <tr class="searchable" data-search="get_git_status def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">get_git_status:45</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L45" rel="noopener noreferrer">get_git_status:45</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8120,7 +8223,7 @@
             
 
             <tr class="searchable" data-search="run_push def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">run_push:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L59" rel="noopener noreferrer">run_push:59</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8128,7 +8231,7 @@
             
 
             <tr class="searchable" data-search="start_deployment_wizard def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">start_deployment_wizard:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L70" rel="noopener noreferrer">start_deployment_wizard:70</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8136,7 +8239,7 @@
             
 
             <tr class="searchable" data-search="check_gate def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">check_gate:431</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L431" rel="noopener noreferrer">check_gate:431</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8144,7 +8247,7 @@
             
 
             <tr class="searchable" data-search="build_summary_markdown def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">build_summary_markdown:524</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L524" rel="noopener noreferrer">build_summary_markdown:524</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8152,7 +8255,7 @@
             
 
             <tr class="searchable" data-search="write_github_summary def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">write_github_summary:567</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L567" rel="noopener noreferrer">write_github_summary:567</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8160,7 +8263,7 @@
             
 
             <tr class="searchable" data-search="run_gate_interaction def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/gatekeeper.py">run_gate_interaction:630</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L630" rel="noopener noreferrer">run_gate_interaction:630</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
@@ -8168,7 +8271,7 @@
             
 
             <tr class="searchable" data-search="file_content_hash def skylos/core/grep_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_cache.py">file_content_hash:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_cache.py#L21" rel="noopener noreferrer">file_content_hash:21</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_cache.py</td>
@@ -8176,7 +8279,7 @@
             
 
             <tr class="searchable" data-search="grepcache class skylos/core/grep_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_cache.py">GrepCache:47</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_cache.py#L47" rel="noopener noreferrer">GrepCache:47</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_cache.py</td>
@@ -8184,7 +8287,7 @@
             
 
             <tr class="searchable" data-search="grepverdict class skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify.py">GrepVerdict:66</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L66" rel="noopener noreferrer">GrepVerdict:66</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
@@ -8192,7 +8295,7 @@
             
 
             <tr class="searchable" data-search="grepstrategy class skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify.py">GrepStrategy:74</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L74" rel="noopener noreferrer">GrepStrategy:74</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
@@ -8200,7 +8303,7 @@
             
 
             <tr class="searchable" data-search="multi_strategy_search def skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify.py">multi_strategy_search:149</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L149" rel="noopener noreferrer">multi_strategy_search:149</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
@@ -8208,7 +8311,7 @@
             
 
             <tr class="searchable" data-search="parallel_multi_strategy_search def skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify.py">parallel_multi_strategy_search:164</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L164" rel="noopener noreferrer">parallel_multi_strategy_search:164</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
@@ -8216,7 +8319,7 @@
             
 
             <tr class="searchable" data-search="grep_verify_findings def skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify.py">grep_verify_findings:228</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L228" rel="noopener noreferrer">grep_verify_findings:228</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
@@ -8224,7 +8327,7 @@
             
 
             <tr class="searchable" data-search="detect_language def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">detect_language:82</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L82" rel="noopener noreferrer">detect_language:82</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8232,7 +8335,7 @@
             
 
             <tr class="searchable" data-search="source_globs_for_language def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">source_globs_for_language:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L101" rel="noopener noreferrer">source_globs_for_language:101</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8240,7 +8343,7 @@
             
 
             <tr class="searchable" data-search="repo_relative_path def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">repo_relative_path:178</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L178" rel="noopener noreferrer">repo_relative_path:178</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8248,7 +8351,7 @@
             
 
             <tr class="searchable" data-search="module_candidates def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">module_candidates:192</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L192" rel="noopener noreferrer">module_candidates:192</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8256,7 +8359,7 @@
             
 
             <tr class="searchable" data-search="parameter_owner_name def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">parameter_owner_name:280</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L280" rel="noopener noreferrer">parameter_owner_name:280</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8264,7 +8367,7 @@
             
 
             <tr class="searchable" data-search="is_definition_line def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">is_definition_line:289</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L289" rel="noopener noreferrer">is_definition_line:289</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8272,7 +8375,7 @@
             
 
             <tr class="searchable" data-search="filter_grep_results def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">filter_grep_results:368</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L368" rel="noopener noreferrer">filter_grep_results:368</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8280,7 +8383,7 @@
             
 
             <tr class="searchable" data-search="is_substring_match def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_common.py">is_substring_match:383</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L383" rel="noopener noreferrer">is_substring_match:383</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
@@ -8288,7 +8391,7 @@
             
 
             <tr class="searchable" data-search="parallel_multi_strategy_search_impl def skylos/core/grep_verify_parallel.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_parallel.py">parallel_multi_strategy_search_impl:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_parallel.py#L17" rel="noopener noreferrer">parallel_multi_strategy_search_impl:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_parallel.py</td>
@@ -8296,7 +8399,7 @@
             
 
             <tr class="searchable" data-search="multi_strategy_search def skylos/core/grep_verify_python_strategy.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_python_strategy.py">multi_strategy_search:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_python_strategy.py#L22" rel="noopener noreferrer">multi_strategy_search:22</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_python_strategy.py</td>
@@ -8304,7 +8407,7 @@
             
 
             <tr class="searchable" data-search="build_parallel_strategy_tasks def skylos/core/grep_verify_strategies.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/grep_verify_strategies.py">build_parallel_strategy_tasks:65</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_strategies.py#L65" rel="noopener noreferrer">build_parallel_strategy_tasks:65</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_strategies.py</td>
@@ -8312,7 +8415,7 @@
             
 
             <tr class="searchable" data-search="lintervisitor class skylos/core/linter.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/linter.py">LinterVisitor:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/linter.py#L5" rel="noopener noreferrer">LinterVisitor:5</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/linter.py</td>
@@ -8320,7 +8423,7 @@
             
 
             <tr class="searchable" data-search="build_trace_cache_key def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/result_cache.py">build_trace_cache_key:117</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L117" rel="noopener noreferrer">build_trace_cache_key:117</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
@@ -8328,7 +8431,7 @@
             
 
             <tr class="searchable" data-search="load_trace_cache def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/result_cache.py">load_trace_cache:153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L153" rel="noopener noreferrer">load_trace_cache:153</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
@@ -8336,7 +8439,7 @@
             
 
             <tr class="searchable" data-search="save_trace_cache def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/result_cache.py">save_trace_cache:181</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L181" rel="noopener noreferrer">save_trace_cache:181</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
@@ -8344,7 +8447,7 @@
             
 
             <tr class="searchable" data-search="clear_run_cache def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/result_cache.py">clear_run_cache:209</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L209" rel="noopener noreferrer">clear_run_cache:209</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
@@ -8352,7 +8455,7 @@
             
 
             <tr class="searchable" data-search="run_cache_stats def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/result_cache.py">run_cache_stats:226</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L226" rel="noopener noreferrer">run_cache_stats:226</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
@@ -8360,7 +8463,7 @@
             
 
             <tr class="searchable" data-search="read_trace_payload def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/result_cache.py">read_trace_payload:320</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L320" rel="noopener noreferrer">read_trace_payload:320</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
@@ -8368,7 +8471,7 @@
             
 
             <tr class="searchable" data-search="write_trace_payload def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/result_cache.py">write_trace_payload:335</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L335" rel="noopener noreferrer">write_trace_payload:335</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
@@ -8376,7 +8479,7 @@
             
 
             <tr class="searchable" data-search="format_suite_table def skylos/core/suite.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/suite.py">format_suite_table:129</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py#L129" rel="noopener noreferrer">format_suite_table:129</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/suite.py</td>
@@ -8384,7 +8487,7 @@
             
 
             <tr class="searchable" data-search="format_suite_json def skylos/core/suite.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/suite.py">format_suite_json:179</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py#L179" rel="noopener noreferrer">format_suite_json:179</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/suite.py</td>
@@ -8392,7 +8495,7 @@
             
 
             <tr class="searchable" data-search="run_suite def skylos/core/suite.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/suite.py">run_suite:183</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py#L183" rel="noopener noreferrer">run_suite:183</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/suite.py</td>
@@ -8400,7 +8503,7 @@
             
 
             <tr class="searchable" data-search="calltracer class skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/tracer.py">CallTracer:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L8" rel="noopener noreferrer">CallTracer:8</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
@@ -8408,7 +8511,7 @@
             
 
             <tr class="searchable" data-search="start_tracing def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/tracer.py">start_tracing:137</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L137" rel="noopener noreferrer">start_tracing:137</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
@@ -8416,7 +8519,7 @@
             
 
             <tr class="searchable" data-search="stop_tracing def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/tracer.py">stop_tracing:144</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L144" rel="noopener noreferrer">stop_tracing:144</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
@@ -8424,7 +8527,7 @@
             
 
             <tr class="searchable" data-search="pytest_configure def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/tracer.py">pytest_configure:157</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L157" rel="noopener noreferrer">pytest_configure:157</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
@@ -8432,7 +8535,7 @@
             
 
             <tr class="searchable" data-search="pytest_unconfigure def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/tracer.py">pytest_unconfigure:168</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L168" rel="noopener noreferrer">pytest_unconfigure:168</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
@@ -8440,7 +8543,7 @@
             
 
             <tr class="searchable" data-search="pytest_addoption def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="../../skylos/core/tracer.py">pytest_addoption:173</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L173" rel="noopener noreferrer">pytest_addoption:173</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
@@ -8448,7 +8551,7 @@
             
 
             <tr class="searchable" data-search="collect_dead_code_findings def skylos/deadcode/collect.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/collect.py">collect_dead_code_findings:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py#L14" rel="noopener noreferrer">collect_dead_code_findings:14</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/collect.py</td>
@@ -8456,7 +8559,7 @@
             
 
             <tr class="searchable" data-search="evidencekind class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/evidence.py">EvidenceKind:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L12" rel="noopener noreferrer">EvidenceKind:12</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
@@ -8464,7 +8567,7 @@
             
 
             <tr class="searchable" data-search="candidateclassification class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/evidence.py">CandidateClassification:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L28" rel="noopener noreferrer">CandidateClassification:28</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
@@ -8472,7 +8575,7 @@
             
 
             <tr class="searchable" data-search="symbolkey class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/evidence.py">SymbolKey:37</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L37" rel="noopener noreferrer">SymbolKey:37</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
@@ -8480,7 +8583,7 @@
             
 
             <tr class="searchable" data-search="evidenceevent class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/evidence.py">EvidenceEvent:89</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L89" rel="noopener noreferrer">EvidenceEvent:89</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
@@ -8488,7 +8591,7 @@
             
 
             <tr class="searchable" data-search="evidenceledger class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/evidence.py">EvidenceLedger:107</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L107" rel="noopener noreferrer">EvidenceLedger:107</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
@@ -8496,7 +8599,7 @@
             
 
             <tr class="searchable" data-search="build_dead_code_evidence def skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/evidence.py">build_dead_code_evidence:189</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L189" rel="noopener noreferrer">build_dead_code_evidence:189</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
@@ -8504,7 +8607,7 @@
             
 
             <tr class="searchable" data-search="livenessrescue class skylos/deadcode/liveness.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/liveness.py">LivenessRescue:61</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L61" rel="noopener noreferrer">LivenessRescue:61</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/liveness.py</td>
@@ -8512,7 +8615,7 @@
             
 
             <tr class="searchable" data-search="livenessreport class skylos/deadcode/liveness.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/liveness.py">LivenessReport:69</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L69" rel="noopener noreferrer">LivenessReport:69</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/liveness.py</td>
@@ -8520,7 +8623,7 @@
             
 
             <tr class="searchable" data-search="apply_dead_code_liveness def skylos/deadcode/liveness.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="../../skylos/deadcode/liveness.py">apply_dead_code_liveness:95</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L95" rel="noopener noreferrer">apply_dead_code_liveness:95</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/liveness.py</td>
@@ -8528,7 +8631,7 @@
             
 
             <tr class="searchable" data-search="augment_hotspots_with_advisories def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/__init__.py">augment_hotspots_with_advisories:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L25" rel="noopener noreferrer">augment_hotspots_with_advisories:25</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
@@ -8536,7 +8639,7 @@
             
 
             <tr class="searchable" data-search="collect_debt_signals def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/__init__.py">collect_debt_signals:33</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L33" rel="noopener noreferrer">collect_debt_signals:33</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
@@ -8544,7 +8647,7 @@
             
 
             <tr class="searchable" data-search="build_debt_snapshot def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/__init__.py">build_debt_snapshot:39</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L39" rel="noopener noreferrer">build_debt_snapshot:39</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
@@ -8552,7 +8655,7 @@
             
 
             <tr class="searchable" data-search="run_debt_analysis def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/__init__.py">run_debt_analysis:45</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L45" rel="noopener noreferrer">run_debt_analysis:45</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
@@ -8560,7 +8663,7 @@
             
 
             <tr class="searchable" data-search="debtadvisor class skylos/debt/advisor.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/advisor.py">DebtAdvisor:226</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L226" rel="noopener noreferrer">DebtAdvisor:226</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/advisor.py</td>
@@ -8568,7 +8671,7 @@
             
 
             <tr class="searchable" data-search="augment_hotspots_with_advisories def skylos/debt/advisor.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/advisor.py">augment_hotspots_with_advisories:263</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L263" rel="noopener noreferrer">augment_hotspots_with_advisories:263</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/advisor.py</td>
@@ -8576,7 +8679,7 @@
             
 
             <tr class="searchable" data-search="save_baseline def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/baseline.py">save_baseline:88</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L88" rel="noopener noreferrer">save_baseline:88</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
@@ -8584,7 +8687,7 @@
             
 
             <tr class="searchable" data-search="load_baseline def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/baseline.py">load_baseline:113</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L113" rel="noopener noreferrer">load_baseline:113</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
@@ -8592,7 +8695,7 @@
             
 
             <tr class="searchable" data-search="load_history def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/baseline.py">load_history:120</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L120" rel="noopener noreferrer">load_history:120</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
@@ -8600,7 +8703,7 @@
             
 
             <tr class="searchable" data-search="annotate_hotspots def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/baseline.py">annotate_hotspots:163</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L163" rel="noopener noreferrer">annotate_hotspots:163</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
@@ -8608,7 +8711,7 @@
             
 
             <tr class="searchable" data-search="compare_to_baseline def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/baseline.py">compare_to_baseline:208</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L208" rel="noopener noreferrer">compare_to_baseline:208</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
@@ -8616,7 +8719,7 @@
             
 
             <tr class="searchable" data-search="append_history def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/baseline.py">append_history:223</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L223" rel="noopener noreferrer">append_history:223</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
@@ -8624,7 +8727,7 @@
             
 
             <tr class="searchable" data-search="run_analyze def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/engine.py">run_analyze:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L43" rel="noopener noreferrer">run_analyze:43</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
@@ -8632,7 +8735,7 @@
             
 
             <tr class="searchable" data-search="collect_debt_signals def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/engine.py">collect_debt_signals:186</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L186" rel="noopener noreferrer">collect_debt_signals:186</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
@@ -8640,7 +8743,7 @@
             
 
             <tr class="searchable" data-search="build_debt_snapshot def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/engine.py">build_debt_snapshot:223</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L223" rel="noopener noreferrer">build_debt_snapshot:223</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
@@ -8648,7 +8751,7 @@
             
 
             <tr class="searchable" data-search="run_debt_analysis def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/engine.py">run_debt_analysis:284</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L284" rel="noopener noreferrer">run_debt_analysis:284</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
@@ -8656,7 +8759,7 @@
             
 
             <tr class="searchable" data-search="debtpolicy class skylos/debt/policy.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/policy.py">DebtPolicy:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py#L24" rel="noopener noreferrer">DebtPolicy:24</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/policy.py</td>
@@ -8664,7 +8767,7 @@
             
 
             <tr class="searchable" data-search="find_policy_path def skylos/debt/policy.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/policy.py">find_policy_path:39</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py#L39" rel="noopener noreferrer">find_policy_path:39</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/policy.py</td>
@@ -8672,7 +8775,7 @@
             
 
             <tr class="searchable" data-search="load_policy def skylos/debt/policy.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/policy.py">load_policy:54</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py#L54" rel="noopener noreferrer">load_policy:54</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/policy.py</td>
@@ -8680,7 +8783,7 @@
             
 
             <tr class="searchable" data-search="format_debt_table def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/report.py">format_debt_table:244</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L244" rel="noopener noreferrer">format_debt_table:244</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
@@ -8688,7 +8791,7 @@
             
 
             <tr class="searchable" data-search="format_debt_json def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/report.py">format_debt_json:280</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L280" rel="noopener noreferrer">format_debt_json:280</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
@@ -8696,7 +8799,7 @@
             
 
             <tr class="searchable" data-search="format_debt_history_table def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/report.py">format_debt_history_table:357</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L357" rel="noopener noreferrer">format_debt_history_table:357</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
@@ -8704,7 +8807,7 @@
             
 
             <tr class="searchable" data-search="format_debt_history_json def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/report.py">format_debt_history_json:388</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L388" rel="noopener noreferrer">format_debt_history_json:388</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
@@ -8712,7 +8815,7 @@
             
 
             <tr class="searchable" data-search="debtadvisory class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/result.py">DebtAdvisory:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L8" rel="noopener noreferrer">DebtAdvisory:8</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
@@ -8720,7 +8823,7 @@
             
 
             <tr class="searchable" data-search="debtsignal class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/result.py">DebtSignal:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L28" rel="noopener noreferrer">DebtSignal:28</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
@@ -8728,7 +8831,7 @@
             
 
             <tr class="searchable" data-search="debthotspot class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/result.py">DebtHotspot:62</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L62" rel="noopener noreferrer">DebtHotspot:62</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
@@ -8736,7 +8839,7 @@
             
 
             <tr class="searchable" data-search="debtscore class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/result.py">DebtScore:94</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L94" rel="noopener noreferrer">DebtScore:94</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
@@ -8744,7 +8847,7 @@
             
 
             <tr class="searchable" data-search="debtsnapshot class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/result.py">DebtSnapshot:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L116" rel="noopener noreferrer">DebtSnapshot:116</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
@@ -8752,7 +8855,7 @@
             
 
             <tr class="searchable" data-search="compute_signal_points def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/scoring.py">compute_signal_points:35</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L35" rel="noopener noreferrer">compute_signal_points:35</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
@@ -8760,7 +8863,7 @@
             
 
             <tr class="searchable" data-search="compute_priority_score def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/scoring.py">compute_priority_score:64</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L64" rel="noopener noreferrer">compute_priority_score:64</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
@@ -8768,7 +8871,7 @@
             
 
             <tr class="searchable" data-search="refresh_hotspot_priority def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/scoring.py">refresh_hotspot_priority:88</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L88" rel="noopener noreferrer">refresh_hotspot_priority:88</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
@@ -8776,7 +8879,7 @@
             
 
             <tr class="searchable" data-search="build_hotspots def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/scoring.py">build_hotspots:103</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L103" rel="noopener noreferrer">build_hotspots:103</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
@@ -8784,7 +8887,7 @@
             
 
             <tr class="searchable" data-search="compute_debt_score def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/scoring.py">compute_debt_score:152</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L152" rel="noopener noreferrer">compute_debt_score:152</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
@@ -8792,7 +8895,7 @@
             
 
             <tr class="searchable" data-search="build_score_breakdown def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/scoring.py">build_score_breakdown:210</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L210" rel="noopener noreferrer">build_score_breakdown:210</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
@@ -8800,7 +8903,7 @@
             
 
             <tr class="searchable" data-search="score_model_metadata def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="../../skylos/debt/scoring.py">score_model_metadata:285</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L285" rel="noopener noreferrer">score_model_metadata:285</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
@@ -8808,7 +8911,7 @@
             
 
             <tr class="searchable" data-search="run_defense_checks def skylos/defend/engine.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/engine.py">run_defense_checks:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/engine.py#L19" rel="noopener noreferrer">run_defense_checks:19</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/engine.py</td>
@@ -8816,7 +8919,7 @@
             
 
             <tr class="searchable" data-search="supported_owasp_frameworks def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">supported_owasp_frameworks:189</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L189" rel="noopener noreferrer">supported_owasp_frameworks:189</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8824,7 +8927,7 @@
             
 
             <tr class="searchable" data-search="supported_owasp_versions def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">supported_owasp_versions:193</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L193" rel="noopener noreferrer">supported_owasp_versions:193</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8832,7 +8935,7 @@
             
 
             <tr class="searchable" data-search="normalize_owasp_framework def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">normalize_owasp_framework:200</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L200" rel="noopener noreferrer">normalize_owasp_framework:200</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8840,7 +8943,7 @@
             
 
             <tr class="searchable" data-search="normalize_owasp_selection def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">normalize_owasp_selection:209</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L209" rel="noopener noreferrer">normalize_owasp_selection:209</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8848,7 +8951,7 @@
             
 
             <tr class="searchable" data-search="get_owasp_mapping def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">get_owasp_mapping:232</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L232" rel="noopener noreferrer">get_owasp_mapping:232</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8856,7 +8959,7 @@
             
 
             <tr class="searchable" data-search="owasp_report_label def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">owasp_report_label:240</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L240" rel="noopener noreferrer">owasp_report_label:240</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8864,7 +8967,7 @@
             
 
             <tr class="searchable" data-search="validate_owasp_ids def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">validate_owasp_ids:248</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L248" rel="noopener noreferrer">validate_owasp_ids:248</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8872,7 +8975,7 @@
             
 
             <tr class="searchable" data-search="plugin_ids_for_owasp_filter def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">plugin_ids_for_owasp_filter:266</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L266" rel="noopener noreferrer">plugin_ids_for_owasp_filter:266</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8880,7 +8983,7 @@
             
 
             <tr class="searchable" data-search="compute_owasp_coverage def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/owasp.py">compute_owasp_coverage:282</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L282" rel="noopener noreferrer">compute_owasp_coverage:282</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
@@ -8888,7 +8991,7 @@
             
 
             <tr class="searchable" data-search="defenseplugin class skylos/defend/plugin.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugin.py">DefensePlugin:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugin.py#L12" rel="noopener noreferrer">DefensePlugin:12</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugin.py</td>
@@ -8896,7 +8999,7 @@
             
 
             <tr class="searchable" data-search="costcontrolsplugin class skylos/defend/plugins/cost_controls.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/cost_controls.py">CostControlsPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/cost_controls.py#L7" rel="noopener noreferrer">CostControlsPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/cost_controls.py</td>
@@ -8904,7 +9007,7 @@
             
 
             <tr class="searchable" data-search="inputlengthlimitplugin class skylos/defend/plugins/input_length_limit.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/input_length_limit.py">InputLengthLimitPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/input_length_limit.py#L7" rel="noopener noreferrer">InputLengthLimitPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/input_length_limit.py</td>
@@ -8912,7 +9015,7 @@
             
 
             <tr class="searchable" data-search="loggingpresentplugin class skylos/defend/plugins/logging_present.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/logging_present.py">LoggingPresentPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/logging_present.py#L7" rel="noopener noreferrer">LoggingPresentPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/logging_present.py</td>
@@ -8920,7 +9023,7 @@
             
 
             <tr class="searchable" data-search="modelpinnedplugin class skylos/defend/plugins/model_pinned.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/model_pinned.py">ModelPinnedPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/model_pinned.py#L7" rel="noopener noreferrer">ModelPinnedPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/model_pinned.py</td>
@@ -8928,7 +9031,7 @@
             
 
             <tr class="searchable" data-search="nodangeroussinkplugin class skylos/defend/plugins/no_dangerous_sink.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/no_dangerous_sink.py">NoDangerousSinkPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/no_dangerous_sink.py#L7" rel="noopener noreferrer">NoDangerousSinkPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/no_dangerous_sink.py</td>
@@ -8936,7 +9039,7 @@
             
 
             <tr class="searchable" data-search="outputpiifilterplugin class skylos/defend/plugins/output_pii_filter.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/output_pii_filter.py">OutputPiiFilterPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/output_pii_filter.py#L7" rel="noopener noreferrer">OutputPiiFilterPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/output_pii_filter.py</td>
@@ -8944,7 +9047,7 @@
             
 
             <tr class="searchable" data-search="outputvalidationplugin class skylos/defend/plugins/output_validation.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/output_validation.py">OutputValidationPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/output_validation.py#L7" rel="noopener noreferrer">OutputValidationPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/output_validation.py</td>
@@ -8952,7 +9055,7 @@
             
 
             <tr class="searchable" data-search="promptdelimiterplugin class skylos/defend/plugins/prompt_delimiter.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/prompt_delimiter.py">PromptDelimiterPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/prompt_delimiter.py#L7" rel="noopener noreferrer">PromptDelimiterPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/prompt_delimiter.py</td>
@@ -8960,7 +9063,7 @@
             
 
             <tr class="searchable" data-search="ragcontextisolationplugin class skylos/defend/plugins/rag_context_isolation.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/rag_context_isolation.py">RagContextIsolationPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/rag_context_isolation.py#L7" rel="noopener noreferrer">RagContextIsolationPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/rag_context_isolation.py</td>
@@ -8968,7 +9071,7 @@
             
 
             <tr class="searchable" data-search="ratelimitingplugin class skylos/defend/plugins/rate_limiting.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/rate_limiting.py">RateLimitingPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/rate_limiting.py#L7" rel="noopener noreferrer">RateLimitingPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/rate_limiting.py</td>
@@ -8976,7 +9079,7 @@
             
 
             <tr class="searchable" data-search="toolschemapresentplugin class skylos/defend/plugins/tool_schema_present.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/tool_schema_present.py">ToolSchemaPresentPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/tool_schema_present.py#L7" rel="noopener noreferrer">ToolSchemaPresentPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/tool_schema_present.py</td>
@@ -8984,7 +9087,7 @@
             
 
             <tr class="searchable" data-search="toolscopeplugin class skylos/defend/plugins/tool_scope.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/tool_scope.py">ToolScopePlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/tool_scope.py#L7" rel="noopener noreferrer">ToolScopePlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/tool_scope.py</td>
@@ -8992,7 +9095,7 @@
             
 
             <tr class="searchable" data-search="untrustedinputtopromptplugin class skylos/defend/plugins/untrusted_input_to_prompt.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/plugins/untrusted_input_to_prompt.py">UntrustedInputToPromptPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/untrusted_input_to_prompt.py#L7" rel="noopener noreferrer">UntrustedInputToPromptPlugin:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/untrusted_input_to_prompt.py</td>
@@ -9000,7 +9103,7 @@
             
 
             <tr class="searchable" data-search="defensepolicy class skylos/defend/policy.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/policy.py">DefensePolicy:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L51" rel="noopener noreferrer">DefensePolicy:51</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/policy.py</td>
@@ -9008,7 +9111,7 @@
             
 
             <tr class="searchable" data-search="load_policy def skylos/defend/policy.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/policy.py">load_policy:66</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L66" rel="noopener noreferrer">load_policy:66</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/policy.py</td>
@@ -9016,7 +9119,7 @@
             
 
             <tr class="searchable" data-search="format_defense_table def skylos/defend/report.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/report.py">format_defense_table:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L17" rel="noopener noreferrer">format_defense_table:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/report.py</td>
@@ -9024,7 +9127,7 @@
             
 
             <tr class="searchable" data-search="format_defense_json def skylos/defend/report.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/report.py">format_defense_json:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L102" rel="noopener noreferrer">format_defense_json:102</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/report.py</td>
@@ -9032,7 +9135,7 @@
             
 
             <tr class="searchable" data-search="defenseresult class skylos/defend/result.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/result.py">DefenseResult:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L8" rel="noopener noreferrer">DefenseResult:8</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/result.py</td>
@@ -9040,7 +9143,7 @@
             
 
             <tr class="searchable" data-search="defensescore class skylos/defend/result.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/result.py">DefenseScore:36</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L36" rel="noopener noreferrer">DefenseScore:36</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/result.py</td>
@@ -9048,7 +9151,7 @@
             
 
             <tr class="searchable" data-search="opsscore class skylos/defend/result.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/result.py">OpsScore:56</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L56" rel="noopener noreferrer">OpsScore:56</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/result.py</td>
@@ -9056,7 +9159,7 @@
             
 
             <tr class="searchable" data-search="compute_defense_score def skylos/defend/scoring.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/scoring.py">compute_defense_score:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L19" rel="noopener noreferrer">compute_defense_score:19</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/scoring.py</td>
@@ -9064,7 +9167,7 @@
             
 
             <tr class="searchable" data-search="compute_ops_score def skylos/defend/scoring.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="../../skylos/defend/scoring.py">compute_ops_score:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L70" rel="noopener noreferrer">compute_ops_score:70</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/scoring.py</td>
@@ -9072,7 +9175,7 @@
             
 
             <tr class="searchable" data-search="detect_integrations def skylos/discover/detector.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/detector.py">detect_integrations:1049</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1049" rel="noopener noreferrer">detect_integrations:1049</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector.py</td>
@@ -9080,7 +9183,7 @@
             
 
             <tr class="searchable" data-search="jsimport class skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/detector_typescript.py">JSImport:173</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L173" rel="noopener noreferrer">JSImport:173</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
@@ -9088,7 +9191,7 @@
             
 
             <tr class="searchable" data-search="tsclient class skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/detector_typescript.py">TSClient:180</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L180" rel="noopener noreferrer">TSClient:180</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
@@ -9096,7 +9199,7 @@
             
 
             <tr class="searchable" data-search="collect_typescript_files def skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/detector_typescript.py">collect_typescript_files:187</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L187" rel="noopener noreferrer">collect_typescript_files:187</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
@@ -9104,7 +9207,7 @@
             
 
             <tr class="searchable" data-search="scan_typescript_file def skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/detector_typescript.py">scan_typescript_file:200</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L200" rel="noopener noreferrer">scan_typescript_file:200</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
@@ -9112,7 +9215,7 @@
             
 
             <tr class="searchable" data-search="nodetype class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/graph.py">NodeType:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L8" rel="noopener noreferrer">NodeType:8</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
@@ -9120,7 +9223,7 @@
             
 
             <tr class="searchable" data-search="graphnode class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/graph.py">GraphNode:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L18" rel="noopener noreferrer">GraphNode:18</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
@@ -9128,7 +9231,7 @@
             
 
             <tr class="searchable" data-search="graphedge class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/graph.py">GraphEdge:36</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L36" rel="noopener noreferrer">GraphEdge:36</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
@@ -9136,7 +9239,7 @@
             
 
             <tr class="searchable" data-search="aiintegrationgraph class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/graph.py">AIIntegrationGraph:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L51" rel="noopener noreferrer">AIIntegrationGraph:51</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
@@ -9144,7 +9247,7 @@
             
 
             <tr class="searchable" data-search="tooldef class skylos/discover/integration.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/integration.py">ToolDef:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py#L7" rel="noopener noreferrer">ToolDef:7</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/integration.py</td>
@@ -9152,7 +9255,7 @@
             
 
             <tr class="searchable" data-search="llmintegration class skylos/discover/integration.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/integration.py">LLMIntegration:23</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py#L23" rel="noopener noreferrer">LLMIntegration:23</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/integration.py</td>
@@ -9160,7 +9263,7 @@
             
 
             <tr class="searchable" data-search="format_table def skylos/discover/report.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/report.py">format_table:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py#L10" rel="noopener noreferrer">format_table:10</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/report.py</td>
@@ -9168,7 +9271,7 @@
             
 
             <tr class="searchable" data-search="format_json def skylos/discover/report.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/report.py">format_json:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py#L51" rel="noopener noreferrer">format_json:51</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/report.py</td>
@@ -9176,7 +9279,7 @@
             
 
             <tr class="searchable" data-search="taintflow class skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/taint.py">TaintFlow:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L9" rel="noopener noreferrer">TaintFlow:9</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/taint.py</td>
@@ -9184,7 +9287,7 @@
             
 
             <tr class="searchable" data-search="analyze_taint_flows def skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="../../skylos/discover/taint.py">analyze_taint_flows:201</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L201" rel="noopener noreferrer">analyze_taint_flows:201</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/taint.py</td>
@@ -9192,7 +9295,7 @@
             
 
             <tr class="searchable" data-search="build_go_engine_args def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="../../skylos/engines/go_contract.py">build_go_engine_args:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L4" rel="noopener noreferrer">build_go_engine_args:4</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_contract.py</td>
@@ -9200,7 +9303,7 @@
             
 
             <tr class="searchable" data-search="validate_go_engine_output def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="../../skylos/engines/go_contract.py">validate_go_engine_output:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L17" rel="noopener noreferrer">validate_go_engine_output:17</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_contract.py</td>
@@ -9208,7 +9311,7 @@
             
 
             <tr class="searchable" data-search="goengineerror class skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="../../skylos/engines/go_runner.py">GoEngineError:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L15" rel="noopener noreferrer">GoEngineError:15</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
@@ -9216,7 +9319,7 @@
             
 
             <tr class="searchable" data-search="discover_go_modules def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="../../skylos/engines/go_runner.py">discover_go_modules:34</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L34" rel="noopener noreferrer">discover_go_modules:34</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
@@ -9224,7 +9327,7 @@
             
 
             <tr class="searchable" data-search="resolve_go_engine_bin def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="../../skylos/engines/go_runner.py">resolve_go_engine_bin:67</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L67" rel="noopener noreferrer">resolve_go_engine_bin:67</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
@@ -9232,7 +9335,7 @@
             
 
             <tr class="searchable" data-search="run_go_engine_for_module def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="../../skylos/engines/go_runner.py">run_go_engine_for_module:96</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L96" rel="noopener noreferrer">run_go_engine_for_module:96</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
@@ -9240,7 +9343,7 @@
             
 
             <tr class="searchable" data-search="is_claude_security_report def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="../../skylos/integrations/ingest.py">is_claude_security_report:27</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L27" rel="noopener noreferrer">is_claude_security_report:27</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/integrations/ingest.py</td>
@@ -9248,7 +9351,7 @@
             
 
             <tr class="searchable" data-search="normalize_claude_security def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="../../skylos/integrations/ingest.py">normalize_claude_security:56</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L56" rel="noopener noreferrer">normalize_claude_security:56</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/integrations/ingest.py</td>
@@ -9256,7 +9359,7 @@
             
 
             <tr class="searchable" data-search="cross_reference def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="../../skylos/integrations/ingest.py">cross_reference:165</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L165" rel="noopener noreferrer">cross_reference:165</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/integrations/ingest.py</td>
@@ -9264,26 +9367,10 @@
             
 
             <tr class="searchable" data-search="print_cross_reference_report def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="../../skylos/integrations/ingest.py">print_cross_reference_report:223</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L223" rel="noopener noreferrer">print_cross_reference_report:223</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/integrations/ingest.py</td>
-            </tr>
-            
-
-            <tr class="searchable" data-search="ingest_claude_security def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="../../skylos/integrations/ingest.py">ingest_claude_security:265</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/integrations/ingest.py</td>
-            </tr>
-            
-
-            <tr class="searchable" data-search="parse_sonar_properties def skylos/integrations/sonar.py external-service integration helpers.">
-              <td><a href="../../skylos/integrations/sonar.py">parse_sonar_properties:16</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/integrations/sonar.py</td>
             </tr>
             </tbody>
       </table>

--- a/docs/repo-map/styles.css
+++ b/docs/repo-map/styles.css
@@ -112,6 +112,7 @@ nav a {
 
 .meta-grid,
 .persona-grid,
+.mode-stack,
 .guide-grid,
 .arch-grid,
 .doc-grid,
@@ -134,6 +135,10 @@ nav a {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.mode-stack {
+  grid-template-columns: 1fr;
+}
+
 .arch-grid,
 .doc-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -145,6 +150,7 @@ nav a {
 }
 
 .metric,
+.mode-panel,
 .persona-card,
 .guide-card,
 .arch-card,
@@ -161,6 +167,7 @@ nav a {
 }
 
 .metric,
+.mode-panel,
 .persona-card,
 .guide-card,
 .arch-card,
@@ -183,6 +190,40 @@ nav a {
 .muted {
   color: var(--muted);
   font-size: 13px;
+}
+
+.mode-panel {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.75fr) minmax(300px, 1.25fr);
+  gap: 18px;
+  border-color: #b7d8d2;
+  background: #fbfefd;
+}
+
+.mode-panel h3 {
+  margin: 4px 0 8px;
+}
+
+.mode-panel p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.mode-panel .step-list {
+  margin-bottom: 8px;
+}
+
+.mode-panel-updated {
+  animation: mode-panel-pulse 650ms ease-out;
+}
+
+@keyframes mode-panel-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(15, 118, 110, 0.28);
+  }
+  100% {
+    box-shadow: 0 0 0 8px rgba(15, 118, 110, 0);
+  }
 }
 
 .guide-card,
@@ -433,6 +474,7 @@ dd {
 
   .meta-grid,
   .persona-grid,
+  .mode-panel,
   .guide-grid,
   .arch-grid,
   .doc-grid,

--- a/scripts/build_repo_map.py
+++ b/scripts/build_repo_map.py
@@ -356,6 +356,17 @@ FIRST_STEPS = [
         ],
         "paths": ["skylos/llm/", "skylos/security/", "skylos/cloud/", "skylos/cicd/"],
     },
+    {
+        "title": "I need the architecture",
+        "time": "15 minutes",
+        "personas": "maintainer",
+        "steps": [
+            "Read the Architecture section before opening shared core files.",
+            "Check hot zones for files that can change many workflows.",
+            "Use the docstring standard before reshaping public entrypoints.",
+        ],
+        "paths": ["skylos/pipeline.py", "skylos/analyzer.py", "skylos/cli.py", "skylos/config.py"],
+    },
 ]
 
 SHARP_EDGES = [

--- a/scripts/repo_map_renderer.py
+++ b/scripts/repo_map_renderer.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import html
 from typing import Any
+from urllib.parse import quote
+
+
+REPO_SOURCE_BASE = "https://github.com/duriantaco/skylos"
 
 
 def _esc(value: Any) -> str:
@@ -10,11 +14,16 @@ def _esc(value: Any) -> str:
 
 def _link(path: str, *, label: str | None = None, line: int | None = None) -> str:
     clean = path.rstrip("/")
-    href = f"../../{clean}"
+    route = "tree" if path.endswith("/") else "blob"
+    href = f"{REPO_SOURCE_BASE}/{route}/main/{quote(clean, safe='/._-')}"
+    if line and route == "blob":
+        href = f"{href}#L{line}"
     text = label or clean
     if line:
         text = f"{text}:{line}"
-    return f'<a href="{_esc(href)}">{_esc(text)}</a>'  # skylos: ignore escaped static repo-map HTML
+    return (  # skylos: ignore escaped static repo-map HTML
+        f'<a href="{_esc(href)}" rel="noopener noreferrer">{_esc(text)}</a>'
+    )
 
 
 def _pill(label: str, value: Any) -> str:
@@ -25,6 +34,123 @@ def _pill(label: str, value: Any) -> str:
 
 def _persona_attr(item: dict[str, Any]) -> str:
     return _esc(item.get("personas", "user contributor debugger security maintainer"))
+
+
+def _personas_for(item: dict[str, Any]) -> set[str]:
+    return set(str(item.get("personas", "")).split())
+
+
+def _first_step_for_mode(mode: str, first_steps: list[dict[str, Any]]) -> dict[str, Any]:
+    candidates = [item for item in first_steps if mode in _personas_for(item)]
+    if not candidates:
+        return {
+            "title": "Use the full map",
+            "time": "10 minutes",
+            "steps": [
+                "Use search when you already know a path, symbol, or rule id.",
+                "Pick a mode when you want unrelated sections hidden.",
+                "Start from route cards before opening folder or symbol indexes.",
+            ],
+            "paths": [],
+        }
+    return sorted(candidates, key=lambda item: len(_personas_for(item)))[0]
+
+
+def _mode_plan_template(mode: str, item: dict[str, Any]) -> str:
+    steps = "\n".join(f"<li>{_esc(step)}</li>" for step in item["steps"])
+    links = " ".join(_link(path) for path in item.get("paths", []))
+    link_row = f'<div class="link-row">{links}</div>' if links else ""
+    return (  # skylos: ignore escaped static repo-map HTML fragments
+        f"""
+      <template data-mode-plan="{_esc(mode)}">
+        <div class="guide-time">{_esc(item["time"])}</div>
+        <h3>{_esc(item["title"])}</h3>
+        <ol class="step-list">{steps}</ol>
+        {link_row}
+      </template>
+    """
+    )
+
+
+def render_mode_plan_templates(
+    personas: list[dict[str, Any]], first_steps: list[dict[str, Any]]
+) -> str:
+    """
+    Render inert mode-plan templates consumed by docs/repo-map/app.js.
+
+    Args:
+        personas: Persona dictionaries with stable ids.
+        first_steps: First-step cards tagged with persona ids.
+
+    Returns:
+        HTML templates keyed by mode. They are static, escaped, and cloned into
+        the visible mode panel when a user chooses a mode.
+
+    Calls: scripts/repo_map_renderer.py _first_step_for_mode;
+        scripts/repo_map_renderer.py _mode_plan_template.
+
+    Called from: scripts/repo_map_renderer.py render_mode_selector.
+    """
+    all_plan = {
+        "title": "Use the full map",
+        "time": "10 minutes",
+        "steps": [
+            "Use search when you already know a path, symbol, or rule id.",
+            "Pick a mode when you want unrelated sections hidden.",
+            "Start from route cards before opening folder or symbol indexes.",
+        ],
+        "paths": [],
+    }
+    modes = ["all", *(persona["id"] for persona in personas)]
+    return "\n".join(
+        _mode_plan_template(
+            mode,
+            all_plan if mode == "all" else _first_step_for_mode(mode, first_steps),
+        )
+        for mode in modes
+    )
+
+
+def render_mode_selector(
+    personas: list[dict[str, Any]], first_steps: list[dict[str, Any]]
+) -> str:
+    """
+    Render the mode picker plus an immediately visible first-step preview.
+
+    Args:
+        personas: Curated mode cards.
+        first_steps: First-step cards used to build each mode's preview.
+
+    Returns:
+        HTML for the visible current-mode panel, mode cards, and inert
+        per-mode templates.
+
+    Calls: scripts/repo_map_renderer.py render_personas;
+        scripts/repo_map_renderer.py render_mode_plan_templates.
+
+    Called from: scripts/repo_map_renderer.py render_html.
+    """
+    return (  # skylos: ignore escaped static repo-map HTML fragments
+        f"""
+      <div id="mode-panel" class="mode-panel" aria-live="polite">
+        <div>
+          <div class="mini-label">Current mode</div>
+          <h3 id="active-mode-title">Show everything</h3>
+          <p id="active-mode-summary">Everything is visible. Choose a mode to hide unrelated cards and rows.</p>
+        </div>
+        <div>
+          <div class="mini-label">First 10 minutes</div>
+          <div id="active-mode-plan"></div>
+        </div>
+      </div>
+      <div class="persona-grid">
+        {render_personas(personas)}
+      </div>
+      <div id="mode-plan-templates" hidden>
+        {render_mode_plan_templates(personas, first_steps)}
+      </div>
+    """
+    )
 
 
 def render_personas(personas: list[dict[str, Any]]) -> str:
@@ -46,7 +172,7 @@ def render_personas(personas: list[dict[str, Any]]) -> str:
     """
     cards = [
         """
-        <button class="persona-card active" type="button" data-mode="all" data-search="all everything full map reset">
+        <button class="persona-card active" type="button" data-mode="all" data-mode-title="Show everything" data-mode-summary="Everything is visible. Choose a mode to hide unrelated cards and rows." data-search="all everything full map reset" aria-pressed="true">
           <span class="persona-title">Show everything</span>
           <span class="persona-summary">Use this when you already know what you are looking for.</span>
           <span class="link-row"><span class="muted">Full map</span></span>
@@ -58,7 +184,7 @@ def render_personas(personas: list[dict[str, Any]]) -> str:
         search_text = " ".join([persona["title"], persona["summary"], persona.get("search", ""), *persona["paths"]])
         cards.append(
             f"""
-            <button class="persona-card searchable" type="button" data-mode="{_esc(persona["id"])}" data-search="{_esc(search_text.lower())}">
+            <button class="persona-card searchable" type="button" data-mode="{_esc(persona["id"])}" data-mode-title="{_esc(persona["title"])}" data-mode-summary="{_esc(persona["summary"])}" data-search="{_esc(search_text.lower())}" aria-pressed="false">
               <span class="persona-title">{_esc(persona["title"])}</span>
               <span class="persona-summary">{_esc(persona["summary"])}</span>
               <span class="link-row">{links}</span>
@@ -473,7 +599,13 @@ def render_html(data: dict[str, Any]) -> str:
     """
     sections = [
         render_snapshot(data),
-        section("personas", "Choose A Mode", render_personas(data["personas"]), PERSONA_COPY, "persona-grid"),
+        section(
+            "personas",
+            "Choose A Mode",
+            render_mode_selector(data["personas"], data["first_steps"]),
+            PERSONA_COPY,
+            "mode-stack",
+        ),
         section("first-steps", "First 10 Minutes", render_first_steps(data["first_steps"]), FIRST_STEPS_COPY),
         section("routes", "Start Here", render_workflows(data["workflows"])),
         section("sharp-edges", "Safe Path", render_sharp_edges(data["sharp_edges"]), SAFE_PATH_COPY),

--- a/test/test_repo_map.py
+++ b/test/test_repo_map.py
@@ -53,6 +53,8 @@ def test_collect_repo_map_extracts_routes_and_symbols(tmp_path):
 def test_render_html_prioritizes_start_routes_and_search(tmp_path):
     repo_map = _load_repo_map_module()
     _write(tmp_path / "skylos" / "config.py", "def load_config():\n    return {}\n")
+    _write(tmp_path / "dictionary.md", "# Rules\n")
+    _write(tmp_path / "test" / "test_config.py", "def test_config():\n    assert True\n")
     data = repo_map.collect_repo_map(tmp_path)
 
     page = repo_map.render_html(data)
@@ -63,12 +65,17 @@ def test_render_html_prioritizes_start_routes_and_search(tmp_path):
     assert "Architecture" in page
     assert "Docstring Standard" in page
     assert "First 10 Minutes" in page
+    assert "Current mode" in page
+    assert "active-mode-plan" in page
     assert "Safe Path" in page
     assert "I am debugging a bad finding" in page
     assert "Trust Boundary" in page
     assert "I want to understand a normal scan" in page
     assert "repo-search" in page
     assert "load_config" in page
+    assert 'href="../../' not in page
+    assert "https://github.com/duriantaco/skylos/blob/main/dictionary.md" in page
+    assert "https://github.com/duriantaco/skylos/tree/main/test" in page
 
 
 def test_main_check_detects_stale_output(tmp_path):


### PR DESCRIPTION
## Summary
- send repo-map file and folder chips to GitHub `blob`/`tree` URLs instead of broken Pages-relative paths
- add a visible current-mode panel so mode changes immediately update the first-step guidance
- add a maintainer architecture first-step path and regression coverage for generated links

## Tests
- `.venv/bin/python scripts/build_repo_map.py --check`
- `.venv/bin/python -m pytest test/test_repo_map.py -q`
- `node --check docs/repo-map/app.js`

## Notes
- Separate from the terminal-probe fix; this PR only contains repo-map/docs navigation changes.