### PR TITLE
fix(gate): avoid terminal probe output during concise gate checks

### DIFF
--- a/benchmarks/security/README.md
+++ b/benchmarks/security/README.md
@@ -37,8 +37,14 @@ python scripts/security_compare_scanners.py
 Competitor scanners are optional local tools, not project dependencies. If a
 competitor such as Bandit is unavailable, the comparison script reports it as
 skipped and still prints the Skylos scorecard. Python-only scanners are scored
-only on Python cases; Go, Java, and TypeScript cases are reported as skipped for
-that scanner instead of being counted as false negatives.
+only on Python cases; Go, Java, TypeScript, C#, PHP, Rust, and Dart cases are
+reported as skipped for that scanner instead of being counted as false
+negatives.
+
+Each Skylos benchmark case is scanned with a fixture-local changed-file set.
+This keeps repository-level config findings from the Skylos repo itself out of
+the case score while still allowing a fixture to include and test its own
+workflow or config files.
 
 ## Adding Cases
 
@@ -51,5 +57,6 @@ that scanner instead of being counted as false negatives.
 Current golden cases cover SQL injection, SSRF, command injection, YAML loader
 precision, path traversal, XSS, open redirect, JWT verification bypass, and CORS
 misconfiguration. The cross-language cases currently cover Go Zip Slip
-path traversal, Java servlet path traversal, and TypeScript unsafe eval with
-matched safe guards.
+path traversal, Java servlet path traversal, TypeScript unsafe eval, C# command
+execution/SQL/SSRF/path/open-redirect flows, and PHP unsafe
+deserialization/path traversal with matched safe guards.

--- a/benchmarks/security/fixtures/csharp_command_injection/App.cs
+++ b/benchmarks/security/fixtures/csharp_command_injection/App.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics;
+
+public class Runner
+{
+    public void Run(string command)
+    {
+        Process.Start(command);
+    }
+}

--- a/benchmarks/security/fixtures/csharp_command_literal_safe/App.cs
+++ b/benchmarks/security/fixtures/csharp_command_literal_safe/App.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics;
+
+public class Runner
+{
+    public void Status()
+    {
+        Process.Start("git", "status");
+    }
+}

--- a/benchmarks/security/fixtures/csharp_open_redirect/App.cs
+++ b/benchmarks/security/fixtures/csharp_open_redirect/App.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
+
+public class AccountController : Controller
+{
+    public IActionResult Next(string redirect)
+    {
+        return Redirect(redirect);
+    }
+}

--- a/benchmarks/security/fixtures/csharp_open_redirect_literal_safe/App.cs
+++ b/benchmarks/security/fixtures/csharp_open_redirect_literal_safe/App.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
+
+public class AccountController : Controller
+{
+    public IActionResult Next()
+    {
+        return Redirect("/dashboard");
+    }
+}

--- a/benchmarks/security/fixtures/csharp_path_basename_safe/App.cs
+++ b/benchmarks/security/fixtures/csharp_path_basename_safe/App.cs
@@ -1,0 +1,10 @@
+using System.IO;
+
+public class Files
+{
+    public string Read(string path)
+    {
+        var name = Path.GetFileName(path);
+        return File.ReadAllText(Path.Combine("uploads", name));
+    }
+}

--- a/benchmarks/security/fixtures/csharp_path_traversal/App.cs
+++ b/benchmarks/security/fixtures/csharp_path_traversal/App.cs
@@ -1,0 +1,9 @@
+using System.IO;
+
+public class Files
+{
+    public string Read(string path)
+    {
+        return File.ReadAllText(path);
+    }
+}

--- a/benchmarks/security/fixtures/csharp_sql_injection/App.cs
+++ b/benchmarks/security/fixtures/csharp_sql_injection/App.cs
@@ -1,0 +1,10 @@
+using Microsoft.Data.SqlClient;
+
+public class Repository
+{
+    public void Find(string sql, SqlConnection connection)
+    {
+        var command = new SqlCommand(sql, connection);
+        command.ExecuteNonQuery();
+    }
+}

