### PR TITLE
feat(corpus): capture local structural signals

### DIFF
--- a/skylos/agents/service.py
+++ b/skylos/agents/service.py
@@ -16,6 +16,7 @@ from skylos.agents.center import (
     resolve_state_path,
     update_action_triage,
 )
+from skylos.core.contribution_events import record_structural_event
 
 
 def _error_payload(message: str) -> dict[str, str]:
@@ -155,12 +156,16 @@ class AgentServiceController:
 
     def dismiss(self, action_id: str) -> dict[str, Any]:
         with self._lock:
-            return update_action_triage(
+            state = self.get_state()
+            finding = _finding_by_fingerprint(state, action_id)
+            updated = update_action_triage(
                 self.project_root,
                 action_id,
                 status="dismissed",
                 state_file=self.state_file,
             )
+            self._record_contribution_event(finding, event_type="dismiss")
+            return updated
 
     def snooze(self, action_id: str, *, hours: float) -> dict[str, Any]:
         with self._lock:
@@ -197,6 +202,10 @@ class AgentServiceController:
         updated = learner.learn_from_triage(finding, action)
         learner.save(str(self.project_root))
 
+        event_type = _contribution_event_type(action)
+        if event_type is not None:
+            self._record_contribution_event(finding, event_type=event_type)
+
         return {
             "ok": True,
             "patterns_updated": len(updated),
@@ -229,6 +238,18 @@ class AgentServiceController:
             "total_patterns": learner.pattern_count,
         }
 
+    def _record_contribution_event(
+        self,
+        finding: dict[str, Any] | None,
+        *,
+        event_type: str,
+    ) -> None:
+        record_structural_event(
+            self.project_root,
+            finding,
+            event_type=event_type,
+        )
+
 
 def _resolve_refresh_query(query: str) -> bool:
     params = parse_qs(query or "", keep_blank_values=False)
@@ -243,6 +264,32 @@ def _resolve_limit_query(query: str, default: int) -> int:
     except ValueError:
         return default
     return max(1, min(value, 100))
+
+
+def _finding_by_fingerprint(
+    state: dict[str, Any],
+    action_id: str,
+) -> dict[str, Any] | None:
+    findings = state.get("findings")
+    if not isinstance(findings, list):
+        return None
+
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        fingerprint = finding.get("fingerprint")
+        if fingerprint == action_id:
+            return finding
+    return None
+
+
+def _contribution_event_type(action: str) -> str | None:
+    normalized = str(action).strip().lower()
+    if normalized == "accept":
+        return "accept"
+    if normalized == "dismiss":
+        return "dismiss"
+    return None
 
 
 def _dispatch_get_request(

--- a/skylos/config.py
+++ b/skylos/config.py
@@ -48,6 +48,12 @@ DEFAULTS = {
         "security_audit": None,
         "review": None,
     },
+    "contribution": {
+        "collect_local_signals": False,
+        "contribute_public_corpus": False,
+        "structural_signatures_only": True,
+        "include_source": False,
+    },
     "security_enabled": False,
     "secrets_enabled": False,
     "quality_enabled": False,
@@ -348,9 +354,13 @@ def _merge_user_config(base_cfg: dict, user_cfg: dict | None) -> dict:
                 merged_masking.update(value)
                 final_cfg["masking"] = merged_masking
             continue
-        if key in ("gate", "templates", "vibe", "architecture") and isinstance(
-            value, dict
-        ):
+        if key in (
+            "gate",
+            "templates",
+            "vibe",
+            "architecture",
+            "contribution",
+        ) and isinstance(value, dict):
             merged_section = {}
             current_section = final_cfg.get(key)
             if isinstance(current_section, dict):
@@ -412,6 +422,7 @@ def _sanitize_config(cfg: dict) -> dict:
     )
     safe["masking"] = _sanitize_masking_section(safe.get("masking"))
     safe["templates"] = _sanitize_templates_section(safe.get("templates"))
+    safe["contribution"] = _sanitize_contribution_section(safe.get("contribution"))
     safe["vibe"] = _sanitize_vibe_section(safe.get("vibe"))
     safe["architecture"] = _sanitize_architecture_section(safe.get("architecture"))
 
@@ -523,6 +534,29 @@ def _sanitize_templates_section(value):
         candidate = raw.get(key)
         if candidate is None or isinstance(candidate, str):
             safe[key] = candidate
+    return safe
+
+
+def _sanitize_contribution_section(value):
+    if isinstance(value, dict):
+        raw = value
+    else:
+        raw = {}
+
+    safe = copy.deepcopy(DEFAULTS["contribution"])
+    safe["collect_local_signals"] = _safe_bool(
+        raw.get("collect_local_signals"),
+        safe["collect_local_signals"],
+    )
+    safe["contribute_public_corpus"] = _safe_bool(
+        raw.get("contribute_public_corpus"),
+        safe["contribute_public_corpus"],
+    )
+    safe["structural_signatures_only"] = _safe_bool(
+        raw.get("structural_signatures_only"),
+        safe["structural_signatures_only"],
+    )
+    safe["include_source"] = False
     return safe
 
 

--- a/skylos/core/contribution_events.py
+++ b/skylos/core/contribution_events.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from skylos.core.contribution_settings import (
+    ContributionSettings,
+    load_contribution_settings,
+)
+from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
+
+
+EVENT_SCHEMA_VERSION = 1
+EVENT_CACHE_PATH = Path(".skylos") / "contribution" / "events.json"
+MAX_LOCAL_EVENTS = 1_000
+
+
+def record_structural_event(
+    project_root: str | Path,
+    finding: dict[str, Any] | None,
+    *,
+    event_type: str,
+    settings: ContributionSettings | None = None,
+) -> bool:
+    if finding is None:
+        return False
+
+    resolved_settings = _settings(project_root, settings)
+    if not resolved_settings.collect_local_signals:
+        return False
+
+    event = build_structural_event(finding, event_type=event_type)
+    payload = load_local_events(project_root)
+    events = _events_list(payload)
+    events.append(event)
+    payload["events"] = _bounded_events(events)
+    return save_project_json_cache(project_root, EVENT_CACHE_PATH, payload)
+
+
+def load_local_events(project_root: str | Path) -> dict[str, Any]:
+    payload = load_project_json_cache(project_root, EVENT_CACHE_PATH)
+    if not isinstance(payload, dict):
+        return _empty_payload()
+    if payload.get("schema_version") != EVENT_SCHEMA_VERSION:
+        return _empty_payload()
+
+    events = payload.get("events")
+    if not isinstance(events, list):
+        payload["events"] = []
+    return payload
+
+
+def build_structural_event(
+    finding: dict[str, Any],
+    *,
+    event_type: str,
+) -> dict[str, Any]:
+    event = {
+        "schema_version": EVENT_SCHEMA_VERSION,
+        "event_type": str(event_type),
+        "rule_id": _string_field(finding, ("rule_id", "ruleId", "rule")),
+        "category": _string_field(finding, ("category",)),
+        "severity": _string_field(finding, ("severity",)),
+        "vibe_category": _string_field(finding, ("vibe_category",)),
+        "ai_likelihood": _string_field(finding, ("ai_likelihood",)),
+        "file_ext": _file_ext(finding),
+        "line_bucket": _line_bucket(finding.get("line")),
+        "message_hash": _hash_value(_string_field(finding, ("message",))),
+        "created_at": _utc_timestamp(),
+    }
+    event["structural_hash"] = _structural_hash(event)
+    return event
+
+
+def _settings(
+    project_root: str | Path,
+    settings: ContributionSettings | None,
+) -> ContributionSettings:
+    if settings is not None:
+        return settings
+    return load_contribution_settings(project_root)
+
+
+def _empty_payload() -> dict[str, Any]:
+    return {"schema_version": EVENT_SCHEMA_VERSION, "events": []}
+
+
+def _events_list(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    events = payload.get("events")
+    if not isinstance(events, list):
+        return []
+
+    safe_events = []
+    for event in events:
+        if isinstance(event, dict):
+            safe_events.append(copy.deepcopy(event))
+    return safe_events
+
+
+def _bounded_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if len(events) <= MAX_LOCAL_EVENTS:
+        return events
+    start = len(events) - MAX_LOCAL_EVENTS
+    return events[start:]
+
+
+def _string_field(finding: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = finding.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _file_ext(finding: dict[str, Any]) -> str:
+    file_value = _string_field(finding, ("file", "absolute_file", "relativePath"))
+    if not file_value:
+        return ""
+    return Path(file_value).suffix.lower()
+
+
+def _line_bucket(value: Any) -> str:
+    try:
+        line = int(value)
+    except (TypeError, ValueError):
+        return "unknown"
+
+    if line <= 0:
+        return "unknown"
+    bucket_start = ((line - 1) // 10) * 10 + 1
+    bucket_end = bucket_start + 9
+    return f"{bucket_start}-{bucket_end}"
+
+
+def _hash_value(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def _structural_hash(event: dict[str, Any]) -> str:
+    structural = {}
+    for key, value in event.items():
+        if key == "created_at":
+            continue
+        if key == "structural_hash":
+            continue
+        structural[key] = value
+    raw = json.dumps(structural, sort_keys=True, separators=(",", ":"))
+    return _hash_value(raw)
+
+
+def _utc_timestamp() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/skylos/core/contribution_settings.py
+++ b/skylos/core/contribution_settings.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from skylos.config import load_config
+
+
+@dataclass(frozen=True)
+class ContributionSettings:
+    collect_local_signals: bool
+    contribute_public_corpus: bool
+    structural_signatures_only: bool
+    include_source: bool
+
+    @property
+    def local_only(self) -> bool:
+        if not self.collect_local_signals:
+            return False
+        if self.contribute_public_corpus:
+            return False
+        return True
+
+
+def load_contribution_settings(
+    project_root: str | Path,
+    *,
+    config_file: str | Path | None = None,
+) -> ContributionSettings:
+    config = load_config(project_root, config_file=config_file)
+    return contribution_settings_from_config(config)
+
+
+def contribution_settings_from_config(config: dict[str, Any]) -> ContributionSettings:
+    contribution = config.get("contribution")
+    if not isinstance(contribution, dict):
+        contribution = {}
+
+    return ContributionSettings(
+        collect_local_signals=_bool_value(contribution, "collect_local_signals"),
+        contribute_public_corpus=_bool_value(contribution, "contribute_public_corpus"),
+        structural_signatures_only=_bool_value(
+            contribution,
+            "structural_signatures_only",
+            default=True,
+        ),
+        include_source=False,
+    )
+
+
+def _bool_value(
+    config: dict[str, Any],
+    key: str,
+    *,
+    default: bool = False,
+) -> bool:
+    value = config.get(key)
+    if isinstance(value, bool):
+        return value
+    return default

--- a/test/test_agent_service.py
+++ b/test/test_agent_service.py
@@ -11,6 +11,7 @@ from skylos.agents.service import (
     _default_allowed_origins,
     create_agent_service,
 )
+from skylos.core.contribution_events import load_local_events
 
 
 @contextlib.contextmanager
@@ -116,6 +117,20 @@ def build_service_state(project_root, findings):
     return state
 
 
+def enable_local_contribution(project_root):
+    config_path = project_root / "pyproject.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[tool.skylos.contribution]",
+                "collect_local_signals = true",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_agent_service_controller_serves_command_center_and_triage_updates(tmp_path):
     project_root = tmp_path / "repo"
     project_root.mkdir()
@@ -163,6 +178,71 @@ def test_agent_service_controller_serves_command_center_and_triage_updates(tmp_p
     restored = controller.restore("security:1")
     assert restored["triage"] == {}
     assert restored["actions"][0]["id"] == "security:1"
+
+
+def test_agent_service_dismiss_records_local_contribution_event(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    enable_local_contribution(project_root)
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "vibe:1",
+                "rule_id": "SKY-L012",
+                "category": "quality",
+                "severity": "MEDIUM",
+                "message": "validate_token is never defined",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 27,
+                "vibe_category": "hallucinated_reference",
+                "ai_likelihood": "high",
+            },
+        ],
+    )
+
+    controller = AgentServiceController(str(project_root))
+    dismissed = controller.dismiss("vibe:1")
+    payload = load_local_events(project_root)
+
+    assert dismissed["triage"]["vibe:1"]["status"] == "dismissed"
+    assert len(payload["events"]) == 1
+    assert payload["events"][0]["event_type"] == "dismiss"
+    assert payload["events"][0]["rule_id"] == "SKY-L012"
+    assert payload["events"][0]["vibe_category"] == "hallucinated_reference"
+
+
+def test_agent_service_learn_accept_records_local_contribution_event(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    enable_local_contribution(project_root)
+    build_service_state(
+        project_root,
+        [
+            {
+                "fingerprint": "vibe:1",
+                "rule_id": "SKY-L012",
+                "category": "quality",
+                "severity": "MEDIUM",
+                "message": "validate_token is never defined",
+                "file": "src/auth.py",
+                "absolute_file": str(project_root / "src" / "auth.py"),
+                "line": 27,
+                "vibe_category": "hallucinated_reference",
+                "ai_likelihood": "high",
+            },
+        ],
+    )
+
+    controller = AgentServiceController(str(project_root))
+    result = controller.learn_triage("vibe:1", "accept")
+    payload = load_local_events(project_root)
+
+    assert result["ok"] is True
+    assert len(payload["events"]) == 1
+    assert payload["events"][0]["event_type"] == "accept"
+    assert payload["events"][0]["rule_id"] == "SKY-L012"
 
 
 def test_agent_service_controller_tracks_snoozed_actions(tmp_path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -13,6 +13,7 @@ from skylos.config import (
     get_all_ignore_lines,
     suggest_pattern,
 )
+from skylos.core.contribution_settings import load_contribution_settings
 
 
 class TestSkylosConfig(unittest.TestCase):
@@ -27,6 +28,57 @@ class TestSkylosConfig(unittest.TestCase):
         config = load_config(self.root)
         self.assertEqual(config["complexity"], DEFAULTS["complexity"])
         self.assertEqual(config["ignore"], [])
+        self.assertEqual(config["contribution"], DEFAULTS["contribution"])
+
+    def test_contribution_settings_default_to_no_capture_or_upload(self):
+        settings = load_contribution_settings(self.root)
+
+        self.assertFalse(settings.collect_local_signals)
+        self.assertFalse(settings.contribute_public_corpus)
+        self.assertTrue(settings.structural_signatures_only)
+        self.assertFalse(settings.include_source)
+        self.assertFalse(settings.local_only)
+
+    def test_contribution_settings_allow_explicit_local_only_capture(self):
+        toml_path = self.root / "pyproject.toml"
+        toml_path.write_text(
+            """
+[tool.skylos.contribution]
+collect_local_signals = true
+contribute_public_corpus = false
+structural_signatures_only = true
+include_source = true
+""".strip(),
+            encoding="utf-8",
+        )
+
+        settings = load_contribution_settings(self.root)
+
+        self.assertTrue(settings.collect_local_signals)
+        self.assertFalse(settings.contribute_public_corpus)
+        self.assertTrue(settings.structural_signatures_only)
+        self.assertFalse(settings.include_source)
+        self.assertTrue(settings.local_only)
+
+    def test_contribution_settings_require_explicit_public_corpus_opt_in(self):
+        toml_path = self.root / "pyproject.toml"
+        toml_path.write_text(
+            """
+[tool.skylos.contribution]
+collect_local_signals = true
+contribute_public_corpus = true
+structural_signatures_only = false
+""".strip(),
+            encoding="utf-8",
+        )
+
+        settings = load_contribution_settings(self.root)
+
+        self.assertTrue(settings.collect_local_signals)
+        self.assertTrue(settings.contribute_public_corpus)
+        self.assertFalse(settings.structural_signatures_only)
+        self.assertFalse(settings.include_source)
+        self.assertFalse(settings.local_only)
 
     def test_load_config_traversal(self):
         toml_path = self.root / "pyproject.toml"

--- a/test/test_contribution_events.py
+++ b/test/test_contribution_events.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from skylos.core.contribution_events import (
+    build_structural_event,
+    load_local_events,
+    record_structural_event,
+)
+from skylos.core.contribution_settings import ContributionSettings
+
+
+def _enabled_settings() -> ContributionSettings:
+    return ContributionSettings(
+        collect_local_signals=True,
+        contribute_public_corpus=False,
+        structural_signatures_only=True,
+        include_source=False,
+    )
+
+
+def _finding() -> dict:
+    return {
+        "fingerprint": "vibe:1",
+        "rule_id": "SKY-L012",
+        "category": "quality",
+        "severity": "MEDIUM",
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+        "message": "validate_token is never defined",
+        "file": "src/auth.py",
+        "absolute_file": "/private/project/src/auth.py",
+        "line": 27,
+        "code": "validate_token(request)",
+        "source": "validate_token(request)",
+    }
+
+
+def test_record_structural_event_is_off_by_default(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+
+    recorded = record_structural_event(
+        project_root,
+        _finding(),
+        event_type="dismiss",
+    )
+    payload = load_local_events(project_root)
+
+    assert recorded is False
+    assert payload == {"schema_version": 1, "events": []}
+
+
+def test_record_structural_event_stores_privacy_clean_signature(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+
+    recorded = record_structural_event(
+        project_root,
+        _finding(),
+        event_type="dismiss",
+        settings=_enabled_settings(),
+    )
+    payload = load_local_events(project_root)
+
+    assert recorded is True
+    assert len(payload["events"]) == 1
+
+    event = payload["events"][0]
+    assert event["schema_version"] == 1
+    assert event["event_type"] == "dismiss"
+    assert event["rule_id"] == "SKY-L012"
+    assert event["vibe_category"] == "hallucinated_reference"
+    assert event["ai_likelihood"] == "high"
+    assert event["file_ext"] == ".py"
+    assert event["line_bucket"] == "21-30"
+    assert event["message_hash"]
+    assert event["structural_hash"]
+    assert "message" not in event
+    assert "file" not in event
+    assert "absolute_file" not in event
+    assert "code" not in event
+    assert "source" not in event
+
+
+def test_build_structural_event_supports_rule_alias_without_source():
+    finding = {
+        "rule": "SKY-D222",
+        "message": "package does not exist",
+        "file": "package.json",
+        "line": 1,
+    }
+
+    event = build_structural_event(finding, event_type="accept")
+
+    assert event["event_type"] == "accept"
+    assert event["rule_id"] == "SKY-D222"
+    assert event["file_ext"] == ".json"
+    assert event["line_bucket"] == "1-10"


### PR DESCRIPTION
## Summary

  - Add local-only contribution settings, disabled by default.
  - Record structural accept, dismiss, learn events for AI defect findings.
  - Wire local signal capture into the agent service

  ## Tests

  - `pytest test/test_config.py test/test_agent_service.py test/test_contribution_events.py`