### PR TITLE
fix(security): harden repo-controlled IO surfaces

### DIFF
--- a/skylos/analysis/implicit_refs.py
+++ b/skylos/analysis/implicit_refs.py
@@ -1,6 +1,7 @@
 import re
-import json
 from pathlib import Path
+
+from skylos.core.result_cache import read_trace_payload
 
 
 def _compile_pattern_ref(pattern):
@@ -89,11 +90,11 @@ class ImplicitRefTracker:
         if not path.exists():
             return False
 
-        try:
-            data = json.loads(
-                path.read_text()
-            )  # skylos: ignore[SKY-D215] local trace file
+        data = read_trace_payload(path)
+        if data is None:
+            return False
 
+        try:
             for item in data.get("calls", []):
                 filename = item["file"]
                 func_name = item["function"]

--- a/skylos/core/result_cache.py
+++ b/skylos/core/result_cache.py
@@ -15,12 +15,14 @@ from pathlib import Path
 from typing import Any
 
 import skylos
+from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
 
 SCHEMA_VERSION = 1
 CACHE_KIND_TRACE = "trace"
 RUN_CACHE_DIR = Path(".skylos") / "cache" / "runs"
 TRACE_CACHE_DIR = RUN_CACHE_DIR / "v1" / "trace"
 MAX_CACHE_STAT_ENTRIES = 100_000
