### PR TITLE
fix(docs): avoid repo map line churn

### DIFF
--- a/.github/workflows/repo-map-pages.yml
+++ b/.github/workflows/repo-map-pages.yml
@@ -5,9 +5,11 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/repo-map-pages.yml"
+      - "benchmarks/**"
       - "docs/**"
-      - "scripts/build_repo_map.py"
-      - "scripts/repo_map_*.py"
+      - "scripts/**"
+      - "skylos/**"
+      - "test/**"
   workflow_dispatch:
 
 permissions:
@@ -30,8 +32,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Verify generated repo map
-        run: python scripts/build_repo_map.py --check
+      - name: Build repo map
+        run: python scripts/build_repo_map.py
 
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
         with:

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>650</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5395</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>5397</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -550,13 +550,12 @@
     <section id="folders">
       <h2>Folders</h2>
       <div class="folder-grid">
-    <article class="folder-card searchable" data-search="benchmarks benchmark data and generated comparison artifacts. use this when storing benchmark fixtures or outputs that explain scanner quality. benchmarks/  benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py">
+    <article class="folder-card searchable" data-search="benchmarks benchmark data and generated comparison artifacts. use this when storing benchmark fixtures or outputs that explain scanner quality. benchmarks/  benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmarks/dead_code/fixtures/celery_tasks/app.py benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks" rel="noopener noreferrer">benchmarks</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 129</span>
           <span class="pill"><strong>symbols</strong> 225</span>
-          <span class="pill"><strong>lines</strong> 1670</span>
         </div>
       </div>
       <p>Benchmark data and generated comparison artifacts.</p>
@@ -570,44 +569,43 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</a> <span>28 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/pydantic_validators/app.py</a> <span>30 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</a> <span>29 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</a> <span>29 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</a> <span>28 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</a> <span>27 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</a> <span>27 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</a> <span>27 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/celery_tasks/app.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py" rel="noopener noreferrer">benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L4" rel="noopener noreferrer">register:4</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L13" rel="noopener noreferrer">handle_create:13</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L18" rel="noopener noreferrer">handle_update:18</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L22" rel="noopener noreferrer">dispatch:22</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L26" rel="noopener noreferrer">unused_handler:26</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L4" rel="noopener noreferrer">UserInput:4</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L17" rel="noopener noreferrer">UnusedSchema:17</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L21" rel="noopener noreferrer">build_user:21</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L25" rel="noopener noreferrer">unused_normalizer:25</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L9" rel="noopener noreferrer">UsedWorker:9</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L14" rel="noopener noreferrer">UnusedWorker:14</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L19" rel="noopener noreferrer">used_helper:19</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L24" rel="noopener noreferrer">unused_helper:24</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L5" rel="noopener noreferrer">Base:5</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">register</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">handle_create</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">handle_update</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">dispatch</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">unused_handler</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_dynamic_hook</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_registered_hook</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_mutable_runner</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_sample</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">upgrade</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">downgrade</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">unused_migration_helper</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">UnusedMigrationState</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">UsedWorker</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="scripts repository maintenance, benchmark, parity, and regression scripts. use this for repeatable evidence and local automation that should not live in runtime package code. scripts/security_benchmark.py scripts/quality_benchmark.py scripts/check_rule_docs_parity.py test/test_typescript_safe_glob.py scripts/build_repo_map.py scripts/repo_map_renderer.py scripts/regression_delta.py scripts/compare_codex_skylos_quality.py scripts/compare_codex_skylos_agent_review.py scripts/analyzer_speed_check.py scripts/compare_codex_skylos_demo_deadcode.py scripts/dead_code_compare_scanners.py">
+    <article class="folder-card searchable" data-search="scripts repository maintenance, benchmark, parity, and regression scripts. use this for repeatable evidence and local automation that should not live in runtime package code. scripts/security_benchmark.py scripts/quality_benchmark.py scripts/check_rule_docs_parity.py test/test_typescript_safe_glob.py scripts/repo_map_renderer.py scripts/build_repo_map.py scripts/regression_delta.py scripts/compare_codex_skylos_quality.py scripts/compare_codex_skylos_agent_review.py scripts/analyzer_speed_check.py scripts/compare_codex_skylos_demo_deadcode.py scripts/dead_code_compare_scanners.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/scripts" rel="noopener noreferrer">scripts</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 16</span>
-          <span class="pill"><strong>symbols</strong> 124</span>
-          <span class="pill"><strong>lines</strong> 4548</span>
+          <span class="pill"><strong>symbols</strong> 125</span>
         </div>
       </div>
       <p>Repository maintenance, benchmark, parity, and regression scripts.</p>
@@ -621,44 +619,43 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">scripts/build_repo_map.py</a> <span>1197 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">scripts/repo_map_renderer.py</a> <span>791 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">scripts/regression_delta.py</a> <span>353 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_quality.py" rel="noopener noreferrer">scripts/compare_codex_skylos_quality.py</a> <span>420 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_agent_review.py" rel="noopener noreferrer">scripts/compare_codex_skylos_agent_review.py</a> <span>424 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">scripts/analyzer_speed_check.py</a> <span>315 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_demo_deadcode.py" rel="noopener noreferrer">scripts/compare_codex_skylos_demo_deadcode.py</a> <span>280 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_compare_scanners.py" rel="noopener noreferrer">scripts/dead_code_compare_scanners.py</a> <span>152 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">scripts/repo_map_renderer.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">scripts/build_repo_map.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">scripts/regression_delta.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_quality.py" rel="noopener noreferrer">scripts/compare_codex_skylos_quality.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_agent_review.py" rel="noopener noreferrer">scripts/compare_codex_skylos_agent_review.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">scripts/analyzer_speed_check.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_demo_deadcode.py" rel="noopener noreferrer">scripts/compare_codex_skylos_demo_deadcode.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_compare_scanners.py" rel="noopener noreferrer">scripts/dead_code_compare_scanners.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L546" rel="noopener noreferrer">SymbolInfo:546</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L569" rel="noopener noreferrer">ModuleInfo:569</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L817" rel="noopener noreferrer">collect_repo_map:817</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1105" rel="noopener noreferrer">write_repo_map:1105</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1131" rel="noopener noreferrer">main:1131</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L75" rel="noopener noreferrer">render_mode_plan_templates:75</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L114" rel="noopener noreferrer">render_mode_selector:114</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L156" rel="noopener noreferrer">render_personas:156</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L197" rel="noopener noreferrer">render_workflows:197</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L239" rel="noopener noreferrer">render_first_steps:239</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L177" rel="noopener noreferrer">compare_corpus:177</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L210" rel="noopener noreferrer">compare_agent_review:210</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L267" rel="noopener noreferrer">compare_quality:267</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L323" rel="noopener noreferrer">compare:323</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_mode_plan_templates</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_mode_selector</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_personas</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_workflows</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_first_steps</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">SymbolInfo</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">ModuleInfo</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">collect_repo_map</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">write_repo_map</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">main</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare_corpus</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare_agent_review</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare_quality</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos root entrypoints and shared scan orchestration. start here when cli behavior, scan flow, or global configuration changes. skylos/cli.py skylos/analyzer.py skylos/pipeline.py skylos/config.py test/test_skylos.py skylos/cli.py skylos/analyzer.py skylos/pipeline.py skylos/config.py skylos/constants.py skylos/__init__.py">
+    <article class="folder-card searchable" data-search="skylos root entrypoints and shared scan orchestration. start here when cli behavior, scan flow, or global configuration changes. skylos/cli.py skylos/analyzer.py skylos/pipeline.py skylos/config.py test/test_skylos.py skylos/cli.py skylos/config.py skylos/analyzer.py skylos/pipeline.py skylos/constants.py skylos/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 250</span>
-          <span class="pill"><strong>lines</strong> 11144</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -672,42 +669,41 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a> <span>5492 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a> <span>3778 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a> <span>989 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a> <span>616 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">skylos/constants.py</a> <span>229 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py" rel="noopener noreferrer">skylos/__init__.py</a> <span>40 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">skylos/constants.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py" rel="noopener noreferrer">skylos/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L115" rel="noopener noreferrer">remove_unused_import_cst:115</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L119" rel="noopener noreferrer">remove_unused_function_cst:119</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L123" rel="noopener noreferrer">comment_out_unused_import_cst:123</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">comment_out_unused_function_cst:127</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L131" rel="noopener noreferrer">run_analyze:131</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L463" rel="noopener noreferrer">Skylos:463</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3059" rel="noopener noreferrer">proc_file:3059</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3586" rel="noopener noreferrer">analyze:3586</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L152" rel="noopener noreferrer">_entrypoint_module_name:152</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L159" rel="noopener noreferrer">_architecture_iad_strict:159</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L306" rel="noopener noreferrer">run_static_on_files:306</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L400" rel="noopener noreferrer">run_pipeline:400</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L77" rel="noopener noreferrer">_enrich_with_llm_suggestions:77</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py#L169" rel="noopener noreferrer">_norm:169</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_import_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_function_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_import_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_function_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_analyze</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">load_config</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_path_excluded</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_whitelisted</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_expired_whitelists</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_all_ignore_lines</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">Skylos</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">proc_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">analyze</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_entrypoint_module_name</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/adapters provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor. change this when adding or hardening an llm provider boundary. skylos/adapters/base.py skylos/adapters/litellm_adapter.py  skylos/adapters/litellm_adapter.py skylos/adapters/base.py skylos/adapters/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/adapters provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor. change this when adding or hardening an llm provider boundary. skylos/adapters/base.py skylos/adapters/litellm_adapter.py  skylos/adapters/__init__.py skylos/adapters/base.py skylos/adapters/litellm_adapter.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters" rel="noopener noreferrer">skylos/adapters</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 3</span>
-          <span class="pill"><strong>lines</strong> 444</span>
         </div>
       </div>
       <p>Provider adapters that let Skylos talk to model runtimes without coupling core logic to one vendor.</p>
@@ -721,28 +717,27 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py" rel="noopener noreferrer">skylos/adapters/litellm_adapter.py</a> <span>423 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py" rel="noopener noreferrer">skylos/adapters/base.py</a> <span>12 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py" rel="noopener noreferrer">skylos/adapters/__init__.py</a> <span>9 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py" rel="noopener noreferrer">skylos/adapters/__init__.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py" rel="noopener noreferrer">skylos/adapters/base.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py" rel="noopener noreferrer">skylos/adapters/litellm_adapter.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py#L7" rel="noopener noreferrer">LiteLLMAdapter:7</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py#L4" rel="noopener noreferrer">BaseAdapter:4</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py#L7" rel="noopener noreferrer">get_adapter:7</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py" rel="noopener noreferrer">get_adapter</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py" rel="noopener noreferrer">BaseAdapter</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py" rel="noopener noreferrer">LiteLLMAdapter</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/agents agent-facing payloads, service helpers, and review triage learning. use this area for agent review workflows and normalized agent result handling. skylos/agents/service.py skylos/agents/payload.py test/test_agent_service.py test/test_agents.py skylos/agents/center.py skylos/agents/service.py skylos/agents/triage_learner.py skylos/agents/payload.py skylos/agents/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/agents agent-facing payloads, service helpers, and review triage learning. use this area for agent review workflows and normalized agent result handling. skylos/agents/service.py skylos/agents/payload.py test/test_agent_service.py test/test_agents.py skylos/agents/center.py skylos/agents/service.py skylos/agents/payload.py skylos/agents/triage_learner.py skylos/agents/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents" rel="noopener noreferrer">skylos/agents</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 5</span>
           <span class="pill"><strong>symbols</strong> 91</span>
-          <span class="pill"><strong>lines</strong> 2179</span>
         </div>
       </div>
       <p>Agent-facing payloads, service helpers, and review triage learning.</p>
@@ -756,41 +751,40 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">skylos/agents/center.py</a> <span>1068 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">skylos/agents/service.py</a> <span>539 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py" rel="noopener noreferrer">skylos/agents/triage_learner.py</a> <span>327 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">skylos/agents/payload.py</a> <span>243 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/__init__.py" rel="noopener noreferrer">skylos/agents/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">skylos/agents/center.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">skylos/agents/service.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">skylos/agents/payload.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py" rel="noopener noreferrer">skylos/agents/triage_learner.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/__init__.py" rel="noopener noreferrer">skylos/agents/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L52" rel="noopener noreferrer">run_analyze:52</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L58" rel="noopener noreferrer">collect_debt_signals:58</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L64" rel="noopener noreferrer">discover_source_files:64</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L72" rel="noopener noreferrer">resolve_project_root:72</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L87" rel="noopener noreferrer">resolve_state_path:87</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L83" rel="noopener noreferrer">AgentServiceController:83</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L296" rel="noopener noreferrer">AgentServiceHandler:296</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L428" rel="noopener noreferrer">SafeAgentServiceHandler:428</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L467" rel="noopener noreferrer">create_agent_service:467</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L508" rel="noopener noreferrer">serve_agent_service:508</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L22" rel="noopener noreferrer">TriagePattern:22</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L143" rel="noopener noreferrer">TriageLearner:143</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L47" rel="noopener noreferrer">_pattern_key:47</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L53" rel="noopener noreferrer">_make_pattern:53</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">run_analyze</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">collect_debt_signals</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">discover_source_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">resolve_project_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">resolve_state_path</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">AgentServiceController</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">AgentServiceHandler</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">SafeAgentServiceHandler</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">create_agent_service</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">serve_agent_service</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">severity_score</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_action_title</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_action_subtitle</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_action_reason</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/analysis reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references. change this when multiple scanners need the same code-understanding primitive. skylos/analysis/module_reachability.py skylos/analysis/control_flow.py  skylos/analysis/penalties.py skylos/analysis/architecture.py skylos/analysis/known_patterns.py skylos/analysis/circular_deps.py skylos/analysis/control_flow.py skylos/analysis/ast_mask.py skylos/analysis/architecture_findings.py skylos/analysis/module_reachability.py">
+    <article class="folder-card searchable" data-search="skylos/analysis reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references. change this when multiple scanners need the same code-understanding primitive. skylos/analysis/module_reachability.py skylos/analysis/control_flow.py  skylos/analysis/penalties.py skylos/analysis/architecture.py skylos/analysis/circular_deps.py skylos/analysis/ast_mask.py skylos/analysis/control_flow.py skylos/analysis/architecture_findings.py skylos/analysis/architecture_layers.py skylos/analysis/implicit_refs.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis" rel="noopener noreferrer">skylos/analysis</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 12</span>
           <span class="pill"><strong>symbols</strong> 83</span>
-          <span class="pill"><strong>lines</strong> 4028</span>
         </div>
       </div>
       <p>Reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.</p>
@@ -804,31 +798,31 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">skylos/analysis/penalties.py</a> <span>1146 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">skylos/analysis/architecture.py</a> <span>594 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py" rel="noopener noreferrer">skylos/analysis/known_patterns.py</a> <span>619 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">skylos/analysis/circular_deps.py</a> <span>390 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">skylos/analysis/control_flow.py</a> <span>219 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">skylos/analysis/ast_mask.py</a> <span>162 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_findings.py" rel="noopener noreferrer">skylos/analysis/architecture_findings.py</a> <span>206 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py" rel="noopener noreferrer">skylos/analysis/module_reachability.py</a> <span>250 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">skylos/analysis/penalties.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">skylos/analysis/architecture.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">skylos/analysis/circular_deps.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">skylos/analysis/ast_mask.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">skylos/analysis/control_flow.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_findings.py" rel="noopener noreferrer">skylos/analysis/architecture_findings.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_layers.py" rel="noopener noreferrer">skylos/analysis/architecture_layers.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/implicit_refs.py" rel="noopener noreferrer">skylos/analysis/implicit_refs.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L1038" rel="noopener noreferrer">apply_penalties:1038</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L202" rel="noopener noreferrer">_suppress:202</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L213" rel="noopener noreferrer">_class_base_names:213</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L228" rel="noopener noreferrer">_class_declares_attr:228</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L248" rel="noopener noreferrer">_name_parent_has_base:248</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L22" rel="noopener noreferrer">ModuleMetrics:22</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L45" rel="noopener noreferrer">DIPViolation:45</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L54" rel="noopener noreferrer">ArchitectureResult:54</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L200" rel="noopener noreferrer">analyze_architecture:200</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L428" rel="noopener noreferrer">get_architecture_findings:428</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L592" rel="noopener noreferrer">matches_pattern:592</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L596" rel="noopener noreferrer">has_base_class:596</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L57" rel="noopener noreferrer">ModuleDependency:57</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L66" rel="noopener noreferrer">CircularDependency:66</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">apply_penalties</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">_suppress</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">_class_base_names</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">_class_declares_attr</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">_name_parent_has_base</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">ModuleMetrics</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">DIPViolation</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">ArchitectureResult</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">analyze_architecture</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">get_architecture_findings</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">ModuleDependency</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">CircularDependency</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">DependencyGraphBuilder</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">CircularDependencyAnalyzer</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -841,7 +835,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 150</span>
-          <span class="pill"><strong>lines</strong> 3120</span>
         </div>
       </div>
       <p>Public API facade and private helpers for payloads, snippets, findings, URLs, and AI-detection metadata.</p>
@@ -855,43 +848,42 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a> <span>1970 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">skylos/api/_artifacts.py</a> <span>324 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">skylos/api/_payloads.py</a> <span>240 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_findings.py" rel="noopener noreferrer">skylos/api/_findings.py</a> <span>206 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_urls.py" rel="noopener noreferrer">skylos/api/_urls.py</a> <span>154 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_ai_detection.py" rel="noopener noreferrer">skylos/api/_ai_detection.py</a> <span>180 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_snippets.py" rel="noopener noreferrer">skylos/api/_snippets.py</a> <span>46 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">skylos/api/_artifacts.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">skylos/api/_payloads.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_findings.py" rel="noopener noreferrer">skylos/api/_findings.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_urls.py" rel="noopener noreferrer">skylos/api/_urls.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_ai_detection.py" rel="noopener noreferrer">skylos/api/_ai_detection.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_snippets.py" rel="noopener noreferrer">skylos/api/_snippets.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L338" rel="noopener noreferrer">get_project_token:338</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L368" rel="noopener noreferrer">get_project_info:368</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L386" rel="noopener noreferrer">get_credit_balance:386</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L404" rel="noopener noreferrer">print_credit_status:404</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L422" rel="noopener noreferrer">get_git_root:422</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L39" rel="noopener noreferrer">UploadArtifact:39</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L65" rel="noopener noreferrer">PreparedReportUpload:65</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L162" rel="noopener noreferrer">upload_artifact:162</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L77" rel="noopener noreferrer">_sha256_file:77</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L85" rel="noopener noreferrer">_write_gzip_json_artifact:85</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L20" rel="noopener noreferrer">_json_size_bytes:20</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L24" rel="noopener noreferrer">_coerce_debt_snapshot_dict:24</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L35" rel="noopener noreferrer">_infer_upload_project_root:35</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py#L71" rel="noopener noreferrer">_extract_workspace_upload_metadata:71</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_project_token</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_project_info</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_credit_balance</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">print_credit_status</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_git_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">UploadArtifact</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">PreparedReportUpload</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">upload_artifact</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">_sha256_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">_write_gzip_json_artifact</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">_json_size_bytes</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">_coerce_debt_snapshot_dict</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">_infer_upload_project_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">_extract_workspace_upload_metadata</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/candidates.py skylos/audit/processor.py skylos/audit/types.py skylos/audit/polyglot.py skylos/audit/revalidator.py skylos/audit/store.py skylos/audit/ci.py">
+    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/candidates.py skylos/audit/processor.py skylos/audit/types.py skylos/audit/revalidator.py skylos/audit/ci.py skylos/audit/polyglot.py skylos/audit/redaction.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit" rel="noopener noreferrer">skylos/audit</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 10</span>
           <span class="pill"><strong>symbols</strong> 96</span>
-          <span class="pill"><strong>lines</strong> 3438</span>
         </div>
       </div>
       <p>Deep-audit candidate selection, processing, redaction, export, and revalidation.</p>
@@ -905,31 +897,31 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">skylos/audit/export.py</a> <span>559 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a> <span>636 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">skylos/audit/processor.py</a> <span>477 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">skylos/audit/types.py</a> <span>405 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py" rel="noopener noreferrer">skylos/audit/polyglot.py</a> <span>430 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">skylos/audit/revalidator.py</a> <span>294 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/store.py" rel="noopener noreferrer">skylos/audit/store.py</a> <span>383 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py" rel="noopener noreferrer">skylos/audit/ci.py</a> <span>174 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">skylos/audit/export.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">skylos/audit/processor.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">skylos/audit/types.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">skylos/audit/revalidator.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py" rel="noopener noreferrer">skylos/audit/ci.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py" rel="noopener noreferrer">skylos/audit/polyglot.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/redaction.py" rel="noopener noreferrer">skylos/audit/redaction.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L49" rel="noopener noreferrer">build_deep_audit_export:49</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L102" rel="noopener noreferrer">render_deep_audit_export:102</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L116" rel="noopener noreferrer">write_deep_audit_export:116</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L131" rel="noopener noreferrer">_resolve_deep_audit_export_path:131</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L140" rel="noopener noreferrer">_normalized_allowed_files:140</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L83" rel="noopener noreferrer">scan_deep_audit_candidates:83</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L218" rel="noopener noreferrer">_project_root:218</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L223" rel="noopener noreferrer">_resolve_audit_file:223</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L240" rel="noopener noreferrer">_discover_audit_files:240</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L300" rel="noopener noreferrer">_is_audit_file:300</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L29" rel="noopener noreferrer">process_deep_audit_records:29</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L184" rel="noopener noreferrer">_record_sort_key:184</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L191" rel="noopener noreferrer">_normalized_allowed_files:191</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L208" rel="noopener noreferrer">_is_active_record:208</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">build_deep_audit_export</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">render_deep_audit_export</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">write_deep_audit_export</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">_resolve_deep_audit_export_path</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">_normalized_allowed_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">scan_deep_audit_candidates</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_project_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_resolve_audit_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_discover_audit_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_is_audit_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">process_deep_audit_records</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_record_sort_key</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_normalized_allowed_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_is_active_record</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -942,7 +934,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 90</span>
-          <span class="pill"><strong>lines</strong> 3422</span>
         </div>
       </div>
       <p>Benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.</p>
@@ -956,43 +947,42 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a> <span>1084 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a> <span>756 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a> <span>662 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a> <span>518 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a> <span>228 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">skylos/benchmarks/demo_deadcode.py</a> <span>172 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/__init__.py" rel="noopener noreferrer">skylos/benchmarks/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">skylos/benchmarks/dead_code.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">skylos/benchmarks/security.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">skylos/benchmarks/agent_review.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">skylos/benchmarks/quality.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">skylos/benchmarks/corpus_ci.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">skylos/benchmarks/demo_deadcode.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/__init__.py" rel="noopener noreferrer">skylos/benchmarks/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L103" rel="noopener noreferrer">DeadCodeKey:103</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L113" rel="noopener noreferrer">DeadCodeBenchmarkFailure:113</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L130" rel="noopener noreferrer">load_manifest:130</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L134" rel="noopener noreferrer">load_external_targets:134</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L306" rel="noopener noreferrer">validate_manifest:306</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L88" rel="noopener noreferrer">SecurityBenchmarkFailure:88</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L107" rel="noopener noreferrer">load_manifest:107</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L111" rel="noopener noreferrer">validate_manifest:111</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L519" rel="noopener noreferrer">run_case:519</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L606" rel="noopener noreferrer">run_manifest:606</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L243" rel="noopener noreferrer">prepare_case_scan:243</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">DeadCodeKey</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">DeadCodeBenchmarkFailure</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">load_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">load_external_targets</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">validate_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">SecurityBenchmarkFailure</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">load_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">validate_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">run_case</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">run_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">AgentReviewBenchmarkFailure</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">load_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">validate_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">prepare_case_scan</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/cicd ci workflow generation, annotations, review comments, evidence, and risk passport output. use this when changing github/gitlab integration behavior or ci gate messaging. skylos/cicd/workflow.py skylos/cicd/review.py skylos/cicd/evidence.py test/test_cicd_annotate.py test/test_cicd_evidence.py test/test_cicd_gate.py test/test_cicd_review.py test/test_cicd_risk_passport.py test/test_cicd_workflow.py skylos/cicd/review.py skylos/cicd/evidence.py skylos/cicd/risk_passport.py skylos/cicd/workflow.py skylos/cicd/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/cicd ci workflow generation, annotations, review comments, evidence, and risk passport output. use this when changing github/gitlab integration behavior or ci gate messaging. skylos/cicd/workflow.py skylos/cicd/review.py skylos/cicd/evidence.py test/test_cicd_annotate.py test/test_cicd_evidence.py test/test_cicd_gate.py test/test_cicd_review.py test/test_cicd_risk_passport.py test/test_cicd_workflow.py skylos/cicd/evidence.py skylos/cicd/review.py skylos/cicd/risk_passport.py skylos/cicd/workflow.py skylos/cicd/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd" rel="noopener noreferrer">skylos/cicd</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 5</span>
           <span class="pill"><strong>symbols</strong> 61</span>
-          <span class="pill"><strong>lines</strong> 1873</span>
         </div>
       </div>
       <p>CI workflow generation, annotations, review comments, evidence, and risk passport output.</p>
@@ -1006,41 +996,40 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">skylos/cicd/review.py</a> <span>858 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">skylos/cicd/evidence.py</a> <span>377 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">skylos/cicd/risk_passport.py</a> <span>305 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">skylos/cicd/workflow.py</a> <span>331 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/__init__.py" rel="noopener noreferrer">skylos/cicd/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">skylos/cicd/evidence.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">skylos/cicd/review.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">skylos/cicd/risk_passport.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">skylos/cicd/workflow.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/__init__.py" rel="noopener noreferrer">skylos/cicd/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L30" rel="noopener noreferrer">run_pr_review:30</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L130" rel="noopener noreferrer">get_changed_line_ranges:130</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L229" rel="noopener noreferrer">filter_findings_to_diff:229</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L115" rel="noopener noreferrer">_resolve_review_provenance:115</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L145" rel="noopener noreferrer">_parse_unified_diff:145</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L19" rel="noopener noreferrer">EvidenceCard:19</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L112" rel="noopener noreferrer">build_evidence_cards:112</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L116" rel="noopener noreferrer">build_evidence_card:116</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L139" rel="noopener noreferrer">evidence_counts:139</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L150" rel="noopener noreferrer">evidence_label_title:150</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L19" rel="noopener noreferrer">build_risk_passport:19</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L116" rel="noopener noreferrer">format_risk_passport_markdown:116</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L159" rel="noopener noreferrer">_defense_risk:159</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L196" rel="noopener noreferrer">_is_ai_authored_finding:196</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">EvidenceCard</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">build_evidence_cards</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">build_evidence_card</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">evidence_counts</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">evidence_label_title</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">run_pr_review</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">get_changed_line_ranges</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">filter_findings_to_diff</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">_resolve_review_provenance</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">_parse_unified_diff</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">build_risk_passport</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">format_risk_passport_markdown</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">_defense_risk</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">_is_ai_authored_finding</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/cli_core smaller cli parser and dispatch pieces peeled away from the main cli module. prefer this for new command wiring when it fits the newer cli split. skylos/cli_core/main_parser.py skylos/cli_core/dispatch.py  skylos/cli_core/main_parser.py skylos/cli_core/dispatch.py skylos/cli_core/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/cli_core smaller cli parser and dispatch pieces peeled away from the main cli module. prefer this for new command wiring when it fits the newer cli split. skylos/cli_core/main_parser.py skylos/cli_core/dispatch.py  skylos/cli_core/dispatch.py skylos/cli_core/main_parser.py skylos/cli_core/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core" rel="noopener noreferrer">skylos/cli_core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 6</span>
-          <span class="pill"><strong>lines</strong> 451</span>
         </div>
       </div>
       <p>Smaller CLI parser and dispatch pieces peeled away from the main CLI module.</p>
@@ -1054,18 +1043,18 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">skylos/cli_core/main_parser.py</a> <span>362 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">skylos/cli_core/dispatch.py</a> <span>89 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/__init__.py" rel="noopener noreferrer">skylos/cli_core/__init__.py</a> <span>0 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">skylos/cli_core/dispatch.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">skylos/cli_core/main_parser.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/__init__.py" rel="noopener noreferrer">skylos/cli_core/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L7" rel="noopener noreferrer">build_main_parser:7</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L305" rel="noopener noreferrer">apply_main_output_format:305</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L335" rel="noopener noreferrer">parse_main_cli_args:335</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L37" rel="noopener noreferrer">is_first_level_help_request:37</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L41" rel="noopener noreferrer">run_early_command_help:41</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L71" rel="noopener noreferrer">dispatch_early_command:71</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">is_first_level_help_request</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">run_early_command_help</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">dispatch_early_command</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">build_main_parser</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">apply_main_output_format</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">parse_main_cli_args</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1078,7 +1067,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 74</span>
-          <span class="pill"><strong>lines</strong> 1939</span>
         </div>
       </div>
       <p>Skylos Cloud login, credentials, policy sync, project context, and upload manifest support.</p>
