### PR TITLE
feat(docs): add Claude Code skill and CLAUDE.md

### DIFF
--- a/.claude/skills/skylos/SKILL.md
+++ b/.claude/skills/skylos/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: skylos
+description: >-
+  Run Skylos static analysis on a codebase and interpret its findings. Skylos
+  detects dead code, security flaws, secrets, dependency CVEs, quality
+  regressions, and AI-generated-code mistakes for Python, TS/JS, Java, Go, PHP,
+  Rust, and Dart. Use this skill when asked to scan code, find unused/dead
+  code, audit security or secrets, gate a PR/diff, or read Skylos output.
+---
+
+# Skylos
+
+Skylos is the local-first static analysis CLI built in this repository. It is
+both the product and the codebase here. This skill explains how to run it and
+read its results.
+
+## Setup
+
+Skylos is **not installed by default** in this environment — only the source is
+present. Install it editable from the repo root before use:
+
+```bash
+pip install -e .            # core CLI; installs the `skylos` command + deps
+pip install -e ".[llm]"     # add LLM-powered `skylos agent` / `skylos defend`
+pip install -e ".[all]"     # add web dashboard + test extras too
+```
+
+Verify: `skylos --version` then `skylos doctor` (checks install health).
+
+Notes:
+- `inquirer` is a required dependency. If the CLI crashes with
+  `module 'skylos.cli' has no attribute 'inquirer'`, the install is incomplete —
+  rerun `pip install -e .`.
+- Do not run `python -m skylos`; the package has no `__main__`. The entry point
+  is the `skylos` console script (`skylos.cli:main`).
+- Pinned/release install instead of source: `pip install skylos`.
+
+## Core usage
+
+```bash
+skylos .                       # dead-code scan of the current dir
+skylos . -a                    # all checks: --danger --secrets --quality --sca
+skylos path/to/pkg             # scan a specific path (one or more)
+```
+
+Individual check flags (all off by default except dead code):
+`--danger` (security flows), `--secrets`, `--quality`, `--sca` (dependency CVEs
+via OSV.dev). `-a` / `--all` enables all four.
+
+## Output formats — pick by consumer
+
+| Need | Flag | Behavior |
+|:---|:---|:---|
+| Default human report | *(none)* / `--format rich` | Full `rich` terminal report |
+| Compact human review | `--format pretty` | File-grouped, severity badges, snippets |
+| **Agent/programmatic** | `--format json` (or `--json`) | Raw JSON; parse this |
+| Findings for an LLM to fix | `--format llm` | Markdown with code context per finding |
+| IDE / test scripts | `--format concise` | Only `file:line`; **exits non-zero if findings exist** |
+| GitHub Actions | `--format github` | `::warning` / `::error` annotations |
+| SARIF | `--sarif [path]` | SARIF 2.1.0 file |
+| Interactive triage | `--tui` | Keyboard-driven; screen-only, no `--output` |
+
+Write any non-TUI report to disk with `--output FILE` / `-o FILE`.
+
+**When running Skylos as part of a task, prefer `--format json`** and parse the
+result. Finding arrays in the JSON: `unused_functions`, `unused_imports`,
+`unused_variables`, `unused_classes`, `unused_parameters`, `unused_files`,
+`danger`, `secrets`, `quality`, `dependency_vulnerabilities` — plus
+`custom_rules` and `circular_dependencies` when those apply. The top level also
+carries `grade`, `provenance`, and `analysis_summary`. Some arrays are omitted
+entirely when empty, so read keys with `.get(key, [])` rather than `d[key]`.
+
+## Filtering & focus
+
+- `--diff origin/main` — only findings on **lines** changed since a ref (best
+  for PR review). `--diff` alone auto-detects the base.
+- `--diff-base REF` — only findings in **files** changed since a ref.
+- `--baseline` — only findings not in the saved baseline (run
+  `skylos baseline .` first to create it).
+- `--severity high` — minimum severity (`critical|high|medium|low`).
+- `--category security,secret` — limit to categories (`security`, `secret`,
+  `quality`, `dead_code`, `dependency`).
+- `--file-filter auth/` — substring match on file path.
+- `--confidence N` (`-c`, default 60) — dead-code confidence threshold; lower
+  surfaces more candidates.
+- `--exclude-folder NAME` / `--include-folder NAME` — folder scope.
+- `--limit N` — cap findings shown per category.
+
+## Gating (CI / pass-fail)
+
+- `skylos . --gate` — run as a quality gate; non-zero exit blocks deployment.
+  Thresholds live in `pyproject.toml` under `[tool.skylos.gate]`.
+- `--strict` — fail if **any** issue is found.
+- `--force` / `-f` — bypass the gate (always exit 0).
+- `--format concise` also exits non-zero whenever findings exist.
+
+## Key subcommands
+
+Run `skylos commands` for the full flat list, `skylos tour` for a walkthrough,
+or `skylos <command> --help`.
+
+- `skylos init` — write `[tool.skylos]` config (thresholds, ignores, templates,
+  vibe dictionary) into `pyproject.toml`.
+- `skylos suite .` — full local analysis bundle.
+- `skylos discover .` — map LLM/AI integrations in the codebase.
+- `skylos defend .` — check LLM integrations for missing guardrails (OWASP LLM).
+- `skylos debt .` — rank technical-debt hotspots and trends.
+- `skylos agent scan|verify|remediate|audit|watch|pre-commit|triage .` — hybrid
+  static + LLM analysis (needs the `[llm]` extra and a model key).
+- `skylos rules init|validate|list` — scaffold/manage local YAML rule packs
+  under `.skylos/rules/`.
+- `skylos cicd init` — generate a GitHub Actions PR-gate workflow.
+- `skylos baseline .` — save current findings as a baseline.
+- `skylos whitelist <pattern>` — manage whitelisted symbols.
+- `skylos clean` — interactively remove dead code (`-i` / `--comment-out` /
+  `--dry-run` on the main scan also act on dead code).
+- `skylos cache stats|clear [path]` — manage cached run data.
+- `skylos doctor` — check installation health.
+
+## Reducing dead-code false positives
+
+Skylos is framework-aware (FastAPI, Django, Flask, pytest, SQLAlchemy, Next.js,
+React, package entrypoints). For genuinely dynamic code, use, in order of
+preference: inline suppressions, whitelists, a baseline, or runtime tracing
+(`skylos . --trace`, optionally `--cache`).
+
+Suppression syntax:
+- `# skylos: ignore` — suppress findings on that line.
+- `# skylos: ignore-start` / `# skylos: ignore-end` — suppress a block.
+- `ignore = ["SKY-XXX"]` in `[tool.skylos]` — suppress a rule project-wide.
+
+## Reading rule IDs
+
+Finding IDs are prefixed by family (see `dictionary.md` for the full table):
+
+| Prefix | Family |
+|:---|:---|
+| `SKY-U`, `SKY-DC`, `SKY-UC` | Dead code / unreachable code |
+| `SKY-D` | Security / dangerous flows |
+| `SKY-S` | Secrets |
+| `SKY-SCA` | Dependency (CVE) vulnerabilities |
+| `SKY-SC` | Security-contract regressions (removed auth/CSRF/etc.) |
+| `SKY-L` | Logic & AI-code mistakes / resilience |
+| `SKY-Q`, `SKY-C`, `SKY-P` | Quality, structure/clones, performance |
+| `SKY-CIRC` | Circular dependency |
+
+## Reference docs in this repo
+
+- `README.md` — overview, workflow table, language support.
+- `docs/cli-output.md` — output modes and TUI keys.
+- `dictionary.md` — every rule ID and product term.
+- `BENCHMARK.md` — benchmark methodology. `QUALITY.md` — gate expectations.
+- `llms.txt` / `llms-full.txt` — condensed machine-readable summary.
+- Full docs: https://docs.skylos.dev — CLI reference, configuration, CI/CD.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## What this repo is
+
+**Skylos** — a local-first static analysis CLI for Python, TS/JS, Java, Go,
+PHP, Rust, and Dart. It detects dead code, security flaws, secrets, dependency
+CVEs, quality regressions, and AI-generated-code mistakes. The CLI entry point
+is `skylos.cli:main`, exposed as the `skylos` command.
+
+## Install
+
+Skylos is not installed by default — only the source is present. Install it
+editable from the repo root:
+
+```bash
+pip install -e .            # core CLI + dependencies
+pip install -e ".[llm]"     # also enables `skylos agent` / `skylos defend`
+```
+
+Then verify with `skylos --version` and `skylos doctor`.
+
+Notes:
+- Do **not** run `python -m skylos` — the package has no `__main__`. Use the
+  `skylos` command.
+- A `module 'skylos.cli' has no attribute 'inquirer'` error means the install
+  is incomplete; rerun `pip install -e .`.
+
+## Use
+
+```bash
+skylos .                 # dead-code scan of the current directory
+skylos . -a              # all checks: security, secrets, quality, deps
+skylos . -a --format json   # machine-readable output (best for automation)
+skylos . --diff origin/main # only findings on changed lines (PR review)
+skylos . --gate          # quality gate; non-zero exit blocks on failure
+```
+
+Run `skylos commands` for the full command list and `skylos <cmd> --help` for
+details on any subcommand.
+
+## Skill for using Skylos
+
+A detailed agent skill for installing, running, and interpreting Skylos lives
+at:
+
+```
+.claude/skills/skylos/SKILL.md
+```
+
+It is auto-discovered by Claude Code. Consult it for output formats, JSON
+result keys, filtering flags, gating/exit codes, suppression syntax, the
+`SKY-*` rule-ID families, and subcommand reference.
+
+## Reference docs
+
+- `README.md` — overview, workflow table, language support.
+- `docs/cli-output.md` — output modes and TUI keys.
+- `dictionary.md` — every rule ID and product term.
+- `CONTRIBUTING.md` / `QUALITY.md` — contribution and quality-gate expectations.
+- Full docs: https://docs.skylos.dev