+MAX_TRACE_PAYLOAD_BYTES = 10_000_000
 
 TRACE_ENV_VARS = (
     "PYTHONPATH",
@@ -151,14 +153,14 @@ def build_trace_cache_key(
 
 
 def load_trace_cache(project_root: str | Path, key: str) -> dict[str, Any] | None:
-    path = _trace_cache_path(project_root, key)
-    try:
-        entry = json.loads(
-            path.read_text(
-                encoding="utf-8"
-            )  # skylos: ignore[SKY-D215] project-local trace cache
-        )
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+    root = _normalize_root(project_root)
+    path = _trace_cache_path(root, key)
+    entry = load_project_json_cache(
+        root,
+        path,
+        max_bytes=MAX_TRACE_PAYLOAD_BYTES,
+    )
+    if not entry:
         return None
 
     if not isinstance(entry, dict):
@@ -202,7 +204,8 @@ def save_trace_cache(
         "pytest_returncode": int(pytest_returncode),
         "trace": trace_payload,
     }
-    _write_json_atomic(path, entry)
+    if not save_project_json_cache(root, path, entry):
+        return None
     return path
 
 
@@ -217,9 +220,7 @@ def clear_run_cache(project_root: str | Path) -> bool:
         return False
     if not path.exists():
         return False
-    shutil.rmtree(
-        path
-    )  # skylos: ignore[SKY-D215] guarded project-local cache directory
+    shutil.rmtree(path)  # skylos: ignore[SKY-D215] guarded project-local cache directory
     return True
 
 
@@ -319,13 +320,12 @@ def run_cache_stats(project_root: str | Path) -> dict[str, Any]:
 
 def read_trace_payload(trace_file: str | Path) -> dict[str, Any] | None:
     path = Path(trace_file)
-    try:
-        payload = json.loads(
-            path.read_text(
-                encoding="utf-8"
-            )  # skylos: ignore[SKY-D215] local trace file
-        )
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+    payload = load_project_json_cache(
+        path.parent,
+        path,
+        max_bytes=MAX_TRACE_PAYLOAD_BYTES,
+    )
+    if not payload:
         return None
     if not _is_valid_trace_payload(payload):
         return None

--- a/skylos/core/safe_cache_io.py
+++ b/skylos/core/safe_cache_io.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MAX_JSON_CACHE_BYTES = 2_000_000
+
+
+def read_text_no_symlink(
+    path: str | Path,
+    *,
+    max_bytes: int,
+    encoding: str = "utf-8",
+    errors: str | None = None,
+) -> str | None:
+    try:
+        if Path(path).is_symlink():
+            return None
+    except OSError:
+        return None
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(path, flags)  # skylos: ignore[SKY-D215] caller supplies guarded source/cache path
+        stat_result = os.fstat(fd)
+        if not stat.S_ISREG(stat_result.st_mode):
+            return None
+        if stat_result.st_size > max_bytes:
+            return None
+        with os.fdopen(fd, "r", encoding=encoding, errors=errors) as handle:
+            fd = None
+            text = handle.read(max_bytes + 1)
+    except (OSError, UnicodeError):
+        return None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    encoded_errors = errors or "strict"
+    if len(text.encode(encoding, encoded_errors)) > max_bytes:
+        return None
+    return text
+
+
+def write_existing_text_no_symlink(
+    path: str | Path,
+    text: str,
+    *,
+    encoding: str = "utf-8",
+) -> bool:
+    try:
+        if Path(path).is_symlink():
+            return False
+    except OSError:
+        return False
+
+    flags = os.O_WRONLY | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(path, flags)  # skylos: ignore[SKY-D215] caller supplies guarded existing file path
+        stat_result = os.fstat(fd)
+        if not stat.S_ISREG(stat_result.st_mode):
+            return False
+        with os.fdopen(fd, "w", encoding=encoding) as handle:
+            fd = None
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return True
+    except (OSError, UnicodeError):
+        return False
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _project_cache_path(
+    project_root: str | Path,
+    cache_path: str | Path,
+    *,
+    create: bool,
+) -> Path | None:
+    resolved = _resolve_project_cache_path(project_root, cache_path)
+    if resolved is None:
+        return None
+    root, path = resolved
+    if not _ensure_cache_parent(root, path, create=create):
+        return None
+    if not _is_regular_cache_file(path):
+        return None
+    return path
+
+
+def _resolve_project_cache_path(
+    project_root: str | Path,
+    cache_path: str | Path,
+) -> tuple[Path, Path] | None:
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+
+    path = Path(cache_path)
+    if not path.is_absolute():
+        path = root / path
+
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return None
+    if any(part == ".." for part in relative.parts):
+        return None
+
+    return root, path
+
+
+def _ensure_cache_parent(root: Path, path: Path, *, create: bool) -> bool:
+    try:
+        relative_parent = path.parent.relative_to(root)
+    except ValueError:
+        return False
+
+    current = root
+    for part in relative_parent.parts:
+        current = current / part
+        if not _ensure_cache_dir(root, current, create=create):
+            return False
+    return True
+
+
+def _ensure_cache_dir(root: Path, current: Path, *, create: bool) -> bool:
+    try:
+        if current.is_symlink():
+            return False
+        if current.exists():
+            current.resolve(strict=True).relative_to(root)
+            return current.is_dir()
+        if not create:
+            return False
+        current.mkdir(mode=0o700)  # skylos: ignore[SKY-D215] bounded project-local cache directory
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _is_regular_cache_file(path: Path) -> bool:
+    try:
+        if path.is_symlink():
+            return False
+        if path.exists():
+            path.resolve(strict=True).relative_to(path.parent.resolve(strict=True))
+            return path.is_file()
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def load_project_json_cache(
+    project_root: str | Path,
+    cache_path: str | Path,
+    *,
+    max_bytes: int = DEFAULT_MAX_JSON_CACHE_BYTES,
+) -> dict[str, Any]:
+    path = _project_cache_path(project_root, cache_path, create=False)
+    if path is None:
+        return {}
+
+    text = read_text_no_symlink(path, max_bytes=max_bytes, encoding="utf-8")
+    if text is None:
+        return {}
+
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_project_json_cache(
+    project_root: str | Path,
+    cache_path: str | Path,
+    payload: dict[str, Any],
+) -> bool:
+    path = _project_cache_path(project_root, cache_path, create=True)
+    if path is None:
+        return False
+
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(temp_path, flags, 0o600)  # skylos: ignore[SKY-D215] guarded project-local cache temp path
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.is_symlink():
+            return False
+        os.replace(temp_path, path)
+        return True
+    except (OSError, TypeError, ValueError):
+        return False
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            if temp_path.exists() and not temp_path.is_symlink():
+                temp_path.unlink()
+        except OSError:
+            pass

--- a/skylos/llm/entry_points.py
+++ b/skylos/llm/entry_points.py
@@ -7,8 +7,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from skylos.core.safe_cache_io import (
+    load_project_json_cache,
+    read_text_no_symlink,
+    save_project_json_cache,
+)
 
 logger = logging.getLogger(__name__)
+MAX_CONFIG_FILE_BYTES = 50_000
 
 
 @dataclass
@@ -121,7 +127,14 @@ def _gather_config_files(project_root: Path) -> dict[str, str]:
         if "*" in pattern:
             for p in project_root.glob(pattern):
                 try:
-                    text = p.read_text(encoding="utf-8", errors="ignore")
+                    text = read_text_no_symlink(
+                        p,
+                        max_bytes=MAX_CONFIG_FILE_BYTES,
+                        encoding="utf-8",
+                        errors="ignore",
+                    )
+                    if text is None:
+                        continue
                     if len(text) > 10_000:
                         text = text[:10_000] + "\n... (truncated)"
                     configs[str(p.relative_to(project_root))] = text
@@ -131,7 +144,14 @@ def _gather_config_files(project_root: Path) -> dict[str, str]:
             p = project_root / pattern
             if p.exists():
                 try:
-                    text = p.read_text(encoding="utf-8", errors="ignore")
+                    text = read_text_no_symlink(
+                        p,
+                        max_bytes=MAX_CONFIG_FILE_BYTES,
+                        encoding="utf-8",
+                        errors="ignore",
+                    )
+                    if text is None:
+                        continue
                     if len(text) > 10_000:
                         text = text[:10_000] + "\n... (truncated)"
                     configs[pattern] = text
@@ -197,8 +217,15 @@ def _build_repo_facts(
     pyproject_path = project_root / "pyproject.toml"
     if pyproject_path.exists():
         try:
-            with pyproject_path.open("rb") as handle:
-                pyproject = tomllib.load(handle)
+            pyproject_text = read_text_no_symlink(
+                pyproject_path,
+                max_bytes=MAX_CONFIG_FILE_BYTES,
+                encoding="utf-8",
+            )
+            if pyproject_text is None:
+                pyproject = {}
+            else:
+                pyproject = tomllib.loads(pyproject_text)
             ini_options = (
                 pyproject.get("tool", {}).get("pytest", {}).get("ini_options", {})
             )
@@ -287,7 +314,7 @@ def discover_entry_points(
     current_hash = (config_files_hash or _config_files_hash)(configs)
     if cache_path.exists():
         try:
-            cached = json.loads(cache_path.read_text())
+            cached = load_project_json_cache(project_root, cache_path)
             if cached.get("hash") == current_hash:
                 return [
                     EntryPoint(
@@ -354,12 +381,9 @@ def discover_entry_points(
                     )
 
         try:
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            cache_path.write_text(
-                json.dumps(
-                    {"hash": current_hash, "entry_points": all_discovered}, indent=2
-                )
-            )
+            payload = {"hash": current_hash, "entry_points": all_discovered}
+            if not save_project_json_cache(project_root, cache_path, payload):
+                raise OSError("unsafe entry point cache path")
         except OSError as exc:
             logger.debug("Failed to write entry point cache %s: %s", cache_path, exc)
 

--- a/skylos/llm/executor.py
+++ b/skylos/llm/executor.py
@@ -10,6 +10,13 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from skylos.core.safe_cache_io import (
+    read_text_no_symlink,
+    write_existing_text_no_symlink,
+)
+
+MAX_REMEDIATION_FILE_BYTES = 5_000_000
+
 
 @dataclass
 class TestResult:
@@ -63,13 +70,15 @@ class RemediationExecutor:
         p = self._safe_file_path(file_path)
         if p is None:
             return False
-        try:
-            original = p.read_text(encoding="utf-8")
-            self._backups[str(p)] = original
-            p.write_text(fixed_code, encoding="utf-8")
-            return True
-        except OSError:
+        original = read_text_no_symlink(
+            p,
+            max_bytes=MAX_REMEDIATION_FILE_BYTES,
+            encoding="utf-8",
+        )
+        if original is None:
             return False
+        self._backups[str(p)] = original
+        return write_existing_text_no_symlink(p, fixed_code, encoding="utf-8")
 
     def revert_fix(self, file_path: str) -> bool:
         p = self._safe_file_path(file_path)
@@ -79,11 +88,7 @@ class RemediationExecutor:
         original = self._backups.pop(key, None)
         if original is None:
             return False
-        try:
-            p.write_text(original, encoding="utf-8")
-            return True
-        except OSError:
-            return False
+        return write_existing_text_no_symlink(p, original, encoding="utf-8")
 
     def revert_all(self):
         for fp in list(self._backups.keys()):
@@ -209,7 +214,7 @@ class RemediationExecutor:
 
     def create_branch(self, prefix: str = "skylos/fix") -> str:
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        short = hashlib.sha1(ts.encode()).hexdigest()[:6]
+        short = hashlib.sha256(ts.encode()).hexdigest()[:6]
         branch = f"{prefix}-{ts[:8]}-{short}"
         subprocess.run(
             ["git", "checkout", "-b", branch],

--- a/skylos/llm/security_taskflow.py
+++ b/skylos/llm/security_taskflow.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from skylos.core.safe_cache_io import read_text_no_symlink, save_project_json_cache
+
 from .repo_activation import FileActivation, build_repo_activation_index
 from .schemas import AnalysisResult
 from .security_verifier import (
@@ -41,6 +43,7 @@ REVIEWED_CANDIDATES_KEY = "reviewed_candidates"
 DEFAULT_CANDIDATE_STATE = "pending_review"
 HYPOTHESIS_EVIDENCE = "hypothesis"
 MAX_SECURITY_FACTS = 6
+MAX_SECURITY_FACT_SOURCE_BYTES = 1_000_000
 FLASK_FRAMEWORK = "flask"
 FASTAPI_FRAMEWORK = "fastapi"
 DJANGO_FRAMEWORK = "django"
@@ -408,9 +411,12 @@ def _names_from_tree(tree: ast.AST) -> tuple[str | None, set[str], set[str], set
 
 
 def _extract_security_file_facts(file_path: Path) -> SecurityFileFacts:
-    try:
-        source = file_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    source = read_text_no_symlink(
+        file_path,
+        max_bytes=MAX_SECURITY_FACT_SOURCE_BYTES,
+        encoding="utf-8",
+    )
+    if source is None:
         return SecurityFileFacts()
 
     try:
@@ -725,12 +731,21 @@ def _review_result_payload(
     }
 
 
-def _write_json_payload(file_path: Path, payload: dict[str, Any]) -> None:
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+def _artifact_project_root(artifact_dir: Path) -> Path | None:
+    if artifact_dir.parent.name != RUNS_DIRNAME:
+        return None
+    if artifact_dir.parent.parent.name != SKYLOS_DIRNAME:
+        return None
+    return artifact_dir.parent.parent.parent
+
+
+def _write_json_payload(
+    project_root: Path,
+    file_path: Path,
+    payload: dict[str, Any],
+) -> None:
+    if not save_project_json_cache(project_root, file_path, payload):
+        raise OSError("unsafe artifact path")
 
 
 def _repo_map_payload(run: SecurityTaskflowRun) -> dict[str, Any]:
@@ -812,6 +827,10 @@ def _record_artifact_error(
 
 def _write_run_artifacts(run: SecurityTaskflowRun) -> None:
     artifact_dir = Path(run.artifacts_dir)
+    project_root = _artifact_project_root(artifact_dir)
+    if project_root is None:
+        _record_artifact_error(run, str(artifact_dir), OSError("unsafe artifact path"))
+        return
     payloads = (
         (REPO_MAP_FILENAME, _repo_map_payload(run)),
         (THREAT_TRACES_FILENAME, _threat_traces_payload(run)),
@@ -821,7 +840,7 @@ def _write_run_artifacts(run: SecurityTaskflowRun) -> None:
     )
     for filename, payload in payloads:
         try:
-            _write_json_payload(artifact_dir / filename, payload)
+            _write_json_payload(project_root, artifact_dir / filename, payload)
         except OSError as exc:
             _record_artifact_error(run, filename, exc)
 

--- a/skylos/rules/config/cicd/github_actions.py
+++ b/skylos/rules/config/cicd/github_actions.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from skylos.core.safe_cache_io import read_text_no_symlink
 from skylos.rules.config.findings import config_finding
 
 try:
@@ -259,9 +260,10 @@ def _load_yaml(path: Path) -> dict[str, Any] | None:
     if yaml is None:
         return None
     try:
-        if path.stat().st_size > MAX_YAML_BYTES:
+        text = read_text_no_symlink(path, max_bytes=MAX_YAML_BYTES, encoding="utf-8")
+        if text is None:
             return None
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        raw = yaml.safe_load(text)
     except Exception:
         return None
     if not isinstance(raw, dict):
@@ -1900,10 +1902,8 @@ def scan_github_actions_file(
     if data is None:
         return []
 
-    try:
-        lines = file_path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        lines = []
+    text = read_text_no_symlink(file_path, max_bytes=MAX_YAML_BYTES, encoding="utf-8")
+    lines = text.splitlines() if text is not None else []
 
     ignore = ignore or set()
     findings: list[dict[str, Any]] = []

--- a/skylos/rules/config/cicd/gitlab_ci.py
+++ b/skylos/rules/config/cicd/gitlab_ci.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from skylos.core.safe_cache_io import read_text_no_symlink
 from skylos.rules.config.findings import config_finding
 
 try:
@@ -28,6 +29,9 @@ SKIP_DIR_NAMES = {
 }
 
 GITLAB_CI_FILENAMES = {".gitlab-ci.yml"}
+MAX_YAML_BYTES = 1_000_000
+MAX_YAML_GRAPH_DEPTH = 100
+MAX_YAML_GRAPH_NODES = 50_000
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 SECRET_VARIABLE_RE = re.compile(
     r"(?:^|_)(?:SECRET|TOKEN|PASSWORD|PASS|API_KEY|PRIVATE_KEY|ACCESS_KEY|"
@@ -190,10 +194,78 @@ def _load_yaml(path: Path) -> dict[str, Any] | None:
     if yaml is None:
         return None
     try:
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        text = read_text_no_symlink(path, max_bytes=MAX_YAML_BYTES, encoding="utf-8")
+        if text is None:
+            return None
+        raw = yaml.safe_load(text)
     except Exception:
         return None
-    return raw if isinstance(raw, dict) else None
+    if not isinstance(raw, dict):
+        return None
+    if not _yaml_graph_is_safe(raw):
+        return None
+    return raw
+
+
+def _yaml_graph_is_safe(value: Any) -> bool:
+    active: set[int] = set()
+    visited: set[int] = set()
+    nodes_seen = 0
+    stack: list[tuple[Any, int, bool]] = [(value, 0, False)]
+
+    while stack:
+        current, depth, leaving = stack.pop()
+        if depth > MAX_YAML_GRAPH_DEPTH:
+            return False
+
+        children = _yaml_graph_children(current)
+        if children is None:
+            nodes_seen += 1
+            if nodes_seen > MAX_YAML_GRAPH_NODES:
+                return False
+            continue
+
+        state = _yaml_graph_visit_state(current, leaving, active, visited)
+        if state == "cycle":
+            return False
+        if state != "enter":
+            continue
+
+        nodes_seen += 1
+        if nodes_seen > MAX_YAML_GRAPH_NODES:
+            return False
+        stack.append((current, depth, True))
+        for child in reversed(children):
+            stack.append((child, depth + 1, False))
+
+    return True
+
+
+def _yaml_graph_children(value: Any) -> tuple[Any, ...] | None:
+    if isinstance(value, dict):
+        return tuple(value.values())
+    if isinstance(value, list):
+        return tuple(value)
+    return None
+
+
+def _yaml_graph_visit_state(
+    value: Any,
+    leaving: bool,
+    active: set[int],
+    visited: set[int],
+) -> str:
+    value_id = id(value)
+    if leaving:
+        active.discard(value_id)
+        visited.add(value_id)
+        return "leave"
+    if value_id in active:
+        return "cycle"
+    if value_id in visited:
+        return "visited"
+    active.add(value_id)
+    return "enter"
 
 
 def _line_for_contains(lines: list[str], needle: str, *, start: int = 1) -> int:
@@ -912,10 +984,8 @@ def scan_gitlab_ci_file(
     if data is None:
         return []
 
-    try:
-        lines = file_path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        lines = []
+    text = read_text_no_symlink(file_path, max_bytes=MAX_YAML_BYTES, encoding="utf-8")
+    lines = text.splitlines() if text is not None else []
 
     ignore = ignore or set()
     findings: list[dict[str, Any]] = []

--- a/skylos/rules/danger/danger_hallucination/dependency_hallucination.py
+++ b/skylos/rules/danger/danger_hallucination/dependency_hallucination.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
@@ -9,6 +8,12 @@ import sys
 import urllib.request
 import urllib.error
 from pathlib import Path
+
+from skylos.core.safe_cache_io import (
+    load_project_json_cache,
+    read_text_no_symlink,
+    save_project_json_cache,
+)
 
 # ---------------------------------------------------------------------------
 # The mapping file uses the pipreqs format: "import_name:dist_name" per line.
@@ -20,6 +25,7 @@ from pathlib import Path
 
 _IMPORT_TO_DIST_MAPPING: dict[str, str] | None = None
 _MAPPING_FILENAME = "pipreqs_import_mapping.txt"
+MAX_DEPENDENCY_MANIFEST_BYTES = 5_000_000
 logger = logging.getLogger(__name__)
 
 
@@ -332,10 +338,15 @@ def _collect_local_modules(repo_root):
 def _parse_requirements_txt(path):
     deps = set()
 
-    try:
-        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
-    except OSError:
+    text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if text is None:
         return deps
+    lines = text.splitlines()
 
     for line in lines:
         line = line.strip()
@@ -404,9 +415,13 @@ def _parse_pyproject_toml(path):
     deps = set()
     project_name = None
 
-    try:
-        txt = path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
+    txt = read_text_no_symlink(
+        path,
+        max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if txt is None:
         return deps, project_name
 
     name_match = re.search(r'(?m)^\s*name\s*=\s*["\']([^"\']+)["\']', txt)
@@ -499,9 +514,13 @@ def _parse_setup_py(path):
     deps = set()
     project_name = None
 
-    try:
-        txt = path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
+    txt = read_text_no_symlink(
+        path,
+        max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if txt is None:
         return deps, project_name
 
     name_match = re.search(r"""name\s*=\s*['"]([^'"]+)['"]""", txt)
@@ -649,23 +668,13 @@ def _load_private_allowlist():
     return allow
 
 
-def _load_pypi_cache(cache_path):
-    cache = {}
-    try:
-        if cache_path.exists():
-            txt = cache_path.read_text(encoding="utf-8")
-            cache = json.loads(txt)
-    except (OSError, json.JSONDecodeError, TypeError) as exc:
-        logger.debug("Ignoring invalid PyPI cache %s: %s", cache_path, exc)
-    return cache
+def _load_pypi_cache(repo_root, cache_path):
+    return load_project_json_cache(repo_root, cache_path)
 
 
-def _save_pypi_cache(cache_path, cache):
-    try:
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_text(json.dumps(cache, indent=2), encoding="utf-8")
-    except (OSError, TypeError) as exc:
-        logger.debug("Failed to save PyPI cache %s: %s", cache_path, exc)
+def _save_pypi_cache(repo_root, cache_path, cache):
+    if not save_project_json_cache(repo_root, cache_path, cache):
+        logger.debug("Failed to save PyPI cache %s", cache_path)
 
 
 def _check_pypi_status(package_name, cache):
@@ -739,7 +748,7 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
     import_to_dist = _load_import_to_dist_mapping()
 
     cache_path = repo_root / ".skylos" / "cache" / "pypi_exists.json"
-    pypi_cache = _load_pypi_cache(cache_path)
+    pypi_cache = _load_pypi_cache(repo_root, cache_path)
     cache_modified = False
 
     for file_path in py_files:
@@ -889,6 +898,6 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
                 )
 
     if cache_modified:
-        _save_pypi_cache(cache_path, pypi_cache)
+        _save_pypi_cache(repo_root, cache_path, pypi_cache)
 
     return findings

--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -7,6 +7,12 @@ import time
 import logging
 from pathlib import Path
 
+from skylos.core.safe_cache_io import (
+    load_project_json_cache,
+    read_text_no_symlink,
+    save_project_json_cache,
+)
+
 try:
     import requests as _requests
 except ImportError:
@@ -17,6 +23,7 @@ logger = logging.getLogger("skylos.sca")
 OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
 OSV_BATCH_LIMIT = 1000
 CACHE_TTL_SECONDS = 3600
+MAX_MANIFEST_BYTES = 10_000_000
 
 ECOSYSTEM_PYPI = "PyPI"
 ECOSYSTEM_NPM = "npm"
@@ -38,10 +45,15 @@ def _extract_pinned_version(spec: str) -> str | None:
 
 def parse_requirements_txt(path: Path) -> list[dict]:
     deps = []
-    try:
-        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
-    except Exception:
+    text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if text is None:
         return deps
+    lines = text.splitlines()
 
     for lineno, line in enumerate(lines, 1):
         raw = line.strip()
@@ -76,9 +88,13 @@ def parse_requirements_txt(path: Path) -> list[dict]:
 
 def parse_pyproject_toml(path: Path) -> list[dict]:
     deps = []
-    try:
-        txt = path.read_text(encoding="utf-8", errors="ignore")
-    except Exception:
+    txt = read_text_no_symlink(
+        path,
+        max_bytes=MAX_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if txt is None:
         return deps
 
     dep_block = _extract_toml_array(txt, "dependencies")
@@ -144,12 +160,18 @@ def parse_pyproject_toml(path: Path) -> list[dict]:
 
 def parse_package_json(path: Path) -> list[dict]:
     deps = []
+    txt = read_text_no_symlink(
+        path,
+        max_bytes=MAX_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if txt is None:
+        return deps
     try:
-        data = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+        data = json.loads(txt)
     except Exception:
         return deps
-
-    txt = path.read_text(encoding="utf-8", errors="ignore")
 
     for section in ("dependencies", "devDependencies"):
         pkg_deps = data.get(section, {})
@@ -181,10 +203,15 @@ def parse_package_json(path: Path) -> list[dict]:
 
 def parse_go_mod(path: Path) -> list[dict]:
     deps = []
-    try:
-        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
-    except Exception:
+    text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if text is None:
         return deps
+    lines = text.splitlines()
 
     in_require = False
     for lineno, line in enumerate(lines, 1):
@@ -323,24 +350,17 @@ def _get_affected_range(vuln: dict) -> str:
     return "; ".join(parts) if parts else "unknown"
 
 
-def _load_cache(cache_path: Path) -> dict:
-    try:
-        if cache_path.exists():
-            data = json.loads(cache_path.read_text(encoding="utf-8"))
-            if data.get("_ts", 0) + CACHE_TTL_SECONDS > time.time():
-                return data
-    except Exception:
-        pass
+def _load_cache(root: Path, cache_path: Path) -> dict:
+    data = load_project_json_cache(root, cache_path)
+    if data.get("_ts", 0) + CACHE_TTL_SECONDS > time.time():
+        return data
     return {}
 
 
-def _save_cache(cache_path: Path, cache: dict):
-    try:
-        cache["_ts"] = time.time()
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_text(json.dumps(cache, indent=2), encoding="utf-8")
-    except Exception:
-        pass
+def _save_cache(root: Path, cache_path: Path, cache: dict):
+    cache["_ts"] = time.time()
+    if not save_project_json_cache(root, cache_path, cache):
+        logger.debug("Failed to save OSV cache %s", cache_path)
 
 
 def scan_dependencies(root: Path) -> list[dict]:
@@ -402,7 +422,7 @@ def scan_dependencies(root: Path) -> list[dict]:
             unique_deps.append(dep)
 
     cache_path = root / ".skylos" / "cache" / "osv_cache.json"
-    cache = _load_cache(cache_path)
+    cache = _load_cache(root, cache_path)
 
     findings = []
     to_query = []
@@ -419,7 +439,7 @@ def scan_dependencies(root: Path) -> list[dict]:
 
     if to_query:
         findings.extend(_query_osv_batch(to_query, cache))
-        _save_cache(cache_path, cache)
+        _save_cache(root, cache_path, cache)
 
     return findings
 

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -2280,7 +2280,7 @@ class Visitor(ast.NodeVisitor):
 
     def _apply_string_patterns(self) -> None:
         for pattern in self._string_ref_patterns:
-            regex_pattern = pattern.replace("*", ".*")
+            regex_pattern = re.escape(pattern).replace(r"\*", ".*")
             try:
                 regex = re.compile(f"^{regex_pattern}$")
             except re.error:

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -275,6 +275,20 @@ jobs:
     assert scan_github_actions(tmp_path) == []
 
 
+def test_github_actions_scanner_rejects_symlinked_workflow(tmp_path):
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    target = tmp_path / "outside-workflow.yml"
+    target.write_text("name: outside\non: push\n", encoding="utf-8")
+    link = workflows / "ci.yml"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        return
+
+    assert scan_github_actions(tmp_path) == []
+
+
 def test_github_actions_scanner_handles_shared_yaml_alias_once(tmp_path):
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)

--- a/test/test_gitlab_ci_security.py
+++ b/test/test_gitlab_ci_security.py
@@ -134,6 +134,18 @@ def test_gitlab_ci_changed_files_stay_under_scan_root(tmp_path):
     assert findings == []
 
 
+def test_gitlab_ci_scanner_rejects_symlinked_workflow(tmp_path):
+    target = tmp_path / "outside-gitlab-ci.yml"
+    target.write_text("image: python:latest\n", encoding="utf-8")
+    link = tmp_path / ".gitlab-ci.yml"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        return
+
+    assert scan_gitlab_ci(tmp_path) == []
+
+
 def test_config_scanner_routes_single_gitlab_ci_file(tmp_path):
     gitlab_ci = tmp_path / ".gitlab-ci.yml"
     _write_risky_gitlab_ci(gitlab_ci)
@@ -173,6 +185,45 @@ deploy:
     assert scan_config_files(tmp_path / "Jenkinsfile") == []
     assert scan_config_files(tmp_path / "Dockerfile") == []
     assert scan_config_files(tmp_path / "main.tf") == []
+
+
+def test_gitlab_ci_scanner_rejects_recursive_yaml_alias(tmp_path):
+    gitlab_ci = tmp_path / ".gitlab-ci.yml"
+    gitlab_ci.write_text(
+        """
+deploy: &deploy
+  stage: deploy
+  script:
+    - echo ok
+  self: *deploy
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    assert scan_gitlab_ci(tmp_path) == []
+
+
+def test_gitlab_ci_scanner_handles_shared_yaml_alias_once(tmp_path):
+    gitlab_ci = tmp_path / ".gitlab-ci.yml"
+    gitlab_ci.write_text(
+        """
+.secret-script: &secret-script
+  - echo "$DEPLOY_TOKEN"
+
+variables:
+  DEPLOY_TOKEN: plaintext-token-123
+
+deploy:
+  stage: deploy
+  script: *secret-script
+  after_script: *secret-script
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_gitlab_ci(tmp_path)
+
+    assert "SKY-D316" in _rule_ids(findings)
 
 
 def test_gitlab_ci_scanner_detects_ambiguous_secret_token(tmp_path):

--- a/test/test_hallucination_dependency.py
+++ b/test/test_hallucination_dependency.py
@@ -60,6 +60,18 @@ def test_parse_requirements_txt_basic(tmp_path):
     assert "numpy" in deps
 
 
+def test_parse_requirements_txt_rejects_symlink(tmp_path):
+    target = tmp_path / "outside-requirements.txt"
+    target.write_text("notarealpackage==1.0.0\n", encoding="utf-8")
+    link = tmp_path / "requirements.txt"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        return
+
+    assert dep._parse_requirements_txt(link) == set()
+
+
 def test_parse_pyproject_toml_dependencies_array(tmp_path):
     py = tmp_path / "pyproject.toml"
     py.write_text(
@@ -278,6 +290,47 @@ def test_scan_cache_is_written_when_modified(monkeypatch, tmp_path):
     data = json.loads(cache_path.read_text(encoding="utf-8"))
     assert "somepkg" in data
     assert data["somepkg"] == "exists"
+
+
+def test_scan_rejects_symlinked_pypi_cache_file(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\ndependencies = []\n',
+        encoding="utf-8",
+    )
+
+    f = _write_py(repo / "x.py", "import somepkg\n")
+
+    monkeypatch.setattr(dep, "_get_stdlib_modules", lambda: set())
+    monkeypatch.setattr(dep, "_collect_local_modules", lambda root: set())
+    monkeypatch.setattr(dep, "_collect_declared_deps", lambda root: set())
+    monkeypatch.setattr(dep, "_load_private_allowlist", lambda: set())
+    monkeypatch.setattr(dep, "_build_installed_module_mapping", lambda: {})
+
+    def fake_check(name, cache):
+        cache[dep._normalize_name(name)] = "exists"
+        return "exists"
+
+    monkeypatch.setattr(dep, "_check_pypi_status", fake_check)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "pypi_exists.json"
+    target.write_text('{"somepkg": "missing"}', encoding="utf-8")
+    cache_path = repo / ".skylos" / "cache" / "pypi_exists.json"
+    cache_path.parent.mkdir(parents=True)
+    try:
+        cache_path.symlink_to(target)
+    except OSError:
+        import pytest
+
+        pytest.skip("filesystem does not allow symlink creation")
+
+    _ = dep.scan_python_dependency_hallucinations(repo, [f])
+
+    assert target.read_text(encoding="utf-8") == '{"somepkg": "missing"}'
+    assert cache_path.is_symlink()
 
 
 def test_scan_does_not_write_cache_when_not_modified(monkeypatch, tmp_path):

--- a/test/test_sca_cache.py
+++ b/test/test_sca_cache.py
@@ -1,0 +1,48 @@
+from skylos.rules.sca import vulnerability_scanner as sca
+
+
+def test_parse_requirements_txt_rejects_symlink(tmp_path):
+    target = tmp_path / "outside-requirements.txt"
+    target.write_text("requests==2.31.0\n", encoding="utf-8")
+    link = tmp_path / "requirements.txt"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        return
+
+    assert sca.parse_requirements_txt(link) == []
+
+
+def test_scan_dependencies_rejects_symlinked_osv_cache_file(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("requests==2.31.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(sca, "_requests", object())
+
+    def fake_query(deps, cache):
+        cache["PyPI:requests:2.31.0"] = []
+        return []
+
+    monkeypatch.setattr(sca, "_query_osv_batch", fake_query)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "osv_cache.json"
+    target.write_text('{"_ts": 9999999999, "PyPI:requests:2.31.0": []}', encoding="utf-8")
+    cache_path = repo / ".skylos" / "cache" / "osv_cache.json"
+    cache_path.parent.mkdir(parents=True)
+    try:
+        cache_path.symlink_to(target)
+    except OSError:
+        import pytest
+
+        pytest.skip("filesystem does not allow symlink creation")
+
+    findings = sca.scan_dependencies(repo)
+
+    assert findings == []
+    assert target.read_text(encoding="utf-8") == (
+        '{"_ts": 9999999999, "PyPI:requests:2.31.0": []}'
+    )
+    assert cache_path.is_symlink()

--- a/test/test_security_taskflow.py
+++ b/test/test_security_taskflow.py
@@ -19,6 +19,7 @@ from skylos.llm.security_taskflow import (
     REPO_MAP_STAGE,
     VERIFY_STAGE,
     DEFAULT_CANDIDATE_STATE,
+    _extract_security_file_facts,
     run_security_taskflow,
 )
 from skylos.llm.security_verifier import annotate_security_finding
@@ -469,6 +470,51 @@ def test_run_security_taskflow_writes_run_artifacts(tmp_path):
     assert summary_payload["final_finding_count"] == 1
     assert summary_payload["stages"][-1]["name"] == FINALIZE_STAGE
     assert summary_payload["artifact_write_error"] is None
+
+
+def test_run_security_taskflow_rejects_symlinked_artifact_dir(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("print('hi')\n", encoding="utf-8")
+    outside = tmp_path / "outside-artifacts"
+    outside.mkdir()
+    try:
+        (tmp_path / ".skylos").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        return
+
+    analyzer = _FakeAnalyzer(AnalysisResult(findings=[], files_analyzed=1))
+    with patch(
+        "skylos.llm.security_taskflow._generate_run_id",
+        return_value="run-test-123",
+    ):
+        run = run_security_taskflow(
+            path=tmp_path,
+            files=[app],
+            analyzer=analyzer,
+            model="gpt-4.1",
+            api_key="k",
+        )
+
+    assert run.artifact_write_error is not None
+    assert not (outside / "runs").exists()
+
+
+def test_extract_security_file_facts_rejects_symlink(tmp_path):
+    target = tmp_path / "outside.py"
+    target.write_text(
+        "from flask import request\nurl = request.args.get('next')\n",
+        encoding="utf-8",
+    )
+    link = tmp_path / "app.py"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        return
+
+    facts = _extract_security_file_facts(link)
+
+    assert facts.framework is None
+    assert facts.sources == ()
 
 
 def test_run_security_taskflow_challenges_uncertain_findings(tmp_path):

--- a/test/test_trace_cache_cli.py
+++ b/test/test_trace_cache_cli.py
@@ -11,6 +11,7 @@ from skylos.core.result_cache import (
     RUN_CACHE_DIR,
     TRACE_CACHE_DIR,
     build_trace_cache_key,
+    read_trace_payload,
     save_trace_cache,
 )
 from skylos.commands.cache_cmd import run_cache_command
@@ -155,6 +156,39 @@ def test_trace_cache_hit_skips_trace_subprocess_and_writes_trace(tmp_path):
     assert (
         json.loads((tmp_path / ".skylos_trace").read_text(encoding="utf-8")) == payload
     )
+
+
+def test_read_trace_payload_rejects_symlink(tmp_path):
+    _write_minimal_project(tmp_path)
+    target = tmp_path / "outside-trace.json"
+    target.write_text(json.dumps(_trace_payload(tmp_path)), encoding="utf-8")
+    link = tmp_path / ".skylos_trace"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        return
+
+    assert read_trace_payload(link) is None
+
+
+def test_trace_cache_save_rejects_symlinked_cache_dir(tmp_path):
+    _write_minimal_project(tmp_path)
+    outside = tmp_path / "outside-cache"
+    outside.mkdir()
+    try:
+        (tmp_path / ".skylos").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        return
+
+    saved = save_trace_cache(
+        tmp_path,
+        "abc123",
+        _trace_payload(tmp_path),
+        pytest_returncode=0,
+    )
+
+    assert saved is None
+    assert not (outside / "cache").exists()
 
 
 def test_refresh_cache_runs_subprocess_despite_hit(tmp_path):

--- a/test/test_trace_file_analyzer.py
+++ b/test/test_trace_file_analyzer.py
@@ -85,3 +85,19 @@ def test_analyzer_default_trace_file_preserves_legacy_root_trace(tmp_path):
 
     assert "root_traced" not in names
     assert "alt_traced" in names
+
+
+def test_analyzer_default_trace_file_rejects_symlink(tmp_path):
+    module = _write_project(tmp_path)
+    target = tmp_path / "outside-trace.json"
+    _write_trace(target, module, "root_traced", 1)
+    try:
+        (tmp_path / ".skylos_trace").symlink_to(target)
+    except OSError:
+        return
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    names = _unused_function_names(result)
+
+    assert "root_traced" in names
+    assert "alt_traced" in names

--- a/test/test_verify_orchestrator.py
+++ b/test/test_verify_orchestrator.py
@@ -2483,6 +2483,17 @@ class TestEntryPointCache:
         h2 = _config_files_hash({"a.toml": "v2"})
         assert h1 != h2
 
+    def test_gather_config_files_rejects_symlink(self, tmp_path):
+        target = tmp_path / "outside-pyproject.toml"
+        target.write_text("[project]\nname = 'outside'\n", encoding="utf-8")
+        link = tmp_path / "pyproject.toml"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            return
+
+        assert _gather_config_files(tmp_path) == {}
+
     def test_discover_uses_cache(self, tmp_path):
         configs = {"pyproject.toml": "[project]\nname = 'test'"}
         cache_path = _entry_point_cache_path(tmp_path)
@@ -2508,6 +2519,58 @@ class TestEntryPointCache:
         mock_agent.assert_not_called()
         assert len(results) == 1
         assert results[0].name == "main"
+
+    def test_discover_rejects_symlinked_cache(self, tmp_path):
+        configs = {"pyproject.toml": "[project]\nname = 'test'"}
+        current_hash = _config_files_hash(configs)
+        target = tmp_path / "outside-entry-points.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "hash": current_hash,
+                    "entry_points": [
+                        {"name": "cached", "source": "config", "reason": "entry"}
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        cache_path = _entry_point_cache_path(tmp_path)
+        cache_path.parent.mkdir(parents=True)
+        try:
+            cache_path.symlink_to(target)
+        except OSError:
+            return
+
+        mock_agent = MagicMock(spec=DeadCodeVerifierAgent)
+        with (
+            patch(
+                "skylos.llm.verify_orchestrator._gather_config_files",
+                return_value=configs,
+            ),
+            patch(
+                "skylos.llm.verify_orchestrator._call_llm_with_retry",
+                return_value=json.dumps(
+                    {
+                        "entry_points": [
+                            {
+                                "name": "fresh",
+                                "source": "llm",
+                                "reason": "recomputed",
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ):
+            results = discover_entry_points(mock_agent, tmp_path, [])
+
+        assert len(results) == 1
+        assert results[0].name == "fresh"
+        assert cache_path.is_symlink()
+        assert json.loads(target.read_text(encoding="utf-8"))["entry_points"][0][
+            "name"
+        ] == "cached"
 
     def test_discover_skips_stale_cache(self, tmp_path):
         configs = {"pyproject.toml": "[project]\nname = 'changed'"}

--- a/test/test_visitor.py
+++ b/test/test_visitor.py
@@ -6,6 +6,7 @@ import warnings
 from pathlib import Path
 import tempfile
 
+from skylos.analysis.implicit_refs import ImplicitRefTracker
 import skylos.visitors.base as visitor_mod
 from skylos.visitors.base import Visitor, Definition, PYTHON_BUILTINS, DYNAMIC_PATTERNS
 
@@ -105,6 +106,18 @@ def my_function():
         definition = visitor.defs[0]
         self.assertEqual(definition.type, "function")
         self.assertEqual(definition.simple_name, "my_function")
+
+    def test_string_ref_patterns_escape_regex_metacharacters(self):
+        self.visitor.pattern_tracker = ImplicitRefTracker()
+        self.visitor.defs = [
+            Definition("test_module.handlerXsave", "function", self.temp_file.name, 1)
+        ]
+        self.visitor._string_ref_patterns = ["handler.*"]
+
+        self.visitor._apply_string_patterns()
+
+        self.assertEqual(self.visitor.defs[0].references, 0)
+        self.assertNotIn("handlerXsave", self.visitor.pattern_tracker.known_refs)
 
     def test_async_function(self):
         code = """


### PR DESCRIPTION
## Summary

  - Add guarded project-local text/JSON IO helpers that reject symlinks, enforce regular files, and cap read sizes.
  - Hardened cache/artifact surfaces for PyPI, OSV, trace payloads, entry-point discovery, and security taskflow artifacts.
  - Harden github actions and gitlab CI YAML reads, dependency manifest reads, and LLM remediation file writes.
  - Escape dynamic dead-code string patterns so only `*` acts as a wildcard

  ## Tests

  - `pytest .`