### PR TITLE
feat(verify): detect API and dependency hallucinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Use Skylos when you want one command to check a repo or pull request for:
 - secrets and dependency CVEs
 - CI/CD and edge-device deployment misconfigurations
 - quality regressions such as complexity, duplicate branches, and deep nesting
-- common AI-generated code mistakes, including missing guards and fake helpers
+- common AI-generated code mistakes, including missing guards, fake helpers,
+  invented package APIs, and impossible dependency versions
 - LLM app risks such as unsafe tool use and missing output validation
 
 ## Start In 60 Seconds
@@ -113,7 +114,7 @@ Need more commands? Read the [CLI Reference](https://docs.skylos.dev/cli-referen
 | CI/CD workflows | GitHub Actions and GitLab CI dangerous triggers, unpinned actions/includes, broad tokens, OIDC misuse, cache poisoning, mutable images | reduces CI/CD supply-chain risk before release jobs run |
 | Edge deployment config | Docker Compose privileged device access, host networking, systemd root services, broad capabilities, missing sandboxing | catches repo-controlled settings that turn app bugs into device compromise |
 | Quality regressions | complexity, deep nesting, duplicate branches, long functions, inconsistent returns | keeps AI-assisted refactors from adding brittle code |
-| AI code mistakes | phantom security calls, missing decorators, unfinished stubs, disabled controls, network calls without timeouts | catches common hallucinated or incomplete code paths |
+| AI code mistakes | phantom security calls, missing decorators, unfinished stubs, disabled controls, real packages called with invented APIs, impossible npm/Go versions | catches common hallucinated or incomplete code paths before they reach review |
 | LLM app risks | unsafe tool use, prompt injection exposure, missing output validation, missing rate limits | helps teams ship AI features with guardrails |
 
 See the full [Rules Reference](https://docs.skylos.dev/rules-reference).
@@ -130,7 +131,8 @@ repo and PR checker that puts several common review checks behind one CLI.
 - **Local-first operation:** core static analysis does not require cloud upload
   or LLM calls.
 - **AI-assisted change review:** checks for removed validation, auth, logging,
-  CSRF, rate limiting, timeouts, and other guards in generated or edited code.
+  CSRF, rate limiting, timeouts, real-package API hallucinations, and other
+  guardrails in generated or edited code.
 - **Project-specific rules:** add local YAML rules and extend prompt, credential,
   sensitive-file, and timeout dictionaries from config.
 - **One command surface:** dead code, security, secrets, dependency, quality,

--- a/dictionary.md
+++ b/dictionary.md
@@ -98,6 +98,8 @@ Rule IDs are unified across languages where the same vulnerability exists.
 | D220 | CRITICAL | SQL injection in added code / diff validation | MCP code-change validator | CWE-89 / A03 |
 | D222 | MEDIUM | Dependency hallucination | Python | AI supply-chain |
 | D223 | MEDIUM | Undeclared third-party dependency | Python | supply-chain |
+| D224 | HIGH | API signature hallucination | Python | AI-code runtime failure |
+| D225 | HIGH | Dependency version hallucination | npm, Go | AI supply-chain |
 | D226 | CRITICAL | XSS: unsafe DOM or HTML rendering | Python, TS/JS, Java, audit | CWE-79 / A03 |
 | D227 | HIGH | XSS: unsafe template rendering | Python | CWE-79 / A03 |
 | D228 | HIGH | XSS: unescaped HTML output | Python | CWE-79 / A03 |

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -119,6 +119,39 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger("Skylos")
+PYTHON_SIGNATURE_SUFFIXES = (".py", ".pyi", ".pyw")
+
+
+def _python_signature_files(files):
+    py_files = []
+    for file_path in files:
+        if str(file_path).endswith(PYTHON_SIGNATURE_SUFFIXES):
+            py_files.append(file_path)
+    return py_files
+
+
+def _extend_unsuppressed_danger_findings(
+    findings,
+    *,
+    project_ignore,
+    per_file_ignore_lines,
+    all_dangers,
+    all_suppressed,
+):
+    for finding in findings:
+        if finding.get("rule_id") in project_ignore:
+            continue
+
+        file_key = str(finding.get("file", ""))
+        f_ignore = per_file_ignore_lines.get(file_key, set())
+        if finding.get("line") in f_ignore:
+            suppressed = dict(finding)
+            suppressed["category"] = "danger"
+            suppressed["reason"] = "inline ignore comment"
+            all_suppressed.append(suppressed)
+            continue
+
+        all_dangers.append(finding)
 
 _SECRET_CONFIG_SUFFIXES = {
     ".yaml",
@@ -2692,6 +2725,47 @@ class Skylos:
                             unsuppressed_dep_findings.append(finding)
                         dep_findings = unsuppressed_dep_findings
                         all_dangers.extend(dep_findings)
+            except Exception:
+                if os.getenv("SKYLOS_DEBUG"):
+                    logger.error(traceback.format_exc())
+
+            try:
+                from skylos.rules.danger.danger_hallucination.api_signature_hallucination import (
+                    scan_python_api_signature_hallucinations,
+                )
+
+                py_files = _python_signature_files(files)
+                if py_files:
+                    api_findings = scan_python_api_signature_hallucinations(
+                        project_root,
+                        py_files,
+                    )
+                    _extend_unsuppressed_danger_findings(
+                        api_findings,
+                        project_ignore=project_ignore,
+                        per_file_ignore_lines=per_file_ignore_lines,
+                        all_dangers=all_dangers,
+                        all_suppressed=all_suppressed,
+                    )
+            except Exception:
+                if os.getenv("SKYLOS_DEBUG"):
+                    logger.error(traceback.format_exc())
+
+            try:
+                from skylos.rules.danger.danger_hallucination.manifest_dependency_hallucination import (
+                    scan_manifest_dependency_hallucinations,
+                )
+
+                manifest_findings = scan_manifest_dependency_hallucinations(
+                    project_root,
+                )
+                _extend_unsuppressed_danger_findings(
+                    manifest_findings,
+                    project_ignore=project_ignore,
+                    per_file_ignore_lines=per_file_ignore_lines,
+                    all_dangers=all_dangers,
+                    all_suppressed=all_suppressed,
+                )
             except Exception:
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error(traceback.format_exc())

--- a/skylos/core/python_api_surface.py
+++ b/skylos/core/python_api_surface.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import inspect
+import json
+import site
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
+
+
+PYTHON_API_SURFACE_SCHEMA_VERSION = 1
+PYTHON_API_SURFACE_CACHE_PATH = Path(".skylos") / "cache" / "python_api_surface.json"
+MAX_PYTHON_API_SURFACE_BYTES = 10_000_000
+MAX_MODULE_MEMBERS = 500
+MAX_CLASS_MEMBERS = 200
+
+Importer = Callable[[str], ModuleType]
+
+
+def load_python_api_surface_cache(
+    project_root: str | Path,
+    *,
+    cache_path: str | Path = PYTHON_API_SURFACE_CACHE_PATH,
+) -> dict[str, Any]:
+    payload = load_project_json_cache(
+        project_root,
+        cache_path,
+        max_bytes=MAX_PYTHON_API_SURFACE_BYTES,
+    )
+    if not _valid_cache_payload(payload):
+        return _empty_cache_payload()
+
+    environment = payload.get("environment")
+    if not isinstance(environment, dict):
+        return _empty_cache_payload()
+    if environment.get("key") != python_environment_key():
+        return _empty_cache_payload()
+
+    modules = payload.get("modules")
+    if not isinstance(modules, dict):
+        payload["modules"] = {}
+    return payload
+
+
+def save_python_api_surface_cache(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    cache_path: str | Path = PYTHON_API_SURFACE_CACHE_PATH,
+) -> bool:
+    if not _valid_cache_payload(payload):
+        return False
+    return save_project_json_cache(project_root, cache_path, payload)
+
+
+def cached_python_api_surface(
+    project_root: str | Path,
+    module_name: str,
+    *,
+    cache_path: str | Path = PYTHON_API_SURFACE_CACHE_PATH,
+) -> dict[str, Any] | None:
+    safe_name = _safe_module_name(module_name)
+    if safe_name is None:
+        return None
+
+    payload = load_python_api_surface_cache(project_root, cache_path=cache_path)
+    modules = _modules_map(payload)
+    surface = modules.get(safe_name)
+    if not isinstance(surface, dict):
+        return None
+    return surface
+
+
+def cache_python_api_surface(
+    project_root: str | Path,
+    module_name: str,
+    *,
+    cache_path: str | Path = PYTHON_API_SURFACE_CACHE_PATH,
+    importer: Importer | None = None,
+) -> dict[str, Any] | None:
+    safe_name = _safe_module_name(module_name)
+    if safe_name is None:
+        return None
+
+    surface = build_python_api_surface(safe_name, importer=importer)
+    if surface is None:
+        return None
+
+    payload = load_python_api_surface_cache(project_root, cache_path=cache_path)
+    modules = _modules_map(payload)
+    modules[safe_name] = surface
+    payload["modules"] = modules
+    save_python_api_surface_cache(project_root, payload, cache_path=cache_path)
+    return surface
+
+
+def build_python_api_surface(
+    module_name: str,
+    *,
+    importer: Importer | None = None,
+) -> dict[str, Any] | None:
+    safe_name = _safe_module_name(module_name)
+    if safe_name is None:
+        return None
+
+    resolved_importer = _importer(importer)
+    try:
+        module = resolved_importer(safe_name)
+    except (ImportError, AttributeError, TypeError, ValueError):
+        return None
+
+    if not isinstance(module, ModuleType):
+        return None
+
+    return {
+        "module": safe_name,
+        "origin": _module_origin(module),
+        "captured_at": _utc_timestamp(),
+        "members": _module_members(module),
+    }
+
+
+def python_environment_key() -> str:
+    environment = _environment_info()
+    key = environment.get("key")
+    if isinstance(key, str):
+        return key
+    return ""
+
+
+def _empty_cache_payload() -> dict[str, Any]:
+    return {
+        "schema_version": PYTHON_API_SURFACE_SCHEMA_VERSION,
+        "environment": _environment_info(),
+        "modules": {},
+    }
+
+
+def _valid_cache_payload(payload: dict[str, Any]) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("schema_version") != PYTHON_API_SURFACE_SCHEMA_VERSION:
+        return False
+    return True
+
+
+def _modules_map(payload: dict[str, Any]) -> dict[str, Any]:
+    modules = payload.get("modules")
+    if not isinstance(modules, dict):
+        return {}
+
+    safe_modules: dict[str, Any] = {}
+    for name, surface in modules.items():
+        safe_name = _safe_module_name(str(name))
+        if safe_name is None:
+            continue
+        if isinstance(surface, dict):
+            safe_modules[safe_name] = surface
+    return safe_modules
+
+
+def _safe_module_name(value: str) -> str | None:
+    raw = str(value).strip()
+    if not raw:
+        return None
+
+    parts = raw.split(".")
+    for part in parts:
+        if not part:
+            return None
+        if not part.isidentifier():
+            return None
+    return raw
+
+
+def _importer(importer: Importer | None) -> Importer:
+    if importer is not None:
+        return importer
+    return importlib.import_module
+
+
+def _module_origin(module: ModuleType) -> str:
+    origin = getattr(module, "__file__", None)
+    if not isinstance(origin, str):
+        return ""
+    return origin
+
+
+def _module_members(module: ModuleType) -> dict[str, Any]:
+    members: dict[str, Any] = {}
+    for name in _public_names(module, MAX_MODULE_MEMBERS):
+        try:
+            value = getattr(module, name)
+        except Exception:
+            continue
+
+        entry = _member_entry(value)
+        if entry is None:
+            continue
+        members[name] = entry
+    return members
+
+
+def _member_entry(value: Any) -> dict[str, Any] | None:
+    if inspect.isclass(value):
+        return _class_entry(value)
+    if _callable_member(value):
+        return _callable_entry(value)
+    return None
+
+
+def _class_entry(value: type) -> dict[str, Any]:
+    return {
+        "kind": "class",
+        "signature": _signature_for(value),
+        "parameters": _parameters_for(value),
+        "methods": _class_methods(value),
+    }
+
+
+def _class_methods(value: type) -> dict[str, Any]:
+    methods: dict[str, Any] = {}
+    for name in _public_names(value, MAX_CLASS_MEMBERS):
+        try:
+            member = getattr(value, name)
+        except Exception:
+            continue
+
+        if not _callable_member(member):
+            continue
+
+        methods[name] = {
+            "kind": "method",
+            "signature": _signature_for(member),
+            "parameters": _parameters_for(member),
+        }
+    return methods
+
+
+def _callable_entry(value: Any) -> dict[str, Any]:
+    return {
+        "kind": "function",
+        "signature": _signature_for(value),
+        "parameters": _parameters_for(value),
+    }
+
+
+def _callable_member(value: Any) -> bool:
+    if inspect.isfunction(value):
+        return True
+    if inspect.isbuiltin(value):
+        return True
+    if inspect.ismethod(value):
+        return True
+    return callable(value)
+
+
+def _signature_for(value: Any) -> str:
+    try:
+        signature = inspect.signature(value)
+    except (TypeError, ValueError):
+        return ""
+    return str(signature)
+
+
+def _parameters_for(value: Any) -> list[dict[str, Any]]:
+    try:
+        signature = inspect.signature(value)
+    except (TypeError, ValueError):
+        return []
+
+    parameters: list[dict[str, Any]] = []
+    for name, parameter in signature.parameters.items():
+        parameters.append(
+            {
+                "name": name,
+                "kind": parameter.kind.name,
+                "required": parameter.default is inspect._empty,
+            }
+        )
+    return parameters
+
+
+def _public_names(value: Any, limit: int) -> list[str]:
+    names: list[str] = []
+    try:
+        raw_names = dir(value)
+    except Exception:
+        return names
+
+    for name in raw_names:
+        if len(names) >= limit:
+            break
+        if not isinstance(name, str):
+            continue
+        if name.startswith("_"):
+            continue
+        names.append(name)
+    return names
+
+
+def _environment_info() -> dict[str, Any]:
+    info = {
+        "key": "",
+        "executable": sys.executable,
+        "version": sys.version,
+        "prefix": sys.prefix,
+        "base_prefix": sys.base_prefix,
+        "site_paths": _site_paths(),
+    }
+    raw = json.dumps(info, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    info["key"] = digest[:16]
+    return info
+
+
+def _site_paths() -> list[str]:
+    paths: list[str] = []
+    try:
+        for path in site.getsitepackages():
+            paths.append(str(path))
+    except (AttributeError, OSError):
+        pass
+
+    try:
+        user_site = site.getusersitepackages()
+    except (AttributeError, OSError):
+        user_site = ""
+
+    if user_site:
+        paths.append(str(user_site))
+    return sorted(paths)
+
+
+def _utc_timestamp() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -13,12 +13,15 @@ AI_VIBE_CATEGORIES = {
     "ghost_config",
     "stale_reference",
     "missing_resilience_control",
+    "api_signature_hallucination",
 }
 
 AI_RULE_DEFAULTS = {
     "SKY-L011": ("disabled_security_control", "medium"),
     "SKY-D222": ("dependency_hallucination", "high"),
     "SKY-D223": ("dependency_hallucination", "medium"),
+    "SKY-D224": ("api_signature_hallucination", "high"),
+    "SKY-D225": ("dependency_hallucination", "high"),
 }
 
 FINDING_SECTIONS = (
@@ -38,6 +41,9 @@ SUGGESTED_FIX_BY_VIBE = {
     "disabled_security_control": "Re-enable the security control or remove the bypass.",
     "dependency_hallucination": (
         "Remove the hallucinated dependency or replace it with a real package."
+    ),
+    "api_signature_hallucination": (
+        "Update the call to match the installed package API surface."
     ),
 }
 

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -107,6 +107,8 @@ _RULES = (
     RuleCatalogEntry("SKY-D217", "Raw SQL execution", "security", "CRITICAL"),
     RuleCatalogEntry("SKY-D222", "Dependency hallucination", "security", "CRITICAL"),
     RuleCatalogEntry("SKY-D223", "Undeclared third-party dependency", "security", "MEDIUM"),
+    RuleCatalogEntry("SKY-D224", "API signature hallucination", "security", "HIGH"),
+    RuleCatalogEntry("SKY-D225", "Dependency version hallucination", "security", "HIGH"),
     RuleCatalogEntry("SKY-D226", "Cross-site scripting: untrusted content marked safe", "security", "CRITICAL",aliases=("xss", "cross site scripting", "cross-site scripting"),),
     RuleCatalogEntry("SKY-D227", "Cross-site scripting: unsafe inline template", "security", "HIGH", aliases=("xss", "cross site scripting", "cross-site scripting"),),
     RuleCatalogEntry("SKY-D228", "Cross-site scripting: HTML built from user input", "security", "HIGH", aliases=("xss", "cross site scripting", "cross-site scripting"),),

--- a/skylos/rules/danger/danger.py
+++ b/skylos/rules/danger/danger.py
@@ -18,6 +18,9 @@ from .danger_webhook.webhook_flow import scan as scan_webhook
 from .danger_hallucination.dependency_hallucination import (
     scan_python_dependency_hallucinations,
 )
+from .danger_hallucination.api_signature_hallucination import (
+    scan_python_api_signature_hallucinations,
+)
 from skylos.security.command_guard import (
     findings_for_command,
     is_external_url,
@@ -498,6 +501,10 @@ def scan_ctx(_, files):
             dep_findings = scan_python_dependency_hallucinations(repo_root, py_files)
             if dep_findings:
                 findings.extend(dep_findings)
+
+            api_findings = scan_python_api_signature_hallucinations(repo_root, py_files)
+            if api_findings:
+                findings.extend(api_findings)
 
     except Exception as e:
         print(f"Dependency hallucination scan failed: {e}", file=sys.stderr)

--- a/skylos/rules/danger/danger_hallucination/api_signature_hallucination.py
+++ b/skylos/rules/danger/danger_hallucination/api_signature_hallucination.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from skylos.core.python_api_surface import cache_python_api_surface
+from skylos.core.safe_cache_io import read_text_no_symlink
+
+
+RULE_ID_API_SIGNATURE = "SKY-D224"
+SEV_HIGH = "HIGH"
+DEFAULT_API_SIGNATURE_ALLOWLIST = ("requests", "pandas", "boto3")
+VIBE_CATEGORY = "api_signature_hallucination"
+AI_LIKELIHOOD = "high"
+MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES = 1_000_000
+
+SurfaceLoader = Callable[[str | Path, str], dict[str, Any] | None]
+
+
+@dataclass(frozen=True)
+class _CallTarget:
+    module_name: str
+    label: str
+    entry: dict[str, Any] | None
+    missing_kind: str
+
+
+class _ApiSignatureChecker(ast.NodeVisitor):
+    def __init__(
+        self,
+        project_root: Path,
+        file_path: Path,
+        allowed_roots: set[str],
+        local_modules: set[str],
+        surfaces: dict[str, dict[str, Any] | None],
+        surface_loader: SurfaceLoader,
+        findings: list[dict[str, Any]],
+    ) -> None:
+        self.project_root = project_root
+        self.file_path = file_path
+        self.allowed_roots = allowed_roots
+        self.local_modules = local_modules
+        self.surfaces = surfaces
+        self.surface_loader = surface_loader
+        self.findings = findings
+        self.module_aliases: dict[str, str] = {}
+        self.function_aliases: dict[str, tuple[str, str]] = {}
+        self.class_aliases: dict[str, tuple[str, str]] = {}
+        self.instance_stack: list[dict[str, tuple[str, str]]] = [{}]
+
+    def generic_visit(self, node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            self.visit(child)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            module_name = _safe_module_name(alias.name)
+            if module_name is None:
+                continue
+            if not self._allowed_module(module_name):
+                continue
+
+            local_name = _import_alias_name(alias, module_name)
+            self.module_aliases[local_name] = module_name
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module_name = _safe_module_name(node.module)
+        if module_name is None:
+            self.generic_visit(node)
+            return
+        if not self._allowed_module(module_name):
+            self.generic_visit(node)
+            return
+
+        for alias in node.names:
+            imported_name = _safe_member_name(alias.name)
+            if imported_name is None:
+                continue
+
+            local_name = _member_alias_name(alias, imported_name)
+            member = self._module_member(module_name, imported_name)
+            if _entry_kind(member) == "class":
+                self.class_aliases[local_name] = (module_name, imported_name)
+                continue
+            if member is not None:
+                self.function_aliases[local_name] = (module_name, imported_name)
+
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.instance_stack.append({})
+        self.generic_visit(node)
+        self.instance_stack.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.instance_stack.append({})
+        self.generic_visit(node)
+        self.instance_stack.pop()
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        constructed = self._constructed_class(node.value)
+        if constructed is not None:
+            for target in node.targets:
+                for name in _assigned_names(target):
+                    self._current_instances()[name] = constructed
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        target = self._call_target(node)
+        if target is not None:
+            self._check_call_target(node, target)
+        self.generic_visit(node)
+
+    def _allowed_module(self, module_name: str) -> bool:
+        root = _module_root(module_name)
+        if root in self.local_modules:
+            return False
+        return root in self.allowed_roots
+
+    def _current_instances(self) -> dict[str, tuple[str, str]]:
+        return self.instance_stack[-1]
+
+    def _surface(self, module_name: str) -> dict[str, Any] | None:
+        if module_name not in self.surfaces:
+            self.surfaces[module_name] = self.surface_loader(
+                self.project_root,
+                module_name,
+            )
+        return self.surfaces[module_name]
+
+    def _module_member(
+        self,
+        module_name: str,
+        member_name: str,
+    ) -> dict[str, Any] | None:
+        surface = self._surface(module_name)
+        if surface is None:
+            return None
+
+        members = surface.get("members")
+        if not isinstance(members, dict):
+            return None
+
+        member = members.get(member_name)
+        if isinstance(member, dict):
+            return member
+        return None
+
+    def _constructed_class(self, value: ast.AST) -> tuple[str, str] | None:
+        if not isinstance(value, ast.Call):
+            return None
+
+        target = self._call_target(value)
+        if target is None:
+            return None
+        if target.entry is None:
+            return None
+        if _entry_kind(target.entry) != "class":
+            return None
+
+        parts = target.label.split(".")
+        if len(parts) < 2:
+            return None
+        class_name = parts[-1]
+        return target.module_name, class_name
+
+    def _call_target(self, node: ast.Call) -> _CallTarget | None:
+        func = node.func
+        if isinstance(func, ast.Name):
+            return self._name_call_target(func.id)
+        if isinstance(func, ast.Attribute):
+            return self._attribute_call_target(func)
+        return None
+
+    def _name_call_target(self, name: str) -> _CallTarget | None:
+        function_alias = self.function_aliases.get(name)
+        if function_alias is not None:
+            module_name, member_name = function_alias
+            entry = self._module_member(module_name, member_name)
+            return _CallTarget(module_name, f"{module_name}.{member_name}", entry, "")
+
+        class_alias = self.class_aliases.get(name)
+        if class_alias is not None:
+            module_name, class_name = class_alias
+            entry = self._module_member(module_name, class_name)
+            return _CallTarget(module_name, f"{module_name}.{class_name}", entry, "")
+
+        return None
+
+    def _attribute_call_target(self, func: ast.Attribute) -> _CallTarget | None:
+        value = func.value
+        if isinstance(value, ast.Name):
+            module_target = self._module_attribute_target(value.id, func.attr)
+            if module_target is not None:
+                return module_target
+
+            instance_target = self._instance_method_target(value.id, func.attr)
+            if instance_target is not None:
+                return instance_target
+
+        return None
+
+    def _module_attribute_target(
+        self,
+        alias_name: str,
+        member_name: str,
+    ) -> _CallTarget | None:
+        module_name = self.module_aliases.get(alias_name)
+        if module_name is None:
+            return None
+
+        entry = self._module_member(module_name, member_name)
+        label = f"{module_name}.{member_name}"
+        if entry is None:
+            return _CallTarget(module_name, label, None, "module_member")
+        return _CallTarget(module_name, label, entry, "")
+
+    def _instance_method_target(
+        self,
+        instance_name: str,
+        method_name: str,
+    ) -> _CallTarget | None:
+        instance_type = self._current_instances().get(instance_name)
+        if instance_type is None:
+            return None
+
+        module_name, class_name = instance_type
+        class_entry = self._module_member(module_name, class_name)
+        methods = _entry_methods(class_entry)
+        method = methods.get(method_name)
+        label = f"{module_name}.{class_name}.{method_name}"
+        if not isinstance(method, dict):
+            return _CallTarget(module_name, label, None, "method")
+        return _CallTarget(module_name, label, method, "")
+
+    def _check_call_target(self, node: ast.Call, target: _CallTarget) -> None:
+        if target.entry is None:
+            self._add_missing_finding(node, target)
+            return
+
+        for keyword in node.keywords:
+            if keyword.arg is None:
+                continue
+            if _keyword_accepted(target.entry, keyword.arg):
+                continue
+            self._add_keyword_finding(node, target, keyword.arg)
+
+    def _add_missing_finding(self, node: ast.AST, target: _CallTarget) -> None:
+        if target.missing_kind == "method":
+            message = f"Installed API '{target.label}' does not expose this method."
+        else:
+            message = (
+                f"Installed package '{target.module_name}' does not expose "
+                f"callable API '{target.label}'."
+            )
+        self.findings.append(_finding(self.file_path, node, target.label, message))
+
+    def _add_keyword_finding(
+        self,
+        node: ast.AST,
+        target: _CallTarget,
+        keyword: str,
+    ) -> None:
+        message = (
+            f"Installed API '{target.label}' does not accept keyword "
+            f"argument '{keyword}'."
+        )
+        self.findings.append(_finding(self.file_path, node, target.label, message))
+
+
+def scan_python_api_signature_hallucinations(
+    repo_root: str | Path | None,
+    py_files: list[Path],
+    *,
+    allowed_modules: tuple[str, ...] | None = None,
+    surface_loader: SurfaceLoader | None = None,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    root = _repo_root(repo_root)
+    if root is None:
+        return findings
+
+    allowed_roots = _allowed_roots(allowed_modules)
+    if not allowed_roots:
+        return findings
+
+    loader = _surface_loader(surface_loader)
+    local_modules = _local_module_roots(root, py_files)
+    surfaces: dict[str, dict[str, Any] | None] = {}
+
+    for file_path in py_files:
+        tree = _parse_python_file(root, file_path)
+        if tree is None:
+            continue
+
+        checker = _ApiSignatureChecker(
+            root,
+            file_path,
+            allowed_roots,
+            local_modules,
+            surfaces,
+            loader,
+            findings,
+        )
+        checker.visit(tree)
+
+    return findings
+
+
+def _repo_root(value: str | Path | None) -> Path | None:
+    if value is None:
+        return None
+    try:
+        return Path(value).resolve()
+    except OSError:
+        return Path(value)
+
+
+def _surface_loader(surface_loader: SurfaceLoader | None) -> SurfaceLoader:
+    if surface_loader is not None:
+        return surface_loader
+    return cache_python_api_surface
+
+
+def _allowed_roots(allowed_modules: tuple[str, ...] | None) -> set[str]:
+    source = allowed_modules
+    if source is None:
+        source = DEFAULT_API_SIGNATURE_ALLOWLIST
+
+    roots: set[str] = set()
+    for module_name in source:
+        safe_name = _safe_module_name(module_name)
+        if safe_name is None:
+            continue
+        roots.add(_module_root(safe_name))
+    return roots
+
+
+def _parse_python_file(root: Path, file_path: Path) -> ast.AST | None:
+    try:
+        resolved = Path(file_path).resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+
+    if not resolved.is_file():
+        return None
+
+    source = read_text_no_symlink(
+        resolved,
+        max_bytes=MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if source is None:
+        return None
+
+    try:
+        return ast.parse(source)
+    except SyntaxError:
+        return None
+
+
+def _safe_module_name(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    raw = str(value).strip()
+    if not raw:
+        return None
+
+    parts = raw.split(".")
+    for part in parts:
+        if not part:
+            return None
+        if not part.isidentifier():
+            return None
+    return raw
+
+
+def _safe_member_name(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if not raw.isidentifier():
+        return None
+    return raw
+
+
+def _module_root(module_name: str) -> str:
+    parts = module_name.split(".")
+    return parts[0]
+
+
+def _import_alias_name(alias: ast.alias, module_name: str) -> str:
+    if alias.asname:
+        return alias.asname
+    return _module_root(module_name)
+
+
+def _member_alias_name(alias: ast.alias, imported_name: str) -> str:
+    if alias.asname:
+        return alias.asname
+    return imported_name
+
+
+def _assigned_names(target: ast.AST) -> list[str]:
+    names: list[str] = []
+    if isinstance(target, ast.Name):
+        names.append(target.id)
+        return names
+    if isinstance(target, (ast.Tuple, ast.List)):
+        for item in target.elts:
+            names.extend(_assigned_names(item))
+    return names
+
+
+def _local_module_roots(project_root: Path, py_files: list[Path]) -> set[str]:
+    roots: set[str] = set()
+    for root_name in _top_level_python_modules(project_root):
+        roots.add(root_name)
+
+    for file_path in py_files:
+        relative = _relative_path(project_root, file_path)
+        if relative is None:
+            continue
+
+        root = _module_root_for_relative_path(relative)
+        if root is not None:
+            roots.add(root)
+    return roots
+
+
+def _top_level_python_modules(project_root: Path) -> set[str]:
+    modules: set[str] = set()
+    try:
+        children = list(project_root.iterdir())
+    except OSError:
+        return modules
+
+    for child in children:
+        if child.name.startswith("."):
+            continue
+        if child.is_symlink():
+            continue
+
+        module_name = _top_level_file_module(child)
+        if module_name is not None:
+            modules.add(module_name)
+            continue
+
+        module_name = _top_level_package_module(child)
+        if module_name is not None:
+            modules.add(module_name)
+    return modules
+
+
+def _module_root_for_relative_path(relative: Path) -> str | None:
+    if not relative.parts:
+        return None
+    if len(relative.parts) > 1:
+        return relative.parts[0]
+    if relative.stem == "__init__":
+        return None
+    return relative.stem
+
+
+def _top_level_file_module(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    if path.suffix != ".py":
+        return None
+    if path.stem == "__init__":
+        return None
+    return path.stem
+
+
+def _top_level_package_module(path: Path) -> str | None:
+    if not path.is_dir():
+        return None
+    init_file = path / "__init__.py"
+    if not init_file.exists():
+        return None
+    return path.name
+
+
+def _relative_path(project_root: Path, file_path: Path) -> Path | None:
+    try:
+        return file_path.resolve().relative_to(project_root)
+    except (OSError, ValueError):
+        return None
+
+
+def _entry_kind(entry: dict[str, Any] | None) -> str:
+    if not isinstance(entry, dict):
+        return ""
+
+    kind = entry.get("kind")
+    if isinstance(kind, str):
+        return kind
+    return ""
+
+
+def _entry_methods(entry: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        return {}
+
+    methods = entry.get("methods")
+    if isinstance(methods, dict):
+        return methods
+    return {}
+
+
+def _keyword_accepted(entry: dict[str, Any], keyword: str) -> bool:
+    parameters = entry.get("parameters")
+    if not isinstance(parameters, list):
+        return True
+    if not parameters:
+        return True
+
+    for parameter in parameters:
+        if not isinstance(parameter, dict):
+            continue
+
+        kind = str(parameter.get("kind"))
+        if kind == "VAR_KEYWORD":
+            return True
+
+        name = parameter.get("name")
+        if name != keyword:
+            continue
+        if kind == "POSITIONAL_OR_KEYWORD":
+            return True
+        if kind == "KEYWORD_ONLY":
+            return True
+
+    return False
+
+
+def _finding(
+    file_path: Path,
+    node: ast.AST,
+    symbol: str,
+    message: str,
+) -> dict[str, Any]:
+    line = getattr(node, "lineno", 1)
+    col = getattr(node, "col_offset", 0)
+    return {
+        "rule_id": RULE_ID_API_SIGNATURE,
+        "severity": SEV_HIGH,
+        "message": message,
+        "file": str(file_path),
+        "line": line,
+        "col": col,
+        "symbol": symbol,
+        "vibe_category": VIBE_CATEGORY,
+        "ai_likelihood": AI_LIKELIHOOD,
+        "confidence": 88,
+    }

--- a/skylos/rules/danger/danger_hallucination/manifest_dependency_hallucination.py
+++ b/skylos/rules/danger/danger_hallucination/manifest_dependency_hallucination.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import quote, urlsplit
+
+from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
+from skylos.rules.sca.vulnerability_scanner import (
+    ECOSYSTEM_GO,
+    ECOSYSTEM_NPM,
+    parse_go_mod,
+    parse_package_json,
+)
+
+
+RULE_ID_DEPENDENCY_HALLUCINATION = "SKY-D222"
+RULE_ID_VERSION_HALLUCINATION = "SKY-D225"
+SEV_CRITICAL = "CRITICAL"
+SEV_HIGH = "HIGH"
+VIBE_CATEGORY = "dependency_hallucination"
+AI_LIKELIHOOD = "high"
+STATUS_EXISTS = "exists"
+STATUS_MISSING_PACKAGE = "missing_package"
+STATUS_MISSING_VERSION = "missing_version"
+STATUS_UNKNOWN = "unknown"
+VERSION_CACHE_SCHEMA_VERSION = 1
+VERSION_CACHE_PATH = Path(".skylos") / "cache" / "dependency_versions.json"
+MAX_VERSION_CACHE_BYTES = 5_000_000
+MAX_REGISTRY_RESPONSE_BYTES = 1_000_000
+NPM_REGISTRY_ORIGIN = "https://registry.npmjs.org"
+GO_PROXY_ORIGIN = "https://proxy.golang.org"
+ALLOWED_REGISTRY_HOSTS = {
+    "registry.npmjs.org",
+    "proxy.golang.org",
+}
+
+StatusChecker = Callable[[str, str, str, dict[str, Any]], str]
+
+logger = logging.getLogger(__name__)
+
+
+def scan_manifest_dependency_hallucinations(
+    repo_root: str | Path | None,
+    *,
+    status_checker: StatusChecker | None = None,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    root = _repo_root(repo_root)
+    if root is None:
+        return findings
+
+    dependencies = _collect_manifest_dependencies(root)
+    if not dependencies:
+        return findings
+
+    cache = _load_version_cache(root)
+    checker = _status_checker(status_checker)
+    cache_changed = False
+
+    for dependency in _unique_dependencies(dependencies):
+        status = _cached_dependency_status(dependency, cache)
+        if status is None:
+            status = checker(
+                str(dependency["ecosystem"]),
+                str(dependency["name"]),
+                str(dependency["version"]),
+                cache,
+            )
+            _record_dependency_status(dependency, cache, status)
+            cache_changed = True
+
+        finding = _finding_for_status(dependency, status)
+        if finding is not None:
+            findings.append(finding)
+
+    if cache_changed:
+        _save_version_cache(root, cache)
+
+    return findings
+
+
+def check_dependency_version_status(
+    ecosystem: str,
+    name: str,
+    version: str,
+    cache: dict[str, Any],
+) -> str:
+    if ecosystem == ECOSYSTEM_NPM:
+        return _check_npm_version(name, version)
+    if ecosystem == ECOSYSTEM_GO:
+        return _check_go_version(name, version)
+    return STATUS_UNKNOWN
+
+
+def _repo_root(value: str | Path | None) -> Path | None:
+    if value is None:
+        return None
+    try:
+        return Path(value).resolve()
+    except OSError:
+        return Path(value)
+
+
+def _status_checker(status_checker: StatusChecker | None) -> StatusChecker:
+    if status_checker is not None:
+        return status_checker
+    return check_dependency_version_status
+
+
+def _collect_manifest_dependencies(root: Path) -> list[dict[str, Any]]:
+    dependencies: list[dict[str, Any]] = []
+    parsers = {
+        "package.json": parse_package_json,
+        "go.mod": parse_go_mod,
+    }
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        _filter_manifest_dirs(dirnames)
+        if _manifest_depth(root, dirpath) > 3:
+            dirnames.clear()
+            continue
+
+        for filename in filenames:
+            parser = parsers.get(filename)
+            if parser is None:
+                continue
+            path = Path(dirpath) / filename
+            try:
+                dependencies.extend(parser(path))
+            except Exception as exc:
+                logger.debug("Failed to parse dependency manifest %s: %s", path, exc)
+
+    return dependencies
+
+
+def _filter_manifest_dirs(dirnames: list[str]) -> None:
+    skipped = {
+        ".git",
+        ".skylos",
+        "node_modules",
+        "vendor",
+        "dist",
+        "build",
+    }
+    kept = []
+    for dirname in dirnames:
+        if dirname in skipped:
+            continue
+        kept.append(dirname)
+    dirnames[:] = kept
+
+
+def _manifest_depth(root: Path, dirpath: str) -> int:
+    try:
+        relative = Path(dirpath).resolve().relative_to(root)
+    except (OSError, ValueError):
+        return 0
+    if not relative.parts:
+        return 0
+    return len(relative.parts)
+
+
+def _unique_dependencies(dependencies: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    unique: list[dict[str, Any]] = []
+    for dependency in dependencies:
+        key = _dependency_key(dependency)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(dependency)
+    return unique
+
+
+def _dependency_key(dependency: dict[str, Any]) -> str:
+    ecosystem = str(dependency.get("ecosystem", ""))
+    name = str(dependency.get("name", ""))
+    version = str(dependency.get("version", ""))
+    return f"{ecosystem}:{name}:{version}"
+
+
+def _load_version_cache(root: Path) -> dict[str, Any]:
+    payload = load_project_json_cache(
+        root,
+        VERSION_CACHE_PATH,
+        max_bytes=MAX_VERSION_CACHE_BYTES,
+    )
+    if payload.get("schema_version") != VERSION_CACHE_SCHEMA_VERSION:
+        return _empty_version_cache()
+    statuses = payload.get("statuses")
+    if not isinstance(statuses, dict):
+        payload["statuses"] = {}
+    return payload
+
+
+def _save_version_cache(root: Path, cache: dict[str, Any]) -> None:
+    if not save_project_json_cache(root, VERSION_CACHE_PATH, cache):
+        logger.debug("Failed to save dependency version cache")
+
+
+def _empty_version_cache() -> dict[str, Any]:
+    return {
+        "schema_version": VERSION_CACHE_SCHEMA_VERSION,
+        "statuses": {},
+    }
+
+
+def _cached_dependency_status(
+    dependency: dict[str, Any],
+    cache: dict[str, Any],
+) -> str | None:
+    statuses = cache.get("statuses")
+    if not isinstance(statuses, dict):
+        return None
+
+    status = statuses.get(_dependency_key(dependency))
+    if isinstance(status, str):
+        return status
+    return None
+
+
+def _record_dependency_status(
+    dependency: dict[str, Any],
+    cache: dict[str, Any],
+    status: str,
+) -> None:
+    statuses = cache.get("statuses")
+    if not isinstance(statuses, dict):
+        statuses = {}
+        cache["statuses"] = statuses
+    statuses[_dependency_key(dependency)] = status
+
+
+def _finding_for_status(
+    dependency: dict[str, Any],
+    status: str,
+) -> dict[str, Any] | None:
+    if status == STATUS_MISSING_PACKAGE:
+        return _missing_package_finding(dependency)
+    if status == STATUS_MISSING_VERSION:
+        return _missing_version_finding(dependency)
+    return None
+
+
+def _missing_package_finding(dependency: dict[str, Any]) -> dict[str, Any]:
+    ecosystem = str(dependency["ecosystem"])
+    name = str(dependency["name"])
+    registry = _registry_label(ecosystem)
+    message = (
+        f"Hallucinated {ecosystem} dependency '{name}'. "
+        f"Package does not exist in {registry}."
+    )
+    return _finding(
+        dependency,
+        rule_id=RULE_ID_DEPENDENCY_HALLUCINATION,
+        severity=SEV_CRITICAL,
+        message=message,
+    )
+
+
+def _missing_version_finding(dependency: dict[str, Any]) -> dict[str, Any]:
+    ecosystem = str(dependency["ecosystem"])
+    name = str(dependency["name"])
+    version = str(dependency["version"])
+    registry = _registry_label(ecosystem)
+    message = (
+        f"Hallucinated {ecosystem} dependency version '{name}@{version}'. "
+        f"Version does not exist in {registry}."
+    )
+    return _finding(
+        dependency,
+        rule_id=RULE_ID_VERSION_HALLUCINATION,
+        severity=SEV_HIGH,
+        message=message,
+    )
+
+
+def _finding(
+    dependency: dict[str, Any],
+    *,
+    rule_id: str,
+    severity: str,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "rule_id": rule_id,
+        "severity": severity,
+        "message": message,
+        "file": str(dependency["file"]),
+        "line": int(dependency["line"]),
+        "col": 0,
+        "symbol": f"{dependency['name']}@{dependency['version']}",
+        "vibe_category": VIBE_CATEGORY,
+        "ai_likelihood": AI_LIKELIHOOD,
+        "confidence": 86,
+        "metadata": {
+            "ecosystem": dependency["ecosystem"],
+            "package_name": dependency["name"],
+            "package_version": dependency["version"],
+        },
+    }
+
+
+def _registry_label(ecosystem: str) -> str:
+    if ecosystem == ECOSYSTEM_NPM:
+        return "the npm registry"
+    if ecosystem == ECOSYSTEM_GO:
+        return "the Go module proxy"
+    return "the package registry"
+
+
+def _check_npm_version(name: str, version: str) -> str:
+    package_path = _safe_npm_package_path(name)
+    if package_path is None:
+        return STATUS_UNKNOWN
+
+    url = f"{NPM_REGISTRY_ORIGIN}/{package_path}"
+    try:
+        data = _fetch_json(url, user_agent="skylos-npm-dep-scanner/1.0")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return STATUS_MISSING_PACKAGE
+        return STATUS_UNKNOWN
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return STATUS_UNKNOWN
+
+    versions = data.get("versions")
+    if not isinstance(versions, dict):
+        return STATUS_UNKNOWN
+    if version in versions:
+        return STATUS_EXISTS
+    return STATUS_MISSING_VERSION
+
+
+def _check_go_version(name: str, version: str) -> str:
+    module_path = _safe_go_module_path(name)
+    if module_path is None:
+        return STATUS_UNKNOWN
+
+    go_version = _go_version(version)
+    safe_go_version = quote(go_version, safe="")
+    info_url = f"{GO_PROXY_ORIGIN}/{module_path}/@v/{safe_go_version}.info"
+    try:
+        _fetch_text(info_url, user_agent="skylos-go-dep-scanner/1.0")
+        return STATUS_EXISTS
+    except urllib.error.HTTPError as exc:
+        if exc.code != 404:
+            return STATUS_UNKNOWN
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return STATUS_UNKNOWN
+
+    list_url = f"{GO_PROXY_ORIGIN}/{module_path}/@v/list"
+    try:
+        _fetch_text(list_url, user_agent="skylos-go-dep-scanner/1.0")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return STATUS_MISSING_PACKAGE
+        return STATUS_UNKNOWN
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return STATUS_UNKNOWN
+    return STATUS_MISSING_VERSION
+
+
+def _go_version(version: str) -> str:
+    if version.startswith("v"):
+        return version
+    return f"v{version}"
+
+
+def _safe_npm_package_path(name: str) -> str | None:
+    raw = name.strip()
+    if not raw:
+        return None
+    if raw.startswith("."):
+        return None
+    if "\\" in raw:
+        return None
+    if ".." in raw:
+        return None
+    if raw.startswith("@"):
+        parts = raw.split("/")
+        if len(parts) != 2:
+            return None
+        if not _safe_npm_name_part(parts[0][1:]):
+            return None
+        if not _safe_npm_name_part(parts[1]):
+            return None
+    else:
+        if "/" in raw:
+            return None
+        if not _safe_npm_name_part(raw):
+            return None
+    return quote(raw, safe="@")
+
+
+def _safe_npm_name_part(value: str) -> bool:
+    if not value:
+        return False
+    for char in value:
+        if char.isalnum():
+            continue
+        if char in ("-", "_", "."):
+            continue
+        return False
+    return True
+
+
+def _safe_go_module_path(name: str) -> str | None:
+    raw = name.strip()
+    if not raw:
+        return None
+    if raw.startswith("/"):
+        return None
+    if "\\" in raw:
+        return None
+    if ".." in raw:
+        return None
+    parts = raw.split("/")
+    encoded_parts = []
+    for part in parts:
+        if not _safe_go_path_part(part):
+            return None
+        encoded_parts.append(quote(part, safe=""))
+    return "/".join(encoded_parts)
+
+
+def _safe_go_path_part(value: str) -> bool:
+    if not value:
+        return False
+    for char in value:
+        if char.isalnum():
+            continue
+        if char in ("-", "_", ".", "~"):
+            continue
+        return False
+    return True
+
+
+def _fetch_json(url: str, *, user_agent: str) -> dict[str, Any]:
+    text = _fetch_text(url, user_agent=user_agent)
+    data = json.loads(text)
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _fetch_text(url: str, *, user_agent: str) -> str:
+    if not _allowed_registry_url(url):
+        raise ValueError("Registry URL host is not allowed")
+
+    request = urllib.request.Request(url, method="GET")
+    request.add_header("User-Agent", user_agent)
+    with urllib.request.urlopen(  # skylos: ignore[SKY-D216] URL is validated against fixed registry hosts above.
+        request,
+        timeout=5,
+    ) as response:
+        raw = response.read(MAX_REGISTRY_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_REGISTRY_RESPONSE_BYTES:
+        raise ValueError("Registry response exceeds size limit")
+    return raw.decode("utf-8", errors="replace")
+
+
+def _allowed_registry_url(url: str) -> bool:
+    parsed = urlsplit(url)
+    if parsed.scheme != "https":
+        return False
+    if parsed.hostname not in ALLOWED_REGISTRY_HOSTS:
+        return False
+    if parsed.username:
+        return False
+    if parsed.password:
+        return False
+    if parsed.port is not None:
+        return False
+    return True

--- a/test/test_api_signature_hallucination.py
+++ b/test/test_api_signature_hallucination.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from skylos.rules.danger.danger_hallucination.api_signature_hallucination import (
+    RULE_ID_API_SIGNATURE,
+    scan_python_api_signature_hallucinations,
+)
+
+
+def _write_sample_package(site_root):
+    package_dir = site_root / "sampleapi"
+    package_dir.mkdir(parents=True)
+    package_file = package_dir / "__init__.py"
+    package_file.write_text(
+        "\n".join(
+            [
+                "def make_user(name: str, *, active: bool = True) -> dict:",
+                "    return {'name': name, 'active': active}",
+                "",
+                "class Client:",
+                "    def connect(self, timeout: int = 5) -> str:",
+                "        return str(timeout)",
+                "",
+                "    @classmethod",
+                "    def from_env(cls):",
+                "        return cls()",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_py(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _scan(repo, py_file):
+    return scan_python_api_signature_hallucinations(
+        repo,
+        [py_file],
+        allowed_modules=("sampleapi",),
+    )
+
+
+def test_scan_flags_missing_members_and_bad_keywords(tmp_path, monkeypatch):
+    site_root = tmp_path / "site"
+    _write_sample_package(site_root)
+    monkeypatch.syspath_prepend(str(site_root))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    py_file = _write_py(
+        repo / "app.py",
+        "\n".join(
+            [
+                "import sampleapi as api",
+                "",
+                "def handler():",
+                "    api.missing()",
+                "    api.make_user(name='ada', active=True, imaginary=True)",
+                "    client = api.Client()",
+                "    client.missing()",
+                "    client.connect(timeout=1, wait=True)",
+                "",
+            ]
+        ),
+    )
+
+    findings = _scan(repo, py_file)
+    messages = []
+    for finding in findings:
+        messages.append(finding["message"])
+
+    assert len(findings) == 4
+    assert all(finding["rule_id"] == RULE_ID_API_SIGNATURE for finding in findings)
+    assert any("sampleapi.missing" in message for message in messages)
+    assert any("argument 'imaginary'" in message for message in messages)
+    assert any("sampleapi.Client.missing" in message for message in messages)
+    assert any("argument 'wait'" in message for message in messages)
+
+
+def test_scan_allows_known_members_and_keywords(tmp_path, monkeypatch):
+    site_root = tmp_path / "site"
+    _write_sample_package(site_root)
+    monkeypatch.syspath_prepend(str(site_root))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    py_file = _write_py(
+        repo / "app.py",
+        "\n".join(
+            [
+                "import sampleapi as api",
+                "",
+                "def handler():",
+                "    api.make_user(name='ada', active=False)",
+                "    client = api.Client()",
+                "    client.connect(timeout=1)",
+                "",
+            ]
+        ),
+    )
+
+    findings = _scan(repo, py_file)
+
+    assert findings == []
+
+
+def test_scan_handles_from_import_aliases(tmp_path, monkeypatch):
+    site_root = tmp_path / "site"
+    _write_sample_package(site_root)
+    monkeypatch.syspath_prepend(str(site_root))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    py_file = _write_py(
+        repo / "app.py",
+        "\n".join(
+            [
+                "from sampleapi import Client, make_user as build",
+                "",
+                "def handler():",
+                "    build(unknown=True)",
+                "    client = Client()",
+                "    client.connect(wait=True)",
+                "",
+            ]
+        ),
+    )
+
+    findings = _scan(repo, py_file)
+    messages = []
+    for finding in findings:
+        messages.append(finding["message"])
+
+    assert len(findings) == 2
+    assert any("argument 'unknown'" in message for message in messages)
+    assert any("argument 'wait'" in message for message in messages)
+
+
+def test_scan_skips_local_modules_named_like_allowlisted_package(
+    tmp_path,
+    monkeypatch,
+):
+    site_root = tmp_path / "site"
+    _write_sample_package(site_root)
+    monkeypatch.syspath_prepend(str(site_root))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_py(repo / "sampleapi.py", "def local():\n    return None\n")
+    py_file = _write_py(
+        repo / "app.py",
+        "\n".join(
+            [
+                "import sampleapi",
+                "sampleapi.missing()",
+                "",
+            ]
+        ),
+    )
+
+    findings = _scan(repo, py_file)
+
+    assert findings == []

--- a/test/test_manifest_dependency_hallucination.py
+++ b/test/test_manifest_dependency_hallucination.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+
+from skylos.rules.danger.danger_hallucination.manifest_dependency_hallucination import (
+    RULE_ID_DEPENDENCY_HALLUCINATION,
+    RULE_ID_VERSION_HALLUCINATION,
+    STATUS_EXISTS,
+    STATUS_MISSING_PACKAGE,
+    STATUS_MISSING_VERSION,
+    scan_manifest_dependency_hallucinations,
+)
+from skylos.rules.sca.vulnerability_scanner import ECOSYSTEM_GO, ECOSYSTEM_NPM
+
+
+def _status_checker(statuses, calls):
+    def checker(ecosystem, name, version, _cache):
+        calls.append((ecosystem, name, version))
+        key = (ecosystem, name, version)
+        if key in statuses:
+            return statuses[key]
+        return STATUS_EXISTS
+
+    return checker
+
+
+def _messages(findings):
+    messages = []
+    for finding in findings:
+        messages.append(finding["message"])
+    return messages
+
+
+def test_scan_package_json_flags_missing_npm_package_and_version(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = {
+        "dependencies": {
+            "leftpadz": "9.9.9",
+            "stale-version": "^99.0.0",
+            "realpkg": "1.2.3",
+        },
+        "devDependencies": {
+            "devghost": "2.0.0",
+        },
+    }
+    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    calls = []
+    statuses = {
+        (ECOSYSTEM_NPM, "leftpadz", "9.9.9"): STATUS_MISSING_PACKAGE,
+        (ECOSYSTEM_NPM, "stale-version", "99.0.0"): STATUS_MISSING_VERSION,
+        (ECOSYSTEM_NPM, "devghost", "2.0.0"): STATUS_MISSING_VERSION,
+    }
+
+    findings = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=_status_checker(statuses, calls),
+    )
+    rule_ids = []
+    for finding in findings:
+        rule_ids.append(finding["rule_id"])
+
+    assert len(findings) == 3
+    assert RULE_ID_DEPENDENCY_HALLUCINATION in rule_ids
+    assert rule_ids.count(RULE_ID_VERSION_HALLUCINATION) == 2
+    assert any("leftpadz" in message for message in _messages(findings))
+    assert any("stale-version@99.0.0" in message for message in _messages(findings))
+    assert (ECOSYSTEM_NPM, "realpkg", "1.2.3") in calls
+
+
+def test_scan_go_mod_flags_missing_go_module_and_version(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "go.mod").write_text(
+        "\n".join(
+            [
+                "module example.com/demo",
+                "",
+                "go 1.22",
+                "",
+                "require (",
+                "    github.com/real/pkg v1.2.3",
+                "    github.com/no/module v0.0.1",
+                "    github.com/real/pkg v9.9.9",
+                ")",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+    statuses = {
+        (ECOSYSTEM_GO, "github.com/no/module", "0.0.1"): STATUS_MISSING_PACKAGE,
+        (ECOSYSTEM_GO, "github.com/real/pkg", "9.9.9"): STATUS_MISSING_VERSION,
+    }
+
+    findings = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=_status_checker(statuses, calls),
+    )
+    messages = _messages(findings)
+
+    assert len(findings) == 2
+    assert any("github.com/no/module" in message for message in messages)
+    assert any("github.com/real/pkg@9.9.9" in message for message in messages)
+    assert (ECOSYSTEM_GO, "github.com/real/pkg", "1.2.3") in calls
+
+
+def test_scan_manifest_dependency_statuses_are_cached(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = {"dependencies": {"stale-version": "99.0.0"}}
+    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    calls = []
+    statuses = {
+        (ECOSYSTEM_NPM, "stale-version", "99.0.0"): STATUS_MISSING_VERSION,
+    }
+
+    first = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=_status_checker(statuses, calls),
+    )
+
+    def fail_checker(_ecosystem, _name, _version, _cache):
+        raise AssertionError("cached dependency status should be reused")
+
+    second = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=fail_checker,
+    )
+
+    assert len(first) == 1
+    assert len(second) == 1
+    assert calls == [(ECOSYSTEM_NPM, "stale-version", "99.0.0")]

--- a/test/test_python_api_surface.py
+++ b/test/test_python_api_surface.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from skylos.core.python_api_surface import (
+    build_python_api_surface,
+    cache_python_api_surface,
+    cached_python_api_surface,
+    load_python_api_surface_cache,
+    save_python_api_surface_cache,
+)
+
+
+def _write_sample_package(site_root):
+    package_dir = site_root / "sampleapi"
+    package_dir.mkdir(parents=True)
+    package_file = package_dir / "__init__.py"
+    package_file.write_text(
+        "\n".join(
+            [
+                "def make_user(name: str, *, active: bool = True) -> dict:",
+                "    return {'name': name, 'active': active}",
+                "",
+                "class Client:",
+                "    def connect(self, timeout: int = 5) -> str:",
+                "        return str(timeout)",
+                "",
+                "    @classmethod",
+                "    def from_env(cls):",
+                "        return cls()",
+                "",
+                "VALUE = 42",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_cache_python_api_surface_records_functions_and_methods(tmp_path, monkeypatch):
+    site_root = tmp_path / "site"
+    _write_sample_package(site_root)
+    monkeypatch.syspath_prepend(str(site_root))
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+
+    surface = cache_python_api_surface(project_root, "sampleapi")
+    cached = cached_python_api_surface(project_root, "sampleapi")
+
+    assert surface is not None
+    assert cached is not None
+    assert cached["module"] == "sampleapi"
+    assert cached["origin"].endswith("__init__.py")
+
+    members = cached["members"]
+    assert "make_user" in members
+    assert members["make_user"]["kind"] == "function"
+    assert "name: str" in members["make_user"]["signature"]
+    assert "active: bool = True" in members["make_user"]["signature"]
+    assert _parameter_names(members["make_user"]) == ["name", "active"]
+
+    assert "Client" in members
+    client = members["Client"]
+    assert client["kind"] == "class"
+    assert "connect" in client["methods"]
+    assert "timeout: int = 5" in client["methods"]["connect"]["signature"]
+    assert _parameter_names(client["methods"]["connect"]) == ["self", "timeout"]
+    assert "VALUE" not in members
+
+
+def test_python_api_surface_cache_invalidates_environment_key(tmp_path, monkeypatch):
+    site_root = tmp_path / "site"
+    _write_sample_package(site_root)
+    monkeypatch.syspath_prepend(str(site_root))
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+
+    surface = cache_python_api_surface(project_root, "sampleapi")
+    payload = load_python_api_surface_cache(project_root)
+
+    assert surface is not None
+    assert "sampleapi" in payload["modules"]
+
+    payload["environment"]["key"] = "stale"
+    saved = save_python_api_surface_cache(project_root, payload)
+    reloaded = load_python_api_surface_cache(project_root)
+
+    assert saved is True
+    assert reloaded["modules"] == {}
+
+
+def test_build_python_api_surface_rejects_unsafe_module_name():
+    imported = []
+
+    def importer(name):
+        imported.append(name)
+        raise AssertionError("unsafe module name should not import")
+
+    surface = build_python_api_surface("sampleapi;rm", importer=importer)
+
+    assert surface is None
+    assert imported == []
+
+
+def _parameter_names(entry):
+    names = []
+    for parameter in entry["parameters"]:
+        names.append(parameter["name"])
+    return names

--- a/test/test_verify_change.py
+++ b/test/test_verify_change.py
@@ -77,6 +77,51 @@ def test_build_verify_change_response_applies_rule_defaults(tmp_path):
     assert finding["confidence"] == 70
 
 
+def test_build_verify_change_response_applies_api_signature_defaults(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("api.missing(arg=True)\n")
+    result = {
+        "danger": [
+            {
+                "rule_id": "SKY-D224",
+                "severity": "HIGH",
+                "file": str(app),
+                "line": 1,
+                "message": "Installed API does not accept keyword.",
+            }
+        ]
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    finding = payload["findings"][0]
+    assert finding["vibe_category"] == "api_signature_hallucination"
+    assert finding["ai_likelihood"] == "high"
+    assert finding["suggested_fix"]
+
+
+def test_build_verify_change_response_applies_version_hallucination_defaults(tmp_path):
+    manifest = tmp_path / "package.json"
+    manifest.write_text('{"dependencies": {"ghost": "9.9.9"}}\n')
+    result = {
+        "danger": [
+            {
+                "rule_id": "SKY-D225",
+                "severity": "HIGH",
+                "file": str(manifest),
+                "line": 1,
+                "message": "Dependency version does not exist.",
+            }
+        ]
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    finding = payload["findings"][0]
+    assert finding["vibe_category"] == "dependency_hallucination"
+    assert finding["ai_likelihood"] == "high"
+
+
 def test_build_verify_change_response_filters_target_file_and_range(tmp_path):
     app = tmp_path / "app.py"
     other = tmp_path / "other.py"


### PR DESCRIPTION
## Summary

  - Adds `SKY-D224` API Signature Hallucination for Python.
  - Adds `SKY-D225` Dependency Version Hallucination.
  - Adds a Python API surface cache for installed-package introspection.
  - Wires the new rules into analyzer danger scans, rule catalog, and `skylos verify` AI-default metadata.

  ## Tests

  - `pytest test/test_api_signature_hallucination.py test/test_manifest_dependency_hallucination.py test/test_python_api_surface.py test/test_verify_change.py`