### PR DESCRIPTION
Add an agent skill and repo guidance so Claude Code can install and operate the Skylos CLI.

- .claude/skills/skylos/SKILL.md: discoverable skill covering install, output formats, JSON result keys, filtering flags, gating/exit codes, suppression syntax, SKY-* rule families, and subcommands.
- CLAUDE.md: simplified install/use instructions with a pointer to the skill file.

Skill contents were verified by installing Skylos (pip install -e .) and running each documented command:

- skylos --version / doctor / commands / --help: OK
- scans: skylos . , -a , per-category flags: OK
- formats: rich / pretty / json / llm / concise / github / --sarif: OK
- --format concise exits non-zero when findings exist; default scan exits 0: OK
- gating: --gate and --strict exit 1 on findings; --force exits 0: OK
- filters: --diff, --baseline, --severity, --category, --confidence: OK
- suppression: "# skylos: ignore" suppresses the flagged line: OK
- subcommands: suite, discover, defend, debt, baseline, rules list, cache stats: OK
- python -m skylos correctly fails (no __main__); documented as such

Fix found during testing: the JSON output omits empty finding arrays (e.g. custom_rules, circular_dependencies) entirely rather than emitting them empty. The skill now marks those arrays as conditional and tells consumers to read keys with .get(key, []).

## What does this PR do?

Add an agent skill and repo guidance so Claude Code can install and operate the Skylos CLI.

## Why?

More user friendly to Claude base workflows.

## How to test

Install Claude Code with Opus 4.7 and test.

## Precision Impact

No code changes. So should have minimal impact.

## Checklist

- [x] Tests pass (`python3 -m pytest test/`)
- [x] No new false positives introduced (if modifying analysis logic)
- [x] Added or updated a corpus case for any confirmed precision regression or false positive fix
- [x] Ran the corpus guard (`python3 scripts/corpus_ci.py --manifest corpus/manifest.json`) if analysis logic changed
- [ ] CHANGELOG updated (if user-facing change)
