### PR TITLE
feat(vscode): route idle analysis through verify

### DIFF
--- a/editors/vscode/out/ai.js
+++ b/editors/vscode/out/ai.js
@@ -10,6 +10,7 @@ const vscode = require("vscode");
 const crypto = require("crypto");
 const config_1 = require("./config");
 const scanner_1 = require("./scanner");
+const verifyCore_1 = require("./verifyCore");
 class AIAnalyzer {
     constructor(store) {
         this.store = store;
@@ -27,9 +28,6 @@ class AIAnalyzer {
     }
     async maybeAnalyze(document) {
         if (!(0, config_1.isRealtimeAIEnabled)())
-            return;
-        const apiKey = (0, config_1.getAIApiKey)();
-        if (!apiKey)
             return;
         const currentContent = document.getText();
         const filePath = document.uri.fsPath;
@@ -50,10 +48,6 @@ class AIAnalyzer {
     async analyzeChangedFunctions(document, functions) {
         if (this.inFlight || functions.length === 0)
             return;
-        const provider = (0, config_1.getAIProvider)();
-        const apiKey = (0, config_1.getAIApiKey)();
-        if (!apiKey)
-            return;
         if (this.abortController) {
             this.abortController.abort();
             this.streamingManager?.clearAll();
@@ -63,37 +57,9 @@ class AIAnalyzer {
         this.inFlight = true;
         const prevText = this.statusBar?.text ?? "";
         if (this.statusBar)
-            this.statusBar.text = "$(sync~spin) Skylos AI...";
+            this.statusBar.text = "$(sync~spin) Skylos verify...";
         try {
-            const langId = document.languageId;
-            const langLabel = langId === "typescriptreact" ? "TypeScript (React)" : langId;
-            const codeToAnalyze = functions
-                .map((fn) => `# Function: ${fn.name} (line ${fn.startLine + 1})\n${fn.content}`)
-                .join("\n\n---\n\n");
-            const editor = vscode.window.activeTextEditor;
-            const useStreaming = (0, config_1.isStreamingEnabled)() && editor && editor.document === document;
-            let issues;
-            if (useStreaming) {
-                const startLines = functions.map((fn) => fn.startLine);
-                this.streamingManager?.showAnalyzing(editor, startLines);
-                const { StreamingJsonParser } = await Promise.resolve().then(() => require("./streaming"));
-                const streamedIssues = [];
-                const parser = new StreamingJsonParser((issue) => {
-                    streamedIssues.push(issue);
-                    if (this.streamingManager && !signal.aborted) {
-                        const line = Math.max(0, issue.line - 1);
-                        this.streamingManager.streamIssueText(editor, line, issue.message);
-                    }
-                });
-                await callLLMStreamingWithCallback(apiKey, codeToAnalyze, provider, langLabel, (chunk) => {
-                    parser.feed(chunk);
-                }, signal);
-                issues = streamedIssues;
-                this.streamingManager?.clearAll();
-            }
-            else {
-                issues = await callLLMForIssues(apiKey, codeToAnalyze, provider, langLabel);
-            }
+            const issues = await this.verifyChangedFunctions(document, functions);
             if (signal.aborted)
                 return;
             const now = Date.now();
@@ -119,7 +85,12 @@ class AIAnalyzer {
                     this.maybeShowPopup(document, critical);
             }
             if (this.statusBar) {
-                this.statusBar.text = issues.length > 0 ? `$(eye) AI: ${issues.length}` : prevText;
+                if (issues.length > 0) {
+                    this.statusBar.text = `$(eye) AI: ${issues.length}`;
+                }
+                else {
+                    this.statusBar.text = prevText;
+                }
             }
         }
         catch (err) {
@@ -134,6 +105,22 @@ class AIAnalyzer {
         finally {
             this.inFlight = false;
         }
+    }
+    async verifyChangedFunctions(document, functions) {
+        const workspace = vscode.workspace.workspaceFolders?.[0];
+        if (!workspace) {
+            return [];
+        }
+        const request = {
+            bin: (0, config_1.getSkylosBin)(),
+            workspaceRoot: workspace.uri.fsPath,
+            filePath: document.uri.fsPath,
+            code: document.getText(),
+            lineRange: lineRangeForFunctions(functions),
+            confidence: (0, config_1.getConfidenceThreshold)(),
+        };
+        scanner_1.out.appendLine(`Running realtime verifier: ${(0, verifyCore_1.buildVerifyCommandDisplay)(request)}`);
+        return (0, verifyCore_1.runSkylosVerify)(request);
     }
     maybeShowPopup(document, issue) {
         const cooldown = (0, config_1.getPopupCooldownMs)();
@@ -168,6 +155,24 @@ class AIAnalyzer {
     }
 }
 exports.AIAnalyzer = AIAnalyzer;
+function lineRangeForFunctions(functions) {
+    if (functions.length === 0) {
+        return undefined;
+    }
+    let startLine = functions[0].startLine + 1;
+    let endLine = functions[0].endLine + 1;
+    for (const fn of functions) {
+        const candidateStart = fn.startLine + 1;
+        const candidateEnd = fn.endLine + 1;
+        if (candidateStart < startLine) {
+            startLine = candidateStart;
+        }
+        if (candidateEnd > endLine) {
+            endLine = candidateEnd;
+        }
+    }
+    return `${startLine}:${endLine}`;
+}
 function formatAIError(err) {
     if (err instanceof Error)
         return `${err.name}: ${err.message}`;

--- a/editors/vscode/out/verifyCore.js
+++ b/editors/vscode/out/verifyCore.js
@@ -1,0 +1,122 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildVerifyArgs = buildVerifyArgs;
+exports.buildVerifyManifest = buildVerifyManifest;
+exports.buildVerifyCommandDisplay = buildVerifyCommandDisplay;
+exports.runSkylosVerify = runSkylosVerify;
+exports.normalizeVerifyIssues = normalizeVerifyIssues;
+const child_process_1 = require("child_process");
+const scanCore_1 = require("./scanCore");
+function buildVerifyArgs(request) {
+    const args = [
+        "verify",
+        request.workspaceRoot,
+        "--stdin",
+        "--no-fail",
+        "--confidence",
+        String(request.confidence),
+    ];
+    return args;
+}
+function buildVerifyManifest(request) {
+    const manifest = {
+        path: request.workspaceRoot,
+        file: request.filePath,
+        code: request.code,
+    };
+    if (request.lineRange) {
+        manifest.range = request.lineRange;
+    }
+    return manifest;
+}
+function buildVerifyCommandDisplay(request) {
+    return (0, scanCore_1.formatCommand)(request.bin, buildVerifyArgs(request));
+}
+async function runSkylosVerify(request) {
+    const args = buildVerifyArgs(request);
+    const manifest = buildVerifyManifest(request);
+    const manifestText = JSON.stringify(manifest);
+    return new Promise((resolve, reject) => {
+        const proc = (0, child_process_1.spawn)(request.bin, args, { cwd: request.workspaceRoot });
+        let stdout = "";
+        let stderr = "";
+        proc.stdout.on("data", (data) => {
+            stdout += data.toString();
+        });
+        proc.stderr.on("data", (data) => {
+            stderr += data.toString();
+        });
+        proc.on("close", (code) => {
+            if (code !== 0) {
+                reject(new Error(`skylos verify exited with code ${code}: ${stderr}`));
+                return;
+            }
+            try {
+                const payload = JSON.parse(stdout);
+                resolve(normalizeVerifyIssues(payload));
+            }
+            catch {
+                reject(new Error("skylos verify returned invalid JSON"));
+            }
+        });
+        proc.on("error", (error) => {
+            reject(error);
+        });
+        proc.stdin.write(manifestText);
+        proc.stdin.end();
+    });
+}
+function normalizeVerifyIssues(payload) {
+    const findings = payload.findings;
+    if (!Array.isArray(findings)) {
+        return [];
+    }
+    const issues = [];
+    for (const finding of findings) {
+        const issue = normalizeVerifyIssue(finding);
+        if (issue) {
+            issues.push(issue);
+        }
+    }
+    return issues;
+}
+function normalizeVerifyIssue(finding) {
+    const message = finding.message;
+    if (!message) {
+        return undefined;
+    }
+    return {
+        line: verifyIssueLine(finding),
+        message,
+        severity: verifyIssueSeverity(finding),
+    };
+}
+function verifyIssueLine(finding) {
+    const startLine = finding.range?.start_line;
+    if (typeof startLine === "number") {
+        if (startLine > 0) {
+            return startLine;
+        }
+    }
+    return 1;
+}
+function verifyIssueSeverity(finding) {
+    const severity = optionalString(finding.severity).toUpperCase();
+    if (severity === "CRITICAL") {
+        return "error";
+    }
+    if (severity === "HIGH") {
+        return "error";
+    }
+    const likelihood = optionalString(finding.ai_likelihood).toLowerCase();
+    if (likelihood === "high") {
+        return "error";
+    }
+    return "warning";
+}
+function optionalString(value) {
+    if (typeof value === "string") {
+        return value;
+    }
+    return "";
+}

--- a/editors/vscode/src/ai.ts
+++ b/editors/vscode/src/ai.ts
@@ -2,8 +2,20 @@ import * as vscode from "vscode";
 import * as crypto from "crypto";
 import type { FindingsStore } from "./store";
 import type { SkylosFinding, AIIssue, FunctionBlock, AIProvider } from "./types";
-import { getAIProvider, getAIApiKey, getAIModel, getOpenAIBaseUrl, getPopupCooldownMs, isStreamingEnabled, isFixPreviewFirst, getPostFixCommand, isRealtimeAIEnabled } from "./config";
+import {
+  getAIProvider,
+  getAIApiKey,
+  getAIModel,
+  getOpenAIBaseUrl,
+  getPopupCooldownMs,
+  isFixPreviewFirst,
+  getPostFixCommand,
+  isRealtimeAIEnabled,
+  getSkylosBin,
+  getConfidenceThreshold,
+} from "./config";
 import { out } from "./scanner";
+import { buildVerifyCommandDisplay, runSkylosVerify } from "./verifyCore";
 
 
 export class AIAnalyzer {
@@ -29,10 +41,6 @@ export class AIAnalyzer {
 
   async maybeAnalyze(document: vscode.TextDocument): Promise<void> {
     if (!isRealtimeAIEnabled())
-      return;
-
-    const apiKey = getAIApiKey();
-    if (!apiKey) 
       return;
 
     const currentContent = document.getText();
@@ -62,11 +70,6 @@ export class AIAnalyzer {
     if (this.inFlight || functions.length === 0) 
       return;
 
-    const provider = getAIProvider();
-    const apiKey = getAIApiKey();
-    if (!apiKey) 
-      return;
-
     if (this.abortController) {
       this.abortController.abort();
       this.streamingManager?.clearAll();
@@ -76,44 +79,10 @@ export class AIAnalyzer {
 
     this.inFlight = true;
     const prevText = this.statusBar?.text ?? "";
-    if (this.statusBar) this.statusBar.text = "$(sync~spin) Skylos AI...";
+    if (this.statusBar) this.statusBar.text = "$(sync~spin) Skylos verify...";
 
     try {
-      const langId = document.languageId;
-      const langLabel = langId === "typescriptreact" ? "TypeScript (React)" : langId;
-
-      const codeToAnalyze = functions
-        .map((fn) => `# Function: ${fn.name} (line ${fn.startLine + 1})\n${fn.content}`)
-        .join("\n\n---\n\n");
-
-      const editor = vscode.window.activeTextEditor;
-      const useStreaming = isStreamingEnabled() && editor && editor.document === document;
-
-      let issues: AIIssue[];
-
-      if (useStreaming) {
-        const startLines = functions.map((fn) => fn.startLine);
-        this.streamingManager?.showAnalyzing(editor, startLines);
-
-        const { StreamingJsonParser } = await import("./streaming");
-        const streamedIssues: AIIssue[] = [];
-        const parser = new StreamingJsonParser((issue) => {
-          streamedIssues.push(issue);
-          if (this.streamingManager && !signal.aborted) {
-            const line = Math.max(0, issue.line - 1);
-            this.streamingManager.streamIssueText(editor, line, issue.message);
-          }
-        });
-
-        await callLLMStreamingWithCallback(apiKey, codeToAnalyze, provider, langLabel, (chunk) => {
-          parser.feed(chunk);
-        }, signal);
-
-        issues = streamedIssues;
-        this.streamingManager?.clearAll();
-      } else {
-        issues = await callLLMForIssues(apiKey, codeToAnalyze, provider, langLabel);
-      }
+      const issues = await this.verifyChangedFunctions(document, functions);
 
       if (signal.aborted) 
         return;
@@ -146,7 +115,11 @@ export class AIAnalyzer {
       }
 
       if (this.statusBar) {
-        this.statusBar.text = issues.length > 0 ? `$(eye) AI: ${issues.length}` : prevText;
+        if (issues.length > 0) {
+          this.statusBar.text = `$(eye) AI: ${issues.length}`;
+        } else {
+          this.statusBar.text = prevText;
+        }
       }
     } catch (err) {
       if (signal.aborted) {
@@ -158,6 +131,27 @@ export class AIAnalyzer {
     } finally {
       this.inFlight = false;
     }
+  }
+
+  private async verifyChangedFunctions(
+    document: vscode.TextDocument,
+    functions: FunctionBlock[],
+  ): Promise<AIIssue[]> {
+    const workspace = vscode.workspace.workspaceFolders?.[0];
+    if (!workspace) {
+      return [];
+    }
+
+    const request = {
+      bin: getSkylosBin(),
+      workspaceRoot: workspace.uri.fsPath,
+      filePath: document.uri.fsPath,
+      code: document.getText(),
+      lineRange: lineRangeForFunctions(functions),
+      confidence: getConfidenceThreshold(),
+    };
+    out.appendLine(`Running realtime verifier: ${buildVerifyCommandDisplay(request)}`);
+    return runSkylosVerify(request);
   }
 
   private maybeShowPopup(document: vscode.TextDocument, issue: AIIssue): void {
@@ -200,6 +194,26 @@ export class AIAnalyzer {
   dispose(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
   }
+}
+
+function lineRangeForFunctions(functions: FunctionBlock[]): string | undefined {
+  if (functions.length === 0) {
+    return undefined;
+  }
+
+  let startLine = functions[0].startLine + 1;
+  let endLine = functions[0].endLine + 1;
+  for (const fn of functions) {
+    const candidateStart = fn.startLine + 1;
+    const candidateEnd = fn.endLine + 1;
+    if (candidateStart < startLine) {
+      startLine = candidateStart;
+    }
+    if (candidateEnd > endLine) {
+      endLine = candidateEnd;
+    }
+  }
+  return `${startLine}:${endLine}`;
 }
 
 function formatAIError(err: unknown): string {

--- a/editors/vscode/src/verifyCore.ts
+++ b/editors/vscode/src/verifyCore.ts
@@ -1,0 +1,156 @@
+import { spawn } from "child_process";
+import type { AIIssue } from "./types";
+import { formatCommand } from "./scanCore";
+
+export interface VerifyRequest {
+  bin: string;
+  workspaceRoot: string;
+  filePath: string;
+  code: string;
+  lineRange?: string;
+  confidence: number;
+}
+
+interface VerifyFindingRange {
+  start_line?: number;
+  end_line?: number;
+}
+
+interface VerifyFinding {
+  rule_id?: string;
+  ai_likelihood?: string;
+  severity?: string;
+  message?: string;
+  range?: VerifyFindingRange;
+}
+
+interface VerifyPayload {
+  findings?: VerifyFinding[];
+}
+
+export function buildVerifyArgs(request: VerifyRequest): string[] {
+  const args = [
+    "verify",
+    request.workspaceRoot,
+    "--stdin",
+    "--no-fail",
+    "--confidence",
+    String(request.confidence),
+  ];
+  return args;
+}
+
+export function buildVerifyManifest(request: VerifyRequest): Record<string, unknown> {
+  const manifest: Record<string, unknown> = {
+    path: request.workspaceRoot,
+    file: request.filePath,
+    code: request.code,
+  };
+  if (request.lineRange) {
+    manifest.range = request.lineRange;
+  }
+  return manifest;
+}
+
+export function buildVerifyCommandDisplay(request: VerifyRequest): string {
+  return formatCommand(request.bin, buildVerifyArgs(request));
+}
+
+export async function runSkylosVerify(request: VerifyRequest): Promise<AIIssue[]> {
+  const args = buildVerifyArgs(request);
+  const manifest = buildVerifyManifest(request);
+  const manifestText = JSON.stringify(manifest);
+
+  return new Promise<AIIssue[]>((resolve, reject) => {
+    const proc = spawn(request.bin, args, { cwd: request.workspaceRoot });
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`skylos verify exited with code ${code}: ${stderr}`));
+        return;
+      }
+
+      try {
+        const payload = JSON.parse(stdout);
+        resolve(normalizeVerifyIssues(payload));
+      } catch {
+        reject(new Error("skylos verify returned invalid JSON"));
+      }
+    });
+    proc.on("error", (error) => {
+      reject(error);
+    });
+    proc.stdin.write(manifestText);
+    proc.stdin.end();
+  });
+}
+
+export function normalizeVerifyIssues(payload: VerifyPayload): AIIssue[] {
+  const findings = payload.findings;
+  if (!Array.isArray(findings)) {
+    return [];
+  }
+
+  const issues: AIIssue[] = [];
+  for (const finding of findings) {
+    const issue = normalizeVerifyIssue(finding);
+    if (issue) {
+      issues.push(issue);
+    }
+  }
+  return issues;
+}
+
+function normalizeVerifyIssue(finding: VerifyFinding): AIIssue | undefined {
+  const message = finding.message;
+  if (!message) {
+    return undefined;
+  }
+
+  return {
+    line: verifyIssueLine(finding),
+    message,
+    severity: verifyIssueSeverity(finding),
+  };
+}
+
+function verifyIssueLine(finding: VerifyFinding): number {
+  const startLine = finding.range?.start_line;
+  if (typeof startLine === "number") {
+    if (startLine > 0) {
+      return startLine;
+    }
+  }
+  return 1;
+}
+
+function verifyIssueSeverity(finding: VerifyFinding): "error" | "warning" {
+  const severity = optionalString(finding.severity).toUpperCase();
+  if (severity === "CRITICAL") {
+    return "error";
+  }
+  if (severity === "HIGH") {
+    return "error";
+  }
+
+  const likelihood = optionalString(finding.ai_likelihood).toLowerCase();
+  if (likelihood === "high") {
+    return "error";
+  }
+  return "warning";
+}
+
+function optionalString(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return "";
+}

--- a/editors/vscode/test/verifyCore.test.js
+++ b/editors/vscode/test/verifyCore.test.js
@@ -1,0 +1,81 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  buildVerifyArgs,
+  buildVerifyCommandDisplay,
+  buildVerifyManifest,
+  normalizeVerifyIssues,
+} = require("../out/verifyCore");
+
+function request(overrides = {}) {
+  return {
+    bin: "skylos",
+    workspaceRoot: "/repo",
+    filePath: "/repo/src/app.py",
+    code: "def handler():\n    return validate_token(token)\n",
+    lineRange: "1:2",
+    confidence: 75,
+    ...overrides,
+  };
+}
+
+test("buildVerifyArgs uses stdin verifier with no-fail", () => {
+  assert.deepEqual(buildVerifyArgs(request()), [
+    "verify",
+    "/repo",
+    "--stdin",
+    "--no-fail",
+    "--confidence",
+    "75",
+  ]);
+});
+
+test("buildVerifyManifest includes file code and optional range", () => {
+  assert.deepEqual(buildVerifyManifest(request()), {
+    path: "/repo",
+    file: "/repo/src/app.py",
+    code: "def handler():\n    return validate_token(token)\n",
+    range: "1:2",
+  });
+
+  const withoutRange = buildVerifyManifest(request({ lineRange: undefined }));
+  assert.equal(Object.hasOwn(withoutRange, "range"), false);
+});
+
+test("buildVerifyCommandDisplay quotes verifier args", () => {
+  const display = buildVerifyCommandDisplay(request({ workspaceRoot: "/repo with space" }));
+
+  assert.equal(display, "skylos verify '/repo with space' --stdin --no-fail --confidence 75");
+});
+
+test("normalizeVerifyIssues maps verifier findings to AI issues", () => {
+  const issues = normalizeVerifyIssues({
+    findings: [
+      {
+        rule_id: "SKY-L012",
+        ai_likelihood: "high",
+        severity: "MEDIUM",
+        message: "validate_token is undefined",
+        range: { start_line: 2 },
+      },
+      {
+        rule_id: "SKY-L026",
+        ai_likelihood: "medium",
+        severity: "LOW",
+        message: "Generated stub left behind",
+        range: { start_line: 7 },
+      },
+    ],
+  });
+
+  assert.deepEqual(issues, [
+    { line: 2, message: "validate_token is undefined", severity: "error" },
+    { line: 7, message: "Generated stub left behind", severity: "warning" },
+  ]);
+});
+
+test("normalizeVerifyIssues ignores malformed findings", () => {
+  assert.deepEqual(normalizeVerifyIssues({}), []);
+  assert.deepEqual(normalizeVerifyIssues({ findings: [{ range: { start_line: 3 } }] }), []);
+});


### PR DESCRIPTION
## Summary

  - Add a shared VSCode verify core for running the in-loop verifier path.
  - Route idle AI analysis through the verify flow instead of the older direct analysis path.
  - Preserve the existing editor finding shape while narrowing the implementation around verify results.