### PR TITLE
feat(docs): add agent skills for Skylos

### DIFF
--- a/.agents/skills/skylos/SKILL.md
+++ b/.agents/skills/skylos/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: skylos
-description: >-
-  Run, interpret, or modify Skylos safely. Use when the user asks to scan code
-  with Skylos, explain SKY-* findings, triage dead-code false positives, audit
-  security/secrets/SCA/LLM behavior, update Skylos rules/docs/CI, benchmark
-  analyzer behavior, or change this repository safely.
+description: Run, interpret, or modify Skylos safely. Use when the user asks to scan code with Skylos, explain SKY-* findings, triage dead-code false positives, audit security/secrets/SCA/LLM behavior, update Skylos rules/docs/CI, benchmark analyzer behavior, or change this repository safely.
 ---
 
 # Skylos
@@ -44,11 +40,11 @@ Read only the reference needed for the current task.
 - Do not open or close PRs, issues, or GitHub comments unless the user
   explicitly asks for that action.
 - Do not use `git add .`; stage exact paths.
-- Do not place Claude skill files under `skylos/agents` or `skylos/llm`; those
+- Do not place Codex skill files under `skylos/agents` or `skylos/llm`; those
   are Skylos runtime modules.
 
 ## Invocation
 
-Invoke explicitly with `/skylos`, or rely on automatic selection when the task
+Invoke explicitly with `$skylos`, or rely on automatic selection when the task
 mentions Skylos scans, `SKY-*` findings, static analysis, security hardening,
 dead-code false positives, benchmarks, or this repo's analyzer internals.

--- a/.agents/skills/skylos/agents/openai.yaml
+++ b/.agents/skills/skylos/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skylos"
+  short_description: "Run and interpret Skylos safely."
+  default_prompt: "Use Skylos to scan, triage findings, or work on this repository safely."

--- a/.agents/skills/skylos/references/ci.md
+++ b/.agents/skills/skylos/references/ci.md
@@ -1,0 +1,76 @@
+# Skylos CI And Docs Reference
+
+Use this reference for GitHub Actions, SARIF, gates, docs deploy, repo map, and
+automation output.
+
+## CI Output
+
+```bash
+skylos . -a --format github
+skylos . -a --format json
+skylos . -a --sarif skylos.sarif
+skylos . --gate
+```
+
+Use `--format github` for annotations and `--sarif` for code scanning upload.
+Use `--format json` when another script or agent will parse the result.
+
+## Workflow Areas
+
+Review these files for CI changes:
+
+- `action.yml`
+- `.github/workflows/`
+- `skylos/cicd/`
+- `skylos/gatekeeper.py`
+- `scripts/skylos_gate.py`
+- `test/test_cicd_*.py`
+- `test/test_gatekeeper.py`
+
+Generated workflows should be deterministic, least-privilege, and explicit
+about which events receive secrets.
+
+## Repo Map And Pages
+
+Repo map generation lives in:
+
+- `scripts/build_repo_map.py`
+- `scripts/repo_map_renderer.py`
+- `.github/workflows/repo-map-pages.yml`
+- `docs/repo-map.html`
+
+Validate with:
+
+```bash
+python scripts/build_repo_map.py --check
+```
+
+Pages deployment requires repository Pages settings to be configured for GitHub
+Actions. Workflow code should not assume the token can create the Pages site
+unless that permission is available.
+
+## Rule Docs Parity
+
+When rule IDs or catalog entries change, validate docs parity:
+
+```bash
+python skylos/scripts/check_rule_docs_parity.py --docs dictionary.md --catalog skylos/rules/catalog.json
+```
+
+Update `dictionary.md` and docs in the same change as rule catalog updates.
+
+## Gate And Exit Behavior
+
+- `skylos . --gate`: applies configured thresholds.
+- `--strict`: fails on any issue.
+- `--force`: exits zero even when the gate would fail.
+- `--format concise`: exits non-zero when findings exist.
+
+Preserve exit-code semantics unless the task explicitly asks for a breaking
+change. Add CLI or gatekeeper tests when changing gate behavior.
+
+## Security Notes
+
+Do not design CI that executes untrusted PR code with secrets available. Be
+careful with cloud policy sync: operator-controlled policy should not be
+weakened by PR-controlled repository configuration.

--- a/.agents/skills/skylos/references/cli.md
+++ b/.agents/skills/skylos/references/cli.md
@@ -1,0 +1,115 @@
+# Skylos CLI Reference
+
+Use this reference when running Skylos or interpreting CLI output.
+
+## Install And Verify
+
+```bash
+pip install -e .
+pip install -e ".[llm]"
+pip install -e ".[all]"
+skylos --version
+skylos doctor
+```
+
+Use `pip install skylos` for a released install. Do not run `python -m skylos`;
+the package exposes the `skylos` console script.
+
+If the CLI crashes with `module 'skylos.cli' has no attribute 'inquirer'`, the
+environment is incomplete. Reinstall from the repo root with `pip install -e .`.
+
+## Common Scans
+
+```bash
+skylos .
+skylos . -a
+skylos . -a --format json
+skylos path/to/pkg --format json
+skylos . --diff origin/main --format json
+skylos . --gate
+```
+
+Default scan behavior focuses on dead code. `-a` / `--all` enables danger,
+secrets, quality, and SCA checks.
+
+Individual check flags:
+
+- `--danger`: security and dangerous flows.
+- `--secrets`: leaked secret patterns.
+- `--quality`: maintainability and AI-code mistakes.
+- `--sca`: dependency CVEs through OSV.dev.
+
+## Output Formats
+
+| Need | Flag | Notes |
+| :-- | :-- | :-- |
+| Human terminal report | `--format rich` or no flag | Full rich report |
+| Compact review | `--format pretty` | File grouped with snippets |
+| Agent parsing | `--format json` or `--json` | Preferred for automation |
+| LLM fix context | `--format llm` | Markdown with code context |
+| File-line output | `--format concise` | Exits non-zero if findings exist |
+| GitHub annotations | `--format github` | Emits workflow annotations |
+| SARIF | `--sarif path` | Writes SARIF 2.1.0 |
+| Interactive triage | `--tui` | Screen UI; no `--output` |
+
+Write non-TUI output with `--output FILE`.
+
+## JSON Shape
+
+Expect finding arrays such as:
+
+- `unused_functions`
+- `unused_imports`
+- `unused_variables`
+- `unused_classes`
+- `unused_parameters`
+- `unused_files`
+- `danger`
+- `secrets`
+- `quality`
+- `dependency_vulnerabilities`
+- `custom_rules`
+- `circular_dependencies`
+
+The top level may also include `grade`, `provenance`, and
+`analysis_summary`. Empty arrays can be omitted, so use `.get(key, [])`.
+
+## Filtering
+
+```bash
+skylos . --diff origin/main --format json
+skylos . --diff-base origin/main --format json
+skylos . --severity high --format json
+skylos . --category security,secret --format json
+skylos . --file-filter auth/ --format json
+skylos . --confidence 80 --format json
+skylos . --limit 50 --format json
+```
+
+Use `--diff REF` for findings on changed lines. Use `--diff-base REF` for
+findings in changed files. Use `--baseline` after `skylos baseline .` to show
+only new findings.
+
+## Gating
+
+- `skylos . --gate`: apply `[tool.skylos.gate]` thresholds.
+- `--strict`: fail on any finding.
+- `--force` / `-f`: bypass gate exit failure.
+- `--format concise`: exits non-zero when findings exist.
+
+## Useful Subcommands
+
+- `skylos commands`: list commands.
+- `skylos tour`: walkthrough.
+- `skylos init`: write project config.
+- `skylos suite .`: full local analysis bundle.
+- `skylos discover .`: map LLM/AI integrations.
+- `skylos defend .`: OWASP LLM guardrail checks.
+- `skylos agent scan|verify|remediate|audit|watch|pre-commit|triage .`:
+  hybrid static and LLM analysis, requiring `[llm]` extras and provider config.
+- `skylos rules init|validate|list`: local YAML rule packs.
+- `skylos cicd init`: generate CI workflow.
+- `skylos baseline .`: save current findings baseline.
+- `skylos clean`: interactively remove or comment dead code.
+- `skylos cache stats|clear`: manage cache data.
+- `skylos doctor`: installation health check.

--- a/.agents/skills/skylos/references/dead-code.md
+++ b/.agents/skills/skylos/references/dead-code.md
@@ -1,0 +1,81 @@
+# Skylos Dead-Code Reference
+
+Use this reference for unused-code findings, false-positive reduction, liveness
+analysis, framework entrypoints, traces, and benchmark comparisons.
+
+## Default Commands
+
+```bash
+skylos . --format json
+skylos . --confidence 80 --format json
+skylos . --diff origin/main --format json
+python scripts/dead_code_benchmark.py
+python scripts/dead_code_compare_scanners.py
+```
+
+Use `--confidence` to tune dead-code reporting. Higher confidence reduces
+candidate volume. Lower confidence surfaces riskier candidates.
+
+## False-Positive Reduction Ladder
+
+Prefer evidence in this order:
+
+1. Static symbol references and imports.
+2. Framework entrypoints and decorators.
+3. Package entrypoints and configuration files.
+4. Tests and fixtures that legitimately call the symbol.
+5. Runtime traces, only when executing the target code is acceptable.
+6. Suppressions, whitelist, or baseline for intentionally dynamic patterns.
+
+Do not treat absence of a simple text reference as proof of dead code when the
+framework commonly resolves names dynamically.
+
+## Framework Areas
+
+Skylos has framework-aware behavior for patterns such as:
+
+- FastAPI, Flask, and Django routes.
+- pytest tests, fixtures, and hooks.
+- SQLAlchemy models and metadata.
+- Next.js and React entrypoints.
+- package entrypoints and plugin hooks.
+
+When adding support, include a minimal positive fixture and a negative fixture
+so the analyzer does not simply whitelist too much.
+
+## Trace Mode Caution
+
+`skylos . --trace` and coverage-style checks can execute project code. Only use
+them on trusted repositories or when the user explicitly asks for runtime
+evidence. Do not use trace mode as the default answer for untrusted PR review.
+
+## Suppression Options
+
+- `# skylos: ignore`: suppress a finding on one line.
+- `# skylos: ignore-start` / `# skylos: ignore-end`: suppress a block.
+- `ignore = ["SKY-XXX"]` in `[tool.skylos]`: suppress a rule project-wide.
+- `skylos whitelist <pattern>`: manage whitelisted symbols.
+- `skylos baseline .`: store current findings as accepted baseline.
+
+Prefer analyzer improvements or precise suppressions over broad project-wide
+ignores.
+
+## Benchmark Expectations
+
+For benchmark changes:
+
+1. Use fixtures where ground truth is clear but not encoded in filenames.
+2. Include framework and dynamic-reference patterns that static-only scanners
+   commonly struggle with.
+3. Compare Skylos against Vulture when relevant.
+4. Report score, timing, and examples of true positives and false positives.
+5. Keep public benchmark fixtures understandable and non-secret.
+
+Useful files:
+
+- `benchmarks/`
+- `corpus/fixtures/`
+- `scripts/dead_code_benchmark.py`
+- `scripts/dead_code_compare_scanners.py`
+- `test/test_dead_code*.py`
+- `test/test_framework_aware.py`

