### PR TITLE
chore(docs): refresh repo map

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>647</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5350</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>5355</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -941,8 +941,8 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks" rel="noopener noreferrer">skylos/benchmarks</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 89</span>
-          <span class="pill"><strong>lines</strong> 3406</span>
+          <span class="pill"><strong>symbols</strong> 90</span>
+          <span class="pill"><strong>lines</strong> 3414</span>
         </div>
       </div>
       <p>Benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.</p>
@@ -959,7 +959,7 @@
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1084 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>751 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>507 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>515 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">skylos/benchmarks/demo_deadcode.py</a> <span>172 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/__init__.py" rel="noopener noreferrer">skylos/benchmarks/__init__.py</a> <span>2 lines</span></li></ul>
@@ -1177,8 +1177,8 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 17</span>
-          <span class="pill"><strong>symbols</strong> 144</span>
-          <span class="pill"><strong>lines</strong> 4848</span>
+          <span class="pill"><strong>symbols</strong> 146</span>
+          <span class="pill"><strong>lines</strong> 4868</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1192,7 +1192,7 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">skylos/core/gatekeeper.py</a> <span>674 lines</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">skylos/core/gatekeeper.py</a> <span>694 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">skylos/core/result_cache.py</a> <span>580 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a> <span>500 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">skylos/core/file_discovery.py</a> <span>407 lines</span></li>
@@ -1203,11 +1203,11 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L36" rel="noopener noreferrer">run_cmd:36</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L45" rel="noopener noreferrer">get_git_status:45</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L59" rel="noopener noreferrer">run_push:59</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L70" rel="noopener noreferrer">start_deployment_wizard:70</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L431" rel="noopener noreferrer">check_gate:431</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L56" rel="noopener noreferrer">run_cmd:56</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L65" rel="noopener noreferrer">get_git_status:65</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L79" rel="noopener noreferrer">run_push:79</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L90" rel="noopener noreferrer">start_deployment_wizard:90</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L451" rel="noopener noreferrer">check_gate:451</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L117" rel="noopener noreferrer">build_trace_cache_key:117</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L153" rel="noopener noreferrer">load_trace_cache:153</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L181" rel="noopener noreferrer">save_trace_cache:181</a> <span>def</span></li>
@@ -1985,8 +1985,8 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 191</span>
-          <span class="pill"><strong>symbols</strong> 2296</span>
-          <span class="pill"><strong>lines</strong> 77940</span>
+          <span class="pill"><strong>symbols</strong> 2298</span>
+          <span class="pill"><strong>lines</strong> 78026</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -5318,42 +5318,42 @@
             </tr>
 
             <tr class="searchable" data-search="qualitybenchmarkfailure class skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L43" rel="noopener noreferrer">QualityBenchmarkFailure:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L44" rel="noopener noreferrer">QualityBenchmarkFailure:44</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L62" rel="noopener noreferrer">load_manifest:62</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L63" rel="noopener noreferrer">load_manifest:63</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L67" rel="noopener noreferrer">validate_manifest:67</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L68" rel="noopener noreferrer">validate_manifest:68</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L322" rel="noopener noreferrer">run_case:322</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L330" rel="noopener noreferrer">run_case:330</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L384" rel="noopener noreferrer">run_manifest:384</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L392" rel="noopener noreferrer">run_manifest:392</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L469" rel="noopener noreferrer">format_summary:469</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L477" rel="noopener noreferrer">format_summary:477</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
@@ -7460,56 +7460,56 @@
             </tr>
 
             <tr class="searchable" data-search="run_cmd def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L36" rel="noopener noreferrer">run_cmd:36</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L56" rel="noopener noreferrer">run_cmd:56</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_git_status def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L45" rel="noopener noreferrer">get_git_status:45</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L65" rel="noopener noreferrer">get_git_status:65</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_push def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L59" rel="noopener noreferrer">run_push:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L79" rel="noopener noreferrer">run_push:79</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="start_deployment_wizard def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L70" rel="noopener noreferrer">start_deployment_wizard:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L90" rel="noopener noreferrer">start_deployment_wizard:90</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="check_gate def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L431" rel="noopener noreferrer">check_gate:431</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L451" rel="noopener noreferrer">check_gate:451</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_summary_markdown def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L524" rel="noopener noreferrer">build_summary_markdown:524</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L544" rel="noopener noreferrer">build_summary_markdown:544</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="write_github_summary def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L567" rel="noopener noreferrer">write_github_summary:567</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L587" rel="noopener noreferrer">write_github_summary:587</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_gate_interaction def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L630" rel="noopener noreferrer">run_gate_interaction:630</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L650" rel="noopener noreferrer">run_gate_interaction:650</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>


### PR DESCRIPTION
## Summary

  - Refresh generated repo map after the latest merged changes.
  - Update symbol counts, line counts, and source links in `docs/repo-map/index.html`.