### PR TITLE
fix(verify): handle manifest-only dependency cases

### DIFF
--- a/benchmarks/ai_code_defects/fixtures/dependency_version_hallucination/package.json
+++ b/benchmarks/ai_code_defects/fixtures/dependency_version_hallucination/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "definitely-not-a-real-skylos-benchmark-package": "9.9.9"
+    "left-pad": "99.99.99"
   }
 }

--- a/benchmarks/ai_code_defects/manifest.json
+++ b/benchmarks/ai_code_defects/manifest.json
@@ -65,12 +65,20 @@
       "scan": {
         "confidence": 60,
         "project_context": true,
-        "dependency_hallucinations": true
+        "dependency_hallucinations": true,
+        "dependency_statuses": [
+          {
+            "ecosystem": "npm",
+            "name": "left-pad",
+            "version": "99.99.99",
+            "status": "missing_version"
+          }
+        ]
       },
       "expect": {
         "present": [
           {
-            "rule_id": "SKY-D222",
+            "rule_id": "SKY-D225",
             "vibe_category": "dependency_hallucination"
           }
         ],

--- a/scripts/ai_code_defect_benchmark.py
+++ b/scripts/ai_code_defect_benchmark.py
@@ -37,7 +37,11 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    summary = run_manifest(args.manifest, selected_cases=set(args.case))
+    selected_cases = None
+    if args.case:
+        selected_cases = set(args.case)
+
+    summary = run_manifest(args.manifest, selected_cases=selected_cases)
     if args.json:
         print(json.dumps(summary, indent=2))
     else:

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -426,6 +426,20 @@ def _resolve_analysis_root(path_like: Path) -> Path:
     return current
 
 
+def _no_source_danger_targets(
+    first_path: Path,
+    discovered_root: Path,
+) -> tuple[Path, Path]:
+    if first_path.is_file():
+        scan_target = first_path
+        manifest_root = first_path.parent
+    else:
+        scan_target = discovered_root
+        manifest_root = discovered_root
+
+    return scan_target, manifest_root
+
+
 def _grep_verify_rescue_priority(candidate: dict) -> tuple:
     """Budget grep verification toward candidates most worth rescuing first."""
     return (
@@ -2070,6 +2084,10 @@ class Skylos:
 
         if not files:
             logger.warning(f"No Python files found in {path}")
+            no_source_scan_target, no_source_manifest_root = _no_source_danger_targets(
+                _first,
+                Path(root),
+            )
             result = {
                 "unused_functions": [],
                 "unused_imports": [],
@@ -2088,29 +2106,46 @@ class Skylos:
                 "workspaces": workspace_inventory.to_dict(project_root),
             }
             if enable_danger:
+                danger_findings = []
                 try:
                     from skylos.rules.config import scan_config_files
 
-                    scan_target = _first if _first.is_file() else project_root
                     config_findings = scan_config_files(
-                        scan_target,
+                        no_source_scan_target,
                         changed_files=changed_files,
                         ignore=project_ignore,
                     )
                     if config_findings:
-                        from skylos.rules.compliance import (
-                            enrich_findings_with_compliance,
-                        )
-
-                        result["danger"] = enrich_findings_with_compliance(
-                            config_findings
-                        )
-                        result["analysis_summary"]["danger_count"] = len(
-                            config_findings
-                        )
+                        danger_findings.extend(config_findings)
                 except Exception:
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error("Config scan failed", exc_info=True)
+
+                try:
+                    from skylos.rules.danger.danger_hallucination.manifest_dependency_hallucination import (
+                        scan_manifest_dependency_hallucinations,
+                    )
+
+                    manifest_findings = scan_manifest_dependency_hallucinations(
+                        no_source_manifest_root,
+                    )
+                    for finding in manifest_findings:
+                        if finding.get("rule_id") in project_ignore:
+                            continue
+                        danger_findings.append(finding)
+                except Exception:
+                    if os.getenv("SKYLOS_DEBUG"):
+                        logger.error("Manifest dependency scan failed", exc_info=True)
+
+                if danger_findings:
+                    from skylos.rules.compliance import (
+                        enrich_findings_with_compliance,
+                    )
+
+                    result["danger"] = enrich_findings_with_compliance(
+                        danger_findings
+                    )
+                    result["analysis_summary"]["danger_count"] = len(danger_findings)
             return json.dumps(result)
 
         logger.info(f"Analyzing {len(files)} files...")
@@ -2678,7 +2713,11 @@ class Skylos:
             try:
                 from skylos.rules.config import scan_config_files
 
-                scan_target = _first if _first.is_file() else project_root
+                if _first.is_file():
+                    scan_target = _first
+                else:
+                    scan_target = project_root
+
                 config_findings = scan_config_files(
                     scan_target,
                     changed_files=changed_files,

--- a/skylos/benchmarks/ai_code_defects.py
+++ b/skylos/benchmarks/ai_code_defects.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import json
+import shutil
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from skylos.rules.danger.danger_hallucination.manifest_dependency_hallucination import (
+    VERSION_CACHE_PATH,
+    VERSION_CACHE_SCHEMA_VERSION,
+)
 from skylos.verify_change import verify_change_path
 
 
@@ -22,6 +28,12 @@ IMPORTANCE_WEIGHTS = {
     "medium": 1.0,
     "high": 2.0,
     "critical": 3.0,
+}
+DEPENDENCY_STATUS_VALUES = {
+    "exists",
+    "missing_package",
+    "missing_version",
+    "unknown",
 }
 
 VerifyFunc = Callable[..., dict[str, Any]]
@@ -291,6 +303,51 @@ def _validate_scan(case: dict[str, Any], case_id: str) -> None:
         raise ValueError(
             f"AI-code-defect benchmark case {case_id} scan config must be an object"
         )
+    _validate_dependency_statuses(scan, case_id)
+
+
+def _validate_dependency_statuses(scan: dict[str, Any], case_id: str) -> None:
+    dependency_statuses = scan.get("dependency_statuses")
+    if dependency_statuses is None:
+        return
+    if not isinstance(dependency_statuses, list):
+        raise ValueError(
+            f"AI-code-defect benchmark case {case_id} scan.dependency_statuses "
+            "must be a list"
+        )
+
+    for entry in dependency_statuses:
+        _validate_dependency_status_entry(entry, case_id)
+
+
+def _validate_dependency_status_entry(entry: Any, case_id: str) -> None:
+    if not isinstance(entry, dict):
+        raise ValueError(
+            f"AI-code-defect benchmark case {case_id} dependency status entries "
+            "must be objects"
+        )
+
+    for key in ("ecosystem", "name", "version", "status"):
+        value = entry.get(key)
+        if not isinstance(value, str):
+            raise ValueError(
+                f"AI-code-defect benchmark case {case_id} dependency status "
+                f"needs string {key}"
+            )
+        if not value.strip():
+            raise ValueError(
+                f"AI-code-defect benchmark case {case_id} dependency status "
+                f"needs non-empty {key}"
+            )
+
+    if entry["status"] in DEPENDENCY_STATUS_VALUES:
+        return
+
+    allowed = ", ".join(sorted(DEPENDENCY_STATUS_VALUES))
+    raise ValueError(
+        f"AI-code-defect benchmark case {case_id} dependency status must be "
+        f"one of: {allowed}"
+    )
 
 
 def _selected_cases(selected_cases: set[str] | None) -> set[str] | None:
@@ -318,17 +375,22 @@ def _run_case(
     if not isinstance(scan, dict):
         scan = {}
 
+    run_case_path, temp_case = _prepared_case_path(case_path, scan)
     started = time.perf_counter()
-    result = verify_func(
-        case_path,
-        line_range=scan.get("range"),
-        confidence=int(scan.get("confidence", 60)),
-        project_context=bool(scan.get("project_context", True)),
-        include_dependency_hallucinations=bool(
-            scan.get("dependency_hallucinations", False)
-        ),
-    )
-    elapsed = time.perf_counter() - started
+    try:
+        result = verify_func(
+            run_case_path,
+            line_range=scan.get("range"),
+            confidence=int(scan.get("confidence", 60)),
+            project_context=bool(scan.get("project_context", True)),
+            include_dependency_hallucinations=bool(
+                scan.get("dependency_hallucinations", False)
+            ),
+        )
+        elapsed = time.perf_counter() - started
+    finally:
+        if temp_case is not None:
+            temp_case.cleanup()
 
     failures, counts = _evaluate_case(case, result)
     return {
@@ -344,6 +406,69 @@ def _run_case(
         "absent_total": counts["absent_total"],
         "absent_violations": counts["absent_violations"],
     }
+
+
+def _prepared_case_path(
+    case_path: Path,
+    scan: dict[str, Any],
+) -> tuple[Path, tempfile.TemporaryDirectory[str] | None]:
+    dependency_statuses = _dependency_status_entries(scan)
+    if not dependency_statuses:
+        return case_path, None
+
+    temp_case = tempfile.TemporaryDirectory(prefix="skylos-ai-defect-")
+    prepared_path = Path(temp_case.name) / case_path.name
+    if case_path.is_dir():
+        shutil.copytree(case_path, prepared_path)
+    else:
+        prepared_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(case_path, prepared_path)
+
+    _write_dependency_status_cache(prepared_path, dependency_statuses)
+    return prepared_path, temp_case
+
+
+def _dependency_status_entries(scan: dict[str, Any]) -> list[dict[str, Any]]:
+    entries = scan.get("dependency_statuses")
+    if not isinstance(entries, list):
+        return []
+
+    statuses: list[dict[str, Any]] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            statuses.append(entry)
+    return statuses
+
+
+def _write_dependency_status_cache(
+    case_path: Path,
+    dependency_statuses: list[dict[str, Any]],
+) -> None:
+    if case_path.is_file():
+        cache_root = case_path.parent
+    else:
+        cache_root = case_path
+
+    cache_path = cache_root / VERSION_CACHE_PATH
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    statuses: dict[str, str] = {}
+    for entry in dependency_statuses:
+        key = _dependency_status_key(entry)
+        statuses[key] = str(entry["status"])
+
+    payload = {
+        "schema_version": VERSION_CACHE_SCHEMA_VERSION,
+        "statuses": statuses,
+    }
+    cache_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _dependency_status_key(entry: dict[str, Any]) -> str:
+    ecosystem = str(entry["ecosystem"])
+    name = str(entry["name"])
+    version = str(entry["version"])
+    return f"{ecosystem}:{name}:{version}"
 
 
 def _evaluate_case(

--- a/test/test_ai_code_defect_benchmark.py
+++ b/test/test_ai_code_defect_benchmark.py
@@ -65,7 +65,7 @@ def test_ai_code_defect_runner_scores_expectations(monkeypatch):
         return {
             "findings": [
                 {
-                    "rule_id": "SKY-D222",
+                    "rule_id": "SKY-D225",
                     "vibe_category": "dependency_hallucination",
                 }
             ]
@@ -81,6 +81,71 @@ def test_ai_code_defect_runner_scores_expectations(monkeypatch):
     assert summary["failure_count"] == 0
     assert summary["scores"]["overall_score"] == pytest.approx(100.0)
     assert seen[2][1]["include_dependency_hallucinations"] is True
+
+
+def test_ai_code_defect_runner_empty_selection_runs_all_cases(monkeypatch):
+    seen = []
+
+    def fake_verify(case_path, **_kwargs):
+        seen.append(Path(case_path).name)
+        return {
+            "findings": [
+                {
+                    "rule_id": "SKY-L012",
+                    "vibe_category": "hallucinated_reference",
+                },
+                {
+                    "rule_id": "SKY-L026",
+                    "vibe_category": "incomplete_generation",
+                },
+                {
+                    "rule_id": "SKY-D225",
+                    "vibe_category": "dependency_hallucination",
+                },
+            ]
+        }
+
+    summary = run_manifest(MANIFEST_PATH, selected_cases=None, verify_func=fake_verify)
+
+    assert summary["case_count"] == 3
+    assert seen == [
+        "hallucinated_reference",
+        "incomplete_generation",
+        "dependency_version_hallucination",
+    ]
+
+
+def test_ai_code_defect_runner_seeds_dependency_status_cache():
+    cache_payloads = []
+    prepared_paths = []
+
+    def fake_verify(case_path, **_kwargs):
+        prepared_path = Path(case_path)
+        prepared_paths.append(prepared_path)
+        cache_path = prepared_path / ".skylos" / "cache" / "dependency_versions.json"
+        cache_payloads.append(json.loads(cache_path.read_text(encoding="utf-8")))
+        return {
+            "findings": [
+                {
+                    "rule_id": "SKY-D225",
+                    "vibe_category": "dependency_hallucination",
+                }
+            ]
+        }
+
+    summary = run_manifest(
+        MANIFEST_PATH,
+        selected_cases={"dependency-version-hallucination"},
+        verify_func=fake_verify,
+    )
+
+    assert summary["case_count"] == 1
+    assert summary["pass_count"] == 1
+    assert cache_payloads[0]["schema_version"] == 1
+    assert cache_payloads[0]["statuses"] == {
+        "npm:left-pad:99.99.99": "missing_version"
+    }
+    assert not prepared_paths[0].exists()
 
 
 def test_ai_code_defect_runner_reports_missing_expectation(monkeypatch):

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -2887,6 +2887,52 @@ def handler(request):
         assert result["analysis_summary"]["sca_count"] == 1
         assert result["dependency_vulnerabilities"][0]["rule_id"] == "CVE-TEST"
 
+    def test_danger_scan_checks_manifest_dependencies_without_python_files(
+        self, tmp_path, monkeypatch
+    ):
+        project = tmp_path / "repo"
+        manifest_only = project / "fixtures" / "manifest_only"
+        manifest_only.mkdir(parents=True)
+        (project / "pyproject.toml").write_text(
+            "[tool.skylos]\n",
+            encoding="utf-8",
+        )
+        (project / "package.json").write_text(
+            json.dumps({"dependencies": {"parent-only": "99.99.99"}}),
+            encoding="utf-8",
+        )
+        (manifest_only / "package.json").write_text(
+            json.dumps({"dependencies": {"child-only": "99.99.99"}}),
+            encoding="utf-8",
+        )
+
+        from skylos.rules.danger.danger_hallucination import (
+            manifest_dependency_hallucination,
+        )
+
+        def fake_status_checker(_ecosystem, _name, _version, _cache):
+            return manifest_dependency_hallucination.STATUS_MISSING_VERSION
+
+        monkeypatch.setattr(
+            manifest_dependency_hallucination,
+            "check_dependency_version_status",
+            fake_status_checker,
+        )
+
+        raw_result = analyze(
+            str(manifest_only),
+            conf=0,
+            enable_danger=True,
+            grep_verify=False,
+        )
+        result = json.loads(raw_result)
+
+        danger = result.get("danger")
+        assert isinstance(danger, list)
+        assert result["analysis_summary"]["danger_count"] == 1
+        assert danger[0]["rule_id"] == "SKY-D225"
+        assert danger[0]["metadata"]["package_name"] == "child-only"
+
     def test_danger_dependency_scan_uses_project_root_for_src_layout(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary
  - fix AI-code defect benchmark default runs so all cases execute when no `--case` filter is passed
  - scan manifest only dependency hallucination targets from the requested path
  - make the dependency version benchmark deterministic

  ## Tests
  - `pytest .`