### PR TITLE
chore(docs): refresh repo map

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>647</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5355</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>5356</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -942,7 +942,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 90</span>
-          <span class="pill"><strong>lines</strong> 3414</span>
+          <span class="pill"><strong>lines</strong> 3420</span>
         </div>
       </div>
       <p>Benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.</p>
@@ -957,9 +957,9 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1084 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>751 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>754 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>515 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>518 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">skylos/benchmarks/demo_deadcode.py</a> <span>172 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/__init__.py" rel="noopener noreferrer">skylos/benchmarks/__init__.py</a> <span>2 lines</span></li></ul>
@@ -971,11 +971,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L130" rel="noopener noreferrer">load_manifest:130</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L134" rel="noopener noreferrer">load_external_targets:134</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L306" rel="noopener noreferrer">validate_manifest:306</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L83" rel="noopener noreferrer">SecurityBenchmarkFailure:83</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">load_manifest:102</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L106" rel="noopener noreferrer">validate_manifest:106</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L514" rel="noopener noreferrer">run_case:514</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L601" rel="noopener noreferrer">run_manifest:601</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L86" rel="noopener noreferrer">SecurityBenchmarkFailure:86</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L105" rel="noopener noreferrer">load_manifest:105</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L109" rel="noopener noreferrer">validate_manifest:109</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L517" rel="noopener noreferrer">run_case:517</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L604" rel="noopener noreferrer">run_manifest:604</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a> <span>def</span></li>
@@ -1896,8 +1896,8 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 37</span>
-          <span class="pill"><strong>symbols</strong> 308</span>
-          <span class="pill"><strong>lines</strong> 17623</span>
+          <span class="pill"><strong>symbols</strong> 309</span>
+          <span class="pill"><strong>lines</strong> 17666</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1912,7 +1912,7 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a> <span>1846 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a> <span>1590 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a> <span>1594 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py" rel="noopener noreferrer">skylos/visitors/base.py</a> <span>2316 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a> <span>1377 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/flow.py" rel="noopener noreferrer">skylos/visitors/languages/java/flow.py</a> <span>1997 lines</span></li>
@@ -1986,7 +1986,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 191</span>
           <span class="pill"><strong>symbols</strong> 2298</span>
-          <span class="pill"><strong>lines</strong> 78026</span>
+          <span class="pill"><strong>lines</strong> 78068</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2145,7 +2145,7 @@
 
             <tr class="searchable" data-search="skylos/visitors/languages/typescript/danger.py ast/tree visitors that collect findings and semantic evidence.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a></td>
-              <td>1590</td>
+              <td>1594</td>
               <td>1 / 44</td>
               <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
               <td>AST/tree visitors that collect findings and semantic evidence.</td>
@@ -5318,84 +5318,84 @@
             </tr>
 
             <tr class="searchable" data-search="qualitybenchmarkfailure class skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L44" rel="noopener noreferrer">QualityBenchmarkFailure:44</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L47" rel="noopener noreferrer">QualityBenchmarkFailure:47</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L63" rel="noopener noreferrer">load_manifest:63</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L66" rel="noopener noreferrer">load_manifest:66</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L68" rel="noopener noreferrer">validate_manifest:68</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L71" rel="noopener noreferrer">validate_manifest:71</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L330" rel="noopener noreferrer">run_case:330</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L333" rel="noopener noreferrer">run_case:333</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L392" rel="noopener noreferrer">run_manifest:392</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L395" rel="noopener noreferrer">run_manifest:395</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L477" rel="noopener noreferrer">format_summary:477</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L480" rel="noopener noreferrer">format_summary:480</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="securitybenchmarkfailure class skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L83" rel="noopener noreferrer">SecurityBenchmarkFailure:83</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L86" rel="noopener noreferrer">SecurityBenchmarkFailure:86</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L102" rel="noopener noreferrer">load_manifest:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L105" rel="noopener noreferrer">load_manifest:105</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L106" rel="noopener noreferrer">validate_manifest:106</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L109" rel="noopener noreferrer">validate_manifest:109</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L514" rel="noopener noreferrer">run_case:514</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L517" rel="noopener noreferrer">run_case:517</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L601" rel="noopener noreferrer">run_manifest:601</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L604" rel="noopener noreferrer">run_manifest:604</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L693" rel="noopener noreferrer">format_summary:693</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L696" rel="noopener noreferrer">format_summary:696</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>


### PR DESCRIPTION
## Summary

  - Refresh generated `docs/repo-map/index.html` after the translated README reorganization.
  - Updates repo-map counts, line references, and generated ownership metadata.