### PR TITLE
fix(cicd): gate dependency vulnerabilities by default

### DIFF
--- a/skylos/cicd/workflow.py
+++ b/skylos/cicd/workflow.py
@@ -10,6 +10,9 @@ console = Console()
 
 ANALYSIS_FLAG_MAP: dict[str, str] = {
     "dead-code": "",
+    "dependency": "--sca",
+    "dependencies": "--sca",
+    "sca": "--sca",
     "security": "--danger",
     "quality": "--quality",
     "secrets": "--secrets",
@@ -67,6 +70,7 @@ def generate_workflow(
     use_claude_security: bool = False,
     use_upload: bool = False,
     use_defend: bool = False,
+    advisory_gate: bool = False,
     scan_path: str = ".",
     skylos_version: str | None = None,
 ) -> str:
@@ -81,7 +85,13 @@ def generate_workflow(
     Called from: skylos/commands/cicd_cmd.py run_cicd_command.
     """
     triggers = triggers or ["pull_request", "push"]
-    analysis_types = analysis_types or ["dead-code", "security", "quality", "secrets"]
+    analysis_types = analysis_types or [
+        "dead-code",
+        "security",
+        "quality",
+        "secrets",
+        "dependency",
+    ]
 
     trigger_block = _build_trigger_block(triggers)
     install_command = _skylos_install_command(skylos_version)
@@ -160,6 +170,7 @@ def generate_workflow(
         ]
     )
     skylos_environment = "\n    environment: skylos-security" if use_llm else ""
+    gate_advisory_flag = " --advisory" if advisory_gate else ""
 
     permissions_block = """permissions:
   contents: read"""
@@ -208,7 +219,7 @@ jobs:
 {llm_step}{defend_step}
       - name: Quality Gate
         if: always()
-        run: skylos cicd gate --input skylos-results.json --summary --advisory
+        run: skylos cicd gate --input skylos-results.json --summary{gate_advisory_flag}
 
       - name: GitHub Annotations
         if: always()

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -149,7 +149,7 @@ def run_cicd_command(
     p_ci_init.add_argument(
         "--analysis",
         nargs="+",
-        default=["dead-code", "security", "quality", "secrets"],
+        default=["dead-code", "security", "quality", "secrets", "dependency"],
         help="Analysis types to run",
     )
     p_ci_init.add_argument("--no-baseline", action="store_true")
@@ -172,6 +172,11 @@ def run_cicd_command(
         "--defend",
         action="store_true",
         help="Include AI Defense check step (skylos defend)",
+    )
+    p_ci_init.add_argument(
+        "--advisory-gate",
+        action="store_true",
+        help="Report gate failures but let the generated CI job pass.",
     )
     p_ci_init.add_argument(
         "--scan-path",
@@ -264,6 +269,7 @@ def run_cicd_command(
                 use_claude_security=cicd_args.claude_security,
                 use_upload=cicd_args.upload,
                 use_defend=cicd_args.defend,
+                advisory_gate=cicd_args.advisory_gate,
                 scan_path=cicd_args.scan_path,
             )
         except ValueError as e:

--- a/skylos/core/gatekeeper.py
+++ b/skylos/core/gatekeeper.py
@@ -48,6 +48,7 @@ BASELINE_GATE_CONFIG = {
     "max_security": 10,
     "max_quality": 10,
     "max_secrets": 0,
+    "max_dependency_vulnerabilities": 0,
     "max_dead_code": None,
 }
 ADVISORY_QUALITY_RULE_IDS = {"SKY-Q802", "SKY-Q803"}
@@ -358,9 +359,15 @@ def _check_agent_gate(findings_lists, agent_file_set, agent_cfg, reasons):
     return agent_passed
 
 
-def _check_strict_gate(*, total_findings, danger, quality, secrets):
+def _check_strict_gate(*, total_findings, danger, quality, secrets, dependencies):
     gate_quality = _gate_quality_findings(quality)
-    total_issues = total_findings + len(danger) + len(gate_quality) + len(secrets)
+    total_issues = (
+        total_findings
+        + len(danger)
+        + len(gate_quality)
+        + len(secrets)
+        + len(dependencies)
+    )
     if total_issues > 0:
         return False, [f"Strict mode: {total_issues} issue(s) found"]
     return True, []
@@ -380,6 +387,8 @@ def _apply_gate_thresholds(
     max_quality,
     secrets_count,
     max_secrets,
+    dependency_count,
+    max_dependency_vulnerabilities,
     dead_code_count,
     max_dead_code,
 ):
@@ -430,6 +439,14 @@ def _apply_gate_thresholds(
 
     if not _append_threshold_reason(
         reasons,
+        count=dependency_count,
+        limit=max_dependency_vulnerabilities,
+        message_template="{count} dependency vulnerabilities (max: {limit})",
+    ):
+        passed = False
+
+    if not _append_threshold_reason(
+        reasons,
         count=dead_code_count,
         limit=max_dead_code,
         message_template="{count} dead code issue(s) (max: {limit})",
@@ -470,6 +487,7 @@ def check_gate(results, config, strict=False, provenance=None):
     quality = results.get("quality", []) or []
     gate_quality = _gate_quality_findings(quality)
     secrets = results.get("secrets", []) or []
+    dependencies = results.get("dependency_vulnerabilities", []) or []
     gate_config = _effective_gate_config(config)
 
     if strict:
@@ -478,6 +496,7 @@ def check_gate(results, config, strict=False, provenance=None):
             danger=danger,
             quality=gate_quality,
             secrets=secrets,
+            dependencies=dependencies,
         )
 
     critical_issues, high_issues = _split_danger_by_severity(danger)
@@ -494,6 +513,11 @@ def check_gate(results, config, strict=False, provenance=None):
         max_quality=gate_config.get("max_quality", 10),
         secrets_count=len(secrets),
         max_secrets=gate_config.get("max_secrets", None),
+        dependency_count=len(dependencies),
+        max_dependency_vulnerabilities=gate_config.get(
+            "max_dependency_vulnerabilities",
+            0,
+        ),
         dead_code_count=total_findings,
         max_dead_code=gate_config.get("max_dead_code", None),
     )
@@ -521,6 +545,7 @@ def _build_summary_rows(
     security_count,
     quality_count,
     secrets_count,
+    dependency_count,
     dead_code_count,
 ):
     return [
@@ -529,6 +554,10 @@ def _build_summary_rows(
         f"| Security (total) | {security_count} | {'✅' if security_count <= 10 else '⚠️'} |",
         f"| Quality | {quality_count} | {'✅' if quality_count <= 10 else '⚠️'} |",
         f"| Secrets | {secrets_count} | {'✅' if secrets_count == 0 else '❌'} |",
+        (
+            f"| Dependency vulnerabilities | {dependency_count} | "
+            f"{'✅' if dependency_count == 0 else '❌'} |"
+        ),
         f"| Dead Code | {dead_code_count} | ℹ️ |",
     ]
 
@@ -547,6 +576,7 @@ def build_summary_markdown(results, passed, reasons, *, advisory=False):
     danger = results.get("danger", []) or []
     quality = results.get("quality", []) or []
     secrets = results.get("secrets", []) or []
+    dependencies = results.get("dependency_vulnerabilities", []) or []
     critical_issues, high_issues = _split_danger_by_severity(danger)
     critical_count = len(critical_issues)
     high_count = len(high_issues)
@@ -570,6 +600,7 @@ def build_summary_markdown(results, passed, reasons, *, advisory=False):
             security_count=len(danger),
             quality_count=len(quality),
             secrets_count=len(secrets),
+            dependency_count=len(dependencies),
             dead_code_count=dead_code_count,
         ),
         "",

--- a/test/test_cicd_gate.py
+++ b/test/test_cicd_gate.py
@@ -21,6 +21,7 @@ def clean_results():
         "danger": [],
         "quality": [],
         "secrets": [],
+        "dependency_vulnerabilities": [],
     }
 
 
@@ -43,6 +44,7 @@ def failing_results():
         ],
         "quality": [],
         "secrets": [],
+        "dependency_vulnerabilities": [],
     }
 
 
@@ -56,6 +58,17 @@ def test_gate_fails_on_critical(failing_results):
     passed, reasons = check_gate(failing_results, {})
     assert passed is False
     assert len(reasons) > 0
+
+
+def test_gate_fails_on_dependency_vulnerability(clean_results):
+    clean_results["dependency_vulnerabilities"] = [
+        {"rule_id": "SKY-SCA-GHSA-test", "severity": "HIGH"}
+    ]
+
+    passed, reasons = check_gate(clean_results, {})
+
+    assert passed is False
+    assert "1 dependency vulnerabilities (max: 0)" in reasons
 
 
 def test_gate_strict_mode(clean_results):
@@ -146,6 +159,7 @@ def test_summary_markdown_mixed_output_is_stable():
         ],
         "quality": [{"rule_id": f"Q{i}"} for i in range(11)],
         "secrets": [{"rule_id": "S1"}],
+        "dependency_vulnerabilities": [{"rule_id": "SKY-SCA-GHSA-test"}],
     }
 
     md = build_summary_markdown(
@@ -164,6 +178,7 @@ def test_summary_markdown_mixed_output_is_stable():
         "| Security (total) | 11 | ⚠️ |\n"
         "| Quality | 11 | ⚠️ |\n"
         "| Secrets | 1 | ❌ |\n"
+        "| Dependency vulnerabilities | 1 | ❌ |\n"
         "| Dead Code | 3 | ℹ️ |\n"
         "\n"
         "**Result: ❌ FAILED**\n"

--- a/test/test_cicd_workflow.py
+++ b/test/test_cicd_workflow.py
@@ -27,9 +27,17 @@ def test_workflow_has_all_steps():
     assert "GitHub Annotations" in step_names
     assert "PR Review Comments" in step_names
     quality_gate = next(s for s in steps if s.get("name") == "Quality Gate")
-    assert "--advisory" in quality_gate["run"]
+    assert "--advisory" not in quality_gate["run"]
     pr_review = next(s for s in steps if s.get("name") == "PR Review Comments")
     assert "--evidence-cards" in pr_review["run"]
+
+
+def test_workflow_can_generate_advisory_gate():
+    content = generate_workflow(advisory_gate=True)
+    parsed = yaml.safe_load(content)
+    steps = parsed["jobs"]["skylos"]["steps"]
+    quality_gate = next(s for s in steps if s.get("name") == "Quality Gate")
+    assert "--advisory" in quality_gate["run"]
 
 
 def test_workflow_triggers():
@@ -49,6 +57,12 @@ def test_workflow_analysis_flags():
     assert "--danger" in content
     assert "--quality" in content
     assert "--secrets" not in content
+    assert "--sca" not in content
+
+
+def test_workflow_includes_dependency_scan_by_default():
+    content = generate_workflow()
+    assert "--sca" in content
 
 
 def test_workflow_uses_baseline_by_default():


### PR DESCRIPTION
## Summary

  Makes dependency vulnerability findings part of the default Skylos CI quality gate. This PR makes dependency vulnerability failures explicit and blocking by default.

  - Adds `dependency_vulnerabilities` to the default gate thresholds.
  - Sets the default allowed dependency vulnerabilities to `0`.
  - Adds dependency vulnerability counts to gate summaries.
  - Updates generated CI workflow defaults to include dependency/SCA analysis.
  - Updates `skylos cicd init --analysis` defaults to include dependency scanning.
  - Makes advisory gating opt-in via `--advisory-gate` instead of enabling advisory behavior by
  default.

  ## Tests

  - `pytest test/test_cicd_gate.py test/test_cicd_workflow.py test/test_gatekeeper.py`