--- a/.agents/skills/skylos/references/repo-workflow.md
+++ b/.agents/skills/skylos/references/repo-workflow.md
@@ -1,0 +1,80 @@
+# Skylos Repo Workflow Reference
+
+Use this reference when the user asks the agent to change Skylos itself.
+
+## Repo Boundaries
+
+- `skylos/analyzer.py`: main static analyzer orchestration.
+- `skylos/cli.py` and `skylos/api/`: CLI and public API surface.
+- `skylos/rules/`, `skylos/dangerous.py`, `skylos/security/`: rule and
+  security detector logic.
+- `skylos/llm/`: LLM adapters, prompts, evidence filters, and verification.
+- `skylos/agents/`: Skylos product runtime state/service code, not Codex or
+  Claude skill files.
+- `skylos/cicd/`, `skylos/gatekeeper.py`: CI output, gates, workflows.
+- `scripts/`: benchmarks, corpus guard, repo map generation, rule parity.
+- `test/`: regression tests.
+- `dictionary.md` and `docs/`: rule/user documentation.
+
+## Change Workflow
+
+1. Inspect existing patterns before editing.
+2. Keep the change in the smallest ownership area that solves the task.
+3. Add or update focused tests for analyzer behavior, rule behavior, or CLI
+   behavior that changed.
+4. Update docs when public rule IDs, output fields, commands, or workflows
+   change.
+5. Run focused tests first, then broader checks if the change touches shared
+   analyzer paths.
+
+## Focused Test Selection
+
+Use these starting points:
+
+- CLI behavior: `pytest -q test/test_cli*.py`
+- Security rules: `pytest -q test/test_dangerous.py test/test_cmd_injection.py`
+- Dead-code analysis: `pytest -q test/test_dead_code*.py test/test_framework_aware.py`
+- CI/gates: `pytest -q test/test_cicd_*.py test/test_gatekeeper.py`
+- Agent service/state: `pytest -q test/test_agent*.py`
+- Repo map: `python scripts/build_repo_map.py --check`
+- Rule docs parity:
+  `python skylos/scripts/check_rule_docs_parity.py --docs dictionary.md --catalog skylos/rules/catalog.json`
+- Corpus guard:
+  `python scripts/corpus_ci.py --manifest corpus/manifest.json`
+
+Prefer the exact file near the changed module when one exists.
+
+## Rule And Docs Hygiene
+
+When adding or renaming rule IDs:
+
+1. Update the rule catalog.
+2. Update `dictionary.md` and relevant docs.
+3. Run rule docs parity.
+4. Add a regression test with a minimal fixture.
+
+Do not add rule IDs that overlap existing meanings. Keep severity and category
+consistent with nearby rules.
+
+## Git Hygiene
+
+- Preserve unrelated user changes.
+- Do not use `git add .`.
+- Split commits by purpose when the user asks for commits.
+- Use existing commit style, such as `feat(docs): ...`, `fix(cli): ...`, or
+  `test(analyzer): ...`.
+- Do not open PRs, close issues, add comments, or mutate GitHub state unless
+  explicitly asked.
+
+## Public Surface Caution
+
+Treat these as public or semi-public surfaces:
+
+- CLI command names, flags, output fields, and exit behavior.
+- Rule IDs and dictionary descriptions.
+- Public imports from `skylos.api` and documented modules.
+- GitHub Action behavior.
+- Generated docs and repo map output.
+
+When changing a public surface, preserve compatibility unless the user
+explicitly wants a breaking cleanup.

--- a/.agents/skills/skylos/references/security.md
+++ b/.agents/skills/skylos/references/security.md
@@ -1,0 +1,81 @@
+# Skylos Security Reference
+
+Use this reference for security findings, hardening work, LLM evidence filters,
+cloud policy, and CI trust boundaries.
+
+## Threat Model Defaults
+
+Skylos often scans attacker-controlled repositories or pull requests. Treat
+scanned source code, repository config, package scripts, tests, and generated
+artifacts as untrusted unless the user says the repo is trusted.
+
+Avoid executing target code during security review. Static scans are safe by
+default; trace, coverage, tests, dependency install scripts, or package scripts
+can execute target-controlled code.
+
+## Security Scan Commands
+
+```bash
+skylos . --danger --format json
+skylos . --secrets --format json
+skylos . --sca --format json
+skylos . -a --format json
+skylos defend . --format json
+```
+
+Use `--diff origin/main` for PR review when appropriate.
+
+## LLM And Evidence Filter Reviews
+
+For LLM security behavior, inspect:
+
+- `skylos/llm/analyzer.py`
+- `skylos/llm/finding_evidence.py`
+- `skylos/llm/verify_orchestrator.py`
+- `skylos/llm/security_verifier.py`
+- `skylos/llm/prompts.py`
+- `test/test_*llm*.py`, `test/test_*evidence*.py`, and targeted security tests.
+
+Do not suppress a security finding unless the code proves safety, not merely a
+plausible benign pattern. Safe-sink heuristics must prove trusted literals,
+immutable allowlists, or framework guarantees. Uppercase variable names,
+comments, or absence of local mutation are not sufficient proof.
+
+## Cloud Policy And Config Trust
+
+Security policy that comes from operator-controlled cloud sync must not be
+overridden by attacker-controlled repository files in a CI/PR context. Review:
+
+- `skylos/config.py`
+- `skylos/cloud/`
+- `skylos/cicd/`
+- `skylos/cli.py`
+- `skylos/analyzer.py`
+
+When config precedence changes, add tests that show mandatory security
+contracts cannot be disabled by PR-controlled `pyproject.toml` or local config.
+
+## CI Security Boundaries
+
+For GitHub Actions, check whether the workflow runs on `pull_request`,
+`pull_request_target`, or trusted branch events. Fork PRs usually do not receive
+secrets, but same-repo PRs may. Treat checked-out repository content as
+attacker controlled before analysis.
+
+Do not recommend workflows that execute untrusted scripts with secrets in
+scope. Generated workflows should avoid placing tokens in steps that run
+target-controlled code.
+
+## Validation Pattern
+
+For a suspected scanner bypass:
+
+1. Reproduce the unsafe source pattern as a minimal fixture.
+2. Confirm the finding appears before the filter or regression point.
+3. Confirm the finding is removed or changed by the suspect logic.
+4. Fix the proof condition or precedence issue.
+5. Add an end-to-end regression test that would fail on the old behavior.
+6. Run the focused security tests plus any affected analyzer tests.
+
+Keep severity analysis tied to impact on scan integrity, CI gates, credentials,
+or code execution.

--- a/.claude/skills/skylos/references/ci.md
+++ b/.claude/skills/skylos/references/ci.md
@@ -1,0 +1,76 @@
+# Skylos CI And Docs Reference
+
+Use this reference for GitHub Actions, SARIF, gates, docs deploy, repo map, and
+automation output.
+
+## CI Output
+
+```bash
+skylos . -a --format github
+skylos . -a --format json
+skylos . -a --sarif skylos.sarif
+skylos . --gate
+```
+
+Use `--format github` for annotations and `--sarif` for code scanning upload.
+Use `--format json` when another script or agent will parse the result.
+
+## Workflow Areas
+
+Review these files for CI changes:
+
+- `action.yml`
+- `.github/workflows/`
+- `skylos/cicd/`
+- `skylos/gatekeeper.py`
+- `scripts/skylos_gate.py`
+- `test/test_cicd_*.py`
+- `test/test_gatekeeper.py`
+
+Generated workflows should be deterministic, least-privilege, and explicit
+about which events receive secrets.
+
+## Repo Map And Pages
+
+Repo map generation lives in:
+
+- `scripts/build_repo_map.py`
+- `scripts/repo_map_renderer.py`
+- `.github/workflows/repo-map-pages.yml`
+- `docs/repo-map.html`
+
+Validate with:
+
+```bash
+python scripts/build_repo_map.py --check
+```
+
+Pages deployment requires repository Pages settings to be configured for GitHub
+Actions. Workflow code should not assume the token can create the Pages site
+unless that permission is available.
+
+## Rule Docs Parity
+
+When rule IDs or catalog entries change, validate docs parity:
+
+```bash
+python skylos/scripts/check_rule_docs_parity.py --docs dictionary.md --catalog skylos/rules/catalog.json
+```
+
+Update `dictionary.md` and docs in the same change as rule catalog updates.
+
+## Gate And Exit Behavior
+
+- `skylos . --gate`: applies configured thresholds.
+- `--strict`: fails on any issue.
+- `--force`: exits zero even when the gate would fail.
+- `--format concise`: exits non-zero when findings exist.
+
+Preserve exit-code semantics unless the task explicitly asks for a breaking
+change. Add CLI or gatekeeper tests when changing gate behavior.
+
+## Security Notes
+
+Do not design CI that executes untrusted PR code with secrets available. Be
+careful with cloud policy sync: operator-controlled policy should not be
+weakened by PR-controlled repository configuration.