@@ -1092,42 +1080,41 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">skylos/cloud/sync.py</a> <span>1197 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">skylos/cloud/login.py</a> <span>489 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">skylos/cloud/upload_manifest.py</a> <span>129 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py" rel="noopener noreferrer">skylos/cloud/credentials.py</a> <span>67 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py" rel="noopener noreferrer">skylos/cloud/project_context.py</a> <span>55 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/__init__.py" rel="noopener noreferrer">skylos/cloud/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">skylos/cloud/sync.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">skylos/cloud/login.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">skylos/cloud/upload_manifest.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py" rel="noopener noreferrer">skylos/cloud/credentials.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py" rel="noopener noreferrer">skylos/cloud/project_context.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/__init__.py" rel="noopener noreferrer">skylos/cloud/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L267" rel="noopener noreferrer">get_api_url:267</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L315" rel="noopener noreferrer">get_token:315</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L342" rel="noopener noreferrer">save_token:342</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L379" rel="noopener noreferrer">clear_token:379</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L386" rel="noopener noreferrer">mask_token:386</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L18" rel="noopener noreferrer">LoginResult:18</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L149" rel="noopener noreferrer">browser_login:149</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L228" rel="noopener noreferrer">manual_token_fallback:228</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L299" rel="noopener noreferrer">get_current_connection:299</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L350" rel="noopener noreferrer">run_login:350</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L7" rel="noopener noreferrer">UploadFamilyManifest:7</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L24" rel="noopener noreferrer">build_code_scan_manifest:24</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L48" rel="noopener noreferrer">build_defense_manifest:48</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L63" rel="noopener noreferrer">build_debt_manifest:63</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">get_api_url</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">get_token</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">save_token</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">clear_token</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">mask_token</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">LoginResult</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">browser_login</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">manual_token_fallback</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">get_current_connection</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">run_login</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">UploadFamilyManifest</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">build_code_scan_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">build_defense_manifest</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">build_debt_manifest</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/commands command modules used by the cli for focused command behavior. put command-specific behavior here instead of growing skylos/cli.py. skylos/commands/run_cmd.py skylos/commands/cicd_cmd.py skylos/commands/sync_cmd.py  skylos/commands/scan_cmd.py skylos/commands/suite_cmd.py skylos/commands/rules_cmd.py skylos/commands/defend_cmd.py skylos/commands/debt_cmd.py skylos/commands/cicd_cmd.py skylos/commands/key_cmd.py skylos/commands/clean_cmd.py">
+    <article class="folder-card searchable" data-search="skylos/commands command modules used by the cli for focused command behavior. put command-specific behavior here instead of growing skylos/cli.py. skylos/commands/run_cmd.py skylos/commands/cicd_cmd.py skylos/commands/sync_cmd.py  skylos/commands/suite_cmd.py skylos/commands/defend_cmd.py skylos/commands/rules_cmd.py skylos/commands/key_cmd.py skylos/commands/cache_cmd.py skylos/commands/cicd_cmd.py skylos/commands/debt_cmd.py skylos/commands/clean_cmd.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands" rel="noopener noreferrer">skylos/commands</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 25</span>
           <span class="pill"><strong>symbols</strong> 97</span>
-          <span class="pill"><strong>lines</strong> 4897</span>
         </div>
       </div>
       <p>Command modules used by the CLI for focused command behavior.</p>
@@ -1141,44 +1128,43 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/scan_cmd.py" rel="noopener noreferrer">skylos/commands/scan_cmd.py</a> <span>961 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">skylos/commands/suite_cmd.py</a> <span>506 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">skylos/commands/rules_cmd.py</a> <span>516 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">skylos/commands/defend_cmd.py</a> <span>496 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/debt_cmd.py" rel="noopener noreferrer">skylos/commands/debt_cmd.py</a> <span>440 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py" rel="noopener noreferrer">skylos/commands/cicd_cmd.py</a> <span>361 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py" rel="noopener noreferrer">skylos/commands/key_cmd.py</a> <span>223 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">skylos/commands/clean_cmd.py</a> <span>201 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">skylos/commands/suite_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">skylos/commands/defend_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">skylos/commands/rules_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py" rel="noopener noreferrer">skylos/commands/key_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cache_cmd.py" rel="noopener noreferrer">skylos/commands/cache_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py" rel="noopener noreferrer">skylos/commands/cicd_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/debt_cmd.py" rel="noopener noreferrer">skylos/commands/debt_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">skylos/commands/clean_cmd.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/scan_cmd.py#L7" rel="noopener noreferrer">run_scan_command:7</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L446" rel="noopener noreferrer">run_suite_command:446</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L20" rel="noopener noreferrer">_parse_csv_selection:20</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L42" rel="noopener noreferrer">_build_static_upload_result:42</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L83" rel="noopener noreferrer">_static_upload_failed_quality_gate:83</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L90" rel="noopener noreferrer">_build_suite_parser:90</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L17" rel="noopener noreferrer">run_rules_command:17</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L109" rel="noopener noreferrer">init_rules:109</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L170" rel="noopener noreferrer">install_rules:170</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L220" rel="noopener noreferrer">list_rules:220</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L252" rel="noopener noreferrer">list_rule_packs:252</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L389" rel="noopener noreferrer">run_defend_command:389</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L41" rel="noopener noreferrer">_build_empty_defense_json:41</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L80" rel="noopener noreferrer">_build_defend_parser:80</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">run_suite_command</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_parse_csv_selection</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_build_static_upload_result</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_static_upload_failed_quality_gate</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_build_suite_parser</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">run_defend_command</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">_build_empty_defense_json</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">_build_defend_parser</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">_validate_defend_target</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">_validate_min_score</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">run_rules_command</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">init_rules</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">install_rules</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">list_rules</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/gatekeeper.py skylos/core/result_cache.py skylos/core/grep_verify_common.py skylos/core/file_discovery.py skylos/core/grep_verify.py skylos/core/grep_verify_language_strategies.py skylos/core/suite.py skylos/core/grep_verify_python_strategy.py">
+    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/gatekeeper.py skylos/core/result_cache.py skylos/core/file_discovery.py skylos/core/grep_verify_common.py skylos/core/grep_verify.py skylos/core/grep_verify_language_strategies.py skylos/core/suite.py skylos/core/cli_shared.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 17</span>
           <span class="pill"><strong>symbols</strong> 146</span>
-          <span class="pill"><strong>lines</strong> 4868</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1192,44 +1178,43 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">skylos/core/gatekeeper.py</a> <span>694 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">skylos/core/result_cache.py</a> <span>580 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a> <span>500 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">skylos/core/file_discovery.py</a> <span>407 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a> <span>372 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_language_strategies.py" rel="noopener noreferrer">skylos/core/grep_verify_language_strategies.py</a> <span>391 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">skylos/core/suite.py</a> <span>388 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_python_strategy.py" rel="noopener noreferrer">skylos/core/grep_verify_python_strategy.py</a> <span>418 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">skylos/core/gatekeeper.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">skylos/core/result_cache.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">skylos/core/file_discovery.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_language_strategies.py" rel="noopener noreferrer">skylos/core/grep_verify_language_strategies.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">skylos/core/suite.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py" rel="noopener noreferrer">skylos/core/cli_shared.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L56" rel="noopener noreferrer">run_cmd:56</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L65" rel="noopener noreferrer">get_git_status:65</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L79" rel="noopener noreferrer">run_push:79</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L90" rel="noopener noreferrer">start_deployment_wizard:90</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L451" rel="noopener noreferrer">check_gate:451</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L117" rel="noopener noreferrer">build_trace_cache_key:117</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L153" rel="noopener noreferrer">load_trace_cache:153</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L181" rel="noopener noreferrer">save_trace_cache:181</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L209" rel="noopener noreferrer">clear_run_cache:209</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L226" rel="noopener noreferrer">run_cache_stats:226</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L82" rel="noopener noreferrer">detect_language:82</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L101" rel="noopener noreferrer">source_globs_for_language:101</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L178" rel="noopener noreferrer">repo_relative_path:178</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L192" rel="noopener noreferrer">module_candidates:192</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">run_cmd</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">get_git_status</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">run_push</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">start_deployment_wizard</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">check_gate</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">build_trace_cache_key</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">load_trace_cache</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">save_trace_cache</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">clear_run_cache</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">run_cache_stats</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">should_exclude_path</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">should_include_path</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">find_git_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">list_git_visible_files</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/collect.py skylos/deadcode/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/liveness.py skylos/deadcode/evidence.py skylos/deadcode/collect.py skylos/deadcode/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 40</span>
-          <span class="pill"><strong>lines</strong> 994</span>
         </div>
       </div>
       <p>Dead-code specific analysis, framework liveness, and evidence support.</p>
@@ -1243,37 +1228,36 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">skylos/deadcode/evidence.py</a> <span>535 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">skylos/deadcode/liveness.py</a> <span>437 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py" rel="noopener noreferrer">skylos/deadcode/collect.py</a> <span>20 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/__init__.py" rel="noopener noreferrer">skylos/deadcode/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">skylos/deadcode/liveness.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">skylos/deadcode/evidence.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py" rel="noopener noreferrer">skylos/deadcode/collect.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/__init__.py" rel="noopener noreferrer">skylos/deadcode/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L12" rel="noopener noreferrer">EvidenceKind:12</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L28" rel="noopener noreferrer">CandidateClassification:28</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L37" rel="noopener noreferrer">SymbolKey:37</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L89" rel="noopener noreferrer">EvidenceEvent:89</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L107" rel="noopener noreferrer">EvidenceLedger:107</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L61" rel="noopener noreferrer">LivenessRescue:61</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L69" rel="noopener noreferrer">LivenessReport:69</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L95" rel="noopener noreferrer">apply_dead_code_liveness:95</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L88" rel="noopener noreferrer">_AttrCall:88</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L129" rel="noopener noreferrer">_mark:129</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py#L14" rel="noopener noreferrer">collect_dead_code_findings:14</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">LivenessRescue</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">LivenessReport</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">apply_dead_code_liveness</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">_AttrCall</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">_mark</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">EvidenceKind</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">CandidateClassification</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">SymbolKey</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">EvidenceEvent</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">EvidenceLedger</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py" rel="noopener noreferrer">collect_dead_code_findings</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/debt technical-debt detection and reporting helpers. use this for code-health signals that are not direct security findings. skylos/debt/ test/test_debt.py skylos/debt/report.py skylos/debt/baseline.py skylos/debt/engine.py skylos/debt/advisor.py skylos/debt/scoring.py skylos/debt/policy.py skylos/debt/result.py skylos/debt/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/debt technical-debt detection and reporting helpers. use this for code-health signals that are not direct security findings. skylos/debt/ test/test_debt.py skylos/debt/report.py skylos/debt/baseline.py skylos/debt/advisor.py skylos/debt/engine.py skylos/debt/scoring.py skylos/debt/policy.py skylos/debt/result.py skylos/debt/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt" rel="noopener noreferrer">skylos/debt</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 8</span>
           <span class="pill"><strong>symbols</strong> 104</span>
-          <span class="pill"><strong>lines</strong> 2153</span>
         </div>
       </div>
       <p>Technical-debt detection and reporting helpers.</p>
@@ -1287,44 +1271,43 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">skylos/debt/report.py</a> <span>390 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">skylos/debt/baseline.py</a> <span>468 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py" rel="noopener noreferrer">skylos/debt/engine.py</a> <span>316 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">skylos/debt/advisor.py</a> <span>292 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">skylos/debt/scoring.py</a> <span>301 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py" rel="noopener noreferrer">skylos/debt/policy.py</a> <span>174 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">skylos/debt/result.py</a> <span>138 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py" rel="noopener noreferrer">skylos/debt/__init__.py</a> <span>74 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">skylos/debt/report.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">skylos/debt/baseline.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">skylos/debt/advisor.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py" rel="noopener noreferrer">skylos/debt/engine.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">skylos/debt/scoring.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py" rel="noopener noreferrer">skylos/debt/policy.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">skylos/debt/result.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py" rel="noopener noreferrer">skylos/debt/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L244" rel="noopener noreferrer">format_debt_table:244</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L280" rel="noopener noreferrer">format_debt_json:280</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L357" rel="noopener noreferrer">format_debt_history_table:357</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L388" rel="noopener noreferrer">format_debt_history_json:388</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L9" rel="noopener noreferrer">_ordered_hotspots:9</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L272" rel="noopener noreferrer">save_baseline:272</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L308" rel="noopener noreferrer">load_baseline:308</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L332" rel="noopener noreferrer">load_history:332</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L384" rel="noopener noreferrer">annotate_hotspots:384</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L426" rel="noopener noreferrer">compare_to_baseline:426</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L43" rel="noopener noreferrer">run_analyze:43</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L186" rel="noopener noreferrer">collect_debt_signals:186</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L223" rel="noopener noreferrer">build_debt_snapshot:223</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L284" rel="noopener noreferrer">run_debt_analysis:284</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_table</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_json</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_history_table</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_history_json</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">_ordered_hotspots</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">save_baseline</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">load_baseline</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">load_history</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">annotate_hotspots</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">compare_to_baseline</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">DebtAdvisor</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">augment_hotspots_with_advisories</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">_system_prompt</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">_safe_excerpt</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/defend defensive scanning plugins and checks for suspicious package or code patterns. use this for supply-chain or malicious-code detection extensions. skylos/defend/ test/test_defend.py test/test_defend_typescript.py skylos/defend/owasp.py skylos/defend/report.py skylos/defend/policy.py skylos/defend/scoring.py skylos/defend/result.py skylos/defend/engine.py skylos/defend/plugin.py skylos/defend/plugins/untrusted_input_to_prompt.py">
+    <article class="folder-card searchable" data-search="skylos/defend defensive scanning plugins and checks for suspicious package or code patterns. use this for supply-chain or malicious-code detection extensions. skylos/defend/ test/test_defend.py test/test_defend_typescript.py skylos/defend/owasp.py skylos/defend/policy.py skylos/defend/result.py skylos/defend/scoring.py skylos/defend/engine.py skylos/defend/report.py skylos/defend/plugin.py skylos/defend/plugins/cost_controls.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend" rel="noopener noreferrer">skylos/defend</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 22</span>
           <span class="pill"><strong>symbols</strong> 36</span>
-          <span class="pill"><strong>lines</strong> 1555</span>
         </div>
       </div>
       <p>Defensive scanning plugins and checks for suspicious package or code patterns.</p>
@@ -1338,44 +1321,43 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">skylos/defend/owasp.py</a> <span>319 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py" rel="noopener noreferrer">skylos/defend/report.py</a> <span>198 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">skylos/defend/policy.py</a> <span>150 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">skylos/defend/scoring.py</a> <span>100 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">skylos/defend/result.py</a> <span>69 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/engine.py" rel="noopener noreferrer">skylos/defend/engine.py</a> <span>80 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugin.py" rel="noopener noreferrer">skylos/defend/plugin.py</a> <span>65 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/untrusted_input_to_prompt.py" rel="noopener noreferrer">skylos/defend/plugins/untrusted_input_to_prompt.py</a> <span>44 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">skylos/defend/owasp.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">skylos/defend/policy.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">skylos/defend/result.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">skylos/defend/scoring.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/engine.py" rel="noopener noreferrer">skylos/defend/engine.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py" rel="noopener noreferrer">skylos/defend/report.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugin.py" rel="noopener noreferrer">skylos/defend/plugin.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/cost_controls.py" rel="noopener noreferrer">skylos/defend/plugins/cost_controls.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L189" rel="noopener noreferrer">supported_owasp_frameworks:189</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L193" rel="noopener noreferrer">supported_owasp_versions:193</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L200" rel="noopener noreferrer">normalize_owasp_framework:200</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L209" rel="noopener noreferrer">normalize_owasp_selection:209</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L232" rel="noopener noreferrer">get_owasp_mapping:232</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L17" rel="noopener noreferrer">format_defense_table:17</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L102" rel="noopener noreferrer">format_defense_json:102</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L51" rel="noopener noreferrer">DefensePolicy:51</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L66" rel="noopener noreferrer">load_policy:66</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L89" rel="noopener noreferrer">_parse_policy:89</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L19" rel="noopener noreferrer">compute_defense_score:19</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L70" rel="noopener noreferrer">compute_ops_score:70</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L13" rel="noopener noreferrer">_score_pct:13</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L8" rel="noopener noreferrer">DefenseResult:8</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">supported_owasp_frameworks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">supported_owasp_versions</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">normalize_owasp_framework</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">normalize_owasp_selection</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">get_owasp_mapping</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">DefensePolicy</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">load_policy</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">_parse_policy</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">DefenseResult</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">DefenseScore</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">OpsScore</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">compute_defense_score</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">compute_ops_score</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">_score_pct</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/discover source discovery and language/workspace detection. change this when skylos misses files or scans too much.  test/test_discover.py test/test_discover_typescript.py test/test_file_discovery.py skylos/discover/detector.py skylos/discover/detector_typescript.py skylos/discover/taint.py skylos/discover/graph.py skylos/discover/integration.py skylos/discover/report.py skylos/discover/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/discover source discovery and language/workspace detection. change this when skylos misses files or scans too much.  test/test_discover.py test/test_discover_typescript.py test/test_file_discovery.py skylos/discover/detector_typescript.py skylos/discover/detector.py skylos/discover/graph.py skylos/discover/taint.py skylos/discover/integration.py skylos/discover/report.py skylos/discover/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover" rel="noopener noreferrer">skylos/discover</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
           <span class="pill"><strong>symbols</strong> 45</span>
-          <span class="pill"><strong>lines</strong> 2393</span>
         </div>
       </div>
       <p>Source discovery and language/workspace detection.</p>
@@ -1389,30 +1371,30 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">skylos/discover/detector.py</a> <span>1308 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">skylos/discover/detector_typescript.py</a> <span>626 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">skylos/discover/taint.py</a> <span>210 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">skylos/discover/graph.py</a> <span>98 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py" rel="noopener noreferrer">skylos/discover/integration.py</a> <span>68 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py" rel="noopener noreferrer">skylos/discover/report.py</a> <span>67 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/__init__.py" rel="noopener noreferrer">skylos/discover/__init__.py</a> <span>16 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">skylos/discover/detector_typescript.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">skylos/discover/detector.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">skylos/discover/graph.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">skylos/discover/taint.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py" rel="noopener noreferrer">skylos/discover/integration.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py" rel="noopener noreferrer">skylos/discover/report.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/__init__.py" rel="noopener noreferrer">skylos/discover/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1049" rel="noopener noreferrer">detect_integrations:1049</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L233" rel="noopener noreferrer">_LLMDetectorVisitor:233</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1082" rel="noopener noreferrer">_default_exclude_folders:1082</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1102" rel="noopener noreferrer">_scan_python_file:1102</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1118" rel="noopener noreferrer">_collect_python_files:1118</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L173" rel="noopener noreferrer">JSImport:173</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L180" rel="noopener noreferrer">TSClient:180</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L187" rel="noopener noreferrer">collect_typescript_files:187</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L200" rel="noopener noreferrer">scan_typescript_file:200</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L290" rel="noopener noreferrer">_should_skip_typescript_file:290</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L9" rel="noopener noreferrer">TaintFlow:9</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L201" rel="noopener noreferrer">analyze_taint_flows:201</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L26" rel="noopener noreferrer">_TaintVisitor:26</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L8" rel="noopener noreferrer">NodeType:8</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">JSImport</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">TSClient</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">collect_typescript_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">scan_typescript_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">_should_skip_typescript_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">detect_integrations</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">_LLMDetectorVisitor</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">_default_exclude_folders</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">_scan_python_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">_collect_python_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">NodeType</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">GraphNode</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">GraphEdge</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">AIIntegrationGraph</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -1425,7 +1407,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 7</span>
-          <span class="pill"><strong>lines</strong> 195</span>
         </div>
       </div>
       <p>Language-specific engines and parsers beyond the Python AST path.</p>
@@ -1439,19 +1420,19 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">skylos/engines/go_runner.py</a> <span>147 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">skylos/engines/go_contract.py</a> <span>48 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/__init__.py" rel="noopener noreferrer">skylos/engines/__init__.py</a> <span>0 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">skylos/engines/go_runner.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">skylos/engines/go_contract.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/__init__.py" rel="noopener noreferrer">skylos/engines/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L15" rel="noopener noreferrer">GoEngineError:15</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L34" rel="noopener noreferrer">discover_go_modules:34</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L67" rel="noopener noreferrer">resolve_go_engine_bin:67</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L96" rel="noopener noreferrer">run_go_engine_for_module:96</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L19" rel="noopener noreferrer">_is_runnable_go_engine:19</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L4" rel="noopener noreferrer">build_go_engine_args:4</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L17" rel="noopener noreferrer">validate_go_engine_output:17</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">GoEngineError</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">discover_go_modules</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">resolve_go_engine_bin</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">run_go_engine_for_module</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">_is_runnable_go_engine</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">build_go_engine_args</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">validate_go_engine_output</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1464,7 +1445,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 16</span>
-          <span class="pill"><strong>lines</strong> 502</span>
         </div>
       </div>
       <p>External-service integration helpers.</p>
@@ -1478,35 +1458,34 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">skylos/integrations/ingest.py</a> <span>344 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">skylos/integrations/sonar.py</a> <span>156 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/__init__.py" rel="noopener noreferrer">skylos/integrations/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">skylos/integrations/ingest.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">skylos/integrations/sonar.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/__init__.py" rel="noopener noreferrer">skylos/integrations/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L27" rel="noopener noreferrer">is_claude_security_report:27</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L56" rel="noopener noreferrer">normalize_claude_security:56</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L165" rel="noopener noreferrer">cross_reference:165</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L223" rel="noopener noreferrer">print_cross_reference_report:223</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L265" rel="noopener noreferrer">ingest_claude_security:265</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L16" rel="noopener noreferrer">parse_sonar_properties:16</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L86" rel="noopener noreferrer">split_sonar_list:86</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L92" rel="noopener noreferrer">build_sonar_migration_plan:92</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L139" rel="noopener noreferrer">write_skylos_yaml_config:139</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py#L154" rel="noopener noreferrer">format_migration_plan_json:154</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">is_claude_security_report</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">normalize_claude_security</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">cross_reference</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">print_cross_reference_report</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">ingest_claude_security</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">parse_sonar_properties</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">split_sonar_list</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">build_sonar_migration_plan</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">write_skylos_yaml_config</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/sonar.py" rel="noopener noreferrer">format_migration_plan_json</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_context.py test/test_llm_finding_evidence.py test/test_llm_graph.py skylos/llm/verify_orchestrator.py skylos/llm/security_taskflow.py skylos/llm/analyzer.py skylos/llm/agents.py skylos/llm/_grounding.py skylos/llm/context.py skylos/llm/finding_evidence.py skylos/llm/prompts.py">
+    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_context.py test/test_llm_finding_evidence.py test/test_llm_graph.py skylos/llm/security_taskflow.py skylos/llm/verify_orchestrator.py skylos/llm/_grounding.py skylos/llm/finding_evidence.py skylos/llm/liveness.py skylos/llm/prompts.py skylos/llm/security_verifier.py skylos/llm/agents.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 28</span>
           <span class="pill"><strong>symbols</strong> 346</span>
-          <span class="pill"><strong>lines</strong> 14152</span>
         </div>
       </div>
       <p>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</p>
@@ -1520,31 +1499,31 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a> <span>3110 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">skylos/llm/security_taskflow.py</a> <span>940 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py" rel="noopener noreferrer">skylos/llm/analyzer.py</a> <span>882 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/agents.py" rel="noopener noreferrer">skylos/llm/agents.py</a> <span>754 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">skylos/llm/_grounding.py</a> <span>466 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/context.py" rel="noopener noreferrer">skylos/llm/context.py</a> <span>749 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a> <span>344 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/prompts.py" rel="noopener noreferrer">skylos/llm/prompts.py</a> <span>460 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">skylos/llm/security_taskflow.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">skylos/llm/_grounding.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/liveness.py" rel="noopener noreferrer">skylos/llm/liveness.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/prompts.py" rel="noopener noreferrer">skylos/llm/prompts.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_verifier.py" rel="noopener noreferrer">skylos/llm/security_verifier.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/agents.py" rel="noopener noreferrer">skylos/llm/agents.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L292" rel="noopener noreferrer">discover_entry_points:292</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L1457" rel="noopener noreferrer">verify_with_graph_context:1457</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L1551" rel="noopener noreferrer">audit_suppressed_finding:1551</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L2480" rel="noopener noreferrer">run_verification:2480</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py#L72" rel="noopener noreferrer">_gather_config_files:72</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L50" rel="noopener noreferrer">SecurityTaskStage:50</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L57" rel="noopener noreferrer">SecurityRepoNode:57</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L71" rel="noopener noreferrer">SecurityEntrypoint:71</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L77" rel="noopener noreferrer">SecurityTrustBoundary:77</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py#L83" rel="noopener noreferrer">SecurityFileFacts:83</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L39" rel="noopener noreferrer">AnalyzerConfig:39</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L102" rel="noopener noreferrer">SkylosLLM:102</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L862" rel="noopener noreferrer">analyze:862</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/analyzer.py#L874" rel="noopener noreferrer">audit:874</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">SecurityTaskStage</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">SecurityRepoNode</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">SecurityEntrypoint</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">SecurityTrustBoundary</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">SecurityFileFacts</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">discover_entry_points</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">verify_with_graph_context</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">audit_suppressed_finding</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">run_verification</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">_gather_config_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">SymbolDef</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">build_grounding_context</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">read_bounded_bytes</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">_ParsedFile</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -1557,7 +1536,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 1</span>
           <span class="pill"><strong>symbols</strong> 7</span>
-          <span class="pill"><strong>lines</strong> 309</span>
         </div>
       </div>
       <p>Generated facts are available; this folder still needs a curated summary.</p>
@@ -1571,15 +1549,15 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">skylos/misc/update_mapping.py</a> <span>309 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">skylos/misc/update_mapping.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L17" rel="noopener noreferrer">load_existing:17</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L32" rel="noopener noreferrer">bootstrap_from_pipreqs:32</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L98" rel="noopener noreferrer">get_stdlib:98</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L190" rel="noopener noreferrer">scan:190</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py#L268" rel="noopener noreferrer">main:268</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">load_existing</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">bootstrap_from_pipreqs</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">get_stdlib</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">scan</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/misc/update_mapping.py" rel="noopener noreferrer">main</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1592,7 +1570,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 2</span>
           <span class="pill"><strong>symbols</strong> 4</span>
-          <span class="pill"><strong>lines</strong> 191</span>
         </div>
       </div>
       <p>Plugin interfaces and loading support.</p>
@@ -1606,15 +1583,15 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py" rel="noopener noreferrer">skylos/plugins/pytest_unused_fixtures.py</a> <span>189 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/__init__.py" rel="noopener noreferrer">skylos/plugins/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py" rel="noopener noreferrer">skylos/plugins/pytest_unused_fixtures.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/__init__.py" rel="noopener noreferrer">skylos/plugins/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L9" rel="noopener noreferrer">UnsafeFixtureReportPath:9</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L13" rel="noopener noreferrer">FixtureInfo:13</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L21" rel="noopener noreferrer">UnusedFixturesPlugin:21</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py#L185" rel="noopener noreferrer">pytest_configure:185</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py" rel="noopener noreferrer">UnsafeFixtureReportPath</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py" rel="noopener noreferrer">FixtureInfo</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py" rel="noopener noreferrer">UnusedFixturesPlugin</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/plugins/pytest_unused_fixtures.py" rel="noopener noreferrer">pytest_configure</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1627,7 +1604,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 42</span>
-          <span class="pill"><strong>lines</strong> 1018</span>
         </div>
       </div>
       <p>Autofix and cleanup support for selected findings.</p>
@@ -1641,37 +1617,36 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">skylos/remediation/fixgen.py</a> <span>590 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">skylos/remediation/codemods.py</a> <span>390 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/safety.py" rel="noopener noreferrer">skylos/remediation/safety.py</a> <span>36 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/__init__.py" rel="noopener noreferrer">skylos/remediation/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">skylos/remediation/fixgen.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">skylos/remediation/codemods.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/safety.py" rel="noopener noreferrer">skylos/remediation/safety.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/__init__.py" rel="noopener noreferrer">skylos/remediation/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L186" rel="noopener noreferrer">RemovalPatch:186</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L428" rel="noopener noreferrer">generate_removal_plan:428</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L463" rel="noopener noreferrer">generate_unified_diff:463</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L514" rel="noopener noreferrer">apply_patches:514</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py#L558" rel="noopener noreferrer">validate_patches:558</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L203" rel="noopener noreferrer">comment_out_unused_function_cst:203</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L212" rel="noopener noreferrer">comment_out_unused_import_cst:212</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L316" rel="noopener noreferrer">remove_unused_import_cst:316</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L323" rel="noopener noreferrer">remove_unused_function_cst:323</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py#L376" rel="noopener noreferrer">remove_unused_class_cst:376</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/safety.py#L6" rel="noopener noreferrer">resolve_remediation_path:6</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">RemovalPatch</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">generate_removal_plan</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">generate_unified_diff</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">apply_patches</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/fixgen.py" rel="noopener noreferrer">validate_patches</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">comment_out_unused_function_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">comment_out_unused_import_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">remove_unused_import_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">remove_unused_function_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/codemods.py" rel="noopener noreferrer">remove_unused_class_cst</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/remediation/safety.py" rel="noopener noreferrer">resolve_remediation_path</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/reporting output formatters and exports such as sarif, compact json, and human-readable reports. use this when scan results are right but the output is wrong or hard to consume. skylos/reporting/  skylos/reporting/provenance.py skylos/reporting/grader.py skylos/reporting/sarif.py skylos/reporting/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/reporting output formatters and exports such as sarif, compact json, and human-readable reports. use this when scan results are right but the output is wrong or hard to consume. skylos/reporting/  skylos/reporting/grader.py skylos/reporting/provenance.py skylos/reporting/sarif.py skylos/reporting/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 30</span>
-          <span class="pill"><strong>lines</strong> 1073</span>
         </div>
       </div>
       <p>Output formatters and exports such as SARIF, compact JSON, and human-readable reports.</p>
