### PR TITLE
feat(csharp): add C# analyzer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 ## What Is Skylos?
 
 Skylos is an open-source static analysis tool and CI/CD PR gate for Python,
-TypeScript, JavaScript, Java, Go, PHP, Rust, and Dart repositories. It combines
+TypeScript, JavaScript, Java, Go, PHP, Rust, Dart, and C# repositories. It combines
 dead code detection, security scanning, secrets detection, code quality checks,
 and AI-generated code guardrails in one local-first workflow.
 
@@ -206,6 +206,7 @@ credential names, sensitive files, and network calls that must set timeouts.
 | PHP | Yes | Yes | Partial | PHP parser coverage plus taint-style security sinks and sources |
 | Rust | Yes | Yes | Partial | Rust parser coverage plus security sink/source checks |
 | Dart | Yes | Yes | Partial | Dart parser coverage plus selected security sinks and sources |
+| C# | Yes | Yes | Partial | C# symbol coverage plus selected ASP.NET, process, SQL, HTTP, and file sinks |
 
 See [Rules Reference](https://docs.skylos.dev/rules-reference) for rule families
 and scanner scope.

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>642</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5247</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>647</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>5304</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -658,7 +658,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 250</span>
-          <span class="pill"><strong>lines</strong> 11106</span>
+          <span class="pill"><strong>lines</strong> 11121</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -673,7 +673,7 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <span>5492 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <span>3740 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <span>3755 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <span>989 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <span>616 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">skylos/constants.py</a> <span>229 lines</span></li>
@@ -686,11 +686,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L123" rel="noopener noreferrer">comment_out_unused_import_cst:123</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">comment_out_unused_function_cst:127</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L131" rel="noopener noreferrer">run_analyze:131</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L459" rel="noopener noreferrer">Skylos:459</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3041" rel="noopener noreferrer">proc_file:3041</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3548" rel="noopener noreferrer">analyze:3548</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L148" rel="noopener noreferrer">_entrypoint_module_name:148</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L155" rel="noopener noreferrer">_architecture_iad_strict:155</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L461" rel="noopener noreferrer">Skylos:461</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3046" rel="noopener noreferrer">proc_file:3046</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3563" rel="noopener noreferrer">analyze:3563</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L150" rel="noopener noreferrer">_entrypoint_module_name:150</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L157" rel="noopener noreferrer">_architecture_iad_strict:157</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L306" rel="noopener noreferrer">run_static_on_files:306</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L400" rel="noopener noreferrer">run_pipeline:400</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L77" rel="noopener noreferrer">_enrich_with_llm_suggestions:77</a> <span>def</span></li>
@@ -885,13 +885,13 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/candidates.py skylos/audit/processor.py skylos/audit/types.py skylos/audit/revalidator.py skylos/audit/polyglot.py skylos/audit/store.py skylos/audit/ci.py">
+    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/candidates.py skylos/audit/processor.py skylos/audit/types.py skylos/audit/polyglot.py skylos/audit/revalidator.py skylos/audit/store.py skylos/audit/ci.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit" rel="noopener noreferrer">skylos/audit</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 10</span>
           <span class="pill"><strong>symbols</strong> 96</span>
-          <span class="pill"><strong>lines</strong> 3394</span>
+          <span class="pill"><strong>lines</strong> 3438</span>
         </div>
       </div>
       <p>Deep-audit candidate selection, processing, redaction, export, and revalidation.</p>
@@ -906,11 +906,11 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">skylos/audit/export.py</a> <span>559 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a> <span>635 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a> <span>636 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">skylos/audit/processor.py</a> <span>477 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">skylos/audit/types.py</a> <span>404 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">skylos/audit/types.py</a> <span>405 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py" rel="noopener noreferrer">skylos/audit/polyglot.py</a> <span>430 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">skylos/audit/revalidator.py</a> <span>294 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py" rel="noopener noreferrer">skylos/audit/polyglot.py</a> <span>388 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/store.py" rel="noopener noreferrer">skylos/audit/store.py</a> <span>383 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py" rel="noopener noreferrer">skylos/audit/ci.py</a> <span>174 lines</span></li></ul>
       </div>
@@ -921,11 +921,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L116" rel="noopener noreferrer">write_deep_audit_export:116</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L131" rel="noopener noreferrer">_resolve_deep_audit_export_path:131</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L140" rel="noopener noreferrer">_normalized_allowed_files:140</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L82" rel="noopener noreferrer">scan_deep_audit_candidates:82</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L217" rel="noopener noreferrer">_project_root:217</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L222" rel="noopener noreferrer">_resolve_audit_file:222</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L239" rel="noopener noreferrer">_discover_audit_files:239</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L299" rel="noopener noreferrer">_is_audit_file:299</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L83" rel="noopener noreferrer">scan_deep_audit_candidates:83</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L218" rel="noopener noreferrer">_project_root:218</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L223" rel="noopener noreferrer">_resolve_audit_file:223</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L240" rel="noopener noreferrer">_discover_audit_files:240</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L300" rel="noopener noreferrer">_is_audit_file:300</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L29" rel="noopener noreferrer">process_deep_audit_records:29</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L184" rel="noopener noreferrer">_record_sort_key:184</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L191" rel="noopener noreferrer">_normalized_allowed_files:191</a> <span>def</span></li>
@@ -942,7 +942,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 88</span>
-          <span class="pill"><strong>lines</strong> 3379</span>
+          <span class="pill"><strong>lines</strong> 3381</span>
         </div>
       </div>
       <p>Benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.</p>
@@ -956,8 +956,8 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1083 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>725 lines</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1084 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>726 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>507 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
@@ -966,16 +966,16 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L102" rel="noopener noreferrer">DeadCodeKey:102</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L112" rel="noopener noreferrer">DeadCodeBenchmarkFailure:112</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L129" rel="noopener noreferrer">load_manifest:129</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L133" rel="noopener noreferrer">load_external_targets:133</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L305" rel="noopener noreferrer">validate_manifest:305</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L78" rel="noopener noreferrer">SecurityBenchmarkFailure:78</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L97" rel="noopener noreferrer">load_manifest:97</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L101" rel="noopener noreferrer">validate_manifest:101</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L488" rel="noopener noreferrer">run_case:488</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L575" rel="noopener noreferrer">run_manifest:575</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L103" rel="noopener noreferrer">DeadCodeKey:103</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L113" rel="noopener noreferrer">DeadCodeBenchmarkFailure:113</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L130" rel="noopener noreferrer">load_manifest:130</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L134" rel="noopener noreferrer">load_external_targets:134</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L306" rel="noopener noreferrer">validate_manifest:306</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L79" rel="noopener noreferrer">SecurityBenchmarkFailure:79</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L98" rel="noopener noreferrer">load_manifest:98</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">validate_manifest:102</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L489" rel="noopener noreferrer">run_case:489</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L576" rel="noopener noreferrer">run_manifest:576</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a> <span>def</span></li>
@@ -1795,7 +1795,7 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/security security contract detection, secret handling, and security-specific analysis helpers. treat this as gate-sensitive; regressions here can hide vulnerabilities. skylos/security/ test/test_dart_security.py test/test_github_actions_security.py test/test_gitlab_ci_security.py test/test_go_security.py test/test_java_security.py test/test_mcp_security.py skylos/security/contracts.py skylos/security/injection_scanner.py skylos/security/canonicalize.py skylos/security/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/security security contract detection, secret handling, and security-specific analysis helpers. treat this as gate-sensitive; regressions here can hide vulnerabilities. skylos/security/ test/test_csharp_security.py test/test_dart_security.py test/test_github_actions_security.py test/test_gitlab_ci_security.py test/test_go_security.py test/test_java_security.py skylos/security/contracts.py skylos/security/injection_scanner.py skylos/security/canonicalize.py skylos/security/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security" rel="noopener noreferrer">skylos/security</a></h3>
         <div class="stat-row">
@@ -1811,7 +1811,7 @@
         <div class="mini-label">Entrypoints</div>
         <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/security" rel="noopener noreferrer">skylos/security</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_dart_security.py" rel="noopener noreferrer">test/test_dart_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_github_actions_security.py" rel="noopener noreferrer">test/test_github_actions_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_gitlab_ci_security.py" rel="noopener noreferrer">test/test_gitlab_ci_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_go_security.py" rel="noopener noreferrer">test/test_go_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_mcp_security.py" rel="noopener noreferrer">test/test_mcp_security.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_csharp_security.py" rel="noopener noreferrer">test/test_csharp_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dart_security.py" rel="noopener noreferrer">test/test_dart_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_github_actions_security.py" rel="noopener noreferrer">test/test_github_actions_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_gitlab_ci_security.py" rel="noopener noreferrer">test/test_gitlab_ci_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_go_security.py" rel="noopener noreferrer">test/test_go_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
@@ -1895,9 +1895,9 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 33</span>
-          <span class="pill"><strong>symbols</strong> 271</span>
-          <span class="pill"><strong>lines</strong> 16974</span>
+          <span class="pill"><strong>files</strong> 37</span>
+          <span class="pill"><strong>symbols</strong> 308</span>
+          <span class="pill"><strong>lines</strong> 17594</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1984,9 +1984,9 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 190</span>
-          <span class="pill"><strong>symbols</strong> 2245</span>
-          <span class="pill"><strong>lines</strong> 77080</span>
+          <span class="pill"><strong>files</strong> 191</span>
+          <span class="pill"><strong>symbols</strong> 2265</span>
+          <span class="pill"><strong>lines</strong> 77467</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2002,7 +2002,7 @@
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a> <span>2542 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a> <span>1901 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a> <span>3105 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a> <span>3158 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a> <span>1878 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_vibe_rules.py" rel="noopener noreferrer">test/test_vibe_rules.py</a> <span>2201 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_defend.py" rel="noopener noreferrer">test/test_defend.py</a> <span>2132 lines</span></li>
@@ -2077,7 +2077,7 @@
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3740</td>
+              <td>3755</td>
               <td>3 / 19</td>
               <td><span class="warn">large</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
@@ -2104,7 +2104,7 @@
 
             <tr class="searchable" data-search="test/test_analyzer.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a></td>
-              <td>3105</td>
+              <td>3158</td>
               <td>15 / 15</td>
               <td><span class="warn">large</span></td>
               <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
@@ -5031,7 +5031,7 @@
             
 
             <tr class="searchable" data-search="_entrypoint_module_name def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L148" rel="noopener noreferrer">_entrypoint_module_name:148</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L150" rel="noopener noreferrer">_entrypoint_module_name:150</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5039,7 +5039,7 @@
             
 
             <tr class="searchable" data-search="_architecture_iad_strict def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L155" rel="noopener noreferrer">_architecture_iad_strict:155</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L157" rel="noopener noreferrer">_architecture_iad_strict:157</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5047,7 +5047,7 @@
             
 
             <tr class="searchable" data-search="_expand_reexported_entrypoint_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L164" rel="noopener noreferrer">_expand_reexported_entrypoint_modules:164</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L166" rel="noopener noreferrer">_expand_reexported_entrypoint_modules:166</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5055,7 +5055,7 @@
             
 
             <tr class="searchable" data-search="_find_package_boundary_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L194" rel="noopener noreferrer">_find_package_boundary_modules:194</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L196" rel="noopener noreferrer">_find_package_boundary_modules:196</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5063,7 +5063,7 @@
             
 
             <tr class="searchable" data-search="_set_linter_node_types def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L294" rel="noopener noreferrer">_set_linter_node_types:294</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L296" rel="noopener noreferrer">_set_linter_node_types:296</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5071,7 +5071,7 @@
             
 
             <tr class="searchable" data-search="_is_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L301" rel="noopener noreferrer">_is_secret_config_candidate:301</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L303" rel="noopener noreferrer">_is_secret_config_candidate:303</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5079,7 +5079,7 @@
             
 
             <tr class="searchable" data-search="_resolve_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L308" rel="noopener noreferrer">_resolve_secret_config_candidate:308</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L310" rel="noopener noreferrer">_resolve_secret_config_candidate:310</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5087,7 +5087,7 @@
             
 
             <tr class="searchable" data-search="_definition_module_and_class def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L344" rel="noopener noreferrer">_definition_module_and_class:344</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L346" rel="noopener noreferrer">_definition_module_and_class:346</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5095,7 +5095,7 @@
             
 
             <tr class="searchable" data-search="_resolve_analysis_root def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L354" rel="noopener noreferrer">_resolve_analysis_root:354</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L356" rel="noopener noreferrer">_resolve_analysis_root:356</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5103,7 +5103,7 @@
             
 
             <tr class="searchable" data-search="_grep_verify_rescue_priority def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L391" rel="noopener noreferrer">_grep_verify_rescue_priority:391</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L393" rel="noopener noreferrer">_grep_verify_rescue_priority:393</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5111,7 +5111,7 @@
             
 
             <tr class="searchable" data-search="_confidence_as_unit_interval def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L402" rel="noopener noreferrer">_confidence_as_unit_interval:402</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L404" rel="noopener noreferrer">_confidence_as_unit_interval:404</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5119,7 +5119,7 @@
             
 
             <tr class="searchable" data-search="_implicit_ref_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L412" rel="noopener noreferrer">_implicit_ref_evidence_marker:412</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L414" rel="noopener noreferrer">_implicit_ref_evidence_marker:414</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5127,7 +5127,7 @@
             
 
             <tr class="searchable" data-search="_mark_evidence_ref def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L426" rel="noopener noreferrer">_mark_evidence_ref:426</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L428" rel="noopener noreferrer">_mark_evidence_ref:428</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5135,7 +5135,7 @@
             
 
             <tr class="searchable" data-search="_has_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L433" rel="noopener noreferrer">_has_evidence_marker:433</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L435" rel="noopener noreferrer">_has_evidence_marker:435</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5143,7 +5143,7 @@
             
 
             <tr class="searchable" data-search="_annotate_dead_code_evidence_sources def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L440" rel="noopener noreferrer">_annotate_dead_code_evidence_sources:440</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L442" rel="noopener noreferrer">_annotate_dead_code_evidence_sources:442</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5151,7 +5151,7 @@
             
 
             <tr class="searchable" data-search="skylos class skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L459" rel="noopener noreferrer">Skylos:459</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L461" rel="noopener noreferrer">Skylos:461</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
@@ -5159,7 +5159,7 @@
             
 
             <tr class="searchable" data-search="_is_truly_empty_or_docstring_only def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3023" rel="noopener noreferrer">_is_truly_empty_or_docstring_only:3023</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3028" rel="noopener noreferrer">_is_truly_empty_or_docstring_only:3028</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -5167,7 +5167,7 @@
             
 
             <tr class="searchable" data-search="proc_file def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3041" rel="noopener noreferrer">proc_file:3041</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3046" rel="noopener noreferrer">proc_file:3046</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
@@ -5175,7 +5175,7 @@
             
 
             <tr class="searchable" data-search="analyze def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3548" rel="noopener noreferrer">analyze:3548</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3563" rel="noopener noreferrer">analyze:3563</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
@@ -5343,7 +5343,7 @@
             
 
             <tr class="searchable" data-search="scan_deep_audit_candidates def skylos/audit/candidates.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L82" rel="noopener noreferrer">scan_deep_audit_candidates:82</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L83" rel="noopener noreferrer">scan_deep_audit_candidates:83</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/candidates.py</td>
@@ -5391,7 +5391,7 @@
             
 
             <tr class="searchable" data-search="build_polyglot_signal_candidates def skylos/audit/polyglot.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py#L300" rel="noopener noreferrer">build_polyglot_signal_candidates:300</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py#L342" rel="noopener noreferrer">build_polyglot_signal_candidates:342</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/polyglot.py</td>
@@ -5487,7 +5487,7 @@
             
 
             <tr class="searchable" data-search="code_region_hash def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L101" rel="noopener noreferrer">code_region_hash:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L102" rel="noopener noreferrer">code_region_hash:102</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5495,7 +5495,7 @@
             
 
             <tr class="searchable" data-search="auditcandidate class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L116" rel="noopener noreferrer">AuditCandidate:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L117" rel="noopener noreferrer">AuditCandidate:117</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5503,7 +5503,7 @@
             
 
             <tr class="searchable" data-search="auditfilerecord class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L174" rel="noopener noreferrer">AuditFileRecord:174</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L175" rel="noopener noreferrer">AuditFileRecord:175</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5511,7 +5511,7 @@
             
 
             <tr class="searchable" data-search="auditscansummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L277" rel="noopener noreferrer">AuditScanSummary:277</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L278" rel="noopener noreferrer">AuditScanSummary:278</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5519,7 +5519,7 @@
             
 
             <tr class="searchable" data-search="auditprocesssummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L309" rel="noopener noreferrer">AuditProcessSummary:309</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L310" rel="noopener noreferrer">AuditProcessSummary:310</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5527,7 +5527,7 @@
             
 
             <tr class="searchable" data-search="auditcigatesummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L351" rel="noopener noreferrer">AuditCIGateSummary:351</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L352" rel="noopener noreferrer">AuditCIGateSummary:352</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5535,7 +5535,7 @@
             
 
             <tr class="searchable" data-search="auditrevalidationsummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L369" rel="noopener noreferrer">AuditRevalidationSummary:369</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L370" rel="noopener noreferrer">AuditRevalidationSummary:370</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
@@ -5647,7 +5647,7 @@
             
 
             <tr class="searchable" data-search="deadcodekey class skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L102" rel="noopener noreferrer">DeadCodeKey:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L103" rel="noopener noreferrer">DeadCodeKey:103</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5655,7 +5655,7 @@
             
 
             <tr class="searchable" data-search="deadcodebenchmarkfailure class skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L112" rel="noopener noreferrer">DeadCodeBenchmarkFailure:112</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L113" rel="noopener noreferrer">DeadCodeBenchmarkFailure:113</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5663,7 +5663,7 @@
             
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L129" rel="noopener noreferrer">load_manifest:129</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L130" rel="noopener noreferrer">load_manifest:130</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5671,7 +5671,7 @@
             
 
             <tr class="searchable" data-search="load_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L133" rel="noopener noreferrer">load_external_targets:133</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L134" rel="noopener noreferrer">load_external_targets:134</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5679,7 +5679,7 @@
             
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L305" rel="noopener noreferrer">validate_manifest:305</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L306" rel="noopener noreferrer">validate_manifest:306</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5687,7 +5687,7 @@
             
 
             <tr class="searchable" data-search="validate_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L331" rel="noopener noreferrer">validate_external_targets:331</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L332" rel="noopener noreferrer">validate_external_targets:332</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5695,7 +5695,7 @@
             
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L688" rel="noopener noreferrer">run_case:688</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L689" rel="noopener noreferrer">run_case:689</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5703,7 +5703,7 @@
             
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L915" rel="noopener noreferrer">run_manifest:915</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L916" rel="noopener noreferrer">run_manifest:916</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5711,7 +5711,7 @@
             
 
             <tr class="searchable" data-search="run_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L981" rel="noopener noreferrer">run_external_targets:981</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L982" rel="noopener noreferrer">run_external_targets:982</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5719,7 +5719,7 @@
             
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L1019" rel="noopener noreferrer">format_summary:1019</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L1020" rel="noopener noreferrer">format_summary:1020</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
@@ -5831,7 +5831,7 @@
             
 
             <tr class="searchable" data-search="securitybenchmarkfailure class skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L78" rel="noopener noreferrer">SecurityBenchmarkFailure:78</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L79" rel="noopener noreferrer">SecurityBenchmarkFailure:79</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5839,7 +5839,7 @@
             
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L97" rel="noopener noreferrer">load_manifest:97</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L98" rel="noopener noreferrer">load_manifest:98</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5847,7 +5847,7 @@
             
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L101" rel="noopener noreferrer">validate_manifest:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">validate_manifest:102</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5855,7 +5855,7 @@
             
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L488" rel="noopener noreferrer">run_case:488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L489" rel="noopener noreferrer">run_case:489</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5863,7 +5863,7 @@
             
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L575" rel="noopener noreferrer">run_manifest:575</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L576" rel="noopener noreferrer">run_manifest:576</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
@@ -5871,7 +5871,7 @@
             
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L667" rel="noopener noreferrer">format_summary:667</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L668" rel="noopener noreferrer">format_summary:668</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -36,6 +36,7 @@ from skylos.visitors.languages.typescript.analysis import (
 from skylos.visitors.languages.go import scan_go_file, clear_go_cache
 from skylos.visitors.languages.java import scan_java_file
 from skylos.visitors.languages.rust import scan_rust_file
+from skylos.visitors.languages.csharp import scan_csharp_file
 
 from skylos.rules.secrets import scan_ctx as _secrets_scan_ctx
 
@@ -140,6 +141,7 @@ _TS_JS_SOURCE_EXTS = (
 _PHP_SOURCE_EXTS = (".php",)
 _RUST_SOURCE_EXTS = (".rs",)
 _DART_SOURCE_EXTS = (".dart",)
+_CSHARP_SOURCE_EXTS = (".cs",)
 _PYTHON_SOURCE_ROOT_NAMES = {"src", "lib", "python"}
 
 _TRY_NODE_TYPES = (ast.Try, getattr(ast, "TryStar", ast.Try))
@@ -544,6 +546,7 @@ class Skylos:
         ".php": "PHP",
         ".rs": "Rust",
         ".dart": "Dart",
+        ".cs": "C#",
     }
 
     def _count_languages(self, files) -> dict[str, int]:
@@ -572,6 +575,7 @@ class Skylos:
             *(_PHP_SOURCE_EXTS),
             *(_RUST_SOURCE_EXTS),
             *(_DART_SOURCE_EXTS),
+            *(_CSHARP_SOURCE_EXTS),
         }
         ext_list = [
             "py",
@@ -588,6 +592,7 @@ class Skylos:
             "php",
             "rs",
             "dart",
+            "cs",
         ]
 
         # use rust file discovery when avail
@@ -721,7 +726,7 @@ class Skylos:
             for def_name, def_obj in self.defs.items():
                 if def_obj.type not in ("function", "method"):
                     continue
-                if str(def_obj.filename).endswith(".java"):
+                if str(def_obj.filename).endswith((".java",) + _CSHARP_SOURCE_EXTS):
                     continue
                 if "." not in def_obj.name:
                     continue
@@ -3106,6 +3111,16 @@ def proc_file(
 
     if str(file).endswith(".dart"):
         out = scan_dart_file(
+            file,
+            cfg,
+            enable_danger_rules=enable_danger_rules,
+        )
+        if isinstance(out, tuple) and len(out) < 13:
+            return (*out, *([None] * (13 - len(out))))
+        return out[:13]
+
+    if str(file).endswith(".cs"):
+        out = scan_csharp_file(
             file,
             cfg,
             enable_danger_rules=enable_danger_rules,

--- a/skylos/audit/candidates.py
+++ b/skylos/audit/candidates.py
@@ -43,6 +43,7 @@ DEEP_AUDIT_EXTENSIONS = (
     ".php",
     ".rs",
     ".dart",
+    ".cs",
     ".env",
     ".yaml",
     ".yml",

--- a/skylos/audit/polyglot.py
+++ b/skylos/audit/polyglot.py
@@ -31,6 +31,7 @@ POLYGLOT_LANGUAGES = {
     "php",
     "rust",
     "dart",
+    "csharp",
 }
 
 _TS_JS_RULES = (
@@ -278,6 +279,46 @@ _DART_RULES = (
     ),
 )
 
+_CSHARP_RULES = (
+    PolyglotSignalRule(
+        rule_id="SKY-D212",
+        pattern_id="csharp-process",
+        severity="high",
+        reason="Process execution should be reviewed for command injection risk.",
+        regex=re.compile(r"\b(?:Process\.Start|new\s+ProcessStartInfo)\s*\("),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D211",
+        pattern_id="csharp-sql-dynamic",
+        severity="high",
+        reason="SQL command construction with dynamic strings needs review.",
+        regex=re.compile(
+            r"\b(?:new\s+(?:SqlCommand|DbCommand|NpgsqlCommand|MySqlCommand)|FromSqlRaw|ExecuteSqlRaw)\s*\([^;\n]*(?:\+|\$\{)",
+            re.IGNORECASE,
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D216",
+        pattern_id="csharp-http-client",
+        severity="high",
+        reason="Outbound HTTP calls with dynamic URLs should be reviewed for SSRF.",
+        regex=re.compile(
+            r"\b(?:GetAsync|PostAsync|SendAsync|WebRequest\.Create)\s*\([^;\n]*(?:url|uri|Request\.)",
+            re.IGNORECASE,
+        ),
+    ),
+    PolyglotSignalRule(
+        rule_id="SKY-D215",
+        pattern_id="csharp-file-path",
+        severity="medium",
+        reason="File access with dynamic paths should be reviewed.",
+        regex=re.compile(
+            r"\b(?:File|Directory)\.(?:ReadAllText|ReadAllBytes|Open|WriteAllText|Delete)\s*\([^;\n]*(?:path|file|Request\.)",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
 _RULES_BY_LANGUAGE = {
     "typescript": _TS_JS_RULES,
     "javascript": _TS_JS_RULES,
@@ -286,6 +327,7 @@ _RULES_BY_LANGUAGE = {
     "php": _PHP_RULES,
     "rust": _RUST_RULES,
     "dart": _DART_RULES,
+    "csharp": _CSHARP_RULES,
 }
 
 _SEVERITY_PRIORITY = {

--- a/skylos/audit/types.py
+++ b/skylos/audit/types.py
@@ -87,6 +87,7 @@ def language_for_path(path: str | Path) -> str:
         ".php": "php",
         ".rs": "rust",
         ".dart": "dart",
+        ".cs": "csharp",
         ".env": "env",
         ".yaml": "yaml",
         ".yml": "yaml",

--- a/skylos/benchmarks/dead_code.py
+++ b/skylos/benchmarks/dead_code.py
@@ -73,6 +73,7 @@ SUPPORTED_LANGUAGES = {
     "typescript",
     "rust",
     "dart",
+    "csharp",
 }
 SCANNER_LANGUAGE_SUPPORT = {
     "skylos": SUPPORTED_LANGUAGES,

--- a/skylos/benchmarks/security.py
+++ b/skylos/benchmarks/security.py
@@ -53,6 +53,7 @@ SUPPORTED_LANGUAGES = {
     "typescript",
     "rust",
     "dart",
+    "csharp",
 }
 SCANNER_LANGUAGE_SUPPORT = {
     "skylos": SUPPORTED_LANGUAGES,

--- a/skylos/cli_core/main_parser.py
+++ b/skylos/cli_core/main_parser.py
@@ -8,7 +8,7 @@ def build_main_parser(*, version: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Find dead code, secrets, and risky flows in Python, JS/TS, Go, "
-            "Java, PHP, Rust, and Dart"
+            "Java, PHP, Rust, Dart, and C#"
         ),
         epilog="""
 Run 'skylos commands' for a full list of all available commands.

--- a/skylos/visitors/languages/csharp/__init__.py
+++ b/skylos/visitors/languages/csharp/__init__.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .core import scan_symbols
+from .danger import scan_danger
+
+
+class DummyVisitor:
+    def __init__(self) -> None:
+        self.is_test_file: bool = False
+        self.test_decorated_lines: set[int] = set()
+        self.dataclass_fields: set[str] = set()
+        self.pydantic_models: set[str] = set()
+        self.class_defs: dict = {}
+        self.first_read_lineno: dict = {}
+        self.framework_decorated_lines: set[int] = set()
+        self.detected_frameworks: set[str] = set()
+
+
+def _empty_result(config: dict) -> tuple:
+    return (
+        [],
+        [],
+        set(),
+        set(),
+        DummyVisitor(),
+        DummyVisitor(),
+        [],
+        [],
+        [],
+        None,
+        None,
+        config,
+        [],
+    )
+
+
+def scan_csharp_file(
+    file_path: str,
+    config: dict | None = None,
+    *,
+    enable_danger_rules: bool = True,
+) -> tuple:
+    if config is None:
+        config = {}
+
+    try:
+        path = Path(file_path)
+        if path.suffix.lower() != ".cs":
+            raise ValueError("unsupported C# path")
+        source = path.read_text(  # skylos: ignore[SKY-D215] analyzer reads discovered C# source files
+            encoding="utf-8",
+            errors="ignore",
+        )
+    except Exception:
+        return _empty_result(config)
+
+    defs, refs, raw_imports = scan_symbols(str(path), source)
+    findings = scan_danger(str(path), source) if enable_danger_rules else []
+
+    return (
+        defs,
+        refs,
+        set(),
+        set(),
+        DummyVisitor(),
+        DummyVisitor(),
+        [],
+        findings,
+        [],
+        None,
+        None,
+        config,
+        raw_imports,
+    )
+
+
+__all__ = ["scan_csharp_file"]

--- a/skylos/visitors/languages/csharp/_lex.py
+++ b/skylos/visitors/languages/csharp/_lex.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+
+_TOKEN_RE = re.compile(
+    r"""
+    //[^\n]*
+    |/\*.*?\*/
+    |(?:\$@|@\$|@|\$)?"(?:""|\\.|[^"\\])*"
+    |'(?:\\.|[^'\\])*'
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+
+def matching_brace(text: str, open_brace: int) -> int:
+    depth = 0
+    for index in range(open_brace, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+def mask_comments_and_strings(source: str) -> str:
+    return _TOKEN_RE.sub(_mask_token, source)
+
+
+def _mask_token(match: re.Match[str]) -> str:
+    return "".join("\n" if char == "\n" else " " for char in match.group(0))

--- a/skylos/visitors/languages/csharp/core.py
+++ b/skylos/visitors/languages/csharp/core.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from skylos.visitors.base import Definition
+from skylos.visitors.languages.csharp._lex import mask_comments_and_strings, matching_brace
+
+_TYPE_RE = re.compile(
+    r"(?m)^\s*(?P<mods>(?:(?:public|private|protected|internal|static|sealed|abstract|partial|readonly|unsafe)\s+)*)"
+    r"(?P<kind>class|interface|struct|enum|record)\s+"
+    r"(?P<name>[A-Za-z_]\w*)"
+)
+_METHOD_RE = re.compile(
+    r"(?m)^\s*(?:\[[^\]\n]+\]\s*)*"
+    r"(?P<mods>(?:(?:public|private|protected|internal|static|async|virtual|override|sealed|abstract|extern|partial|unsafe|new)\s+)*)"
+    r"(?P<rtype>[A-Za-z_][\w.<>\[\],?]*\s+)+"
+    r"(?P<name>[A-Za-z_]\w*)\s*\([^;{}]*\)\s*"
+    r"(?:where\s+[^{=>]+)?(?:\{|=>)"
+)
+_CALL_RE = re.compile(r"\b(?P<name>[A-Za-z_]\w*)\s*\(")
+_NEW_TYPE_RE = re.compile(r"\bnew\s+(?P<name>[A-Za-z_][\w.]*)\s*[({]")
+
+_CLASS_KIND = "class"
+_KIND_MAP = dict.fromkeys(("class", "interface", "struct", "record", "enum"), _CLASS_KIND)
+_NON_CALL_KEYWORDS = {
+    "catch",
+    "for",
+    "foreach",
+    "if",
+    "lock",
+    "return",
+    "switch",
+    "using",
+    "while",
+}
+_LIFECYCLE_METHODS = {
+    "Configure",
+    "ConfigureServices",
+    "Dispose",
+    "Equals",
+    "GetHashCode",
+    "Main",
+    "OnActionExecuted",
+    "OnActionExecuting",
+    "OnAuthorization",
+    "OnDelete",
+    "OnException",
+    "OnGet",
+    "OnPost",
+    "OnPut",
+    "Run",
+    "StartAsync",
+    "StopAsync",
+    "ToString",
+}
+
+
+@dataclass
+class _RefState:
+    file_path: str
+    refs: list[tuple[str, str]] = field(default_factory=list)
+    seen: set[tuple[str, int]] = field(default_factory=set)
+
+
+def scan_symbols(
+    file_path: str, source: str
+) -> tuple[list[Definition], list[tuple[str, str]], list[dict]]:
+    masked = mask_comments_and_strings(source)
+    type_ranges = _type_ranges(masked)
+    defs = _type_defs(file_path, source, masked)
+    methods, method_decl_offsets = _method_defs(file_path, source, masked, type_ranges)
+    return defs + methods, _refs(file_path, masked, type_ranges, method_decl_offsets), []
+
+
+def _type_defs(file_path: str, source: str, masked: str) -> list[Definition]:
+    defs: list[Definition] = []
+    for match in _TYPE_RE.finditer(masked):
+        name = match.group("name")
+        line = _line_for_offset(source, match.start("name"))
+        definition = Definition(
+            name, _KIND_MAP.get(match.group("kind"), _CLASS_KIND), file_path, line
+        )
+        definition.is_exported = _is_exported(match.group("mods"))
+        if definition.is_exported:
+            definition.references = 1
+        defs.append(definition)
+    return defs
+
+
+def _method_defs(
+    file_path: str,
+    source: str,
+    masked: str,
+    type_ranges: list[tuple[int, int, str]],
+) -> tuple[list[Definition], set[int]]:
+    defs: list[Definition] = []
+    method_decl_offsets: set[int] = set()
+    for match in _METHOD_RE.finditer(masked):
+        name = match.group("name")
+        if name in _NON_CALL_KEYWORDS:
+            continue
+        method_decl_offsets.add(match.start("name"))
+        line = _line_for_offset(source, match.start("name"))
+        owner = _containing_type(type_ranges, match.start())
+        definition = Definition(
+            f"{owner}.{name}" if owner else name, "method", file_path, line
+        )
+        definition.is_exported = _is_exported(match.group("mods")) or name in _LIFECYCLE_METHODS
+        if definition.is_exported:
+            definition.references = 1
+        defs.append(definition)
+    return defs, method_decl_offsets
+
+
+def _refs(
+    file_path: str,
+    masked: str,
+    type_ranges: list[tuple[int, int, str]],
+    method_decl_offsets: set[int],
+) -> list[tuple[str, str]]:
+    state = _RefState(file_path=file_path)
+    type_names = {item[2] for item in type_ranges}
+    _collect_call_refs(masked, method_decl_offsets, type_names, state)
+    _collect_new_refs(masked, type_names, state)
+    return state.refs
+
+
+def _collect_call_refs(
+    masked: str,
+    method_decl_offsets: set[int],
+    type_names: set[str],
+    state: _RefState,
+) -> None:
+    for match in _CALL_RE.finditer(masked):
+        name = match.group("name")
+        if _skip_call_ref(name, match.start("name"), method_decl_offsets, type_names):
+            continue
+        _append_ref(name, match.start("name"), state)
+
+
+def _collect_new_refs(
+    masked: str,
+    type_names: set[str],
+    state: _RefState,
+) -> None:
+    for match in _NEW_TYPE_RE.finditer(masked):
+        name = match.group("name").split(".")[-1]
+        if name not in type_names:
+            _append_ref(name, match.start("name"), state)
+
+
+def _skip_call_ref(
+    name: str,
+    offset: int,
+    method_decl_offsets: set[int],
+    type_names: set[str],
+) -> bool:
+    return (
+        offset in method_decl_offsets
+        or name in _NON_CALL_KEYWORDS
+        or name in type_names
+    )
+
+
+def _append_ref(
+    name: str,
+    offset: int,
+    state: _RefState,
+) -> None:
+    key = (name, offset)
+    if key not in state.seen:
+        state.seen.add(key)
+        state.refs.append((name, state.file_path))
+
+
+def _type_ranges(masked: str) -> list[tuple[int, int, str]]:
+    ranges: list[tuple[int, int, str]] = []
+    for match in _TYPE_RE.finditer(masked):
+        open_brace = masked.find("{", match.end())
+        if open_brace == -1:
+            continue
+        close_brace = matching_brace(masked, open_brace)
+        if close_brace != -1:
+            ranges.append((open_brace, close_brace, match.group("name")))
+    return ranges
+
+
+def _containing_type(ranges: list[tuple[int, int, str]], offset: int) -> str | None:
+    candidates = [
+        (start, end, name) for start, end, name in ranges if start <= offset <= end
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[2]
+
+
+def _is_exported(modifiers: str) -> bool:
+    return bool(re.search(r"\b(public|protected)\b", modifiers or ""))
+
+
+def _line_for_offset(source: str, offset: int) -> int:
+    return source.count("\n", 0, max(offset, 0)) + 1

--- a/skylos/visitors/languages/csharp/danger.py
+++ b/skylos/visitors/languages/csharp/danger.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from skylos.visitors.languages.csharp._lex import mask_comments_and_strings, matching_brace
+
+_TAINT_NAME_RE = re.compile(
+    r"(arg|cmd|command|file|filename|id|input|name|path|payload|query|redirect|request|sql|target|url|uri|user)",
+    re.I,
+)
+_PARAM_RE = re.compile(
+    r"(?:params\s+)?(?:this\s+)?(?:[\w.<>\[\],?]+\s+)+@?(?P<name>[A-Za-z_]\w*)$"
+)
+_ASSIGN_RE = re.compile(
+    r"^\s*(?:(?:var|string|object|Uri|HttpRequestMessage|ProcessStartInfo|SqlCommand|[\w.<>\[\],?]+)\s+)?"
+    r"(?P<lhs>@?[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)?)\s*=\s*(?P<rhs>.+?);?\s*$",
+    re.DOTALL,
+)
+_METHOD_RE = re.compile(
+    r"(?m)^\s*(?:\[[^\]\n]+\]\s*)*"
+    r"(?:(?:public|private|protected|internal|static|async|virtual|override|sealed|abstract|extern|partial|unsafe|new)\s+)*"
+    r"(?:[A-Za-z_][\w.<>\[\],?]*\s+)+"
+    r"(?P<name>[A-Za-z_]\w*)\s*\((?P<params>[^)]*)\)\s*"
+    r"(?:where\s+[^{=>]+)?\{"
+)
+
+_SOURCE_HINTS = (
+    "Request.Query",
+    "Request.Form",
+    "Request.Headers",
+    "Request.Cookies",
+    "Request.RouteValues",
+    "Request.Path",
+    "Request.Body",
+    "HttpContext.Request",
+    "Environment.GetEnvironmentVariable",
+    "Console.ReadLine",
+    "IFormFile.FileName",
+    "args[",
+)
+_SANITIZER_HINTS = (
+    "Path.GetFileName(",
+    "Path.GetRandomFileName(",
+    "Uri.EscapeDataString(",
+    "WebUtility.UrlEncode(",
+    "HttpUtility.UrlEncode(",
+)
+_COMMAND_SINK_RE = re.compile(r"\b(?:Process\.Start|new\s+ProcessStartInfo)\s*\(")
+_COMMAND_PROPERTY_RE = re.compile(
+    r"\b(?P<owner>@?[A-Za-z_]\w*)\.(?:FileName|Arguments)\s*="
+)
+_PATH_SINK_RE = re.compile(
+    r"\b(?:File|Directory)\.(?:Open|OpenRead|OpenWrite|ReadAllText|ReadAllBytes|"
+    r"ReadLines|WriteAllText|WriteAllBytes|AppendAllText|Delete|Copy|Move|Exists|"
+    r"GetFiles|GetDirectories)\s*\("
+)
+_SSRF_SINK_RE = re.compile(
+    r"\b(?:GetAsync|PostAsync|PutAsync|PatchAsync|DeleteAsync|SendAsync|"
+    r"WebRequest\.Create|WebRequest\.CreateHttp)\s*\("
+    r"|\bnew\s+HttpRequestMessage\s*\("
+)
+_SQL_SINK_RE = re.compile(
+    r"\b(?:new\s+(?:SqlCommand|DbCommand|NpgsqlCommand|MySqlCommand|OleDbCommand)\s*\(|"
+    r"FromSqlRaw\s*\(|ExecuteSqlRaw\s*\()"
+)
+_SQL_COMMAND_TYPE_RE = re.compile(
+    r"\b(?:SqlCommand|DbCommand|NpgsqlCommand|MySqlCommand|OleDbCommand)\b"
+)
+_COMMAND_TEXT_RE = re.compile(r"\b(?P<owner>@?[A-Za-z_]\w*)\.CommandText\s*=")
+_REDIRECT_RE = re.compile(r"\b(?:Redirect|RedirectPermanent|LocalRedirect)\s*\(")
+
+_COMMAND_FINDING = (
+    "SKY-D212",
+    "Process execution receives tainted input; validate or allowlist the command.",
+)
+_PATH_FINDING = (
+    "SKY-D215",
+    "User-controlled path reaches a filesystem sink without path validation.",
+)
+_SSRF_FINDING = ("SKY-D216", "User-controlled URL reaches an outbound request sink.")
+_SQL_FINDING = ("SKY-D211", "SQL command text is built from tainted input; use parameters.")
+_REDIRECT_FINDING = (
+    "SKY-D230",
+    "Redirect target is controlled by input; validate allowed destinations.",
+)
+
+
+@dataclass
+class _ScopeState:
+    tainted_vars: set[str]
+    process_info_vars: set[str] = field(default_factory=set)
+    sql_command_vars: set[str] = field(default_factory=set)
+
+
+def scan_danger(file_path: str, source: str) -> list[dict]:
+    findings: list[dict] = []
+    seen: set[tuple[str, int, str]] = set()
+
+    for body, start_line, params in _iter_scopes(source):
+        _scan_scope(body, start_line, params, file_path=file_path, findings=findings, seen=seen)
+
+    return findings
+
+
+def _scan_scope(
+    body: str,
+    start_line: int,
+    tainted_params: set[str],
+    *,
+    file_path: str,
+    findings: list[dict],
+    seen: set[tuple[str, int, str]],
+) -> None:
+    state = _ScopeState(tainted_vars=set(tainted_params))
+    for offset, statement in _iter_statements(body):
+        text = statement.strip()
+        if not text:
+            continue
+        line = start_line + body.count("\n", 0, offset)
+        _handle_assignment(text, state)
+        if spec := _finding_for_sink(text, state):
+            _add_finding(
+                findings,
+                seen,
+                rule_id=spec[0],
+                message=spec[1],
+                file_path=file_path,
+                line=line,
+                statement=text,
+            )
+
+
+def _handle_assignment(statement: str, state: _ScopeState) -> None:
+    match = _ASSIGN_RE.match(statement)
+    if not match:
+        return
+    lhs = match.group("lhs").lstrip("@")
+    if lhs.endswith((".CommandText", ".FileName", ".Arguments")):
+        return
+
+    name = lhs.rsplit(".", 1)[-1]
+    rhs = match.group("rhs")
+    _track_typed_variable(name, rhs, "ProcessStartInfo", state.process_info_vars)
+    _track_typed_variable(name, rhs, _SQL_COMMAND_TYPE_RE, state.sql_command_vars)
+    _track_taint(name, rhs, state.tainted_vars)
+
+
+def _track_typed_variable(
+    name: str, rhs: str, type_hint: str | re.Pattern[str], tracked: set[str]
+) -> None:
+    matched = type_hint in rhs if isinstance(type_hint, str) else bool(type_hint.search(rhs))
+    if matched:
+        tracked.add(name)
+    else:
+        tracked.discard(name)
+
+
+def _track_taint(name: str, rhs: str, tainted_vars: set[str]) -> None:
+    if _is_tainted(rhs, tainted_vars):
+        tainted_vars.add(name)
+    else:
+        tainted_vars.discard(name)
+
+
+def _finding_for_sink(statement: str, state: _ScopeState) -> tuple[str, str] | None:
+    if not _is_tainted(statement, state.tainted_vars):
+        return None
+    checks = (
+        (_is_command_sink(statement, state), _COMMAND_FINDING),
+        (bool(_PATH_SINK_RE.search(statement)), _PATH_FINDING),
+        (bool(_SSRF_SINK_RE.search(statement)), _SSRF_FINDING),
+        (_is_sql_sink(statement, state), _SQL_FINDING),
+        (bool(_REDIRECT_RE.search(statement)), _REDIRECT_FINDING),
+    )
+    for matched, spec in checks:
+        if matched:
+            return spec
+    return None
+
+
+def _is_command_sink(statement: str, state: _ScopeState) -> bool:
+    return bool(_COMMAND_SINK_RE.search(statement)) or _tracked_property_sink(
+        statement, _COMMAND_PROPERTY_RE, state.process_info_vars
+    )
+
+
+def _is_sql_sink(statement: str, state: _ScopeState) -> bool:
+    return bool(_SQL_SINK_RE.search(statement)) or _tracked_property_sink(
+        statement, _COMMAND_TEXT_RE, state.sql_command_vars
+    )
+
+
+def _tracked_property_sink(
+    statement: str, regex: re.Pattern[str], tracked_names: set[str]
+) -> bool:
+    match = regex.search(statement)
+    return bool(match and match.group("owner").lstrip("@") in tracked_names)
+
+
+def _is_tainted(expr: str, tainted_vars: set[str]) -> bool:
+    if not expr or any(hint in expr for hint in _SANITIZER_HINTS):
+        return False
+    if any(hint in expr for hint in _SOURCE_HINTS):
+        return True
+    return any(re.search(rf"\b@?{re.escape(name)}\b", expr) for name in tainted_vars)
+
+
+def _iter_scopes(source: str) -> list[tuple[str, int, set[str]]]:
+    masked = mask_comments_and_strings(source)
+    scopes: list[tuple[str, int, set[str]]] = []
+    spans: list[tuple[int, int]] = []
+
+    for match in _METHOD_RE.finditer(masked):
+        open_brace = masked.find("{", match.end() - 1)
+        if open_brace == -1:
+            continue
+        close_brace = matching_brace(masked, open_brace)
+        if close_brace == -1:
+            continue
+        scopes.append(_method_scope(source, open_brace, close_brace, match.group("params")))
+        spans.append((open_brace, close_brace + 1))
+
+    scopes.append((_blank_spans(source, spans), 1, {"args"}))
+    return scopes
+
+
+def _method_scope(
+    source: str, open_brace: int, close_brace: int, params: str
+) -> tuple[str, int, set[str]]:
+    return (
+        source[open_brace + 1 : close_brace],
+        source.count("\n", 0, open_brace + 1) + 1,
+        _tainted_params(params),
+    )
+
+
+def _blank_spans(source: str, spans: list[tuple[int, int]]) -> str:
+    pieces: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        pieces.append(source[cursor:start])
+        pieces.append(_blank_non_newlines(source[start:end]))
+        cursor = end
+    pieces.append(source[cursor:])
+    return "".join(pieces)
+
+
+def _blank_non_newlines(text: str) -> str:
+    return "".join("\n" if char == "\n" else " " for char in text)
+
+
+def _tainted_params(params: str) -> set[str]:
+    tainted: set[str] = set()
+    for raw in params.split(","):
+        cleaned = re.sub(r"\[[^\]]+\]", " ", raw).strip()
+        match = _PARAM_RE.search(cleaned)
+        if match and _TAINT_NAME_RE.search(match.group("name")):
+            tainted.add(match.group("name"))
+    return tainted
+
+
+def _iter_statements(body: str):
+    masked = mask_comments_and_strings(body)
+    start = 0
+    for match in re.finditer(r";", masked):
+        end = match.end()
+        if chunk := body[start:end].strip():
+            yield start, chunk
+        start = end
+    if tail := body[start:].strip():
+        yield start, tail
+
+
+def _add_finding(
+    findings: list[dict],
+    seen: set[tuple[str, int, str]],
+    *,
+    rule_id: str,
+    message: str,
+    file_path: str,
+    line: int,
+    statement: str,
+) -> None:
+    key = (rule_id, line, statement)
+    if key in seen:
+        return
+    seen.add(key)
+    findings.append(
+        {
+            "rule_id": rule_id,
+            "severity": "HIGH",
+            "message": message,
+            "file": str(Path(file_path)),
+            "line": line,
+            "col": 0,
+            "category": "danger",
+        }
+    )

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -731,6 +731,59 @@ class TestAnalyze:
         }
         mock_log_info.assert_any_call("Analyzing 2 files...")
 
+    @patch("skylos.analyzer.logger.info")
+    def test_analyze_mixed_languages_includes_csharp_in_summary(self, mock_log_info):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "main.py").write_text(
+                "def hello():\n    return 1\n", encoding="utf-8"
+            )
+            (root / "Program.cs").write_text(
+                "public class Program {\n"
+                "    public static void Main(string[] args) {\n"
+                '        System.Console.WriteLine("hi");\n'
+                "    }\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), conf=0)
+
+        result = json.loads(result_json)
+
+        assert result["analysis_summary"]["total_files"] == 2
+        assert result["analysis_summary"]["languages"] == {
+            "C#": 1,
+            "Python": 1,
+        }
+        mock_log_info.assert_any_call("Analyzing 2 files...")
+
+    def test_analyze_csharp_unused_private_method_without_using_noise(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "Demo.cs").write_text(
+                "using System;\n"
+                "\n"
+                "public class Demo {\n"
+                "    private void DeadHelper() { }\n"
+                "    public void Alive() {\n"
+                "        Used();\n"
+                "    }\n"
+                "    private void Used() { }\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            result_json = analyze(str(root), conf=0)
+
+        result = json.loads(result_json)
+
+        assert result["analysis_summary"]["languages"] == {"C#": 1}
+        assert {item["name"] for item in result["unused_functions"]} == {
+            "Demo.DeadHelper"
+        }
+        assert result["unused_imports"] == []
+
     def test_analyze_malformed_pyproject_config_does_not_suppress_findings(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -244,6 +244,7 @@ class TestSkylos:
                 ".php",
                 ".rs",
                 ".dart",
+                ".cs",
             },
             exclude_folders=None,
         )

--- a/test/test_csharp_security.py
+++ b/test/test_csharp_security.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from skylos.visitors.languages.csharp import scan_csharp_file
+
+
+def _write_fixture(path: Path, code: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)  # skylos: ignore[SKY-D215] pytest tmp fixture
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(code)
+
+
+def _scan_csharp_findings(tmp_path: Path, code: str) -> list[dict]:
+    file_path = tmp_path / "Controller.cs"
+    _write_fixture(file_path, code)
+    return scan_csharp_file(str(file_path), {})[7]
+
+
+def _rule_ids(findings: list[dict]) -> set[str]:
+    return {finding["rule_id"] for finding in findings}
+
+
+def test_csharp_symbols_include_import_class_method_and_refs(tmp_path):
+    file_path = tmp_path / "Controller.cs"
+    _write_fixture(
+        file_path,
+        """
+using System.Net.Http;
+
+public class FetchController {
+    public async Task Fetch(string url) {
+        var client = new HttpClient();
+        await client.GetAsync(url);
+    }
+}
+""",
+    )
+
+    defs, refs = scan_csharp_file(str(file_path), {})[:2]
+
+    assert {definition.name for definition in defs} >= {
+        "FetchController",
+        "FetchController.Fetch",
+    }
+    assert "GetAsync" in {name for name, _ in refs}
+
+
+def test_process_start_with_tainted_command_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Diagnostics;
+
+public class JobsController {
+    public void Run(string command) {
+        Process.Start(command);
+    }
+}
+""",
+    )
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_process_start_with_literal_command_is_safe(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Diagnostics;
+
+public class JobsController {
+    public void Run() {
+        Process.Start("dotnet", "--info");
+    }
+}
+""",
+    )
+    assert "SKY-D212" not in _rule_ids(findings)
+
+
+def test_process_start_info_property_with_tainted_command_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Diagnostics;
+
+public class JobsController {
+    public void Run(string command) {
+        var info = new ProcessStartInfo();
+        info.FileName = command;
+    }
+}
+""",
+    )
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_regular_file_name_property_assignment_is_safe(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+public class UploadModel {
+    public string FileName { get; set; }
+}
+
+public class UploadController {
+    public void Save(string fileName) {
+        var model = new UploadModel();
+        model.FileName = fileName;
+    }
+}
+""",
+    )
+    assert "SKY-D212" not in _rule_ids(findings)
+
+
+def test_sql_command_with_tainted_string_concat_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Data.SqlClient;
+
+public class UserRepository {
+    public void Find(string userId, SqlConnection connection) {
+        var sql = "SELECT * FROM Users WHERE Id = " + userId;
+        new SqlCommand(sql, connection);
+    }
+}
+""",
+    )
+    assert "SKY-D211" in _rule_ids(findings)
+
+
+def test_sql_command_with_multiline_tainted_string_concat_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Data.SqlClient;
+
+public class UserRepository {
+    public void Find(string userId, SqlConnection connection) {
+        var sql =
+            "SELECT; * FROM Users WHERE Id = " + userId;
+        new SqlCommand(sql, connection);
+    }
+}
+""",
+    )
+    assert "SKY-D211" in _rule_ids(findings)
+
+
+def test_sql_command_text_property_with_tainted_value_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Data.SqlClient;
+
+public class UserRepository {
+    public void Find(string userId, SqlConnection connection) {
+        var sql = "SELECT * FROM Users WHERE Id = " + userId;
+        var command = new SqlCommand();
+        command.CommandText = sql;
+    }
+}
+""",
+    )
+    assert "SKY-D211" in _rule_ids(findings)
+
+
+def test_regular_command_text_property_assignment_is_safe(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+public class UiCommand {
+    public string CommandText { get; set; }
+}
+
+public class MenuController {
+    public void Label(string query) {
+        var command = new UiCommand();
+        command.CommandText = query;
+    }
+}
+""",
+    )
+    assert "SKY-D211" not in _rule_ids(findings)
+
+
+def test_parameterized_sql_literal_is_safe(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Data.SqlClient;
+
+public class UserRepository {
+    public void Find(string userId, SqlConnection connection) {
+        var command = new SqlCommand("SELECT * FROM Users WHERE Id = @id", connection);
+        command.Parameters.AddWithValue("@id", userId);
+    }
+}
+""",
+    )
+    assert "SKY-D211" not in _rule_ids(findings)
+
+
+def test_http_client_with_tainted_url_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Net.Http;
+
+public class FetchController {
+    public async Task Fetch(string url) {
+        var client = new HttpClient();
+        await client.GetAsync(url);
+    }
+}
+""",
+    )
+    assert "SKY-D216" in _rule_ids(findings)
+
+
+def test_http_client_multiline_call_with_tainted_url_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Net.Http;
+
+public class FetchController {
+    public async Task Fetch(string url) {
+        var client = new HttpClient();
+        await client.GetAsync(
+            url
+        );
+    }
+}
+""",
+    )
+    assert "SKY-D216" in _rule_ids(findings)
+
+
+def test_http_client_literal_url_is_safe(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Net.Http;
+
+public class FetchController {
+    public async Task Fetch() {
+        var client = new HttpClient();
+        await client.GetAsync("https://example.com/health");
+    }
+}
+""",
+    )
+    assert "SKY-D216" not in _rule_ids(findings)
+
+
+def test_file_read_with_tainted_path_flags(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.IO;
+
+public class FilesController {
+    public string Read(string path) {
+        var requested = path;
+        return File.ReadAllText(requested);
+    }
+}
+""",
+    )
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_path_get_file_name_sanitized_file_path_is_safe(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.IO;
+
+public class FilesController {
+    public string Read(string fileName) {
+        var safe = Path.GetFileName(fileName);
+        return File.ReadAllText(Path.Combine("/srv/data", safe));
+    }
+}
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_request_query_source_propagates_to_redirect(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using Microsoft.AspNetCore.Mvc;
+
+public class LoginController : Controller {
+    public IActionResult Done() {
+        var next = Request.Query["next"].ToString();
+        return Redirect(next);
+    }
+}
+""",
+    )
+    assert "SKY-D230" in _rule_ids(findings)
+
+
+def test_taint_does_not_leak_across_methods(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Diagnostics;
+using System.IO;
+
+public class JobsController {
+    public void Unsafe(string command) {
+        Process.Start(command);
+    }
+
+    public string Safe() {
+        var path = "/srv/data/report.txt";
+        return File.ReadAllText(path);
+    }
+}
+""",
+    )
+    assert _rule_ids(findings) == {"SKY-D212"}


### PR DESCRIPTION
## Summary
- add a C# language visitor with symbol extraction, private-method dead-code support, and selected security sink detection
- wire `.cs` discovery into analyzer summaries, deep-audit candidates, polyglot audit signals, and benchmark language support
- update CLI/README language support plus the generated repo map

## Validation
- `pytest -q test/test_csharp_security.py test/test_analyzer.py::TestAnalyze test/test_security_benchmark.py test/test_dead_code_benchmark.py test/test_audit_candidates.py test/test_audit_processor.py test/test_audit_ci.py test/test_audit_export.py`
- `python scripts/build_repo_map.py --check`
- `git diff --check`
- staged Skylos gate passed during commit
- push parity check passed: `32 passed, 27 deselected`

## Notes
- no new rule IDs were introduced; C# findings reuse existing SKY-D rule IDs
- `scripts/check_rule_docs_parity.py` still fails on existing catalog/docs drift unrelated to this branch
