### PR TITLE
feat(shell): add shell security scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 ## What Is Skylos?
 
 Skylos is an open-source static analysis CLI for Python, TypeScript,
-JavaScript, Java, Go, PHP, Rust, Dart, and C# repositories. It runs locally by
-default and can also be used as a CI/CD PR gate.
+JavaScript, Java, Go, PHP, Rust, Dart, C#, and Shell repositories. It runs
+locally by default and can also be used as a CI/CD PR gate.
 
 Use Skylos when you want one command to check a repo or pull request for:
 
@@ -190,6 +190,7 @@ credential names, sensitive files, and network calls that must set timeouts.
 | Rust | Yes | Yes | Partial | Rust parser coverage plus security sink/source checks |
 | Dart | Yes | Yes | Partial | Dart parser coverage plus selected security sinks and sources |
 | C# | Yes | Yes | Partial | C# symbol coverage plus selected ASP.NET, process, SQL, HTTP, and file sinks |
+| Shell | No | Yes | Partial | shell-script security checks for command injection, SSRF, and path traversal |
 
 See [Rules Reference](https://docs.skylos.dev/rules-reference) for rule families
 and scanner scope.
@@ -203,7 +204,7 @@ tool is universally state of the art.
 | Suite | Current Skylos Result | Baseline |
 |:---|:---|:---|
 | Dead code regression | 16 cases, TP=36 FP=0 FN=0 TN=59, score 100.0 | Ruff score 62.67; Vulture not installed in latest local rerun |
-| Security regression | 49 cases, TP=30 FP=0 FN=0 TN=21, score 100.0 | Bandit score 47.14 on Python-applicable cases |
+| Security regression | 56 cases, TP=35 FP=0 FN=0 TN=23, score 100.0 | Bandit score 47.14 on Python-applicable cases |
 | Quality regression | 13 cases, score 100.0 | regression gate only |
 | Agent review | 25 cases, score 100.0 | regression gate only |
 

--- a/benchmarks/security/fixtures/shell_basename_safe/read.sh
+++ b/benchmarks/security/fixtures/shell_basename_safe/read.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+backup_name="$(basename -- "$1")"
+cat "/srv/backups/$backup_name"

--- a/benchmarks/security/fixtures/shell_c_flag_arg/run.sh
+++ b/benchmarks/security/fixtures/shell_c_flag_arg/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+task="$1"
+bash -c "$task"

--- a/benchmarks/security/fixtures/shell_curl_fixed_host_path/fetch.sh
+++ b/benchmarks/security/fixtures/shell_curl_fixed_host_path/fetch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact="$1"
+curl -fsSL "https://downloads.example.com/releases/$artifact"

--- a/benchmarks/security/fixtures/shell_curl_tainted_url/fetch.sh
+++ b/benchmarks/security/fixtures/shell_curl_tainted_url/fetch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+read -r url
+curl -fsSL "$url"

--- a/benchmarks/security/fixtures/shell_eval_arg/deploy.sh
+++ b/benchmarks/security/fixtures/shell_eval_arg/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="$1"
+eval "$cmd"

--- a/benchmarks/security/fixtures/shell_path_read_arg/read.sh
+++ b/benchmarks/security/fixtures/shell_path_read_arg/read.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+backup_name="$1"
+cat "/srv/backups/$backup_name"

--- a/benchmarks/security/fixtures/shell_source_arg/run.sh
+++ b/benchmarks/security/fixtures/shell_source_arg/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin="$1"
+source "$plugin"

--- a/benchmarks/security/manifest.json
+++ b/benchmarks/security/manifest.json
@@ -1064,6 +1064,160 @@
         },
         "absent": {}
       }
