### PR TITLE
feat(cli): add security agent aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Need more commands? Read the [CLI Reference](https://docs.skylos.dev/cli-referen
 | Changed-lines review | `skylos . -a --diff origin/main` | Keeps findings focused on active work instead of legacy debt | [Quality gate docs](https://docs.skylos.dev/quality-gate) |
 | Runtime-assisted dead-code check | `skylos . --trace` | Uses runtime traces to reduce dynamic-code false positives | [Smart tracing](https://docs.skylos.dev/smart-tracing) |
 | Local rule pack | `skylos rules init` | Scaffolds YAML rules for project-specific security and quality checks | [Custom rules](https://docs.skylos.dev/custom-rules) |
+| Security agent quick scan | `skylos agent security-quick .` | One-shot LLM security audit; compatibility alias for `skylos agent scan . --security` | [AI features](https://docs.skylos.dev/ai-features) |
+| Security agent deep scan | `skylos agent security-deep .` | Three-stage security workflow: threat-model context, discovery/validation, and remediation handoff | [AI features](https://docs.skylos.dev/ai-features) |
 | AI-assisted review | `skylos agent scan .` | Static analysis plus optional LLM review and fix suggestions | [AI features](https://docs.skylos.dev/ai-features) |
 | LLM app defense | `skylos defend .` | Finds missing AI app guardrails mapped to OWASP LLM risks | [AI defense](https://docs.skylos.dev/ai-defense) |
 | Technical debt triage | `skylos debt .` | Ranks hotspots and debt trends | [Technical debt](https://docs.skylos.dev/technical-debt) |

--- a/dictionary.md
+++ b/dictionary.md
@@ -37,6 +37,8 @@ Rule IDs use a stable public prefix:
 | Secrets | Hardcoded credentials, tokens, API keys, and client-side exposure of server-only values. |
 | Quality | Maintainability, complexity, architecture, resilience, typing, framework practice, and repo policy issues. |
 | AI code mistakes | Hallucinated security calls, phantom decorators, unfinished stubs, disabled controls, placeholder data, stale mocks, and missing timeouts. |
+| Security quick | `skylos agent security-quick .`; one-shot LLM security audit, equivalent to `skylos agent scan . --security`. |
+| Security deep | `skylos agent security-deep .`; three-stage security workflow for threat-model context, discovery/validation, and remediation handoff, equivalent to `skylos agent audit . --deep`. |
 | LLM app defense | `skylos defend .`; checks LLM integrations for guardrails such as tool safety, output validation, rate limits, and prompt-injection exposure. |
 | Prompt templates | Maintainer-provided files under `[tool.skylos.templates]` that extend built-in LLM prompts without replacing safety and JSON-output contracts. |
 | Vibe dictionary | Project-specific keyword extensions under `[tool.skylos.vibe]` for phantom security names, credential names, sensitive files, and timeout-required calls. |

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -31,6 +31,7 @@ from skylos.visitors.languages.typescript import scan_typescript_file
 from skylos.visitors.languages.typescript.analysis import (
     build_ts_import_graph,
     demote_unconsumed_ts_exports,
+    _discover_ts_vscode_lifecycle_entry_files,
     find_dead_ts_files,
     find_unused_ts_exports,
 )
@@ -797,11 +798,21 @@ class Skylos:
             self._ts_importers_of,
         ) = build_ts_import_graph(ts_raw_imports, self.defs, monorepo_resolver)
 
-    def _demote_unconsumed_ts_exports(self):
+    def _demote_unconsumed_ts_exports(
+        self, files=None, exclude_folders=None, workspace_inventory=None
+    ):
         if not hasattr(self, "ts_consumed_exports"):
             return
+        lifecycle_entry_points = _discover_ts_vscode_lifecycle_entry_files(
+            files or [],
+            project_root=str(self._project_root),
+            workspace_inventory=workspace_inventory,
+            exclude_folders=exclude_folders,
+        )
         self._ts_demoted_exports = demote_unconsumed_ts_exports(
-            self.defs, self.ts_consumed_exports
+            self.defs,
+            self.ts_consumed_exports,
+            lifecycle_entry_points=lifecycle_entry_points,
         )
 
     def _find_dead_ts_files(self, files, exclude_folders, workspace_inventory=None):
@@ -2966,7 +2977,9 @@ class Skylos:
             progress_callback(0, 1, Path("PHASE: exports"))
         self._mark_exports()
 
-        self._demote_unconsumed_ts_exports()
+        self._demote_unconsumed_ts_exports(
+            files, exclude_folders, workspace_inventory=workspace_inventory
+        )
 
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: entry reachability"))

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -3390,6 +3390,201 @@ def _add_agent_prompt_template_arg(parser):
     )
 
 
+def _add_agent_security_quick_args(parser):
+    parser.add_argument(
+        "path", nargs="?", default=".", help="File or directory to analyze"
+    )
+    _add_agent_model_arg(parser)
+    parser.add_argument(
+        "--format", choices=["table", "tree", "json", "sarif"], default="table"
+    )
+    _add_agent_output_arg(parser)
+    _add_agent_quiet_arg(parser)
+    _add_agent_provider_arg(parser)
+    _add_agent_base_url_arg(parser)
+    _add_agent_prompt_template_arg(parser)
+    parser.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        help="Interactive file selection",
+    )
+
+
+def _add_agent_security_deep_args(parser):
+    parser.add_argument("path", nargs="?", default=".")
+    _add_agent_model_arg(parser)
+    _add_agent_provider_arg(parser)
+    _add_agent_base_url_arg(parser)
+    _add_agent_prompt_template_arg(parser)
+    parser.add_argument(
+        "--scan-only",
+        action="store_true",
+        help=(
+            "Stage 1 only: update static threat-model/candidate state without "
+            "LLM calls"
+        ),
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume pending Deep Mode processing work",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force Deep Mode reprocessing for already analyzed files",
+    )
+    parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="Restrict Deep Mode security work to git-changed files",
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Base ref for changed-file scans",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit Deep Mode agent processing; scan-only records all candidates",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=["critical", "high", "medium", "low"],
+        default=None,
+        help="Exit 1 when Deep Mode work at or above this severity remains",
+    )
+    parser.add_argument(
+        "--revalidate",
+        action="store_true",
+        help="Stage 2 validation: revalidate stored Deep Mode findings",
+    )
+    parser.add_argument(
+        "--challenge",
+        action="store_true",
+        help="Challenge prior uncertain Deep Mode revalidation verdicts",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "sarif", "md", "markdown", "md-dir"],
+        default="table",
+    )
+    parser.add_argument(
+        "--severity",
+        choices=["critical", "high", "medium", "low", "info"],
+        default=None,
+        help="Filter Deep Mode export entries to this severity or higher",
+    )
+    parser.add_argument(
+        "--verdict",
+        action="append",
+        choices=[
+            "true_positive",
+            "false_positive",
+            "fixed",
+            "uncertain",
+            "pending",
+            "not_analyzed",
+            "error",
+            "skipped",
+            "deleted",
+        ],
+        help="Filter Deep Mode export entries by verdict/status",
+    )
+    parser.add_argument(
+        "--include-deleted",
+        action="store_true",
+        help="Include deleted Deep Mode audit records in exports",
+    )
+    parser.add_argument("--out", "--output", "-o", dest="output")
+    _add_agent_quiet_arg(parser)
+
+
+def _security_deep_workflow_payload(
+    *,
+    mode: str,
+    summary,
+    process_summary=None,
+    revalidation_summary=None,
+):
+    discovery_status = "queued"
+    discovery_detail = "Static candidates were recorded for later agent processing."
+    if process_summary is not None:
+        discovery_status = "completed" if process_summary.complete else "incomplete"
+        discovery_detail = (
+            f"Processed {process_summary.processed_files} file(s), "
+            f"added {process_summary.findings_added} finding(s)."
+        )
+    elif revalidation_summary is not None:
+        discovery_status = (
+            "completed" if revalidation_summary.complete else "incomplete"
+        )
+        discovery_detail = (
+            f"Revalidated {revalidation_summary.revalidated_findings} finding(s), "
+            f"challenged {revalidation_summary.challenged_findings}."
+        )
+
+    remediation_status = "handoff"
+    remediation_detail = (
+        "Validated findings are kept in Deep Mode state/export formats; patch "
+        "application remains explicit through `skylos agent remediate`."
+    )
+    if process_summary is None and revalidation_summary is None:
+        remediation_status = "pending" if summary.candidate_count else "not_needed"
+        remediation_detail = (
+            "Run `skylos agent security-deep` without `--scan-only` or run "
+            "`--revalidate` before remediation."
+        )
+    if summary.candidate_count == 0 and process_summary is None:
+        remediation_status = "not_needed"
+        remediation_detail = "No Deep Mode security candidates were found."
+
+    return {
+        "name": "security-deep",
+        "compatibility": (
+            "Equivalent to `skylos agent audit --deep` with clearer workflow "
+            "naming."
+        ),
+        "mode": mode,
+        "stages": [
+            {
+                "number": 1,
+                "name": "threat_model_context",
+                "status": "completed",
+                "detail": (
+                    f"Scanned {summary.files_scanned} file(s), recorded "
+                    f"{summary.candidate_count} security candidate(s), and "
+                    "updated persisted Deep Mode project context."
+                ),
+            },
+            {
+                "number": 2,
+                "name": "discovery_validation",
+                "status": discovery_status,
+                "detail": discovery_detail,
+            },
+            {
+                "number": 3,
+                "name": "remediation_handoff",
+                "status": remediation_status,
+                "detail": remediation_detail,
+            },
+        ],
+    }
+
+
+def _print_security_deep_workflow(console, workflow):
+    console.print("[brand]Security Deep stages:[/brand]")
+    for stage in workflow.get("stages", []):
+        console.print(
+            f"  Stage {stage['number']}: {stage['name']} "
+            f"({stage['status']})"
+        )
+
+
 def _explicit_prompt_templates_from_args(agent_args, console):
     values = list(getattr(agent_args, "prompt_template", None) or [])
     if not values:
@@ -3610,6 +3805,21 @@ def _build_agent_parser():
     )
     p_audit.add_argument("--out", "--output", "-o", dest="output")
     _add_agent_quiet_arg(p_audit)
+
+    p_security_quick = agent_sub.add_parser(
+        "security-quick",
+        help="Quick one-shot LLM security audit (alias for scan --security)",
+    )
+    _add_agent_security_quick_args(p_security_quick)
+
+    p_security_deep = agent_sub.add_parser(
+        "security-deep",
+        help=(
+            "Three-stage security workflow: threat model/context, "
+            "discovery/validation, and remediation handoff"
+        ),
+    )
+    _add_agent_security_deep_args(p_security_deep)
 
     p_remediate = agent_sub.add_parser(
         "remediate",
@@ -3902,6 +4112,16 @@ def main() -> None:
         agent_args = agent_parser.parse_args(sys.argv[2:])
         console = Console()
         cmd = agent_args.agent_cmd
+        if cmd == "security-quick":
+            agent_args.security = True
+            agent_args.agent_cmd = "scan"
+            agent_args.security_workflow_alias = "security-quick"
+            cmd = "scan"
+        elif cmd == "security-deep":
+            agent_args.deep = True
+            agent_args.agent_cmd = "audit"
+            agent_args.security_workflow_alias = "security-deep"
+            cmd = "audit"
 
         if cmd in {"watch", "pre-commit", "triage", "status", "serve"}:
             from skylos.agents.center import (
@@ -4693,6 +4913,13 @@ def main() -> None:
                 payload["revalidation"] = revalidation_summary.to_dict()
             if ci_summary is not None:
                 payload["ci"] = ci_summary.to_dict()
+            if getattr(agent_args, "security_workflow_alias", None) == "security-deep":
+                payload["workflow"] = _security_deep_workflow_payload(
+                    mode=mode,
+                    summary=summary,
+                    process_summary=process_summary,
+                    revalidation_summary=revalidation_summary,
+                )
 
             export_payload = None
             export_format = getattr(agent_args, "format", "table")
@@ -4824,6 +5051,8 @@ def main() -> None:
                 if ci_summary is not None:
                     console.print(f"[brand]Deep audit CI:[/brand] {ci_summary.reason}")
                 console.print(f"  Store: {store.project_dir}")
+                if workflow := payload.get("workflow"):
+                    _print_security_deep_workflow(console, workflow)
             sys.exit(ci_summary.exit_code if ci_summary is not None else 0)
 
         if not _ensure_llm_support():

--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -304,7 +304,13 @@ def _resolve_namespace_reexports(
                                         defs[target_key].references += 1
 
 
-def demote_unconsumed_ts_exports(defs, consumed_exports):
+_VSCODE_EXTENSION_LIFECYCLE_EXPORTS = frozenset({"activate", "deactivate"})
+
+
+def demote_unconsumed_ts_exports(defs, consumed_exports, lifecycle_entry_points=None):
+    lifecycle_entry_points = {
+        os.path.realpath(str(path)) for path in lifecycle_entry_points or ()
+    }
     demoted = []
     for _name, defn in defs.items():
         if not defn.is_exported:
@@ -312,6 +318,11 @@ def demote_unconsumed_ts_exports(defs, consumed_exports):
         if not str(defn.filename).endswith(_TS_JS_EXTENSIONS):
             continue
         if defn.type == "import":
+            continue
+        if (
+            os.path.realpath(str(defn.filename)) in lifecycle_entry_points
+            and defn.simple_name in _VSCODE_EXTENSION_LIFECYCLE_EXPORTS
+        ):
             continue
 
         consumed = consumed_exports.get(str(defn.filename), set())
@@ -1223,6 +1234,70 @@ def _discover_ts_reachability_entry_files(
         if discovery.file in ts_files
         and (include_dev_roots or discovery.scope == "prod")
     }
+
+
+def _has_vscode_extension_metadata(data: dict) -> bool:
+    engines = data.get("engines")
+    if isinstance(engines, dict) and isinstance(engines.get("vscode"), str):
+        return True
+
+    activation_events = data.get("activationEvents")
+    if isinstance(activation_events, list) and activation_events:
+        return True
+
+    contributes = data.get("contributes")
+    if isinstance(contributes, dict):
+        return any(
+            key in contributes
+            for key in ("commands", "views", "viewsContainers", "menus")
+        )
+    return False
+
+
+def _discover_ts_vscode_lifecycle_entry_files(
+    files,
+    project_root: str | None = None,
+    workspace_inventory=None,
+    exclude_folders=None,
+) -> set[str]:
+    exclude_root = _resolve_exclude_root(files, project_root)
+    ts_files = {
+        os.path.realpath(str(f))
+        for f in files
+        if str(f).endswith(_TS_JS_EXTENSIONS)
+        and not _is_excluded_path(str(f), exclude_folders, exclude_root)
+    }
+    if not ts_files:
+        return set()
+
+    package_roots = set(_workspace_package_roots(workspace_inventory))
+    if workspace_inventory is None or not workspace_inventory.is_monorepo:
+        package_roots.update(
+            _discover_package_roots_from_files(
+                list(ts_files),
+                project_root,
+                exclude_folders=exclude_folders,
+            )
+        )
+    if project_root and workspace_inventory is not None:
+        package_roots.update(
+            _discover_referenced_package_roots(
+                list(ts_files),
+                project_root,
+                workspace_inventory,
+                exclude_folders=exclude_folders,
+            )
+        )
+
+    entry_files: set[str] = set()
+    for package_root in package_roots:
+        data = _read_json_file(os.path.join(str(package_root), "package.json"))
+        if not _has_vscode_extension_metadata(data):
+            continue
+        for entry_file in _discover_package_entry_files(str(package_root)):
+            if entry_file in ts_files:
+                entry_files.add(entry_file)
+    return entry_files
 
 
 def _is_ts_reachability_root(path: str, entry_files: set[str]) -> bool:

--- a/skylos/visitors/languages/typescript/resolve.py
+++ b/skylos/visitors/languages/typescript/resolve.py
@@ -263,7 +263,11 @@ def _find_nearest_package_dir(start_path: str, stop_dir: str) -> str | None:
 
 
 def _candidate_package_targets(target: str) -> list[str]:
-    base_target = target.replace("dist/", "src/").replace("/prod/", "/")
+    base_target = (
+        target.replace("dist/", "src/")
+        .replace("out/", "src/")
+        .replace("/prod/", "/")
+    )
     candidates = [base_target]
 
     if base_target.endswith(".d.ts"):

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -498,6 +498,37 @@ def test_security_audit_uses_security_taskflow_runner(tmp_path):
     fake_llm.analyze_files.assert_not_called()
 
 
+def test_security_quick_alias_uses_security_taskflow_runner(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("print('hi')\n")
+
+    fake_llm = MagicMock()
+    fake_taskflow = MagicMock(result=AnalysisResult(findings=[], files_analyzed=1))
+
+    with (
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(1, 0.01)),
+        patch("skylos.cli.SkylosLLM", return_value=fake_llm),
+        patch(
+            "skylos.cli.run_security_taskflow", return_value=fake_taskflow
+        ) as mock_run,
+        patch("sys.argv", ["skylos", "agent", "security-quick", str(tmp_path)]),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["files"] == [sample]
+    fake_llm.analyze_files.assert_not_called()
+
+
 def test_security_audit_passes_provider_and_base_url_into_analyzer_config(tmp_path):
     sample = tmp_path / "sample.py"
     sample.write_text("print('hi')\n")

--- a/test/test_audit_cli.py
+++ b/test/test_audit_cli.py
@@ -444,8 +444,109 @@ def test_agent_audit_deep_processing_runs_after_scan(tmp_path: Path, monkeypatch
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["mode"] == "deep_process"
     assert payload["processing"]["processed_files"] == 1
+    assert "workflow" not in payload
     assert calls["process"]["limit"] == 3
     assert calls["process"]["force"] is False
+
+
+def test_agent_security_deep_alias_runs_deep_processing_with_workflow_stages(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = tmp_path / "security-deep.json"
+    store = SimpleNamespace(
+        project_dir=repo / ".skylos" / "audit" / "projects" / "default"
+    )
+    calls = {}
+
+    def fake_scan(path, *, changed_files=None):
+        calls["scan_path"] = Path(path)
+        return (
+            AuditScanSummary(
+                project_id="default",
+                project_root=str(repo),
+                files_scanned=1,
+                records_written=1,
+                candidate_count=1,
+                redacted_candidates=0,
+                pending_files=1,
+                not_analyzed_files=0,
+                complete=False,
+            ),
+            store,
+        )
+
+    def fake_process(**kwargs):
+        calls["process"] = kwargs
+        return AuditProcessSummary(
+            run_id="process-one",
+            project_id="default",
+            project_root=str(repo),
+            considered_files=1,
+            processed_files=1,
+            findings_added=1,
+            skipped_secret_files=0,
+            unsupported_files=0,
+            locked_files=0,
+            error_files=0,
+            remaining_pending_files=0,
+            limited=False,
+            complete=True,
+        )
+
+    class FakeLLM:
+        def __init__(self, config):
+            self.config = config
+
+    monkeypatch.setattr(
+        "skylos.audit.candidates.scan_deep_audit_candidates",
+        fake_scan,
+    )
+    monkeypatch.setattr(
+        "skylos.audit.processor.process_deep_audit_records",
+        fake_process,
+    )
+    monkeypatch.setattr(cli, "_ensure_llm_support", lambda: True)
+    monkeypatch.setattr(cli, "_build_analyzer_config", lambda **kwargs: kwargs)
+    monkeypatch.setattr(cli, "SkylosLLM", FakeLLM)
+    monkeypatch.setattr(
+        cli,
+        "resolve_llm_runtime",
+        lambda **kwargs: ("ollama", None, None, True),
+    )
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "security-deep",
+            str(repo),
+            "--limit",
+            "3",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert exc.value.code == 0
+    assert payload["mode"] == "deep_process"
+    assert payload["workflow"]["name"] == "security-deep"
+    assert [stage["name"] for stage in payload["workflow"]["stages"]] == [
+        "threat_model_context",
+        "discovery_validation",
+        "remediation_handoff",
+    ]
+    assert payload["workflow"]["stages"][1]["status"] == "completed"
+    assert calls["scan_path"] == repo
+    assert calls["process"]["limit"] == 3
 
 
 def test_agent_audit_uses_only_explicit_prompt_template_file(

--- a/test/test_ts_exports.py
+++ b/test/test_ts_exports.py
@@ -460,6 +460,29 @@ class TestTypeScriptDeadFiles:
 
         assert dead_files == []
 
+    def test_package_json_out_entrypoint_keeps_source_file_live(self, tmp_path):
+        extension_file = tmp_path / "src" / "extension.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"vscode-ext","main":"./out/extension.js"}',
+            encoding="utf-8",
+        )
+        extension_file.parent.mkdir(parents=True, exist_ok=True)
+        extension_file.write_text(
+            "export function activate() { return true; }\n", encoding="utf-8"
+        )
+
+        dead_files = find_dead_ts_files(
+            [extension_file],
+            [],
+            {},
+            {},
+            project_root=str(extension_file.parent),
+            workspace_inventory=None,
+        )
+
+        assert dead_files == []
+
     def test_package_json_subpath_export_keeps_exported_file_live(self, tmp_path):
         helper_file = tmp_path / "packages" / "ui" / "src" / "helpers.ts"
 
@@ -822,6 +845,31 @@ class TestTypeScriptUnusedExports:
             {},
             project_root=str(tmp_path),
             workspace_inventory=inventory,
+        )
+
+        assert findings == []
+
+    def test_package_json_out_entrypoint_export_is_not_flagged(self, tmp_path):
+        extension_file = tmp_path / "src" / "extension.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"vscode-ext","main":"./out/extension.js"}',
+            encoding="utf-8",
+        )
+        extension_file.parent.mkdir(parents=True, exist_ok=True)
+        extension_file.write_text(
+            "export function activate() { return true; }\n", encoding="utf-8"
+        )
+
+        defn = _make_def("activate", "function", str(extension_file), exported=True)
+        defn.references = 1
+        defn.is_exported = False
+
+        findings = find_unused_ts_exports(
+            [defn],
+            {},
+            project_root=str(extension_file.parent),
+            workspace_inventory=None,
         )
 
         assert findings == []

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -666,6 +666,48 @@ class TestTSMonorepoReachability:
         assert "makeLabel" not in unused_exports
         assert "previewText" not in unused_exports
 
+    def test_out_package_entrypoint_exports_are_not_reported_unused_functions(
+        self, tmp_path
+    ):
+        from skylos.analyzer import analyze
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (tmp_path / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "vscode-ext",
+                    "main": "./out/extension.js",
+                    "engines": {"vscode": "^1.87.0"},
+                    "activationEvents": ["onCommand:vscode-ext.run"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (src_dir / "extension.ts").write_text(
+            "export function activate() { return true; }\n"
+            "export function deactivate() { return false; }\n"
+            "export function orphanHandler() { return null; }\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(src_dir), conf=0, grep_verify=False))
+
+        unused_functions = {
+            item["name"] for item in result.get("unused_functions", [])
+        }
+        unused_files = {
+            Path(item["file"]).name for item in result.get("unused_files", [])
+        }
+        unused_exports = {item["name"] for item in result.get("unused_exports", [])}
+
+        assert "extension.ts" not in unused_files
+        assert "activate" not in unused_functions
+        assert "deactivate" not in unused_functions
+        assert "orphanHandler" in unused_functions
+        assert "activate" not in unused_exports
+        assert "deactivate" not in unused_exports
+
     def test_direct_project_reference_keeps_referenced_package_entrypoint_live(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

  - add `skylos agent security-quick` as alias for `skylos agent scan --security`
  - add `skylos agent security-deep` as alias for `skylos agent audit --deep`
  - keep existing `scan --security` and `audit --deep` behavior backward compatible

## Tests

  - `pytest test/test_agent_integration.py test/test_audit_cli.py`