### PR TITLE
fix(analyzer): reduce vscode extension dead-code false positives

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -31,6 +31,7 @@ from skylos.visitors.languages.typescript import scan_typescript_file
 from skylos.visitors.languages.typescript.analysis import (
     build_ts_import_graph,
     demote_unconsumed_ts_exports,
+    _discover_ts_vscode_lifecycle_entry_files,
     find_dead_ts_files,
     find_unused_ts_exports,
 )
@@ -797,11 +798,21 @@ class Skylos:
             self._ts_importers_of,
         ) = build_ts_import_graph(ts_raw_imports, self.defs, monorepo_resolver)
 
-    def _demote_unconsumed_ts_exports(self):
+    def _demote_unconsumed_ts_exports(
+        self, files=None, exclude_folders=None, workspace_inventory=None
+    ):
         if not hasattr(self, "ts_consumed_exports"):
             return
+        lifecycle_entry_points = _discover_ts_vscode_lifecycle_entry_files(
+            files or [],
+            project_root=str(self._project_root),
+            workspace_inventory=workspace_inventory,
+            exclude_folders=exclude_folders,
+        )
         self._ts_demoted_exports = demote_unconsumed_ts_exports(
-            self.defs, self.ts_consumed_exports
+            self.defs,
+            self.ts_consumed_exports,
+            lifecycle_entry_points=lifecycle_entry_points,
         )
 
     def _find_dead_ts_files(self, files, exclude_folders, workspace_inventory=None):
@@ -2966,7 +2977,9 @@ class Skylos:
             progress_callback(0, 1, Path("PHASE: exports"))
         self._mark_exports()
 
-        self._demote_unconsumed_ts_exports()
+        self._demote_unconsumed_ts_exports(
+            files, exclude_folders, workspace_inventory=workspace_inventory
+        )
 
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: entry reachability"))

--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -304,7 +304,13 @@ def _resolve_namespace_reexports(
                                         defs[target_key].references += 1
 
 
-def demote_unconsumed_ts_exports(defs, consumed_exports):
+_VSCODE_EXTENSION_LIFECYCLE_EXPORTS = frozenset({"activate", "deactivate"})
+
+
+def demote_unconsumed_ts_exports(defs, consumed_exports, lifecycle_entry_points=None):
+    lifecycle_entry_points = {
+        os.path.realpath(str(path)) for path in lifecycle_entry_points or ()
+    }
     demoted = []
     for _name, defn in defs.items():
         if not defn.is_exported:
@@ -312,6 +318,11 @@ def demote_unconsumed_ts_exports(defs, consumed_exports):
         if not str(defn.filename).endswith(_TS_JS_EXTENSIONS):
             continue
         if defn.type == "import":
+            continue
+        if (
+            os.path.realpath(str(defn.filename)) in lifecycle_entry_points
+            and defn.simple_name in _VSCODE_EXTENSION_LIFECYCLE_EXPORTS
+        ):
             continue
 
         consumed = consumed_exports.get(str(defn.filename), set())
@@ -1223,6 +1234,70 @@ def _discover_ts_reachability_entry_files(
         if discovery.file in ts_files
         and (include_dev_roots or discovery.scope == "prod")
     }
+
+
+def _has_vscode_extension_metadata(data: dict) -> bool:
+    engines = data.get("engines")
+    if isinstance(engines, dict) and isinstance(engines.get("vscode"), str):
+        return True
+
+    activation_events = data.get("activationEvents")
+    if isinstance(activation_events, list) and activation_events:
+        return True
+
+    contributes = data.get("contributes")
+    if isinstance(contributes, dict):
+        return any(
+            key in contributes
+            for key in ("commands", "views", "viewsContainers", "menus")
+        )
+    return False
+
+
+def _discover_ts_vscode_lifecycle_entry_files(
+    files,
+    project_root: str | None = None,
+    workspace_inventory=None,
+    exclude_folders=None,
+) -> set[str]:
+    exclude_root = _resolve_exclude_root(files, project_root)
+    ts_files = {
+        os.path.realpath(str(f))
+        for f in files
+        if str(f).endswith(_TS_JS_EXTENSIONS)
+        and not _is_excluded_path(str(f), exclude_folders, exclude_root)
+    }
+    if not ts_files:
+        return set()
+
+    package_roots = set(_workspace_package_roots(workspace_inventory))
+    if workspace_inventory is None or not workspace_inventory.is_monorepo:
+        package_roots.update(
+            _discover_package_roots_from_files(
+                list(ts_files),
+                project_root,
+                exclude_folders=exclude_folders,
+            )
+        )
+    if project_root and workspace_inventory is not None:
+        package_roots.update(
+            _discover_referenced_package_roots(
+                list(ts_files),
+                project_root,
+                workspace_inventory,
+                exclude_folders=exclude_folders,
+            )
+        )
+
+    entry_files: set[str] = set()
+    for package_root in package_roots:
+        data = _read_json_file(os.path.join(str(package_root), "package.json"))
+        if not _has_vscode_extension_metadata(data):
+            continue
+        for entry_file in _discover_package_entry_files(str(package_root)):
+            if entry_file in ts_files:
+                entry_files.add(entry_file)
+    return entry_files
 
 
 def _is_ts_reachability_root(path: str, entry_files: set[str]) -> bool:

--- a/skylos/visitors/languages/typescript/resolve.py
+++ b/skylos/visitors/languages/typescript/resolve.py
@@ -263,7 +263,11 @@ def _find_nearest_package_dir(start_path: str, stop_dir: str) -> str | None:
 
 
 def _candidate_package_targets(target: str) -> list[str]:
-    base_target = target.replace("dist/", "src/").replace("/prod/", "/")
+    base_target = (
+        target.replace("dist/", "src/")
+        .replace("out/", "src/")
+        .replace("/prod/", "/")
+    )
     candidates = [base_target]
 
     if base_target.endswith(".d.ts"):

--- a/test/test_ts_exports.py
+++ b/test/test_ts_exports.py
@@ -460,6 +460,29 @@ class TestTypeScriptDeadFiles:
 
         assert dead_files == []
 
+    def test_package_json_out_entrypoint_keeps_source_file_live(self, tmp_path):
+        extension_file = tmp_path / "src" / "extension.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"vscode-ext","main":"./out/extension.js"}',
+            encoding="utf-8",
+        )
+        extension_file.parent.mkdir(parents=True, exist_ok=True)
+        extension_file.write_text(
+            "export function activate() { return true; }\n", encoding="utf-8"
+        )
+
+        dead_files = find_dead_ts_files(
+            [extension_file],
+            [],
+            {},
+            {},
+            project_root=str(extension_file.parent),
+            workspace_inventory=None,
+        )
+
+        assert dead_files == []
+
     def test_package_json_subpath_export_keeps_exported_file_live(self, tmp_path):
         helper_file = tmp_path / "packages" / "ui" / "src" / "helpers.ts"
 
