### PR TITLE
feat(cli): support explicit config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ JSON-only output contract or untrusted-code safety rules. Vibe dictionary
 extensions let teams teach Skylos about local fake-auth helpers, project
 credential names, sensitive files, and network calls that must set timeouts.
 
+By default Skylos discovers `[tool.skylos]` in `pyproject.toml` by walking up
+from the scan path. To use a dedicated TOML config, pass `--config-file PATH`
+or set `SKYLOS_CONFIG_FILE`; standalone files may use either `[tool.skylos]`
+or top-level `[skylos]`. Synced Skylos Cloud policy keeps its protected
+precedence over repository-controlled config.
+
 ## Language Support
 
 | Language | Dead Code | Security | Quality | Notes |

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1633,6 +1633,7 @@ class Skylos:
         architecture_main_guard_modules=None,
         pyproject_entrypoint_qnames=None,
         pyproject_entrypoint_modules=None,
+        config_file=None,
     ):
         """Assemble the final result dict from analysis outputs."""
         architecture_main_guard_modules = set(architecture_main_guard_modules or ())
@@ -1859,7 +1860,10 @@ class Skylos:
             result["unused_exports"].extend(unused_ts_exports)
             result["analysis_summary"]["unused_exports_count"] = len(unused_ts_exports)
 
-        project_cfg = load_config(path[0] if isinstance(path, (list, tuple)) else path)
+        project_cfg = load_config(
+            path[0] if isinstance(path, (list, tuple)) else path,
+            config_file=config_file,
+        )
         if project_cfg.get("check_circular", True):
             circular_rule = CircularDependencyRule()
 
@@ -1998,6 +2002,7 @@ class Skylos:
         grep_verify=True,
         enable_sca=False,
         trace_file=None,
+        config_file=None,
     ) -> str:
         if not isinstance(path, (str, list, tuple)):
             raise TypeError(
@@ -2027,7 +2032,7 @@ class Skylos:
         )
 
         workspace_inventory = discover_workspace_inventory(project_root)
-        project_cfg = load_config(project_root)
+        project_cfg = load_config(project_root, config_file=config_file)
         project_ignore = set(project_cfg.get("ignore", []))
 
         if not files:
@@ -2200,6 +2205,7 @@ class Skylos:
                 collect_architecture_metrics=enable_quality,
                 enable_quality_rules=enable_quality,
                 enable_danger_rules=enable_danger,
+                config_file=config_file,
             )
 
             if os.getenv("SKYLOS_DEBUG"):
@@ -3046,6 +3052,7 @@ class Skylos:
             architecture_main_guard_modules=architecture_main_guard_modules,
             pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
             pyproject_entrypoint_modules=pyproject_entrypoint_modules,
+            config_file=config_file,
         )
 
         return json.dumps(result, indent=2)
@@ -3079,13 +3086,14 @@ def proc_file(
     collect_architecture_metrics=False,
     enable_quality_rules=True,
     enable_danger_rules=True,
+    config_file=None,
 ) -> dict | None:
     if mod is None and isinstance(file_or_args, tuple):
         file, mod = file_or_args
     else:
         file = file_or_args
 
