### PR TITLE
chore(docs): organize translated READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [Roadmap](./ROADMAP.md) |
 [Contributing](./CONTRIBUTING.md)
 
-**English** | [Chinese README](./README_CN.md)
+**English** | [Deutsch](./docs/i18n/README.de.md) | [简体中文](./docs/i18n/README.zh-CN.md) | [Translations](./docs/i18n/README.md)
 
 ## What Is Skylos?
 

--- a/dictionary.md
+++ b/dictionary.md
@@ -1,8 +1,8 @@
 # Skylos Rule Dictionary and Product Glossary
 
 This file is the repo-local glossary for public Skylos terminology and emitted
-rule IDs. Keep it aligned with `README.md`, `README_CN.md`, `docs/*.md`, CLI
-help text, and rule implementations.
+rule IDs. Keep it aligned with `README.md`, translated READMEs in
+`docs/i18n/`, `docs/*.md`, CLI help text, and rule implementations.
 
 Rule IDs use a stable public prefix:
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -1,0 +1,330 @@
+<div align="center">
+    <img src="../../assets/DOG_1.png" alt="Skylos" width="260">
+    <h1>Skylos</h1>
+    <h3>Open Source, lokal zuerst: Prüfungen auf toten Code, Sicherheitsprobleme, Secrets, Qualitätsregressionen und AI-Code-Fehler vor dem Merge.</h3>
+</div>
+
+![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
+[![codecov](https://codecov.io/gh/duriantaco/skylos/branch/main/graph/badge.svg)](https://codecov.io/gh/duriantaco/skylos)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/skylos)
+[![PyPI version](https://img.shields.io/pypi/v/skylos)](https://pypi.org/project/skylos/)
+![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/oha.skylos-vscode-extension)
+[![Astronomer Trust](https://img.shields.io/badge/Astronomer%20Trust-A-brightgreen?style=flat&logo=github&logoColor=white)](#star-authenticity-audit)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/Ftn9t9tErf)
+
+[Website](https://skylos.dev) |
+[Docs](https://docs.skylos.dev) |
+[Repo Map](https://duriantaco.github.io/skylos/repo-map/) |
+[Quick Start](https://docs.skylos.dev/quick-start) |
+[GitHub Action](../../action.yml) |
+[VS Code Extension](../../editors/vscode/README.md) |
+[Real-World Results](../../REAL_WORLD_RESULTS.md) |
+[Benchmarks](../../BENCHMARK.md) |
+[Roadmap](../../ROADMAP.md) |
+[Contributing](../../CONTRIBUTING.md)
+
+[English](../../README.md) | **Deutsch** | [简体中文](./README.zh-CN.md) | [Translations](./README.md)
+
+## Was ist Skylos?
+
+Skylos ist eine Open-Source-CLI für statische Analyse in Python-, TypeScript-,
+JavaScript-, Java-, Go-, PHP-, Rust-, Dart- und C#-Repositories. Skylos läuft
+standardmäßig lokal und kann auch als CI/CD-PR-Gate verwendet werden.
+
+Nutze Skylos, wenn du mit einem Befehl ein Repository oder einen Pull Request
+prüfen möchtest auf:
+
+- toten Code und ungenutzte Dateien
+- Sicherheitslücken und gefährliche Datenflüsse
+- Secrets und Dependency-CVEs
+- Qualitätsregressionen wie Komplexität, doppelte Branches und tiefe
+  Verschachtelung
+- typische Fehler in AI-generiertem Code, etwa fehlende Guards oder erfundene
+  Helper
+- Risiken in LLM-Apps, etwa unsichere Tool-Nutzung und fehlende
+  Ausgabevalidierung
+
+## Start in 60 Sekunden
+
+```bash
+pip install skylos
+skylos .
+```
+
+Der Standardscan fokussiert sich auf toten Code. Mit `-a` aktivierst du
+zusätzlich Security-, Secret-, Quality- und Dependency-Prüfungen:
+
+```bash
+skylos . -a
+```
+
+Erzeuge eine Projektkonfiguration mit Grenzwerten, Ignorierregeln,
+Template-Hooks und Erweiterungen für Vibe-Wörterbücher:
+
+```bash
+skylos init
+```
+
+Erzeuge ein lokales Starter-Rule-Pack:
+
+```bash
+skylos rules init
+skylos rules validate .skylos/rules/local.yml
+skylos rules list --json
+skylos rules list cross --json
+skylos rules list --packs --json
+skylos cache stats
+```
+
+Erzeuge ein GitHub-Actions-PR-Gate:
+
+```bash
+skylos cicd init
+git add .github/workflows/skylos.yml
+git commit -m "Add Skylos CI gate"
+git push
+```
+
+Mehr Befehle stehen in der [CLI Reference](https://docs.skylos.dev/cli-reference).
+
+## Häufige Workflows
+
+| Ziel | Befehl | Ergebnis | Details |
+|:---|:---|:---|:---|
+| Erster Dead-Code-Scan | `skylos .` | Findet ungenutzte Funktionen, Klassen, Imports, Dateien und Fehler bei Framework-Entrypoints | [Dead-code docs](https://docs.skylos.dev/dead-code-detection) |
+| Security- und Quality-Audit | `skylos . -a` | Aktiviert gefährliche Datenflüsse, Secrets, Dependencies und Quality-Prüfungen | [Security docs](https://docs.skylos.dev/security-analysis) |
+| PR-Gate | `skylos cicd init` | Erzeugt einen GitHub-Actions-Workflow mit Annotationen und Failure-Thresholds | [CI/CD guide](https://docs.skylos.dev/ci-cd) |
+| Lesbarer Terminalreport | `skylos . --format pretty` | Gruppiert Findings nach Datei, mit Severity, Snippets und kopierbaren `file:line`-Positionen | [CLI output modes](../cli-output.md) |
+| Interaktive Terminaltriage | `skylos . --tui` | Öffnet eine tastaturgesteuerte Ansicht für Kategorien, Findings und Details | [CLI output modes](../cli-output.md) |
+| IDE- und Testscript-Ausgabe | `skylos --format concise src/test.py` | Gibt nur `file:line`-Findings aus und endet mit Non-Zero-Exit, wenn Findings existieren | [CLI Reference](https://docs.skylos.dev/cli-reference) |
+| Review geänderter Zeilen | `skylos . -a --diff origin/main` | Fokussiert Findings auf aktive Arbeit statt auf Legacy-Schulden | [Quality gate docs](https://docs.skylos.dev/quality-gate) |
+| Laufzeitgestützter Dead-Code-Check | `skylos . --trace` | Nutzt Runtime-Traces, um False Positives bei dynamischem Code zu reduzieren | [Smart tracing](https://docs.skylos.dev/smart-tracing) |
+| Lokales Rule-Pack | `skylos rules init` | Erstellt YAML-Regeln für projektspezifische Security- und Quality-Prüfungen | [Custom rules](https://docs.skylos.dev/custom-rules) |
+| AI-gestütztes Review | `skylos agent scan .` | Statische Analyse plus optionales LLM-Review und Fix-Vorschläge | [AI features](https://docs.skylos.dev/ai-features) |
+| LLM-App-Defense | `skylos defend .` | Findet fehlende AI-App-Guardrails, gemappt auf OWASP-LLM-Risiken | [AI defense](https://docs.skylos.dev/ai-defense) |
+| Technical-Debt-Triage | `skylos debt .` | Sortiert Hotspots und Debt-Trends | [Technical debt](https://docs.skylos.dev/technical-debt) |
+
+## Was Skylos findet
+
+| Kategorie | Beispiele | Warum es wichtig ist |
+|:---|:---|:---|
+| Toter Code | ungenutzte Funktionen, Klassen, Imports, Paket-Entrypoints, Route-Handler | reduziert Wartungskosten, ohne dynamische Frameworks unnötig zu beschädigen |
+| Sicherheitsprobleme | SQL Injection, XSS, SSRF, Path Traversal, Command Injection, unsichere Deserialisierung | findet ausnutzbare Pfade, bevor Code in `main` landet |
+| Secrets | API-Keys, Tokens, private Credentials, Strings mit hoher Entropie | verhindert, dass Credentials über Commits und PRs leaken |
+| CI/CD-Workflows | gefährliche GitHub-Actions- und GitLab-CI-Trigger, unpinned Actions/Includes, breite Tokens, OIDC-Missbrauch, Cache Poisoning, mutable Images | reduziert Supply-Chain-Risiken in CI/CD vor Release-Jobs |
+| Qualitätsregressionen | Komplexität, tiefe Verschachtelung, doppelte Branches, lange Funktionen, inkonsistente Returns | verhindert, dass AI-gestützte Refactorings fragilen Code erzeugen |
+| AI-Code-Fehler | erfundene Security-Calls, fehlende Decorators, unfertige Stubs, deaktivierte Controls, Netzwerkaufrufe ohne Timeouts | findet häufige halluzinierte oder unvollständige Codepfade |
+| LLM-App-Risiken | unsichere Tool-Nutzung, Prompt-Injection-Exposition, fehlende Ausgabevalidierung, fehlende Rate Limits | hilft Teams, AI-Features mit Guardrails zu veröffentlichen |
+
+Siehe die vollständige [Rules Reference](https://docs.skylos.dev/rules-reference).
+
+## Wie Skylos einzuordnen ist
+
+Skylos ersetzt nicht jeden spezialisierten Scanner. Es ist ein lokaler Repo-
+und PR-Checker, der mehrere häufige Review-Prüfungen hinter einer CLI bündelt.
+
+- **Framework-aware Dead-Code-Erkennung:** FastAPI, Django, Flask, pytest,
+  SQLAlchemy, Next.js, React, Paket-Entrypoints und gängige Plugin-Muster.
+- **PR-fokussierte Ausgabe:** Diff-Scanning, CI-Grenzwerte,
+  GitHub-Annotationen und Baselines für bestehende Findings.
+- **Local-first-Betrieb:** Die Kernanalyse benötigt keinen Cloud-Upload und
+  keine LLM-Aufrufe.
+- **Review AI-gestützter Änderungen:** prüft auf entfernte Validierung, Auth,
+  Logging, CSRF, Rate Limiting, Timeouts und andere Guards in generiertem oder
+  editiertem Code.
+- **Projektspezifische Regeln:** lokale YAML-Regeln sowie erweiterbare Prompt-,
+  Credential-, Sensitive-File- und Timeout-Wörterbücher über Config.
+- **Eine CLI-Oberfläche:** Dead Code, Security, Secrets, Dependencies, Quality,
+  Technical Debt, Agent Review und AI Defense nutzen dieselbe CLI.
+
+## Installation
+
+```bash
+# Kernanalyse
+pip install skylos
+
+# LLM-gestützte Agent-Workflows
+pip install "skylos[llm]"
+
+# Alle veröffentlichten optionalen Extras
+pip install "skylos[all]"
+```
+
+Container-Image:
+
+```bash
+docker pull ghcr.io/duriantaco/skylos:latest
+docker run --rm -v "$PWD":/work -w /work ghcr.io/duriantaco/skylos:latest . --json --no-provenance
+```
+
+Quellinstallation, Container-Nutzung und optionale Dependencies stehen in der
+[Installation](https://docs.skylos.dev/installation).
+
+## Templates und Vibe-Checks konfigurieren
+
+`skylos init` ergänzt diese Abschnitte in `pyproject.toml`:
+
+```toml
+[tool.skylos.templates]
+# security = ".skylos/templates/security.md"
+# quality = ".skylos/templates/quality.md"
+# security_audit = ".skylos/templates/security_audit.md"
+# review = ".skylos/templates/review.md"
+
+[tool.skylos.vibe]
+extra_phantom_names = ["verify_enterprise_auth"]
+extra_phantom_decorators = ["tenant_admin_required"]
+extra_credential_names = ["tenant_signing_secret"]
+extra_network_timeout_calls = ["vendor_sdk.fetch"]
+```
+
+Template-Dateien erweitern die eingebauten Prompts von Skylos. Sie ersetzen
+nicht den JSON-only-Ausgabevertrag und nicht die Sicherheitsregeln für
+untrusted code. Vibe-Wörterbücher helfen Teams, Skylos lokale Fake-Auth-Helper,
+projektspezifische Credential-Namen, sensible Dateien und Netzwerkaufrufe mit
+Timeout-Pflicht beizubringen.
+
+## Sprachunterstützung
+
+| Sprache | Dead Code | Security | Quality | Hinweise |
+|:---|:---:|:---:|:---:|:---|
+| Python | Ja | Ja | Ja | stärkste Abdeckung; framework-aware statische Analyse und optionales Tracing |
+| TypeScript / JavaScript | Ja | Ja | Ja | Tree-sitter-Parsing, Paketgraph-Reachability, Framework-Konventionen |
+| Java | Ja | Ja | Ja | Tree-sitter-Parsing und strukturierte Security-Flow-Analyse |
+| Go | Ja | Teilweise | Teilweise | Dead-Code- und ausgewählte Security-Benchmark-Abdeckung |
+| PHP | Ja | Ja | Teilweise | PHP-Parser-Abdeckung plus taint-artige Security-Sinks und -Sources |
+| Rust | Ja | Ja | Teilweise | Rust-Parser-Abdeckung plus Security-Sink/Source-Prüfungen |
+| Dart | Ja | Ja | Teilweise | Dart-Parser-Abdeckung plus ausgewählte Security-Sinks und -Sources |
+| C# | Ja | Ja | Teilweise | C#-Symbolabdeckung plus ausgewählte ASP.NET-, Process-, SQL-, HTTP- und File-Sinks |
+
+Regelfamilien und Scanner-Scope stehen in der
+[Rules Reference](https://docs.skylos.dev/rules-reference).
+
+## Benchmark-Snapshot
+
+Skylos enthält Regression-Benchmarks für Dead Code, Security, Quality und
+Agent Review. Diese sind strikte Regression-Gates, kein umfassender Beweis,
+dass ein Tool in jeder Situation State of the Art ist.
+
+| Suite | Aktuelles Skylos-Ergebnis | Baseline |
+|:---|:---|:---|
+| Dead-code regression | 16 cases, TP=36 FP=0 FN=0 TN=59, score 100.0 | Ruff score 62.67; Vulture im letzten lokalen Rerun nicht installiert |
+| Security regression | 49 cases, TP=30 FP=0 FN=0 TN=21, score 100.0 | Bandit score 47.14 auf Python-anwendbaren Cases |
+| Quality regression | 13 cases, score 100.0 | nur Regression-Gate |
+| Agent review | 25 cases, score 100.0 | nur Regression-Gate |
+
+Highlights aus `golden-v0.2`:
+
+| Frozen Suite | Skylos-Ergebnis | Hinweis |
+|:---|:---|:---|
+| Dead code seeded dev | overall score 96.28; TS/JS/Go/Java score 100.0; Python score 93.33 | Python-Restpunkte sind Label-Review-Themen |
+| Security seeded dev | overall score 96.52; vollständige Recall mit einem Python-`urljoin`-False-Positive | Label sollte geprüft werden |
+| OWASP Java security dev | TP=105 FP=0 FN=15 TN=120, score 94.37 | request-wrapper-, LDAP-, XPath- und property-weak-hash-Lücken bleiben |
+| Quality seeded dev | TP=1 FP=0 FN=0 TN=1, score 100.0 | aktuell nur ein seeded case |
+
+Methodik, Befehle, Vergleichszeilen und Caveats stehen in
+[BENCHMARK.md](../../BENCHMARK.md).
+
+## Projektnachweise
+
+Skylos-unterstützte Dead-Code-Cleanup-PRs wurden in
+[Black](https://github.com/psf/black/pull/5041),
+[NetworkX](https://github.com/networkx/networkx/pull/8572),
+[Optuna](https://github.com/optuna/optuna/pull/6547),
+[mitmproxy](https://github.com/mitmproxy/mitmproxy/pull/8136),
+[pypdf](https://github.com/py-pdf/pypdf/pull/3685),
+[beets](https://github.com/beetbox/beets/pull/6473) und
+[Flagsmith](https://github.com/Flagsmith/flagsmith/pull/6953) gemerged. Das
+sind akzeptierte Cleanup-PRs, keine Empfehlungen oder Endorsements dieser
+Projekte. Siehe [Real-World Results](../../REAL_WORLD_RESULTS.md).
+
+<a id="star-authenticity-audit"></a>
+
+Ein lokaler Astronomer-Scan vom 26. April 2026 zählte 420 Stargazer und gab
+**overall trust: A** zurück. StarGuard meldete außerdem **low fake-star risk**.
+
+## Integrationen
+
+| Integration | Link | Zweck |
+|:---|:---|:---|
+| GitHub Action | [GitHub Action](../../action.yml) | PR-Gates, Annotationen und CI-Enforcement |
+| VS Code Extension | [VS Code extension](../../editors/vscode/README.md) | Findings im Editor und AI-gestützte Fixes |
+| MCP server | [MCP setup](https://docs.skylos.dev/mcp-server) | Skylos-Scans für AI Agents und Coding Assistants bereitstellen |
+| Docker image | [Installation](https://docs.skylos.dev/installation) | Skylos ohne lokale Python-Installation ausführen |
+| Skylos Cloud | [Cloud workflow](https://docs.skylos.dev/cloud-workflow) | optionale Upload- und Dashboard-Workflows |
+
+GitHub-Actions-Workflow über die CLI erzeugen:
+
+```bash
+skylos cicd init --upload
+skylos cicd init --upload --scan-path apps/api
+```
+
+Der erzeugte Upload-Workflow nutzt GitHub OIDC, sendet PR-Head-Commit- und
+Branch-Metadaten und unterstützt Monorepo-Subprojekte über `--scan-path`.
+
+## Dokumentationskarte
+
+| Bedarf | Dokument |
+|:---|:---|
+| Installation, Quellinstallation und Docker | [Installation](https://docs.skylos.dev/installation) |
+| Erster Scan und Kernworkflows | [Quick Start](https://docs.skylos.dev/quick-start) |
+| CLI-Befehle, Flags und Beispiele | [CLI Reference](https://docs.skylos.dev/cli-reference) |
+| CLI-Ausgabemodi, Pretty Reports und TUI-Steuerung | [CLI Output Modes](../cli-output.md) |
+| CI-Setup, PR-Gates, Annotationen und Branch Protection | [CI/CD](https://docs.skylos.dev/ci-cd) |
+| Dead-Code-Verhalten und Framework-Awareness | [Dead Code Detection](https://docs.skylos.dev/dead-code-detection) |
+| Security-Scanning und Taint-Analyse | [Security Analysis](https://docs.skylos.dev/security-analysis) |
+| Rule-ID-Präfixe und Produktterminologie | [Rule Dictionary](../../dictionary.md) |
+| Agent Scan, Verifikation, Remediation und Modellsetup | [AI Features](https://docs.skylos.dev/ai-features) |
+| AI-Defense-Prüfungen und LLM-Guardrails | [AI Defense](https://docs.skylos.dev/ai-defense) |
+| MCP-Server-Setup | [MCP Server](https://docs.skylos.dev/mcp-server) |
+| Real-world gemergte Cleanup-PRs | [Real-World Results](../../REAL_WORLD_RESULTS.md) |
+| Baselines, Filtering, Suppressions und Whitelists | [Configuration](https://docs.skylos.dev/configuration) |
+| Smart Tracing | [Smart Tracing](https://docs.skylos.dev/smart-tracing) |
+| Regelfamilien und Sprachunterstützung | [Rules Reference](https://docs.skylos.dev/rules-reference) |
+| Cloud-Uploads und Dashboard-Flow | [CLI to Dashboard](https://docs.skylos.dev/cloud-workflow) |
+| VS Code Extension | [VS Code Extension](https://docs.skylos.dev/vscode) |
+| Benchmarks und Methodik | [BENCHMARK.md](../../BENCHMARK.md) |
+| Security Policy | [SECURITY.md](../../SECURITY.md) |
+| Release-Prozess | [RELEASE_WORKFLOW.md](../../RELEASE_WORKFLOW.md) |
+| Contribution-Prioritäten | [ROADMAP.md](../../ROADMAP.md) |
+| Contributing | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
+
+## Häufige Fragen
+
+**Ersetzt Skylos Bandit, Semgrep, CodeQL oder Vulture?**
+
+Nein. Skylos kann parallel zu diesen Tools laufen. Der Fokus liegt auf
+framework-aware Dead-Code-Signal, PR-Gating, AI-era Regression Checks und einem
+kombinierten Workflow für Dead Code, Security, Secrets und Quality.
+
+**Benötigt Skylos ein LLM?**
+
+Nein. Die Kernanalyse läuft lokal ohne API Keys. LLM-Funktionen sind optional
+über `skylos[llm]` und Agent-Befehle.
+
+**Kann ich nur geänderten Code prüfen?**
+
+Ja. Lokal mit `skylos . -a --diff origin/main` oder in CI-Gates, die auf neue
+Findings fokussieren.
+
+**Wie gehe ich mit absichtlich dynamischem Code um?**
+
+Nutze Baselines, Whitelists, Inline-Suppressions oder Runtime-Tracing. Siehe
+[configuration docs](https://docs.skylos.dev/configuration) und
+[smart tracing docs](https://docs.skylos.dev/smart-tracing).
+
+## Mitwirken und Support
+
+- Sicherheitsprobleme über [SECURITY.md](../../SECURITY.md) melden.
+- Bugs und False Positives mit minimaler Reproduktion öffnen.
+- [ROADMAP.md](../../ROADMAP.md) für sinnvolle Contribution-Bereiche prüfen.
+- Vor Pull Requests [CONTRIBUTING.md](../../CONTRIBUTING.md) lesen.
+- [QUALITY.md](../../QUALITY.md) beschreibt Qualitäts- und Gate-Erwartungen.
+- Für Community-Support dem [Discord](https://discord.gg/Ftn9t9tErf) beitreten.
+
+## Lizenz
+
+Skylos steht unter der [Apache License 2.0](../../LICENSE).
+
+<!-- mcp-name: io.github.duriantaco/skylos -->

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -1,0 +1,23 @@
+# Skylos Translations
+
+The root [README](../../README.md) stays English-first. Translated READMEs live
+in this directory so the repository root stays focused.
+
+## Available
+
+| Language | File |
+|:---|:---|
+| English | [README.md](../../README.md) |
+| German | [README.de.md](./README.de.md) |
+| Simplified Chinese | [README.zh-CN.md](./README.zh-CN.md) |
+
+## Maintenance
+
+When the English README changes materially, keep these sections aligned in each
+translation:
+
+- product description and first-run commands
+- common workflows
+- language support
+- benchmark snapshot counts
+- links to root docs and policies

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -1,32 +1,30 @@
 <div align="center">
-    <img src="assets/DOG_1.png" alt="Skylos 开源 Python SAST、死代码检测、AI 代码安全和 CI/CD PR 门控" width="260">
-    <h1>Skylos：开源 Python SAST、死代码检测和 AI 代码安全</h1>
-    <h3>在代码进入 main 之前，发现无用代码、硬编码密钥、可利用的数据流和 AI 生成的安全回归。</h3>
+    <img src="../../assets/DOG_1.png" alt="Skylos" width="260">
+    <h1>Skylos</h1>
+    <h3>开源、本地优先，在代码合并前检查死代码、安全问题、密钥、质量回归和 AI 代码错误。</h3>
 </div>
 
 ![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
-![CI/CD Ready](https://img.shields.io/badge/CI%2FCD-30s%20Setup-brightgreen?style=flat&logo=github-actions&logoColor=white)
 [![codecov](https://codecov.io/gh/duriantaco/skylos/branch/main/graph/badge.svg)](https://codecov.io/gh/duriantaco/skylos)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/skylos)
 [![PyPI version](https://img.shields.io/pypi/v/skylos)](https://pypi.org/project/skylos/)
-[![Downloads/month](https://img.shields.io/pypi/dm/skylos)](https://pypistats.org/packages/skylos)
 ![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/oha.skylos-vscode-extension)
-[![GitHub stars](https://img.shields.io/github/stars/duriantaco/skylos)](https://github.com/duriantaco/skylos/stargazers)
+[![Astronomer Trust](https://img.shields.io/badge/Astronomer%20Trust-A-brightgreen?style=flat&logo=github&logoColor=white)](#star-authenticity-audit)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/Ftn9t9tErf)
 
 [官网](https://skylos.dev) |
 [文档](https://docs.skylos.dev) |
 [快速开始](https://docs.skylos.dev/quick-start) |
-[GitHub Action](./action.yml) |
-[VS Code 扩展](./editors/vscode/README.md) |
-[基准测试](./BENCHMARK.md) |
-[贡献指南](./CONTRIBUTING.md)
+[GitHub Action](../../action.yml) |
+[VS Code 扩展](../../editors/vscode/README.md) |
+[基准测试](../../BENCHMARK.md) |
+[贡献指南](../../CONTRIBUTING.md)
 
-[English](./README.md) | **中文**
+[English](../../README.md) | [Deutsch](./README.de.md) | **简体中文** | [其他翻译](./README.md)
 
 ## Skylos 是什么？
 
-Skylos 是一款面向 Python、TypeScript、JavaScript、Java、Go、PHP、Rust 和 Dart 仓库的开源静态分析工具与 CI/CD PR 门控。它把死代码检测、安全扫描、密钥检测、代码质量检查和 AI 生成代码防护整合进一个本地优先的工作流。
+Skylos 是一款面向 Python、TypeScript、JavaScript、Java、Go、PHP、Rust、Dart 和 C# 仓库的开源静态分析 CLI。它默认在本地运行，也可以作为 CI/CD PR 门控使用。
 
 如果你使用 Vulture 检测死代码、Bandit 做安全检查，或使用 Semgrep、CodeQL、GitHub Advanced Security 做 CI 门控，Skylos 可以作为补充：它更关注框架感知的死代码检测、差异感知的回归检查，以及适合 PR 审查的反馈。
 
@@ -61,8 +59,8 @@ git push
 | 第一次死代码扫描 | `skylos .` | 发现未使用的函数、类、导入、文件和框架入口点问题 | [死代码文档](https://docs.skylos.dev/dead-code-detection) |
 | 安全与质量审计 | `skylos . -a` | 增加危险数据流、密钥、依赖和质量检查 | [安全文档](https://docs.skylos.dev/security-analysis) |
 | PR 门控 | `skylos cicd init` | 生成带注释和失败阈值的 GitHub Actions 工作流 | [CI/CD 指南](https://docs.skylos.dev/ci-cd) |
-| 更易读的终端报告 | `skylos . --format pretty` | 按文件分组展示发现，包含严重级别标记、代码片段和可复制的 `file:line` 位置 | [CLI Output Modes](./docs/cli-output.md) |
-| 可选择的终端界面 | `skylos . --tui` | 打开键盘驱动的分类列表、发现列表和详情面板 | [CLI Output Modes](./docs/cli-output.md) |
+| 更易读的终端报告 | `skylos . --format pretty` | 按文件分组展示发现，包含严重级别标记、代码片段和可复制的 `file:line` 位置 | [CLI Output Modes](../cli-output.md) |
+| 可选择的终端界面 | `skylos . --tui` | 打开键盘驱动的分类列表、发现列表和详情面板 | [CLI Output Modes](../cli-output.md) |
 | 只审查变更行 | `skylos . -a --diff origin/main` | 聚焦当前 PR，避免被历史债务淹没 | [质量门控](https://docs.skylos.dev/quality-gate) |
 | 运行时辅助死代码检测 | `skylos . --trace` | 用测试运行轨迹降低动态代码误报 | [Smart Tracing](https://docs.skylos.dev/smart-tracing) |
 | AI 辅助审查 | `skylos agent scan .` | 静态分析加可选 LLM 审查和修复建议 | [AI Features](https://docs.skylos.dev/ai-features) |
@@ -123,6 +121,7 @@ docker run --rm -v "$PWD":/work -w /work ghcr.io/duriantaco/skylos:latest . --js
 | PHP | 是 | 是 | 部分 | PHP parser 覆盖，加上污点式安全 sinks 和 sources |
 | Rust | 是 | 是 | 部分 | Rust parser 覆盖，加上安全 sinks 和 sources |
 | Dart | 是 | 是 | 部分 | Dart parser 覆盖，加上部分安全 sinks 和 sources |
+| C# | 是 | 是 | 部分 | C# 符号覆盖，加上部分 ASP.NET、process、SQL、HTTP 和文件 sinks |
 
 规则族和扫描范围请看 [Rules Reference](https://docs.skylos.dev/rules-reference)。
 
@@ -133,8 +132,8 @@ Skylos 有已提交的死代码、安全、质量和 Agent 审查回归基准。
 | 套件 | 当前 Skylos 结果 | 基线 |
 |:---|:---|:---|
 | 死代码回归 | 16 cases, TP=36 FP=0 FN=0 TN=59, score 100.0 | Ruff score 62.67；最新本地重跑未安装 Vulture |
-| 安全回归 | 20 cases, TP=11 FP=0 FN=0 TN=10, score 100.0 | Bandit 在 Python 适用 cases 上 score 47.14 |
-| 质量回归 | 6 cases, score 100.0 | 仅作为回归门控 |
+| 安全回归 | 49 cases, TP=30 FP=0 FN=0 TN=21, score 100.0 | Bandit 在 Python 适用 cases 上 score 47.14 |
+| 质量回归 | 13 cases, score 100.0 | 仅作为回归门控 |
 | Agent 审查 | 25 cases, score 100.0 | 仅作为回归门控 |
 
 冻结的 `golden-v0.2` 重点结果：
@@ -146,14 +145,31 @@ Skylos 有已提交的死代码、安全、质量和 Agent 审查回归基准。
 | OWASP Java security dev | TP=105 FP=0 FN=15 TN=120, score 94.37 | request-wrapper、LDAP、XPath、property weak-hash 仍有缺口 |
 | Quality seeded dev | TP=1 FP=0 FN=0 TN=1, score 100.0 | 目前只有一个 seeded case |
 
-方法论、命令、竞品行和 caveats 请看 [BENCHMARK.md](./BENCHMARK.md)。
+方法论、命令、竞品行和 caveats 请看 [BENCHMARK.md](../../BENCHMARK.md)。
+
+## 项目证据
+
+Skylos 辅助的死代码清理 PR 已被
+[Black](https://github.com/psf/black/pull/5041)、
+[NetworkX](https://github.com/networkx/networkx/pull/8572)、
+[Optuna](https://github.com/optuna/optuna/pull/6547)、
+[mitmproxy](https://github.com/mitmproxy/mitmproxy/pull/8136)、
+[pypdf](https://github.com/py-pdf/pypdf/pull/3685)、
+[beets](https://github.com/beetbox/beets/pull/6473) 和
+[Flagsmith](https://github.com/Flagsmith/flagsmith/pull/6953) 合并。这些是已被接受的清理 PR，不代表相关项目背书。详见
+[Real-World Results](../../REAL_WORLD_RESULTS.md)。
+
+<a id="star-authenticity-audit"></a>
+
+2026 年 4 月 26 日，本地 Astronomer 扫描统计 420 个 stargazer，返回
+**overall trust: A**。StarGuard 同时报告 **low fake-star risk**。
 
 ## 集成
 
 | 集成 | 链接 | 用途 |
 |:---|:---|:---|
-| GitHub Action | [GitHub Action](./action.yml) | PR 门控、注释和 CI 执行 |
-| VS Code 扩展 | [VS Code extension](./editors/vscode/README.md) | 编辑器内发现和 AI 辅助修复 |
+| GitHub Action | [GitHub Action](../../action.yml) | PR 门控、注释和 CI 执行 |
+| VS Code 扩展 | [VS Code extension](../../editors/vscode/README.md) | 编辑器内发现和 AI 辅助修复 |
 | MCP server | [MCP setup](https://docs.skylos.dev/mcp-server) | 将 Skylos 扫描暴露给 AI Agent 和编码助手 |
 | Docker image | [Installation](https://docs.skylos.dev/installation) | 无需本地 Python 安装即可运行 Skylos |
 | Skylos Cloud | [Cloud workflow](https://docs.skylos.dev/cloud-workflow) | 可选上传和仪表盘工作流 |
@@ -165,11 +181,11 @@ Skylos 有已提交的死代码、安全、质量和 Agent 审查回归基准。
 | 安装、源码安装和 Docker | [Installation](https://docs.skylos.dev/installation) |
 | 第一次扫描和核心工作流 | [Quick Start](https://docs.skylos.dev/quick-start) |
 | CLI 命令、flags 和示例 | [CLI Reference](https://docs.skylos.dev/cli-reference) |
-| CLI 输出模式、pretty 报告和 TUI 快捷键 | [CLI Output Modes](./docs/cli-output.md) |
+| CLI 输出模式、pretty 报告和 TUI 快捷键 | [CLI Output Modes](../cli-output.md) |
 | CI 设置、PR 门控、注释和分支保护 | [CI/CD](https://docs.skylos.dev/ci-cd) |
 | 死代码行为和框架感知 | [Dead Code Detection](https://docs.skylos.dev/dead-code-detection) |
 | 安全扫描和污点分析 | [Security Analysis](https://docs.skylos.dev/security-analysis) |
-| Rule ID 前缀和产品术语 | [Rule Dictionary](./dictionary.md) |
+| Rule ID 前缀和产品术语 | [Rule Dictionary](../../dictionary.md) |
 | Agent 扫描、验证、修复和模型设置 | [AI Features](https://docs.skylos.dev/ai-features) |
 | AI 防御和 LLM guardrails | [AI Defense](https://docs.skylos.dev/ai-defense) |
 | MCP server 设置 | [MCP Server](https://docs.skylos.dev/mcp-server) |
@@ -178,10 +194,10 @@ Skylos 有已提交的死代码、安全、质量和 Agent 审查回归基准。
 | 规则族和语言支持 | [Rules Reference](https://docs.skylos.dev/rules-reference) |
 | 云端上传和仪表盘流程 | [CLI to Dashboard](https://docs.skylos.dev/cloud-workflow) |
 | VS Code 扩展 | [VS Code Extension](https://docs.skylos.dev/vscode) |
-| 基准测试和方法论 | [BENCHMARK.md](./BENCHMARK.md) |
-| 安全政策 | [SECURITY.md](./SECURITY.md) |
-| 发布流程 | [RELEASE_WORKFLOW.md](./RELEASE_WORKFLOW.md) |
-| 贡献 | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| 基准测试和方法论 | [BENCHMARK.md](../../BENCHMARK.md) |
+| 安全政策 | [SECURITY.md](../../SECURITY.md) |
+| 发布流程 | [RELEASE_WORKFLOW.md](../../RELEASE_WORKFLOW.md) |
+| 贡献 | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
 ## 常见问题
 
@@ -203,14 +219,14 @@ Skylos 有已提交的死代码、安全、质量和 Agent 审查回归基准。
 
 ## 贡献与支持
 
-- 安全问题请通过 [SECURITY.md](./SECURITY.md) 报告。
+- 安全问题请通过 [SECURITY.md](../../SECURITY.md) 报告。
 - Bug 和误报请附带最小复现。
-- 发送 PR 前请阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)。
-- 项目质量和门控要求请看 [QUALITY.md](./QUALITY.md)。
+- 发送 PR 前请阅读 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
+- 项目质量和门控要求请看 [QUALITY.md](../../QUALITY.md)。
 - 社区支持请加入 [Discord](https://discord.gg/Ftn9t9tErf)。
 
 ## 许可证
 
-Skylos 使用 [Apache License 2.0](./LICENSE)。
+Skylos 使用 [Apache License 2.0](../../LICENSE)。
 
 <!-- mcp-name: io.github.duriantaco/skylos -->


### PR DESCRIPTION
## Summary

  - Move the Simplified Chinese README from the repository root to `docs/i18n/README.zh-CN.md`.
  - Add a German README at `docs/i18n/README.de.md`.
  - Add `docs/i18n/README.md` as the translation index.
  - Update the root README language links to point to the translation directory.
  - Update `dictionary.md` to reference translated READMEs under `docs/i18n/`.

## Tests
N/A