@@ -822,6 +845,31 @@ class TestTypeScriptUnusedExports:
             {},
             project_root=str(tmp_path),
             workspace_inventory=inventory,
+        )
+
+        assert findings == []
+
+    def test_package_json_out_entrypoint_export_is_not_flagged(self, tmp_path):
+        extension_file = tmp_path / "src" / "extension.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"vscode-ext","main":"./out/extension.js"}',
+            encoding="utf-8",
+        )
+        extension_file.parent.mkdir(parents=True, exist_ok=True)
+        extension_file.write_text(
+            "export function activate() { return true; }\n", encoding="utf-8"
+        )
+
+        defn = _make_def("activate", "function", str(extension_file), exported=True)
+        defn.references = 1
+        defn.is_exported = False
+
+        findings = find_unused_ts_exports(
+            [defn],
+            {},
+            project_root=str(extension_file.parent),
+            workspace_inventory=None,
         )
 
         assert findings == []

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -666,6 +666,48 @@ class TestTSMonorepoReachability:
         assert "makeLabel" not in unused_exports
         assert "previewText" not in unused_exports
 
+    def test_out_package_entrypoint_exports_are_not_reported_unused_functions(
+        self, tmp_path
+    ):
+        from skylos.analyzer import analyze
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (tmp_path / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "vscode-ext",
+                    "main": "./out/extension.js",
+                    "engines": {"vscode": "^1.87.0"},
+                    "activationEvents": ["onCommand:vscode-ext.run"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (src_dir / "extension.ts").write_text(
+            "export function activate() { return true; }\n"
+            "export function deactivate() { return false; }\n"
+            "export function orphanHandler() { return null; }\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(src_dir), conf=0, grep_verify=False))
+
+        unused_functions = {
+            item["name"] for item in result.get("unused_functions", [])
+        }
+        unused_files = {
+            Path(item["file"]).name for item in result.get("unused_files", [])
+        }
+        unused_exports = {item["name"] for item in result.get("unused_exports", [])}
+
+        assert "extension.ts" not in unused_files
+        assert "activate" not in unused_functions
+        assert "deactivate" not in unused_functions
+        assert "orphanHandler" in unused_functions
+        assert "activate" not in unused_exports
+        assert "deactivate" not in unused_exports
+
     def test_direct_project_reference_keeps_referenced_package_entrypoint_live(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary
  - Resolve VS Code extension package entries from `out/*.js` back to `src/*.ts`

## Why
  Skylos was reporting VS Code extension source files/functions as dead code because `package.json` points to the compiled `out/extension.js`, but the source lives at `src/extension.ts`.

  ## Validation
  - `pytest .`