@@ -1685,39 +1660,38 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">skylos/reporting/provenance.py</a> <span>529 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">skylos/reporting/grader.py</a> <span>346 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py" rel="noopener noreferrer">skylos/reporting/sarif.py</a> <span>196 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/__init__.py" rel="noopener noreferrer">skylos/reporting/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">skylos/reporting/grader.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">skylos/reporting/provenance.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py" rel="noopener noreferrer">skylos/reporting/sarif.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/__init__.py" rel="noopener noreferrer">skylos/reporting/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L59" rel="noopener noreferrer">FileProvenance:59</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L68" rel="noopener noreferrer">ProvenanceReport:68</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L151" rel="noopener noreferrer">analyze_provenance:151</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L356" rel="noopener noreferrer">annotate_findings_with_provenance:356</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py#L395" rel="noopener noreferrer">compute_ai_security_stats:395</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L72" rel="noopener noreferrer">score_to_letter:72</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L80" rel="noopener noreferrer">count_lines_of_code:80</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L144" rel="noopener noreferrer">score_security:144</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L148" rel="noopener noreferrer">score_quality:148</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py#L167" rel="noopener noreferrer">score_dead_code:167</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py#L5" rel="noopener noreferrer">severity_to_sarif_level:5</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py#L14" rel="noopener noreferrer">normalize_file_path_for_sarif:14</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py#L32" rel="noopener noreferrer">SarifExporter:32</a> <span>class</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">score_to_letter</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">count_lines_of_code</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">score_security</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">score_quality</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">score_dead_code</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">FileProvenance</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">ProvenanceReport</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">analyze_provenance</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">annotate_findings_with_provenance</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">compute_ai_security_stats</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py" rel="noopener noreferrer">severity_to_sarif_level</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py" rel="noopener noreferrer">normalize_file_path_for_sarif</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/sarif.py" rel="noopener noreferrer">SarifExporter</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/rules rule catalog and concrete rule implementations for quality, security, config, and sca findings. start here when adding rule ids, tuning scanner semantics, or changing rule docs parity. skylos/rules/catalog.py skylos/rules/danger skylos/rules/quality test/test_community_rules.py test/test_good_practices_rules.py test/test_mcp_rules.py test/test_quality_new_rules.py test/test_quality_rules.py test/test_rules_cmd.py skylos/rules/config/cicd/github_actions.py skylos/rules/quality/logic_security.py skylos/rules/config/cicd/gitlab_ci.py skylos/rules/quality/logic_foundation.py skylos/rules/danger/danger_hallucination/dependency_hallucination.py skylos/rules/quality/_readability.py skylos/rules/quality/clones.py skylos/rules/quality/phantom_refs.py">
+    <article class="folder-card searchable" data-search="skylos/rules rule catalog and concrete rule implementations for quality, security, config, and sca findings. start here when adding rule ids, tuning scanner semantics, or changing rule docs parity. skylos/rules/catalog.py skylos/rules/danger skylos/rules/quality test/test_community_rules.py test/test_good_practices_rules.py test/test_mcp_rules.py test/test_quality_new_rules.py test/test_quality_rules.py test/test_rules_cmd.py skylos/rules/config/cicd/github_actions.py skylos/rules/config/cicd/gitlab_ci.py skylos/rules/quality/logic_foundation.py skylos/rules/quality/logic_security.py skylos/rules/quality/_readability.py skylos/rules/quality/clones.py skylos/rules/danger/danger_hallucination/dependency_hallucination.py skylos/rules/danger/danger_net/ssrf_flow.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 67</span>
           <span class="pill"><strong>symbols</strong> 489</span>
-          <span class="pill"><strong>lines</strong> 18872</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, config, and SCA findings.</p>
@@ -1731,31 +1705,31 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">skylos/rules/config/cicd/github_actions.py</a> <span>1963 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py" rel="noopener noreferrer">skylos/rules/quality/logic_security.py</a> <span>1720 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">skylos/rules/config/cicd/gitlab_ci.py</a> <span>946 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">skylos/rules/quality/logic_foundation.py</a> <span>1024 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/danger/danger_hallucination/dependency_hallucination.py" rel="noopener noreferrer">skylos/rules/danger/danger_hallucination/dependency_hallucination.py</a> <span>895 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/_readability.py" rel="noopener noreferrer">skylos/rules/quality/_readability.py</a> <span>603 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/clones.py" rel="noopener noreferrer">skylos/rules/quality/clones.py</a> <span>543 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/phantom_refs.py" rel="noopener noreferrer">skylos/rules/quality/phantom_refs.py</a> <span>565 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">skylos/rules/config/cicd/github_actions.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">skylos/rules/config/cicd/gitlab_ci.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">skylos/rules/quality/logic_foundation.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py" rel="noopener noreferrer">skylos/rules/quality/logic_security.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/_readability.py" rel="noopener noreferrer">skylos/rules/quality/_readability.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/clones.py" rel="noopener noreferrer">skylos/rules/quality/clones.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/danger/danger_hallucination/dependency_hallucination.py" rel="noopener noreferrer">skylos/rules/danger/danger_hallucination/dependency_hallucination.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/danger/danger_net/ssrf_flow.py" rel="noopener noreferrer">skylos/rules/danger/danger_net/ssrf_flow.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L1889" rel="noopener noreferrer">scan_github_actions_file:1889</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L1950" rel="noopener noreferrer">scan_github_actions:1950</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L165" rel="noopener noreferrer">_finding:165</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L189" rel="noopener noreferrer">_is_workflow_file:189</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py#L199" rel="noopener noreferrer">_is_action_file:199</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L49" rel="noopener noreferrer">DebugLeftoverRule:49</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L143" rel="noopener noreferrer">SecurityTodoRule:143</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L195" rel="noopener noreferrer">DisabledSecurityRule:195</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L350" rel="noopener noreferrer">PhantomCallRule:350</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_security.py#L438" rel="noopener noreferrer">PhantomDecoratorRule:438</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L901" rel="noopener noreferrer">scan_gitlab_ci_file:901</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L935" rel="noopener noreferrer">scan_gitlab_ci:935</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L110" rel="noopener noreferrer">_finding:110</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py#L134" rel="noopener noreferrer">_is_gitlab_ci_file:134</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">scan_github_actions_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">scan_github_actions</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">_finding</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">_is_workflow_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">_is_action_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">scan_gitlab_ci_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">scan_gitlab_ci</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">_finding</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">_is_gitlab_ci_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/gitlab_ci.py" rel="noopener noreferrer">_is_under_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">MutableDefaultRule</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">BareExceptRule</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">DangerousComparisonRule</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">DuplicateBranchRule</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -1768,7 +1742,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 2</span>
           <span class="pill"><strong>symbols</strong> 2</span>
-          <span class="pill"><strong>lines</strong> 157</span>
         </div>
       </div>
       <p>Scale and performance helpers for larger repositories.</p>
@@ -1782,13 +1755,13 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py" rel="noopener noreferrer">skylos/scale/parallel_static.py</a> <span>157 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/__init__.py" rel="noopener noreferrer">skylos/scale/__init__.py</a> <span>0 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py" rel="noopener noreferrer">skylos/scale/parallel_static.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/__init__.py" rel="noopener noreferrer">skylos/scale/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L35" rel="noopener noreferrer">run_proc_file_parallel:35</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py#L8" rel="noopener noreferrer">_worker:8</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py" rel="noopener noreferrer">run_proc_file_parallel</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/scale/parallel_static.py" rel="noopener noreferrer">_worker</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1801,7 +1774,6 @@
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 4</span>
           <span class="pill"><strong>symbols</strong> 35</span>
-          <span class="pill"><strong>lines</strong> 1102</span>
         </div>
       </div>
       <p>Security contract detection, secret handling, and security-specific analysis helpers.</p>
@@ -1815,40 +1787,39 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">skylos/security/contracts.py</a> <span>471 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">skylos/security/injection_scanner.py</a> <span>462 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">skylos/security/canonicalize.py</a> <span>167 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/__init__.py" rel="noopener noreferrer">skylos/security/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">skylos/security/contracts.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">skylos/security/injection_scanner.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">skylos/security/canonicalize.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/__init__.py" rel="noopener noreferrer">skylos/security/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L26" rel="noopener noreferrer">SecurityContract:26</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L37" rel="noopener noreferrer">RouteSnapshot:37</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L46" rel="noopener noreferrer">load_security_contracts:46</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L101" rel="noopener noreferrer">resolve_diff_base_ref:101</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py#L117" rel="noopener noreferrer">detect_security_contract_regressions:117</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L105" rel="noopener noreferrer">scan_file:105</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L228" rel="noopener noreferrer">scan_directory:228</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L256" rel="noopener noreferrer">_extract_segments:256</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L327" rel="noopener noreferrer">_markdown_fence_marker:327</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py#L345" rel="noopener noreferrer">_matched_fenced_block_lines:345</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L80" rel="noopener noreferrer">normalize:80</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L86" rel="noopener noreferrer">strip_zero_width:86</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L105" rel="noopener noreferrer">decode_base64_blobs:105</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py#L149" rel="noopener noreferrer">detect_homoglyphs:149</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">SecurityContract</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">RouteSnapshot</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">load_security_contracts</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">resolve_diff_base_ref</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">detect_security_contract_regressions</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">scan_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">scan_directory</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_extract_segments</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_markdown_fence_marker</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_matched_fenced_block_lines</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">normalize</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">strip_zero_width</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">decode_base64_blobs</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">detect_homoglyphs</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/ui terminal ui and presentation helpers. use this when the scan is correct but terminal interaction is confusing. skylos/ui/ test/test_suite.py test/test_tui.py skylos/ui/tui.py skylos/ui/terminal_report.py skylos/ui/help.py skylos/ui/nudge.py skylos/ui/tour.py skylos/ui/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/ui terminal ui and presentation helpers. use this when the scan is correct but terminal interaction is confusing. skylos/ui/ test/test_suite.py test/test_tui.py skylos/ui/terminal_report.py skylos/ui/tui.py skylos/ui/nudge.py skylos/ui/help.py skylos/ui/tour.py skylos/ui/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
           <span class="pill"><strong>symbols</strong> 40</span>
-          <span class="pill"><strong>lines</strong> 1799</span>
         </div>
       </div>
       <p>Terminal UI and presentation helpers.</p>
@@ -1862,42 +1833,41 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">skylos/ui/tui.py</a> <span>802 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">skylos/ui/terminal_report.py</a> <span>477 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py" rel="noopener noreferrer">skylos/ui/help.py</a> <span>236 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">skylos/ui/nudge.py</a> <span>152 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tour.py" rel="noopener noreferrer">skylos/ui/tour.py</a> <span>130 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/__init__.py" rel="noopener noreferrer">skylos/ui/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">skylos/ui/terminal_report.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">skylos/ui/tui.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">skylos/ui/nudge.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py" rel="noopener noreferrer">skylos/ui/help.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tour.py" rel="noopener noreferrer">skylos/ui/tour.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/__init__.py" rel="noopener noreferrer">skylos/ui/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L68" rel="noopener noreferrer">prepare_category_data:68</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L179" rel="noopener noreferrer">CategoryItem:179</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L191" rel="noopener noreferrer">FindingItem:191</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L274" rel="noopener noreferrer">OverviewPanel:274</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py#L355" rel="noopener noreferrer">DetailPanel:355</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L71" rel="noopener noreferrer">PrettyFinding:71</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L84" rel="noopener noreferrer">render_pretty_results:84</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L139" rel="noopener noreferrer">collect_pretty_findings:139</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L169" rel="noopener noreferrer">_make_pretty_finding:169</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py#L203" rel="noopener noreferrer">_print_finding:203</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py#L174" rel="noopener noreferrer">print_command_overview:174</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py#L216" rel="noopener noreferrer">print_flat_commands:216</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py#L99" rel="noopener noreferrer">pick_nudge:99</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py#L8" rel="noopener noreferrer">_is_ci:8</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">PrettyFinding</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">render_pretty_results</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">collect_pretty_findings</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">_make_pretty_finding</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">_print_finding</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">prepare_category_data</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">CategoryItem</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">FindingItem</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">OverviewPanel</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">DetailPanel</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">pick_nudge</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">_is_ci</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">_nudges_enabled</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">_safe_pyproject_path</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/danger.py skylos/visitors/base.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/java/flow.py skylos/visitors/languages/shell/danger.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/typescript/resolve.py">
+    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/shell/danger.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/csharp/danger.py skylos/visitors/languages/typescript/resolve.py skylos/visitors/languages/csharp/core.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 39</span>
           <span class="pill"><strong>symbols</strong> 336</span>
-          <span class="pill"><strong>lines</strong> 18224</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1911,44 +1881,43 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a> <span>1846 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a> <span>1594 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py" rel="noopener noreferrer">skylos/visitors/base.py</a> <span>2316 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a> <span>1377 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/flow.py" rel="noopener noreferrer">skylos/visitors/languages/java/flow.py</a> <span>1997 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/shell/danger.py" rel="noopener noreferrer">skylos/visitors/languages/shell/danger.py</a> <span>477 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/workspace.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/workspace.py</a> <span>563 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/resolve.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/resolve.py</a> <span>623 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/shell/danger.py" rel="noopener noreferrer">skylos/visitors/languages/shell/danger.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/workspace.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/workspace.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/csharp/danger.py" rel="noopener noreferrer">skylos/visitors/languages/csharp/danger.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/resolve.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/resolve.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/csharp/core.py" rel="noopener noreferrer">skylos/visitors/languages/csharp/core.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L1692" rel="noopener noreferrer">scan_danger:1692</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L261" rel="noopener noreferrer">_shannon_entropy:261</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L271" rel="noopener noreferrer">_get_query:271</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L281" rel="noopener noreferrer">_get_text:281</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py#L285" rel="noopener noreferrer">_run_batch:285</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L490" rel="noopener noreferrer">scan_danger:490</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L255" rel="noopener noreferrer">_shannon_entropy:255</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L265" rel="noopener noreferrer">_get_query:265</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L275" rel="noopener noreferrer">_get_text:275</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py#L279" rel="noopener noreferrer">_is_sensitive_name:279</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py#L182" rel="noopener noreferrer">Definition:182</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/base.py#L313" rel="noopener noreferrer">Visitor:313</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py#L96" rel="noopener noreferrer">resolve_ts_module:96</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py#L148" rel="noopener noreferrer">build_ts_import_graph:148</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_run_batch</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">resolve_ts_module</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">build_ts_import_graph</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">demote_unconsumed_ts_exports</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">find_dead_ts_files</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">find_unused_ts_exports</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/web optional web server helpers. keep this separate from core cli scanning. skylos/web/ test/test_webhook_signature.py skylos/web/frontend.py skylos/web/server.py skylos/web/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/web optional web server helpers. keep this separate from core cli scanning. skylos/web/ test/test_webhook_signature.py skylos/web/server.py skylos/web/frontend.py skylos/web/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web" rel="noopener noreferrer">skylos/web</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 3</span>
           <span class="pill"><strong>symbols</strong> 10</span>
-          <span class="pill"><strong>lines</strong> 738</span>
         </div>
       </div>
       <p>Optional web server helpers.</p>
@@ -1962,31 +1931,30 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/frontend.py" rel="noopener noreferrer">skylos/web/frontend.py</a> <span>544 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">skylos/web/server.py</a> <span>192 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/__init__.py" rel="noopener noreferrer">skylos/web/__init__.py</a> <span>2 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">skylos/web/server.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/frontend.py" rel="noopener noreferrer">skylos/web/frontend.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/__init__.py" rel="noopener noreferrer">skylos/web/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/frontend.py#L540" rel="noopener noreferrer">render_frontend_html:540</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L111" rel="noopener noreferrer">serve_frontend:111</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L116" rel="noopener noreferrer">analyze_project:116</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L171" rel="noopener noreferrer">start_server:171</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L23" rel="noopener noreferrer">_normalize_exclude_folders:23</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py#L36" rel="noopener noreferrer">_get_server_port:36</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">serve_frontend</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">analyze_project</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">start_server</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">_normalize_exclude_folders</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/server.py" rel="noopener noreferrer">_get_server_port</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/web/frontend.py" rel="noopener noreferrer">render_frontend_html</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
     
 
-    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_center.py test/test_agent_integration.py test/test_agent_remediate.py test/test_agent_review_benchmark.py test/test_verify_orchestrator.py test/test_java_security.py test/test_analyzer.py test/test_debt.py test/test_cli.py test/test_vibe_rules.py test/test_defend.py test/test_cli_refactor_guardrails.py">
+    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_center.py test/test_agent_integration.py test/test_agent_remediate.py test/test_agent_review_benchmark.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_sync.py test/test_cli.py test/test_provenance.py test/test_cli_uncovered_paths.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 192</span>
-          <span class="pill"><strong>symbols</strong> 2310</span>
-          <span class="pill"><strong>lines</strong> 78224</span>
+          <span class="pill"><strong>symbols</strong> 2311</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2000,31 +1968,31 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a> <span>2542 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a> <span>1901 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a> <span>3159 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a> <span>1592 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a> <span>1878 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_vibe_rules.py" rel="noopener noreferrer">test/test_vibe_rules.py</a> <span>2201 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_defend.py" rel="noopener noreferrer">test/test_defend.py</a> <span>2132 lines</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a> <span>1310 lines</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_sync.py" rel="noopener noreferrer">test/test_sync.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_provenance.py" rel="noopener noreferrer">test/test_provenance.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_uncovered_paths.py" rel="noopener noreferrer">test/test_cli_uncovered_paths.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L40" rel="noopener noreferrer">sample_finding:40</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L62" rel="noopener noreferrer">sample_finding_with_callers:62</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L84" rel="noopener noreferrer">sample_defs_map:84</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L108" rel="noopener noreferrer">sample_source_cache:108</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py#L134" rel="noopener noreferrer">survivor_with_heuristic:134</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L39" rel="noopener noreferrer">test_java_constant_folding_caps_string_concatenation:39</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L49" rel="noopener noreferrer">test_java_constant_store_has_total_string_budget:49</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L69" rel="noopener noreferrer">test_object_input_stream_flags:69</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L85" rel="noopener noreferrer">test_zip_slip_style_archive_extraction_flags:85</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py#L105" rel="noopener noreferrer">test_archive_extraction_with_normalize_guard_is_safe:105</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L23" rel="noopener noreferrer">mock_definition:23</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L63" rel="noopener noreferrer">mock_test_aware_visitor:63</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L71" rel="noopener noreferrer">mock_framework_aware_visitor:71</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py#L78" rel="noopener noreferrer">temp_python_project:78</a> <span>def</span></li></ul>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test_java_constant_folding_caps_string_concatenation</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test_java_constant_store_has_total_string_budget</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test_object_input_stream_flags</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test_zip_slip_style_archive_extraction_flags</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test_archive_extraction_with_normalize_guard_is_safe</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">sample_finding</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">sample_finding_with_callers</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">sample_defs_map</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">sample_source_cache</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">survivor_with_heuristic</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_collect_debt_signals_maps_dimensions_and_dead_code</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_collect_debt_signals_skips_paths_outside_project_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_god_file_signal_becomes_modularity_debt_hotspot</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_collect_debt_signals_filters_to_changed_files</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -2037,118 +2005,104 @@
       <h2>Hot Zones</h2>
       <p class="lede">These files are not bad by default. They are places where a small change can affect many workflows.</p>
       <table>
-        <thead><tr><th>File</th><th>Lines</th><th>Public / all symbols</th><th>Signal</th><th>What it seems to own</th></tr></thead>
+        <thead><tr><th>File</th><th>Public / all symbols</th><th>Signal</th><th>What it seems to own</th></tr></thead>
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>5492</td>
               <td>35 / 183</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span> <span class="warn">shared path</span></td>
+              <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
-            <tr class="searchable" data-search="test/test_verify_orchestrator.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a></td>
-              <td>2542</td>
-              <td>79 / 79</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
-              <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
-            </tr>
-
-            <tr class="searchable" data-search="skylos/llm/verify_orchestrator.py llm security analysis, evidence grounding, provider runtime resolution, and prompt templates.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a></td>
-              <td>3110</td>
-              <td>4 / 56</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
-              <td>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</td>
-            </tr>
-
-            <tr class="searchable" data-search="skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a></td>
-              <td>1970</td>
-              <td>15 / 93</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
-              <td>Public API facade and private helpers for payloads, snippets, findings, URLs, and AI-detection metadata.</td>
+            <tr class="searchable" data-search="skylos/config.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></td>
+              <td>6 / 26</td>
+              <td><span class="warn">shared path</span></td>
+              <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3778</td>
               <td>3 / 19</td>
-              <td><span class="warn">large</span> <span class="warn">shared path</span></td>
+              <td><span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
+            </tr>
+
+            <tr class="searchable" data-search="skylos/pipeline.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/pipeline.py" rel="noopener noreferrer">skylos/pipeline.py</a></td>
+              <td>2 / 12</td>
+              <td><span class="warn">shared path</span></td>
+              <td>Root entrypoints and shared scan orchestration.</td>
+            </tr>
+
+            <tr class="searchable" data-search="skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a></td>
+              <td>15 / 93</td>
+              <td><span class="warn">many symbols</span></td>
+              <td>Public API facade and private helpers for payloads, snippets, findings, URLs, and AI-detection metadata.</td>
             </tr>
 
             <tr class="searchable" data-search="test/test_java_security.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a></td>
-              <td>1901</td>
               <td>85 / 89</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
+              <td><span class="warn">many symbols</span></td>
               <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
             </tr>
 
-            <tr class="searchable" data-search="skylos/rules/config/cicd/github_actions.py rule catalog and concrete rule implementations for quality, security, config, and sca findings.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">skylos/rules/config/cicd/github_actions.py</a></td>
-              <td>1963</td>
-              <td>2 / 63</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
-              <td>Rule catalog and concrete rule implementations for quality, security, config, and SCA findings.</td>
-            </tr>
-
-            <tr class="searchable" data-search="test/test_analyzer.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_analyzer.py" rel="noopener noreferrer">test/test_analyzer.py</a></td>
-              <td>3159</td>
-              <td>15 / 15</td>
-              <td><span class="warn">large</span></td>
+            <tr class="searchable" data-search="test/test_verify_orchestrator.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a></td>
+              <td>79 / 79</td>
+              <td><span class="warn">many symbols</span></td>
               <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
             </tr>
 
             <tr class="searchable" data-search="test/test_debt.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></td>
-              <td>1592</td>
               <td>70 / 73</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
+              <td><span class="warn">many symbols</span></td>
               <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
             </tr>
 
-            <tr class="searchable" data-search="test/test_cli.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></td>
-              <td>1878</td>
-              <td>43 / 44</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
+            <tr class="searchable" data-search="skylos/rules/config/cicd/github_actions.py rule catalog and concrete rule implementations for quality, security, config, and sca findings.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">skylos/rules/config/cicd/github_actions.py</a></td>
+              <td>2 / 63</td>
+              <td><span class="warn">many symbols</span></td>
+              <td>Rule catalog and concrete rule implementations for quality, security, config, and SCA findings.</td>
+            </tr>
+
+            <tr class="searchable" data-search="skylos/llm/security_taskflow.py llm security analysis, evidence grounding, provider runtime resolution, and prompt templates.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">skylos/llm/security_taskflow.py</a></td>
+              <td>11 / 58</td>
+              <td><span class="warn">many symbols</span></td>
+              <td>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</td>
+            </tr>
+
+            <tr class="searchable" data-search="skylos/llm/verify_orchestrator.py llm security analysis, evidence grounding, provider runtime resolution, and prompt templates.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a></td>
+              <td>4 / 56</td>
+              <td><span class="warn">many symbols</span></td>
+              <td>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</td>
+            </tr>
+
+            <tr class="searchable" data-search="test/test_cli_refactor_guardrails.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></td>
+              <td>52 / 54</td>
+              <td><span class="warn">many symbols</span></td>
               <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
             </tr>
 
-            <tr class="searchable" data-search="skylos/visitors/languages/java/danger.py ast/tree visitors that collect findings and semantic evidence.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></td>
-              <td>1846</td>
-              <td>1 / 45</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
-              <td>AST/tree visitors that collect findings and semantic evidence.</td>
+            <tr class="searchable" data-search="skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">skylos/agents/center.py</a></td>
+              <td>38 / 52</td>
+              <td><span class="warn">many symbols</span></td>
+              <td>Agent-facing payloads, service helpers, and review triage learning.</td>
             </tr>
 
-            <tr class="searchable" data-search="test/test_vibe_rules.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_vibe_rules.py" rel="noopener noreferrer">test/test_vibe_rules.py</a></td>
-              <td>2201</td>
-              <td>26 / 27</td>
-              <td><span class="warn">large</span></td>
-              <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
-            </tr>
-
-            <tr class="searchable" data-search="test/test_defend.py tests for the ai defense engine (phase 1b, 1c, 2, 3).">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_defend.py" rel="noopener noreferrer">test/test_defend.py</a></td>
-              <td>2132</td>
-              <td>23 / 25</td>
-              <td><span class="warn">large</span></td>
-              <td>Tests for the AI Defense Engine (Phase 1B, 1C, 2, 3).</td>
-            </tr>
-
-            <tr class="searchable" data-search="skylos/visitors/languages/typescript/danger.py ast/tree visitors that collect findings and semantic evidence.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a></td>
-              <td>1594</td>
-              <td>1 / 44</td>
-              <td><span class="warn">large</span> <span class="warn">many symbols</span></td>
-              <td>AST/tree visitors that collect findings and semantic evidence.</td>
+            <tr class="searchable" data-search="skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">skylos/cloud/sync.py</a></td>
+              <td>22 / 47</td>
+              <td><span class="warn">many symbols</span></td>
+              <td>Skylos Cloud login, credentials, policy sync, project context, and upload manifest support.</td>
             </tr></tbody>
       </table>
     </section>
