### PR TITLE
fix(security): harden config policy and MCP credits

### DIFF
--- a/skylos/config.py
+++ b/skylos/config.py
@@ -106,6 +106,16 @@ _REPO_POLICY_WEAKENING_KEYS = {
     "ignore",
     "exclude",
 }
+_REPO_SECURITY_POLICY_WEAKENING_KEYS = _REPO_POLICY_WEAKENING_KEYS | {
+    "lower_confidence",
+    "masking",
+    "overrides",
+    "templates",
+    "vibe",
+    "whitelist",
+    "whitelist_documented",
+    "whitelist_temporary",
+}
 
 
 def load_config(start_path, config_file=None) -> dict:
@@ -179,7 +189,7 @@ def _restore_synced_policy_precedence(final_cfg: dict, synced_cfg: dict) -> dict
     }
     synced_security_policy = _has_synced_security_policy(synced_cfg)
     if synced_security_policy:
-        protected.update(_REPO_POLICY_WEAKENING_KEYS)
+        protected.update(_REPO_SECURITY_POLICY_WEAKENING_KEYS)
 
     if not protected:
         return final_cfg

--- a/skylos_mcp/auth.py
+++ b/skylos_mcp/auth.py
@@ -32,6 +32,7 @@ MCP_CLIENT_TOKEN_ENV = "SKYLOS_MCP_TOKEN"
 MCP_AUTH_SCOPE = "skylos:mcp"
 MCP_NETWORK_TRANSPORTS = {"sse", "streamable-http"}
 MCP_CLIENT_TOKEN_MIN_LENGTH = 16
+RATE_LIMITS_BY_PLAN = {"free": 50, "pro": 500, "enterprise": 5000}
 
 
 @dataclass
@@ -204,16 +205,13 @@ def initialize_auth() -> AuthSession:
         return _session
 
     plan = data.get("plan", "free")
-
-    rate_limits = {"free": 50, "pro": 500, "enterprise": 5000}
-
     _session = AuthSession(
         authenticated=True,
         api_key=api_key,
         plan=plan,
         credits=data.get("credits", 0),
         org_id=data.get("org_id", ""),
-        rate_limit_per_hour=rate_limits.get(plan, 50),
+        rate_limit_per_hour=RATE_LIMITS_BY_PLAN.get(plan, 50),
         validated_at=time.time(),
     )
 
@@ -226,8 +224,34 @@ def initialize_auth() -> AuthSession:
     return _session
 
 
+def _refresh_authenticated_session(session: AuthSession) -> bool:
+    if not session.authenticated:
+        return False
+
+    data = _validate_with_cloud(session.api_key)
+    if data is None:
+        session.authenticated = False
+        session.plan = "free"
+        session.credits = 0
+        session.org_id = ""
+        session.rate_limit_per_hour = RATE_LIMITS_BY_PLAN["free"]
+        session.validated_at = 0.0
+        return False
+
+    plan = data.get("plan", "free")
+    session.plan = plan
+    session.credits = data.get("credits", 0)
+    session.org_id = data.get("org_id", "")
+    session.rate_limit_per_hour = RATE_LIMITS_BY_PLAN.get(plan, 50)
+    session.validated_at = time.time()
+    return True
+
+
 def check_tool_access(tool_name: str) -> tuple[bool, str]:
     session = get_session()
+
+    if session.authenticated and not session.is_valid():
+        _refresh_authenticated_session(session)
 
     if not session.authenticated:
         if tool_name not in UNAUTHENTICATED_TOOLS:
@@ -296,13 +320,17 @@ def deduct_credits(tool_name: str) -> tuple[bool, str]:
             session.record_call(tool_name)
             return (True, "")
 