--- a/benchmarks/security/fixtures/csharp_sql_parameterized_safe/App.cs
+++ b/benchmarks/security/fixtures/csharp_sql_parameterized_safe/App.cs
@@ -1,0 +1,11 @@
+using Microsoft.Data.SqlClient;
+
+public class Repository
+{
+    public void Find(int id, SqlConnection connection)
+    {
+        var command = new SqlCommand("SELECT email FROM users WHERE id = @id", connection);
+        command.Parameters.AddWithValue("@id", id);
+        command.ExecuteNonQuery();
+    }
+}

--- a/benchmarks/security/fixtures/csharp_ssrf/App.cs
+++ b/benchmarks/security/fixtures/csharp_ssrf/App.cs
@@ -1,0 +1,10 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public class Client
+{
+    public Task<HttpResponseMessage> Fetch(string url, HttpClient client)
+    {
+        return client.GetAsync(url);
+    }
+}

--- a/benchmarks/security/fixtures/csharp_ssrf_fixed_host_safe/App.cs
+++ b/benchmarks/security/fixtures/csharp_ssrf_fixed_host_safe/App.cs
@@ -1,0 +1,10 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public class Client
+{
+    public Task<HttpResponseMessage> Status(HttpClient client)
+    {
+        return client.GetAsync("https://api.example.com/status");
+    }
+}

--- a/benchmarks/security/fixtures/php_json_decode_safe/index.php
+++ b/benchmarks/security/fixtures/php_json_decode_safe/index.php
@@ -1,0 +1,6 @@
+<?php
+
+function load_payload() {
+    $payload = $_POST["payload"];
+    return json_decode($payload, true);
+}

--- a/benchmarks/security/fixtures/php_path_basename_safe/index.php
+++ b/benchmarks/security/fixtures/php_path_basename_safe/index.php
@@ -1,0 +1,6 @@
+<?php
+
+function read_file() {
+    $name = basename($_GET["path"]);
+    return file_get_contents(__DIR__ . "/uploads/" . $name);
+}

--- a/benchmarks/security/fixtures/php_path_traversal/index.php
+++ b/benchmarks/security/fixtures/php_path_traversal/index.php
@@ -1,0 +1,6 @@
+<?php
+
+function read_file() {
+    $path = $_GET["path"];
+    return file_get_contents($path);
+}

--- a/benchmarks/security/fixtures/php_unserialize/index.php
+++ b/benchmarks/security/fixtures/php_unserialize/index.php
@@ -1,0 +1,6 @@
+<?php
+
+function load_payload() {
+    $payload = $_POST["payload"];
+    return unserialize($payload);
+}