--- a/.claude/skills/skylos/references/cli.md
+++ b/.claude/skills/skylos/references/cli.md
@@ -1,0 +1,115 @@
+# Skylos CLI Reference
+
+Use this reference when running Skylos or interpreting CLI output.
+
+## Install And Verify
+
+```bash
+pip install -e .
+pip install -e ".[llm]"
+pip install -e ".[all]"
+skylos --version
+skylos doctor
+```
+
+Use `pip install skylos` for a released install. Do not run `python -m skylos`;
+the package exposes the `skylos` console script.
+
+If the CLI crashes with `module 'skylos.cli' has no attribute 'inquirer'`, the
+environment is incomplete. Reinstall from the repo root with `pip install -e .`.
+
+## Common Scans
+
+```bash
+skylos .
+skylos . -a
+skylos . -a --format json
+skylos path/to/pkg --format json
+skylos . --diff origin/main --format json
+skylos . --gate
+```
+
+Default scan behavior focuses on dead code. `-a` / `--all` enables danger,
+secrets, quality, and SCA checks.
+
+Individual check flags:
+
+- `--danger`: security and dangerous flows.
+- `--secrets`: leaked secret patterns.
+- `--quality`: maintainability and AI-code mistakes.
+- `--sca`: dependency CVEs through OSV.dev.
+
+## Output Formats
+
+| Need | Flag | Notes |
+| :-- | :-- | :-- |
+| Human terminal report | `--format rich` or no flag | Full rich report |
+| Compact review | `--format pretty` | File grouped with snippets |
+| Agent parsing | `--format json` or `--json` | Preferred for automation |
+| LLM fix context | `--format llm` | Markdown with code context |
+| File-line output | `--format concise` | Exits non-zero if findings exist |
+| GitHub annotations | `--format github` | Emits workflow annotations |
+| SARIF | `--sarif path` | Writes SARIF 2.1.0 |
+| Interactive triage | `--tui` | Screen UI; no `--output` |
+
+Write non-TUI output with `--output FILE`.
+
+## JSON Shape
+
+Expect finding arrays such as:
+
+- `unused_functions`
+- `unused_imports`
+- `unused_variables`
+- `unused_classes`
+- `unused_parameters`
+- `unused_files`
+- `danger`
+- `secrets`
+- `quality`
+- `dependency_vulnerabilities`
+- `custom_rules`
+- `circular_dependencies`
+
+The top level may also include `grade`, `provenance`, and
+`analysis_summary`. Empty arrays can be omitted, so use `.get(key, [])`.
+
+## Filtering
+
+```bash
+skylos . --diff origin/main --format json
+skylos . --diff-base origin/main --format json
+skylos . --severity high --format json
+skylos . --category security,secret --format json
+skylos . --file-filter auth/ --format json
+skylos . --confidence 80 --format json
+skylos . --limit 50 --format json
+```
+
+Use `--diff REF` for findings on changed lines. Use `--diff-base REF` for
+findings in changed files. Use `--baseline` after `skylos baseline .` to show
+only new findings.
+
+## Gating
+
+- `skylos . --gate`: apply `[tool.skylos.gate]` thresholds.
+- `--strict`: fail on any finding.
+- `--force` / `-f`: bypass gate exit failure.
+- `--format concise`: exits non-zero when findings exist.
+
+## Useful Subcommands
+
+- `skylos commands`: list commands.
+- `skylos tour`: walkthrough.
+- `skylos init`: write project config.
+- `skylos suite .`: full local analysis bundle.
+- `skylos discover .`: map LLM/AI integrations.
+- `skylos defend .`: OWASP LLM guardrail checks.
+- `skylos agent scan|verify|remediate|audit|watch|pre-commit|triage .`:
+  hybrid static and LLM analysis, requiring `[llm]` extras and provider config.
+- `skylos rules init|validate|list`: local YAML rule packs.
+- `skylos cicd init`: generate CI workflow.
+- `skylos baseline .`: save current findings baseline.
+- `skylos clean`: interactively remove or comment dead code.
+- `skylos cache stats|clear`: manage cache data.
+- `skylos doctor`: installation health check.

--- a/.claude/skills/skylos/references/dead-code.md
+++ b/.claude/skills/skylos/references/dead-code.md
@@ -1,0 +1,81 @@
+# Skylos Dead-Code Reference
+
+Use this reference for unused-code findings, false-positive reduction, liveness
+analysis, framework entrypoints, traces, and benchmark comparisons.
+
+## Default Commands
+
+```bash
+skylos . --format json
+skylos . --confidence 80 --format json
+skylos . --diff origin/main --format json
+python scripts/dead_code_benchmark.py
+python scripts/dead_code_compare_scanners.py
+```
+
+Use `--confidence` to tune dead-code reporting. Higher confidence reduces
+candidate volume. Lower confidence surfaces riskier candidates.
+
+## False-Positive Reduction Ladder
+
+Prefer evidence in this order:
+
+1. Static symbol references and imports.
+2. Framework entrypoints and decorators.
+3. Package entrypoints and configuration files.
+4. Tests and fixtures that legitimately call the symbol.
+5. Runtime traces, only when executing the target code is acceptable.
+6. Suppressions, whitelist, or baseline for intentionally dynamic patterns.
+
+Do not treat absence of a simple text reference as proof of dead code when the
+framework commonly resolves names dynamically.
+
+## Framework Areas
+
+Skylos has framework-aware behavior for patterns such as:
+
+- FastAPI, Flask, and Django routes.
+- pytest tests, fixtures, and hooks.
+- SQLAlchemy models and metadata.
+- Next.js and React entrypoints.
+- package entrypoints and plugin hooks.
+
+When adding support, include a minimal positive fixture and a negative fixture
+so the analyzer does not simply whitelist too much.
+
+## Trace Mode Caution
+
+`skylos . --trace` and coverage-style checks can execute project code. Only use
+them on trusted repositories or when the user explicitly asks for runtime
+evidence. Do not use trace mode as the default answer for untrusted PR review.
+
+## Suppression Options
+
+- `# skylos: ignore`: suppress a finding on one line.
+- `# skylos: ignore-start` / `# skylos: ignore-end`: suppress a block.
+- `ignore = ["SKY-XXX"]` in `[tool.skylos]`: suppress a rule project-wide.
+- `skylos whitelist <pattern>`: manage whitelisted symbols.
+- `skylos baseline .`: store current findings as accepted baseline.
+
+Prefer analyzer improvements or precise suppressions over broad project-wide
+ignores.
+
+## Benchmark Expectations
+
+For benchmark changes:
+
+1. Use fixtures where ground truth is clear but not encoded in filenames.
+2. Include framework and dynamic-reference patterns that static-only scanners
+   commonly struggle with.
+3. Compare Skylos against Vulture when relevant.
+4. Report score, timing, and examples of true positives and false positives.
+5. Keep public benchmark fixtures understandable and non-secret.
+
+Useful files:
+
+- `benchmarks/`
+- `corpus/fixtures/`
+- `scripts/dead_code_benchmark.py`
+- `scripts/dead_code_compare_scanners.py`
+- `test/test_dead_code*.py`
+- `test/test_framework_aware.py`

--- a/.claude/skills/skylos/references/repo-workflow.md
+++ b/.claude/skills/skylos/references/repo-workflow.md
@@ -1,0 +1,80 @@
+# Skylos Repo Workflow Reference
+
+Use this reference when the user asks the agent to change Skylos itself.
+
+## Repo Boundaries
+
+- `skylos/analyzer.py`: main static analyzer orchestration.
+- `skylos/cli.py` and `skylos/api/`: CLI and public API surface.
+- `skylos/rules/`, `skylos/dangerous.py`, `skylos/security/`: rule and
+  security detector logic.
+- `skylos/llm/`: LLM adapters, prompts, evidence filters, and verification.
+- `skylos/agents/`: Skylos product runtime state/service code, not Codex or
+  Claude skill files.
+- `skylos/cicd/`, `skylos/gatekeeper.py`: CI output, gates, workflows.
+- `scripts/`: benchmarks, corpus guard, repo map generation, rule parity.
+- `test/`: regression tests.
+- `dictionary.md` and `docs/`: rule/user documentation.
+
+## Change Workflow
+
+1. Inspect existing patterns before editing.
+2. Keep the change in the smallest ownership area that solves the task.
+3. Add or update focused tests for analyzer behavior, rule behavior, or CLI
+   behavior that changed.
+4. Update docs when public rule IDs, output fields, commands, or workflows
+   change.
+5. Run focused tests first, then broader checks if the change touches shared
+   analyzer paths.
+
+## Focused Test Selection
+
+Use these starting points:
+
+- CLI behavior: `pytest -q test/test_cli*.py`
+- Security rules: `pytest -q test/test_dangerous.py test/test_cmd_injection.py`
+- Dead-code analysis: `pytest -q test/test_dead_code*.py test/test_framework_aware.py`
+- CI/gates: `pytest -q test/test_cicd_*.py test/test_gatekeeper.py`
+- Agent service/state: `pytest -q test/test_agent*.py`
+- Repo map: `python scripts/build_repo_map.py --check`
+- Rule docs parity:
+  `python skylos/scripts/check_rule_docs_parity.py --docs dictionary.md --catalog skylos/rules/catalog.json`
+- Corpus guard:
+  `python scripts/corpus_ci.py --manifest corpus/manifest.json`
+
+Prefer the exact file near the changed module when one exists.
+
+## Rule And Docs Hygiene
+
+When adding or renaming rule IDs:
+
+1. Update the rule catalog.
+2. Update `dictionary.md` and relevant docs.
+3. Run rule docs parity.
+4. Add a regression test with a minimal fixture.
+
+Do not add rule IDs that overlap existing meanings. Keep severity and category
+consistent with nearby rules.
+
+## Git Hygiene
+
+- Preserve unrelated user changes.
+- Do not use `git add .`.
+- Split commits by purpose when the user asks for commits.
+- Use existing commit style, such as `feat(docs): ...`, `fix(cli): ...`, or
+  `test(analyzer): ...`.
+- Do not open PRs, close issues, add comments, or mutate GitHub state unless
+  explicitly asked.
+
+## Public Surface Caution
+
+Treat these as public or semi-public surfaces:
+
+- CLI command names, flags, output fields, and exit behavior.
+- Rule IDs and dictionary descriptions.
+- Public imports from `skylos.api` and documented modules.
+- GitHub Action behavior.
+- Generated docs and repo map output.
+
+When changing a public surface, preserve compatibility unless the user
+explicitly wants a breaking cleanup.