-    cfg = load_config(file)
+    cfg = load_config(file, config_file=config_file)
 
     if str(file).endswith(_TS_JS_SOURCE_EXTS):
         out = scan_typescript_file(
@@ -3610,21 +3618,23 @@ def analyze(
     grep_verify=True,
     enable_sca=False,
     trace_file=None,
+    config_file=None,
 ) -> str:
     return Skylos().analyze(
         path,
-        conf,
-        exclude_folders,
-        enable_secrets,
-        enable_danger,
-        enable_quality,
-        extra_visitors,
-        progress_callback,
-        custom_rules_data,
-        changed_files,
+        thr=conf,
+        exclude_folders=exclude_folders,
+        enable_secrets=enable_secrets,
+        enable_danger=enable_danger,
+        enable_quality=enable_quality,
+        extra_visitors=extra_visitors,
+        progress_callback=progress_callback,
+        custom_rules_data=custom_rules_data,
+        changed_files=changed_files,
         grep_verify=grep_verify,
         enable_sca=enable_sca,
         trace_file=trace_file,
+        config_file=config_file,
     )
 
 

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -26,7 +26,7 @@ from skylos.constants import (
     DEFAULT_EXCLUDE_FOLDERS,
     get_non_library_dir_kind,
 )
-from skylos.config import load_config
+from skylos.config import ConfigError, load_config, resolve_config_file_path
 from skylos.cloud.credentials import PROVIDERS
 from skylos.core.result_cache import (
     build_trace_cache_key,
@@ -2791,7 +2791,8 @@ def _build_main_scan_context(args):
             logger.debug(f"Excluding folders: {args.exclude_folders}")
 
     use_defaults = not args.no_default_excludes
-    project_cfg = load_config(project_root)
+    config_file = resolve_config_file_path(getattr(args, "config_file", None))
+    project_cfg = load_config(project_root, config_file=config_file)
     final_exclude_folders = parse_exclude_folders(
         user_exclude_folders=args.exclude_folders,
         config_exclude_folders=project_cfg.get("exclude"),
@@ -2806,6 +2807,7 @@ def _build_main_scan_context(args):
         console=console,
         final_exclude_folders=final_exclude_folders,
         config=project_cfg,
+        config_file=config_file,
     )
 
 

--- a/skylos/cli_core/main_parser.py
+++ b/skylos/cli_core/main_parser.py
@@ -17,6 +17,15 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
     )
     parser.add_argument("path", nargs="+", help="Path(s) to the project")
     parser.add_argument(
+        "--config-file",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Read Skylos config from this TOML file instead of discovering "
+            "pyproject.toml. Relative paths are resolved from the current directory."
+        ),
+    )
+    parser.add_argument(
         "--gate",
         action="store_true",
         help="Run as a quality gate (block deployment on failure)",

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -72,12 +72,18 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
         if not _is_tty():
             parser.error("--tui requires an interactive terminal")
     args._explicit_upload_requested = bool(getattr(args, "upload", False))
-    context = _build_main_scan_context(args)
+
+    try:
+        context = _build_main_scan_context(args)
+    except cli_module.ConfigError as exc:
+        parser.error(str(exc))
+
     project_root = context.project_root
     logger = context.logger
     console = context.console
     final_exclude_folders = context.final_exclude_folders
     config = context.config
+    config_file = context.config_file
     machine_output = _is_main_machine_output(args)
 
     if _print_main_scan_banner(args, console, final_exclude_folders):
@@ -90,7 +96,10 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
     trace_file = pre_analysis.trace_file
 
     try:
-        scan_path = args.path if len(args.path) > 1 else args.path[0]
+        if len(args.path) > 1:
+            scan_path = args.path
+        else:
+            scan_path = args.path[0]
 
         def run_main_analysis(progress_callback=None):
             return run_analyze(
@@ -106,6 +115,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 grep_verify=not getattr(args, "no_grep_verify", False),
                 enable_sca=bool(args.sca),
                 trace_file=trace_file,
+                config_file=config_file,
             )
 
         quiet_analysis_output = (

--- a/skylos/config.py
+++ b/skylos/config.py
@@ -1,6 +1,13 @@
-from pathlib import Path
-import fnmatch
 import copy
+import fnmatch
+import os
+from pathlib import Path
+
+CONFIG_FILE_ENV_VAR = "SKYLOS_CONFIG_FILE"
+
+
+class ConfigError(ValueError):
+    """thrown when your selected config file cannot be loaded."""
 
 DEFAULTS = {
     "complexity": 10,
@@ -101,12 +108,18 @@ _REPO_POLICY_WEAKENING_KEYS = {
 }
 
 
-def load_config(start_path) -> dict:
+def load_config(start_path, config_file=None) -> dict:
     current = Path(start_path).resolve()
     if current.is_file():
         current = current.parent
 
-    root_config, sync_config = _find_config_paths(current)
+    explicit_config = resolve_config_file_path(config_file)
+    if explicit_config is None:
+        root_config, sync_config = _find_config_paths(current)
+    else:
+        root_config = explicit_config
+        _, sync_config = _find_config_paths(current)
+
     final_cfg = copy.deepcopy(DEFAULTS)
     synced_cfg = _load_synced_config(sync_config) if sync_config else {}
 
@@ -118,11 +131,41 @@ def load_config(start_path) -> dict:
 
     try:
         final_cfg = _merge_user_config(
-            final_cfg, _load_pyproject_user_config(root_config)
+            final_cfg,
+            _load_toml_user_config(root_config, explicit=explicit_config is not None),
         )
+    except ConfigError:
+        raise
     except Exception:
+        if explicit_config is not None:
+            raise ConfigError(f"Could not load config file: {root_config}")
         return final_cfg
     return _restore_synced_policy_precedence(final_cfg, synced_cfg)
+
+
+def resolve_config_file_path(config_file=None) -> Path | None:
+    raw_config_file = config_file
+    if raw_config_file is None:
+        raw_config_file = os.environ.get(CONFIG_FILE_ENV_VAR)
+    if raw_config_file is None:
+        return None
+
+    raw_path = str(raw_config_file).strip()
+    if not raw_path:
+        return None
+
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise ConfigError(f"Config file not found: {raw_path}") from exc
+
+    if not resolved.is_file():
+        raise ConfigError(f"Config path is not a file: {raw_path}")
+    return resolved
 
 
 def _restore_synced_policy_precedence(final_cfg: dict, synced_cfg: dict) -> dict:
@@ -192,10 +235,7 @@ def _find_config_paths(start_dir: Path) -> tuple[Path | None, Path | None]:
     return root_config, sync_config
 
 
-def _load_pyproject_user_config(root_config: Path) -> dict:
-    if not _is_safe_config_file(root_config, "pyproject.toml"):
-        return {}
-
+def _load_toml_data(root_config: Path) -> dict:
     try:
         import tomllib
     except ImportError:
@@ -205,10 +245,33 @@ def _load_pyproject_user_config(root_config: Path) -> dict:
             return {}
 
     with root_config.open("rb") as f:
-        data = tomllib.load(f)
+        return tomllib.load(f)
 
-    user_cfg = dict(data.get("tool", {}).get("skylos", {}) or {})
-    gate_cfg = data.get("tool", {}).get("skylos", {}).get("gate", {})
+
+def _select_skylos_toml_config(data: dict, *, explicit: bool) -> dict:
+    tool_cfg = data.get("tool")
+    if isinstance(tool_cfg, dict) and "skylos" in tool_cfg:
+        tool_skylos = tool_cfg.get("skylos")
+        if isinstance(tool_skylos, dict):
+            return tool_skylos
+
+    top_skylos = data.get("skylos")
+    if explicit and isinstance(top_skylos, dict):
+        return top_skylos
+    if explicit:
+        raise ConfigError("Config file must contain [tool.skylos] or [skylos]")
+
+    return {}
+
+
+def _load_toml_user_config(root_config: Path, *, explicit: bool = False) -> dict:
+    if not explicit and not _is_safe_config_file(root_config, "pyproject.toml"):
+        return {}
+
+    data = _load_toml_data(root_config)
+    skylos_cfg = _select_skylos_toml_config(data, explicit=explicit)
+    user_cfg = dict(skylos_cfg or {})
+    gate_cfg = skylos_cfg.get("gate", {})
     if gate_cfg:
         user_cfg["gate"] = gate_cfg
     return user_cfg
@@ -308,7 +371,10 @@ def _merge_user_config(base_cfg: dict, user_cfg: dict | None) -> dict:
 
 
 def _sanitize_config(cfg: dict) -> dict:
-    safe = copy.deepcopy(cfg) if isinstance(cfg, dict) else copy.deepcopy(DEFAULTS)
+    if isinstance(cfg, dict):
+        safe = copy.deepcopy(cfg)
+    else:
+        safe = copy.deepcopy(DEFAULTS)
 
     for key, minimum in _INT_CONFIG_KEYS.items():
         safe[key] = _safe_int(safe.get(key), DEFAULTS[key], minimum=minimum)
@@ -423,7 +489,10 @@ def _safe_dict_list(value, default):
 
 
 def _sanitize_masking_section(value):
-    raw = value if isinstance(value, dict) else {}
+    if isinstance(value, dict):
+        raw = value
+    else:
+        raw = {}
     safe = copy.deepcopy(DEFAULTS["masking"])
     safe["names"] = _safe_string_list(raw.get("names"), safe["names"])
     safe["decorators"] = _safe_string_list(raw.get("decorators"), safe["decorators"])
@@ -435,7 +504,10 @@ def _sanitize_masking_section(value):
 
 
 def _sanitize_templates_section(value):
-    raw = value if isinstance(value, dict) else {}
+    if isinstance(value, dict):
+        raw = value
+    else:
+        raw = {}
     safe = copy.deepcopy(DEFAULTS["templates"])
     for key in list(safe):
         candidate = raw.get(key)
@@ -445,7 +517,10 @@ def _sanitize_templates_section(value):
 
 
 def _sanitize_vibe_section(value):
-    raw = value if isinstance(value, dict) else {}
+    if isinstance(value, dict):
+        raw = value
+    else:
+        raw = {}
     safe = copy.deepcopy(DEFAULTS["vibe"])
     for key in list(safe):
         safe[key] = _safe_string_list(raw.get(key), safe[key])
@@ -453,7 +528,10 @@ def _sanitize_vibe_section(value):
 
 
 def _sanitize_architecture_section(value):
-    raw = value if isinstance(value, dict) else {}
+    if isinstance(value, dict):
+        raw = value
+    else:
+        raw = {}
     safe = copy.deepcopy(DEFAULTS["architecture"])
     for key in ("strict", "enforce_iad", "strict_iad"):
         if key in raw:

--- a/skylos/scale/parallel_static.py
+++ b/skylos/scale/parallel_static.py
@@ -15,6 +15,7 @@ def _worker(
     collect_architecture_metrics=False,
     enable_quality_rules=True,
     enable_danger_rules=True,
+    config_file=None,
 ):
     from skylos.analyzer import proc_file
 
@@ -28,6 +29,7 @@ def _worker(
         collect_architecture_metrics=collect_architecture_metrics,
         enable_quality_rules=enable_quality_rules,
         enable_danger_rules=enable_danger_rules,
+        config_file=config_file,
     )
     return str(file_path), out
 
@@ -45,6 +47,7 @@ def run_proc_file_parallel(
     collect_architecture_metrics=False,
     enable_quality_rules=True,
     enable_danger_rules=True,
+    config_file=None,
 ):
     import os
 
@@ -76,6 +79,7 @@ def run_proc_file_parallel(
                 collect_architecture_metrics=collect_architecture_metrics,
                 enable_quality_rules=enable_quality_rules,
                 enable_danger_rules=enable_danger_rules,
+                config_file=config_file,
             )
             outs.append(out)
 
@@ -102,6 +106,7 @@ def run_proc_file_parallel(
                 collect_architecture_metrics,
                 enable_quality_rules,
                 enable_danger_rules,
+                config_file,
             )
             fut_to_file[fut] = f
 
@@ -134,6 +139,7 @@ def run_proc_file_parallel(
                         collect_architecture_metrics=collect_architecture_metrics,
                         enable_quality_rules=enable_quality_rules,
                         enable_danger_rules=enable_danger_rules,
+                        config_file=config_file,
                     )
                 except Exception:
                     logger.error(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -339,6 +339,38 @@ class TestMainFunction:
             mock_analyze.assert_called_once()
             mock_print.assert_called_once_with(json.dumps(mock_skylos_result))
 
+    def test_main_config_file_is_loaded_and_forwarded(
+        self, mock_skylos_result, tmp_path, monkeypatch
+    ):
+        config_dir = tmp_path / "quality"
+        config_dir.mkdir()
+        config_path = config_dir / "skylos.toml"
+        config_path.write_text("[skylos]\nquality_enabled = true", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        test_args = [
+            "cli.py",
+            ".",
+            "--json",
+            "--config-file",
+            "quality/skylos.toml",
+            "--no-provenance",
+        ]
+
+        with (
+            patch("sys.argv", test_args),
+            patch("skylos.cli.run_analyze") as mock_analyze,
+            patch("builtins.print"),
+            patch("skylos.cli.setup_logger"),
+            patch("skylos.cli.Progress") as mock_progress,
+        ):
+            mock_progress.return_value.__enter__.return_value = Mock(add_task=Mock())
+            mock_analyze.return_value = json.dumps(mock_skylos_result)
+
+            main()
+
+            assert mock_analyze.call_args.kwargs["enable_quality"] is True
+            assert mock_analyze.call_args.kwargs["config_file"] == config_path.resolve()
+
     def test_main_verbose_output(self, mock_skylos_result):
         """with verbose"""
         test_args = ["cli.py", "test_path", "--verbose"]

--- a/test/test_cli_addopts_safety.py
+++ b/test/test_cli_addopts_safety.py
@@ -33,6 +33,8 @@ def test_sanitize_addopts_keeps_safe_scan_options_only():
             "-f",
             "--output",
             "/tmp/report.json",
+            "--config-file",
+            "quality/skylos.toml",
         ]
     ) == [
         "--json",
@@ -82,3 +84,16 @@ def test_parse_main_cli_args_accepts_pretty_format():
     assert args.llm is False
     assert args.github is False
     assert args.concise is False
+
+
+def test_parse_main_cli_args_accepts_config_file():
+    parser = build_main_parser(version="test")
+
+    args = parse_main_cli_args(
+        parser,
+        [".", "--config-file", "quality/skylos.toml"],
+        addopts_loader=list,
+    )
+
+    assert args.path == ["."]
+    assert args.config_file == "quality/skylos.toml"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,7 +1,10 @@
 import unittest
 import tempfile
+import os
 from pathlib import Path
 from skylos.config import (
+    CONFIG_FILE_ENV_VAR,
+    ConfigError,
     load_config,
     DEFAULTS,
     is_path_excluded,
@@ -36,6 +39,108 @@ class TestSkylosConfig(unittest.TestCase):
 
         self.assertEqual(config["complexity"], 99)
         self.assertEqual(config["nesting"], DEFAULTS["nesting"])
+
+    def test_load_config_explicit_file_replaces_pyproject_discovery(self):
+        (self.root / "pyproject.toml").write_text(
+            "[tool.skylos]\ncomplexity = 99\nmax_args = 2",
+            encoding="utf-8",
+        )
+        quality_dir = self.root / "quality"
+        quality_dir.mkdir()
+        (quality_dir / "skylos.toml").write_text(
+            """
+[skylos]
+complexity = 7
+ignore = ["SKY-Q301"]
+""".strip(),
+            encoding="utf-8",
+        )
+        nested_path = self.root / "a" / "b"
+        nested_path.mkdir(parents=True)
+
+        old_cwd = os.getcwd()
+        os.chdir(self.root)
+        try:
+            config = load_config(nested_path, config_file="quality/skylos.toml")
+        finally:
+            os.chdir(old_cwd)
+
+        self.assertEqual(config["complexity"], 7)
+        self.assertEqual(config["max_args"], DEFAULTS["max_args"])
+        self.assertEqual(config["ignore"], ["SKY-Q301"])
+
+    def test_load_config_explicit_file_accepts_tool_skylos_table(self):
+        config_path = self.root / "quality.toml"
+        config_path.write_text(
+            """
+[tool.skylos]
+max_lines = 42
+
+[tool.skylos.gate]
+strict = true
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = load_config(self.root, config_file=config_path)
+
+        self.assertEqual(config["max_lines"], 42)
+        self.assertTrue(config["gate"]["strict"])
+
+    def test_load_config_env_config_file(self):
+        config_path = self.root / "skylos.toml"
+        config_path.write_text("[skylos]\nnesting = 5", encoding="utf-8")
+        old_value = os.environ.get(CONFIG_FILE_ENV_VAR)
+        os.environ[CONFIG_FILE_ENV_VAR] = str(config_path)
+        try:
+            config = load_config(self.root)
+        finally:
+            if old_value is None:
+                os.environ.pop(CONFIG_FILE_ENV_VAR, None)
+            else:
+                os.environ[CONFIG_FILE_ENV_VAR] = old_value
+
+        self.assertEqual(config["nesting"], 5)
+
+    def test_load_config_explicit_file_requires_skylos_table(self):
+        config_path = self.root / "skylos.toml"
+        config_path.write_text("[tool.other]\ncomplexity = 1", encoding="utf-8")
+
+        with self.assertRaises(ConfigError):
+            load_config(self.root, config_file=config_path)
+
+    def test_load_config_explicit_file_preserves_synced_policy_precedence(self):
+        skylos_dir = self.root / ".skylos"
+        skylos_dir.mkdir()
+        (skylos_dir / "config.yaml").write_text(
+            """
+security_contracts:
+  - framework: fastapi
+    file: app/api/routes.py
+    handler: list_users
+    guards:
+      - require_admin
+""".strip(),
+            encoding="utf-8",
+        )
+        config_path = self.root / "quality" / "skylos.toml"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            """
+[skylos]
+ignore = ["SKY-SC001"]
+exclude = ["app/**"]
+security_contracts = []
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = load_config(self.root, config_file=config_path)
+
+        self.assertEqual(config["exclude"], [])
+        self.assertNotIn("SKY-SC001", config["ignore"])
+        self.assertEqual(len(config["security_contracts"]), 1)
+        self.assertEqual(config["security_contracts"][0]["handler"], "list_users")
 
     def test_load_config_ignores_symlinked_pyproject(self):
         with tempfile.TemporaryDirectory() as outside_dir:


### PR DESCRIPTION
Closes #505 

## Summary

  - Adds `--config-file PATH` to the main CLI.
  - Adds `SKYLOS_CONFIG_FILE` as an env fallback.
  - Supports TOML files containing either `[tool.skylos]` or top-level `[skylos]`.
  - Resolves relative config paths from the current working directory.
  - Replaces `pyproject.toml` walk up discovery when an explicit config file is provided.

## Why

  This enables teams to centralize Skylos config outside `pyproject.toml`, eg:

  ```bash
  skylos . --config-file quality/skylos.toml
  SKYLOS_CONFIG_FILE=quality/skylos-strict.toml skylos .
```

  It also supports CI profile switching without mutating pyproject.toml.

## Tests

  - pytest test/test_config.py test/test_cli_addopts_safety.py test/test_cli.py test/test_security_contracts.py