--- a/benchmarks/security/manifest.json
+++ b/benchmarks/security/manifest.json
@@ -13,7 +13,7 @@
         "notes": "Regression fixture distilled from a confirmed false negative in Skylos SQL flow analysis."
       },
       "budget": {
-        "max_seconds": 5.0
+        "max_seconds": 6.0
       },
       "expect": {
         "present": {
@@ -403,6 +403,314 @@
           "danger": ["SKY-D201"]
         },
         "absent": {}
+      }
+    },
+    {
+      "id": "csharp-command-injection",
+      "path": "fixtures/csharp_command_injection",
+      "description": "C# Process.Start with caller-controlled command input should be reported as command injection.",
+      "languages": ["csharp"],
+      "taxonomy": ["command_injection", "csharp"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden fixture for C# process execution taint."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D212"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "csharp-command-literal-safe",
+      "path": "fixtures/csharp_command_literal_safe",
+      "description": "C# Process.Start with literal argv should not be reported as command injection.",
+      "languages": ["csharp"],
+      "taxonomy": ["command_injection", "csharp", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden precision fixture for literal C# process execution."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D212"]
+        }
+      }
+    },
+    {
+      "id": "csharp-sql-injection",
+      "path": "fixtures/csharp_sql_injection",
+      "description": "C# SqlCommand built from caller-controlled SQL text should be reported.",
+      "languages": ["csharp"],
+      "taxonomy": ["sql_injection", "csharp"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden fixture for C# raw SQL taint."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D211"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "csharp-sql-parameterized-safe",
+      "path": "fixtures/csharp_sql_parameterized_safe",
+      "description": "C# parameterized SqlCommand with literal query text should stay quiet.",
+      "languages": ["csharp"],
+      "taxonomy": ["sql_injection", "csharp", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden precision fixture for parameterized C# SQL."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D211"]
+        }
+      }
+    },
+    {
+      "id": "csharp-ssrf",
+      "path": "fixtures/csharp_ssrf",
+      "description": "C# HttpClient request using caller-controlled URL should be reported as SSRF.",
+      "languages": ["csharp"],
+      "taxonomy": ["ssrf", "csharp"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden fixture for C# outbound request taint."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D216"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "csharp-ssrf-fixed-host-safe",
+      "path": "fixtures/csharp_ssrf_fixed_host_safe",
+      "description": "C# HttpClient request to a literal fixed URL should stay quiet.",
+      "languages": ["csharp"],
+      "taxonomy": ["ssrf", "csharp", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden precision fixture for literal C# outbound request targets."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D216"]
+        }
+      }
+    },
+    {
+      "id": "csharp-path-traversal",
+      "path": "fixtures/csharp_path_traversal",
+      "description": "C# File.ReadAllText with caller-controlled path should be reported as path traversal.",
+      "languages": ["csharp"],
+      "taxonomy": ["path_traversal", "csharp"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden fixture for C# filesystem path taint."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D215"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "csharp-path-basename-safe",
+      "path": "fixtures/csharp_path_basename_safe",
+      "description": "C# path input sanitized with Path.GetFileName before fixed-directory access should stay quiet.",
+      "languages": ["csharp"],
+      "taxonomy": ["path_traversal", "csharp", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden precision fixture for C# path basename sanitization."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D215"]
+        }
+      }
+    },
+    {
+      "id": "csharp-open-redirect",
+      "path": "fixtures/csharp_open_redirect",
+      "description": "C# MVC Redirect using caller-controlled target should be reported as open redirect.",
+      "languages": ["csharp"],
+      "taxonomy": ["open_redirect", "csharp"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden fixture for C# redirect taint."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D230"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "csharp-open-redirect-literal-safe",
+      "path": "fixtures/csharp_open_redirect_literal_safe",
+      "description": "C# MVC Redirect to a literal local route should stay quiet.",
+      "languages": ["csharp"],
+      "taxonomy": ["open_redirect", "csharp", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden precision fixture for literal C# redirects."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D230"]
+        }
+      }
+    },
+    {
+      "id": "php-unserialize",
+      "path": "fixtures/php_unserialize",
+      "description": "PHP unserialize on request-controlled data should be reported as unsafe deserialization.",
+      "languages": ["php"],
+      "taxonomy": ["deserialization", "php"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden fixture for PHP unsafe deserialization."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D204"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "php-json-decode-safe",
+      "path": "fixtures/php_json_decode_safe",
+      "description": "PHP JSON decoding request data should not be treated as unsafe deserialization.",
+      "languages": ["php"],
+      "taxonomy": ["deserialization", "php", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden precision fixture for PHP JSON parsing."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D204"]
+        }
+      }
+    },
+    {
+      "id": "php-path-traversal",
+      "path": "fixtures/php_path_traversal",
+      "description": "PHP filesystem read using request-controlled path should be reported as path traversal.",
+      "languages": ["php"],
+      "taxonomy": ["path_traversal", "php"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden fixture for PHP filesystem path taint."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D215"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "php-path-basename-safe",
+      "path": "fixtures/php_path_basename_safe",
+      "description": "PHP path input sanitized with basename before fixed-directory access should stay quiet.",
+      "languages": ["php"],
+      "taxonomy": ["path_traversal", "php", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Golden precision fixture for PHP basename sanitization."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D215"]
+        }
       }
     },
     {

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>647</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5343</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>5350</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -941,8 +941,8 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks" rel="noopener noreferrer">skylos/benchmarks</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 88</span>
-          <span class="pill"><strong>lines</strong> 3381</span>
+          <span class="pill"><strong>symbols</strong> 89</span>
+          <span class="pill"><strong>lines</strong> 3406</span>
         </div>
       </div>
       <p>Benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.</p>
@@ -957,7 +957,7 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1084 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>726 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>751 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>507 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
@@ -971,11 +971,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L130" rel="noopener noreferrer">load_manifest:130</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L134" rel="noopener noreferrer">load_external_targets:134</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L306" rel="noopener noreferrer">validate_manifest:306</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L79" rel="noopener noreferrer">SecurityBenchmarkFailure:79</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L98" rel="noopener noreferrer">load_manifest:98</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">validate_manifest:102</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L489" rel="noopener noreferrer">run_case:489</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L576" rel="noopener noreferrer">run_manifest:576</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L83" rel="noopener noreferrer">SecurityBenchmarkFailure:83</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">load_manifest:102</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L106" rel="noopener noreferrer">validate_manifest:106</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L514" rel="noopener noreferrer">run_case:514</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L601" rel="noopener noreferrer">run_manifest:601</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a> <span>def</span></li>
@@ -1768,7 +1768,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 2</span>
           <span class="pill"><strong>symbols</strong> 2</span>
-          <span class="pill"><strong>lines</strong> 125</span>
+          <span class="pill"><strong>lines</strong> 157</span>
         </div>
       </div>
       <p>Scale and performance helpers for larger repositories.</p>
@@ -1782,13 +1782,13 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py" rel="noopener noreferrer">skylos/scale/parallel_static.py</a> <span>125 lines</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py" rel="noopener noreferrer">skylos/scale/parallel_static.py</a> <span>157 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/__init__.py" rel="noopener noreferrer">skylos/scale/__init__.py</a> <span>0 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L31" rel="noopener noreferrer">run_proc_file_parallel:31</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L4" rel="noopener noreferrer">_worker:4</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L35" rel="noopener noreferrer">run_proc_file_parallel:35</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L8" rel="noopener noreferrer">_worker:8</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1897,7 +1897,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 37</span>
           <span class="pill"><strong>symbols</strong> 308</span>
-          <span class="pill"><strong>lines</strong> 17594</span>
+          <span class="pill"><strong>lines</strong> 17623</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1985,8 +1985,8 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 191</span>
-          <span class="pill"><strong>symbols</strong> 2290</span>
-          <span class="pill"><strong>lines</strong> 77843</span>
+          <span class="pill"><strong>symbols</strong> 2296</span>
+          <span class="pill"><strong>lines</strong> 77940</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -5360,42 +5360,42 @@
             </tr>
 
             <tr class="searchable" data-search="securitybenchmarkfailure class skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L79" rel="noopener noreferrer">SecurityBenchmarkFailure:79</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L83" rel="noopener noreferrer">SecurityBenchmarkFailure:83</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L98" rel="noopener noreferrer">load_manifest:98</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">load_manifest:102</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">validate_manifest:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L106" rel="noopener noreferrer">validate_manifest:106</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L489" rel="noopener noreferrer">run_case:489</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L514" rel="noopener noreferrer">run_case:514</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L576" rel="noopener noreferrer">run_manifest:576</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L601" rel="noopener noreferrer">run_manifest:601</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L668" rel="noopener noreferrer">format_summary:668</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L693" rel="noopener noreferrer">format_summary:693</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>

--- a/skylos/benchmarks/quality.py
+++ b/skylos/benchmarks/quality.py
@@ -37,6 +37,7 @@ DEFAULT_SCAN = {
     "enable_secrets": False,
     "grep_verify": False,
 }
+MAX_SECONDS_FAILURE_GRACE_RATIO = 0.10
 
 
 @dataclass(frozen=True)
@@ -319,6 +320,13 @@ def _score_case(
     }
 
 
+def _exceeds_runtime_budget(elapsed_seconds: float, max_seconds: float | None) -> bool:
+    if max_seconds is None:
+        return False
+    hard_limit = max_seconds * (1.0 + MAX_SECONDS_FAILURE_GRACE_RATIO)
+    return elapsed_seconds > hard_limit
+
+
 def run_case(case: dict[str, Any], manifest_path: str | Path) -> dict[str, Any]:
     manifest_root = Path(manifest_path).parent
     case_path = (manifest_root / case["path"]).resolve()
@@ -337,7 +345,7 @@ def run_case(case: dict[str, Any], manifest_path: str | Path) -> dict[str, Any]:
 
     budget = case.get("budget", {}) or {}
     max_seconds = budget.get("max_seconds")
-    if max_seconds is not None and elapsed_seconds > max_seconds:
+    if _exceeds_runtime_budget(elapsed_seconds, max_seconds):
         failures.append(
             QualityBenchmarkFailure(
                 case_id=case["id"],

--- a/skylos/benchmarks/security.py
+++ b/skylos/benchmarks/security.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 import subprocess
 import time
@@ -25,8 +26,10 @@ SECURITY_TAXONOMY: dict[str, str] = {
     "go": "Go security flow and sanitizer patterns.",
     "java": "Java security flow and sanitizer patterns.",
     "javascript": "JavaScript security flow and sanitizer patterns.",
+    "php": "PHP security flow and sanitizer patterns.",
     "rust": "Rust security flow and sanitizer patterns.",
     "typescript": "TypeScript security flow and sanitizer patterns.",
+    "csharp": "C# security flow and sanitizer patterns.",
     "precision_guard": "Clean patterns that should stay free of noisy security findings.",
 }
 
@@ -51,6 +54,7 @@ SUPPORTED_LANGUAGES = {
     "java",
     "javascript",
     "typescript",
+    "php",
     "rust",
     "dart",
     "csharp",
@@ -300,11 +304,32 @@ def _scan_case(case_path: Path, scan: dict[str, Any] | None = None) -> dict[str,
             enable_quality=bool(scan_cfg.get("enable_quality", False)),
             enable_danger=bool(scan_cfg.get("enable_danger", True)),
             enable_secrets=bool(scan_cfg.get("enable_secrets", False)),
+            changed_files=_case_changed_files(case_path),
             grep_verify=bool(scan_cfg.get("grep_verify", False)),
         )
     finally:
         analyzer_logger.setLevel(prev_level)
     return json.loads(raw)
+
+
+def _case_changed_files(case_path: Path) -> set[str]:
+    if case_path.is_file():
+        return {str(case_path.resolve())} if not case_path.is_symlink() else set()
+
+    changed_files: set[str] = set()
+    for current_root, dirnames, filenames in os.walk(case_path, followlinks=False):
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if not (Path(current_root) / name).is_symlink()
+        ]
+        base = Path(current_root)
+        for filename in filenames:
+            path = base / filename
+            if path.is_symlink() or not path.is_file():
+                continue
+            changed_files.add(str(path.resolve()))
+    return changed_files
 
 
 def _scan_bandit_case(

--- a/skylos/core/gatekeeper.py
+++ b/skylos/core/gatekeeper.py
@@ -1,3 +1,5 @@
+import importlib  # skylos: ignore[SKY-Q502] legacy gate flow module is being split incrementally
+import importlib.util
 import os
 import subprocess
 import sys
@@ -5,12 +7,30 @@ import sys
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
-try:
-    import inquirer
 
-    INTERACTIVE = True
-except ImportError:
-    INTERACTIVE = False
+class _LazyInquirer:
+    """Import inquirer only when an interactive prompt is actually used."""
+
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            self._module = importlib.import_module("inquirer")
+        return self._module
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+def _inquirer_available() -> bool:
+    try:
+        return importlib.util.find_spec("inquirer") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+INTERACTIVE = _inquirer_available()
+inquirer = _LazyInquirer() if INTERACTIVE else None
 
 console = Console()
 DEAD_CODE_RESULT_KEYS = (

--- a/skylos/scale/parallel_static.py
+++ b/skylos/scale/parallel_static.py
@@ -1,4 +1,8 @@
 from concurrent.futures import ProcessPoolExecutor, as_completed
+import logging
+
+
+logger = logging.getLogger("Skylos")
 
 
 def _worker(
@@ -49,6 +53,8 @@ def run_proc_file_parallel(
 
     if jobs <= 0:
         jobs = max(1, (os.cpu_count() or 4) - 1)
+    if len(files) <= 1:
+        jobs = 1
 
     if jobs <= 1:
         outs = []
@@ -109,7 +115,33 @@ def run_proc_file_parallel(
                 file_str, out = fut.result()
             except Exception:
                 file_str = str(f)
-                out = None
+                logger.warning(
+                    "Parallel static worker failed for %s; retrying in parent process",
+                    file_str,
+                    exc_info=True,
+                )
+                try:
+                    from skylos.analyzer import proc_file
+
+                    full_scan = changed_files is None or str(f) in changed_files
+                    out = proc_file(
+                        f,
+                        modmap[f],
+                        extra_visitors=extra_visitors,
+                        full_scan=full_scan,
+                        collect_clone_fragments=collect_clone_fragments,
+                        clone_cfg=clone_cfg,
+                        collect_architecture_metrics=collect_architecture_metrics,
+                        enable_quality_rules=enable_quality_rules,
+                        enable_danger_rules=enable_danger_rules,
+                    )
+                except Exception:
+                    logger.error(
+                        "Parent-process static retry failed for %s",
+                        file_str,
+                        exc_info=True,
+                    )
+                    out = None
 
             results[file_str] = out
 

--- a/skylos/visitors/languages/csharp/danger.py
+++ b/skylos/visitors/languages/csharp/danger.py
@@ -200,11 +200,16 @@ def _tracked_property_sink(
 
 
 def _is_tainted(expr: str, tainted_vars: set[str]) -> bool:
-    if not expr or any(hint in expr for hint in _SANITIZER_HINTS):
+    if not expr:
         return False
-    if any(hint in expr for hint in _SOURCE_HINTS):
+    masked = mask_comments_and_strings(expr)
+    if any(hint in masked for hint in _SANITIZER_HINTS):
+        return False
+    if any(hint in masked for hint in _SOURCE_HINTS):
         return True
-    return any(re.search(rf"\b@?{re.escape(name)}\b", expr) for name in tainted_vars)
+    return any(
+        re.search(rf"\b@?{re.escape(name)}\b", masked) for name in tainted_vars
+    )
 
 
 def _iter_scopes(source: str) -> list[tuple[str, int, set[str]]]:

--- a/skylos/visitors/languages/typescript/framework.py
+++ b/skylos/visitors/languages/typescript/framework.py
@@ -57,6 +57,30 @@ class TSFrameworkVisitor:
         self.framework_decorated_lines: set[int] = set()
         self.detected_frameworks: set[str] = set()
 
+    def __getstate__(self) -> dict:
+        return {
+            "is_test_file": self.is_test_file,
+            "test_decorated_lines": self.test_decorated_lines,
+            "dataclass_fields": self.dataclass_fields,
+            "pydantic_models": self.pydantic_models,
+            "class_defs": self.class_defs,
+            "first_read_lineno": self.first_read_lineno,
+            "framework_decorated_lines": self.framework_decorated_lines,
+            "detected_frameworks": self.detected_frameworks,
+        }
+
+    def __setstate__(self, state: dict) -> None:
+        self.is_test_file = bool(state.get("is_test_file", False))
+        self.test_decorated_lines = set(state.get("test_decorated_lines", set()))
+        self.dataclass_fields = set(state.get("dataclass_fields", set()))
+        self.pydantic_models = set(state.get("pydantic_models", set()))
+        self.class_defs = dict(state.get("class_defs", {}))
+        self.first_read_lineno = dict(state.get("first_read_lineno", {}))
+        self.framework_decorated_lines = set(
+            state.get("framework_decorated_lines", set())
+        )
+        self.detected_frameworks = set(state.get("detected_frameworks", set()))
+
     def scan(
         self,
         file_path: str,

--- a/test/test_cli_terminal_probe.py
+++ b/test/test_cli_terminal_probe.py
@@ -37,3 +37,40 @@ def test_version_does_not_import_inquirer_at_startup(tmp_path):
     assert completed.returncode == 0
     assert fake_probe not in completed.stdout
     assert completed.stdout.strip() == f"skylos {skylos.__version__}"
+
+
+def test_concise_gate_exit_code_does_not_import_inquirer(tmp_path):
+    fake_probe = (
+        "+q544e+q524742+q636f6c6f7273+q626c696e6b+q7369746d"
+        "+q7269746d+q6376766973+q536d756c78+q536574756c63+q4d73"
+    )
+    (tmp_path / "inquirer.py").write_text(
+        "import sys\n" f"sys.stdout.write({fake_probe!r})\n", encoding="utf-8"
+    )
+
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(tmp_path), repo_root, env.get("PYTHONPATH", "")]
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from types import SimpleNamespace; "
+            "from skylos.cli import _concise_scan_exit_code; "
+            "args=SimpleNamespace(gate=True, strict=False, summary=False, force=False); "
+            "result={'quality':[{'file':'app.py','line':1,'severity':'high'}]}; "
+            "raise SystemExit(_concise_scan_exit_code(result, {'gate': {'max_quality': 0}}, args))",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 1
+    assert fake_probe not in completed.stdout
+    assert completed.stdout == ""

--- a/test/test_csharp_security.py
+++ b/test/test_csharp_security.py
@@ -207,6 +207,23 @@ public class UserRepository {
     assert "SKY-D211" not in _rule_ids(findings)
 
 
+def test_parameterized_sql_literal_with_id_token_is_safe(tmp_path):
+    findings = _scan_csharp_findings(
+        tmp_path,
+        """
+using System.Data.SqlClient;
+
+public class UserRepository {
+    public void Find(int id, SqlConnection connection) {
+        var command = new SqlCommand("SELECT * FROM Users WHERE id = @id", connection);
+        command.Parameters.AddWithValue("@id", id);
+    }
+}
+""",
+    )
+    assert "SKY-D211" not in _rule_ids(findings)
+
+
 def test_http_client_with_tainted_url_flags(tmp_path):
     findings = _scan_csharp_findings(
         tmp_path,

--- a/test/test_parallel_static.py
+++ b/test/test_parallel_static.py
@@ -9,6 +9,11 @@ class DummyFuture:
         return self._value
 
 
+class ExplodingFuture:
+    def result(self):
+        raise TypeError("cannot pickle tree_sitter.Language object")
+
+
 class DummyExecutor:
     def __init__(self, max_workers=None):
         self.max_workers = max_workers
@@ -23,6 +28,23 @@ class DummyExecutor:
     def submit(self, fn, *args, **kwargs):
         file_str, out = fn(*args, **kwargs)
         fut = DummyFuture((file_str, out))
+        self.futures.append(fut)
+        return fut
+
+
+class ExplodingExecutor:
+    def __init__(self, max_workers=None):
+        self.max_workers = max_workers
+        self.futures = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def submit(self, fn, *args, **kwargs):
+        fut = ExplodingFuture()
         self.futures.append(fut)
         return fut
 
@@ -55,3 +77,25 @@ def test_parallel_path_preserves_order(monkeypatch, tmp_path):
     assert out[0] == ("ok", str(files[0]), "mx")
     assert out[1] == ("ok", str(files[1]), "my")
     assert out[2] == ("ok", str(files[2]), "mz")
+
+
+def test_parallel_path_retries_parent_process_when_worker_result_fails(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(ps, "ProcessPoolExecutor", ExplodingExecutor)
+    monkeypatch.setattr(ps, "as_completed", fake_as_completed)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    def fake_proc_file(file_path, mod, extra_visitors=None, full_scan=True, **kwargs):
+        return ("retry-ok", str(file_path), mod)
+
+    import skylos.analyzer
+
+    monkeypatch.setattr(skylos.analyzer, "proc_file", fake_proc_file)
+
+    file_path = tmp_path / "app.ts"
+    modmap = {file_path: "app"}
+
+    out = ps.run_proc_file_parallel([file_path], modmap, jobs=2)
+
+    assert out == [("retry-ok", str(file_path), "app")]

--- a/test/test_quality_benchmark.py
+++ b/test/test_quality_benchmark.py
@@ -102,6 +102,55 @@ def test_runner_reports_present_and_budget_failures(tmp_path, monkeypatch):
     assert summary["scores"]["overall_score"] < 50.0
 
 
+def test_runner_treats_small_budget_overrun_as_latency_penalty(tmp_path, monkeypatch):
+    case_dir = tmp_path / "slightly_slow_case"
+    case_dir.mkdir()
+    (case_dir / "demo.py").write_text(
+        "def demo(flag):\n    return flag\n", encoding="utf-8"
+    )
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "slightly-slow-quality-case",
+                "path": "slightly_slow_case",
+                "description": "Synthetic benchmark timing grace case.",
+                "taxonomy": ["control_flow"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "Test-only fixture.",
+                },
+                "budget": {"max_seconds": 0.5},
+                "expect": {
+                    "present": {"quality": ["SKY-L006"]},
+                    "absent": {},
+                },
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.setattr(
+        benchmark,
+        "_scan_case",
+        lambda case_path, scan=None: {
+            "quality": [{"rule_id": "SKY-L006"}],
+        },
+    )
+
+    ticks = iter([0.0, 0.54])
+    monkeypatch.setattr(benchmark.time, "perf_counter", lambda: next(ticks))
+
+    summary = run_manifest(manifest_path)
+
+    assert summary["failure_count"] == 0
+    assert summary["scores"]["latency_score"] < 1.0
+
+
 def test_format_summary_includes_taxonomy_and_metrics():
     summary = {
         "case_count": 1,

--- a/test/test_security_benchmark.py
+++ b/test/test_security_benchmark.py
@@ -29,10 +29,35 @@ def test_checked_in_security_manifest_validates():
         "ssrf-fixed-host-path",
         "subprocess-alias-shell",
         "yaml-safeloader-positional",
+        "csharp-command-injection",
+        "csharp-sql-parameterized-safe",
+        "php-unserialize",
+        "php-path-basename-safe",
     }
 
     labels = {label for case in cases for label in case["taxonomy"]}
     assert labels <= set(SECURITY_TAXONOMY)
+
+
+def test_security_benchmark_scans_only_fixture_changed_files(tmp_path, monkeypatch):
+    case_dir = tmp_path / "case"
+    case_dir.mkdir()
+    app = case_dir / "app.py"
+    app.write_text("def demo():\n    return 1\n", encoding="utf-8")
+
+    captured = {}
+
+    def fake_analyze(path, **kwargs):
+        captured["path"] = path
+        captured["changed_files"] = kwargs.get("changed_files")
+        return json.dumps({})
+
+    monkeypatch.setattr(benchmark, "analyze", fake_analyze)
+
+    benchmark._scan_case(case_dir)
+
+    assert captured["path"] == str(case_dir)
+    assert captured["changed_files"] == {str(app.resolve())}
 
 
 def test_checked_in_security_benchmark_passes():

--- a/test/test_typescript.py
+++ b/test/test_typescript.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 from skylos.visitors.languages.typescript import scan_typescript_file
@@ -102,3 +104,12 @@ def test_jsx_scanner_parses_component_file(tmp_path):
     assert "div" not in ref_names
     assert quality == []
     assert danger == []
+
+
+def test_typescript_scan_result_is_parallel_worker_picklable(tmp_path):
+    p = tmp_path / "app.ts"
+    p.write_text("export function run(input: string) { return eval(input); }\n")
+
+    result = scan_typescript_file(str(p), {}, enable_quality_rules=False)
+
+    pickle.dumps(result)


### PR DESCRIPTION
## Summary
  - Lazy-load `inquirer` in `gatekeeper.py` so concise gate checks do not trigger terminal capability probes.

## Test
  - `pytest test/test_cli_terminal_probe.py test/test_gatekeeper.py test/test_cicd_gate.py test/test_gate_kwargs.py`
  - `pytest test/test_quality_benchmark.py`