--- a/.claude/skills/skylos/references/security.md
+++ b/.claude/skills/skylos/references/security.md
@@ -1,0 +1,81 @@
+# Skylos Security Reference
+
+Use this reference for security findings, hardening work, LLM evidence filters,
+cloud policy, and CI trust boundaries.
+
+## Threat Model Defaults
+
+Skylos often scans attacker-controlled repositories or pull requests. Treat
+scanned source code, repository config, package scripts, tests, and generated
+artifacts as untrusted unless the user says the repo is trusted.
+
+Avoid executing target code during security review. Static scans are safe by
+default; trace, coverage, tests, dependency install scripts, or package scripts
+can execute target-controlled code.
+
+## Security Scan Commands
+
+```bash
+skylos . --danger --format json
+skylos . --secrets --format json
+skylos . --sca --format json
+skylos . -a --format json
+skylos defend . --format json
+```
+
+Use `--diff origin/main` for PR review when appropriate.
+
+## LLM And Evidence Filter Reviews
+
+For LLM security behavior, inspect:
+
+- `skylos/llm/analyzer.py`
+- `skylos/llm/finding_evidence.py`
+- `skylos/llm/verify_orchestrator.py`
+- `skylos/llm/security_verifier.py`
+- `skylos/llm/prompts.py`
+- `test/test_*llm*.py`, `test/test_*evidence*.py`, and targeted security tests.
+
+Do not suppress a security finding unless the code proves safety, not merely a
+plausible benign pattern. Safe-sink heuristics must prove trusted literals,
+immutable allowlists, or framework guarantees. Uppercase variable names,
+comments, or absence of local mutation are not sufficient proof.
+
+## Cloud Policy And Config Trust
+
+Security policy that comes from operator-controlled cloud sync must not be
+overridden by attacker-controlled repository files in a CI/PR context. Review:
+
+- `skylos/config.py`
+- `skylos/cloud/`
+- `skylos/cicd/`
+- `skylos/cli.py`
+- `skylos/analyzer.py`
+
+When config precedence changes, add tests that show mandatory security
+contracts cannot be disabled by PR-controlled `pyproject.toml` or local config.
+
+## CI Security Boundaries
+
+For GitHub Actions, check whether the workflow runs on `pull_request`,
+`pull_request_target`, or trusted branch events. Fork PRs usually do not receive
+secrets, but same-repo PRs may. Treat checked-out repository content as
+attacker controlled before analysis.
+
+Do not recommend workflows that execute untrusted scripts with secrets in
+scope. Generated workflows should avoid placing tokens in steps that run
+target-controlled code.
+
+## Validation Pattern
+
+For a suspected scanner bypass:
+
+1. Reproduce the unsafe source pattern as a minimal fixture.
+2. Confirm the finding appears before the filter or regression point.
+3. Confirm the finding is removed or changed by the suspect logic.
+4. Fix the proof condition or precedence issue.
+5. Add an end-to-end regression test that would fail on the old behavior.
+6. Run the focused security tests plus any affected analyzer tests.
+
+Keep severity analysis tied to impact on scan integrity, CI gates, credentials,
+or code execution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Guidance for Codex when working in this repository.
+
+## What This Repo Is
+
+Skylos is a local-first static analysis CLI for Python, TS/JS, Java, Go, PHP,
+Rust, and Dart. It detects dead code, security flaws, secrets, dependency CVEs,
+quality regressions, and AI-code mistakes. The CLI entry point is
+`skylos.cli:main`, exposed as the `skylos` command.
+
+## Use The Skylos Skill
+
+Codex-specific Skylos instructions live at:
+
+```text
+.agents/skills/skylos/SKILL.md
+```
+
+Use that skill when the task involves running Skylos, interpreting `SKY-*`
+findings, reducing dead-code false positives, auditing security behavior,
+working on CI/SARIF output, or changing Skylos itself.
+
+## Work Safely
+
+- Preserve user changes. Do not revert unrelated work.
+- Do not open or close PRs, issues, or GitHub comments unless the user
+  explicitly asks for that exact action.
+- Do not run `git add .`; stage focused paths only when committing.
+- Do not run `python -m skylos`; the package has no `__main__`. Use `skylos`.
+- Prefer machine-readable Skylos output with `--format json` for agent work.
+- Treat scanned repositories as untrusted input. Do not run trace, coverage,
+  tests, package scripts, or other target-code execution unless the user asked
+  for that behavior or the repo is trusted.
+
+## Common Commands
+
+```bash
+pip install -e .
+pip install -e ".[llm]"
+skylos --version
+skylos doctor
+skylos . -a --format json
+skylos . --diff origin/main --format json
+pytest -q test/test_file_you_changed.py
+python scripts/corpus_ci.py --manifest corpus/manifest.json
+python scripts/build_repo_map.py --check
+```
+
+Use focused tests first, then broaden when shared analysis behavior changed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ skylos . --gate          # quality gate; non-zero exit blocks on failure
 Run `skylos commands` for the full command list and `skylos <cmd> --help` for
 details on any subcommand.
 
-## Skill for using Skylos
+## Skill For Using Skylos
 
 A detailed agent skill for installing, running, and interpreting Skylos lives
 at:
