### PR TITLE
feat(security): add static threat traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Need more commands? Read the [CLI Reference](https://docs.skylos.dev/cli-referen
 | Runtime-assisted dead-code check | `skylos . --trace` | Uses runtime traces to reduce dynamic-code false positives | [Smart tracing](https://docs.skylos.dev/smart-tracing) |
 | Local rule pack | `skylos rules init` | Scaffolds YAML rules for project-specific security and quality checks | [Custom rules](https://docs.skylos.dev/custom-rules) |
 | Security agent quick scan | `skylos agent security-quick .` | One-shot LLM security audit; compatibility alias for `skylos agent scan . --security` | [AI features](https://docs.skylos.dev/ai-features) |
-| Security agent deep scan | `skylos agent security-deep .` | Three-stage security workflow: threat-model context, discovery/validation, and remediation handoff | [AI features](https://docs.skylos.dev/ai-features) |
+| Security agent deep scan | `skylos agent security-deep .` | Three-stage security workflow with threat-model context, static threat traces, discovery/validation, and remediation handoff | [AI features](https://docs.skylos.dev/ai-features) |
 | AI-assisted review | `skylos agent scan .` | Static analysis plus optional LLM review and fix suggestions | [AI features](https://docs.skylos.dev/ai-features) |
 | LLM app defense | `skylos defend .` | Finds missing AI app guardrails mapped to OWASP LLM risks | [AI defense](https://docs.skylos.dev/ai-defense) |
 | Technical debt triage | `skylos debt .` | Ranks hotspots and debt trends | [Technical debt](https://docs.skylos.dev/technical-debt) |

--- a/dictionary.md
+++ b/dictionary.md
@@ -38,7 +38,8 @@ Rule IDs use a stable public prefix:
 | Quality | Maintainability, complexity, architecture, resilience, typing, framework practice, and repo policy issues. |
 | AI code mistakes | Hallucinated security calls, phantom decorators, unfinished stubs, disabled controls, placeholder data, stale mocks, and missing timeouts. |
 | Security quick | `skylos agent security-quick .`; one-shot LLM security audit, equivalent to `skylos agent scan . --security`. |
-| Security deep | `skylos agent security-deep .`; three-stage security workflow for threat-model context, discovery/validation, and remediation handoff, equivalent to `skylos agent audit . --deep`. |
+| Security deep | `skylos agent security-deep .`; three-stage security workflow for threat-model context, static threat tracing, discovery/validation, and remediation handoff, equivalent to `skylos agent audit . --deep`. |
+| Threat trace | Static source-to-sink evidence showing how user-controlled input reaches a sensitive sink, recorded on security-deep findings and run artifacts. |
 | LLM app defense | `skylos defend .`; checks LLM integrations for guardrails such as tool safety, output validation, rate limits, and prompt-injection exposure. |
 | Prompt templates | Maintainer-provided files under `[tool.skylos.templates]` that extend built-in LLM prompts without replacing safety and JSON-output contracts. |
 | Vibe dictionary | Project-specific keyword extensions under `[tool.skylos.vibe]` for phantom security names, credential names, sensitive files, and timeout-required calls. |

--- a/skylos/audit/candidates.py
+++ b/skylos/audit/candidates.py
@@ -26,6 +26,7 @@ from skylos.audit.types import (
 from skylos.config import load_config
 from skylos.constants import parse_exclude_folders
 from skylos.core.file_discovery import discover_source_files, should_exclude_path
+from skylos.llm.threat_trace import build_static_threat_traces
 from skylos.llm.repo_activation import build_repo_activation_index
 from skylos.pipeline import run_static_on_files
 from skylos.rules.secrets import scan_ctx as scan_secrets_ctx
@@ -78,6 +79,8 @@ SECURITY_PATH_TOKENS = (
     "token",
     "upload",
 )
+THREAT_TRACE_KIND = "threat_trace"
+THREAT_TRACE_RULE_ID = "SKY-AUDIT-TRACE"
 
 
 def scan_deep_audit_candidates(
@@ -135,6 +138,11 @@ def scan_deep_audit_candidates(
         static_result=static_result,
     )
     _add_polyglot_signal_candidates(
+        candidates_by_file,
+        files,
+        project_root=project_root,
+    )
+    _add_threat_trace_candidates(
         candidates_by_file,
         files,
         project_root=project_root,
@@ -507,6 +515,49 @@ def _add_polyglot_signal_candidates(
                 continue
             existing.append(candidate)
             existing_locations.add((candidate.rule_id, candidate.line))
+
+
+def _add_threat_trace_candidates(
+    candidates_by_file: dict[str, list[AuditCandidate]],
+    files: list[Path],
+    *,
+    project_root: Path,
+) -> None:
+    for trace in build_static_threat_traces(project_root, files):
+        rel_path = normalize_relative_path(project_root, trace.file)
+        if rel_path not in candidates_by_file:
+            continue
+        reason = (
+            "Static threat trace: "
+            f"{trace.source.name} reaches {trace.sink.name} in {trace.entrypoint}"
+        )
+        candidate_id = _candidate_id(
+            rel_path=rel_path,
+            kind=THREAT_TRACE_KIND,
+            rule_id=THREAT_TRACE_RULE_ID,
+            line=trace.sink.line,
+            source_kind=trace.source.name,
+            sink_kind=trace.sink.name,
+            code_hash=trace.trace_id,
+        )
+        candidates_by_file.setdefault(rel_path, []).append(
+            AuditCandidate(
+                candidate_id=candidate_id,
+                kind=THREAT_TRACE_KIND,
+                rule_id=THREAT_TRACE_RULE_ID,
+                line=trace.sink.line,
+                severity_hint="high",
+                reason=reason,
+                evidence=trace.validation,
+                redacted=False,
+                priority=875,
+                symbol=trace.entrypoint,
+                source_kind=trace.source.name,
+                sink_kind=trace.sink.name,
+                code_hash=trace.trace_id,
+                data={"threat_trace": trace.to_dict()},
+            )
+        )
 
 
 def _add_path_signal_candidates(

--- a/skylos/audit/processor.py
+++ b/skylos/audit/processor.py
@@ -15,6 +15,7 @@ from skylos.audit.types import (
     STATUS_PROCESSING,
     STATUS_SKIPPED,
     AuditFileRecord,
+    AuditCandidate,
     AuditProcessSummary,
     code_region_hash,
     normalize_relative_path,
@@ -92,7 +93,7 @@ def process_deep_audit_records(
 
         file_path = store.project_root / record.file
         try:
-            result = _analyze_file_with_redaction(analyzer, file_path)
+            result = _analyze_file_with_redaction(analyzer, file_path, record=record)
             findings = _normalize_findings(result, record=record, file_path=file_path)
         except Exception as exc:
             store.mark_error(record.file, f"Agent processing failed: {exc}")
@@ -355,19 +356,27 @@ def _normalize_findings(
         else:
             continue
         payload = sanitize_for_audit(payload)
+        _attach_candidate_threat_trace(payload, record=record)
         payload["audit_finding_id"] = _finding_id(payload, record=record, source=source)
         normalized.append(payload)
     return normalized
 
 
-def _analyze_file_with_redaction(analyzer: Any, file_path: Path) -> Any:
+def _analyze_file_with_redaction(
+    analyzer: Any, file_path: Path, *, record: AuditFileRecord
+) -> Any:
     source = file_path.read_text(encoding="utf-8", errors="ignore")
     redacted_source = redact_text(source)
 
     get_agent = getattr(analyzer, "_get_agent", None)
     if callable(get_agent):
         agent = get_agent(SECURITY_AUDIT_ISSUE)
-        context = _build_redacted_context(analyzer, redacted_source, file_path)
+        context = _build_redacted_context(
+            analyzer,
+            redacted_source,
+            file_path,
+            record=record,
+        )
         return agent.analyze(redacted_source, str(file_path), context=context)
 
     whole_file_analyzer = getattr(analyzer, "_analyze_whole_file", None)
@@ -390,10 +399,13 @@ def _analyze_file_with_redaction(analyzer: Any, file_path: Path) -> Any:
     )
 
 
-def _build_redacted_context(analyzer: Any, source: str, file_path: Path) -> str | None:
+def _build_redacted_context(
+    analyzer: Any, source: str, file_path: Path, *, record: AuditFileRecord
+) -> str | None:
+    candidate_context = _candidate_context(record)
     context_builder = getattr(analyzer, "context_builder", None)
     if context_builder is None:
-        return None
+        return candidate_context
 
     config = getattr(analyzer, "config", None)
     repo_context_map = getattr(config, "repo_context_map", {}) or {}
@@ -402,6 +414,10 @@ def _build_redacted_context(analyzer: Any, source: str, file_path: Path) -> str 
         or repo_context_map.get(file_path.as_posix())
         or repo_context_map.get(file_path.name)
     )
+    if candidate_context:
+        repo_metadata = (
+            f"{repo_metadata}\n{candidate_context}" if repo_metadata else candidate_context
+        )
 
     try:
         return context_builder.build_analysis_context(
@@ -418,6 +434,66 @@ def _build_redacted_context(analyzer: Any, source: str, file_path: Path) -> str 
             defs_map=None,
             include_review_hints=False,
         )
+
+
+def _candidate_context(record: AuditFileRecord) -> str | None:
+    if not record.candidates:
+        return None
+    lines = ["[DEEP AUDIT CANDIDATES]"]
+    for candidate in sorted(
+        record.candidates,
+        key=lambda item: (-item.priority, item.line, item.candidate_id),
+    )[:8]:
+        lines.append(
+            f"- {candidate.kind} {candidate.rule_id} L{candidate.line}: "
+            f"{candidate.reason}"
+        )
+        trace = _candidate_threat_trace(candidate)
+        if trace is not None:
+            source = trace.get("source") if isinstance(trace.get("source"), dict) else {}
+            sink = trace.get("sink") if isinstance(trace.get("sink"), dict) else {}
+            lines.append(
+                "  threat trace: "
+                f"{source.get('name')}@L{source.get('line')} -> "
+                f"{sink.get('name')}@L{sink.get('line')} "
+                f"({trace.get('validation')})"
+            )
+    return "\n".join(lines)
+
+
+def _candidate_threat_trace(candidate: AuditCandidate) -> dict[str, Any] | None:
+    data = candidate.data if isinstance(candidate.data, dict) else {}
+    trace = data.get("threat_trace")
+    return dict(trace) if isinstance(trace, dict) else None
+
+
+def _candidate_threat_traces_by_line(
+    record: AuditFileRecord,
+) -> dict[int, dict[str, Any]]:
+    by_line: dict[int, dict[str, Any]] = {}
+    for candidate in record.candidates:
+        trace = _candidate_threat_trace(candidate)
+        if trace is not None:
+            by_line.setdefault(candidate.line, trace)
+    return by_line
+
+
+def _attach_candidate_threat_trace(
+    finding: dict[str, Any], *, record: AuditFileRecord
+) -> None:
+    location = finding.get("location") if isinstance(finding.get("location"), dict) else {}
+    try:
+        line = int(finding.get("line") or location.get("line") or 0)
+    except (TypeError, ValueError):
+        return
+    trace = _candidate_threat_traces_by_line(record).get(line)
+    if trace is None:
+        return
+    metadata = finding.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    metadata.setdefault("threat_trace", trace)
+    finding["metadata"] = metadata
 
 
 def _finding_id(

--- a/skylos/llm/security_taskflow.py
+++ b/skylos/llm/security_taskflow.py
@@ -16,6 +16,12 @@ from .security_verifier import (
     annotate_security_finding,
     is_security_finding,
 )
+from .threat_trace import (
+    ThreatTrace,
+    attach_threat_traces_to_findings,
+    build_static_threat_traces,
+    threat_trace_context_lines,
+)
 
 COMPLETED_STATUS = "completed"
 REPO_MAP_STAGE = "repo_map"
@@ -44,6 +50,7 @@ REPO_MAP_FILENAME = "repo_map.json"
 CANDIDATES_FILENAME = "candidates.json"
 VERIFIED_FILENAME = "verified.json"
 SUMMARY_FILENAME = "summary.json"
+THREAT_TRACES_FILENAME = "threat_traces.json"
 
 
 @dataclass(frozen=True)
@@ -128,6 +135,8 @@ class SecurityFindingCandidate:
     evidence: str = HYPOTHESIS_EVIDENCE
     review_verdict: str | None = None
     review_reason: str | None = None
+    threat_trace_id: str | None = None
+    threat_trace_validation: str | None = None
     history: list[SecurityCandidateEvent] = field(default_factory=list)
 
 
@@ -142,6 +151,7 @@ class SecurityTaskflowRun:
     preferred_audit_targets: list[str] = field(default_factory=list)
     entry_points: list[SecurityEntrypoint] = field(default_factory=list)
     trust_boundaries: list[SecurityTrustBoundary] = field(default_factory=list)
+    threat_traces: list[ThreatTrace] = field(default_factory=list)
     stages: list[SecurityTaskStage] = field(default_factory=list)
     candidate_count: int = 0
     supported_count: int = 0
@@ -170,6 +180,7 @@ class SecurityTaskflowRun:
             "trust_boundaries": [
                 _trust_boundary_dict(item) for item in self.trust_boundaries
             ],
+            "threat_traces": [trace.to_dict() for trace in self.threat_traces],
             "stages": [_stage_dict(stage) for stage in self.stages],
             "candidate_count": self.candidate_count,
             "supported_count": self.supported_count,
@@ -239,7 +250,7 @@ def _candidate_event_dict(event: SecurityCandidateEvent) -> dict[str, Any]:
 
 
 def _candidate_dict(candidate: SecurityFindingCandidate) -> dict[str, Any]:
-    return {
+    payload = {
         "candidate_id": candidate.candidate_id,
         "fingerprint": candidate.fingerprint,
         "file": candidate.file,
@@ -253,6 +264,11 @@ def _candidate_dict(candidate: SecurityFindingCandidate) -> dict[str, Any]:
         "review_reason": candidate.review_reason,
         "history": [_candidate_event_dict(event) for event in candidate.history],
     }
+    if candidate.threat_trace_id:
+        payload["threat_trace_id"] = candidate.threat_trace_id
+    if candidate.threat_trace_validation:
+        payload["threat_trace_validation"] = candidate.threat_trace_validation
+    return payload
 
 
 def _repo_node(meta: FileActivation) -> SecurityRepoNode:
@@ -465,6 +481,12 @@ def _finding_review_verdict(finding: Any) -> str | None:
     return str(verdict).upper() if verdict else None
 
 
+def _finding_threat_trace(finding: Any) -> dict[str, Any] | None:
+    metadata = _finding_metadata(finding)
+    trace = metadata.get("threat_trace")
+    return dict(trace) if isinstance(trace, dict) else None
+
+
 def _candidate_fingerprint(finding: Any) -> str:
     raw = "|".join(
         [
@@ -507,6 +529,12 @@ def _build_candidate_ledger(findings: list[Any]) -> list[SecurityFindingCandidat
             message=_finding_message(finding),
             symbol=_finding_symbol(finding),
         )
+        threat_trace = _finding_threat_trace(finding)
+        if threat_trace is not None:
+            candidate.threat_trace_id = str(threat_trace.get("trace_id") or "")
+            candidate.threat_trace_validation = str(
+                threat_trace.get("validation") or ""
+            )
         candidate.history.append(
             SecurityCandidateEvent(
                 stage=AUDIT_STAGE,
@@ -534,6 +562,12 @@ def _update_candidate_ledger(
         candidate.evidence = event.evidence
         candidate.review_verdict = event.review_verdict
         candidate.review_reason = event.review_reason
+        threat_trace = _finding_threat_trace(finding)
+        if threat_trace is not None:
+            candidate.threat_trace_id = str(threat_trace.get("trace_id") or "")
+            candidate.threat_trace_validation = str(
+                threat_trace.get("validation") or ""
+            )
         candidate.history.append(event)
 
 
@@ -621,6 +655,25 @@ def _build_repo_map(
     )
 
 
+def _add_threat_traces_to_repo_context(
+    repo_context_map: dict[str, str], traces: list[ThreatTrace]
+) -> dict[str, str]:
+    trace_lines_by_file = threat_trace_context_lines(traces)
+    if not trace_lines_by_file:
+        return repo_context_map
+
+    enriched = dict(repo_context_map)
+    for file_path, lines in trace_lines_by_file.items():
+        if not lines:
+            continue
+        existing = enriched.get(file_path)
+        trace_context = "\n".join(["[THREAT TRACE EVIDENCE]", *lines])
+        enriched[file_path] = (
+            f"{existing}\n{trace_context}" if existing else trace_context
+        )
+    return enriched
+
+
 def _security_review_defaults(
     result: AnalysisResult, findings: list[Any]
 ) -> dict[str, Any]:
@@ -705,6 +758,16 @@ def _candidate_ledger_payload(run: SecurityTaskflowRun) -> dict[str, Any]:
     }
 
 
+def _threat_traces_payload(run: SecurityTaskflowRun) -> dict[str, Any]:
+    return {
+        "run_id": run.run_id,
+        "project_root": run.project_root,
+        "trace_count": len(run.threat_traces),
+        "validation": "static_unvalidated",
+        "traces": [trace.to_dict() for trace in run.threat_traces],
+    }
+
+
 def _verified_payload(run: SecurityTaskflowRun) -> dict[str, Any]:
     result_payload = (
         run.result.to_dict() if run.result is not None else AnalysisResult().to_dict()
@@ -726,6 +789,7 @@ def _summary_payload(run: SecurityTaskflowRun) -> dict[str, Any]:
         "artifacts_dir": run.artifacts_dir,
         "scanned_files": list(run.scanned_files),
         "candidate_count": run.candidate_count,
+        "threat_trace_count": len(run.threat_traces),
         "supported_count": run.supported_count,
         "refuted_count": run.refuted_count,
         "hypothesis_count": run.hypothesis_count,
@@ -750,6 +814,7 @@ def _write_run_artifacts(run: SecurityTaskflowRun) -> None:
     artifact_dir = Path(run.artifacts_dir)
     payloads = (
         (REPO_MAP_FILENAME, _repo_map_payload(run)),
+        (THREAT_TRACES_FILENAME, _threat_traces_payload(run)),
         (CANDIDATES_FILENAME, _candidate_ledger_payload(run)),
         (VERIFIED_FILENAME, _verified_payload(run)),
         (SUMMARY_FILENAME, _summary_payload(run)),
@@ -829,6 +894,11 @@ def _build_taskflow_run(
         entry_points,
         trust_boundaries,
     ) = _build_repo_map(project_root, files)
+    threat_traces = build_static_threat_traces(project_root, files)
+    repo_context_map = _add_threat_traces_to_repo_context(
+        repo_context_map,
+        threat_traces,
+    )
     run = SecurityTaskflowRun(
         run_id=run_id,
         project_root=str(project_root),
@@ -839,6 +909,7 @@ def _build_taskflow_run(
         preferred_audit_targets=preferred_targets,
         entry_points=entry_points,
         trust_boundaries=trust_boundaries,
+        threat_traces=threat_traces,
     )
     run.add_stage(
         REPO_MAP_STAGE,
@@ -850,6 +921,7 @@ def _build_taskflow_run(
         ENTRY_POINTS_STAGE,
         entry_points=len(entry_points),
         trust_boundaries=len(trust_boundaries),
+        threat_traces=len(threat_traces),
     )
     return run
 
@@ -910,6 +982,7 @@ def run_security_taskflow(
     run = _build_taskflow_run(project_root, files)
     analyzer.config.repo_context_map = dict(run.repo_context_map)
     result = analyzer.analyze_files(files, issue_types=["security_audit"])
+    attach_threat_traces_to_findings(result.findings, run.threat_traces)
     run.candidate_ledger = _build_candidate_ledger(result.findings)
     review = review_security_analysis_result(
         result=result,

--- a/skylos/llm/security_verifier.py
+++ b/skylos/llm/security_verifier.py
@@ -167,6 +167,12 @@ def _get_message(finding: Finding | dict[str, Any]) -> str:
     return str(finding.get("message") if isinstance(finding, dict) else finding.message)
 
 
+def _get_metadata(finding: Finding | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(finding, dict):
+        return dict(finding.get("metadata") or {})
+    return dict(getattr(finding, "metadata", None) or {})
+
+
 def _new_review_result(reviewable_count: int, reviewed_count: int) -> dict[str, Any]:
     return {
         SUPPORTED_COUNT: 0,
@@ -390,16 +396,47 @@ class SecurityVerifier:
     ) -> str:
         line_num = _get_line_number(finding)
         context = self._build_context(line_num, lines)
+        parts = [
+            f"### Candidate {index}",
+            f"- Rule: {_get_rule_id(finding)}",
+            f"- Severity: {_get_severity(finding)}",
+            f"- Line: {line_num}",
+            f"- Message: {_get_message(finding)}",
+        ]
+        threat_trace = self._format_threat_trace(finding)
+        if threat_trace:
+            parts.extend(["", "Threat trace evidence:", threat_trace])
+        parts.extend(["", "Code context:", context])
+        return "\n".join(parts)
+
+    def _format_threat_trace(self, finding: Finding | dict[str, Any]) -> str | None:
+        metadata = _get_metadata(finding)
+        trace = metadata.get("threat_trace")
+        if not isinstance(trace, dict):
+            return None
+
+        source = trace.get("source") if isinstance(trace.get("source"), dict) else {}
+        sink = trace.get("sink") if isinstance(trace.get("sink"), dict) else {}
+        source_name = str(source.get("name") or "unknown source")
+        source_line = source.get("line") or "?"
+        sink_name = str(sink.get("name") or "unknown sink")
+        sink_line = sink.get("line") or "?"
+        guards = trace.get("guards") if isinstance(trace.get("guards"), list) else []
+        guard_text = "none observed"
+        if guards:
+            guard_text = ", ".join(
+                f"{guard.get('name')}@L{guard.get('line')}"
+                for guard in guards
+                if isinstance(guard, dict)
+            )
         return "\n".join(
             [
-                f"### Candidate {index}",
-                f"- Rule: {_get_rule_id(finding)}",
-                f"- Severity: {_get_severity(finding)}",
-                f"- Line: {line_num}",
-                f"- Message: {_get_message(finding)}",
-                "",
-                "Code context:",
-                context,
+                f"- Trace ID: {trace.get('trace_id')}",
+                f"- Entry point: {trace.get('entrypoint')}",
+                f"- Source: {source_name} at line {source_line}",
+                f"- Sink: {sink_name} at line {sink_line}",
+                f"- Validation: {trace.get('validation')}",
+                f"- Guards: {guard_text}",
             ]
         )
 

--- a/skylos/llm/threat_trace.py
+++ b/skylos/llm/threat_trace.py
@@ -1,0 +1,642 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+STATIC_VALIDATION = "static_unvalidated"
+MEDIUM_CONFIDENCE = "medium"
+PYTHON_INTRA_PROCEDURAL_LIMITATION = "python_intra_procedural_only"
+MAX_CONTEXT_TRACES_PER_FILE = 5
+MAX_THREAT_TRACE_SOURCE_BYTES = 1_000_000
+
+_REQUEST_SOURCE_CALLS = {
+    "input",
+    "request.args.get",
+    "request.form.get",
+    "request.headers.get",
+    "request.query_params.get",
+    "request.GET.get",
+    "request.POST.get",
+    "request.files.get",
+    "request.get_json",
+    "request.json.get",
+}
+_REQUEST_SOURCE_OBJECTS = {
+    "request.args",
+    "request.form",
+    "request.headers",
+    "request.query_params",
+    "request.GET",
+    "request.POST",
+    "request.files",
+    "request.json",
+}
+_SANITIZER_CALLS = {
+    "ast.literal_eval",
+    "bleach.clean",
+    "html.escape",
+    "int",
+    "float",
+    "bool",
+    "json.load",
+    "json.loads",
+    "markupsafe.escape",
+    "os.path.basename",
+    "secure_filename",
+    "shlex.quote",
+    "Path.resolve",
+    "urllib.parse.quote",
+}
+_GUARD_CALLS = {
+    "urlparse",
+    "urllib.parse.urlparse",
+    "html.escape",
+    "markupsafe.escape",
+    "os.path.basename",
+    "secure_filename",
+    "Path.resolve",
+}
+_HTTP_SINKS = {
+    "requests.get",
+    "requests.post",
+    "httpx.get",
+    "httpx.post",
+    "urllib.request.urlopen",
+}
+_COMMAND_SINKS = {
+    "os.system",
+    "os.popen",
+}
+_SUBPROCESS_SINKS = {
+    "subprocess.run",
+    "subprocess.call",
+    "subprocess.Popen",
+    "subprocess.check_output",
+}
+_PATH_SINKS = {
+    "open",
+    "Path.open",
+    "Path.read_text",
+    "Path.write_text",
+}
+_REDIRECT_SINKS = {"redirect", "flask.redirect"}
+_TEMPLATE_SINKS = {"render_template_string", "flask.render_template_string"}
+_ROUTE_DECORATOR_SUFFIXES = {
+    ".route",
+    ".get",
+    ".post",
+    ".put",
+    ".patch",
+    ".delete",
+    ".head",
+    ".options",
+    ".websocket",
+}
+
+
+@dataclass(frozen=True)
+class ThreatTraceStep:
+    kind: str
+    name: str
+    line: int
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "kind": self.kind,
+            "name": self.name,
+            "line": self.line,
+        }
+        if self.detail:
+            data["detail"] = self.detail
+        return data
+
+
+@dataclass(frozen=True)
+class ThreatTracePoint:
+    file: str
+    line: int
+    name: str
+    kind: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "line": self.line,
+            "name": self.name,
+            "kind": self.kind,
+        }
+
+
+@dataclass(frozen=True)
+class ThreatTrace:
+    trace_id: str
+    file: str
+    entrypoint: str
+    source: ThreatTracePoint
+    sink: ThreatTracePoint
+    sink_category: str
+    path: tuple[ThreatTraceStep, ...]
+    guards: tuple[ThreatTraceStep, ...] = ()
+    confidence: str = MEDIUM_CONFIDENCE
+    validation: str = STATIC_VALIDATION
+    limitations: tuple[str, ...] = (PYTHON_INTRA_PROCEDURAL_LIMITATION,)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "trace_id": self.trace_id,
+            "file": self.file,
+            "entrypoint": self.entrypoint,
+            "source": self.source.to_dict(),
+            "sink": self.sink.to_dict(),
+            "sink_category": self.sink_category,
+            "path": [step.to_dict() for step in self.path],
+            "guards": [guard.to_dict() for guard in self.guards],
+            "confidence": self.confidence,
+            "validation": self.validation,
+            "limitations": list(self.limitations),
+        }
+
+
+@dataclass(frozen=True)
+class _TaintState:
+    source: ThreatTracePoint
+    path: tuple[ThreatTraceStep, ...]
+    guards: tuple[ThreatTraceStep, ...] = ()
+
+
+def build_static_threat_traces(
+    project_root: str | Path, files: list[Path]
+) -> list[ThreatTrace]:
+    root = Path(project_root).resolve()
+    traces: list[ThreatTrace] = []
+    for file_path in files:
+        path = Path(file_path)
+        if path.suffix != ".py":
+            continue
+        traces.extend(_build_python_file_traces(root, path))
+    return sorted(
+        traces,
+        key=lambda trace: (
+            trace.file,
+            trace.sink.line,
+            trace.source.line,
+            trace.sink.name,
+        ),
+    )
+
+
+def threat_trace_context_lines(traces: list[ThreatTrace]) -> dict[str, list[str]]:
+    by_file: dict[str, list[str]] = {}
+    for trace in traces:
+        lines = by_file.setdefault(trace.file, [])
+        if len(lines) >= MAX_CONTEXT_TRACES_PER_FILE:
+            continue
+        guard_text = ""
+        if trace.guards:
+            guard_text = (
+                " with guards "
+                + ", ".join(f"{guard.name}@L{guard.line}" for guard in trace.guards)
+            )
+        lines.append(
+            "- threat trace: "
+            f"{trace.entrypoint} source {trace.source.name}@L{trace.source.line} "
+            f"reaches {trace.sink.name}@L{trace.sink.line}{guard_text} "
+            f"({trace.validation})"
+        )
+    return by_file
+
+
+def attach_threat_traces_to_findings(
+    findings: list[Any], traces: list[ThreatTrace]
+) -> None:
+    by_location: dict[tuple[str, int], list[ThreatTrace]] = {}
+    for trace in traces:
+        by_location.setdefault((str(Path(trace.file).resolve()), trace.sink.line), [])
+        by_location[(str(Path(trace.file).resolve()), trace.sink.line)].append(trace)
+
+    for finding in findings:
+        location = _finding_location(finding)
+        if location is None:
+            continue
+        matched = by_location.get(location)
+        if not matched:
+            continue
+        payloads = [trace.to_dict() for trace in matched]
+        metadata = _finding_metadata(finding)
+        metadata["threat_trace"] = payloads[0]
+        if len(payloads) > 1:
+            metadata["threat_traces"] = payloads
+        _set_finding_metadata(finding, metadata)
+
+
+def _build_python_file_traces(project_root: Path, file_path: Path) -> list[ThreatTrace]:
+    resolved_path, source = _read_trace_source(project_root, file_path)
+    if resolved_path is None or source is None:
+        return []
+    try:
+        tree = ast.parse(source, filename=str(resolved_path))
+    except SyntaxError:
+        return []
+
+    traces: list[ThreatTrace] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            analyzer = _FunctionThreatTraceAnalyzer(project_root, resolved_path, node)
+            traces.extend(analyzer.analyze())
+    return traces
+
+
+def _read_trace_source(
+    project_root: Path, file_path: Path
+) -> tuple[Path | None, str | None]:
+    try:
+        file_stat = file_path.lstat()
+    except OSError:
+        return None, None
+
+    if file_path.is_symlink() or not stat.S_ISREG(file_stat.st_mode):
+        return None, None
+    if file_stat.st_size > MAX_THREAT_TRACE_SOURCE_BYTES:
+        return None, None
+
+    try:
+        resolved_root = project_root.resolve(strict=True)
+        resolved_path = file_path.resolve(strict=True)
+        resolved_path.relative_to(resolved_root)
+    except (OSError, ValueError):
+        return None, None
+
+    try:
+        return resolved_path, resolved_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None, None
+
+
+class _FunctionThreatTraceAnalyzer:
+    def __init__(
+        self,
+        project_root: Path,
+        file_path: Path,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        self.project_root = project_root
+        self.file_path = str(file_path)
+        self.function = node
+        self.entrypoint = _entrypoint_name(node)
+        self.tainted: dict[str, _TaintState] = {}
+        self.active_guards: tuple[ThreatTraceStep, ...] = ()
+        self.traces: list[ThreatTrace] = []
+
+    def analyze(self) -> list[ThreatTrace]:
+        for arg in self.function.args.args:
+            if arg.arg in {"request", "req"}:
+                source = ThreatTracePoint(
+                    file=self.file_path,
+                    line=self.function.lineno,
+                    name=f"{arg.arg} parameter",
+                    kind="source",
+                )
+                self.tainted[arg.arg] = _TaintState(
+                    source=source,
+                    path=(
+                        ThreatTraceStep(
+                            kind="source",
+                            name=f"{arg.arg} parameter",
+                            line=self.function.lineno,
+                            detail="HTTP request object",
+                        ),
+                    ),
+                )
+
+        for statement in self.function.body:
+            self._visit_statement(statement)
+        return self.traces
+
+    def _visit_statement(self, statement: ast.stmt) -> None:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return
+        if isinstance(statement, ast.Assign):
+            self._record_sinks_in_expr(statement.value)
+            self._handle_assign(statement.targets, statement.value, statement.lineno)
+            return
+        if isinstance(statement, ast.AnnAssign):
+            if statement.value is not None:
+                self._record_sinks_in_expr(statement.value)
+                self._handle_assign([statement.target], statement.value, statement.lineno)
+            return
+        if isinstance(statement, ast.AugAssign):
+            self._record_sinks_in_expr(statement.value)
+            self._handle_assign([statement.target], statement.value, statement.lineno)
+            return
+        if isinstance(statement, ast.If):
+            self._visit_if(statement)
+            return
+
+        for child in ast.iter_child_nodes(statement):
+            if isinstance(child, ast.expr):
+                self._record_sinks_in_expr(child)
+            elif isinstance(child, ast.stmt):
+                self._visit_statement(child)
+
+    def _visit_if(self, statement: ast.If) -> None:
+        guards = self._guards_in_expr(statement.test)
+        self._record_sinks_in_expr(statement.test)
+        previous_guards = self.active_guards
+        initial_taint = dict(self.tainted)
+
+        self.active_guards = previous_guards + tuple(guards)
+        body_traces_start = len(self.traces)
+        for child in statement.body:
+            self._visit_statement(child)
+        body_result = dict(self.tainted)
+        body_traces = self.traces[body_traces_start:]
+
+        self.tainted = dict(initial_taint)
+        self.traces = self.traces[:body_traces_start]
+        self.active_guards = previous_guards
+        for child in statement.orelse:
+            self._visit_statement(child)
+        else_result = dict(self.tainted)
+        else_traces = self.traces[body_traces_start:]
+
+        self.traces = self.traces[:body_traces_start] + body_traces + else_traces
+        self.tainted = _intersect_taint_states(body_result, else_result)
+        self.active_guards = previous_guards
+
+    def _handle_assign(
+        self, targets: list[ast.expr], value: ast.expr, line: int
+    ) -> None:
+        taint = self._expr_taint(value)
+        for target in targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if taint is not None and not self._is_sanitized_expr(value):
+                step = ThreatTraceStep(
+                    kind="propagation",
+                    name=target.id,
+                    line=line,
+                    detail="assigned from tainted expression",
+                )
+                self.tainted[target.id] = _TaintState(
+                    source=taint.source,
+                    path=taint.path + (step,),
+                    guards=taint.guards + self.active_guards,
+                )
+            else:
+                self.tainted.pop(target.id, None)
+
+    def _record_sinks_in_expr(self, expr: ast.expr) -> None:
+        for node in ast.walk(expr):
+            if not isinstance(node, ast.Call):
+                continue
+            sink = self._sink_for_call(node)
+            if sink is None:
+                continue
+            for taint in self._call_taints(node):
+                self._append_trace(node, sink, taint)
+
+    def _append_trace(
+        self, node: ast.Call, sink: tuple[str, str], taint: _TaintState
+    ) -> None:
+        sink_name, sink_category = sink
+        sink_step = ThreatTraceStep(
+            kind="sink",
+            name=sink_name,
+            line=node.lineno,
+            detail=f"{sink_category} sink",
+        )
+        guards = _dedupe_steps(taint.guards + self.active_guards)
+        path = _dedupe_steps(taint.path + (sink_step,))
+        trace_id = _trace_id(
+            self.file_path,
+            self.entrypoint,
+            taint.source.name,
+            taint.source.line,
+            sink_name,
+            node.lineno,
+            [step.name for step in path],
+        )
+        self.traces.append(
+            ThreatTrace(
+                trace_id=trace_id,
+                file=self.file_path,
+                entrypoint=self.entrypoint,
+                source=taint.source,
+                sink=ThreatTracePoint(
+                    file=self.file_path,
+                    line=node.lineno,
+                    name=sink_name,
+                    kind="sink",
+                ),
+                sink_category=sink_category,
+                path=path,
+                guards=guards,
+            )
+        )
+
+    def _call_taints(self, node: ast.Call) -> list[_TaintState]:
+        taints: list[_TaintState] = []
+        for expr in list(node.args) + [keyword.value for keyword in node.keywords]:
+            taint = self._expr_taint(expr)
+            if taint is not None and not self._is_sanitized_expr(expr):
+                taints.append(taint)
+        return _dedupe_taints(taints)
+
+    def _expr_taint(self, expr: ast.expr) -> _TaintState | None:
+        source_call = self._source_call(expr)
+        if source_call is not None:
+            source = ThreatTracePoint(
+                file=self.file_path,
+                line=getattr(expr, "lineno", self.function.lineno),
+                name=source_call,
+                kind="source",
+            )
+            return _TaintState(
+                source=source,
+                path=(
+                    ThreatTraceStep(
+                        kind="source",
+                        name=source_call,
+                        line=getattr(expr, "lineno", self.function.lineno),
+                        detail="user-controlled input",
+                    ),
+                ),
+                guards=self.active_guards,
+            )
+
+        if isinstance(expr, ast.Name):
+            return self.tainted.get(expr.id)
+
+        child_taints = []
+        for child in ast.iter_child_nodes(expr):
+            if isinstance(child, ast.expr):
+                taint = self._expr_taint(child)
+                if taint is not None:
+                    child_taints.append(taint)
+        return child_taints[0] if child_taints else None
+
+    def _source_call(self, expr: ast.expr) -> str | None:
+        if isinstance(expr, ast.Call):
+            call_name = _call_name(expr)
+            if call_name in _REQUEST_SOURCE_CALLS:
+                return call_name
+        if isinstance(expr, ast.Subscript):
+            object_name = _dotted_name(expr.value)
+            if object_name in _REQUEST_SOURCE_OBJECTS:
+                return f"{object_name}[]"
+        return None
+
+    def _sink_for_call(self, node: ast.Call) -> tuple[str, str] | None:
+        call_name = _call_name(node)
+        if call_name in _HTTP_SINKS:
+            return call_name, "ssrf"
+        if call_name in _COMMAND_SINKS:
+            return call_name, "command_execution"
+        if call_name in _SUBPROCESS_SINKS and _shell_true(node):
+            return f"{call_name}(shell=True)", "command_execution"
+        if call_name in _PATH_SINKS:
+            return call_name, "filesystem"
+        if call_name.endswith(".execute") or call_name.endswith(".executemany"):
+            return call_name, "sql"
+        if call_name in _REDIRECT_SINKS:
+            return call_name, "redirect"
+        if call_name in _TEMPLATE_SINKS:
+            return call_name, "template"
+        return None
+
+    def _is_sanitized_expr(self, expr: ast.expr) -> bool:
+        if isinstance(expr, ast.Call) and _call_name(expr) in _SANITIZER_CALLS:
+            return True
+        return any(
+            isinstance(child, ast.Call) and _call_name(child) in _SANITIZER_CALLS
+            for child in ast.walk(expr)
+        )
+
+    def _guards_in_expr(self, expr: ast.expr) -> list[ThreatTraceStep]:
+        guards = []
+        for child in ast.walk(expr):
+            if isinstance(child, ast.Call):
+                call_name = _call_name(child)
+                if call_name in _GUARD_CALLS:
+                    guards.append(
+                        ThreatTraceStep(
+                            kind="guard",
+                            name=call_name,
+                            line=child.lineno,
+                            detail="guard or sanitizer check",
+                        )
+                    )
+        return guards
+
+
+def _entrypoint_name(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    for decorator in node.decorator_list:
+        decorator_name = _dotted_name(decorator)
+        if _is_route_decorator(decorator_name):
+            return f"{node.name} [{decorator_name}]"
+    return node.name
+
+
+def _is_route_decorator(name: str) -> bool:
+    return any(name.endswith(suffix) for suffix in _ROUTE_DECORATOR_SUFFIXES)
+
+
+def _call_name(node: ast.Call) -> str:
+    return _dotted_name(node.func)
+
+
+def _dotted_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Call):
+        return _dotted_name(node.func)
+    if isinstance(node, ast.Subscript):
+        return _dotted_name(node.value)
+    return ""
+
+
+def _shell_true(node: ast.Call) -> bool:
+    return any(
+        keyword.arg == "shell"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value is True
+        for keyword in node.keywords
+    )
+
+
+def _trace_id(*parts: Any) -> str:
+    raw = "|".join(str(part) for part in parts)
+    return "trace-" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def _dedupe_steps(steps: tuple[ThreatTraceStep, ...]) -> tuple[ThreatTraceStep, ...]:
+    seen = set()
+    deduped = []
+    for step in steps:
+        key = (step.kind, step.name, step.line)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(step)
+    return tuple(deduped)
+
+
+def _dedupe_taints(taints: list[_TaintState]) -> list[_TaintState]:
+    seen = set()
+    deduped = []
+    for taint in taints:
+        key = (taint.source.name, taint.source.line, tuple(step.name for step in taint.path))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(taint)
+    return deduped
+
+
+def _intersect_taint_states(
+    left: dict[str, _TaintState], right: dict[str, _TaintState]
+) -> dict[str, _TaintState]:
+    return {
+        name: state
+        for name, state in left.items()
+        if name in right
+        and state.source.name == right[name].source.name
+        and state.source.line == right[name].source.line
+    }
+
+
+def _finding_location(finding: Any) -> tuple[str, int] | None:
+    try:
+        if isinstance(finding, dict):
+            location = finding.get("location") or {}
+            file_path = str(finding.get("file") or location.get("file") or "")
+            line = int(finding.get("line") or location.get("line") or 0)
+        else:
+            file_path = str(finding.location.file)
+            line = int(finding.location.line)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if not file_path or line <= 0:
+        return None
+    return str(Path(file_path).resolve()), line
+
+
+def _finding_metadata(finding: Any) -> dict[str, Any]:
+    if isinstance(finding, dict):
+        return dict(finding.get("metadata") or {})
+    return dict(getattr(finding, "metadata", None) or {})
+
+
+def _set_finding_metadata(finding: Any, metadata: dict[str, Any]) -> None:
+    if isinstance(finding, dict):
+        finding["metadata"] = metadata
+    else:
+        finding.metadata = metadata

--- a/test/test_audit_candidates.py
+++ b/test/test_audit_candidates.py
@@ -199,6 +199,49 @@ def test_scan_deep_audit_candidates_is_stable_across_reruns(
     assert len(ids) == len(set(ids))
 
 
+def test_scan_deep_audit_candidates_records_static_threat_trace_candidate(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text(
+        "from flask import Flask, request\n"
+        "import requests\n"
+        "app = Flask(__name__)\n"
+        "@app.get('/proxy')\n"
+        "def proxy():\n"
+        "    url = request.args.get('url')\n"
+        "    return requests.get(url).text\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        audit_candidates,
+        "run_static_on_files",
+        lambda files, **kwargs: {"danger": [], "secrets": []},
+    )
+
+    summary, store = audit_candidates.scan_deep_audit_candidates(repo)
+    record = store.read_file_record(app)
+
+    assert summary.candidate_count >= 1
+    assert record is not None
+    trace_candidates = [
+        candidate
+        for candidate in record.candidates
+        if candidate.kind == "threat_trace"
+        and candidate.rule_id == "SKY-AUDIT-TRACE"
+    ]
+    assert len(trace_candidates) == 1
+    candidate = trace_candidates[0]
+    assert candidate.line == 7
+    assert candidate.source_kind == "request.args.get"
+    assert candidate.sink_kind == "requests.get"
+    assert candidate.evidence == "static_unvalidated"
+    assert candidate.data["threat_trace"]["validation"] == "static_unvalidated"
+
+
 def test_scan_deep_audit_candidates_records_non_candidate_files(
     tmp_path: Path, monkeypatch
 ):

--- a/test/test_audit_processor.py
+++ b/test/test_audit_processor.py
@@ -30,12 +30,28 @@ class FakeAnalyzer:
         ]
 
 
+class LineThreeAnalyzer:
+    def analyze_file(self, file_path, issue_types=None):
+        return [
+            {
+                "rule_id": "SKY-D216",
+                "issue_type": "security",
+                "severity": "high",
+                "message": "Possible SSRF",
+                "location": {"file": str(file_path), "line": 3},
+                "confidence": "high",
+            }
+        ]
+
+
 class CapturingAgent:
     def __init__(self):
         self.sources: list[str] = []
+        self.contexts: list[str | None] = []
 
     def analyze(self, source, file_path, defs_map=None, context=None):
         self.sources.append(source)
+        self.contexts.append(context)
         return []
 
 
@@ -77,6 +93,41 @@ def _candidate(
         redacted=redacted,
         priority=priority,
         code_hash=candidate_id,
+    )
+
+
+def _threat_trace_candidate() -> AuditCandidate:
+    return AuditCandidate(
+        candidate_id="trace-cand",
+        kind="threat_trace",
+        rule_id="SKY-AUDIT-TRACE",
+        line=3,
+        severity_hint="high",
+        reason="Static threat trace: request.args.get reaches requests.get in proxy",
+        evidence="static_unvalidated",
+        priority=875,
+        source_kind="request.args.get",
+        sink_kind="requests.get",
+        code_hash="trace-123",
+        data={
+            "threat_trace": {
+                "trace_id": "trace-123",
+                "entrypoint": "proxy [app.get]",
+                "source": {
+                    "file": "app.py",
+                    "line": 2,
+                    "name": "request.args.get",
+                    "kind": "source",
+                },
+                "sink": {
+                    "file": "app.py",
+                    "line": 3,
+                    "name": "requests.get",
+                    "kind": "sink",
+                },
+                "validation": "static_unvalidated",
+            }
+        },
     )
 
 
@@ -314,6 +365,64 @@ def test_process_deep_audit_records_redacts_incidental_secrets_before_agent_call
     assert raw_secret not in analyzer.agent.sources[0]
     assert REDACTION in analyzer.agent.sources[0]
     assert store.read_file_record(app).status == "analyzed"
+
+
+def test_process_deep_audit_records_passes_threat_trace_candidate_context(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text(
+        "from flask import request\n"
+        "import requests\n"
+        "def proxy():\n"
+        "    url = request.args.get('url')\n"
+        "    return requests.get(url).text\n",
+        encoding="utf-8",
+    )
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, candidates=[_threat_trace_candidate()])
+
+    analyzer = AgentBackedAnalyzer()
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=analyzer,
+        model="test-model",
+        run_id="run-threat-context",
+    )
+
+    assert summary.processed_files == 1
+    assert len(analyzer.agent.contexts) == 1
+    context = analyzer.agent.contexts[0]
+    assert context is not None
+    assert "[DEEP AUDIT CANDIDATES]" in context
+    assert "request.args.get@L2 -> requests.get@L3" in context
+
+
+def test_process_deep_audit_records_attaches_threat_trace_to_matching_finding(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app = repo / "app.py"
+    app.write_text("import requests\nurl = 'x'\nrequests.get(url)\n", encoding="utf-8")
+    store = AuditStore(repo)
+    store.init_project(config_hash="cfg")
+    _write_record(store, app, candidates=[_threat_trace_candidate()])
+
+    summary = process_deep_audit_records(
+        store=store,
+        analyzer=LineThreeAnalyzer(),
+        model="test-model",
+        run_id="run-threat-finding",
+    )
+
+    record = store.read_file_record(app)
+    assert summary.processed_files == 1
+    assert record is not None
+    assert record.findings[0]["metadata"]["threat_trace"]["trace_id"] == "trace-123"
 
 
 def test_process_deep_audit_records_marks_agent_errors_without_raw_secret(

--- a/test/test_security_taskflow.py
+++ b/test/test_security_taskflow.py
@@ -106,6 +106,123 @@ def test_run_security_taskflow_builds_repo_context_and_entry_points(tmp_path):
     assert run.candidate_ledger == []
 
 
+def test_run_security_taskflow_attaches_static_threat_trace_evidence(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text(
+        "from flask import Flask, request\n"
+        "import requests\n"
+        "app = Flask(__name__)\n"
+        "@app.get('/proxy')\n"
+        "def proxy():\n"
+        "    url = request.args.get('url')\n"
+        "    return requests.get(url).text\n",
+        encoding="utf-8",
+    )
+    finding = _security_finding(str(app), 7, "SKY-D216")
+    analyzer = _FakeAnalyzer(AnalysisResult(findings=[finding], files_analyzed=1))
+
+    def _review(found):
+        annotate_security_finding(
+            found[0],
+            evidence="review_supported",
+            review_verdict="SUPPORTED",
+            review_reason="static threat trace shows request source reaches HTTP sink",
+            needs_review=True,
+            ci_blocking=False,
+        )
+        return {
+            "supported": 1,
+            "refuted": 0,
+            "undecided": 0,
+            "refuted_findings": [],
+        }
+
+    with (
+        patch(
+            "skylos.llm.security_taskflow._generate_run_id",
+            return_value="run-trace-123",
+        ),
+        patch(
+            "skylos.llm.security_taskflow.SecurityVerifier.review_findings",
+            side_effect=_review,
+        ),
+    ):
+        run = run_security_taskflow(
+            path=tmp_path,
+            files=[app],
+            analyzer=analyzer,
+            model="gpt-4.1",
+            api_key="k",
+        )
+
+    assert len(run.threat_traces) == 1
+    trace = run.threat_traces[0]
+    assert trace.entrypoint == "proxy [app.get]"
+    assert trace.source.name == "request.args.get"
+    assert trace.sink.name == "requests.get"
+    assert trace.sink.line == 7
+    assert trace.validation == "static_unvalidated"
+
+    context = analyzer.config.repo_context_map[str(app.resolve())]
+    assert "[THREAT TRACE EVIDENCE]" in context
+    assert "source request.args.get@L6 reaches requests.get@L7" in context
+
+    metadata = run.result.findings[0].metadata
+    assert metadata["threat_trace"]["trace_id"] == trace.trace_id
+    assert metadata["threat_trace"]["sink"]["name"] == "requests.get"
+
+    candidate = run.candidate_ledger[0]
+    assert candidate.threat_trace_id == trace.trace_id
+    assert candidate.threat_trace_validation == "static_unvalidated"
+
+    artifacts_dir = tmp_path / ".skylos" / "runs" / "run-trace-123"
+    threat_payload = json.loads((artifacts_dir / "threat_traces.json").read_text())
+    verified_payload = json.loads((artifacts_dir / "verified.json").read_text())
+    candidates_payload = json.loads((artifacts_dir / "candidates.json").read_text())
+
+    assert threat_payload["trace_count"] == 1
+    assert threat_payload["traces"][0]["trace_id"] == trace.trace_id
+    assert (
+        verified_payload["result"]["findings"][0]["metadata"]["threat_trace"][
+            "trace_id"
+        ]
+        == trace.trace_id
+    )
+    assert candidates_payload["candidates"][0]["threat_trace_id"] == trace.trace_id
+
+
+def test_run_security_taskflow_does_not_trace_sanitized_or_unrelated_sinks(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text(
+        "from flask import request\n"
+        "import os\n"
+        "import requests\n\n"
+        "def sanitized_path():\n"
+        "    name = request.args.get('name')\n"
+        "    safe = os.path.basename(name)\n"
+        "    return open(safe).read()\n\n"
+        "def unrelated_sink():\n"
+        "    url = request.args.get('url')\n"
+        "    return requests.get('https://example.com').text\n",
+        encoding="utf-8",
+    )
+    analyzer = _FakeAnalyzer(AnalysisResult(findings=[], files_analyzed=1))
+
+    run = run_security_taskflow(
+        path=tmp_path,
+        files=[app],
+        analyzer=analyzer,
+        model="gpt-4.1",
+        api_key="k",
+    )
+
+    assert run.threat_traces == []
+    assert "[THREAT TRACE EVIDENCE]" not in analyzer.config.repo_context_map.get(
+        str(app.resolve()),
+        "",
+    )
+
+
 def test_run_security_taskflow_tolerates_non_utf8_python_file(tmp_path):
     malformed = tmp_path / "malformed.py"
     malformed.write_bytes(b"def handler():\n    return b'\\xff' + \xff\n")


### PR DESCRIPTION
## Summary

  - add static Python threat traces for source-to-sink security evidence
  - attach matching threat traces to security taskflow findings and artifacts
  - add threat trace candidates to `security-deep` / deep audit scans
  - pass deep audit threat trace context into agent processing

  ## Tests

  - `pytest test/test_security_taskflow.py test/test_security_verifier.py test/test_agent_integration.py test/test_audit_cli.py test/test_audit_candidates.py test/test_audit_processor.py`