+    },
+    {
+      "id": "shell-eval-arg",
+      "path": "fixtures/shell_eval_arg",
+      "description": "Shell positional argument assigned to a command and passed to eval should be reported as command injection.",
+      "languages": ["shell"],
+      "taxonomy": ["command_injection", "shell"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/koalaman/shellcheck",
+        "license": "GPL-3.0",
+        "notes": "Distilled from shell injection guidance around eval of externally controlled input."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D212"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "shell-source-arg",
+      "path": "fixtures/shell_source_arg",
+      "description": "Shell source of a positional-argument path should be reported because the sourced file executes in-process.",
+      "languages": ["shell"],
+      "taxonomy": ["command_injection", "shell"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/koalaman/shellcheck",
+        "license": "GPL-3.0",
+        "notes": "Distilled from dynamic source/include patterns that execute attacker-selected shell code."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D212"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "shell-c-flag-arg",
+      "path": "fixtures/shell_c_flag_arg",
+      "description": "Shell command string passed to bash -c from a positional argument should be reported.",
+      "languages": ["shell"],
+      "taxonomy": ["command_injection", "shell"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/OWASP/CheatSheetSeries",
+        "license": "CC-BY-SA-4.0",
+        "notes": "Distilled from OS command injection guidance around shell interpreters and command strings."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D212"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "shell-curl-tainted-url",
+      "path": "fixtures/shell_curl_tainted_url",
+      "description": "Shell read input passed as a curl URL should be reported as SSRF.",
+      "languages": ["shell"],
+      "taxonomy": ["ssrf", "shell"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/OWASP/CheatSheetSeries",
+        "license": "CC-BY-SA-4.0",
+        "notes": "Distilled from SSRF guidance around complete user-controlled URLs."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D216"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "shell-curl-fixed-host-path",
+      "path": "fixtures/shell_curl_fixed_host_path",
+      "description": "Shell curl to a fixed host with only the path segment tainted should stay quiet for SSRF.",
+      "languages": ["shell"],
+      "taxonomy": ["ssrf", "shell", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/OWASP/CheatSheetSeries",
+        "license": "CC-BY-SA-4.0",
+        "notes": "Distilled precision guard for fixed-destination requests with attacker-controlled path data."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D216"]
+        }
+      }
+    },
+    {
+      "id": "shell-path-read-arg",
+      "path": "fixtures/shell_path_read_arg",
+      "description": "Shell positional argument interpolated into a filesystem path should be reported as path traversal.",
+      "languages": ["shell"],
+      "taxonomy": ["path_traversal", "shell"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/OWASP/CheatSheetSeries",
+        "license": "CC-BY-SA-4.0",
+        "notes": "Distilled from path traversal guidance around joining untrusted file names to fixed directories."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {
+          "danger": ["SKY-D215"]
+        },
+        "absent": {}
+      }
+    },
+    {
+      "id": "shell-basename-safe",
+      "path": "fixtures/shell_basename_safe",
+      "description": "Shell positional argument reduced with basename before fixed-directory file access should stay quiet for path traversal.",
+      "languages": ["shell"],
+      "taxonomy": ["path_traversal", "shell", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/OWASP/CheatSheetSeries",
+        "license": "CC-BY-SA-4.0",
+        "notes": "Distilled precision guard for basename-style shell path sanitization."
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "present": {},
+        "absent": {
+          "danger": ["SKY-D215"]
+        }
+      }
     }
   ]
 }

--- a/dictionary.md
+++ b/dictionary.md
@@ -87,10 +87,10 @@ Rule IDs are unified across languages where the same vulnerability exists.
 | D209 | HIGH | `subprocess` with `shell=True` | Python | CWE-78 / A03 |
 | D210 | HIGH | TLS verification disabled | Python, Go | A02 |
 | D211 | CRITICAL | SQL injection | Python, TS/JS, Go, Java, PHP, audit | CWE-89 / A03 |
-| D212 | CRITICAL | Command injection | Python, TS/JS, Go, Java, Rust, Dart, audit | CWE-78 / A03 |
+| D212 | CRITICAL | Command injection | Python, TS/JS, Go, Java, Rust, Dart, Shell, audit | CWE-78 / A03 |
 | D214 | HIGH | Broken access control | Python | A01 |
-| D215 | HIGH | Path traversal and archive extraction traversal | Python, TS/JS, Go, Java, PHP, Rust, Dart | CWE-22 / A01 |
-| D216 | CRITICAL | Server-side request forgery | Python, TS/JS, Go, Java, Dart, audit | CWE-918 / A10 |
+| D215 | HIGH | Path traversal and archive extraction traversal | Python, TS/JS, Go, Java, PHP, Rust, Dart, Shell | CWE-22 / A01 |
+| D216 | CRITICAL | Server-side request forgery | Python, TS/JS, Go, Java, Dart, Shell, audit | CWE-918 / A10 |
 | D217 | CRITICAL | Raw SQL / ORM SQL injection | Python | CWE-89 / A03 |
 | D220 | CRITICAL | SQL injection in added code / diff validation | MCP code-change validator | CWE-89 / A03 |
 | D222 | MEDIUM | Dependency hallucination | Python | AI supply-chain |

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -28,8 +28,9 @@
 ## Was ist Skylos?
 
 Skylos ist eine Open-Source-CLI für statische Analyse in Python-, TypeScript-,
-JavaScript-, Java-, Go-, PHP-, Rust-, Dart- und C#-Repositories. Skylos läuft
-standardmäßig lokal und kann auch als CI/CD-PR-Gate verwendet werden.
+JavaScript-, Java-, Go-, PHP-, Rust-, Dart-, C#- und Shell-Repositories.
+Skylos läuft standardmäßig lokal und kann auch als CI/CD-PR-Gate verwendet
+werden.
 
 Nutze Skylos, wenn du mit einem Befehl ein Repository oder einen Pull Request
 prüfen möchtest auf:
@@ -196,6 +197,7 @@ Timeout-Pflicht beizubringen.
 | Rust | Ja | Ja | Teilweise | Rust-Parser-Abdeckung plus Security-Sink/Source-Prüfungen |
 | Dart | Ja | Ja | Teilweise | Dart-Parser-Abdeckung plus ausgewählte Security-Sinks und -Sources |
 | C# | Ja | Ja | Teilweise | C#-Symbolabdeckung plus ausgewählte ASP.NET-, Process-, SQL-, HTTP- und File-Sinks |
+| Shell | Nein | Ja | Teilweise | Shell-Script-Security-Prüfungen für Command Injection, SSRF und Path Traversal |
 
 Regelfamilien und Scanner-Scope stehen in der
 [Rules Reference](https://docs.skylos.dev/rules-reference).
@@ -209,7 +211,7 @@ dass ein Tool in jeder Situation State of the Art ist.
 | Suite | Aktuelles Skylos-Ergebnis | Baseline |
 |:---|:---|:---|
 | Dead-code regression | 16 cases, TP=36 FP=0 FN=0 TN=59, score 100.0 | Ruff score 62.67; Vulture im letzten lokalen Rerun nicht installiert |
-| Security regression | 49 cases, TP=30 FP=0 FN=0 TN=21, score 100.0 | Bandit score 47.14 auf Python-anwendbaren Cases |
+| Security regression | 56 cases, TP=35 FP=0 FN=0 TN=23, score 100.0 | Bandit score 47.14 auf Python-anwendbaren Cases |
 | Quality regression | 13 cases, score 100.0 | nur Regression-Gate |
 | Agent review | 25 cases, score 100.0 | nur Regression-Gate |
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -24,7 +24,7 @@
 
 ## Skylos 是什么？
 
-Skylos 是一款面向 Python、TypeScript、JavaScript、Java、Go、PHP、Rust、Dart 和 C# 仓库的开源静态分析 CLI。它默认在本地运行，也可以作为 CI/CD PR 门控使用。
+Skylos 是一款面向 Python、TypeScript、JavaScript、Java、Go、PHP、Rust、Dart、C# 和 Shell 仓库的开源静态分析 CLI。它默认在本地运行，也可以作为 CI/CD PR 门控使用。
 
 如果你使用 Vulture 检测死代码、Bandit 做安全检查，或使用 Semgrep、CodeQL、GitHub Advanced Security 做 CI 门控，Skylos 可以作为补充：它更关注框架感知的死代码检测、差异感知的回归检查，以及适合 PR 审查的反馈。
 
@@ -122,6 +122,7 @@ docker run --rm -v "$PWD":/work -w /work ghcr.io/duriantaco/skylos:latest . --js
 | Rust | 是 | 是 | 部分 | Rust parser 覆盖，加上安全 sinks 和 sources |
 | Dart | 是 | 是 | 部分 | Dart parser 覆盖，加上部分安全 sinks 和 sources |
 | C# | 是 | 是 | 部分 | C# 符号覆盖，加上部分 ASP.NET、process、SQL、HTTP 和文件 sinks |
+| Shell | 否 | 是 | 部分 | shell 脚本安全检查，覆盖命令注入、SSRF 和路径穿越 |
 
 规则族和扫描范围请看 [Rules Reference](https://docs.skylos.dev/rules-reference)。
 
@@ -132,7 +133,7 @@ Skylos 有已提交的死代码、安全、质量和 Agent 审查回归基准。
 | 套件 | 当前 Skylos 结果 | 基线 |
 |:---|:---|:---|
 | 死代码回归 | 16 cases, TP=36 FP=0 FN=0 TN=59, score 100.0 | Ruff score 62.67；最新本地重跑未安装 Vulture |
-| 安全回归 | 49 cases, TP=30 FP=0 FN=0 TN=21, score 100.0 | Bandit 在 Python 适用 cases 上 score 47.14 |
+| 安全回归 | 56 cases, TP=35 FP=0 FN=0 TN=23, score 100.0 | Bandit 在 Python 适用 cases 上 score 47.14 |
 | 质量回归 | 13 cases, score 100.0 | 仅作为回归门控 |
 | Agent 审查 | 25 cases, score 100.0 | 仅作为回归门控 |
 

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>647</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5356</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>650</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>5395</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -658,7 +658,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 250</span>
-          <span class="pill"><strong>lines</strong> 11121</span>
+          <span class="pill"><strong>lines</strong> 11144</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -673,7 +673,7 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <span>5492 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <span>3755 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <span>3778 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <span>989 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <span>616 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">skylos/constants.py</a> <span>229 lines</span></li>
@@ -686,11 +686,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L123" rel="noopener noreferrer">comment_out_unused_import_cst:123</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">comment_out_unused_function_cst:127</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L131" rel="noopener noreferrer">run_analyze:131</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L461" rel="noopener noreferrer">Skylos:461</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3046" rel="noopener noreferrer">proc_file:3046</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3563" rel="noopener noreferrer">analyze:3563</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L150" rel="noopener noreferrer">_entrypoint_module_name:150</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L157" rel="noopener noreferrer">_architecture_iad_strict:157</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L463" rel="noopener noreferrer">Skylos:463</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3059" rel="noopener noreferrer">proc_file:3059</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3586" rel="noopener noreferrer">analyze:3586</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L152" rel="noopener noreferrer">_entrypoint_module_name:152</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L159" rel="noopener noreferrer">_architecture_iad_strict:159</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L306" rel="noopener noreferrer">run_static_on_files:306</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L400" rel="noopener noreferrer">run_pipeline:400</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L77" rel="noopener noreferrer">_enrich_with_llm_suggestions:77</a> <span>def</span></li>
@@ -942,7 +942,7 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 90</span>
-          <span class="pill"><strong>lines</strong> 3420</span>
+          <span class="pill"><strong>lines</strong> 3422</span>
         </div>
       </div>
       <p>Benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.</p>
@@ -957,7 +957,7 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1084 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>754 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>756 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>518 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
@@ -971,11 +971,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L130" rel="noopener noreferrer">load_manifest:130</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L134" rel="noopener noreferrer">load_external_targets:134</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L306" rel="noopener noreferrer">validate_manifest:306</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L86" rel="noopener noreferrer">SecurityBenchmarkFailure:86</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L105" rel="noopener noreferrer">load_manifest:105</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L109" rel="noopener noreferrer">validate_manifest:109</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L517" rel="noopener noreferrer">run_case:517</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L604" rel="noopener noreferrer">run_manifest:604</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L88" rel="noopener noreferrer">SecurityBenchmarkFailure:88</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L107" rel="noopener noreferrer">load_manifest:107</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L111" rel="noopener noreferrer">validate_manifest:111</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L519" rel="noopener noreferrer">run_case:519</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L606" rel="noopener noreferrer">run_manifest:606</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a> <span>def</span></li>
@@ -1891,13 +1891,13 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/danger.py skylos/visitors/base.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/java/flow.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/typescript/resolve.py skylos/visitors/languages/typescript/core.py">
+    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/danger.py skylos/visitors/base.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/java/flow.py skylos/visitors/languages/shell/danger.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/typescript/resolve.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 37</span>
-          <span class="pill"><strong>symbols</strong> 309</span>
-          <span class="pill"><strong>lines</strong> 17666</span>
+          <span class="pill"><strong>files</strong> 39</span>
+          <span class="pill"><strong>symbols</strong> 336</span>
+          <span class="pill"><strong>lines</strong> 18224</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1916,9 +1916,9 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py" rel="noopener noreferrer">skylos/visitors/base.py</a> <span>2316 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a> <span>1377 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/flow.py" rel="noopener noreferrer">skylos/visitors/languages/java/flow.py</a> <span>1997 lines</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/shell/danger.py" rel="noopener noreferrer">skylos/visitors/languages/shell/danger.py</a> <span>477 lines</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/workspace.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/workspace.py</a> <span>563 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/resolve.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/resolve.py</a> <span>623 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/core.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/core.py</a> <span>742 lines</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/resolve.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/resolve.py</a> <span>623 lines</span></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1984,9 +1984,9 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 191</span>
-          <span class="pill"><strong>symbols</strong> 2298</span>
-          <span class="pill"><strong>lines</strong> 78068</span>
+          <span class="pill"><strong>files</strong> 192</span>
+          <span class="pill"><strong>symbols</strong> 2310</span>
+          <span class="pill"><strong>lines</strong> 78224</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2073,7 +2073,7 @@
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3755</td>
+              <td>3778</td>
               <td>3 / 19</td>
               <td><span class="warn">large</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
@@ -4660,133 +4660,133 @@
             </tr>
 
             <tr class="searchable" data-search="_entrypoint_module_name def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L150" rel="noopener noreferrer">_entrypoint_module_name:150</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L152" rel="noopener noreferrer">_entrypoint_module_name:152</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_architecture_iad_strict def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L157" rel="noopener noreferrer">_architecture_iad_strict:157</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L159" rel="noopener noreferrer">_architecture_iad_strict:159</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_expand_reexported_entrypoint_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L166" rel="noopener noreferrer">_expand_reexported_entrypoint_modules:166</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L168" rel="noopener noreferrer">_expand_reexported_entrypoint_modules:168</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_find_package_boundary_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L196" rel="noopener noreferrer">_find_package_boundary_modules:196</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L198" rel="noopener noreferrer">_find_package_boundary_modules:198</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_set_linter_node_types def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L296" rel="noopener noreferrer">_set_linter_node_types:296</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L298" rel="noopener noreferrer">_set_linter_node_types:298</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L303" rel="noopener noreferrer">_is_secret_config_candidate:303</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L305" rel="noopener noreferrer">_is_secret_config_candidate:305</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_resolve_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L310" rel="noopener noreferrer">_resolve_secret_config_candidate:310</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L312" rel="noopener noreferrer">_resolve_secret_config_candidate:312</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_definition_module_and_class def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L346" rel="noopener noreferrer">_definition_module_and_class:346</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L348" rel="noopener noreferrer">_definition_module_and_class:348</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_resolve_analysis_root def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L356" rel="noopener noreferrer">_resolve_analysis_root:356</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L358" rel="noopener noreferrer">_resolve_analysis_root:358</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_grep_verify_rescue_priority def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L393" rel="noopener noreferrer">_grep_verify_rescue_priority:393</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L395" rel="noopener noreferrer">_grep_verify_rescue_priority:395</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_confidence_as_unit_interval def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L404" rel="noopener noreferrer">_confidence_as_unit_interval:404</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L406" rel="noopener noreferrer">_confidence_as_unit_interval:406</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_implicit_ref_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L414" rel="noopener noreferrer">_implicit_ref_evidence_marker:414</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L416" rel="noopener noreferrer">_implicit_ref_evidence_marker:416</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_mark_evidence_ref def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L428" rel="noopener noreferrer">_mark_evidence_ref:428</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L430" rel="noopener noreferrer">_mark_evidence_ref:430</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_has_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L435" rel="noopener noreferrer">_has_evidence_marker:435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L437" rel="noopener noreferrer">_has_evidence_marker:437</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_annotate_dead_code_evidence_sources def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L442" rel="noopener noreferrer">_annotate_dead_code_evidence_sources:442</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L444" rel="noopener noreferrer">_annotate_dead_code_evidence_sources:444</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="skylos class skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L461" rel="noopener noreferrer">Skylos:461</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L463" rel="noopener noreferrer">Skylos:463</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_truly_empty_or_docstring_only def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3028" rel="noopener noreferrer">_is_truly_empty_or_docstring_only:3028</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3041" rel="noopener noreferrer">_is_truly_empty_or_docstring_only:3041</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="proc_file def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3046" rel="noopener noreferrer">proc_file:3046</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3059" rel="noopener noreferrer">proc_file:3059</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="analyze def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3563" rel="noopener noreferrer">analyze:3563</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3586" rel="noopener noreferrer">analyze:3586</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
@@ -5360,42 +5360,42 @@
             </tr>
 
             <tr class="searchable" data-search="securitybenchmarkfailure class skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L86" rel="noopener noreferrer">SecurityBenchmarkFailure:86</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L88" rel="noopener noreferrer">SecurityBenchmarkFailure:88</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L105" rel="noopener noreferrer">load_manifest:105</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L107" rel="noopener noreferrer">load_manifest:107</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L109" rel="noopener noreferrer">validate_manifest:109</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L111" rel="noopener noreferrer">validate_manifest:111</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L517" rel="noopener noreferrer">run_case:517</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L519" rel="noopener noreferrer">run_case:519</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L604" rel="noopener noreferrer">run_manifest:604</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L606" rel="noopener noreferrer">run_manifest:606</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L696" rel="noopener noreferrer">format_summary:696</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L698" rel="noopener noreferrer">format_summary:698</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "skylos"
 version = "4.19.0"
 requires-python = ">=3.10"
-description = "Open-source, local-first static analysis and PR gates for Python, TypeScript/JavaScript, Go, Java, PHP, Rust, Dart, and C#. Finds dead code, security issues, secrets, quality regressions, and AI-code mistakes."
+description = "Open-source, local-first static analysis and PR gates for Python, TypeScript/JavaScript, Go, Java, PHP, Rust, Dart, C#, and Shell. Finds dead code, security issues, secrets, quality regressions, and AI-code mistakes."
 authors = [{name = "Aaron Oh", email = "aaronoh2015@gmail.com"}]
 readme = "README.md"
 license = "Apache-2.0"
@@ -31,6 +31,7 @@ keywords = [
     "github-actions-security",
     "gitlab-ci",
     "gitlab-ci-security",
+    "shell-security",
     "supply-chain-security",
     "code-review",
     "secrets-detection",

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -26,6 +26,7 @@ from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.languages.php import scan_php_file
 from skylos.visitors.languages.dart import scan_dart_file
+from skylos.visitors.languages.shell import SHELL_SOURCE_EXTS, scan_shell_file
 from skylos.visitors.languages.typescript import scan_typescript_file
 from skylos.visitors.languages.typescript.analysis import (
     build_ts_import_graph,
@@ -142,6 +143,7 @@ _PHP_SOURCE_EXTS = (".php",)
 _RUST_SOURCE_EXTS = (".rs",)
 _DART_SOURCE_EXTS = (".dart",)
 _CSHARP_SOURCE_EXTS = (".cs",)
+_SHELL_SOURCE_EXTS = SHELL_SOURCE_EXTS
 _PYTHON_SOURCE_ROOT_NAMES = {"src", "lib", "python"}
 
 _TRY_NODE_TYPES = (ast.Try, getattr(ast, "TryStar", ast.Try))
@@ -547,6 +549,11 @@ class Skylos:
         ".rs": "Rust",
         ".dart": "Dart",
         ".cs": "C#",
+        ".sh": "Shell",
+        ".bash": "Shell",
+        ".zsh": "Shell",
+        ".ksh": "Shell",
+        ".bats": "Shell",
     }
 
     def _count_languages(self, files) -> dict[str, int]:
@@ -576,6 +583,7 @@ class Skylos:
             *(_RUST_SOURCE_EXTS),
             *(_DART_SOURCE_EXTS),
             *(_CSHARP_SOURCE_EXTS),
+            *(_SHELL_SOURCE_EXTS),
         }
         ext_list = [
             "py",
@@ -593,6 +601,11 @@ class Skylos:
             "rs",
             "dart",
             "cs",
+            "sh",
+            "bash",
+            "zsh",
+            "ksh",
+            "bats",
         ]
 
         # use rust file discovery when avail
@@ -3121,6 +3134,16 @@ def proc_file(
 
     if str(file).endswith(".cs"):
         out = scan_csharp_file(
+            file,
+            cfg,
+            enable_danger_rules=enable_danger_rules,
+        )
+        if isinstance(out, tuple) and len(out) < 13:
+            return (*out, *([None] * (13 - len(out))))
+        return out[:13]
+
+    if str(file).endswith(_SHELL_SOURCE_EXTS):
+        out = scan_shell_file(
             file,
             cfg,
             enable_danger_rules=enable_danger_rules,

--- a/skylos/benchmarks/security.py
+++ b/skylos/benchmarks/security.py
@@ -31,6 +31,7 @@ SECURITY_TAXONOMY: dict[str, str] = {
     "javascript": "JavaScript security flow and sanitizer patterns.",
     "php": "PHP security flow and sanitizer patterns.",
     "rust": "Rust security flow and sanitizer patterns.",
+    "shell": "Shell security flow and sanitizer patterns.",
     "typescript": "TypeScript security flow and sanitizer patterns.",
     "csharp": "C# security flow and sanitizer patterns.",
     "precision_guard": "Clean patterns that should stay free of noisy security findings.",
@@ -59,6 +60,7 @@ SUPPORTED_LANGUAGES = {
     "typescript",
     "php",
     "rust",
+    "shell",
     "dart",
     "csharp",
 }

--- a/skylos/visitors/languages/shell/__init__.py
+++ b/skylos/visitors/languages/shell/__init__.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .danger import scan_danger
+
+
+SHELL_SOURCE_EXTS = (".sh", ".bash", ".zsh", ".ksh", ".bats")
+
+
+class DummyVisitor:
+    def __init__(self) -> None:
+        self.is_test_file: bool = False
+        self.test_decorated_lines: set[int] = set()
+        self.dataclass_fields: set[str] = set()
+        self.pydantic_models: set[str] = set()
+        self.class_defs: dict = {}
+        self.first_read_lineno: dict = {}
+        self.framework_decorated_lines: set[int] = set()
+        self.detected_frameworks: set[str] = set()
+
+
+def _empty_result(config: dict) -> tuple:
+    return (
+        [],
+        [],
+        set(),
+        set(),
+        DummyVisitor(),
+        DummyVisitor(),
+        [],
+        [],
+        [],
+        None,
+        None,
+        config,
+        [],
+    )
+
+
+def scan_shell_file(
+    file_path: str,
+    config: dict | None = None,
+    *,
+    enable_danger_rules: bool = True,
+) -> tuple:
+    if config is None:
+        config = {}
+
+    try:
+        path = Path(file_path)
+        if path.suffix.lower() not in SHELL_SOURCE_EXTS:
+            raise ValueError("unsupported shell path")
+        source = path.read_text(  # skylos: ignore[SKY-D215] analyzer reads discovered shell source files
+            encoding="utf-8",
+            errors="ignore",
+        )
+    except Exception:
+        return _empty_result(config)
+
+    findings = scan_danger(str(path), source) if enable_danger_rules else []
+
+    return (
+        [],
+        [],
+        set(),
+        set(),
+        DummyVisitor(),
+        DummyVisitor(),
+        [],
+        findings,
+        [],
+        None,
+        None,
+        config,
+        [],
+    )
+
+
+__all__ = ["SHELL_SOURCE_EXTS", "scan_shell_file"]

--- a/skylos/visitors/languages/shell/danger.py
+++ b/skylos/visitors/languages/shell/danger.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+_POSITIONAL_RE = re.compile(r"\$(?:\d+|[@*])|\$\{(?:\d+|[@*])(?:[:?+\-][^}]*)?\}")
+_VAR_REF_RE = re.compile(
+    r"\$(?P<simple>[A-Za-z_][A-Za-z0-9_]*)|\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?:[:?+\-][^}]*)?\}"
+)
+_ASSIGN_RE = re.compile(
+    r"^(?:(?:local|declare|typeset|readonly|export)\b(?:\s+-[A-Za-z]+\b)*)?\s*"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=(?P<rhs>.+)$"
+)
+_READ_RE = re.compile(r"^(?:IFS=\\?[^\s]+\s+)?read(?:\s+|$)(?P<args>.*)$")
+_SHELL_NAMES = {"bash", "dash", "ksh", "sh", "zsh"}
+_URL_FETCHERS = {"curl", "wget"}
+_PATH_SINKS = {
+    "cat",
+    "chmod",
+    "chown",
+    "cp",
+    "head",
+    "less",
+    "ln",
+    "mkdir",
+    "more",
+    "mv",
+    "rm",
+    "rmdir",
+    "tail",
+    "tar",
+    "touch",
+    "unzip",
+}
+_COMMAND_PREFIXES = {"command", "env", "nohup", "sudo", "time"}
+_OPTIONS_WITH_VALUES = {
+    "-C",
+    "-H",
+    "-I",
+    "-O",
+    "-X",
+    "-b",
+    "-c",
+    "-d",
+    "-e",
+    "-f",
+    "-g",
+    "-h",
+    "-i",
+    "-k",
+    "-o",
+    "-p",
+    "-u",
+    "--config",
+    "--connect-timeout",
+    "--data",
+    "--data-binary",
+    "--directory-prefix",
+    "--execute",
+    "--header",
+    "--method",
+    "--output",
+    "--post-data",
+    "--post-file",
+    "--user",
+}
+_PREFIX_OPTIONS_WITH_VALUES = {
+    "env": {"-C", "-S", "-u"},
+    "sudo": {"-C", "-g", "-h", "-p", "-T", "-u"},
+}
+_REDIRECT_RE = re.compile(
+    r"(?:^|[^\d])(?:>>?|<)\s*(?P<target>(?:\"[^\"]+\"|'[^']+'|\S+))"
+)
+
+_COMMAND_FINDING = (
+    "SKY-D212",
+    "Shell command execution receives untrusted input; use fixed commands and strict allowlists.",
+    "CRITICAL",
+)
+_PATH_FINDING = (
+    "SKY-D215",
+    "User-controlled shell path reaches a filesystem sink without basename or canonical path validation.",
+    "HIGH",
+)
+_SSRF_FINDING = (
+    "SKY-D216",
+    "User-controlled URL reaches curl or wget; validate outbound destinations against an allowlist.",
+    "CRITICAL",
+)
+
+
+@dataclass
+class _ShellState:
+    tainted_vars: set[str] = field(default_factory=set)
+    path_sanitized_vars: set[str] = field(default_factory=set)
+
+
+def scan_danger(file_path: str, source: str) -> list[dict]:
+    findings: list[dict] = []
+    seen: set[tuple[str, int, str]] = set()
+    state = _ShellState()
+
+    for line_no, statement in _iter_statements(source):
+        text = statement.strip()
+        if not text:
+            continue
+
+        _handle_read(text, state)
+        _handle_assignment(text, state)
+
+        if _command_sink_is_tainted(text, state):
+            _add_finding(findings, seen, _COMMAND_FINDING, file_path, line_no)
+        if _url_sink_is_tainted(text, state):
+            _add_finding(findings, seen, _SSRF_FINDING, file_path, line_no)
+        if _path_sink_is_tainted(text, state):
+            _add_finding(findings, seen, _PATH_FINDING, file_path, line_no)
+
+    return findings
+
+
+def _iter_statements(source: str) -> list[tuple[int, str]]:
+    statements: list[tuple[int, str]] = []
+    pending = ""
+    pending_line = 1
+    heredoc_end: str | None = None
+
+    for line_no, raw in enumerate(source.splitlines(), 1):
+        if heredoc_end is not None:
+            if raw.strip() == heredoc_end:
+                heredoc_end = None
+            continue
+
+        line = _strip_inline_comment(raw).rstrip()
+        if not line:
+            continue
+
+        marker = _heredoc_marker(line)
+        if marker is not None:
+            heredoc_end = marker
+
+        if pending:
+            pending += line.lstrip()
+        else:
+            pending = line
+            pending_line = line_no
+
+        if pending.endswith("\\"):
+            pending = pending[:-1]
+            continue
+
+        for statement in _split_shell_statements(pending):
+            statements.append((pending_line, statement))
+        pending = ""
+
+    if pending:
+        for statement in _split_shell_statements(pending):
+            statements.append((pending_line, statement))
+
+    return statements
+
+
+def _strip_inline_comment(line: str) -> str:
+    quote: str | None = None
+    escaped = False
+    for idx, char in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char == "#" and (idx == 0 or line[idx - 1].isspace()):
+            return line[:idx]
+    return line
+
+
+def _heredoc_marker(line: str) -> str | None:
+    match = re.search(r"<<-?\s*['\"]?(?P<marker>[A-Za-z_][A-Za-z0-9_]*)['\"]?", line)
+    if match:
+        return match.group("marker")
+    return None
+
+
+def _split_shell_statements(line: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    quote: str | None = None
+    escaped = False
+    idx = 0
+
+    while idx < len(line):
+        char = line[idx]
+        if escaped:
+            escaped = False
+            idx += 1
+            continue
+        if char == "\\":
+            escaped = True
+            idx += 1
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            idx += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            idx += 1
+            continue
+        if char == ";" or line.startswith("&&", idx) or line.startswith("||", idx):
+            part = line[start:idx].strip()
+            if part:
+                parts.append(part)
+            idx += 2 if line.startswith(("&&", "||"), idx) else 1
+            start = idx
+            continue
+        idx += 1
+
+    tail = line[start:].strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def _handle_read(statement: str, state: _ShellState) -> None:
+    match = _READ_RE.match(statement)
+    if not match:
+        return
+
+    tokens = _shell_tokens(match.group("args"))
+    names: list[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in {"-a", "-d", "-n", "-N", "-p", "-t", "-u"}:
+            skip_next = True
+            continue
+        if token.startswith("-") or "=" in token:
+            continue
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", token):
+            names.append(token)
+
+    for name in names:
+        state.tainted_vars.add(name)
+        state.path_sanitized_vars.discard(name)
+
+
+def _handle_assignment(statement: str, state: _ShellState) -> None:
+    match = _ASSIGN_RE.match(statement)
+    if not match:
+        return
+
+    name = match.group("name")
+    rhs = match.group("rhs").strip()
+    if _is_tainted(rhs, state):
+        state.tainted_vars.add(name)
+        if _path_expr_is_sanitized(rhs, state):
+            state.path_sanitized_vars.add(name)
+        else:
+            state.path_sanitized_vars.discard(name)
+    else:
+        state.tainted_vars.discard(name)
+        state.path_sanitized_vars.discard(name)
+
+
+def _command_sink_is_tainted(statement: str, state: _ShellState) -> bool:
+    tokens = _shell_tokens(statement)
+    if not tokens:
+        return False
+
+    command_idx = _command_index(tokens)
+    if command_idx is None:
+        return False
+    command = _command_name(tokens[command_idx])
+
+    if command == "eval":
+        return _is_tainted(" ".join(tokens[command_idx + 1 :]), state)
+    if command == "source" or tokens[command_idx] == ".":
+        return _is_tainted(" ".join(tokens[command_idx + 1 :]), state)
+    if command in _SHELL_NAMES and "-c" in tokens[command_idx + 1 :]:
+        idx = tokens.index("-c", command_idx + 1)
+        return _is_tainted(" ".join(tokens[idx + 1 :]), state)
+
+    return False
+
+
+def _url_sink_is_tainted(statement: str, state: _ShellState) -> bool:
+    tokens = _shell_tokens(statement)
+    command_idx = _command_index(tokens)
+    if command_idx is None or _command_name(tokens[command_idx]) not in _URL_FETCHERS:
+        return False
+
+    for arg in _url_arguments(tokens[command_idx:]):
+        if _url_arg_controls_destination(arg, state):
+            return True
+    return False
+
+
+def _path_sink_is_tainted(statement: str, state: _ShellState) -> bool:
+    for target in _redirection_targets(statement):
+        if _is_tainted(target, state) and not _path_expr_is_sanitized(target, state):
+            return True
+
+    tokens = _shell_tokens(statement)
+    command_idx = _command_index(tokens)
+    if command_idx is None or _command_name(tokens[command_idx]) not in _PATH_SINKS:
+        return False
+
+    for arg in _path_arguments(tokens[command_idx:]):
+        if _is_tainted(arg, state) and not _path_expr_is_sanitized(arg, state):
+            return True
+    return False
+
+
+def _shell_tokens(statement: str) -> list[str]:
+    try:
+        return shlex.split(statement, comments=False, posix=True)
+    except ValueError:
+        return statement.split()
+
+
+def _command_index(tokens: list[str]) -> int | None:
+    idx = 0
+    while idx < len(tokens):
+        token = tokens[idx]
+        name = _command_name(token)
+        if "=" in token and not token.startswith(("$", "./", "/")):
+            idx += 1
+            continue
+        if name in _COMMAND_PREFIXES:
+            idx = _skip_command_prefix(tokens, idx, name)
+            continue
+        return idx
+    return None
+
+
+def _skip_command_prefix(tokens: list[str], idx: int, name: str) -> int:
+    idx += 1
+    options_with_values = _PREFIX_OPTIONS_WITH_VALUES.get(name, set())
+    while idx < len(tokens):
+        token = tokens[idx]
+        if name == "env" and "=" in token and not token.startswith(("$", "./", "/")):
+            idx += 1
+            continue
+        if token in options_with_values:
+            idx += 2
+            continue
+        if token.startswith("-"):
+            idx += 1
+            continue
+        break
+    return idx
+
+
+def _command_name(token: str) -> str:
+    return token.rsplit("/", 1)[-1]
+
+
+def _url_arguments(command_tokens: list[str]) -> list[str]:
+    args: list[str] = []
+    idx = 1
+    while idx < len(command_tokens):
+        token = command_tokens[idx]
+        if token == "--url" and idx + 1 < len(command_tokens):
+            args.append(command_tokens[idx + 1])
+            idx += 2
+            continue
+        if token in _OPTIONS_WITH_VALUES:
+            idx += 2
+            continue
+        if token.startswith("-"):
+            idx += 1
+            continue
+        args.append(token)
+        idx += 1
+    return args
+
+
+def _path_arguments(command_tokens: list[str]) -> list[str]:
+    args: list[str] = []
+    idx = 1
+    while idx < len(command_tokens):
+        token = command_tokens[idx]
+        if token in _OPTIONS_WITH_VALUES:
+            idx += 2
+            continue
+        if token.startswith("-"):
+            idx += 1
+            continue
+        args.append(token)
+        idx += 1
+    return args
+
+
+def _redirection_targets(statement: str) -> list[str]:
+    return [match.group("target") for match in _REDIRECT_RE.finditer(statement)]
+
+
+def _url_arg_controls_destination(arg: str, state: _ShellState) -> bool:
+    if not _is_tainted(arg, state):
+        return False
+
+    match = re.match(r"^https?://(?P<host>[^/?#]+)(?P<rest>.*)$", arg)
+    if match:
+        return _is_tainted(match.group("host"), state)
+    return True
+
+
+def _path_expr_is_sanitized(expr: str, state: _ShellState) -> bool:
+    if _basename_call_is_tainted(expr, state):
+        return True
+    if _POSITIONAL_RE.search(expr):
+        return False
+
+    refs = _tainted_refs(expr, state)
+    return bool(refs) and refs.issubset(state.path_sanitized_vars)
+
+
+def _basename_call_is_tainted(expr: str, state: _ShellState) -> bool:
+    if not re.search(r"(?:^|\$\()\s*basename\b", expr):
+        return False
+    return _is_tainted(expr, state)
+
+
+def _is_tainted(expr: str, state: _ShellState) -> bool:
+    if not expr:
+        return False
+    if _POSITIONAL_RE.search(expr):
+        return True
+    return bool(_tainted_refs(expr, state))
+
+
+def _tainted_refs(expr: str, state: _ShellState) -> set[str]:
+    refs: set[str] = set()
+    for match in _VAR_REF_RE.finditer(expr):
+        name = match.group("simple") or match.group("braced")
+        if name in state.tainted_vars:
+            refs.add(name)
+    return refs
+
+
+def _add_finding(
+    findings: list[dict],
+    seen: set[tuple[str, int, str]],
+    spec: tuple[str, str, str],
+    file_path: str,
+    line: int,
+) -> None:
+    rule_id, message, severity = spec
+    key = (rule_id, line, str(Path(file_path)))
+    if key in seen:
+        return
+    seen.add(key)
+    findings.append(
+        {
+            "rule_id": rule_id,
+            "severity": severity,
+            "message": message,
+            "file": str(Path(file_path)),
+            "line": line,
+            "col": 0,
+            "category": "danger",
+        }
+    )

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -17,6 +17,7 @@ from skylos.analyzer import (
     _architecture_iad_strict,
     _resolve_analysis_root,
 )
+from skylos.visitors.languages.shell import SHELL_SOURCE_EXTS
 
 
 @pytest.fixture
@@ -245,6 +246,7 @@ class TestSkylos:
                 ".rs",
                 ".dart",
                 ".cs",
+                *SHELL_SOURCE_EXTS,
             },
             exclude_folders=None,
         )

--- a/test/test_shell_security.py
+++ b/test/test_shell_security.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skylos.analyzer import analyze
+from skylos.visitors.languages.shell import scan_shell_file
+
+
+def _scan_shell_findings(
+    tmp_path: Path, code: str, filename: str = "deploy.sh"
+) -> list[dict]:
+    file_path = tmp_path / filename
+    file_path.write_text(code, encoding="utf-8")
+    return scan_shell_file(str(file_path), {})[7]
+
+
+def _rule_ids(findings: list[dict]) -> set[str]:
+    return {finding["rule_id"] for finding in findings}
+
+
+def test_eval_with_positional_arg_flags_command_injection(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+cmd="$1"
+eval "$cmd"
+""",
+    )
+
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_source_with_positional_arg_flags_command_injection(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+plugin="$1"
+source "$plugin"
+""",
+    )
+
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_shell_c_with_positional_arg_flags_command_injection(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+task="$1"
+sh -c "$task"
+""",
+    )
+
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_sudo_shell_c_with_positional_arg_flags_command_injection(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+task="$1"
+sudo -u app bash -c "$task"
+""",
+    )
+
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_basename_does_not_sanitize_shell_commands(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+cmd="$(basename -- "$1")"
+eval "$cmd"
+""",
+    )
+
+    assert "SKY-D212" in _rule_ids(findings)
+
+
+def test_curl_with_read_url_flags_ssrf(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+read -r url
+curl -fsSL "$url"
+""",
+    )
+
+    assert "SKY-D216" in _rule_ids(findings)
+
+
+def test_curl_fixed_host_with_tainted_path_is_not_ssrf(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+artifact="$1"
+curl -fsSL "https://downloads.example.com/releases/$artifact"
+""",
+    )
+
+    assert "SKY-D216" not in _rule_ids(findings)
+
+
+def test_file_sink_with_positional_arg_flags_path_traversal(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+backup_name="$1"
+cat "/srv/backups/$backup_name"
+""",
+    )
+
+    assert "SKY-D215" in _rule_ids(findings)
+
+
+def test_basename_sanitized_file_path_is_safe(tmp_path):
+    findings = _scan_shell_findings(
+        tmp_path,
+        """
+#!/usr/bin/env bash
+backup_name="$(basename -- "$1")"
+cat "/srv/backups/$backup_name"
+""",
+    )
+
+    assert "SKY-D215" not in _rule_ids(findings)
+
+
+def test_analyzer_discovers_shell_scripts(tmp_path):
+    script = tmp_path / "deploy.sh"
+    script.write_text(
+        """
+#!/usr/bin/env bash
+cmd="$1"
+eval "$cmd"
+""",
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_danger=True, conf=0, grep_verify=False)
+    )
+
+    assert result["analysis_summary"]["languages"] == {"Shell": 1}
+    assert "SKY-D212" in _rule_ids(result["danger"])


### PR DESCRIPTION
## Summary
  - Add Shell scanning for `.sh`, `.bash`, `.zsh`, `.ksh`, and `.bats` files.
  - Detect shell command injection, SSRF, and path traversal flows from positional args and `read` input.
  - Add shell security benchmark cases and update public language/support docs.

## Tests
  - `pytest test/test_shell_security.py test/test_security_benchmark.py`