@@ -50,13 +50,16 @@ at:
 ```
 
 It is auto-discovered by Claude Code. Consult it for output formats, JSON
-result keys, filtering flags, gating/exit codes, suppression syntax, the
-`SKY-*` rule-ID families, and subcommand reference.
+result keys, filtering flags, gating/exit codes, suppression syntax, security
+guardrails, CI behavior, dead-code false-positive triage, and repo workflow.
+
+Keep Claude skill files under `.claude/skills/`. Do not put them under
+`skylos/agents` or `skylos/llm`; those are Skylos runtime modules.
 
 ## Reference docs
 
 - `README.md` — overview, workflow table, language support.
 - `docs/cli-output.md` — output modes and TUI keys.
 - `dictionary.md` — every rule ID and product term.
-- `CONTRIBUTING.md` / `QUALITY.md` — contribution and quality-gate expectations.
+- `CONTRIBUTING.md` / `QUALITY.md` — repo workflow and quality-gate expectations.
 - Full docs: https://docs.skylos.dev

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>641</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5243</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>642</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>5247</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -657,8 +657,8 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
-          <span class="pill"><strong>symbols</strong> 247</span>
-          <span class="pill"><strong>lines</strong> 11076</span>
+          <span class="pill"><strong>symbols</strong> 250</span>
+          <span class="pill"><strong>lines</strong> 11106</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -672,7 +672,7 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <span>5462 lines</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <span>5492 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <span>3740 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <span>989 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <span>616 lines</span></li>
@@ -681,11 +681,11 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L93" rel="noopener noreferrer">remove_unused_import_cst:93</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L97" rel="noopener noreferrer">remove_unused_function_cst:97</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L101" rel="noopener noreferrer">comment_out_unused_import_cst:101</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L105" rel="noopener noreferrer">comment_out_unused_function_cst:105</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L109" rel="noopener noreferrer">run_analyze:109</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L115" rel="noopener noreferrer">remove_unused_import_cst:115</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L119" rel="noopener noreferrer">remove_unused_function_cst:119</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L123" rel="noopener noreferrer">comment_out_unused_import_cst:123</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">comment_out_unused_function_cst:127</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L131" rel="noopener noreferrer">run_analyze:131</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L459" rel="noopener noreferrer">Skylos:459</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3041" rel="noopener noreferrer">proc_file:3041</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3548" rel="noopener noreferrer">analyze:3548</a> <span>def</span></li>
@@ -1984,9 +1984,9 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 189</span>
-          <span class="pill"><strong>symbols</strong> 2244</span>
-          <span class="pill"><strong>lines</strong> 77040</span>
+          <span class="pill"><strong>files</strong> 190</span>
+          <span class="pill"><strong>symbols</strong> 2245</span>
+          <span class="pill"><strong>lines</strong> 77080</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2041,8 +2041,8 @@
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>5462</td>
-              <td>35 / 180</td>
+              <td>5492</td>
+              <td>35 / 183</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -5982,8 +5982,32 @@
             </tr>
             
 
+            <tr class="searchable" data-search="_lazyinquirer class skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L60" rel="noopener noreferrer">_LazyInquirer:60</a></td>
+              <td>class</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+            
+
+            <tr class="searchable" data-search="_inquirer_available def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L74" rel="noopener noreferrer">_inquirer_available:74</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+            
+
+            <tr class="searchable" data-search="_get_inquirer def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L85" rel="noopener noreferrer">_get_inquirer:85</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+            
+
             <tr class="searchable" data-search="_codemods_module def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L89" rel="noopener noreferrer">_codemods_module:89</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L111" rel="noopener noreferrer">_codemods_module:111</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -5991,7 +6015,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L93" rel="noopener noreferrer">remove_unused_import_cst:93</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L115" rel="noopener noreferrer">remove_unused_import_cst:115</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -5999,7 +6023,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L97" rel="noopener noreferrer">remove_unused_function_cst:97</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L119" rel="noopener noreferrer">remove_unused_function_cst:119</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6007,7 +6031,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L101" rel="noopener noreferrer">comment_out_unused_import_cst:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L123" rel="noopener noreferrer">comment_out_unused_import_cst:123</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6015,7 +6039,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L105" rel="noopener noreferrer">comment_out_unused_function_cst:105</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">comment_out_unused_function_cst:127</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6023,7 +6047,7 @@
             
 
             <tr class="searchable" data-search="run_analyze def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L109" rel="noopener noreferrer">run_analyze:109</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L131" rel="noopener noreferrer">run_analyze:131</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6031,7 +6055,7 @@
             
 
             <tr class="searchable" data-search="resolve_llm_runtime def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L115" rel="noopener noreferrer">resolve_llm_runtime:115</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L137" rel="noopener noreferrer">resolve_llm_runtime:137</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6039,7 +6063,7 @@
             
 
             <tr class="searchable" data-search="run_gate_interaction def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L121" rel="noopener noreferrer">run_gate_interaction:121</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L143" rel="noopener noreferrer">run_gate_interaction:143</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6047,7 +6071,7 @@
             
 
             <tr class="searchable" data-search="upload_report def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">upload_report:127</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L149" rel="noopener noreferrer">upload_report:149</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6055,7 +6079,7 @@
             
 
             <tr class="searchable" data-search="run_pipeline def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L133" rel="noopener noreferrer">run_pipeline:133</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L155" rel="noopener noreferrer">run_pipeline:155</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6063,7 +6087,7 @@
             
 
             <tr class="searchable" data-search="review_security_scan_result def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L139" rel="noopener noreferrer">review_security_scan_result:139</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L161" rel="noopener noreferrer">review_security_scan_result:161</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6071,7 +6095,7 @@
             
 
             <tr class="searchable" data-search="run_security_taskflow def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L147" rel="noopener noreferrer">run_security_taskflow:147</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L169" rel="noopener noreferrer">run_security_taskflow:169</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6079,7 +6103,7 @@
             
 
             <tr class="searchable" data-search="discover_source_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L155" rel="noopener noreferrer">discover_source_files:155</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L177" rel="noopener noreferrer">discover_source_files:177</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6087,7 +6111,7 @@
             
 
             <tr class="searchable" data-search="_read_staged_text def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L163" rel="noopener noreferrer">_read_staged_text:163</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L185" rel="noopener noreferrer">_read_staged_text:185</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6095,7 +6119,7 @@
             
 
             <tr class="searchable" data-search="_scan_staged_secret_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L175" rel="noopener noreferrer">_scan_staged_secret_files:175</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L197" rel="noopener noreferrer">_scan_staged_secret_files:197</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6103,7 +6127,7 @@
             
 
             <tr class="searchable" data-search="_join_phrase def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L201" rel="noopener noreferrer">_join_phrase:201</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L223" rel="noopener noreferrer">_join_phrase:223</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6111,7 +6135,7 @@
             
 
             <tr class="searchable" data-search="_list_dirty_relevant_paths def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L211" rel="noopener noreferrer">_list_dirty_relevant_paths:211</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L233" rel="noopener noreferrer">_list_dirty_relevant_paths:233</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6119,7 +6143,7 @@
             
 
             <tr class="searchable" data-search="_deep_audit_output_exclude_paths def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L239" rel="noopener noreferrer">_deep_audit_output_exclude_paths:239</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L261" rel="noopener noreferrer">_deep_audit_output_exclude_paths:261</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6127,7 +6151,7 @@
             
 
             <tr class="searchable" data-search="_deep_audit_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L259" rel="noopener noreferrer">_deep_audit_project_root:259</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L281" rel="noopener noreferrer">_deep_audit_project_root:281</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6135,7 +6159,7 @@
             
 
             <tr class="searchable" data-search="_empty_changed_deep_audit_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L264" rel="noopener noreferrer">_empty_changed_deep_audit_payload:264</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L286" rel="noopener noreferrer">_empty_changed_deep_audit_payload:286</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6143,7 +6167,7 @@
             
 
             <tr class="searchable" data-search="_write_deep_audit_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L327" rel="noopener noreferrer">_write_deep_audit_payload:327</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L349" rel="noopener noreferrer">_write_deep_audit_payload:349</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6151,7 +6175,7 @@
             
 
             <tr class="searchable" data-search="_handle_empty_changed_deep_audit def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L333" rel="noopener noreferrer">_handle_empty_changed_deep_audit:333</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L355" rel="noopener noreferrer">_handle_empty_changed_deep_audit:355</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6159,7 +6183,7 @@
             
 
             <tr class="searchable" data-search="_create_precommit_snapshot def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L390" rel="noopener noreferrer">_create_precommit_snapshot:390</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L412" rel="noopener noreferrer">_create_precommit_snapshot:412</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6167,7 +6191,7 @@
             
 
             <tr class="searchable" data-search="_remap_precommit_result_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L411" rel="noopener noreferrer">_remap_precommit_result_files:411</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L433" rel="noopener noreferrer">_remap_precommit_result_files:433</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6175,7 +6199,7 @@
             
 
             <tr class="searchable" data-search="_parse_unified_diff_ranges def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L463" rel="noopener noreferrer">_parse_unified_diff_ranges:463</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L485" rel="noopener noreferrer">_parse_unified_diff_ranges:485</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6183,7 +6207,7 @@
             
 
             <tr class="searchable" data-search="_normalize_precommit_path def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L488" rel="noopener noreferrer">_normalize_precommit_path:488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L510" rel="noopener noreferrer">_normalize_precommit_path:510</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6191,7 +6215,7 @@
             
 
             <tr class="searchable" data-search="_path_suffixes def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L492" rel="noopener noreferrer">_path_suffixes:492</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L514" rel="noopener noreferrer">_path_suffixes:514</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6199,7 +6223,7 @@
             
 
             <tr class="searchable" data-search="_build_changed_range_index def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L500" rel="noopener noreferrer">_build_changed_range_index:500</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L522" rel="noopener noreferrer">_build_changed_range_index:522</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6207,7 +6231,7 @@
             
 
             <tr class="searchable" data-search="_ranges_for_precommit_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L510" rel="noopener noreferrer">_ranges_for_precommit_file:510</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L532" rel="noopener noreferrer">_ranges_for_precommit_file:532</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6215,7 +6239,7 @@
             
 
             <tr class="searchable" data-search="_finding_is_in_changed_lines def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L520" rel="noopener noreferrer">_finding_is_in_changed_lines:520</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L542" rel="noopener noreferrer">_finding_is_in_changed_lines:542</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6223,7 +6247,7 @@
             
 
             <tr class="searchable" data-search="_get_cached_changed_line_ranges def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L536" rel="noopener noreferrer">_get_cached_changed_line_ranges:536</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L558" rel="noopener noreferrer">_get_cached_changed_line_ranges:558</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6231,7 +6255,7 @@
             
 
             <tr class="searchable" data-search="_filter_precommit_findings_to_changed_lines def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L553" rel="noopener noreferrer">_filter_precommit_findings_to_changed_lines:553</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L575" rel="noopener noreferrer">_filter_precommit_findings_to_changed_lines:575</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6239,7 +6263,7 @@
             
 
             <tr class="searchable" data-search="_precommit_blocks_finding def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L571" rel="noopener noreferrer">_precommit_blocks_finding:571</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L593" rel="noopener noreferrer">_precommit_blocks_finding:593</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6247,7 +6271,7 @@
             
 
             <tr class="searchable" data-search="_apply_precommit_gate_policy def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L586" rel="noopener noreferrer">_apply_precommit_gate_policy:586</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L608" rel="noopener noreferrer">_apply_precommit_gate_policy:608</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6255,7 +6279,7 @@
             
 
             <tr class="searchable" data-search="llm_estimate_cost def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L597" rel="noopener noreferrer">llm_estimate_cost:597</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L619" rel="noopener noreferrer">llm_estimate_cost:619</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6263,7 +6287,7 @@
             
 
             <tr class="searchable" data-search="_get_sarif_exporter_class def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L612" rel="noopener noreferrer">_get_sarif_exporter_class:612</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L634" rel="noopener noreferrer">_get_sarif_exporter_class:634</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6271,7 +6295,7 @@
             
 
             <tr class="searchable" data-search="_ensure_llm_support def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L623" rel="noopener noreferrer">_ensure_llm_support:623</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L645" rel="noopener noreferrer">_ensure_llm_support:645</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6279,7 +6303,7 @@
             
 
             <tr class="searchable" data-search="_build_analyzer_config def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L645" rel="noopener noreferrer">_build_analyzer_config:645</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L667" rel="noopener noreferrer">_build_analyzer_config:667</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6287,7 +6311,7 @@
             
 
             <tr class="searchable" data-search="cleanformatter class skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L658" rel="noopener noreferrer">CleanFormatter:658</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L680" rel="noopener noreferrer">CleanFormatter:680</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6295,7 +6319,7 @@
             
 
             <tr class="searchable" data-search="_skylos_console_theme def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L663" rel="noopener noreferrer">_skylos_console_theme:663</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L685" rel="noopener noreferrer">_skylos_console_theme:685</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6303,7 +6327,7 @@
             
 
             <tr class="searchable" data-search="setup_logger def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L675" rel="noopener noreferrer">setup_logger:675</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L697" rel="noopener noreferrer">setup_logger:697</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6311,7 +6335,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_import def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L699" rel="noopener noreferrer">remove_unused_import:699</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L721" rel="noopener noreferrer">remove_unused_import:721</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6319,7 +6343,7 @@
             
 
             <tr class="searchable" data-search="remove_unused_function def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L714" rel="noopener noreferrer">remove_unused_function:714</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L736" rel="noopener noreferrer">remove_unused_function:736</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6327,7 +6351,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_import def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L731" rel="noopener noreferrer">comment_out_unused_import:731</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L753" rel="noopener noreferrer">comment_out_unused_import:753</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6335,7 +6359,7 @@
             
 
             <tr class="searchable" data-search="comment_out_unused_function def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L752" rel="noopener noreferrer">comment_out_unused_function:752</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L774" rel="noopener noreferrer">comment_out_unused_function:774</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6343,7 +6367,7 @@
             
 
             <tr class="searchable" data-search="_shorten_path def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L773" rel="noopener noreferrer">_shorten_path:773</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L795" rel="noopener noreferrer">_shorten_path:795</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6351,7 +6375,7 @@
             
 
             <tr class="searchable" data-search="find_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L790" rel="noopener noreferrer">find_project_root:790</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L812" rel="noopener noreferrer">find_project_root:812</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6359,7 +6383,7 @@
             
 
             <tr class="searchable" data-search="_rel_to_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L815" rel="noopener noreferrer">_rel_to_project_root:815</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L837" rel="noopener noreferrer">_rel_to_project_root:837</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6367,7 +6391,7 @@
             
 
             <tr class="searchable" data-search="_normalize_agent_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L826" rel="noopener noreferrer">_normalize_agent_findings:826</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L848" rel="noopener noreferrer">_normalize_agent_findings:848</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6375,7 +6399,7 @@
             
 
             <tr class="searchable" data-search="_agent_findings_to_result_json def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L847" rel="noopener noreferrer">_agent_findings_to_result_json:847</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L869" rel="noopener noreferrer">_agent_findings_to_result_json:869</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6383,7 +6407,7 @@
             
 
             <tr class="searchable" data-search="_is_tty def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L892" rel="noopener noreferrer">_is_tty:892</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L914" rel="noopener noreferrer">_is_tty:914</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6391,7 +6415,7 @@
             
 
             <tr class="searchable" data-search="_is_main_machine_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L899" rel="noopener noreferrer">_is_main_machine_output:899</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L921" rel="noopener noreferrer">_is_main_machine_output:921</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6399,7 +6423,7 @@
             
 
             <tr class="searchable" data-search="_has_high_intent_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L908" rel="noopener noreferrer">_has_high_intent_findings:908</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L930" rel="noopener noreferrer">_has_high_intent_findings:930</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6407,7 +6431,7 @@
             
 
             <tr class="searchable" data-search="_set_no_upload_prompt def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L928" rel="noopener noreferrer">_set_no_upload_prompt:928</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L950" rel="noopener noreferrer">_set_no_upload_prompt:950</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6415,7 +6439,7 @@
             
 
             <tr class="searchable" data-search="_detect_link_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L961" rel="noopener noreferrer">_detect_link_file:961</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L983" rel="noopener noreferrer">_detect_link_file:983</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6423,7 +6447,7 @@
             
 
             <tr class="searchable" data-search="_print_upload_destination def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L970" rel="noopener noreferrer">_print_upload_destination:970</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L992" rel="noopener noreferrer">_print_upload_destination:992</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6431,7 +6455,7 @@
             
 
             <tr class="searchable" data-search="_selected_main_upload_static_categories def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L989" rel="noopener noreferrer">_selected_main_upload_static_categories:989</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1011" rel="noopener noreferrer">_selected_main_upload_static_categories:1011</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6439,7 +6463,7 @@
             
 
             <tr class="searchable" data-search="_print_main_upload_manifest def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1002" rel="noopener noreferrer">_print_main_upload_manifest:1002</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1024" rel="noopener noreferrer">_print_main_upload_manifest:1024</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6447,7 +6471,7 @@
             
 
             <tr class="searchable" data-search="_render_upload_failure def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1020" rel="noopener noreferrer">_render_upload_failure:1020</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1042" rel="noopener noreferrer">_render_upload_failure:1042</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6455,7 +6479,7 @@
             
 
             <tr class="searchable" data-search="_is_ci def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1038" rel="noopener noreferrer">_is_ci:1038</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1060" rel="noopener noreferrer">_is_ci:1060</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6463,7 +6487,7 @@
             
 
             <tr class="searchable" data-search="_print_upload_cta def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1055" rel="noopener noreferrer">_print_upload_cta:1055</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1077" rel="noopener noreferrer">_print_upload_cta:1077</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6471,7 +6495,7 @@
             
 
             <tr class="searchable" data-search="_print_feature_hints def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1101" rel="noopener noreferrer">_print_feature_hints:1101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1123" rel="noopener noreferrer">_print_feature_hints:1123</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6479,7 +6503,7 @@
             
 
             <tr class="searchable" data-search="interactive_selection def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1153" rel="noopener noreferrer">interactive_selection:1153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1175" rel="noopener noreferrer">interactive_selection:1175</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6487,7 +6511,7 @@
             
 
             <tr class="searchable" data-search="print_badge def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1210" rel="noopener noreferrer">print_badge:1210</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1233" rel="noopener noreferrer">print_badge:1233</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6495,7 +6519,7 @@
             
 
             <tr class="searchable" data-search="_default_dead_code_llm_fields def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1272" rel="noopener noreferrer">_default_dead_code_llm_fields:1272</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1295" rel="noopener noreferrer">_default_dead_code_llm_fields:1295</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6503,7 +6527,7 @@
             
 
             <tr class="searchable" data-search="_collect_llm_report_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1288" rel="noopener noreferrer">_collect_llm_report_findings:1288</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1311" rel="noopener noreferrer">_collect_llm_report_findings:1311</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6511,7 +6535,7 @@
             
 
             <tr class="searchable" data-search="_llm_report_sort_key def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1303" rel="noopener noreferrer">_llm_report_sort_key:1303</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1326" rel="noopener noreferrer">_llm_report_sort_key:1326</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6519,7 +6543,7 @@
             
 
             <tr class="searchable" data-search="_llm_report_code_block def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1308" rel="noopener noreferrer">_llm_report_code_block:1308</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1331" rel="noopener noreferrer">_llm_report_code_block:1331</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6527,7 +6551,7 @@
             
 
             <tr class="searchable" data-search="_llm_report_secret_block def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1352" rel="noopener noreferrer">_llm_report_secret_block:1352</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1375" rel="noopener noreferrer">_llm_report_secret_block:1375</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6535,7 +6559,7 @@
             
 
             <tr class="searchable" data-search="_format_llm_report_section def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1357" rel="noopener noreferrer">_format_llm_report_section:1357</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1380" rel="noopener noreferrer">_format_llm_report_section:1380</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6543,7 +6567,7 @@
             
 
             <tr class="searchable" data-search="_generate_llm_report def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1375" rel="noopener noreferrer">_generate_llm_report:1375</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1398" rel="noopener noreferrer">_generate_llm_report:1398</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6551,7 +6575,7 @@
             
 
             <tr class="searchable" data-search="_emit_github_grade_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1426" rel="noopener noreferrer">_emit_github_grade_annotation:1426</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1449" rel="noopener noreferrer">_emit_github_grade_annotation:1449</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6559,7 +6583,7 @@
             
 
             <tr class="searchable" data-search="_github_finding_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1435" rel="noopener noreferrer">_github_finding_annotation:1435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1458" rel="noopener noreferrer">_github_finding_annotation:1458</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6567,7 +6591,7 @@
             
 
             <tr class="searchable" data-search="_github_dead_code_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1456" rel="noopener noreferrer">_github_dead_code_annotation:1456</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1479" rel="noopener noreferrer">_github_dead_code_annotation:1479</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6575,7 +6599,7 @@
             
 
             <tr class="searchable" data-search="_github_annotation_items def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1469" rel="noopener noreferrer">_github_annotation_items:1469</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1492" rel="noopener noreferrer">_github_annotation_items:1492</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6583,7 +6607,7 @@
             
 
             <tr class="searchable" data-search="_filter_github_annotations_by_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1481" rel="noopener noreferrer">_filter_github_annotations_by_severity:1481</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1504" rel="noopener noreferrer">_filter_github_annotations_by_severity:1504</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6591,7 +6615,7 @@
             
 
             <tr class="searchable" data-search="_github_annotation_sort_key def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1488" rel="noopener noreferrer">_github_annotation_sort_key:1488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1511" rel="noopener noreferrer">_github_annotation_sort_key:1511</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6599,7 +6623,7 @@
             
 
             <tr class="searchable" data-search="_emit_github_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1492" rel="noopener noreferrer">_emit_github_annotation:1492</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1515" rel="noopener noreferrer">_emit_github_annotation:1515</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6607,7 +6631,7 @@
             
 
             <tr class="searchable" data-search="_emit_github_annotations def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1500" rel="noopener noreferrer">_emit_github_annotations:1500</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1523" rel="noopener noreferrer">_emit_github_annotations:1523</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6615,7 +6639,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_min_rank def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1527" rel="noopener noreferrer">_display_filter_min_rank:1527</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1550" rel="noopener noreferrer">_display_filter_min_rank:1550</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6623,7 +6647,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_allowed_categories def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1533" rel="noopener noreferrer">_display_filter_allowed_categories:1533</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1556" rel="noopener noreferrer">_display_filter_allowed_categories:1556</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6631,7 +6655,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_matches_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1539" rel="noopener noreferrer">_display_filter_matches_file:1539</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1562" rel="noopener noreferrer">_display_filter_matches_file:1562</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6639,7 +6663,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_has_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1545" rel="noopener noreferrer">_display_filter_has_severity:1545</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1568" rel="noopener noreferrer">_display_filter_has_severity:1568</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6647,7 +6671,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_passes_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1552" rel="noopener noreferrer">_display_filter_passes_severity:1552</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1575" rel="noopener noreferrer">_display_filter_passes_severity:1575</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6655,7 +6679,7 @@
             
 
             <tr class="searchable" data-search="_display_filter_items def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1557" rel="noopener noreferrer">_display_filter_items:1557</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1580" rel="noopener noreferrer">_display_filter_items:1580</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6663,7 +6687,7 @@
             
 
             <tr class="searchable" data-search="_apply_display_filters def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1572" rel="noopener noreferrer">_apply_display_filters:1572</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1595" rel="noopener noreferrer">_apply_display_filters:1595</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6671,7 +6695,7 @@
             
 
             <tr class="searchable" data-search="_results_pill def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1601" rel="noopener noreferrer">_results_pill:1601</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1624" rel="noopener noreferrer">_results_pill:1624</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6679,7 +6703,7 @@
             
 
             <tr class="searchable" data-search="_grep_verify_pill def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1609" rel="noopener noreferrer">_grep_verify_pill:1609</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1632" rel="noopener noreferrer">_grep_verify_pill:1632</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6687,7 +6711,7 @@
             
 
             <tr class="searchable" data-search="_display_cap def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1619" rel="noopener noreferrer">_display_cap:1619</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1642" rel="noopener noreferrer">_display_cap:1642</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6695,7 +6719,7 @@
             
 
             <tr class="searchable" data-search="_score_style def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1624" rel="noopener noreferrer">_score_style:1624</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1647" rel="noopener noreferrer">_score_style:1647</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6703,7 +6727,7 @@
             
 
             <tr class="searchable" data-search="_render_grade def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1634" rel="noopener noreferrer">_render_grade:1634</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1657" rel="noopener noreferrer">_render_grade:1657</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6711,7 +6735,7 @@
             
 
             <tr class="searchable" data-search="_format_confidence def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1715" rel="noopener noreferrer">_format_confidence:1715</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1738" rel="noopener noreferrer">_format_confidence:1738</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6719,7 +6743,7 @@
             
 
             <tr class="searchable" data-search="_render_unused def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1725" rel="noopener noreferrer">_render_unused:1725</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1748" rel="noopener noreferrer">_render_unused:1748</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6727,7 +6751,7 @@
             
 
             <tr class="searchable" data-search="_render_unused_simple def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1757" rel="noopener noreferrer">_render_unused_simple:1757</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1780" rel="noopener noreferrer">_render_unused_simple:1780</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6735,7 +6759,7 @@
             
 
             <tr class="searchable" data-search="_quality_detail def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1785" rel="noopener noreferrer">_quality_detail:1785</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1808" rel="noopener noreferrer">_quality_detail:1808</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6743,7 +6767,7 @@
             
 
             <tr class="searchable" data-search="_render_quality def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1825" rel="noopener noreferrer">_render_quality:1825</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1848" rel="noopener noreferrer">_render_quality:1848</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6751,7 +6775,7 @@
             
 
             <tr class="searchable" data-search="_render_circular_deps def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1859" rel="noopener noreferrer">_render_circular_deps:1859</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1882" rel="noopener noreferrer">_render_circular_deps:1882</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6759,7 +6783,7 @@
             
 
             <tr class="searchable" data-search="_render_custom_rules def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1893" rel="noopener noreferrer">_render_custom_rules:1893</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1916" rel="noopener noreferrer">_render_custom_rules:1916</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6767,7 +6791,7 @@
             
 
             <tr class="searchable" data-search="_render_secrets def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1925" rel="noopener noreferrer">_render_secrets:1925</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1948" rel="noopener noreferrer">_render_secrets:1948</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6775,7 +6799,7 @@
             
 
             <tr class="searchable" data-search="_render_result_tree def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1972" rel="noopener noreferrer">_render_result_tree:1972</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1995" rel="noopener noreferrer">_render_result_tree:1995</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6783,7 +6807,7 @@
             
 
             <tr class="searchable" data-search="_display_rule_name def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2036" rel="noopener noreferrer">_display_rule_name:2036</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2059" rel="noopener noreferrer">_display_rule_name:2059</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6791,7 +6815,7 @@
             
 
             <tr class="searchable" data-search="_verification_proof def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2042" rel="noopener noreferrer">_verification_proof:2042</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2065" rel="noopener noreferrer">_verification_proof:2065</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6799,7 +6823,7 @@
             
 
             <tr class="searchable" data-search="_verification_label def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2073" rel="noopener noreferrer">_verification_label:2073</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2096" rel="noopener noreferrer">_verification_label:2096</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6807,7 +6831,7 @@
             
 
             <tr class="searchable" data-search="_render_danger def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2083" rel="noopener noreferrer">_render_danger:2083</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2106" rel="noopener noreferrer">_render_danger:2106</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6815,7 +6839,7 @@
             
 
             <tr class="searchable" data-search="_render_sca def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2148" rel="noopener noreferrer">_render_sca:2148</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2171" rel="noopener noreferrer">_render_sca:2171</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6823,7 +6847,7 @@
             
 
             <tr class="searchable" data-search="render_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2194" rel="noopener noreferrer">render_results:2194</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2217" rel="noopener noreferrer">render_results:2217</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6831,7 +6855,7 @@
             
 
             <tr class="searchable" data-search="render_pretty_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2312" rel="noopener noreferrer">render_pretty_results:2312</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2335" rel="noopener noreferrer">render_pretty_results:2335</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6839,7 +6863,7 @@
             
 
             <tr class="searchable" data-search="_write_rich_report_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2324" rel="noopener noreferrer">_write_rich_report_output:2324</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2347" rel="noopener noreferrer">_write_rich_report_output:2347</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6847,7 +6871,7 @@
             
 
             <tr class="searchable" data-search="_write_pretty_report_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2349" rel="noopener noreferrer">_write_pretty_report_output:2349</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2372" rel="noopener noreferrer">_write_pretty_report_output:2372</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6855,7 +6879,7 @@
             
 
             <tr class="searchable" data-search="run_init def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2371" rel="noopener noreferrer">run_init:2371</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2394" rel="noopener noreferrer">run_init:2394</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6863,7 +6887,7 @@
             
 
             <tr class="searchable" data-search="run_whitelist def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2377" rel="noopener noreferrer">run_whitelist:2377</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2400" rel="noopener noreferrer">run_whitelist:2400</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6871,7 +6895,7 @@
             
 
             <tr class="searchable" data-search="get_git_changed_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2383" rel="noopener noreferrer">get_git_changed_files:2383</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2406" rel="noopener noreferrer">get_git_changed_files:2406</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6879,7 +6903,7 @@
             
 
             <tr class="searchable" data-search="estimate_cost def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2402" rel="noopener noreferrer">estimate_cost:2402</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2425" rel="noopener noreferrer">estimate_cost:2425</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6887,7 +6911,7 @@
             
 
             <tr class="searchable" data-search="_run_clean_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2408" rel="noopener noreferrer">_run_clean_command:2408</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2431" rel="noopener noreferrer">_run_clean_command:2431</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6895,7 +6919,7 @@
             
 
             <tr class="searchable" data-search="_run_cache_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2414" rel="noopener noreferrer">_run_cache_command:2414</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2437" rel="noopener noreferrer">_run_cache_command:2437</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6903,7 +6927,7 @@
             
 
             <tr class="searchable" data-search="run_debt_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2420" rel="noopener noreferrer">run_debt_command:2420</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2443" rel="noopener noreferrer">run_debt_command:2443</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6911,7 +6935,7 @@
             
 
             <tr class="searchable" data-search="run_defend_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2435" rel="noopener noreferrer">run_defend_command:2435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2458" rel="noopener noreferrer">run_defend_command:2458</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6919,7 +6943,7 @@
             
 
             <tr class="searchable" data-search="run_suite_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2445" rel="noopener noreferrer">run_suite_command:2445</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2468" rel="noopener noreferrer">run_suite_command:2468</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6927,7 +6951,7 @@
             
 
             <tr class="searchable" data-search="run_ingest_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2467" rel="noopener noreferrer">run_ingest_command:2467</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2490" rel="noopener noreferrer">run_ingest_command:2490</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6935,7 +6959,7 @@
             
 
             <tr class="searchable" data-search="run_provenance_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2476" rel="noopener noreferrer">run_provenance_command:2476</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2499" rel="noopener noreferrer">run_provenance_command:2499</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6943,7 +6967,7 @@
             
 
             <tr class="searchable" data-search="run_cicd_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2490" rel="noopener noreferrer">run_cicd_command:2490</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2513" rel="noopener noreferrer">run_cicd_command:2513</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -6951,7 +6975,7 @@
             
 
             <tr class="searchable" data-search="_load_addopts def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2502" rel="noopener noreferrer">_load_addopts:2502</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2525" rel="noopener noreferrer">_load_addopts:2525</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6959,7 +6983,7 @@
             
 
             <tr class="searchable" data-search="_handle_rules_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2508" rel="noopener noreferrer">_handle_rules_command:2508</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2531" rel="noopener noreferrer">_handle_rules_command:2531</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6967,7 +6991,7 @@
             
 
             <tr class="searchable" data-search="_rules_install def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2514" rel="noopener noreferrer">_rules_install:2514</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2537" rel="noopener noreferrer">_rules_install:2537</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6975,7 +6999,7 @@
             
 
             <tr class="searchable" data-search="_rules_list def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2520" rel="noopener noreferrer">_rules_list:2520</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2543" rel="noopener noreferrer">_rules_list:2543</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6983,7 +7007,7 @@
             
 
             <tr class="searchable" data-search="_rules_remove def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2526" rel="noopener noreferrer">_rules_remove:2526</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2549" rel="noopener noreferrer">_rules_remove:2549</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6991,7 +7015,7 @@
             
 
             <tr class="searchable" data-search="_run_command_overview def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2535" rel="noopener noreferrer">_run_command_overview:2535</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2558" rel="noopener noreferrer">_run_command_overview:2558</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -6999,7 +7023,7 @@
             
 
             <tr class="searchable" data-search="_run_commands_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2542" rel="noopener noreferrer">_run_commands_command:2542</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2565" rel="noopener noreferrer">_run_commands_command:2565</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7007,7 +7031,7 @@
             
 
             <tr class="searchable" data-search="_run_tour_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2549" rel="noopener noreferrer">_run_tour_command:2549</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2572" rel="noopener noreferrer">_run_tour_command:2572</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7015,7 +7039,7 @@
             
 
             <tr class="searchable" data-search="_run_key_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2556" rel="noopener noreferrer">_run_key_command:2556</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2579" rel="noopener noreferrer">_run_key_command:2579</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7023,7 +7047,7 @@
             
 
             <tr class="searchable" data-search="_run_credits_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2562" rel="noopener noreferrer">_run_credits_command:2562</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2585" rel="noopener noreferrer">_run_credits_command:2585</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7031,7 +7055,7 @@
             
 
             <tr class="searchable" data-search="_run_init_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2568" rel="noopener noreferrer">_run_init_command:2568</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2591" rel="noopener noreferrer">_run_init_command:2591</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7039,7 +7063,7 @@
             
 
             <tr class="searchable" data-search="_run_baseline_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2572" rel="noopener noreferrer">_run_baseline_command:2572</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2595" rel="noopener noreferrer">_run_baseline_command:2595</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7047,7 +7071,7 @@
             
 
             <tr class="searchable" data-search="_run_badge_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2578" rel="noopener noreferrer">_run_badge_command:2578</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2601" rel="noopener noreferrer">_run_badge_command:2601</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7055,7 +7079,7 @@
             
 
             <tr class="searchable" data-search="_run_whitelist_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2584" rel="noopener noreferrer">_run_whitelist_command:2584</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2607" rel="noopener noreferrer">_run_whitelist_command:2607</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7063,7 +7087,7 @@
             
 
             <tr class="searchable" data-search="_run_doctor_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2590" rel="noopener noreferrer">_run_doctor_command:2590</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2613" rel="noopener noreferrer">_run_doctor_command:2613</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7071,7 +7095,7 @@
             
 
             <tr class="searchable" data-search="_run_whoami_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2596" rel="noopener noreferrer">_run_whoami_command:2596</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2619" rel="noopener noreferrer">_run_whoami_command:2619</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7079,7 +7103,7 @@
             
 
             <tr class="searchable" data-search="_run_login_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2602" rel="noopener noreferrer">_run_login_command:2602</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2625" rel="noopener noreferrer">_run_login_command:2625</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7087,7 +7111,7 @@
             
 
             <tr class="searchable" data-search="_run_sync_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2608" rel="noopener noreferrer">_run_sync_command:2608</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2631" rel="noopener noreferrer">_run_sync_command:2631</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7095,7 +7119,7 @@
             
 
             <tr class="searchable" data-search="_run_project_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2614" rel="noopener noreferrer">_run_project_command:2614</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2637" rel="noopener noreferrer">_run_project_command:2637</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7103,7 +7127,7 @@
             
 
             <tr class="searchable" data-search="_run_sonar_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2620" rel="noopener noreferrer">_run_sonar_command:2620</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2643" rel="noopener noreferrer">_run_sonar_command:2643</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7111,7 +7135,7 @@
             
 
             <tr class="searchable" data-search="_attach_upload_project_context def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2626" rel="noopener noreferrer">_attach_upload_project_context:2626</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2649" rel="noopener noreferrer">_attach_upload_project_context:2649</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7119,7 +7143,7 @@
             
 
             <tr class="searchable" data-search="_upload_agent_run_best_effort def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2640" rel="noopener noreferrer">_upload_agent_run_best_effort:2640</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2663" rel="noopener noreferrer">_upload_agent_run_best_effort:2663</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7127,7 +7151,7 @@
             
 
             <tr class="searchable" data-search="_run_removed_city_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2663" rel="noopener noreferrer">_run_removed_city_command:2663</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2686" rel="noopener noreferrer">_run_removed_city_command:2686</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7135,7 +7159,7 @@
             
 
             <tr class="searchable" data-search="_run_discover_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2674" rel="noopener noreferrer">_run_discover_command:2674</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2697" rel="noopener noreferrer">_run_discover_command:2697</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7143,7 +7167,7 @@
             
 
             <tr class="searchable" data-search="_run_web_server_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2680" rel="noopener noreferrer">_run_web_server_command:2680</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2703" rel="noopener noreferrer">_run_web_server_command:2703</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7151,7 +7175,7 @@
             
 
             <tr class="searchable" data-search="_run_scan_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2691" rel="noopener noreferrer">_run_scan_command:2691</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2714" rel="noopener noreferrer">_run_scan_command:2714</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7159,7 +7183,7 @@
             
 
             <tr class="searchable" data-search="_is_first_level_help_request def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2697" rel="noopener noreferrer">_is_first_level_help_request:2697</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2720" rel="noopener noreferrer">_is_first_level_help_request:2720</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7167,7 +7191,7 @@
             
 
             <tr class="searchable" data-search="_run_early_command_help def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2701" rel="noopener noreferrer">_run_early_command_help:2701</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2724" rel="noopener noreferrer">_run_early_command_help:2724</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7175,7 +7199,7 @@
             
 
             <tr class="searchable" data-search="_dispatch_early_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2705" rel="noopener noreferrer">_dispatch_early_command:2705</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2728" rel="noopener noreferrer">_dispatch_early_command:2728</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7183,7 +7207,7 @@
             
 
             <tr class="searchable" data-search="_rules_validate def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2709" rel="noopener noreferrer">_rules_validate:2709</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2732" rel="noopener noreferrer">_rules_validate:2732</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7191,7 +7215,7 @@
             
 
             <tr class="searchable" data-search="_build_main_parser def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2715" rel="noopener noreferrer">_build_main_parser:2715</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2738" rel="noopener noreferrer">_build_main_parser:2738</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7199,7 +7223,7 @@
             
 
             <tr class="searchable" data-search="_apply_main_output_format def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2719" rel="noopener noreferrer">_apply_main_output_format:2719</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2742" rel="noopener noreferrer">_apply_main_output_format:2742</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7207,7 +7231,7 @@
             
 
             <tr class="searchable" data-search="_parse_main_cli_args def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2723" rel="noopener noreferrer">_parse_main_cli_args:2723</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2746" rel="noopener noreferrer">_parse_main_cli_args:2746</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7215,7 +7239,7 @@
             
 
             <tr class="searchable" data-search="_resolve_main_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2727" rel="noopener noreferrer">_resolve_main_project_root:2727</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2750" rel="noopener noreferrer">_resolve_main_project_root:2750</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7223,7 +7247,7 @@
             
 
             <tr class="searchable" data-search="_print_default_excludes def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2737" rel="noopener noreferrer">_print_default_excludes:2737</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2760" rel="noopener noreferrer">_print_default_excludes:2760</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7231,7 +7255,7 @@
             
 
             <tr class="searchable" data-search="_build_main_scan_context def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2746" rel="noopener noreferrer">_build_main_scan_context:2746</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2769" rel="noopener noreferrer">_build_main_scan_context:2769</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7239,7 +7263,7 @@
             
 
             <tr class="searchable" data-search="_formatted_output_gate_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2782" rel="noopener noreferrer">_formatted_output_gate_exit_code:2782</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2805" rel="noopener noreferrer">_formatted_output_gate_exit_code:2805</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7247,7 +7271,7 @@
             
 
             <tr class="searchable" data-search="_concise_scan_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2809" rel="noopener noreferrer">_concise_scan_exit_code:2809</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2832" rel="noopener noreferrer">_concise_scan_exit_code:2832</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7255,7 +7279,7 @@
             
 
             <tr class="searchable" data-search="_has_concise_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2842" rel="noopener noreferrer">_has_concise_findings:2842</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2865" rel="noopener noreferrer">_has_concise_findings:2865</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7263,7 +7287,7 @@
             
 
             <tr class="searchable" data-search="_concise_line def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2849" rel="noopener noreferrer">_concise_line:2849</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2872" rel="noopener noreferrer">_concise_line:2872</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7271,7 +7295,7 @@
             
 
             <tr class="searchable" data-search="_format_concise_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2859" rel="noopener noreferrer">_format_concise_results:2859</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2882" rel="noopener noreferrer">_format_concise_results:2882</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7279,7 +7303,7 @@
             
 
             <tr class="searchable" data-search="_strict_scan_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2882" rel="noopener noreferrer">_strict_scan_exit_code:2882</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2905" rel="noopener noreferrer">_strict_scan_exit_code:2905</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7287,7 +7311,7 @@
             
 
             <tr class="searchable" data-search="_apply_config_driven_analysis_flags def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2895" rel="noopener noreferrer">_apply_config_driven_analysis_flags:2895</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2918" rel="noopener noreferrer">_apply_config_driven_analysis_flags:2918</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7295,7 +7319,7 @@
             
 
             <tr class="searchable" data-search="_print_main_scan_banner def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2934" rel="noopener noreferrer">_print_main_scan_banner:2934</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2957" rel="noopener noreferrer">_print_main_scan_banner:2957</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7303,7 +7327,7 @@
             
 
             <tr class="searchable" data-search="_trace_cache_requested def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2976" rel="noopener noreferrer">_trace_cache_requested:2976</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2999" rel="noopener noreferrer">_trace_cache_requested:2999</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7311,7 +7335,7 @@
             
 
             <tr class="searchable" data-search="_trusted_module_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2986" rel="noopener noreferrer">_trusted_module_file:2986</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3009" rel="noopener noreferrer">_trusted_module_file:3009</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7319,7 +7343,7 @@
             
 
             <tr class="searchable" data-search="_trace_subprocess_script def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2994" rel="noopener noreferrer">_trace_subprocess_script:2994</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3017" rel="noopener noreferrer">_trace_subprocess_script:3017</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7327,7 +7351,7 @@
             
 
             <tr class="searchable" data-search="_trace_subprocess_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3066" rel="noopener noreferrer">_trace_subprocess_command:3066</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3089" rel="noopener noreferrer">_trace_subprocess_command:3089</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7335,7 +7359,7 @@
             
 
             <tr class="searchable" data-search="_coverage_execution_allowed def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3091" rel="noopener noreferrer">_coverage_execution_allowed:3091</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3114" rel="noopener noreferrer">_coverage_execution_allowed:3114</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7343,7 +7367,7 @@
             
 
             <tr class="searchable" data-search="_run_pre_analysis_steps def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3095" rel="noopener noreferrer">_run_pre_analysis_steps:3095</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3118" rel="noopener noreferrer">_run_pre_analysis_steps:3118</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7351,7 +7375,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_model_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3318" rel="noopener noreferrer">_add_agent_model_arg:3318</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3341" rel="noopener noreferrer">_add_agent_model_arg:3341</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7359,7 +7383,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_output_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3322" rel="noopener noreferrer">_add_agent_output_arg:3322</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3345" rel="noopener noreferrer">_add_agent_output_arg:3345</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7367,7 +7391,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_quiet_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3326" rel="noopener noreferrer">_add_agent_quiet_arg:3326</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3349" rel="noopener noreferrer">_add_agent_quiet_arg:3349</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7375,7 +7399,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_provider_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3330" rel="noopener noreferrer">_add_agent_provider_arg:3330</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3353" rel="noopener noreferrer">_add_agent_provider_arg:3353</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7383,7 +7407,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_base_url_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3339" rel="noopener noreferrer">_add_agent_base_url_arg:3339</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3362" rel="noopener noreferrer">_add_agent_base_url_arg:3362</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7391,7 +7415,7 @@
             
 
             <tr class="searchable" data-search="_add_agent_prompt_template_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3350" rel="noopener noreferrer">_add_agent_prompt_template_arg:3350</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3373" rel="noopener noreferrer">_add_agent_prompt_template_arg:3373</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7399,7 +7423,7 @@
             
 
             <tr class="searchable" data-search="_explicit_prompt_templates_from_args def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3363" rel="noopener noreferrer">_explicit_prompt_templates_from_args:3363</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3386" rel="noopener noreferrer">_explicit_prompt_templates_from_args:3386</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7407,7 +7431,7 @@
             
 
             <tr class="searchable" data-search="_build_agent_parser def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3412" rel="noopener noreferrer">_build_agent_parser:3412</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3435" rel="noopener noreferrer">_build_agent_parser:3435</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
@@ -7415,7 +7439,7 @@
             
 
             <tr class="searchable" data-search="main def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3855" rel="noopener noreferrer">main:3855</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3878" rel="noopener noreferrer">main:3878</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
@@ -9344,30 +9368,6 @@
 
             <tr class="searchable" data-search="is_claude_security_report def skylos/integrations/ingest.py external-service integration helpers.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L27" rel="noopener noreferrer">is_claude_security_report:27</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/integrations/ingest.py</td>
-            </tr>
-            
-
-            <tr class="searchable" data-search="normalize_claude_security def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L56" rel="noopener noreferrer">normalize_claude_security:56</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/integrations/ingest.py</td>
-            </tr>
-            
-
-            <tr class="searchable" data-search="cross_reference def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L165" rel="noopener noreferrer">cross_reference:165</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/integrations/ingest.py</td>
-            </tr>
-            
-
-            <tr class="searchable" data-search="print_cross_reference_report def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L223" rel="noopener noreferrer">print_cross_reference_report:223</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/integrations/ingest.py</td>


### PR DESCRIPTION
## Summary

  - Add codex repo skill at .agents/skills/skylos/SKILL.md
  - Refactor claude code skylos skill into a smaller router style SKILL.md
  - Add shared skill references for cli usage, security, dead-code triage, ci/docs, and repo workflow
  - Add AGENTS.md with always on codex repo guidance