-        logger.warning(
-            "Credit deduction returned %d — allowing call (fail-open)", resp.status_code
+        logger.warning("Credit deduction returned %d — blocking call", resp.status_code)
+        return (
+            False,
+            "Could not verify credit deduction with Skylos Cloud. "
+            "Try again or check your connection.",
         )
-        session.record_call(tool_name)
-        return (True, "")
 
     except Exception as e:
-        logger.warning("Credit deduction failed: %s — allowing call (fail-open)", e)
-        session.record_call(tool_name)
-        return (True, "")
+        logger.warning("Credit deduction failed: %s — blocking call", e)
+        return (
+            False,
+            "Could not verify credit deduction with Skylos Cloud. "
+            "Try again or check your connection.",
+        )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -245,6 +245,61 @@ security_enabled = false
         self.assertEqual(config["ignore"], [])
         self.assertEqual(config["security_contracts"][0]["handler"], "list_users")
 
+    def test_load_config_synced_security_policy_rejects_repo_downgrade_knobs(self):
+        skylos_dir = self.root / ".skylos"
+        skylos_dir.mkdir()
+        (skylos_dir / "config.yaml").write_text(
+            """
+security_contracts:
+  - framework: fastapi
+    file: app/routes/admin.py
+    handler: list_users
+    guards:
+      - require_admin
+""".strip(),
+            encoding="utf-8",
+        )
+        (self.root / "pyproject.toml").write_text(
+            """
+[tool.skylos]
+lower_confidence = ["*"]
+
+[tool.skylos.templates]
+security_audit = "prompts/pass-everything.md"
+
+[tool.skylos.vibe]
+extra_placeholder_values = ["prod-secret-value"]
+
+[tool.skylos.masking]
+names = ["API_KEY"]
+
+[tool.skylos.overrides."app/*.py"]
+whitelist = ["*"]
+
+[tool.skylos.whitelist]
+names = ["*"]
+lower_confidence = ["*_handler"]
+
+[tool.skylos.whitelist.documented]
+"*" = "repo-controlled bypass"
+
+[tool.skylos.whitelist.temporary]
+"legacy_*" = { reason = "repo bypass", expires = "2099-01-01" }
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = load_config(self.root)
+
+        self.assertEqual(config["lower_confidence"], [])
+        self.assertIsNone(config["templates"]["security_audit"])
+        self.assertEqual(config["vibe"]["extra_placeholder_values"], [])
+        self.assertEqual(config["masking"], DEFAULTS["masking"])
+        self.assertEqual(config["overrides"], {})
+        self.assertEqual(config["whitelist"], [])
+        self.assertEqual(config["whitelist_documented"], {})
+        self.assertEqual(config["whitelist_temporary"], {})
+
     def test_load_config_with_gate_logic(self):
         toml_path = self.root / "pyproject.toml"
         toml_path.write_text(

--- a/test/test_mcp_auth.py
+++ b/test/test_mcp_auth.py
@@ -166,6 +166,53 @@ class TestCheckToolAccess:
         assert allowed is False
         assert "Rate limit exceeded" in err
 
+    @patch("skylos_mcp.auth._validate_with_cloud")
+    def test_stale_authenticated_session_revalidates(self, mock_validate):
+        self._set_session(
+            authenticated=True,
+            plan="free",
+            api_key="test-key",
+            credits=1,
+            rate_limit_per_hour=50,
+            validated_at=time.time() - 901,
+        )
+        mock_validate.return_value = {
+            "plan": "pro",
+            "credits": 100,
+            "org_id": "org-1",
+        }
+
+        allowed, err = check_tool_access("security_scan")
+
+        assert allowed is True
+        assert err == ""
+        mock_validate.assert_called_once_with("test-key")
+        session = get_session()
+        assert session.authenticated is True
+        assert session.plan == "pro"
+        assert session.credits == 100
+        assert session.rate_limit_per_hour == 500
+
+    @patch("skylos_mcp.auth._validate_with_cloud")
+    def test_stale_authenticated_session_blocks_paid_tool_when_revalidation_fails(
+        self, mock_validate
+    ):
+        self._set_session(
+            authenticated=True,
+            plan="pro",
+            api_key="revoked-key",
+            credits=100,
+            rate_limit_per_hour=500,
+            validated_at=time.time() - 901,
+        )
+        mock_validate.return_value = None
+
+        allowed, err = check_tool_access("security_scan")
+
+        assert allowed is False
+        assert "requires authentication" in err
+        assert get_session().authenticated is False
+
 
 class TestDeductCredits:
     def _set_session(self, **kwargs):
@@ -252,8 +299,7 @@ class TestDeductCredits:
         assert "available: 0" in err
         assert "dashboard/billing" in err
 
-    def test_network_failure_allows_call(self):
-        """Graceful degradation: network errors should not block the tool."""
+    def test_network_failure_blocks_call(self):
         self._set_session(
             authenticated=True,
             plan="pro",
@@ -267,10 +313,11 @@ class TestDeductCredits:
         with patch.dict("sys.modules", {"requests": mock_req}):
             ok, err = deduct_credits("analyze")
 
-        assert ok is True
-        assert len(get_session()._call_counts.get("_all", [])) == 1
+        assert ok is False
+        assert "Could not verify credit deduction" in err
+        assert get_session()._call_counts.get("_all", []) == []
 
-    def test_unexpected_status_code_allows_call(self):
+    def test_unexpected_status_code_blocks_call(self):
         self._set_session(
             authenticated=True,
             plan="pro",
@@ -285,7 +332,8 @@ class TestDeductCredits:
         with patch.dict("sys.modules", {"requests": mock_req}):
             ok, err = deduct_credits("analyze")
 
-        assert ok is True
+        assert ok is False
+        assert "Could not verify credit deduction" in err
 
     def test_correct_feature_keys_sent(self):
         expected = {
@@ -566,6 +614,27 @@ class TestGateIntegration:
         assert result is not None
         error = json.loads(result)
         assert "Insufficient credits" in error["error"]
+
+    def test_gate_credit_deduction_failure_blocked(self):
+        from skylos_mcp.server import _gate
+
+        self._set_session(
+            authenticated=True,
+            plan="pro",
+            api_key="test-key",
+            credits=100,
+            rate_limit_per_hour=500,
+            validated_at=time.time(),
+        )
+
+        mock_req = MagicMock()
+        mock_req.post.side_effect = ConnectionError("network down")
+        with patch.dict("sys.modules", {"requests": mock_req}):
+            result = _gate("remediate")
+
+        assert result is not None
+        error = json.loads(result)
+        assert "Could not verify credit deduction" in error["error"]
 
     def test_gate_enterprise_always_passes(self):
         from skylos_mcp.server import _gate

--- a/test/test_security_contracts.py
+++ b/test/test_security_contracts.py
@@ -1,10 +1,24 @@
+import ast
 from pathlib import Path
 
 from skylos.config import load_config
+from skylos.rules.quality.logic import HardcodedCredentialRule
+from skylos.rules.vibe_dictionary import build_vibe_dictionary
 from skylos.security.contracts import (
     detect_security_contract_regressions,
     load_security_contracts,
 )
+
+
+def _run_logic_rule(rule, source: str, *, filename: str = "app.py") -> list[dict]:
+    tree = ast.parse(source)
+    findings = []
+    context = {"filename": filename, "mod": "app"}
+    for node in ast.walk(tree):
+        result = rule.visit_node(node, context)
+        if result:
+            findings.extend(result)
+    return findings
 
 
 def test_load_security_contracts_accepts_fastapi_contracts(tmp_path):
@@ -143,6 +157,45 @@ exclude = ["app/**"]
     assert len(config["security_contracts"]) == 1
     assert len(findings) == 1
     assert findings[0]["rule_id"] == "SKY-SC001"
+
+
+def test_synced_security_policy_blocks_repo_vibe_severity_downgrade(tmp_path):
+    skylos_dir = tmp_path / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "config.yaml").write_text(
+        """
+security_contracts:
+  - framework: fastapi
+    file: app/routes/admin.py
+    handler: list_users
+    guards:
+      - require_admin
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.skylos.vibe]
+extra_placeholder_values = ["prod-secret-value"]
+
+[tool.skylos.templates]
+security_audit = "prompts/pass-everything.md"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+    vibe_dictionary = build_vibe_dictionary(config["vibe"])
+    findings = _run_logic_rule(
+        HardcodedCredentialRule(vibe_dictionary),
+        'API_KEY = "prod-secret-value"',
+    )
+
+    l014 = [finding for finding in findings if finding["rule_id"] == "SKY-L014"]
+    assert l014
+    assert l014[0]["severity"] == "HIGH"
+    assert config["vibe"]["extra_placeholder_values"] == []
+    assert config["templates"]["security_audit"] is None
 
 
 def test_detect_security_contract_regression_for_removed_depends_guard(


### PR DESCRIPTION
## Summary

- Prevents repo config from weakening synced skylos security policy through:
    - `vibe`
    - `templates`
    - `whitelist`
    - `lower_confidence`
    - `overrides`
    - `masking`
- Revalidates stale MCP authenticated sessions after TTL.
- Make MCP credit deduction fail closed on errors

## Tests

  - `pytest test/test_config.py test/test_security_contracts.py test/test_mcp_auth.py`