@@ -2161,6300 +2115,6300 @@
         <thead><tr><th>Symbol</th><th>Kind</th><th>Surface</th><th>File</th></tr></thead>
         <tbody>
             <tr class="searchable" data-search="fetch_profile async def benchmarks/agent_review/fixtures/async_blocking_handler/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/async_blocking_handler/app.py#L5" rel="noopener noreferrer">fetch_profile:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/async_blocking_handler/app.py" rel="noopener noreferrer">fetch_profile</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/async_blocking_handler/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_health async def benchmarks/agent_review/fixtures/async_blocking_handler/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/async_blocking_handler/app.py#L14" rel="noopener noreferrer">fetch_health:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/async_blocking_handler/app.py" rel="noopener noreferrer">fetch_health</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/async_blocking_handler/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="handle_search def benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py#L4" rel="noopener noreferrer">handle_search:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py" rel="noopener noreferrer">handle_search</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="handle_homepage def benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py#L8" rel="noopener noreferrer">handle_homepage:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py" rel="noopener noreferrer">handle_homepage</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="query_all def benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py" rel="noopener noreferrer">query_all</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/db.py</td>
             </tr>
 
             <tr class="searchable" data-search="search_users def benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py#L4" rel="noopener noreferrer">search_users:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py" rel="noopener noreferrer">search_users</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py</td>
             </tr>
 
             <tr class="searchable" data-search="list_recent_users def benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py#L13" rel="noopener noreferrer">list_recent_users:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py" rel="noopener noreferrer">list_recent_users</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/repository.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_recent_users_query_shape def benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py#L4" rel="noopener noreferrer">test_recent_users_query_shape:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py" rel="noopener noreferrer">test_recent_users_query_shape</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/cross_file_sql_injection/tests/test_repository.py</td>
             </tr>
 
             <tr class="searchable" data-search="handle_dashboard def benchmarks/agent_review/fixtures/debt_hotspot_service/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/app.py#L4" rel="noopener noreferrer">handle_dashboard:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/app.py" rel="noopener noreferrer">handle_dashboard</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="reconcile_account def benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py#L1" rel="noopener noreferrer">reconcile_account:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py" rel="noopener noreferrer">reconcile_account</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py</td>
             </tr>
 
             <tr class="searchable" data-search="summarize_account def benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py#L41" rel="noopener noreferrer">summarize_account:41</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py" rel="noopener noreferrer">summarize_account</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/ledger.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_dashboard_happy_path def benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py#L4" rel="noopener noreferrer">test_dashboard_happy_path:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py" rel="noopener noreferrer">test_dashboard_happy_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/tests/test_dashboard.py</td>
             </tr>
 
             <tr class="searchable" data-search="process_nightly_account def benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py#L4" rel="noopener noreferrer">process_nightly_account:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py" rel="noopener noreferrer">process_nightly_account</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/debt_hotspot_service/worker.py</td>
             </tr>
 
             <tr class="searchable" data-search="route_request def benchmarks/agent_review/fixtures/duplicate_condition/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/duplicate_condition/module.py#L1" rel="noopener noreferrer">route_request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/duplicate_condition/module.py" rel="noopener noreferrer">route_request</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/duplicate_condition/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="route_request_ok def benchmarks/agent_review/fixtures/duplicate_condition/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/duplicate_condition/module.py#L9" rel="noopener noreferrer">route_request_ok:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/duplicate_condition/module.py" rel="noopener noreferrer">route_request_ok</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/duplicate_condition/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch_http def benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py#L5" rel="noopener noreferrer">dispatch_http:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py" rel="noopener noreferrer">dispatch_http</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/api.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py#L5" rel="noopener noreferrer">main:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="preview def benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py#L11" rel="noopener noreferrer">preview:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py" rel="noopener noreferrer">preview</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch_job def benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py#L4" rel="noopener noreferrer">dispatch_job:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py" rel="noopener noreferrer">dispatch_job</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_account def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py#L5" rel="noopener noreferrer">load_account:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py" rel="noopener noreferrer">load_account</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py</td>
             </tr>
 
             <tr class="searchable" data-search="archive_account def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py#L15" rel="noopener noreferrer">archive_account:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py" rel="noopener noreferrer">archive_account</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py</td>
             </tr>
 
             <tr class="searchable" data-search="dormant_report def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py#L20" rel="noopener noreferrer">dormant_report:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py" rel="noopener noreferrer">dormant_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/account.py</td>
             </tr>
 
             <tr class="searchable" data-search="query_all def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py" rel="noopener noreferrer">query_all</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py</td>
             </tr>
 
             <tr class="searchable" data-search="execute def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py#L5" rel="noopener noreferrer">execute:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py" rel="noopener noreferrer">execute</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/db.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_sort def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py#L4" rel="noopener noreferrer">normalize_sort:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py" rel="noopener noreferrer">normalize_sort</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_host def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py#L10" rel="noopener noreferrer">normalize_host:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py" rel="noopener noreferrer">normalize_host</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/formatters.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_dynamic_hook def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L4" rel="noopener noreferrer">run_dynamic_hook:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_dynamic_hook</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_registered_hook def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L9" rel="noopener noreferrer">run_registered_hook:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_registered_hook</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_mutable_runner def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L17" rel="noopener noreferrer">run_mutable_runner:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_mutable_runner</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_sample def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py#L24" rel="noopener noreferrer">run_sample:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_sample</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_partner def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py#L6" rel="noopener noreferrer">fetch_partner:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py" rel="noopener noreferrer">fetch_partner</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_internal_status def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py#L11" rel="noopener noreferrer">fetch_internal_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py" rel="noopener noreferrer">fetch_internal_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py#L15" rel="noopener noreferrer">lab_fetch:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py" rel="noopener noreferrer">lab_fetch</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/services/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_http_search_reaches_repository def benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py#L5" rel="noopener noreferrer">test_http_search_reaches_repository:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py" rel="noopener noreferrer">test_http_search_reaches_repository</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_registered_hook_is_list_based def benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py#L10" rel="noopener noreferrer">test_registered_hook_is_list_based:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py" rel="noopener noreferrer">test_registered_hook_is_list_based</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
             </tr>
 
             <tr class="searchable" data-search="dangerous_admin def benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py#L4" rel="noopener noreferrer">dangerous_admin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py" rel="noopener noreferrer">dangerous_admin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_admin_status def benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py#L11" rel="noopener noreferrer">format_admin_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py" rel="noopener noreferrer">format_admin_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/tools/admin.py</td>
             </tr>
 
             <tr class="searchable" data-search="request class benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py#L1" rel="noopener noreferrer">Request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py" rel="noopener noreferrer">Request</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py</td>
             </tr>
 
             <tr class="searchable" data-search="app class benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py#L5" rel="noopener noreferrer">App:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py" rel="noopener noreferrer">App</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/framework.py</td>
             </tr>
 
             <tr class="searchable" data-search="admin_query_route def benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py#L6" rel="noopener noreferrer">admin_query_route:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py" rel="noopener noreferrer">admin_query_route</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py</td>
             </tr>
 
             <tr class="searchable" data-search="health_route def benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py#L14" rel="noopener noreferrer">health_route:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py" rel="noopener noreferrer">health_route</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/extreme_grounding_framework/web/routes.py</td>
             </tr>
 
             <tr class="searchable" data-search="mirror_url async def benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py#L9" rel="noopener noreferrer">mirror_url:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py" rel="noopener noreferrer">mirror_url</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_status async def benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py#L15" rel="noopener noreferrer">fetch_status:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py" rel="noopener noreferrer">fetch_status</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/fastapi_query_ssrf/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="extract_bundle def benchmarks/agent_review/fixtures/flask_archive_extraction/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_archive_extraction/app.py#L17" rel="noopener noreferrer">extract_bundle:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_archive_extraction/app.py" rel="noopener noreferrer">extract_bundle</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_archive_extraction/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="extract_bundle_safe def benchmarks/agent_review/fixtures/flask_archive_extraction/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_archive_extraction/app.py#L27" rel="noopener noreferrer">extract_bundle_safe:27</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_archive_extraction/app.py" rel="noopener noreferrer">extract_bundle_safe</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_archive_extraction/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_tool def benchmarks/agent_review/fixtures/flask_getter_shell/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_getter_shell/app.py#L9" rel="noopener noreferrer">run_tool:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_getter_shell/app.py" rel="noopener noreferrer">run_tool</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_getter_shell/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_safe def benchmarks/agent_review/fixtures/flask_getter_shell/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_getter_shell/app.py#L15" rel="noopener noreferrer">run_safe:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_getter_shell/app.py" rel="noopener noreferrer">run_safe</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_getter_shell/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="user def benchmarks/agent_review/fixtures/flask_handler_security/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py#L10" rel="noopener noreferrer">user:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py" rel="noopener noreferrer">user</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_handler_security/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="ls def benchmarks/agent_review/fixtures/flask_handler_security/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py#L17" rel="noopener noreferrer">ls:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py" rel="noopener noreferrer">ls</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_handler_security/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="safe def benchmarks/agent_review/fixtures/flask_handler_security/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py#L23" rel="noopener noreferrer">safe:23</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_handler_security/app.py" rel="noopener noreferrer">safe</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_handler_security/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="bounce def benchmarks/agent_review/fixtures/flask_open_redirect/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_open_redirect/app.py#L10" rel="noopener noreferrer">bounce:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_open_redirect/app.py" rel="noopener noreferrer">bounce</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_open_redirect/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="bounce_safe def benchmarks/agent_review/fixtures/flask_open_redirect/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_open_redirect/app.py#L16" rel="noopener noreferrer">bounce_safe:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_open_redirect/app.py" rel="noopener noreferrer">bounce_safe</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_open_redirect/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="download_file def benchmarks/agent_review/fixtures/flask_path_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_path_traversal/app.py#L11" rel="noopener noreferrer">download_file:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_path_traversal/app.py" rel="noopener noreferrer">download_file</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_path_traversal/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="read_help def benchmarks/agent_review/fixtures/flask_path_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_path_traversal/app.py#L19" rel="noopener noreferrer">read_help:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_path_traversal/app.py" rel="noopener noreferrer">read_help</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_path_traversal/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="restore_session def benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py#L12" rel="noopener noreferrer">restore_session:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py" rel="noopener noreferrer">restore_session</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="restore_session_safe def benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py#L20" rel="noopener noreferrer">restore_session_safe:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py" rel="noopener noreferrer">restore_session_safe</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_pickle_deserialization/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="profile def benchmarks/agent_review/fixtures/flask_reflected_xss/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_reflected_xss/app.py#L10" rel="noopener noreferrer">profile:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_reflected_xss/app.py" rel="noopener noreferrer">profile</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_reflected_xss/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="safe_profile def benchmarks/agent_review/fixtures/flask_reflected_xss/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_reflected_xss/app.py#L16" rel="noopener noreferrer">safe_profile:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_reflected_xss/app.py" rel="noopener noreferrer">safe_profile</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_reflected_xss/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_avatar def benchmarks/agent_review/fixtures/flask_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_ssrf/app.py#L9" rel="noopener noreferrer">fetch_avatar:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_ssrf/app.py" rel="noopener noreferrer">fetch_avatar</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_ssrf/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_health def benchmarks/agent_review/fixtures/flask_ssrf/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_ssrf/app.py#L15" rel="noopener noreferrer">fetch_health:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_ssrf/app.py" rel="noopener noreferrer">fetch_health</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_ssrf/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_file def benchmarks/agent_review/fixtures/flask_upload_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_upload_traversal/app.py#L12" rel="noopener noreferrer">upload_file:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_upload_traversal/app.py" rel="noopener noreferrer">upload_file</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_upload_traversal/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_safe def benchmarks/agent_review/fixtures/flask_upload_traversal/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_upload_traversal/app.py#L22" rel="noopener noreferrer">upload_safe:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/flask_upload_traversal/app.py" rel="noopener noreferrer">upload_safe</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/flask_upload_traversal/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="decode_session def benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py#L4" rel="noopener noreferrer">decode_session:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py" rel="noopener noreferrer">decode_session</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py</td>
             </tr>
 
             <tr class="searchable" data-search="decode_signed_session def benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py#L8" rel="noopener noreferrer">decode_signed_session:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py" rel="noopener noreferrer">decode_signed_session</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/jwt_insecure_decode/auth.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_user async def benchmarks/agent_review/fixtures/missing_await/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py#L1" rel="noopener noreferrer">fetch_user:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py" rel="noopener noreferrer">fetch_user</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/missing_await/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_dashboard async def benchmarks/agent_review/fixtures/missing_await/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py#L5" rel="noopener noreferrer">load_dashboard:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py" rel="noopener noreferrer">load_dashboard</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/missing_await/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_dashboard_ok async def benchmarks/agent_review/fixtures/missing_await/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py#L10" rel="noopener noreferrer">load_dashboard_ok:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/missing_await/module.py" rel="noopener noreferrer">load_dashboard_ok</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/missing_await/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="append_tag def benchmarks/agent_review/fixtures/mutable_default_state/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/mutable_default_state/module.py#L1" rel="noopener noreferrer">append_tag:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/mutable_default_state/module.py" rel="noopener noreferrer">append_tag</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/mutable_default_state/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_headers def benchmarks/agent_review/fixtures/mutable_default_state/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/mutable_default_state/module.py#L6" rel="noopener noreferrer">build_headers:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/mutable_default_state/module.py" rel="noopener noreferrer">build_headers</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/mutable_default_state/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="handle_status def benchmarks/agent_review/fixtures/repo_clean_service/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/app.py#L5" rel="noopener noreferrer">handle_status:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/app.py" rel="noopener noreferrer">handle_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_headers def benchmarks/agent_review/fixtures/repo_clean_service/formatter.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/formatter.py#L1" rel="noopener noreferrer">normalize_headers:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/formatter.py" rel="noopener noreferrer">normalize_headers</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/formatter.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_status def benchmarks/agent_review/fixtures/repo_clean_service/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/service.py#L1" rel="noopener noreferrer">fetch_status:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/service.py" rel="noopener noreferrer">fetch_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="list_checks def benchmarks/agent_review/fixtures/repo_clean_service/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/service.py#L5" rel="noopener noreferrer">list_checks:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/service.py" rel="noopener noreferrer">list_checks</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_status_handler def benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py#L4" rel="noopener noreferrer">test_status_handler:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py" rel="noopener noreferrer">test_status_handler</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/repo_clean_service/tests/test_app.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_first_line def benchmarks/agent_review/fixtures/resource_leak/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/resource_leak/module.py#L1" rel="noopener noreferrer">load_first_line:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/resource_leak/module.py" rel="noopener noreferrer">load_first_line</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/resource_leak/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="safe_preview def benchmarks/agent_review/fixtures/resource_leak/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/resource_leak/module.py#L8" rel="noopener noreferrer">safe_preview:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/resource_leak/module.py" rel="noopener noreferrer">safe_preview</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/resource_leak/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="sync_repository def benchmarks/agent_review/fixtures/shell_hook_runner/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/cli.py#L4" rel="noopener noreferrer">sync_repository:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/cli.py" rel="noopener noreferrer">sync_repository</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="execute_custom_hook def benchmarks/agent_review/fixtures/shell_hook_runner/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/cli.py#L8" rel="noopener noreferrer">execute_custom_hook:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/cli.py" rel="noopener noreferrer">execute_custom_hook</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_named_hook def benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py#L10" rel="noopener noreferrer">run_named_hook:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py" rel="noopener noreferrer">run_named_hook</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_builtin def benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py#L15" rel="noopener noreferrer">run_builtin:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py" rel="noopener noreferrer">run_builtin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_builtin_hook_is_list_based def benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py#L4" rel="noopener noreferrer">test_builtin_hook_is_list_based:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py" rel="noopener noreferrer">test_builtin_hook_is_list_based</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/shell_hook_runner/tests/test_builtin.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py#L4" rel="noopener noreferrer">main:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch_event def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py#L6" rel="noopener noreferrer">dispatch_event:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py" rel="noopener noreferrer">dispatch_event</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/dispatcher.py</td>
             </tr>
 
             <tr class="searchable" data-search="ship_audit def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L4" rel="noopener noreferrer">ship_audit:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py" rel="noopener noreferrer">ship_audit</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
             </tr>
 
             <tr class="searchable" data-search="sample_shell def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L10" rel="noopener noreferrer">sample_shell:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py" rel="noopener noreferrer">sample_shell</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
             </tr>
 
             <tr class="searchable" data-search="query_all def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py" rel="noopener noreferrer">query_all</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/db.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_url def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py#L4" rel="noopener noreferrer">fetch_url:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py" rel="noopener noreferrer">fetch_url</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_fixed_status def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py#L9" rel="noopener noreferrer">fetch_fixed_status:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py" rel="noopener noreferrer">fetch_fixed_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py#L13" rel="noopener noreferrer">lab_fetch:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py" rel="noopener noreferrer">lab_fetch</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="charge_card def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L4" rel="noopener noreferrer">charge_card:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py" rel="noopener noreferrer">charge_card</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
             </tr>
 
             <tr class="searchable" data-search="archived_invoice def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L11" rel="noopener noreferrer">archived_invoice:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py" rel="noopener noreferrer">archived_invoice</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
             </tr>
 
             <tr class="searchable" data-search="debug_query def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L16" rel="noopener noreferrer">debug_query:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py" rel="noopener noreferrer">debug_query</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_safe_builtin def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L4" rel="noopener noreferrer">run_safe_builtin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py" rel="noopener noreferrer">run_safe_builtin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_mutable_registered def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L12" rel="noopener noreferrer">run_mutable_registered:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py" rel="noopener noreferrer">run_mutable_registered</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_pay_handler_dispatches_by_registry_string def benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py#L4" rel="noopener noreferrer">test_pay_handler_dispatches_by_registry_string:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py" rel="noopener noreferrer">test_pay_handler_dispatches_by_registry_string</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_status async def benchmarks/agent_review/fixtures/tricky_clean/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/tricky_clean/module.py#L1" rel="noopener noreferrer">fetch_status:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/tricky_clean/module.py" rel="noopener noreferrer">fetch_status</a></td>
               <td>async def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/tricky_clean/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_headers def benchmarks/agent_review/fixtures/tricky_clean/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/tricky_clean/module.py#L9" rel="noopener noreferrer">normalize_headers:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/agent_review/fixtures/tricky_clean/module.py" rel="noopener noreferrer">normalize_headers</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/agent_review/fixtures/tricky_clean/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="upgrade def benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L9" rel="noopener noreferrer">upgrade:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">upgrade</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
             </tr>
 
             <tr class="searchable" data-search="downgrade def benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L17" rel="noopener noreferrer">downgrade:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">downgrade</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_migration_helper def benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L21" rel="noopener noreferrer">unused_migration_helper:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">unused_migration_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedmigrationstate class benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py#L25" rel="noopener noreferrer">UnusedMigrationState:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py" rel="noopener noreferrer">UnusedMigrationState</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/alembic_migration/versions/20260425_add_orders.py</td>
             </tr>
 
             <tr class="searchable" data-search="usedworker class benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L9" rel="noopener noreferrer">UsedWorker:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">UsedWorker</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedworker class benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L14" rel="noopener noreferrer">UnusedWorker:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">UnusedWorker</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="used_helper def benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L19" rel="noopener noreferrer">used_helper:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">used_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_helper def benchmarks/dead_code/fixtures/basic_unused_symbols/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py#L24" rel="noopener noreferrer">unused_helper:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/basic_unused_symbols/app.py" rel="noopener noreferrer">unused_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/basic_unused_symbols/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="send_receipt def benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L8" rel="noopener noreferrer">send_receipt:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py" rel="noopener noreferrer">send_receipt</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="rebuild_rollups def benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L13" rel="noopener noreferrer">rebuild_rollups:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py" rel="noopener noreferrer">rebuild_rollups</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_task_helper def benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L17" rel="noopener noreferrer">unused_task_helper:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py" rel="noopener noreferrer">unused_task_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedtaskpayload class benchmarks/dead_code/fixtures/celery_tasks/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py#L21" rel="noopener noreferrer">UnusedTaskPayload:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/celery_tasks/app.py" rel="noopener noreferrer">UnusedTaskPayload</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/celery_tasks/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="command class benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L4" rel="noopener noreferrer">Command:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py" rel="noopener noreferrer">Command</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
             </tr>
 
             <tr class="searchable" data-search="rebuild_index def benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L14" rel="noopener noreferrer">rebuild_index:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py" rel="noopener noreferrer">rebuild_index</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_export_job def benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L18" rel="noopener noreferrer">unused_export_job:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py" rel="noopener noreferrer">unused_export_job</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedcommandhelper class benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py#L22" rel="noopener noreferrer">UnusedCommandHelper:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py" rel="noopener noreferrer">UnusedCommandHelper</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/django_management_command/shop/management/commands/rebuild_index.py</td>
             </tr>
 
             <tr class="searchable" data-search="register def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L4" rel="noopener noreferrer">register:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">register</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="handle_create def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L13" rel="noopener noreferrer">handle_create:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">handle_create</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="handle_update def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L18" rel="noopener noreferrer">handle_update:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">handle_update</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L22" rel="noopener noreferrer">dispatch:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">dispatch</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_handler def benchmarks/dead_code/fixtures/dynamic_registry_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py#L26" rel="noopener noreferrer">unused_handler:26</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/dynamic_registry_used/app.py" rel="noopener noreferrer">unused_handler</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/dynamic_registry_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch_http def benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py#L5" rel="noopener noreferrer">dispatch_http:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py" rel="noopener noreferrer">dispatch_http</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/api.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py#L5" rel="noopener noreferrer">main:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="preview def benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py#L11" rel="noopener noreferrer">preview:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py" rel="noopener noreferrer">preview</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch_job def benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py#L4" rel="noopener noreferrer">dispatch_job:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py" rel="noopener noreferrer">dispatch_job</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_account def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py#L5" rel="noopener noreferrer">load_account:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py" rel="noopener noreferrer">load_account</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py</td>
             </tr>
 
             <tr class="searchable" data-search="archive_account def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py#L15" rel="noopener noreferrer">archive_account:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py" rel="noopener noreferrer">archive_account</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py</td>
             </tr>
 
             <tr class="searchable" data-search="dormant_report def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py#L20" rel="noopener noreferrer">dormant_report:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py" rel="noopener noreferrer">dormant_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/account.py</td>
             </tr>
 
             <tr class="searchable" data-search="query_all def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py" rel="noopener noreferrer">query_all</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py</td>
             </tr>
 
             <tr class="searchable" data-search="execute def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py#L5" rel="noopener noreferrer">execute:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py" rel="noopener noreferrer">execute</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/db.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_sort def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py#L4" rel="noopener noreferrer">normalize_sort:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py" rel="noopener noreferrer">normalize_sort</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_host def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py#L10" rel="noopener noreferrer">normalize_host:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py" rel="noopener noreferrer">normalize_host</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/formatters.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_dynamic_hook def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L4" rel="noopener noreferrer">run_dynamic_hook:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_dynamic_hook</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_registered_hook def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L9" rel="noopener noreferrer">run_registered_hook:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_registered_hook</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_mutable_runner def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L17" rel="noopener noreferrer">run_mutable_runner:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_mutable_runner</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_sample def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py#L24" rel="noopener noreferrer">run_sample:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py" rel="noopener noreferrer">run_sample</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/hooks.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_partner def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py#L6" rel="noopener noreferrer">fetch_partner:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py" rel="noopener noreferrer">fetch_partner</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_internal_status def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py#L11" rel="noopener noreferrer">fetch_internal_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py" rel="noopener noreferrer">fetch_internal_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py#L15" rel="noopener noreferrer">lab_fetch:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py" rel="noopener noreferrer">lab_fetch</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/services/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_http_search_reaches_repository def benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py#L5" rel="noopener noreferrer">test_http_search_reaches_repository:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py" rel="noopener noreferrer">test_http_search_reaches_repository</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_registered_hook_is_list_based def benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py#L10" rel="noopener noreferrer">test_registered_hook_is_list_based:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py" rel="noopener noreferrer">test_registered_hook_is_list_based</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tests/test_flow.py</td>
             </tr>
 
             <tr class="searchable" data-search="dangerous_admin def benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py#L4" rel="noopener noreferrer">dangerous_admin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py" rel="noopener noreferrer">dangerous_admin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_admin_status def benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py#L11" rel="noopener noreferrer">format_admin_status:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py" rel="noopener noreferrer">format_admin_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/tools/admin.py</td>
             </tr>
 
             <tr class="searchable" data-search="request class benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py#L1" rel="noopener noreferrer">Request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py" rel="noopener noreferrer">Request</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py</td>
             </tr>
 
             <tr class="searchable" data-search="app class benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py#L5" rel="noopener noreferrer">App:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py" rel="noopener noreferrer">App</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/framework.py</td>
             </tr>
 
             <tr class="searchable" data-search="admin_query_route def benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py#L6" rel="noopener noreferrer">admin_query_route:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py" rel="noopener noreferrer">admin_query_route</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py</td>
             </tr>
 
             <tr class="searchable" data-search="health_route def benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py#L14" rel="noopener noreferrer">health_route:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py" rel="noopener noreferrer">health_route</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/extreme_grounding_framework/web/routes.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_current_user def benchmarks/dead_code/fixtures/fastapi_route_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py#L7" rel="noopener noreferrer">get_current_user:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py" rel="noopener noreferrer">get_current_user</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/fastapi_route_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="read_profile def benchmarks/dead_code/fixtures/fastapi_route_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py#L12" rel="noopener noreferrer">read_profile:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py" rel="noopener noreferrer">read_profile</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/fastapi_route_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_helper def benchmarks/dead_code/fixtures/fastapi_route_used/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py#L16" rel="noopener noreferrer">unused_helper:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/fastapi_route_used/app.py" rel="noopener noreferrer">unused_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/fastapi_route_used/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="show_order def benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L9" rel="noopener noreferrer">show_order:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py" rel="noopener noreferrer">show_order</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="reindex_orders def benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L14" rel="noopener noreferrer">reindex_orders:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py" rel="noopener noreferrer">reindex_orders</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_view_helper def benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L18" rel="noopener noreferrer">unused_view_helper:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py" rel="noopener noreferrer">unused_view_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedformatter class benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py#L22" rel="noopener noreferrer">UnusedFormatter:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py" rel="noopener noreferrer">UnusedFormatter</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/flask_cli_blueprint/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_plugin def benchmarks/dead_code/fixtures/importlib_plugins/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py#L7" rel="noopener noreferrer">load_plugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py" rel="noopener noreferrer">load_plugin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_notification def benchmarks/dead_code/fixtures/importlib_plugins/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py#L12" rel="noopener noreferrer">run_notification:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py" rel="noopener noreferrer">run_notification</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_loader def benchmarks/dead_code/fixtures/importlib_plugins/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py#L17" rel="noopener noreferrer">unused_loader:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/app.py" rel="noopener noreferrer">unused_loader</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="send_email def benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py#L1" rel="noopener noreferrer">send_email:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py" rel="noopener noreferrer">send_email</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_plugin_hook def benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py#L5" rel="noopener noreferrer">unused_plugin_hook:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py" rel="noopener noreferrer">unused_plugin_hook</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedplugin class benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py#L9" rel="noopener noreferrer">UnusedPlugin:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py" rel="noopener noreferrer">UnusedPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/importlib_plugins/plugins/email.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py#L1" rel="noopener noreferrer">main:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_status def benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py#L5" rel="noopener noreferrer">format_status:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py" rel="noopener noreferrer">format_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_entrypoints/bench/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_checkout def benchmarks/dead_code/fixtures/package_service_layers/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/app.py#L4" rel="noopener noreferrer">run_checkout:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/app.py" rel="noopener noreferrer">run_checkout</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="invoicerepository class benchmarks/dead_code/fixtures/package_service_layers/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/repository.py#L1" rel="noopener noreferrer">InvoiceRepository:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/repository.py" rel="noopener noreferrer">InvoiceRepository</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/repository.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedstrategy class benchmarks/dead_code/fixtures/package_service_layers/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/service.py#L11" rel="noopener noreferrer">UnusedStrategy:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/service.py" rel="noopener noreferrer">UnusedStrategy</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="create_invoice def benchmarks/dead_code/fixtures/package_service_layers/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/service.py#L16" rel="noopener noreferrer">create_invoice:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/package_service_layers/service.py" rel="noopener noreferrer">create_invoice</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/package_service_layers/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="userinput class benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L4" rel="noopener noreferrer">UserInput:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py" rel="noopener noreferrer">UserInput</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unusedschema class benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L17" rel="noopener noreferrer">UnusedSchema:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py" rel="noopener noreferrer">UnusedSchema</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_user def benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L21" rel="noopener noreferrer">build_user:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py" rel="noopener noreferrer">build_user</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="unused_normalizer def benchmarks/dead_code/fixtures/pydantic_validators/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py#L25" rel="noopener noreferrer">unused_normalizer:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pydantic_validators/app.py" rel="noopener noreferrer">unused_normalizer</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pydantic_validators/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="api_client def benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py#L5" rel="noopener noreferrer">api_client:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py" rel="noopener noreferrer">api_client</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py</td>
             </tr>
 
             <tr class="searchable" data-search="payload_fixture def benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py#L10" rel="noopener noreferrer">payload_fixture:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py" rel="noopener noreferrer">payload_fixture</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_create_order def benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py#L14" rel="noopener noreferrer">test_create_order:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py" rel="noopener noreferrer">test_create_order</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/pytest_fixtures/tests/test_orders.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_demo_note def benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py#L4" rel="noopener noreferrer">build_demo_note:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py" rel="noopener noreferrer">build_demo_note</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="base class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L5" rel="noopener noreferrer">Base:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py" rel="noopener noreferrer">Base</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
             </tr>
 
             <tr class="searchable" data-search="note class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L9" rel="noopener noreferrer">Note:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py" rel="noopener noreferrer">Note</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditlog class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L17" rel="noopener noreferrer">AuditLog:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py" rel="noopener noreferrer">AuditLog</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
             </tr>
 
             <tr class="searchable" data-search="tag class benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py#L24" rel="noopener noreferrer">Tag:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py" rel="noopener noreferrer">Tag</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/models.py</td>
             </tr>
 
             <tr class="searchable" data-search="create_note def benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py#L4" rel="noopener noreferrer">create_note:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py" rel="noopener noreferrer">create_note</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/sqlalchemy_mixed_models/repository.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py#L4" rel="noopener noreferrer">main:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch_event def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py#L6" rel="noopener noreferrer">dispatch_event:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py" rel="noopener noreferrer">dispatch_event</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/dispatcher.py</td>
             </tr>
 
             <tr class="searchable" data-search="ship_audit def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L4" rel="noopener noreferrer">ship_audit:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py" rel="noopener noreferrer">ship_audit</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
             </tr>
 
             <tr class="searchable" data-search="sample_shell def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py#L10" rel="noopener noreferrer">sample_shell:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py" rel="noopener noreferrer">sample_shell</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/audit.py</td>
             </tr>
 
             <tr class="searchable" data-search="query_all def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py#L1" rel="noopener noreferrer">query_all:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py" rel="noopener noreferrer">query_all</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/db.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_url def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py#L4" rel="noopener noreferrer">fetch_url:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py" rel="noopener noreferrer">fetch_url</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_fixed_status def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py#L9" rel="noopener noreferrer">fetch_fixed_status:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py" rel="noopener noreferrer">fetch_fixed_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="lab_fetch def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py#L13" rel="noopener noreferrer">lab_fetch:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py" rel="noopener noreferrer">lab_fetch</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/network.py</td>
             </tr>
 
             <tr class="searchable" data-search="charge_card def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L4" rel="noopener noreferrer">charge_card:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py" rel="noopener noreferrer">charge_card</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
             </tr>
 
             <tr class="searchable" data-search="archived_invoice def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L11" rel="noopener noreferrer">archived_invoice:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py" rel="noopener noreferrer">archived_invoice</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
             </tr>
 
             <tr class="searchable" data-search="debug_query def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py#L16" rel="noopener noreferrer">debug_query:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py" rel="noopener noreferrer">debug_query</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/payments.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_safe_builtin def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L4" rel="noopener noreferrer">run_safe_builtin:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py" rel="noopener noreferrer">run_safe_builtin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_mutable_registered def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py#L12" rel="noopener noreferrer">run_mutable_registered:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py" rel="noopener noreferrer">run_mutable_registered</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/plugins/tools.py</td>
             </tr>
 
             <tr class="searchable" data-search="test_pay_handler_dispatches_by_registry_string def benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py#L4" rel="noopener noreferrer">test_pay_handler_dispatches_by_registry_string:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py" rel="noopener noreferrer">test_pay_handler_dispatches_by_registry_string</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/dead_code/fixtures/static_blind_plugin_dispatch/tests/test_dispatcher.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_request def benchmarks/quality/fixtures/argument_overload/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/argument_overload/service.py#L1" rel="noopener noreferrer">build_request:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/argument_overload/service.py" rel="noopener noreferrer">build_request</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/argument_overload/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="helper def benchmarks/quality/fixtures/argument_overload/service.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/argument_overload/service.py#L11" rel="noopener noreferrer">helper:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/argument_overload/service.py" rel="noopener noreferrer">helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/argument_overload/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_name def benchmarks/quality/fixtures/clean_module/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/clean_module/module.py#L1" rel="noopener noreferrer">normalize_name:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/clean_module/module.py" rel="noopener noreferrer">normalize_name</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/clean_module/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="join_parts def benchmarks/quality/fixtures/clean_module/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/clean_module/module.py#L7" rel="noopener noreferrer">join_parts:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/clean_module/module.py" rel="noopener noreferrer">join_parts</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/clean_module/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="branchy_handler def benchmarks/quality/fixtures/complexity_hotspot/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/complexity_hotspot/app.py#L1" rel="noopener noreferrer">branchy_handler:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/complexity_hotspot/app.py" rel="noopener noreferrer">branchy_handler</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/complexity_hotspot/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="simple_handler def benchmarks/quality/fixtures/complexity_hotspot/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/complexity_hotspot/app.py#L11" rel="noopener noreferrer">simple_handler:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/complexity_hotspot/app.py" rel="noopener noreferrer">simple_handler</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/complexity_hotspot/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="parse_payload def benchmarks/quality/fixtures/empty_error_handler/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/empty_error_handler/module.py#L1" rel="noopener noreferrer">parse_payload:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/empty_error_handler/module.py" rel="noopener noreferrer">parse_payload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/empty_error_handler/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="require_admin def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L6" rel="noopener noreferrer">require_admin:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py" rel="noopener noreferrer">require_admin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="create_user def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L11" rel="noopener noreferrer">create_user:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py" rel="noopener noreferrer">create_user</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="list_users def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L16" rel="noopener noreferrer">list_users:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py" rel="noopener noreferrer">list_users</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="create_admin def benchmarks/quality/fixtures/framework_route_policy/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py#L21" rel="noopener noreferrer">create_admin:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/framework_route_policy/app.py" rel="noopener noreferrer">create_admin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/framework_route_policy/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="resolve_user def benchmarks/quality/fixtures/inconsistent_return/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/inconsistent_return/module.py#L1" rel="noopener noreferrer">resolve_user:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/inconsistent_return/module.py" rel="noopener noreferrer">resolve_user</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/inconsistent_return/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_report def benchmarks/quality/fixtures/long_function/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/long_function/module.py#L1" rel="noopener noreferrer">render_report:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/long_function/module.py" rel="noopener noreferrer">render_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/long_function/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="tiny_helper def benchmarks/quality/fixtures/long_function/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/long_function/module.py#L12" rel="noopener noreferrer">tiny_helper:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/long_function/module.py" rel="noopener noreferrer">tiny_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/long_function/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_account_snapshot def benchmarks/quality/fixtures/opaque_identifier/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py#L1" rel="noopener noreferrer">load_account_snapshot:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py" rel="noopener noreferrer">load_account_snapshot</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/opaque_identifier/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="coordinate_area def benchmarks/quality/fixtures/opaque_identifier/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py#L20" rel="noopener noreferrer">coordinate_area:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py" rel="noopener noreferrer">coordinate_area</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/opaque_identifier/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize def benchmarks/quality/fixtures/opaque_identifier/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py#L26" rel="noopener noreferrer">normalize:26</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/opaque_identifier/module.py" rel="noopener noreferrer">normalize</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/opaque_identifier/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="configured_helper def benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py#L1" rel="noopener noreferrer">configured_helper:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py" rel="noopener noreferrer">configured_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/repo_policy_missing_typechecker/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_user def benchmarks/quality/fixtures/type_annotation_gaps/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/type_annotation_gaps/module.py#L4" rel="noopener noreferrer">load_user:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/type_annotation_gaps/module.py" rel="noopener noreferrer">load_user</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/type_annotation_gaps/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="typed_helper def benchmarks/quality/fixtures/type_annotation_gaps/module.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/type_annotation_gaps/module.py#L8" rel="noopener noreferrer">typed_helper:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/quality/fixtures/type_annotation_gaps/module.py" rel="noopener noreferrer">typed_helper</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/quality/fixtures/type_annotation_gaps/module.py</td>
             </tr>
 
             <tr class="searchable" data-search="decode_token def benchmarks/security/fixtures/jwt_verify_disabled/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/jwt_verify_disabled/app.py#L4" rel="noopener noreferrer">decode_token:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/jwt_verify_disabled/app.py" rel="noopener noreferrer">decode_token</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/jwt_verify_disabled/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="login def benchmarks/security/fixtures/open_redirect_local_guard/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/open_redirect_local_guard/app.py#L4" rel="noopener noreferrer">login:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/open_redirect_local_guard/app.py" rel="noopener noreferrer">login</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/open_redirect_local_guard/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="login def benchmarks/security/fixtures/open_redirect_tainted/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/open_redirect_tainted/app.py#L4" rel="noopener noreferrer">login:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/open_redirect_tainted/app.py" rel="noopener noreferrer">login</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/open_redirect_tainted/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="read_upload def benchmarks/security/fixtures/path_traversal_basename/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/path_traversal_basename/app.py#L7" rel="noopener noreferrer">read_upload:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/path_traversal_basename/app.py" rel="noopener noreferrer">read_upload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/path_traversal_basename/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="read_upload def benchmarks/security/fixtures/path_traversal_tainted_join/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/path_traversal_tainted_join/app.py#L7" rel="noopener noreferrer">read_upload:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/path_traversal_tainted_join/app.py" rel="noopener noreferrer">read_upload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/path_traversal_tainted_join/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_users def benchmarks/security/fixtures/sql_constant_format/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/sql_constant_format/app.py#L1" rel="noopener noreferrer">load_users:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/sql_constant_format/app.py" rel="noopener noreferrer">load_users</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/sql_constant_format/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_query def benchmarks/security/fixtures/sql_tainted_param/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/sql_tainted_param/app.py#L1" rel="noopener noreferrer">run_query:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/sql_tainted_param/app.py" rel="noopener noreferrer">run_query</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/sql_tainted_param/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_user def benchmarks/security/fixtures/ssrf_fixed_host_path/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/ssrf_fixed_host_path/app.py#L4" rel="noopener noreferrer">fetch_user:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/ssrf_fixed_host_path/app.py" rel="noopener noreferrer">fetch_user</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/ssrf_fixed_host_path/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="fetch_host def benchmarks/security/fixtures/ssrf_tainted_host/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/ssrf_tainted_host/app.py#L4" rel="noopener noreferrer">fetch_host:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/ssrf_tainted_host/app.py" rel="noopener noreferrer">fetch_host</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/ssrf_tainted_host/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="list_files def benchmarks/security/fixtures/subprocess_alias_shell/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/subprocess_alias_shell/app.py#L4" rel="noopener noreferrer">list_files:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/subprocess_alias_shell/app.py" rel="noopener noreferrer">list_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/subprocess_alias_shell/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_name def benchmarks/security/fixtures/xss_escape_safe/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/xss_escape_safe/app.py#L6" rel="noopener noreferrer">render_name:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/xss_escape_safe/app.py" rel="noopener noreferrer">render_name</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/xss_escape_safe/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_name def benchmarks/security/fixtures/xss_mark_safe/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/xss_mark_safe/app.py#L4" rel="noopener noreferrer">render_name:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/xss_mark_safe/app.py" rel="noopener noreferrer">render_name</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/xss_mark_safe/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="parse_config def benchmarks/security/fixtures/yaml_safeloader_positional/app.py benchmark data and generated comparison artifacts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/yaml_safeloader_positional/app.py#L4" rel="noopener noreferrer">parse_config:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/benchmarks/security/fixtures/yaml_safeloader_positional/app.py" rel="noopener noreferrer">parse_config</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>benchmarks/security/fixtures/yaml_safeloader_positional/app.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/agent_review_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/agent_review_benchmark.py#L17" rel="noopener noreferrer">main:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/agent_review_benchmark.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/agent_review_benchmark.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_fixture def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L21" rel="noopener noreferrer">build_fixture:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">build_fixture</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_once def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L192" rel="noopener noreferrer">run_once:192</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">run_once</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_speed_check def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L205" rel="noopener noreferrer">run_speed_check:205</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">run_speed_check</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py#L249" rel="noopener noreferrer">main:249</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/analyzer_speed_check.py</td>
             </tr>
 
             <tr class="searchable" data-search="symbolinfo class scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L546" rel="noopener noreferrer">SymbolInfo:546</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">SymbolInfo</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
             </tr>
 
             <tr class="searchable" data-search="moduleinfo class scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L569" rel="noopener noreferrer">ModuleInfo:569</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">ModuleInfo</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
             </tr>
 
             <tr class="searchable" data-search="collect_repo_map def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L817" rel="noopener noreferrer">collect_repo_map:817</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">collect_repo_map</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
             </tr>
 
             <tr class="searchable" data-search="write_repo_map def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1105" rel="noopener noreferrer">write_repo_map:1105</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">write_repo_map</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/build_repo_map.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py#L1131" rel="noopener noreferrer">main:1131</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/build_repo_map.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/build_repo_map.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/check_rule_docs_parity.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/check_rule_docs_parity.py#L14" rel="noopener noreferrer">main:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/check_rule_docs_parity.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/check_rule_docs_parity.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/compare_codex_skylos_agent_review.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_agent_review.py#L331" rel="noopener noreferrer">main:331</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_agent_review.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/compare_codex_skylos_agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/compare_codex_skylos_demo_deadcode.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_demo_deadcode.py#L216" rel="noopener noreferrer">main:216</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_demo_deadcode.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/compare_codex_skylos_demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/compare_codex_skylos_quality.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_quality.py#L365" rel="noopener noreferrer">main:365</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_quality.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/compare_codex_skylos_quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/corpus_ci.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/corpus_ci.py#L16" rel="noopener noreferrer">main:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/corpus_ci.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/corpus_ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/dead_code_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_benchmark.py#L20" rel="noopener noreferrer">main:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_benchmark.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/dead_code_benchmark.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/dead_code_compare_scanners.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_compare_scanners.py#L74" rel="noopener noreferrer">main:74</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/dead_code_compare_scanners.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/dead_code_compare_scanners.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/quality_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/quality_benchmark.py#L16" rel="noopener noreferrer">main:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/quality_benchmark.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/quality_benchmark.py</td>
             </tr>
 
             <tr class="searchable" data-search="compare_corpus def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L177" rel="noopener noreferrer">compare_corpus:177</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare_corpus</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
             </tr>
 
             <tr class="searchable" data-search="compare_agent_review def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L210" rel="noopener noreferrer">compare_agent_review:210</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare_agent_review</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
             </tr>
 
             <tr class="searchable" data-search="compare_quality def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L267" rel="noopener noreferrer">compare_quality:267</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare_quality</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
             </tr>
 
             <tr class="searchable" data-search="compare def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L323" rel="noopener noreferrer">compare:323</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">compare</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/regression_delta.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py#L335" rel="noopener noreferrer">main:335</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/regression_delta.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_mode_plan_templates def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L75" rel="noopener noreferrer">render_mode_plan_templates:75</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_mode_plan_templates</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_mode_selector def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L114" rel="noopener noreferrer">render_mode_selector:114</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_mode_selector</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_personas def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L156" rel="noopener noreferrer">render_personas:156</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_personas</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_workflows def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L197" rel="noopener noreferrer">render_workflows:197</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_workflows</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_first_steps def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L239" rel="noopener noreferrer">render_first_steps:239</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_first_steps</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_sharp_edges def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L258" rel="noopener noreferrer">render_sharp_edges:258</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_sharp_edges</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_architecture_layers def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L274" rel="noopener noreferrer">render_architecture_layers:274</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_architecture_layers</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_docstring_guide def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L323" rel="noopener noreferrer">render_docstring_guide:323</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_docstring_guide</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_flow def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L350" rel="noopener noreferrer">render_flow:350</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_flow</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_folder_cards def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L385" rel="noopener noreferrer">render_folder_cards:385</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_folder_cards</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_folder_card def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L402" rel="noopener noreferrer">render_folder_card:402</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_folder_card</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_hot_modules def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L486" rel="noopener noreferrer">render_hot_modules:486</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_hot_modules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_symbol_index def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L533" rel="noopener noreferrer">render_symbol_index:533</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_symbol_index</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_glossary def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L562" rel="noopener noreferrer">render_glossary:562</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_glossary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_html def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L574" rel="noopener noreferrer">render_html:574</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_html</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_snapshot def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L623" rel="noopener noreferrer">render_snapshot:623</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_snapshot</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L653" rel="noopener noreferrer">section:653</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">section</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_flow_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L684" rel="noopener noreferrer">render_flow_section:684</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_flow_section</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_folder_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L695" rel="noopener noreferrer">render_folder_section:695</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_folder_section</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_hot_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L706" rel="noopener noreferrer">render_hot_section:706</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_hot_section</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_symbol_section def scripts/repo_map_renderer.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py#L721" rel="noopener noreferrer">render_symbol_section:721</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/repo_map_renderer.py" rel="noopener noreferrer">render_symbol_section</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/repo_map_renderer.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/security_benchmark.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_benchmark.py#L16" rel="noopener noreferrer">main:16</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_benchmark.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/security_benchmark.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/security_compare_scanners.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_compare_scanners.py#L70" rel="noopener noreferrer">main:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/security_compare_scanners.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/security_compare_scanners.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def scripts/skylos_gate.py repository maintenance, benchmark, parity, and regression scripts.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/skylos_gate.py#L9" rel="noopener noreferrer">main:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/skylos_gate.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>scripts/skylos_gate.py</td>
             </tr>
 
             <tr class="searchable" data-search="analyze def skylos/__init__.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py#L29" rel="noopener noreferrer">analyze:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py" rel="noopener noreferrer">analyze</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="debug_test def skylos/__init__.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py#L35" rel="noopener noreferrer">debug_test:35</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/__init__.py" rel="noopener noreferrer">debug_test</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_adapter def skylos/adapters/__init__.py provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py#L7" rel="noopener noreferrer">get_adapter:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/__init__.py" rel="noopener noreferrer">get_adapter</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/adapters/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="baseadapter class skylos/adapters/base.py provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py#L4" rel="noopener noreferrer">BaseAdapter:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/base.py" rel="noopener noreferrer">BaseAdapter</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/adapters/base.py</td>
             </tr>
 
             <tr class="searchable" data-search="litellmadapter class skylos/adapters/litellm_adapter.py provider adapters that let skylos talk to model runtimes without coupling core logic to one vendor.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py#L7" rel="noopener noreferrer">LiteLLMAdapter:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/adapters/litellm_adapter.py" rel="noopener noreferrer">LiteLLMAdapter</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/adapters/litellm_adapter.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_analyze def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L52" rel="noopener noreferrer">run_analyze:52</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">run_analyze</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="collect_debt_signals def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L58" rel="noopener noreferrer">collect_debt_signals:58</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">collect_debt_signals</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="discover_source_files def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L64" rel="noopener noreferrer">discover_source_files:64</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">discover_source_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="resolve_project_root def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L72" rel="noopener noreferrer">resolve_project_root:72</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">resolve_project_root</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="resolve_state_path def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L87" rel="noopener noreferrer">resolve_state_path:87</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">resolve_state_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L99" rel="noopener noreferrer">load_agent_state:99</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">load_agent_state</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="save_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L112" rel="noopener noreferrer">save_agent_state:112</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">save_agent_state</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="snapshot_file_signatures def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L123" rel="noopener noreferrer">snapshot_file_signatures:123</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">snapshot_file_signatures</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="detect_changed_files def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L153" rel="noopener noreferrer">detect_changed_files:153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">detect_changed_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_triage_map def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L170" rel="noopener noreferrer">normalize_triage_map:170</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">normalize_triage_map</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="apply_triage_to_findings def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L192" rel="noopener noreferrer">apply_triage_to_findings:192</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">apply_triage_to_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="compose_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L213" rel="noopener noreferrer">compose_agent_state:213</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">compose_agent_state</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="rebuild_agent_state_from_existing def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L276" rel="noopener noreferrer">rebuild_agent_state_from_existing:276</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">rebuild_agent_state_from_existing</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="update_action_triage def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L302" rel="noopener noreferrer">update_action_triage:302</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">update_action_triage</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="clear_action_triage def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L339" rel="noopener noreferrer">clear_action_triage:339</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">clear_action_triage</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="refresh_agent_state def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L507" rel="noopener noreferrer">refresh_agent_state:507</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">refresh_agent_state</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="watch_project def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L653" rel="noopener noreferrer">watch_project:653</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">watch_project</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_findings def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L703" rel="noopener noreferrer">normalize_findings:703</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">normalize_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_ranked_actions def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L760" rel="noopener noreferrer">build_ranked_actions:760</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">build_ranked_actions</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_summary def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L766" rel="noopener noreferrer">build_summary:766</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">build_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_headline def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L783" rel="noopener noreferrer">build_headline:783</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">build_headline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_status_table def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L802" rel="noopener noreferrer">render_status_table:802</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">render_status_table</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="command_center_payload def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L806" rel="noopener noreferrer">command_center_payload:806</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">command_center_payload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="debt_hotspot_severity def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L860" rel="noopener noreferrer">debt_hotspot_severity:860</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">debt_hotspot_severity</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="debt_hotspot_message def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L884" rel="noopener noreferrer">debt_hotspot_message:884</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">debt_hotspot_message</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="dead_code_rule_id def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L985" rel="noopener noreferrer">dead_code_rule_id:985</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">dead_code_rule_id</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="finding_fingerprint def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L995" rel="noopener noreferrer">finding_fingerprint:995</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">finding_fingerprint</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="relative_path def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1001" rel="noopener noreferrer">relative_path:1001</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">relative_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="resolve_file_path def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1010" rel="noopener noreferrer">resolve_file_path:1010</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">resolve_file_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_severity def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1017" rel="noopener noreferrer">normalize_severity:1017</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">normalize_severity</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="severity_score def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1026" rel="noopener noreferrer">severity_score:1026</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">severity_score</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_action_title def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1030" rel="noopener noreferrer">build_action_title:1030</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">build_action_title</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_action_subtitle def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1034" rel="noopener noreferrer">build_action_subtitle:1034</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">build_action_subtitle</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_action_reason def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1038" rel="noopener noreferrer">build_action_reason:1038</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">build_action_reason</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="infer_action_type def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1042" rel="noopener noreferrer">infer_action_type:1042</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">infer_action_type</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="infer_safe_fix def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1046" rel="noopener noreferrer">infer_safe_fix:1046</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">infer_safe_fix</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="parse_utc_timestamp def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1050" rel="noopener noreferrer">parse_utc_timestamp:1050</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">parse_utc_timestamp</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="utc_now def skylos/agents/center.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py#L1066" rel="noopener noreferrer">utc_now:1066</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/center.py" rel="noopener noreferrer">utc_now</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/center.py</td>
             </tr>
 
             <tr class="searchable" data-search="severity_score def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L6" rel="noopener noreferrer">severity_score:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">severity_score</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_action_title def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L19" rel="noopener noreferrer">build_action_title:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_action_title</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_action_subtitle def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L28" rel="noopener noreferrer">build_action_subtitle:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_action_subtitle</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_action_reason def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L33" rel="noopener noreferrer">build_action_reason:33</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_action_reason</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="infer_action_type def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L54" rel="noopener noreferrer">infer_action_type:54</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">infer_action_type</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="infer_safe_fix def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L64" rel="noopener noreferrer">infer_safe_fix:64</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">infer_safe_fix</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_ranked_actions def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L74" rel="noopener noreferrer">build_ranked_actions:74</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_ranked_actions</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_headline def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L140" rel="noopener noreferrer">build_headline:140</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_headline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_summary def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L163" rel="noopener noreferrer">build_summary:163</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">build_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_status_table def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L229" rel="noopener noreferrer">render_status_table:229</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">render_status_table</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="command_center_payload def skylos/agents/payload.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py#L239" rel="noopener noreferrer">command_center_payload:239</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/payload.py" rel="noopener noreferrer">command_center_payload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/payload.py</td>
             </tr>
 
             <tr class="searchable" data-search="agentservicecontroller class skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L83" rel="noopener noreferrer">AgentServiceController:83</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">AgentServiceController</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="agentservicehandler class skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L296" rel="noopener noreferrer">AgentServiceHandler:296</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">AgentServiceHandler</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="safeagentservicehandler class skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L428" rel="noopener noreferrer">SafeAgentServiceHandler:428</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">SafeAgentServiceHandler</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="create_agent_service def skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L467" rel="noopener noreferrer">create_agent_service:467</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">create_agent_service</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="serve_agent_service def skylos/agents/service.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py#L508" rel="noopener noreferrer">serve_agent_service:508</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/service.py" rel="noopener noreferrer">serve_agent_service</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/service.py</td>
             </tr>
 
             <tr class="searchable" data-search="triagepattern class skylos/agents/triage_learner.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L22" rel="noopener noreferrer">TriagePattern:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py" rel="noopener noreferrer">TriagePattern</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/triage_learner.py</td>
             </tr>
 
             <tr class="searchable" data-search="triagelearner class skylos/agents/triage_learner.py agent-facing payloads, service helpers, and review triage learning.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py#L143" rel="noopener noreferrer">TriageLearner:143</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/agents/triage_learner.py" rel="noopener noreferrer">TriageLearner</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/agents/triage_learner.py</td>
             </tr>
 
             <tr class="searchable" data-search="modulemetrics class skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L22" rel="noopener noreferrer">ModuleMetrics:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">ModuleMetrics</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
             </tr>
 
             <tr class="searchable" data-search="dipviolation class skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L45" rel="noopener noreferrer">DIPViolation:45</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">DIPViolation</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
             </tr>
 
             <tr class="searchable" data-search="architectureresult class skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L54" rel="noopener noreferrer">ArchitectureResult:54</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">ArchitectureResult</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
             </tr>
 
             <tr class="searchable" data-search="analyze_architecture def skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L200" rel="noopener noreferrer">analyze_architecture:200</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">analyze_architecture</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_architecture_findings def skylos/analysis/architecture.py rule ids: - sky-q801: high instability warning - sky-q802: high distance from main sequence - sky-q803: zone of pain / zone of uselessness warning - sky-q804: dependency inversion principle violation - sky-q805: architecture layer policy violation">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py#L428" rel="noopener noreferrer">get_architecture_findings:428</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">get_architecture_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture.py</td>
             </tr>
 
             <tr class="searchable" data-search="generate_architecture_findings def skylos/analysis/architecture_findings.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_findings.py#L102" rel="noopener noreferrer">generate_architecture_findings:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_findings.py" rel="noopener noreferrer">generate_architecture_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture_findings.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_layer_policy_findings def skylos/analysis/architecture_layers.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_layers.py#L117" rel="noopener noreferrer">get_layer_policy_findings:117</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_layers.py" rel="noopener noreferrer">get_layer_policy_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/architecture_layers.py</td>
             </tr>
 
             <tr class="searchable" data-search="maskspec class skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L62" rel="noopener noreferrer">MaskSpec:62</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">MaskSpec</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
             </tr>
 
             <tr class="searchable" data-search="bodymasker class skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L70" rel="noopener noreferrer">BodyMasker:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">BodyMasker</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
             </tr>
 
             <tr class="searchable" data-search="apply_body_mask def skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L140" rel="noopener noreferrer">apply_body_mask:140</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">apply_body_mask</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
             </tr>
 
             <tr class="searchable" data-search="default_mask_spec_from_config def skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py#L150" rel="noopener noreferrer">default_mask_spec_from_config:150</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">default_mask_spec_from_config</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/ast_mask.py</td>
             </tr>
 
             <tr class="searchable" data-search="moduledependency class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L57" rel="noopener noreferrer">ModuleDependency:57</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">ModuleDependency</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
             </tr>
 
             <tr class="searchable" data-search="circulardependency class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L66" rel="noopener noreferrer">CircularDependency:66</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">CircularDependency</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
             </tr>
 
             <tr class="searchable" data-search="dependencygraphbuilder class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L84" rel="noopener noreferrer">DependencyGraphBuilder:84</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">DependencyGraphBuilder</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
             </tr>
 
             <tr class="searchable" data-search="circulardependencyanalyzer class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L152" rel="noopener noreferrer">CircularDependencyAnalyzer:152</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">CircularDependencyAnalyzer</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
             </tr>
 
             <tr class="searchable" data-search="circulardependencyrule class skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L336" rel="noopener noreferrer">CircularDependencyRule:336</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">CircularDependencyRule</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
             </tr>
 
             <tr class="searchable" data-search="analyze_circular_dependencies def skylos/analysis/circular_deps.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py#L381" rel="noopener noreferrer">analyze_circular_dependencies:381</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">analyze_circular_dependencies</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/circular_deps.py</td>
             </tr>
 
             <tr class="searchable" data-search="evaluate_static_condition def skylos/analysis/control_flow.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py#L143" rel="noopener noreferrer">evaluate_static_condition:143</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">evaluate_static_condition</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/control_flow.py</td>
             </tr>
 
             <tr class="searchable" data-search="extract_constant_string def skylos/analysis/control_flow.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py#L215" rel="noopener noreferrer">extract_constant_string:215</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">extract_constant_string</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/control_flow.py</td>
             </tr>
 
             <tr class="searchable" data-search="implicitreftracker class skylos/analysis/implicit_refs.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/implicit_refs.py#L11" rel="noopener noreferrer">ImplicitRefTracker:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/implicit_refs.py" rel="noopener noreferrer">ImplicitRefTracker</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/implicit_refs.py</td>
             </tr>
 
             <tr class="searchable" data-search="matches_pattern def skylos/analysis/known_patterns.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L592" rel="noopener noreferrer">matches_pattern:592</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py" rel="noopener noreferrer">matches_pattern</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/known_patterns.py</td>
             </tr>
 
             <tr class="searchable" data-search="has_base_class def skylos/analysis/known_patterns.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py#L596" rel="noopener noreferrer">has_base_class:596</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/known_patterns.py" rel="noopener noreferrer">has_base_class</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/known_patterns.py</td>
             </tr>
 
             <tr class="searchable" data-search="modulereachabilityanalyzer class skylos/analysis/module_reachability.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py#L28" rel="noopener noreferrer">ModuleReachabilityAnalyzer:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py" rel="noopener noreferrer">ModuleReachabilityAnalyzer</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/module_reachability.py</td>
             </tr>
 
             <tr class="searchable" data-search="find_unreachable_modules def skylos/analysis/module_reachability.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py#L234" rel="noopener noreferrer">find_unreachable_modules:234</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/module_reachability.py" rel="noopener noreferrer">find_unreachable_modules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/module_reachability.py</td>
             </tr>
 
             <tr class="searchable" data-search="apply_penalties def skylos/analysis/penalties.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py#L1038" rel="noopener noreferrer">apply_penalties:1038</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">apply_penalties</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/penalties.py</td>
             </tr>
 
             <tr class="searchable" data-search="extract_entrypoints def skylos/analysis/pyproject_entrypoints.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/pyproject_entrypoints.py#L25" rel="noopener noreferrer">extract_entrypoints:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/pyproject_entrypoints.py" rel="noopener noreferrer">extract_entrypoints</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analysis/pyproject_entrypoints.py</td>
             </tr>
 
             <tr class="searchable" data-search="_entrypoint_module_name def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L152" rel="noopener noreferrer">_entrypoint_module_name:152</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_entrypoint_module_name</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_architecture_iad_strict def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L159" rel="noopener noreferrer">_architecture_iad_strict:159</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_architecture_iad_strict</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_expand_reexported_entrypoint_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L168" rel="noopener noreferrer">_expand_reexported_entrypoint_modules:168</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_expand_reexported_entrypoint_modules</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_find_package_boundary_modules def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L198" rel="noopener noreferrer">_find_package_boundary_modules:198</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_find_package_boundary_modules</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_set_linter_node_types def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L298" rel="noopener noreferrer">_set_linter_node_types:298</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_set_linter_node_types</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L305" rel="noopener noreferrer">_is_secret_config_candidate:305</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_is_secret_config_candidate</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_resolve_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L312" rel="noopener noreferrer">_resolve_secret_config_candidate:312</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_resolve_secret_config_candidate</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_definition_module_and_class def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L348" rel="noopener noreferrer">_definition_module_and_class:348</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_definition_module_and_class</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_resolve_analysis_root def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L358" rel="noopener noreferrer">_resolve_analysis_root:358</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_resolve_analysis_root</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_grep_verify_rescue_priority def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L395" rel="noopener noreferrer">_grep_verify_rescue_priority:395</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_grep_verify_rescue_priority</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_confidence_as_unit_interval def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L406" rel="noopener noreferrer">_confidence_as_unit_interval:406</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_confidence_as_unit_interval</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_implicit_ref_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L416" rel="noopener noreferrer">_implicit_ref_evidence_marker:416</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_implicit_ref_evidence_marker</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_mark_evidence_ref def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L430" rel="noopener noreferrer">_mark_evidence_ref:430</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_mark_evidence_ref</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_has_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L437" rel="noopener noreferrer">_has_evidence_marker:437</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_has_evidence_marker</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_annotate_dead_code_evidence_sources def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L444" rel="noopener noreferrer">_annotate_dead_code_evidence_sources:444</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_annotate_dead_code_evidence_sources</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="skylos class skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L463" rel="noopener noreferrer">Skylos:463</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">Skylos</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_truly_empty_or_docstring_only def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3041" rel="noopener noreferrer">_is_truly_empty_or_docstring_only:3041</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_is_truly_empty_or_docstring_only</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="proc_file def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3059" rel="noopener noreferrer">proc_file:3059</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">proc_file</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="analyze def skylos/analyzer.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py#L3586" rel="noopener noreferrer">analyze:3586</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">analyze</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/analyzer.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_project_token def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L338" rel="noopener noreferrer">get_project_token:338</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_project_token</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_project_info def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L368" rel="noopener noreferrer">get_project_info:368</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_project_info</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_credit_balance def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L386" rel="noopener noreferrer">get_credit_balance:386</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_credit_balance</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="print_credit_status def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L404" rel="noopener noreferrer">print_credit_status:404</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">print_credit_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_git_root def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L422" rel="noopener noreferrer">get_git_root:422</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_git_root</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_git_info def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L486" rel="noopener noreferrer">get_git_info:486</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">get_git_info</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="detect_ai_code def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L595" rel="noopener noreferrer">detect_ai_code:595</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">detect_ai_code</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_report_legacy def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1252" rel="noopener noreferrer">upload_report_legacy:1252</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">upload_report_legacy</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_report_compatibility def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1279" rel="noopener noreferrer">upload_report_compatibility:1279</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">upload_report_compatibility</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_report_v2 def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1301" rel="noopener noreferrer">upload_report_v2:1301</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">upload_report_v2</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1514" rel="noopener noreferrer">upload_report:1514</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">upload_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_debt_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1577" rel="noopener noreferrer">upload_debt_report:1577</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">upload_debt_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_defense_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1652" rel="noopener noreferrer">upload_defense_report:1652</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">upload_defense_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_agent_run def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1782" rel="noopener noreferrer">upload_agent_run:1782</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">upload_agent_run</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="verify_report def skylos/api/__init__.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py#L1821" rel="noopener noreferrer">verify_report:1821</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">verify_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="detect_ai_code def skylos/api/_ai_detection.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_ai_detection.py#L46" rel="noopener noreferrer">detect_ai_code:46</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_ai_detection.py" rel="noopener noreferrer">detect_ai_code</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_ai_detection.py</td>
             </tr>
 
             <tr class="searchable" data-search="uploadartifact class skylos/api/_artifacts.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L39" rel="noopener noreferrer">UploadArtifact:39</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">UploadArtifact</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_artifacts.py</td>
             </tr>
 
             <tr class="searchable" data-search="preparedreportupload class skylos/api/_artifacts.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L65" rel="noopener noreferrer">PreparedReportUpload:65</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">PreparedReportUpload</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_artifacts.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_artifact def skylos/api/_artifacts.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py#L162" rel="noopener noreferrer">upload_artifact:162</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_artifacts.py" rel="noopener noreferrer">upload_artifact</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_artifacts.py</td>
             </tr>
 
             <tr class="searchable" data-search="extract_snippet def skylos/api/_snippets.py public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_snippets.py#L30" rel="noopener noreferrer">extract_snippet:30</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_snippets.py" rel="noopener noreferrer">extract_snippet</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/api/_snippets.py</td>
             </tr>
 
             <tr class="searchable" data-search="scan_deep_audit_candidates def skylos/audit/candidates.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py#L83" rel="noopener noreferrer">scan_deep_audit_candidates:83</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">scan_deep_audit_candidates</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/candidates.py</td>
             </tr>
 
             <tr class="searchable" data-search="evaluate_deep_audit_ci_gate def skylos/audit/ci.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py#L29" rel="noopener noreferrer">evaluate_deep_audit_ci_gate:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py" rel="noopener noreferrer">evaluate_deep_audit_ci_gate</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_deep_audit_export def skylos/audit/export.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L49" rel="noopener noreferrer">build_deep_audit_export:49</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">build_deep_audit_export</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/export.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_deep_audit_export def skylos/audit/export.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L102" rel="noopener noreferrer">render_deep_audit_export:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">render_deep_audit_export</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/export.py</td>
             </tr>
 
             <tr class="searchable" data-search="write_deep_audit_export def skylos/audit/export.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py#L116" rel="noopener noreferrer">write_deep_audit_export:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">write_deep_audit_export</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/export.py</td>
             </tr>
 
             <tr class="searchable" data-search="polyglotsignalrule class skylos/audit/polyglot.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py#L18" rel="noopener noreferrer">PolyglotSignalRule:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py" rel="noopener noreferrer">PolyglotSignalRule</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/polyglot.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_polyglot_signal_candidates def skylos/audit/polyglot.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py#L342" rel="noopener noreferrer">build_polyglot_signal_candidates:342</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/polyglot.py" rel="noopener noreferrer">build_polyglot_signal_candidates</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/polyglot.py</td>
             </tr>
 
             <tr class="searchable" data-search="process_deep_audit_records def skylos/audit/processor.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py#L29" rel="noopener noreferrer">process_deep_audit_records:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">process_deep_audit_records</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/processor.py</td>
             </tr>
 
             <tr class="searchable" data-search="redact_text def skylos/audit/redaction.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/redaction.py#L43" rel="noopener noreferrer">redact_text:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/redaction.py" rel="noopener noreferrer">redact_text</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/redaction.py</td>
             </tr>
 
             <tr class="searchable" data-search="sanitize_for_audit def skylos/audit/redaction.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/redaction.py#L55" rel="noopener noreferrer">sanitize_for_audit:55</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/redaction.py" rel="noopener noreferrer">sanitize_for_audit</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/redaction.py</td>
             </tr>
 
             <tr class="searchable" data-search="revalidate_deep_audit_findings def skylos/audit/revalidator.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py#L22" rel="noopener noreferrer">revalidate_deep_audit_findings:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">revalidate_deep_audit_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/revalidator.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditstore class skylos/audit/store.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/store.py#L30" rel="noopener noreferrer">AuditStore:30</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/store.py" rel="noopener noreferrer">AuditStore</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/store.py</td>
             </tr>
 
             <tr class="searchable" data-search="utc_now def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L35" rel="noopener noreferrer">utc_now:35</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">utc_now</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="sha256_text def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L39" rel="noopener noreferrer">sha256_text:39</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">sha256_text</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="sha256_file def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L43" rel="noopener noreferrer">sha256_file:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">sha256_file</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="stable_json_hash def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L51" rel="noopener noreferrer">stable_json_hash:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">stable_json_hash</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_relative_path def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L59" rel="noopener noreferrer">normalize_relative_path:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">normalize_relative_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="language_for_path def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L72" rel="noopener noreferrer">language_for_path:72</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">language_for_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="code_region_hash def skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L102" rel="noopener noreferrer">code_region_hash:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">code_region_hash</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditcandidate class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L117" rel="noopener noreferrer">AuditCandidate:117</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">AuditCandidate</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditfilerecord class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L175" rel="noopener noreferrer">AuditFileRecord:175</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">AuditFileRecord</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditscansummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L278" rel="noopener noreferrer">AuditScanSummary:278</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">AuditScanSummary</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditprocesssummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L310" rel="noopener noreferrer">AuditProcessSummary:310</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">AuditProcessSummary</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditcigatesummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L352" rel="noopener noreferrer">AuditCIGateSummary:352</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">AuditCIGateSummary</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="auditrevalidationsummary class skylos/audit/types.py deep-audit candidate selection, processing, redaction, export, and revalidation.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py#L370" rel="noopener noreferrer">AuditRevalidationSummary:370</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">AuditRevalidationSummary</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/audit/types.py</td>
             </tr>
 
             <tr class="searchable" data-search="agentreviewbenchmarkfailure class skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L55" rel="noopener noreferrer">AgentReviewBenchmarkFailure:55</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">AgentReviewBenchmarkFailure</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L72" rel="noopener noreferrer">load_manifest:72</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">load_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L76" rel="noopener noreferrer">validate_manifest:76</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">validate_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="prepare_case_scan def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L243" rel="noopener noreferrer">prepare_case_scan:243</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">prepare_case_scan</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L435" rel="noopener noreferrer">run_case:435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">run_case</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L548" rel="noopener noreferrer">run_manifest:548</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">run_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/agent_review.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py#L622" rel="noopener noreferrer">format_summary:622</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/agent_review.py" rel="noopener noreferrer">format_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/agent_review.py</td>
             </tr>
 
             <tr class="searchable" data-search="corpusfailure class skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L12" rel="noopener noreferrer">CorpusFailure:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">CorpusFailure</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L29" rel="noopener noreferrer">load_manifest:29</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">load_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L34" rel="noopener noreferrer">validate_manifest:34</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">validate_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L126" rel="noopener noreferrer">run_case:126</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">run_case</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L185" rel="noopener noreferrer">run_manifest:185</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">run_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/corpus_ci.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py#L207" rel="noopener noreferrer">format_summary:207</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/corpus_ci.py" rel="noopener noreferrer">format_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/corpus_ci.py</td>
             </tr>
 
             <tr class="searchable" data-search="deadcodekey class skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L103" rel="noopener noreferrer">DeadCodeKey:103</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">DeadCodeKey</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="deadcodebenchmarkfailure class skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L113" rel="noopener noreferrer">DeadCodeBenchmarkFailure:113</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">DeadCodeBenchmarkFailure</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L130" rel="noopener noreferrer">load_manifest:130</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">load_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L134" rel="noopener noreferrer">load_external_targets:134</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">load_external_targets</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L306" rel="noopener noreferrer">validate_manifest:306</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">validate_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L332" rel="noopener noreferrer">validate_external_targets:332</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">validate_external_targets</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L689" rel="noopener noreferrer">run_case:689</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">run_case</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L916" rel="noopener noreferrer">run_manifest:916</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">run_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_external_targets def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L982" rel="noopener noreferrer">run_external_targets:982</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">run_external_targets</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/dead_code.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py#L1020" rel="noopener noreferrer">format_summary:1020</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/dead_code.py" rel="noopener noreferrer">format_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/dead_code.py</td>
             </tr>
 
             <tr class="searchable" data-search="demodeadcodecase class skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L54" rel="noopener noreferrer">DemoDeadCodeCase:54</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">DemoDeadCodeCase</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="case_key def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L65" rel="noopener noreferrer">case_key:65</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">case_key</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="hard_cases def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L69" rel="noopener noreferrer">hard_cases:69</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">hard_cases</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="hard_case_keys def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L92" rel="noopener noreferrer">hard_case_keys:92</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">hard_case_keys</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_corrected_ground_truth def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L96" rel="noopener noreferrer">load_corrected_ground_truth:96</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">load_corrected_ground_truth</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_skylos_symbol def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L123" rel="noopener noreferrer">normalize_skylos_symbol:123</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">normalize_skylos_symbol</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="score_case_predictions def skylos/benchmarks/demo_deadcode.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py#L138" rel="noopener noreferrer">score_case_predictions:138</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/demo_deadcode.py" rel="noopener noreferrer">score_case_predictions</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/demo_deadcode.py</td>
             </tr>
 
             <tr class="searchable" data-search="qualitybenchmarkfailure class skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L47" rel="noopener noreferrer">QualityBenchmarkFailure:47</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">QualityBenchmarkFailure</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L66" rel="noopener noreferrer">load_manifest:66</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">load_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L71" rel="noopener noreferrer">validate_manifest:71</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">validate_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L333" rel="noopener noreferrer">run_case:333</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">run_case</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L395" rel="noopener noreferrer">run_manifest:395</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">run_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/quality.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py#L480" rel="noopener noreferrer">format_summary:480</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/quality.py" rel="noopener noreferrer">format_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/quality.py</td>
             </tr>
 
             <tr class="searchable" data-search="securitybenchmarkfailure class skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L88" rel="noopener noreferrer">SecurityBenchmarkFailure:88</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">SecurityBenchmarkFailure</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L107" rel="noopener noreferrer">load_manifest:107</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">load_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L111" rel="noopener noreferrer">validate_manifest:111</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">validate_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_case def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L519" rel="noopener noreferrer">run_case:519</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">run_case</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_manifest def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L606" rel="noopener noreferrer">run_manifest:606</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">run_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_summary def skylos/benchmarks/security.py benchmark fixtures and scoring code for security, quality, dead-code, and agent-review comparisons.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py#L698" rel="noopener noreferrer">format_summary:698</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/benchmarks/security.py" rel="noopener noreferrer">format_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/benchmarks/security.py</td>
             </tr>
 
             <tr class="searchable" data-search="evidencecard class skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L19" rel="noopener noreferrer">EvidenceCard:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">EvidenceCard</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_evidence_cards def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L112" rel="noopener noreferrer">build_evidence_cards:112</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">build_evidence_cards</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_evidence_card def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L116" rel="noopener noreferrer">build_evidence_card:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">build_evidence_card</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="evidence_counts def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L139" rel="noopener noreferrer">evidence_counts:139</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">evidence_counts</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="evidence_label_title def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L150" rel="noopener noreferrer">evidence_label_title:150</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">evidence_label_title</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="redact_sensitive_text def skylos/cicd/evidence.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py#L158" rel="noopener noreferrer">redact_sensitive_text:158</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/evidence.py" rel="noopener noreferrer">redact_sensitive_text</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_pr_review def skylos/cicd/review.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L30" rel="noopener noreferrer">run_pr_review:30</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">run_pr_review</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/review.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_changed_line_ranges def skylos/cicd/review.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L130" rel="noopener noreferrer">get_changed_line_ranges:130</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">get_changed_line_ranges</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/review.py</td>
             </tr>
 
             <tr class="searchable" data-search="filter_findings_to_diff def skylos/cicd/review.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py#L229" rel="noopener noreferrer">filter_findings_to_diff:229</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/review.py" rel="noopener noreferrer">filter_findings_to_diff</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/review.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_risk_passport def skylos/cicd/risk_passport.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L19" rel="noopener noreferrer">build_risk_passport:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">build_risk_passport</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/risk_passport.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_risk_passport_markdown def skylos/cicd/risk_passport.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py#L116" rel="noopener noreferrer">format_risk_passport_markdown:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">format_risk_passport_markdown</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/risk_passport.py</td>
             </tr>
 
             <tr class="searchable" data-search="generate_workflow def skylos/cicd/workflow.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py#L59" rel="noopener noreferrer">generate_workflow:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">generate_workflow</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/workflow.py</td>
             </tr>
 
             <tr class="searchable" data-search="write_workflow def skylos/cicd/workflow.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py#L321" rel="noopener noreferrer">write_workflow:321</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">write_workflow</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/workflow.py</td>
             </tr>
 
             <tr class="searchable" data-search="_lazyinquirer class skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L60" rel="noopener noreferrer">_LazyInquirer:60</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_LazyInquirer</a></td>
               <td>class</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_inquirer_available def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L74" rel="noopener noreferrer">_inquirer_available:74</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_inquirer_available</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_get_inquirer def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L85" rel="noopener noreferrer">_get_inquirer:85</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_get_inquirer</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_codemods_module def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L111" rel="noopener noreferrer">_codemods_module:111</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_codemods_module</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="remove_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L115" rel="noopener noreferrer">remove_unused_import_cst:115</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_import_cst</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="remove_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L119" rel="noopener noreferrer">remove_unused_function_cst:119</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_function_cst</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="comment_out_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L123" rel="noopener noreferrer">comment_out_unused_import_cst:123</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_import_cst</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="comment_out_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L127" rel="noopener noreferrer">comment_out_unused_function_cst:127</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_function_cst</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_analyze def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L131" rel="noopener noreferrer">run_analyze:131</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_analyze</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="resolve_llm_runtime def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L137" rel="noopener noreferrer">resolve_llm_runtime:137</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">resolve_llm_runtime</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_gate_interaction def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L143" rel="noopener noreferrer">run_gate_interaction:143</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_gate_interaction</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="upload_report def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L149" rel="noopener noreferrer">upload_report:149</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">upload_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_pipeline def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L155" rel="noopener noreferrer">run_pipeline:155</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_pipeline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="review_security_scan_result def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L161" rel="noopener noreferrer">review_security_scan_result:161</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">review_security_scan_result</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_security_taskflow def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L169" rel="noopener noreferrer">run_security_taskflow:169</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_security_taskflow</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="discover_source_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L177" rel="noopener noreferrer">discover_source_files:177</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">discover_source_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_read_staged_text def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L185" rel="noopener noreferrer">_read_staged_text:185</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_read_staged_text</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_scan_staged_secret_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L197" rel="noopener noreferrer">_scan_staged_secret_files:197</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_scan_staged_secret_files</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_join_phrase def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L223" rel="noopener noreferrer">_join_phrase:223</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_join_phrase</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_list_dirty_relevant_paths def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L233" rel="noopener noreferrer">_list_dirty_relevant_paths:233</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_list_dirty_relevant_paths</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_deep_audit_output_exclude_paths def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L261" rel="noopener noreferrer">_deep_audit_output_exclude_paths:261</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_deep_audit_output_exclude_paths</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_deep_audit_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L281" rel="noopener noreferrer">_deep_audit_project_root:281</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_deep_audit_project_root</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_empty_changed_deep_audit_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L286" rel="noopener noreferrer">_empty_changed_deep_audit_payload:286</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_empty_changed_deep_audit_payload</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_write_deep_audit_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L349" rel="noopener noreferrer">_write_deep_audit_payload:349</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_write_deep_audit_payload</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_handle_empty_changed_deep_audit def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L355" rel="noopener noreferrer">_handle_empty_changed_deep_audit:355</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_handle_empty_changed_deep_audit</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_create_precommit_snapshot def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L412" rel="noopener noreferrer">_create_precommit_snapshot:412</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_create_precommit_snapshot</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_remap_precommit_result_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L433" rel="noopener noreferrer">_remap_precommit_result_files:433</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_remap_precommit_result_files</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_parse_unified_diff_ranges def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L485" rel="noopener noreferrer">_parse_unified_diff_ranges:485</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_parse_unified_diff_ranges</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_normalize_precommit_path def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L510" rel="noopener noreferrer">_normalize_precommit_path:510</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_normalize_precommit_path</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_path_suffixes def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L514" rel="noopener noreferrer">_path_suffixes:514</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_path_suffixes</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_build_changed_range_index def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L522" rel="noopener noreferrer">_build_changed_range_index:522</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_build_changed_range_index</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_ranges_for_precommit_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L532" rel="noopener noreferrer">_ranges_for_precommit_file:532</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_ranges_for_precommit_file</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_finding_is_in_changed_lines def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L542" rel="noopener noreferrer">_finding_is_in_changed_lines:542</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_finding_is_in_changed_lines</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_get_cached_changed_line_ranges def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L558" rel="noopener noreferrer">_get_cached_changed_line_ranges:558</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_get_cached_changed_line_ranges</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_filter_precommit_findings_to_changed_lines def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L575" rel="noopener noreferrer">_filter_precommit_findings_to_changed_lines:575</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_filter_precommit_findings_to_changed_lines</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_precommit_blocks_finding def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L593" rel="noopener noreferrer">_precommit_blocks_finding:593</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_precommit_blocks_finding</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_apply_precommit_gate_policy def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L608" rel="noopener noreferrer">_apply_precommit_gate_policy:608</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_apply_precommit_gate_policy</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="llm_estimate_cost def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L619" rel="noopener noreferrer">llm_estimate_cost:619</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">llm_estimate_cost</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_get_sarif_exporter_class def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L634" rel="noopener noreferrer">_get_sarif_exporter_class:634</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_get_sarif_exporter_class</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_ensure_llm_support def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L645" rel="noopener noreferrer">_ensure_llm_support:645</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_ensure_llm_support</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_build_analyzer_config def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L667" rel="noopener noreferrer">_build_analyzer_config:667</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_build_analyzer_config</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="cleanformatter class skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L680" rel="noopener noreferrer">CleanFormatter:680</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">CleanFormatter</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_skylos_console_theme def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L685" rel="noopener noreferrer">_skylos_console_theme:685</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_skylos_console_theme</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="setup_logger def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L697" rel="noopener noreferrer">setup_logger:697</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">setup_logger</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="remove_unused_import def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L721" rel="noopener noreferrer">remove_unused_import:721</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_import</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="remove_unused_function def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L736" rel="noopener noreferrer">remove_unused_function:736</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_function</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="comment_out_unused_import def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L753" rel="noopener noreferrer">comment_out_unused_import:753</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_import</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="comment_out_unused_function def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L774" rel="noopener noreferrer">comment_out_unused_function:774</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_function</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_shorten_path def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L795" rel="noopener noreferrer">_shorten_path:795</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_shorten_path</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="find_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L812" rel="noopener noreferrer">find_project_root:812</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">find_project_root</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_rel_to_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L837" rel="noopener noreferrer">_rel_to_project_root:837</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_rel_to_project_root</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_normalize_agent_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L848" rel="noopener noreferrer">_normalize_agent_findings:848</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_normalize_agent_findings</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_agent_findings_to_result_json def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L869" rel="noopener noreferrer">_agent_findings_to_result_json:869</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_agent_findings_to_result_json</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_tty def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L914" rel="noopener noreferrer">_is_tty:914</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_is_tty</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_main_machine_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L921" rel="noopener noreferrer">_is_main_machine_output:921</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_is_main_machine_output</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_has_high_intent_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L930" rel="noopener noreferrer">_has_high_intent_findings:930</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_has_high_intent_findings</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_set_no_upload_prompt def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L950" rel="noopener noreferrer">_set_no_upload_prompt:950</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_set_no_upload_prompt</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_detect_link_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L983" rel="noopener noreferrer">_detect_link_file:983</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_detect_link_file</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_print_upload_destination def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L992" rel="noopener noreferrer">_print_upload_destination:992</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_upload_destination</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_selected_main_upload_static_categories def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1011" rel="noopener noreferrer">_selected_main_upload_static_categories:1011</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_selected_main_upload_static_categories</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_print_main_upload_manifest def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1024" rel="noopener noreferrer">_print_main_upload_manifest:1024</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_main_upload_manifest</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_upload_failure def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1042" rel="noopener noreferrer">_render_upload_failure:1042</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_upload_failure</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_ci def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1060" rel="noopener noreferrer">_is_ci:1060</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_is_ci</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_print_upload_cta def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1077" rel="noopener noreferrer">_print_upload_cta:1077</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_upload_cta</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_print_feature_hints def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1123" rel="noopener noreferrer">_print_feature_hints:1123</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_feature_hints</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="interactive_selection def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1175" rel="noopener noreferrer">interactive_selection:1175</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">interactive_selection</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="print_badge def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1233" rel="noopener noreferrer">print_badge:1233</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">print_badge</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_default_dead_code_llm_fields def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1295" rel="noopener noreferrer">_default_dead_code_llm_fields:1295</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_default_dead_code_llm_fields</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_collect_llm_report_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1311" rel="noopener noreferrer">_collect_llm_report_findings:1311</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_collect_llm_report_findings</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_llm_report_sort_key def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1326" rel="noopener noreferrer">_llm_report_sort_key:1326</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_llm_report_sort_key</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_llm_report_code_block def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1331" rel="noopener noreferrer">_llm_report_code_block:1331</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_llm_report_code_block</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_llm_report_secret_block def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1375" rel="noopener noreferrer">_llm_report_secret_block:1375</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_llm_report_secret_block</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_format_llm_report_section def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1380" rel="noopener noreferrer">_format_llm_report_section:1380</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_format_llm_report_section</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_generate_llm_report def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1398" rel="noopener noreferrer">_generate_llm_report:1398</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_generate_llm_report</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_emit_github_grade_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1449" rel="noopener noreferrer">_emit_github_grade_annotation:1449</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_emit_github_grade_annotation</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_github_finding_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1458" rel="noopener noreferrer">_github_finding_annotation:1458</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_github_finding_annotation</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_github_dead_code_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1479" rel="noopener noreferrer">_github_dead_code_annotation:1479</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_github_dead_code_annotation</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_github_annotation_items def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1492" rel="noopener noreferrer">_github_annotation_items:1492</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_github_annotation_items</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_filter_github_annotations_by_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1504" rel="noopener noreferrer">_filter_github_annotations_by_severity:1504</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_filter_github_annotations_by_severity</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_github_annotation_sort_key def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1511" rel="noopener noreferrer">_github_annotation_sort_key:1511</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_github_annotation_sort_key</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_emit_github_annotation def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1515" rel="noopener noreferrer">_emit_github_annotation:1515</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_emit_github_annotation</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_emit_github_annotations def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1523" rel="noopener noreferrer">_emit_github_annotations:1523</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_emit_github_annotations</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_filter_min_rank def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1550" rel="noopener noreferrer">_display_filter_min_rank:1550</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_filter_min_rank</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_filter_allowed_categories def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1556" rel="noopener noreferrer">_display_filter_allowed_categories:1556</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_filter_allowed_categories</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_filter_matches_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1562" rel="noopener noreferrer">_display_filter_matches_file:1562</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_filter_matches_file</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_filter_has_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1568" rel="noopener noreferrer">_display_filter_has_severity:1568</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_filter_has_severity</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_filter_passes_severity def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1575" rel="noopener noreferrer">_display_filter_passes_severity:1575</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_filter_passes_severity</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_filter_items def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1580" rel="noopener noreferrer">_display_filter_items:1580</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_filter_items</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_apply_display_filters def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1595" rel="noopener noreferrer">_apply_display_filters:1595</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_apply_display_filters</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_results_pill def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1624" rel="noopener noreferrer">_results_pill:1624</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_results_pill</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_grep_verify_pill def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1632" rel="noopener noreferrer">_grep_verify_pill:1632</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_grep_verify_pill</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_cap def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1642" rel="noopener noreferrer">_display_cap:1642</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_cap</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_score_style def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1647" rel="noopener noreferrer">_score_style:1647</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_score_style</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_grade def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1657" rel="noopener noreferrer">_render_grade:1657</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_grade</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_format_confidence def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1738" rel="noopener noreferrer">_format_confidence:1738</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_format_confidence</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_unused def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1748" rel="noopener noreferrer">_render_unused:1748</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_unused</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_unused_simple def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1780" rel="noopener noreferrer">_render_unused_simple:1780</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_unused_simple</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_quality_detail def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1808" rel="noopener noreferrer">_quality_detail:1808</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_quality_detail</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_quality def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1848" rel="noopener noreferrer">_render_quality:1848</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_quality</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_circular_deps def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1882" rel="noopener noreferrer">_render_circular_deps:1882</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_circular_deps</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_custom_rules def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1916" rel="noopener noreferrer">_render_custom_rules:1916</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_custom_rules</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_secrets def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1948" rel="noopener noreferrer">_render_secrets:1948</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_secrets</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_result_tree def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L1995" rel="noopener noreferrer">_render_result_tree:1995</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_result_tree</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_display_rule_name def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2059" rel="noopener noreferrer">_display_rule_name:2059</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_display_rule_name</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_verification_proof def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2065" rel="noopener noreferrer">_verification_proof:2065</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_verification_proof</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_verification_label def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2096" rel="noopener noreferrer">_verification_label:2096</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_verification_label</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_danger def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2106" rel="noopener noreferrer">_render_danger:2106</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_danger</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_render_sca def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2171" rel="noopener noreferrer">_render_sca:2171</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_render_sca</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2217" rel="noopener noreferrer">render_results:2217</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">render_results</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="render_pretty_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2335" rel="noopener noreferrer">render_pretty_results:2335</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">render_pretty_results</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_write_rich_report_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2347" rel="noopener noreferrer">_write_rich_report_output:2347</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_write_rich_report_output</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_write_pretty_report_output def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2372" rel="noopener noreferrer">_write_pretty_report_output:2372</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_write_pretty_report_output</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_init def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2394" rel="noopener noreferrer">run_init:2394</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_init</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_whitelist def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2400" rel="noopener noreferrer">run_whitelist:2400</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_whitelist</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_git_changed_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2406" rel="noopener noreferrer">get_git_changed_files:2406</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">get_git_changed_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="estimate_cost def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2425" rel="noopener noreferrer">estimate_cost:2425</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">estimate_cost</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_clean_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2431" rel="noopener noreferrer">_run_clean_command:2431</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_clean_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_cache_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2437" rel="noopener noreferrer">_run_cache_command:2437</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_cache_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_debt_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2443" rel="noopener noreferrer">run_debt_command:2443</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_debt_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_defend_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2458" rel="noopener noreferrer">run_defend_command:2458</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_defend_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_suite_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2468" rel="noopener noreferrer">run_suite_command:2468</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_suite_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_ingest_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2490" rel="noopener noreferrer">run_ingest_command:2490</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_ingest_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_provenance_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2499" rel="noopener noreferrer">run_provenance_command:2499</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_provenance_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_cicd_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2513" rel="noopener noreferrer">run_cicd_command:2513</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_cicd_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_load_addopts def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2525" rel="noopener noreferrer">_load_addopts:2525</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_load_addopts</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_handle_rules_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2531" rel="noopener noreferrer">_handle_rules_command:2531</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_handle_rules_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_rules_install def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2537" rel="noopener noreferrer">_rules_install:2537</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_rules_install</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_rules_list def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2543" rel="noopener noreferrer">_rules_list:2543</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_rules_list</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_rules_remove def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2549" rel="noopener noreferrer">_rules_remove:2549</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_rules_remove</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_command_overview def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2558" rel="noopener noreferrer">_run_command_overview:2558</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_command_overview</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_commands_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2565" rel="noopener noreferrer">_run_commands_command:2565</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_commands_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_tour_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2572" rel="noopener noreferrer">_run_tour_command:2572</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_tour_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_key_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2579" rel="noopener noreferrer">_run_key_command:2579</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_key_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_credits_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2585" rel="noopener noreferrer">_run_credits_command:2585</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_credits_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_init_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2591" rel="noopener noreferrer">_run_init_command:2591</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_init_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_baseline_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2595" rel="noopener noreferrer">_run_baseline_command:2595</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_baseline_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_badge_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2601" rel="noopener noreferrer">_run_badge_command:2601</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_badge_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_whitelist_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2607" rel="noopener noreferrer">_run_whitelist_command:2607</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_whitelist_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_doctor_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2613" rel="noopener noreferrer">_run_doctor_command:2613</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_doctor_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_whoami_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2619" rel="noopener noreferrer">_run_whoami_command:2619</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_whoami_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_login_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2625" rel="noopener noreferrer">_run_login_command:2625</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_login_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_sync_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2631" rel="noopener noreferrer">_run_sync_command:2631</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_sync_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_project_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2637" rel="noopener noreferrer">_run_project_command:2637</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_project_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_sonar_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2643" rel="noopener noreferrer">_run_sonar_command:2643</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_sonar_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_attach_upload_project_context def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2649" rel="noopener noreferrer">_attach_upload_project_context:2649</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_attach_upload_project_context</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_upload_agent_run_best_effort def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2663" rel="noopener noreferrer">_upload_agent_run_best_effort:2663</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_upload_agent_run_best_effort</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_removed_city_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2686" rel="noopener noreferrer">_run_removed_city_command:2686</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_removed_city_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_discover_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2697" rel="noopener noreferrer">_run_discover_command:2697</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_discover_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_web_server_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2703" rel="noopener noreferrer">_run_web_server_command:2703</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_web_server_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_scan_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2714" rel="noopener noreferrer">_run_scan_command:2714</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_scan_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_is_first_level_help_request def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2720" rel="noopener noreferrer">_is_first_level_help_request:2720</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_is_first_level_help_request</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_early_command_help def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2724" rel="noopener noreferrer">_run_early_command_help:2724</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_early_command_help</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_dispatch_early_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2728" rel="noopener noreferrer">_dispatch_early_command:2728</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_dispatch_early_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_rules_validate def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2732" rel="noopener noreferrer">_rules_validate:2732</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_rules_validate</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_build_main_parser def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2738" rel="noopener noreferrer">_build_main_parser:2738</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_build_main_parser</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_apply_main_output_format def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2742" rel="noopener noreferrer">_apply_main_output_format:2742</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_apply_main_output_format</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_parse_main_cli_args def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2746" rel="noopener noreferrer">_parse_main_cli_args:2746</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_parse_main_cli_args</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_resolve_main_project_root def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2750" rel="noopener noreferrer">_resolve_main_project_root:2750</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_resolve_main_project_root</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_print_default_excludes def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2760" rel="noopener noreferrer">_print_default_excludes:2760</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_default_excludes</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_build_main_scan_context def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2769" rel="noopener noreferrer">_build_main_scan_context:2769</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_build_main_scan_context</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_formatted_output_gate_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2805" rel="noopener noreferrer">_formatted_output_gate_exit_code:2805</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_formatted_output_gate_exit_code</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_concise_scan_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2832" rel="noopener noreferrer">_concise_scan_exit_code:2832</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_concise_scan_exit_code</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_has_concise_findings def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2865" rel="noopener noreferrer">_has_concise_findings:2865</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_has_concise_findings</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_concise_line def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2872" rel="noopener noreferrer">_concise_line:2872</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_concise_line</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_format_concise_results def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2882" rel="noopener noreferrer">_format_concise_results:2882</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_format_concise_results</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_strict_scan_exit_code def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2905" rel="noopener noreferrer">_strict_scan_exit_code:2905</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_strict_scan_exit_code</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_apply_config_driven_analysis_flags def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2918" rel="noopener noreferrer">_apply_config_driven_analysis_flags:2918</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_apply_config_driven_analysis_flags</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_print_main_scan_banner def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2957" rel="noopener noreferrer">_print_main_scan_banner:2957</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_main_scan_banner</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_trace_cache_requested def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L2999" rel="noopener noreferrer">_trace_cache_requested:2999</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_trace_cache_requested</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_trusted_module_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3009" rel="noopener noreferrer">_trusted_module_file:3009</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_trusted_module_file</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_trace_subprocess_script def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3017" rel="noopener noreferrer">_trace_subprocess_script:3017</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_trace_subprocess_script</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_trace_subprocess_command def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3089" rel="noopener noreferrer">_trace_subprocess_command:3089</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_trace_subprocess_command</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_coverage_execution_allowed def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3114" rel="noopener noreferrer">_coverage_execution_allowed:3114</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_coverage_execution_allowed</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_run_pre_analysis_steps def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3118" rel="noopener noreferrer">_run_pre_analysis_steps:3118</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_run_pre_analysis_steps</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_add_agent_model_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3341" rel="noopener noreferrer">_add_agent_model_arg:3341</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_model_arg</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_add_agent_output_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3345" rel="noopener noreferrer">_add_agent_output_arg:3345</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_output_arg</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_add_agent_quiet_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3349" rel="noopener noreferrer">_add_agent_quiet_arg:3349</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_quiet_arg</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_add_agent_provider_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3353" rel="noopener noreferrer">_add_agent_provider_arg:3353</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_provider_arg</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_add_agent_base_url_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3362" rel="noopener noreferrer">_add_agent_base_url_arg:3362</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_base_url_arg</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_add_agent_prompt_template_arg def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3373" rel="noopener noreferrer">_add_agent_prompt_template_arg:3373</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_prompt_template_arg</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_explicit_prompt_templates_from_args def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3386" rel="noopener noreferrer">_explicit_prompt_templates_from_args:3386</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_explicit_prompt_templates_from_args</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="_build_agent_parser def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3435" rel="noopener noreferrer">_build_agent_parser:3435</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_build_agent_parser</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py#L3878" rel="noopener noreferrer">main:3878</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_first_level_help_request def skylos/cli_core/dispatch.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L37" rel="noopener noreferrer">is_first_level_help_request:37</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">is_first_level_help_request</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/dispatch.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_early_command_help def skylos/cli_core/dispatch.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L41" rel="noopener noreferrer">run_early_command_help:41</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">run_early_command_help</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/dispatch.py</td>
             </tr>
 
             <tr class="searchable" data-search="dispatch_early_command def skylos/cli_core/dispatch.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py#L71" rel="noopener noreferrer">dispatch_early_command:71</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/dispatch.py" rel="noopener noreferrer">dispatch_early_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/dispatch.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_main_parser def skylos/cli_core/main_parser.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L7" rel="noopener noreferrer">build_main_parser:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">build_main_parser</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/main_parser.py</td>
             </tr>
 
             <tr class="searchable" data-search="apply_main_output_format def skylos/cli_core/main_parser.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L305" rel="noopener noreferrer">apply_main_output_format:305</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">apply_main_output_format</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/main_parser.py</td>
             </tr>
 
             <tr class="searchable" data-search="parse_main_cli_args def skylos/cli_core/main_parser.py smaller cli parser and dispatch pieces peeled away from the main cli module.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py#L335" rel="noopener noreferrer">parse_main_cli_args:335</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli_core/main_parser.py" rel="noopener noreferrer">parse_main_cli_args</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cli_core/main_parser.py</td>
             </tr>
 
             <tr class="searchable" data-search="save_key def skylos/cloud/credentials.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py#L24" rel="noopener noreferrer">save_key:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py" rel="noopener noreferrer">save_key</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/credentials.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_key def skylos/cloud/credentials.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py#L37" rel="noopener noreferrer">get_key:37</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py" rel="noopener noreferrer">get_key</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/credentials.py</td>
             </tr>
 
             <tr class="searchable" data-search="delete_key def skylos/cloud/credentials.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py#L53" rel="noopener noreferrer">delete_key:53</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/credentials.py" rel="noopener noreferrer">delete_key</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/credentials.py</td>
             </tr>
 
             <tr class="searchable" data-search="loginresult class skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L18" rel="noopener noreferrer">LoginResult:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">LoginResult</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
             </tr>
 
             <tr class="searchable" data-search="browser_login def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L149" rel="noopener noreferrer">browser_login:149</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">browser_login</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
             </tr>
 
             <tr class="searchable" data-search="manual_token_fallback def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L228" rel="noopener noreferrer">manual_token_fallback:228</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">manual_token_fallback</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_current_connection def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L299" rel="noopener noreferrer">get_current_connection:299</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">get_current_connection</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_login def skylos/cloud/login.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py#L350" rel="noopener noreferrer">run_login:350</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/login.py" rel="noopener noreferrer">run_login</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/login.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_repo_subpath def skylos/cloud/project_context.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py#L6" rel="noopener noreferrer">normalize_repo_subpath:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py" rel="noopener noreferrer">normalize_repo_subpath</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/project_context.py</td>
             </tr>
 
             <tr class="searchable" data-search="repo_subpath_for_project def skylos/cloud/project_context.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py#L32" rel="noopener noreferrer">repo_subpath_for_project:32</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py" rel="noopener noreferrer">repo_subpath_for_project</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/project_context.py</td>
             </tr>
 
             <tr class="searchable" data-search="project_context_for_upload def skylos/cloud/project_context.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py#L53" rel="noopener noreferrer">project_context_for_upload:53</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/project_context.py" rel="noopener noreferrer">project_context_for_upload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/project_context.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_api_url def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L267" rel="noopener noreferrer">get_api_url:267</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">get_api_url</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L315" rel="noopener noreferrer">get_token:315</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">get_token</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="save_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L342" rel="noopener noreferrer">save_token:342</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">save_token</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="clear_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L379" rel="noopener noreferrer">clear_token:379</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">clear_token</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="mask_token def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L386" rel="noopener noreferrer">mask_token:386</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">mask_token</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="autherror class skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L392" rel="noopener noreferrer">AuthError:392</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">AuthError</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="api_get def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L405" rel="noopener noreferrer">api_get:405</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">api_get</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_connect def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L464" rel="noopener noreferrer">cmd_connect:464</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_connect</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_status def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L537" rel="noopener noreferrer">cmd_status:537</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_disconnect def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L566" rel="noopener noreferrer">cmd_disconnect:566</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_disconnect</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_project_status def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L593" rel="noopener noreferrer">cmd_project_status:593</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_project_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_project_list def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L640" rel="noopener noreferrer">cmd_project_list:640</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_project_list</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_project_use def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L662" rel="noopener noreferrer">cmd_project_use:662</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_project_use</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_project_create def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L670" rel="noopener noreferrer">cmd_project_create:670</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_project_create</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_project_unlink def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L676" rel="noopener noreferrer">cmd_project_unlink:676</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_project_unlink</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_pull def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L685" rel="noopener noreferrer">cmd_pull:685</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_pull</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="create_precommit_config def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L720" rel="noopener noreferrer">create_precommit_config:720</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">create_precommit_config</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_setup def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L793" rel="noopener noreferrer">cmd_setup:793</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_setup</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="cmd_upgrade def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1030" rel="noopener noreferrer">cmd_upgrade:1030</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">cmd_upgrade</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="main def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1121" rel="noopener noreferrer">main:1121</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="project_main def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1153" rel="noopener noreferrer">project_main:1153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">project_main</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_custom_rules def skylos/cloud/sync.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py#L1183" rel="noopener noreferrer">get_custom_rules:1183</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/sync.py" rel="noopener noreferrer">get_custom_rules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/sync.py</td>
             </tr>
 
             <tr class="searchable" data-search="uploadfamilymanifest class skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L7" rel="noopener noreferrer">UploadFamilyManifest:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">UploadFamilyManifest</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_code_scan_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L24" rel="noopener noreferrer">build_code_scan_manifest:24</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">build_code_scan_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_defense_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L48" rel="noopener noreferrer">build_defense_manifest:48</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">build_defense_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_debt_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L63" rel="noopener noreferrer">build_debt_manifest:63</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">build_debt_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
             </tr>
 
             <tr class="searchable" data-search="print_upload_manifest def skylos/cloud/upload_manifest.py skylos cloud login, credentials, policy sync, project context, and upload manifest support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py#L77" rel="noopener noreferrer">print_upload_manifest:77</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cloud/upload_manifest.py" rel="noopener noreferrer">print_upload_manifest</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cloud/upload_manifest.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_badge_command def skylos/commands/badge_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/badge_cmd.py#L8" rel="noopener noreferrer">run_badge_command:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/badge_cmd.py" rel="noopener noreferrer">run_badge_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/badge_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_baseline_command def skylos/commands/baseline_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/baseline_cmd.py#L9" rel="noopener noreferrer">run_baseline_command:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/baseline_cmd.py" rel="noopener noreferrer">run_baseline_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/baseline_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_cache_command def skylos/commands/cache_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cache_cmd.py#L13" rel="noopener noreferrer">run_cache_command:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cache_cmd.py" rel="noopener noreferrer">run_cache_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/cache_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_cicd_command def skylos/commands/cicd_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py#L119" rel="noopener noreferrer">run_cicd_command:119</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py" rel="noopener noreferrer">run_cicd_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/cicd_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_analyze def skylos/commands/clean_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py#L19" rel="noopener noreferrer">run_analyze:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">run_analyze</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/clean_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_clean_command def skylos/commands/clean_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py#L49" rel="noopener noreferrer">run_clean_command:49</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">run_clean_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/clean_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_credits_command def skylos/commands/credits_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/credits_cmd.py#L6" rel="noopener noreferrer">run_credits_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/credits_cmd.py" rel="noopener noreferrer">run_credits_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/credits_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_debt_command def skylos/commands/debt_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/debt_cmd.py#L69" rel="noopener noreferrer">run_debt_command:69</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/debt_cmd.py" rel="noopener noreferrer">run_debt_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/debt_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_defend_command def skylos/commands/defend_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py#L389" rel="noopener noreferrer">run_defend_command:389</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">run_defend_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/defend_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_discover_command def skylos/commands/discover_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/discover_cmd.py#L8" rel="noopener noreferrer">run_discover_command:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/discover_cmd.py" rel="noopener noreferrer">run_discover_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/discover_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_doctor_command def skylos/commands/doctor_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/doctor_cmd.py#L38" rel="noopener noreferrer">run_doctor_command:38</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/doctor_cmd.py" rel="noopener noreferrer">run_doctor_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/doctor_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_ingest_command def skylos/commands/ingest_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/ingest_cmd.py#L5" rel="noopener noreferrer">run_ingest_command:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/ingest_cmd.py" rel="noopener noreferrer">run_ingest_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/ingest_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_init_command def skylos/commands/init_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/init_cmd.py#L6" rel="noopener noreferrer">run_init_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/init_cmd.py" rel="noopener noreferrer">run_init_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/init_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_key_command def skylos/commands/key_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py#L11" rel="noopener noreferrer">run_key_command:11</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py" rel="noopener noreferrer">run_key_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/key_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_login_command def skylos/commands/login_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/login_cmd.py#L6" rel="noopener noreferrer">run_login_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/login_cmd.py" rel="noopener noreferrer">run_login_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/login_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_project_command def skylos/commands/project_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/project_cmd.py#L1" rel="noopener noreferrer">run_project_command:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/project_cmd.py" rel="noopener noreferrer">run_project_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/project_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_provenance_command def skylos/commands/provenance_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/provenance_cmd.py#L10" rel="noopener noreferrer">run_provenance_command:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/provenance_cmd.py" rel="noopener noreferrer">run_provenance_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/provenance_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_rules_command def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L17" rel="noopener noreferrer">run_rules_command:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">run_rules_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="init_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L109" rel="noopener noreferrer">init_rules:109</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">init_rules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="install_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L170" rel="noopener noreferrer">install_rules:170</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">install_rules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="list_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L220" rel="noopener noreferrer">list_rules:220</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">list_rules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="list_rule_packs def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L252" rel="noopener noreferrer">list_rule_packs:252</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">list_rule_packs</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="remove_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L414" rel="noopener noreferrer">remove_rules:414</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">remove_rules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_rules def skylos/commands/rules_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py#L425" rel="noopener noreferrer">validate_rules:425</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">validate_rules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/rules_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_run_command def skylos/commands/run_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/run_cmd.py#L20" rel="noopener noreferrer">run_run_command:20</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/run_cmd.py" rel="noopener noreferrer">run_run_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/run_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_scan_command def skylos/commands/scan_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/scan_cmd.py#L7" rel="noopener noreferrer">run_scan_command:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/scan_cmd.py" rel="noopener noreferrer">run_scan_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/scan_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_sonar_command def skylos/commands/sonar_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/sonar_cmd.py#L7" rel="noopener noreferrer">run_sonar_command:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/sonar_cmd.py" rel="noopener noreferrer">run_sonar_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/sonar_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_suite_command def skylos/commands/suite_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py#L446" rel="noopener noreferrer">run_suite_command:446</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">run_suite_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/suite_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_sync_command def skylos/commands/sync_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/sync_cmd.py#L1" rel="noopener noreferrer">run_sync_command:1</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/sync_cmd.py" rel="noopener noreferrer">run_sync_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/sync_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_whitelist def skylos/commands/whitelist_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whitelist_cmd.py#L9" rel="noopener noreferrer">run_whitelist:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whitelist_cmd.py" rel="noopener noreferrer">run_whitelist</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/whitelist_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_whitelist_command def skylos/commands/whitelist_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whitelist_cmd.py#L89" rel="noopener noreferrer">run_whitelist_command:89</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whitelist_cmd.py" rel="noopener noreferrer">run_whitelist_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/whitelist_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_whoami_command def skylos/commands/whoami_cmd.py command modules used by the cli for focused command behavior.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whoami_cmd.py#L6" rel="noopener noreferrer">run_whoami_command:6</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/whoami_cmd.py" rel="noopener noreferrer">run_whoami_command</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/commands/whoami_cmd.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_config def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L104" rel="noopener noreferrer">load_config:104</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">load_config</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_path_excluded def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L466" rel="noopener noreferrer">is_path_excluded:466</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_path_excluded</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_whitelisted def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L488" rel="noopener noreferrer">is_whitelisted:488</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_whitelisted</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_expired_whitelists def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L532" rel="noopener noreferrer">get_expired_whitelists:532</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_expired_whitelists</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_all_ignore_lines def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L553" rel="noopener noreferrer">get_all_ignore_lines:553</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_all_ignore_lines</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
             </tr>
 
             <tr class="searchable" data-search="suggest_pattern def skylos/config.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py#L598" rel="noopener noreferrer">suggest_pattern:598</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">suggest_pattern</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_test_path def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L130" rel="noopener noreferrer">is_test_path:130</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">is_test_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_framework_path def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L134" rel="noopener noreferrer">is_framework_path:134</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">is_framework_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_non_library_dir_kind def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L183" rel="noopener noreferrer">get_non_library_dir_kind:183</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">get_non_library_dir_kind</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
             </tr>
 
             <tr class="searchable" data-search="parse_exclude_folders def skylos/constants.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py#L207" rel="noopener noreferrer">parse_exclude_folders:207</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/constants.py" rel="noopener noreferrer">parse_exclude_folders</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/constants.py</td>
             </tr>
 
             <tr class="searchable" data-search="save_baseline def skylos/core/baseline.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py#L13" rel="noopener noreferrer">save_baseline:13</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py" rel="noopener noreferrer">save_baseline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_baseline def skylos/core/baseline.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py#L52" rel="noopener noreferrer">load_baseline:52</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py" rel="noopener noreferrer">load_baseline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="filter_new_findings def skylos/core/baseline.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py#L59" rel="noopener noreferrer">filter_new_findings:59</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/baseline.py" rel="noopener noreferrer">filter_new_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="sanitize_addopts def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L88" rel="noopener noreferrer">sanitize_addopts:88</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py" rel="noopener noreferrer">sanitize_addopts</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_git_changed_files def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L129" rel="noopener noreferrer">get_git_changed_files:129</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py" rel="noopener noreferrer">get_git_changed_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
             </tr>
 
             <tr class="searchable" data-search="estimate_cost def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L224" rel="noopener noreferrer">estimate_cost:224</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py" rel="noopener noreferrer">estimate_cost</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_addopts def skylos/core/cli_shared.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py#L237" rel="noopener noreferrer">load_addopts:237</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py" rel="noopener noreferrer">load_addopts</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/cli_shared.py</td>
             </tr>
 
             <tr class="searchable" data-search="should_exclude_path def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L124" rel="noopener noreferrer">should_exclude_path:124</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">should_exclude_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
             </tr>
 
             <tr class="searchable" data-search="should_include_path def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L148" rel="noopener noreferrer">should_include_path:148</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">should_include_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
             </tr>
 
             <tr class="searchable" data-search="find_git_root def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L156" rel="noopener noreferrer">find_git_root:156</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">find_git_root</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
             </tr>
 
             <tr class="searchable" data-search="list_git_visible_files def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L174" rel="noopener noreferrer">list_git_visible_files:174</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">list_git_visible_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
             </tr>
 
             <tr class="searchable" data-search="discover_source_files def skylos/core/file_discovery.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py#L237" rel="noopener noreferrer">discover_source_files:237</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/file_discovery.py" rel="noopener noreferrer">discover_source_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/file_discovery.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_cmd def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L56" rel="noopener noreferrer">run_cmd:56</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">run_cmd</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_git_status def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L65" rel="noopener noreferrer">get_git_status:65</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">get_git_status</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_push def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L79" rel="noopener noreferrer">run_push:79</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">run_push</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="start_deployment_wizard def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L90" rel="noopener noreferrer">start_deployment_wizard:90</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">start_deployment_wizard</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="check_gate def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L451" rel="noopener noreferrer">check_gate:451</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">check_gate</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_summary_markdown def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L544" rel="noopener noreferrer">build_summary_markdown:544</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">build_summary_markdown</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="write_github_summary def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L587" rel="noopener noreferrer">write_github_summary:587</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">write_github_summary</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_gate_interaction def skylos/core/gatekeeper.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py#L650" rel="noopener noreferrer">run_gate_interaction:650</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">run_gate_interaction</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/gatekeeper.py</td>
             </tr>
 
             <tr class="searchable" data-search="file_content_hash def skylos/core/grep_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_cache.py#L21" rel="noopener noreferrer">file_content_hash:21</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_cache.py" rel="noopener noreferrer">file_content_hash</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="grepcache class skylos/core/grep_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_cache.py#L47" rel="noopener noreferrer">GrepCache:47</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_cache.py" rel="noopener noreferrer">GrepCache</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="grepverdict class skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L66" rel="noopener noreferrer">GrepVerdict:66</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">GrepVerdict</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
             </tr>
 
             <tr class="searchable" data-search="grepstrategy class skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L74" rel="noopener noreferrer">GrepStrategy:74</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">GrepStrategy</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
             </tr>
 
             <tr class="searchable" data-search="multi_strategy_search def skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L149" rel="noopener noreferrer">multi_strategy_search:149</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">multi_strategy_search</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
             </tr>
 
             <tr class="searchable" data-search="parallel_multi_strategy_search def skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L164" rel="noopener noreferrer">parallel_multi_strategy_search:164</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">parallel_multi_strategy_search</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
             </tr>
 
             <tr class="searchable" data-search="grep_verify_findings def skylos/core/grep_verify.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py#L228" rel="noopener noreferrer">grep_verify_findings:228</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">grep_verify_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify.py</td>
             </tr>
 
             <tr class="searchable" data-search="detect_language def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L82" rel="noopener noreferrer">detect_language:82</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">detect_language</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="source_globs_for_language def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L101" rel="noopener noreferrer">source_globs_for_language:101</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">source_globs_for_language</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="repo_relative_path def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L178" rel="noopener noreferrer">repo_relative_path:178</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">repo_relative_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="module_candidates def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L192" rel="noopener noreferrer">module_candidates:192</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">module_candidates</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="parameter_owner_name def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L280" rel="noopener noreferrer">parameter_owner_name:280</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">parameter_owner_name</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_definition_line def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L289" rel="noopener noreferrer">is_definition_line:289</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">is_definition_line</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="filter_grep_results def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L368" rel="noopener noreferrer">filter_grep_results:368</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">filter_grep_results</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_substring_match def skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py#L383" rel="noopener noreferrer">is_substring_match:383</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">is_substring_match</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_common.py</td>
             </tr>
 
             <tr class="searchable" data-search="parallel_multi_strategy_search_impl def skylos/core/grep_verify_parallel.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_parallel.py#L17" rel="noopener noreferrer">parallel_multi_strategy_search_impl:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_parallel.py" rel="noopener noreferrer">parallel_multi_strategy_search_impl</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_parallel.py</td>
             </tr>
 
             <tr class="searchable" data-search="multi_strategy_search def skylos/core/grep_verify_python_strategy.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_python_strategy.py#L22" rel="noopener noreferrer">multi_strategy_search:22</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_python_strategy.py" rel="noopener noreferrer">multi_strategy_search</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_python_strategy.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_parallel_strategy_tasks def skylos/core/grep_verify_strategies.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_strategies.py#L65" rel="noopener noreferrer">build_parallel_strategy_tasks:65</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_strategies.py" rel="noopener noreferrer">build_parallel_strategy_tasks</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/grep_verify_strategies.py</td>
             </tr>
 
             <tr class="searchable" data-search="lintervisitor class skylos/core/linter.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/linter.py#L5" rel="noopener noreferrer">LinterVisitor:5</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/linter.py" rel="noopener noreferrer">LinterVisitor</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/linter.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_trace_cache_key def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L117" rel="noopener noreferrer">build_trace_cache_key:117</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">build_trace_cache_key</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_trace_cache def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L153" rel="noopener noreferrer">load_trace_cache:153</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">load_trace_cache</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="save_trace_cache def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L181" rel="noopener noreferrer">save_trace_cache:181</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">save_trace_cache</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="clear_run_cache def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L209" rel="noopener noreferrer">clear_run_cache:209</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">clear_run_cache</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_cache_stats def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L226" rel="noopener noreferrer">run_cache_stats:226</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">run_cache_stats</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="read_trace_payload def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L320" rel="noopener noreferrer">read_trace_payload:320</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">read_trace_payload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="write_trace_payload def skylos/core/result_cache.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py#L335" rel="noopener noreferrer">write_trace_payload:335</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/result_cache.py" rel="noopener noreferrer">write_trace_payload</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_suite_table def skylos/core/suite.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py#L129" rel="noopener noreferrer">format_suite_table:129</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">format_suite_table</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/suite.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_suite_json def skylos/core/suite.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py#L179" rel="noopener noreferrer">format_suite_json:179</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">format_suite_json</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/suite.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_suite def skylos/core/suite.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py#L183" rel="noopener noreferrer">run_suite:183</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">run_suite</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/suite.py</td>
             </tr>
 
             <tr class="searchable" data-search="calltracer class skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L8" rel="noopener noreferrer">CallTracer:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py" rel="noopener noreferrer">CallTracer</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
             </tr>
 
             <tr class="searchable" data-search="start_tracing def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L137" rel="noopener noreferrer">start_tracing:137</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py" rel="noopener noreferrer">start_tracing</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
             </tr>
 
             <tr class="searchable" data-search="stop_tracing def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L144" rel="noopener noreferrer">stop_tracing:144</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py" rel="noopener noreferrer">stop_tracing</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
             </tr>
 
             <tr class="searchable" data-search="pytest_configure def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L157" rel="noopener noreferrer">pytest_configure:157</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py" rel="noopener noreferrer">pytest_configure</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
             </tr>
 
             <tr class="searchable" data-search="pytest_unconfigure def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L168" rel="noopener noreferrer">pytest_unconfigure:168</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py" rel="noopener noreferrer">pytest_unconfigure</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
             </tr>
 
             <tr class="searchable" data-search="pytest_addoption def skylos/core/tracer.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py#L173" rel="noopener noreferrer">pytest_addoption:173</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/tracer.py" rel="noopener noreferrer">pytest_addoption</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/tracer.py</td>
             </tr>
 
             <tr class="searchable" data-search="collect_dead_code_findings def skylos/deadcode/collect.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py#L14" rel="noopener noreferrer">collect_dead_code_findings:14</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py" rel="noopener noreferrer">collect_dead_code_findings</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/collect.py</td>
             </tr>
 
             <tr class="searchable" data-search="evidencekind class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L12" rel="noopener noreferrer">EvidenceKind:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">EvidenceKind</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="candidateclassification class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L28" rel="noopener noreferrer">CandidateClassification:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">CandidateClassification</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="symbolkey class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L37" rel="noopener noreferrer">SymbolKey:37</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">SymbolKey</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="evidenceevent class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L89" rel="noopener noreferrer">EvidenceEvent:89</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">EvidenceEvent</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="evidenceledger class skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L107" rel="noopener noreferrer">EvidenceLedger:107</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">EvidenceLedger</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_dead_code_evidence def skylos/deadcode/evidence.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py#L189" rel="noopener noreferrer">build_dead_code_evidence:189</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">build_dead_code_evidence</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/evidence.py</td>
             </tr>
 
             <tr class="searchable" data-search="livenessrescue class skylos/deadcode/liveness.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L61" rel="noopener noreferrer">LivenessRescue:61</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">LivenessRescue</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/liveness.py</td>
             </tr>
 
             <tr class="searchable" data-search="livenessreport class skylos/deadcode/liveness.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L69" rel="noopener noreferrer">LivenessReport:69</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">LivenessReport</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/liveness.py</td>
             </tr>
 
             <tr class="searchable" data-search="apply_dead_code_liveness def skylos/deadcode/liveness.py dead-code specific analysis, framework liveness, and evidence support.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py#L95" rel="noopener noreferrer">apply_dead_code_liveness:95</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">apply_dead_code_liveness</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/deadcode/liveness.py</td>
             </tr>
 
             <tr class="searchable" data-search="augment_hotspots_with_advisories def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L25" rel="noopener noreferrer">augment_hotspots_with_advisories:25</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py" rel="noopener noreferrer">augment_hotspots_with_advisories</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="collect_debt_signals def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L33" rel="noopener noreferrer">collect_debt_signals:33</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py" rel="noopener noreferrer">collect_debt_signals</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_debt_snapshot def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L39" rel="noopener noreferrer">build_debt_snapshot:39</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py" rel="noopener noreferrer">build_debt_snapshot</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_debt_analysis def skylos/debt/__init__.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py#L45" rel="noopener noreferrer">run_debt_analysis:45</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/__init__.py" rel="noopener noreferrer">run_debt_analysis</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/__init__.py</td>
             </tr>
 
             <tr class="searchable" data-search="debtadvisor class skylos/debt/advisor.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L226" rel="noopener noreferrer">DebtAdvisor:226</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">DebtAdvisor</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/advisor.py</td>
             </tr>
 
             <tr class="searchable" data-search="augment_hotspots_with_advisories def skylos/debt/advisor.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py#L263" rel="noopener noreferrer">augment_hotspots_with_advisories:263</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/advisor.py" rel="noopener noreferrer">augment_hotspots_with_advisories</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/advisor.py</td>
             </tr>
 
             <tr class="searchable" data-search="save_baseline def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L272" rel="noopener noreferrer">save_baseline:272</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">save_baseline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_baseline def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L308" rel="noopener noreferrer">load_baseline:308</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">load_baseline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_history def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L332" rel="noopener noreferrer">load_history:332</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">load_history</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="annotate_hotspots def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L384" rel="noopener noreferrer">annotate_hotspots:384</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">annotate_hotspots</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="compare_to_baseline def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L426" rel="noopener noreferrer">compare_to_baseline:426</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">compare_to_baseline</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="append_history def skylos/debt/baseline.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py#L444" rel="noopener noreferrer">append_history:444</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/baseline.py" rel="noopener noreferrer">append_history</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/baseline.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_analyze def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L43" rel="noopener noreferrer">run_analyze:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py" rel="noopener noreferrer">run_analyze</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
             </tr>
 
             <tr class="searchable" data-search="collect_debt_signals def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L186" rel="noopener noreferrer">collect_debt_signals:186</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py" rel="noopener noreferrer">collect_debt_signals</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_debt_snapshot def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L223" rel="noopener noreferrer">build_debt_snapshot:223</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py" rel="noopener noreferrer">build_debt_snapshot</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_debt_analysis def skylos/debt/engine.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py#L284" rel="noopener noreferrer">run_debt_analysis:284</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/engine.py" rel="noopener noreferrer">run_debt_analysis</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/engine.py</td>
             </tr>
 
             <tr class="searchable" data-search="debtpolicy class skylos/debt/policy.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py#L28" rel="noopener noreferrer">DebtPolicy:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py" rel="noopener noreferrer">DebtPolicy</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/policy.py</td>
             </tr>
 
             <tr class="searchable" data-search="find_policy_path def skylos/debt/policy.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py#L43" rel="noopener noreferrer">find_policy_path:43</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py" rel="noopener noreferrer">find_policy_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/policy.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_policy def skylos/debt/policy.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py#L112" rel="noopener noreferrer">load_policy:112</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/policy.py" rel="noopener noreferrer">load_policy</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/policy.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_debt_table def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L244" rel="noopener noreferrer">format_debt_table:244</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_table</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_debt_json def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L280" rel="noopener noreferrer">format_debt_json:280</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_json</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_debt_history_table def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L357" rel="noopener noreferrer">format_debt_history_table:357</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_history_table</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_debt_history_json def skylos/debt/report.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py#L388" rel="noopener noreferrer">format_debt_history_json:388</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/report.py" rel="noopener noreferrer">format_debt_history_json</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="debtadvisory class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L8" rel="noopener noreferrer">DebtAdvisory:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">DebtAdvisory</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="debtsignal class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L28" rel="noopener noreferrer">DebtSignal:28</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">DebtSignal</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="debthotspot class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L62" rel="noopener noreferrer">DebtHotspot:62</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">DebtHotspot</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="debtscore class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L94" rel="noopener noreferrer">DebtScore:94</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">DebtScore</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="debtsnapshot class skylos/debt/result.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py#L116" rel="noopener noreferrer">DebtSnapshot:116</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/result.py" rel="noopener noreferrer">DebtSnapshot</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="compute_signal_points def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L35" rel="noopener noreferrer">compute_signal_points:35</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">compute_signal_points</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="compute_priority_score def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L64" rel="noopener noreferrer">compute_priority_score:64</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">compute_priority_score</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="refresh_hotspot_priority def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L88" rel="noopener noreferrer">refresh_hotspot_priority:88</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">refresh_hotspot_priority</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_hotspots def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L103" rel="noopener noreferrer">build_hotspots:103</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">build_hotspots</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="compute_debt_score def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L152" rel="noopener noreferrer">compute_debt_score:152</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">compute_debt_score</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_score_breakdown def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L210" rel="noopener noreferrer">build_score_breakdown:210</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">build_score_breakdown</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="score_model_metadata def skylos/debt/scoring.py technical-debt detection and reporting helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py#L285" rel="noopener noreferrer">score_model_metadata:285</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/debt/scoring.py" rel="noopener noreferrer">score_model_metadata</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/debt/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_defense_checks def skylos/defend/engine.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/engine.py#L19" rel="noopener noreferrer">run_defense_checks:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/engine.py" rel="noopener noreferrer">run_defense_checks</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/engine.py</td>
             </tr>
 
             <tr class="searchable" data-search="supported_owasp_frameworks def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L189" rel="noopener noreferrer">supported_owasp_frameworks:189</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">supported_owasp_frameworks</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="supported_owasp_versions def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L193" rel="noopener noreferrer">supported_owasp_versions:193</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">supported_owasp_versions</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_owasp_framework def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L200" rel="noopener noreferrer">normalize_owasp_framework:200</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">normalize_owasp_framework</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="normalize_owasp_selection def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L209" rel="noopener noreferrer">normalize_owasp_selection:209</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">normalize_owasp_selection</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="get_owasp_mapping def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L232" rel="noopener noreferrer">get_owasp_mapping:232</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">get_owasp_mapping</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="owasp_report_label def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L240" rel="noopener noreferrer">owasp_report_label:240</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">owasp_report_label</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_owasp_ids def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L248" rel="noopener noreferrer">validate_owasp_ids:248</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">validate_owasp_ids</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="plugin_ids_for_owasp_filter def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L266" rel="noopener noreferrer">plugin_ids_for_owasp_filter:266</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">plugin_ids_for_owasp_filter</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="compute_owasp_coverage def skylos/defend/owasp.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py#L282" rel="noopener noreferrer">compute_owasp_coverage:282</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/owasp.py" rel="noopener noreferrer">compute_owasp_coverage</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/owasp.py</td>
             </tr>
 
             <tr class="searchable" data-search="defenseplugin class skylos/defend/plugin.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugin.py#L12" rel="noopener noreferrer">DefensePlugin:12</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugin.py" rel="noopener noreferrer">DefensePlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugin.py</td>
             </tr>
 
             <tr class="searchable" data-search="costcontrolsplugin class skylos/defend/plugins/cost_controls.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/cost_controls.py#L7" rel="noopener noreferrer">CostControlsPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/cost_controls.py" rel="noopener noreferrer">CostControlsPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/cost_controls.py</td>
             </tr>
 
             <tr class="searchable" data-search="inputlengthlimitplugin class skylos/defend/plugins/input_length_limit.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/input_length_limit.py#L7" rel="noopener noreferrer">InputLengthLimitPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/input_length_limit.py" rel="noopener noreferrer">InputLengthLimitPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/input_length_limit.py</td>
             </tr>
 
             <tr class="searchable" data-search="loggingpresentplugin class skylos/defend/plugins/logging_present.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/logging_present.py#L7" rel="noopener noreferrer">LoggingPresentPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/logging_present.py" rel="noopener noreferrer">LoggingPresentPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/logging_present.py</td>
             </tr>
 
             <tr class="searchable" data-search="modelpinnedplugin class skylos/defend/plugins/model_pinned.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/model_pinned.py#L7" rel="noopener noreferrer">ModelPinnedPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/model_pinned.py" rel="noopener noreferrer">ModelPinnedPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/model_pinned.py</td>
             </tr>
 
             <tr class="searchable" data-search="nodangeroussinkplugin class skylos/defend/plugins/no_dangerous_sink.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/no_dangerous_sink.py#L7" rel="noopener noreferrer">NoDangerousSinkPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/no_dangerous_sink.py" rel="noopener noreferrer">NoDangerousSinkPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/no_dangerous_sink.py</td>
             </tr>
 
             <tr class="searchable" data-search="outputpiifilterplugin class skylos/defend/plugins/output_pii_filter.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/output_pii_filter.py#L7" rel="noopener noreferrer">OutputPiiFilterPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/output_pii_filter.py" rel="noopener noreferrer">OutputPiiFilterPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/output_pii_filter.py</td>
             </tr>
 
             <tr class="searchable" data-search="outputvalidationplugin class skylos/defend/plugins/output_validation.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/output_validation.py#L7" rel="noopener noreferrer">OutputValidationPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/output_validation.py" rel="noopener noreferrer">OutputValidationPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/output_validation.py</td>
             </tr>
 
             <tr class="searchable" data-search="promptdelimiterplugin class skylos/defend/plugins/prompt_delimiter.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/prompt_delimiter.py#L7" rel="noopener noreferrer">PromptDelimiterPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/prompt_delimiter.py" rel="noopener noreferrer">PromptDelimiterPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/prompt_delimiter.py</td>
             </tr>
 
             <tr class="searchable" data-search="ragcontextisolationplugin class skylos/defend/plugins/rag_context_isolation.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/rag_context_isolation.py#L7" rel="noopener noreferrer">RagContextIsolationPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/rag_context_isolation.py" rel="noopener noreferrer">RagContextIsolationPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/rag_context_isolation.py</td>
             </tr>
 
             <tr class="searchable" data-search="ratelimitingplugin class skylos/defend/plugins/rate_limiting.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/rate_limiting.py#L7" rel="noopener noreferrer">RateLimitingPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/rate_limiting.py" rel="noopener noreferrer">RateLimitingPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/rate_limiting.py</td>
             </tr>
 
             <tr class="searchable" data-search="toolschemapresentplugin class skylos/defend/plugins/tool_schema_present.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/tool_schema_present.py#L7" rel="noopener noreferrer">ToolSchemaPresentPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/tool_schema_present.py" rel="noopener noreferrer">ToolSchemaPresentPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/tool_schema_present.py</td>
             </tr>
 
             <tr class="searchable" data-search="toolscopeplugin class skylos/defend/plugins/tool_scope.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/tool_scope.py#L7" rel="noopener noreferrer">ToolScopePlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/tool_scope.py" rel="noopener noreferrer">ToolScopePlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/tool_scope.py</td>
             </tr>
 
             <tr class="searchable" data-search="untrustedinputtopromptplugin class skylos/defend/plugins/untrusted_input_to_prompt.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/untrusted_input_to_prompt.py#L7" rel="noopener noreferrer">UntrustedInputToPromptPlugin:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/plugins/untrusted_input_to_prompt.py" rel="noopener noreferrer">UntrustedInputToPromptPlugin</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/plugins/untrusted_input_to_prompt.py</td>
             </tr>
 
             <tr class="searchable" data-search="defensepolicy class skylos/defend/policy.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L51" rel="noopener noreferrer">DefensePolicy:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">DefensePolicy</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/policy.py</td>
             </tr>
 
             <tr class="searchable" data-search="load_policy def skylos/defend/policy.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py#L66" rel="noopener noreferrer">load_policy:66</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/policy.py" rel="noopener noreferrer">load_policy</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/policy.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_defense_table def skylos/defend/report.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L17" rel="noopener noreferrer">format_defense_table:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py" rel="noopener noreferrer">format_defense_table</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_defense_json def skylos/defend/report.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py#L102" rel="noopener noreferrer">format_defense_json:102</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/report.py" rel="noopener noreferrer">format_defense_json</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="defenseresult class skylos/defend/result.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L8" rel="noopener noreferrer">DefenseResult:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">DefenseResult</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="defensescore class skylos/defend/result.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L36" rel="noopener noreferrer">DefenseScore:36</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">DefenseScore</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="opsscore class skylos/defend/result.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py#L56" rel="noopener noreferrer">OpsScore:56</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/result.py" rel="noopener noreferrer">OpsScore</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/result.py</td>
             </tr>
 
             <tr class="searchable" data-search="compute_defense_score def skylos/defend/scoring.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L19" rel="noopener noreferrer">compute_defense_score:19</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">compute_defense_score</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="compute_ops_score def skylos/defend/scoring.py defensive scanning plugins and checks for suspicious package or code patterns.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py#L70" rel="noopener noreferrer">compute_ops_score:70</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/defend/scoring.py" rel="noopener noreferrer">compute_ops_score</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/defend/scoring.py</td>
             </tr>
 
             <tr class="searchable" data-search="detect_integrations def skylos/discover/detector.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py#L1049" rel="noopener noreferrer">detect_integrations:1049</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector.py" rel="noopener noreferrer">detect_integrations</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector.py</td>
             </tr>
 
             <tr class="searchable" data-search="jsimport class skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L173" rel="noopener noreferrer">JSImport:173</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">JSImport</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
             </tr>
 
             <tr class="searchable" data-search="tsclient class skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L180" rel="noopener noreferrer">TSClient:180</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">TSClient</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
             </tr>
 
             <tr class="searchable" data-search="collect_typescript_files def skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L187" rel="noopener noreferrer">collect_typescript_files:187</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">collect_typescript_files</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
             </tr>
 
             <tr class="searchable" data-search="scan_typescript_file def skylos/discover/detector_typescript.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py#L200" rel="noopener noreferrer">scan_typescript_file:200</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/detector_typescript.py" rel="noopener noreferrer">scan_typescript_file</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/detector_typescript.py</td>
             </tr>
 
             <tr class="searchable" data-search="nodetype class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L8" rel="noopener noreferrer">NodeType:8</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">NodeType</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
             </tr>
 
             <tr class="searchable" data-search="graphnode class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L18" rel="noopener noreferrer">GraphNode:18</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">GraphNode</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
             </tr>
 
             <tr class="searchable" data-search="graphedge class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L36" rel="noopener noreferrer">GraphEdge:36</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">GraphEdge</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
             </tr>
 
             <tr class="searchable" data-search="aiintegrationgraph class skylos/discover/graph.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py#L51" rel="noopener noreferrer">AIIntegrationGraph:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/graph.py" rel="noopener noreferrer">AIIntegrationGraph</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/graph.py</td>
             </tr>
 
             <tr class="searchable" data-search="tooldef class skylos/discover/integration.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py#L7" rel="noopener noreferrer">ToolDef:7</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py" rel="noopener noreferrer">ToolDef</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/integration.py</td>
             </tr>
 
             <tr class="searchable" data-search="llmintegration class skylos/discover/integration.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py#L23" rel="noopener noreferrer">LLMIntegration:23</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/integration.py" rel="noopener noreferrer">LLMIntegration</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/integration.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_table def skylos/discover/report.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py#L10" rel="noopener noreferrer">format_table:10</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py" rel="noopener noreferrer">format_table</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_json def skylos/discover/report.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py#L51" rel="noopener noreferrer">format_json:51</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py" rel="noopener noreferrer">format_json</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/report.py</td>
             </tr>
 
             <tr class="searchable" data-search="taintflow class skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L9" rel="noopener noreferrer">TaintFlow:9</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">TaintFlow</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/taint.py</td>
             </tr>
 
             <tr class="searchable" data-search="analyze_taint_flows def skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py#L201" rel="noopener noreferrer">analyze_taint_flows:201</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">analyze_taint_flows</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/taint.py</td>
             </tr>
 
             <tr class="searchable" data-search="build_go_engine_args def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L4" rel="noopener noreferrer">build_go_engine_args:4</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">build_go_engine_args</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_contract.py</td>
             </tr>
 
             <tr class="searchable" data-search="validate_go_engine_output def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py#L17" rel="noopener noreferrer">validate_go_engine_output:17</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">validate_go_engine_output</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_contract.py</td>
             </tr>
 
             <tr class="searchable" data-search="goengineerror class skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L15" rel="noopener noreferrer">GoEngineError:15</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">GoEngineError</a></td>
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
             </tr>
 
             <tr class="searchable" data-search="discover_go_modules def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L34" rel="noopener noreferrer">discover_go_modules:34</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">discover_go_modules</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
             </tr>
 
             <tr class="searchable" data-search="resolve_go_engine_bin def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L67" rel="noopener noreferrer">resolve_go_engine_bin:67</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">resolve_go_engine_bin</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
             </tr>
 
             <tr class="searchable" data-search="run_go_engine_for_module def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py#L96" rel="noopener noreferrer">run_go_engine_for_module:96</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">run_go_engine_for_module</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/engines/go_runner.py</td>
             </tr>
 
             <tr class="searchable" data-search="is_claude_security_report def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py#L27" rel="noopener noreferrer">is_claude_security_report:27</a></td>
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">is_claude_security_report</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/integrations/ingest.py</td>

