### PR TITLE
feat(index): persist reference graph cache

### DIFF
--- a/skylos/core/reference_index.py
+++ b/skylos/core/reference_index.py
@@ -26,6 +26,7 @@ def build_empty_index(project_root: str | Path) -> dict[str, Any]:
         "references": [],
         "imports": {},
         "reverse_dependencies": {},
+        "content_graphs": {},
     }
 
 
@@ -37,6 +38,7 @@ def build_index_payload(
     references: list[dict[str, Any]] | None = None,
     imports: dict[str, Any] | None = None,
     reverse_dependencies: dict[str, list[str]] | None = None,
+    content_graphs: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     payload = build_empty_index(project_root)
     payload["files"] = _dict_copy(files)
@@ -46,6 +48,7 @@ def build_index_payload(
     payload["reverse_dependencies"] = _normalize_reverse_dependencies(
         reverse_dependencies
     )
+    payload["content_graphs"] = _normalize_content_graphs(content_graphs)
     return payload
 
 
@@ -117,6 +120,9 @@ def validate_index_payload(payload: dict[str, Any]) -> bool:
         return False
     if not isinstance(payload["reverse_dependencies"], dict):
         return False
+    if "content_graphs" in payload:
+        if not isinstance(payload["content_graphs"], dict):
+            return False
     return True
 
 
@@ -190,4 +196,18 @@ def _normalize_reverse_dependencies(
         for dependency in dependencies:
             unique_dependencies.add(str(dependency))
         normalized[str(path)] = sorted(unique_dependencies)
+    return normalized
+
+
+def _normalize_content_graphs(
+    content_graphs: dict[str, dict[str, Any]] | None,
+) -> dict[str, dict[str, Any]]:
+    if content_graphs is None:
+        return {}
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for content_hash, graph in content_graphs.items():
+        if not isinstance(graph, dict):
+            continue
+        normalized[str(content_hash)] = dict(graph)
     return normalized

--- a/skylos/core/reference_index_store.py
+++ b/skylos/core/reference_index_store.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from skylos.core.reference_index import (
+    INDEX_CACHE_PATH,
+    build_empty_index,
+    file_signature,
+    validate_index_payload,
+)
+from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
+
+
+MAX_REFERENCE_INDEX_BYTES = 20_000_000
+
+
+def load_reference_index(
+    project_root: str | Path,
+    *,
+    cache_path: str | Path = INDEX_CACHE_PATH,
+) -> dict[str, Any] | None:
+    payload = load_project_json_cache(
+        project_root,
+        cache_path,
+        max_bytes=MAX_REFERENCE_INDEX_BYTES,
+    )
+    if not payload:
+        return None
+    if not validate_index_payload(payload):
+        return None
+    if not _project_root_matches(payload, project_root):
+        return None
+
+    _ensure_content_graphs(payload)
+    return payload
+
+
+def save_reference_index(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    cache_path: str | Path = INDEX_CACHE_PATH,
+) -> bool:
+    if not validate_index_payload(payload):
+        return False
+    if not _project_root_matches(payload, project_root):
+        return False
+
+    _ensure_content_graphs(payload)
+    return save_project_json_cache(project_root, cache_path, payload)
+
+
+def record_file_graph(
+    project_root: str | Path,
+    payload: dict[str, Any] | None,
+    file_path: str | Path,
+    *,
+    definitions: dict[str, Any] | None = None,
+    references: list[dict[str, Any]] | None = None,
+    imports: list[Any] | None = None,
+) -> dict[str, Any] | None:
+    signature = file_signature(project_root, file_path)
+    if signature is None:
+        return None
+
+    if payload is None:
+        updated = build_empty_index(project_root)
+    else:
+        updated = _copy_index_payload(payload)
+
+    _ensure_content_graphs(updated)
+    _record_signature(updated, signature)
+    _record_content_graph(
+        updated,
+        signature,
+        definitions=definitions,
+        references=references,
+        imports=imports,
+    )
+    return updated
+
+
+def changed_index_paths(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    candidate_paths: list[str | Path] | None = None,
+) -> list[str]:
+    if not validate_index_payload(payload):
+        return []
+
+    changed = set()
+    for relpath in _candidate_relpaths(project_root, payload, candidate_paths):
+        if _signature_changed(project_root, payload, relpath):
+            changed.add(relpath)
+    return sorted(changed)
+
+
+def invalidation_paths_for_changes(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    candidate_paths: list[str | Path] | None = None,
+) -> list[str]:
+    changed_paths = changed_index_paths(
+        project_root,
+        payload,
+        candidate_paths=candidate_paths,
+    )
+    invalidated = set()
+    for path in changed_paths:
+        invalidated.add(path)
+        for dependent in _direct_dependents(payload, path):
+            invalidated.add(dependent)
+    return sorted(invalidated)
+
+
+def _record_signature(payload: dict[str, Any], signature: dict[str, Any]) -> None:
+    files = _files_map(payload)
+    path = str(signature["path"])
+    files[path] = dict(signature)
+
+
+def _record_content_graph(
+    payload: dict[str, Any],
+    signature: dict[str, Any],
+    *,
+    definitions: dict[str, Any] | None,
+    references: list[dict[str, Any]] | None,
+    imports: list[Any] | None,
+) -> None:
+    content_graphs = _content_graphs_map(payload)
+    content_hash = str(signature["sha256"])
+    existing = _existing_graph(content_graphs, content_hash)
+    graph = _graph_payload(
+        signature,
+        existing,
+        definitions=definitions,
+        references=references,
+        imports=imports,
+    )
+    content_graphs[content_hash] = graph
+
+
+def _graph_payload(
+    signature: dict[str, Any],
+    existing: dict[str, Any],
+    *,
+    definitions: dict[str, Any] | None,
+    references: list[dict[str, Any]] | None,
+    imports: list[Any] | None,
+) -> dict[str, Any]:
+    path = str(signature["path"])
+    return {
+        "sha256": str(signature["sha256"]),
+        "paths": _graph_paths(existing, path),
+        "definitions": _dict_copy(definitions),
+        "references": _list_copy(references),
+        "imports": _list_copy(imports),
+    }
+
+
+def _graph_paths(existing: dict[str, Any], path: str) -> list[str]:
+    paths = set()
+    existing_paths = existing.get("paths")
+    if isinstance(existing_paths, list):
+        for existing_path in existing_paths:
+            paths.add(str(existing_path))
+    paths.add(path)
+    return sorted(paths)
+
+
+def _existing_graph(
+    content_graphs: dict[str, dict[str, Any]],
+    content_hash: str,
+) -> dict[str, Any]:
+    existing = content_graphs.get(content_hash)
+    if isinstance(existing, dict):
+        return existing
+    return {}
+
+
+def _candidate_relpaths(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    candidate_paths: list[str | Path] | None,
+) -> list[str]:
+    if candidate_paths is None:
+        return sorted(_files_map(payload))
+
+    relpaths = set()
+    for candidate in candidate_paths:
+        relpaths.add(_relative_candidate_path(project_root, candidate))
+    return sorted(relpaths)
+
+
+def _relative_candidate_path(project_root: str | Path, candidate: str | Path) -> str:
+    root = Path(project_root).resolve()
+    raw = Path(candidate)
+    if raw.is_absolute():
+        path = raw
+    else:
+        path = root / raw
+
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except (OSError, ValueError):
+        return str(candidate).replace("\\", "/")
+
+
+def _signature_changed(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    relpath: str,
+) -> bool:
+    stored = _stored_signature(payload, relpath)
+    if stored is None:
+        return True
+
+    current = file_signature(project_root, relpath)
+    if current is None:
+        return True
+
+    return not _same_content_signature(stored, current)
+
+
+def _stored_signature(
+    payload: dict[str, Any],
+    relpath: str,
+) -> dict[str, Any] | None:
+    files = _files_map(payload)
+    stored = files.get(relpath)
+    if isinstance(stored, dict):
+        return stored
+    return None
+
+
+def _same_content_signature(
+    stored: dict[str, Any],
+    current: dict[str, Any],
+) -> bool:
+    stored_hash = stored.get("sha256")
+    current_hash = current.get("sha256")
+    if not isinstance(stored_hash, str):
+        return False
+    if not isinstance(current_hash, str):
+        return False
+    return stored_hash == current_hash
+
+
+def _direct_dependents(payload: dict[str, Any], relpath: str) -> list[str]:
+    reverse_dependencies = payload.get("reverse_dependencies")
+    if not isinstance(reverse_dependencies, dict):
+        return []
+
+    dependents = reverse_dependencies.get(relpath)
+    if not isinstance(dependents, list):
+        return []
+
+    normalized = []
+    for dependent in dependents:
+        normalized.append(str(dependent))
+    return normalized
+
+
+def _copy_index_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    copied: dict[str, Any] = {}
+    for key, value in payload.items():
+        copied[key] = _copy_value(value)
+    return copied
+
+
+def _copy_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        copied: dict[str, Any] = {}
+        for child_key, child_value in value.items():
+            copied[str(child_key)] = _copy_value(child_value)
+        return copied
+    if isinstance(value, list):
+        copied_list = []
+        for item in value:
+            copied_list.append(_copy_value(item))
+        return copied_list
+    return value
+
+
+def _files_map(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    files = payload.get("files")
+    if isinstance(files, dict):
+        return files
+
+    payload["files"] = {}
+    return payload["files"]
+
+
+def _content_graphs_map(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    content_graphs = payload.get("content_graphs")
+    if isinstance(content_graphs, dict):
+        return content_graphs
+
+    payload["content_graphs"] = {}
+    return payload["content_graphs"]
+
+
+def _ensure_content_graphs(payload: dict[str, Any]) -> None:
+    content_graphs = payload.get("content_graphs")
+    if isinstance(content_graphs, dict):
+        return
+    payload["content_graphs"] = {}
+
+
+def _dict_copy(value: dict[str, Any] | None) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return dict(value)
+
+
+def _list_copy(value: list[Any] | None) -> list[Any]:
+    if value is None:
+        return []
+    return list(value)
+
+
+def _project_root_matches(payload: dict[str, Any], project_root: str | Path) -> bool:
+    stored = payload.get("project_root")
+    if not isinstance(stored, str):
+        return False
+
+    try:
+        stored_root = Path(stored).resolve()
+        current_root = Path(project_root).resolve()
+    except OSError:
+        return False
+    return stored_root == current_root

--- a/test/test_reference_index.py
+++ b/test/test_reference_index.py
@@ -9,6 +9,13 @@ from skylos.core.reference_index import (
     file_signature,
     validate_index_payload,
 )
+from skylos.core.reference_index_store import (
+    changed_index_paths,
+    invalidation_paths_for_changes,
+    load_reference_index,
+    record_file_graph,
+    save_reference_index,
+)
 
 
 def test_build_empty_index_has_stable_schema(tmp_path):
@@ -22,6 +29,7 @@ def test_build_empty_index_has_stable_schema(tmp_path):
     assert payload["references"] == []
     assert payload["imports"] == {}
     assert payload["reverse_dependencies"] == {}
+    assert payload["content_graphs"] == {}
     assert validate_index_payload(payload) is True
     assert INDEX_CACHE_PATH.as_posix() == ".skylos/index/v1/reference_graph.json"
 
@@ -61,6 +69,14 @@ def test_file_signature_rejects_oversized_file(tmp_path):
 
 def test_build_index_payload_normalizes_reverse_dependencies(tmp_path):
     files = {"app.py": {"path": "app.py", "sha256": "abc", "size": 1, "mtime_ns": 1}}
+    content_graphs = {
+        "abc": {
+            "paths": ["app.py"],
+            "definitions": {"app.handler": {"line": 1}},
+            "references": [],
+            "imports": ["os"],
+        }
+    }
     payload = build_index_payload(
         tmp_path,
         files=files,
@@ -68,11 +84,13 @@ def test_build_index_payload_normalizes_reverse_dependencies(tmp_path):
         references=[{"from": "app.main", "to": "app.handler"}],
         imports={"app.py": ["os"]},
         reverse_dependencies={"app.py": ["tests/test_app.py", "tests/test_app.py"]},
+        content_graphs=content_graphs,
     )
 
     assert validate_index_payload(payload) is True
     assert payload["files"] == files
     assert payload["reverse_dependencies"] == {"app.py": ["tests/test_app.py"]}
+    assert payload["content_graphs"] == content_graphs
 
 
 def test_validate_index_payload_rejects_wrong_schema(tmp_path):
@@ -80,3 +98,151 @@ def test_validate_index_payload_rejects_wrong_schema(tmp_path):
     payload["schema_version"] = 999
 
     assert validate_index_payload(payload) is False
+
+
+def test_record_file_graph_keys_graph_by_content_hash(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    content = b"import os\n\ndef handler():\n    return os.getcwd()\n"
+    source.write_bytes(content)
+
+    payload = record_file_graph(
+        tmp_path,
+        build_empty_index(tmp_path),
+        source,
+        definitions={"app.handler": {"file": "src/app.py", "line": 3}},
+        references=[{"from": "app.handler", "to": "os.getcwd"}],
+        imports=["os"],
+    )
+
+    digest = hashlib.sha256(content).hexdigest()
+    assert payload is not None
+    assert payload["files"]["src/app.py"]["sha256"] == digest
+    assert payload["content_graphs"][digest] == {
+        "sha256": digest,
+        "paths": ["src/app.py"],
+        "definitions": {"app.handler": {"file": "src/app.py", "line": 3}},
+        "references": [{"from": "app.handler", "to": "os.getcwd"}],
+        "imports": ["os"],
+    }
+
+
+def test_record_file_graph_preserves_paths_for_same_content_hash(tmp_path):
+    first = tmp_path / "src" / "first.py"
+    second = tmp_path / "src" / "second.py"
+    first.parent.mkdir()
+    content = b"def shared():\n    return 1\n"
+    first.write_bytes(content)
+    second.write_bytes(content)
+
+    payload = record_file_graph(
+        tmp_path,
+        None,
+        first,
+        definitions={"first.shared": {"file": "src/first.py", "line": 1}},
+    )
+    payload = record_file_graph(
+        tmp_path,
+        payload,
+        second,
+        definitions={"second.shared": {"file": "src/second.py", "line": 1}},
+    )
+
+    digest = hashlib.sha256(content).hexdigest()
+    assert payload is not None
+    assert payload["content_graphs"][digest]["paths"] == [
+        "src/first.py",
+        "src/second.py",
+    ]
+    assert payload["content_graphs"][digest]["definitions"] == {
+        "second.shared": {"file": "src/second.py", "line": 1}
+    }
+
+
+def test_save_and_load_reference_index_round_trip(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def handler():\n    return 1\n")
+    payload = record_file_graph(
+        tmp_path,
+        None,
+        source,
+        definitions={"app.handler": {"file": "app.py", "line": 1}},
+        references=[],
+        imports=[],
+    )
+
+    assert payload is not None
+    assert save_reference_index(tmp_path, payload) is True
+
+    loaded = load_reference_index(tmp_path)
+
+    assert loaded == payload
+
+
+def test_load_reference_index_rejects_wrong_project_root(tmp_path):
+    project = tmp_path / "project"
+    other = tmp_path / "other"
+    project.mkdir()
+    other.mkdir()
+    payload = build_empty_index(other)
+
+    assert save_reference_index(project, payload) is False
+    assert load_reference_index(project) is None
+
+
+def test_changed_index_paths_ignores_unchanged_content(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def handler():\n    return 1\n")
+    payload = record_file_graph(tmp_path, None, source)
+
+    assert payload is not None
+    assert changed_index_paths(tmp_path, payload) == []
+
+
+def test_invalidation_paths_include_changed_file_and_direct_dependents(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    test_file = tmp_path / "tests" / "test_app.py"
+    source.parent.mkdir()
+    test_file.parent.mkdir()
+    source.write_text("def handler():\n    return 1\n")
+    test_file.write_text("from src.app import handler\n")
+    payload = record_file_graph(tmp_path, None, source)
+
+    assert payload is not None
+    payload["reverse_dependencies"] = {"src/app.py": ["tests/test_app.py"]}
+    source.write_text("def handler():\n    return 2\n")
+
+    assert changed_index_paths(tmp_path, payload) == ["src/app.py"]
+    assert invalidation_paths_for_changes(tmp_path, payload) == [
+        "src/app.py",
+        "tests/test_app.py",
+    ]
+
+
+def test_invalidation_paths_treat_deleted_indexed_file_as_changed(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("def handler():\n    return 1\n")
+    payload = record_file_graph(tmp_path, None, source)
+
+    assert payload is not None
+    payload["reverse_dependencies"] = {"src/app.py": ["tests/test_app.py"]}
+    source.unlink()
+
+    assert invalidation_paths_for_changes(tmp_path, payload) == [
+        "src/app.py",
+        "tests/test_app.py",
+    ]
+
+
+def test_invalidation_paths_treat_new_candidate_as_changed(tmp_path):
+    source = tmp_path / "src" / "new_file.py"
+    source.parent.mkdir()
+    source.write_text("def created():\n    return 1\n")
+    payload = build_empty_index(tmp_path)
+
+    assert invalidation_paths_for_changes(
+        tmp_path,
+        payload,
+        candidate_paths=[source],
+    ) == ["src/new_file.py"]


### PR DESCRIPTION
## Summary

  - Add a persistent reference graph cache for defs, refs, and imports keyed by file content signatures.
  - Reuse cached graph entries for unchanged files across CLI runs.
  - Invalidate changed files and direct dependents so stale references do not survive index updates.

  ## Tests

  - `pytest test/test_reference_index.py`