--- a/scripts/build_repo_map.py
+++ b/scripts/build_repo_map.py
@@ -53,6 +53,8 @@ render_html = _load_renderer()
 SOURCE_ROOTS = ("skylos", "test", "scripts", "benchmarks")
 GENERATED_PATHS = {"docs/repo-map/index.html"}
 MAX_SOURCE_BYTES = 1_000_000
+SHARED_ENTRYPOINTS = {"skylos/cli.py", "skylos/analyzer.py", "skylos/pipeline.py", "skylos/config.py"}
+PRIVATE_SYMBOL_ENTRYPOINTS = {"skylos/cli.py", "skylos/analyzer.py", "skylos/pipeline.py"}
 EXCLUDED_DIRS = {
     ".git",
     ".mypy_cache",
@@ -551,7 +553,9 @@ class SymbolInfo:
         name: Symbol name exactly as it appears in source.
         kind: Human-readable symbol type, such as `class`, `def`, or
             `async def`.
-        line: 1-based source line for the symbol definition.
+        line: 1-based source line for stable in-file ordering. The renderer
+            intentionally does not emit this value because line anchors churn
+            whenever unrelated code moves.
         private: Whether the symbol name starts with `_`.
 
     Used by:
@@ -572,7 +576,6 @@ class ModuleInfo:
 
     Attributes:
         path: Repository-relative POSIX path.
-        lines: Approximate source line count.
         summary: Module docstring summary or curated folder fallback.
         symbols: Top-level symbols extracted from the module AST.
         imports: Top-level import roots used by the module.
@@ -582,7 +585,6 @@ class ModuleInfo:
         scripts/repo_map_renderer.py render_hot_modules.
     """
     path: str
-    lines: int
     summary: str
     symbols: list[SymbolInfo]
     imports: list[str]
@@ -761,9 +763,9 @@ def _parse_python_module(path: Path, root: Path) -> ModuleInfo:
         root: Repository root used to compute display paths.
 
     Returns:
-        ModuleInfo containing path, line count, summary, imports, and top-level
-        symbols. Syntax errors produce an empty-symbol ModuleInfo instead of
-        aborting the whole map.
+        ModuleInfo containing path, summary, imports, and top-level symbols.
+        Syntax errors produce an empty-symbol ModuleInfo instead of aborting
+        the whole map.
 
     Calls: scripts/build_repo_map.py _rel;
         scripts/build_repo_map.py _read_text;
@@ -775,15 +777,13 @@ def _parse_python_module(path: Path, root: Path) -> ModuleInfo:
     """
     relpath = _rel(path, root)
     source = _read_text(path)
-    lines = source.count("\n") + (1 if source else 0)
     try:
         tree = ast.parse(source)
     except SyntaxError:
-        return ModuleInfo(relpath, lines, "Python file could not be parsed by ast.", [], [])
+        return ModuleInfo(relpath, "Python file could not be parsed by ast.", [], [])
     doc_summary = _first_sentence(ast.get_docstring(tree) or "")
     return ModuleInfo(
         path=relpath,
-        lines=lines,
         summary=doc_summary or _fallback_summary(relpath),
         symbols=_extract_symbols(tree),
         imports=_extract_imports(tree),
@@ -799,6 +799,11 @@ def _group_for_path(relpath: str) -> str:
             return f"skylos/{parts[1]}"
         return "skylos"
     return parts[0]
+
+
+def _hot_module_score(module: ModuleInfo) -> int:
+    shared = 1 if module.path in SHARED_ENTRYPOINTS else 0
+    return shared * 1000 + len(module.symbols)
 
 
 def _test_files_for_group(group: str, test_files: list[str]) -> list[str]:
@@ -859,14 +864,12 @@ def collect_repo_map(root: Path) -> dict[str, Any]:
             {
                 "path": group,
                 "files": 0,
-                "lines": 0,
                 "symbols": 0,
                 "public_symbols": 0,
                 "modules": [],
             },
         )
         bucket["files"] += 1
-        bucket["lines"] += module.lines
         bucket["symbols"] += len(module.symbols)
         bucket["public_symbols"] += sum(1 for symbol in module.symbols if not symbol.private)
         bucket["modules"].append(module)
@@ -876,7 +879,7 @@ def collect_repo_map(root: Path) -> dict[str, Any]:
         meta = FOLDER_META.get(group, {})
         modules = sorted(
             groups[group]["modules"],
-            key=lambda item: (-(len(item.symbols) * 20 + item.lines), item.path),
+            key=lambda item: (-len(item.symbols), item.path),
         )
         key_symbols = _key_symbols(modules)
         folder_cards.append(
@@ -887,7 +890,6 @@ def collect_repo_map(root: Path) -> dict[str, Any]:
                 "entrypoints": [path for path in meta.get("entrypoints", []) if _path_exists_or_directory(root, path)],
                 "tests": _test_files_for_group(group, test_files),
                 "files": groups[group]["files"],
-                "lines": groups[group]["lines"],
                 "symbols": groups[group]["symbols"],
                 "public_symbols": groups[group]["public_symbols"],
                 "modules": modules[:8],
@@ -897,7 +899,7 @@ def collect_repo_map(root: Path) -> dict[str, Any]:
 
     hot_modules = sorted(
         python_modules,
-        key=lambda item: (-(item.lines + len(item.symbols) * 25), item.path),
+        key=lambda item: (-_hot_module_score(item), item.path),
     )[:14]
     symbol_index = _symbol_index(python_modules)
 
@@ -1023,7 +1025,7 @@ def _symbol_index(modules: list[ModuleInfo]) -> list[dict[str, Any]]:
     symbols: list[dict[str, Any]] = []
     for module in sorted(modules, key=lambda item: item.path):
         for symbol in module.symbols:
-            if symbol.private and not module.path.startswith(("skylos/cli.py", "skylos/analyzer.py", "skylos/pipeline.py")):
+            if symbol.private and module.path not in PRIVATE_SYMBOL_ENTRYPOINTS:
                 continue
             symbols.append(
                 {

--- a/scripts/repo_map_renderer.py
+++ b/scripts/repo_map_renderer.py
@@ -12,15 +12,11 @@ def _esc(value: Any) -> str:
     return html.escape(str(value), quote=True)
 
 
-def _link(path: str, *, label: str | None = None, line: int | None = None) -> str:
+def _link(path: str, *, label: str | None = None) -> str:
     clean = path.rstrip("/")
     route = "tree" if path.endswith("/") else "blob"
     href = f"{REPO_SOURCE_BASE}/{route}/main/{quote(clean, safe='/._-')}"
-    if line and route == "blob":
-        href = f"{href}#L{line}"
     text = label or clean
-    if line:
-        text = f"{text}:{line}"
     return (  # skylos: ignore escaped static repo-map HTML
         f'<a href="{_esc(href)}" rel="noopener noreferrer">{_esc(text)}</a>'
     )
@@ -419,11 +415,11 @@ def render_folder_card(card: dict[str, Any]) -> str:
     Called from: scripts/repo_map_renderer.py render_folder_cards.
     """
     modules = "\n".join(
-        f"<li>{_link(module.path)} <span>{_esc(module.lines)} lines</span></li>"
+        f"<li>{_link(module.path)}</li>"
         for module in card["modules"]
     )
     symbols = "\n".join(
-        f"<li>{_link(item['path'], label=item['name'], line=item['line'])} <span>{_esc(item['kind'])}</span></li>"
+        f"<li>{_link(item['path'], label=item['name'])} <span>{_esc(item['kind'])}</span></li>"
         for item in card["key_symbols"]
     )
     entrypoints = " ".join(_link(path) for path in card["entrypoints"]) or '<span class="muted">Generated only</span>'
@@ -436,7 +432,6 @@ def render_folder_card(card: dict[str, Any]) -> str:
         <div class="stat-row">
           {_pill("files", card["files"])}
           {_pill("symbols", card["symbols"])}
-          {_pill("lines", card["lines"])}
         </div>
       </div>
       <p>{_esc(card["purpose"])}</p>
@@ -488,11 +483,11 @@ def render_hot_modules(modules: list[Any]) -> str:
     Render high-risk or high-traffic modules.
 
     Args:
-        modules: ModuleInfo-like objects sorted by size and symbol count.
+        modules: ModuleInfo-like objects sorted by coarse risk signals.
 
     Returns:
-        Table rows with path, line count, public/all symbol count, risk labels,
-        and summary.
+        Table rows with path, public/all symbol count, risk labels, and
+        summary.
 
     Calls: scripts/repo_map_renderer.py _hot_module_labels;
         scripts/repo_map_renderer.py _link;
@@ -509,7 +504,6 @@ def render_hot_modules(modules: list[Any]) -> str:
             f"""
             <tr class="searchable" data-search="{_esc((module.path + " " + module.summary).lower())}">
               <td>{_link(module.path)}</td>
-              <td>{_esc(module.lines)}</td>
               <td>{_esc(public_symbols)} / {_esc(len(module.symbols))}</td>
               <td>{label_html}</td>
               <td>{_esc(module.summary)}</td>
@@ -521,8 +515,6 @@ def render_hot_modules(modules: list[Any]) -> str:
 
 def _hot_module_labels(module: Any) -> list[str]:
     labels = []
-    if module.lines >= 600:
-        labels.append("large")
     if len(module.symbols) >= 40:
         labels.append("many symbols")
     if module.path in {"skylos/cli.py", "skylos/analyzer.py", "skylos/pipeline.py", "skylos/config.py"}:
@@ -549,7 +541,7 @@ def render_symbol_index(symbols: list[dict[str, Any]]) -> str:
         rows.append(
             f"""
             <tr class="searchable" data-search="{_esc(search_text.lower())}">
-              <td>{_link(item["path"], label=item["name"], line=item["line"])}</td>
+              <td>{_link(item["path"], label=item["name"])}</td>
               <td>{_esc(item["kind"])}</td>
               <td>{badge}</td>
               <td>{_esc(item["path"])}</td>
@@ -710,7 +702,7 @@ def render_hot_section(data: dict[str, Any]) -> str:
       <h2>Hot Zones</h2>
       <p class="lede">These files are not bad by default. They are places where a small change can affect many workflows.</p>
       <table>
-        <thead><tr><th>File</th><th>Lines</th><th>Public / all symbols</th><th>Signal</th><th>What it seems to own</th></tr></thead>
+        <thead><tr><th>File</th><th>Public / all symbols</th><th>Signal</th><th>What it seems to own</th></tr></thead>
         <tbody>{render_hot_modules(data["hot_modules"])}</tbody>
       </table>
     </section>

--- a/test/test_repo_map.py
+++ b/test/test_repo_map.py
@@ -89,3 +89,17 @@ def test_main_check_detects_stale_output(tmp_path):
     output.write_text("stale", encoding="utf-8")
 
     assert repo_map.main(["--root", str(tmp_path), "--output", str(output), "--check"]) == 1
+
+
+def test_main_check_ignores_line_only_source_churn(tmp_path):
+    repo_map = _load_repo_map_module()
+    source = tmp_path / "skylos" / "config.py"
+    _write(source, "def load_config():\n    return {}\n")
+    output = tmp_path / "docs" / "repo-map" / "index.html"
+
+    assert repo_map.main(["--root", str(tmp_path), "--output", str(output)]) == 0
+
+    line_noise = "\n".join("# implementation note" for _ in range(700))
+    source.write_text(f"{line_noise}\n\ndef load_config():\n    return {{}}\n", encoding="utf-8")
+
+    assert repo_map.main(["--root", str(tmp_path), "--output", str(output), "--check"]) == 0


### PR DESCRIPTION
## Summary
  - Stabilize generated repo map output by removing line count churn.
  - Update the repo map Pages workflow to build the generated map instead of failing on source only line movement.
  - Add a regression test proving `--check` ignores line only source churn.
  - Refresh `docs/repo-map/index.html`.

## Tests
  - `pytest test/test_repo_map.py`