### PR TITLE
fix(verify): catch api and stale-reference hallucinations

### DIFF
--- a/skylos/benchmarks/ai_code_defects.py
+++ b/skylos/benchmarks/ai_code_defects.py
@@ -506,7 +506,7 @@ def _prepared_case_path(
     scan: dict[str, Any],
 ) -> tuple[Path, tempfile.TemporaryDirectory[str] | None]:
     dependency_statuses = _dependency_status_entries(scan)
-    if not dependency_statuses:
+    if not dependency_statuses and not _include_danger_scan(scan):
         return case_path, None
 
     temp_case = tempfile.TemporaryDirectory(prefix="skylos-ai-defect-")
@@ -517,7 +517,8 @@ def _prepared_case_path(
         prepared_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(case_path, prepared_path)
 
-    _write_dependency_status_cache(prepared_path, dependency_statuses)
+    if dependency_statuses:
+        _write_dependency_status_cache(prepared_path, dependency_statuses)
     return prepared_path, temp_case
 
 

--- a/skylos/core/python_api_surface.py
+++ b/skylos/core/python_api_surface.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib
 import inspect
 import json
+import re
 import site
 import sys
 import time
@@ -221,6 +222,7 @@ def _class_entry(value: type) -> dict[str, Any]:
         "signature": _signature_for(value),
         "parameters": _parameters_for(value),
         "methods": _class_methods(value),
+        "properties": _class_properties(value),
     }
 
 
@@ -241,6 +243,123 @@ def _class_methods(value: type) -> dict[str, Any]:
             "parameters": _parameters_for(member),
         }
     return methods
+
+
+def _class_properties(value: type) -> dict[str, Any]:
+    properties: dict[str, Any] = {}
+    for name in _public_names(value, MAX_CLASS_MEMBERS):
+        try:
+            member = getattr(value, name)
+        except Exception:
+            continue
+
+        resource_class = _property_resource_class(member, value)
+        if resource_class is None:
+            continue
+        properties[name] = {
+            "kind": "property",
+            "class": resource_class.__name__,
+            "methods": _class_methods(resource_class),
+        }
+    return properties
+
+
+def _property_resource_class(member: Any, owner: type) -> type | None:
+    getter = _property_getter(member)
+    if getter is None:
+        return None
+
+    resource_class = _property_annotation_class(getter)
+    if resource_class is not None:
+        return resource_class
+    return _property_source_import_class(getter, owner)
+
+
+def _property_getter(member: Any) -> Any | None:
+    getter = getattr(member, "fget", None)
+    if getter is not None:
+        return getter
+
+    getter = getattr(member, "func", None)
+    if getter is not None:
+        return getter
+    return None
+
+
+def _property_annotation_class(getter: Any) -> type | None:
+    annotations = getattr(getter, "__annotations__", {})
+    if not isinstance(annotations, dict):
+        return None
+
+    return_value = annotations.get("return")
+    if inspect.isclass(return_value):
+        return return_value
+    return None
+
+
+def _property_source_import_class(getter: Any, owner: type) -> type | None:
+    try:
+        source = inspect.getsource(getter)
+    except (OSError, TypeError):
+        return None
+
+    return_name = _return_annotation_name(getter)
+    if return_name is None:
+        return None
+
+    import_module = _source_import_module(source, return_name, owner)
+    if import_module is None:
+        return None
+
+    try:
+        module = importlib.import_module(import_module)
+        candidate = getattr(module, return_name)
+    except (AttributeError, ImportError, ValueError):
+        return None
+
+    if inspect.isclass(candidate):
+        return candidate
+    return None
+
+
+def _return_annotation_name(getter: Any) -> str | None:
+    annotations = getattr(getter, "__annotations__", {})
+    if not isinstance(annotations, dict):
+        return None
+
+    return_value = annotations.get("return")
+    if not isinstance(return_value, str):
+        return None
+    if not return_value.isidentifier():
+        return None
+    return return_value
+
+
+def _source_import_module(source: str, class_name: str, owner: type) -> str | None:
+    pattern = re.compile(
+        r"from\s+([.\w]+)\s+import\s+" + re.escape(class_name) + r"\b"
+    )
+    match = pattern.search(source)
+    if match is None:
+        return None
+
+    module_name = match.group(1)
+    if module_name.startswith("."):
+        package = _owner_package(owner)
+        try:
+            return importlib.util.resolve_name(module_name, package)
+        except (ImportError, ValueError):
+            return None
+    return module_name
+
+
+def _owner_package(owner: type) -> str:
+    module_name = getattr(owner, "__module__", "")
+    if not isinstance(module_name, str):
+        return ""
+    if "." not in module_name:
+        return module_name
+    return module_name.rsplit(".", 1)[0]
 
 
 def _callable_entry(value: Any) -> dict[str, Any]:
@@ -264,7 +383,7 @@ def _callable_member(value: Any) -> bool:
 def _signature_for(value: Any) -> str:
     try:
         signature = inspect.signature(value)
-    except (TypeError, ValueError):
+    except Exception:
         return ""
     return str(signature)
 
@@ -272,7 +391,7 @@ def _signature_for(value: Any) -> str:
 def _parameters_for(value: Any) -> list[dict[str, Any]]:
     try:
         signature = inspect.signature(value)
-    except (TypeError, ValueError):
+    except Exception:
         return []
 
     parameters: list[dict[str, Any]] = []

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -19,7 +19,6 @@ AI_VIBE_CATEGORIES = {
 AI_RULE_DEFAULTS = {
     "SKY-L011": ("disabled_security_control", "medium"),
     "SKY-D222": ("dependency_hallucination", "high"),
-    "SKY-D223": ("dependency_hallucination", "medium"),
     "SKY-D224": ("api_signature_hallucination", "high"),
     "SKY-D225": ("dependency_hallucination", "high"),
 }

--- a/skylos/rules/danger/danger_hallucination/api_signature_hallucination.py
+++ b/skylos/rules/danger/danger_hallucination/api_signature_hallucination.py
@@ -11,7 +11,7 @@ from skylos.core.safe_cache_io import read_text_no_symlink
 
 RULE_ID_API_SIGNATURE = "SKY-D224"
 SEV_HIGH = "HIGH"
-DEFAULT_API_SIGNATURE_ALLOWLIST = ("requests", "pandas", "boto3")
+DEFAULT_API_SIGNATURE_ALLOWLIST = ("requests", "pandas", "boto3", "openai")
 VIBE_CATEGORY = "api_signature_hallucination"
 AI_LIKELIHOOD = "high"
 MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES = 1_000_000
@@ -123,6 +123,13 @@ class _ApiSignatureChecker(ast.NodeVisitor):
     def _current_instances(self) -> dict[str, tuple[str, str]]:
         return self.instance_stack[-1]
 
+    def _instance_type(self, name: str) -> tuple[str, str] | None:
+        for instances in reversed(self.instance_stack):
+            instance_type = instances.get(name)
+            if instance_type is not None:
+                return instance_type
+        return None
+
     def _surface(self, module_name: str) -> dict[str, Any] | None:
         if module_name not in self.surfaces:
             self.surfaces[module_name] = self.surface_loader(
@@ -192,6 +199,10 @@ class _ApiSignatureChecker(ast.NodeVisitor):
 
     def _attribute_call_target(self, func: ast.Attribute) -> _CallTarget | None:
         value = func.value
+        resource_target = self._instance_resource_method_target(func)
+        if resource_target is not None:
+            return resource_target
+
         if isinstance(value, ast.Name):
             module_target = self._module_attribute_target(value.id, func.attr)
             if module_target is not None:
@@ -202,6 +213,41 @@ class _ApiSignatureChecker(ast.NodeVisitor):
                 return instance_target
 
         return None
+
+    def _instance_resource_method_target(
+        self,
+        func: ast.Attribute,
+    ) -> _CallTarget | None:
+        chain = _flatten_attribute_chain(func)
+        if chain is None:
+            return None
+        if len(chain) < 3:
+            return None
+
+        instance_type = self._instance_type(chain[0])
+        if instance_type is None:
+            return None
+
+        module_name, class_name = instance_type
+        current_entry = self._module_member(module_name, class_name)
+        if current_entry is None:
+            return None
+
+        for property_name in chain[1:-1]:
+            properties = _entry_properties(current_entry)
+            property_entry = properties.get(property_name)
+            if not isinstance(property_entry, dict):
+                label = f"{module_name}.{class_name}.{'.'.join(chain[1:])}"
+                return _CallTarget(module_name, label, None, "method")
+            current_entry = property_entry
+
+        method_name = chain[-1]
+        methods = _entry_methods(current_entry)
+        method = methods.get(method_name)
+        label = f"{module_name}.{class_name}.{'.'.join(chain[1:])}"
+        if not isinstance(method, dict):
+            return _CallTarget(module_name, label, None, "method")
+        return _CallTarget(module_name, label, method, "")
 
     def _module_attribute_target(
         self,
@@ -223,7 +269,7 @@ class _ApiSignatureChecker(ast.NodeVisitor):
         instance_name: str,
         method_name: str,
     ) -> _CallTarget | None:
-        instance_type = self._current_instances().get(instance_name)
+        instance_type = self._instance_type(instance_name)
         if instance_type is None:
             return None
 
@@ -421,6 +467,22 @@ def _assigned_names(target: ast.AST) -> list[str]:
     return names
 
 
+def _flatten_attribute_chain(expr: ast.AST) -> list[str] | None:
+    parts: list[str] = []
+    current = expr
+
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+
+    if not isinstance(current, ast.Name):
+        return None
+
+    parts.append(current.id)
+    parts.reverse()
+    return parts
+
+
 def _local_module_roots(project_root: Path, py_files: list[Path]) -> set[str]:
     roots: set[str] = set()
     for root_name in _top_level_python_modules(project_root):
@@ -514,6 +576,16 @@ def _entry_methods(entry: dict[str, Any] | None) -> dict[str, Any]:
     methods = entry.get("methods")
     if isinstance(methods, dict):
         return methods
+    return {}
+
+
+def _entry_properties(entry: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        return {}
+
+    properties = entry.get("properties")
+    if isinstance(properties, dict):
+        return properties
     return {}
 
 

--- a/skylos/rules/danger/danger_hallucination/manifest_dependency_hallucination.py
+++ b/skylos/rules/danger/danger_hallucination/manifest_dependency_hallucination.py
@@ -13,8 +13,11 @@ from skylos.core.safe_cache_io import load_project_json_cache, save_project_json
 from skylos.rules.sca.vulnerability_scanner import (
     ECOSYSTEM_GO,
     ECOSYSTEM_NPM,
+    ECOSYSTEM_PYPI,
     parse_go_mod,
     parse_package_json,
+    parse_pyproject_toml,
+    parse_requirements_txt,
 )
 
 
@@ -34,7 +37,9 @@ MAX_VERSION_CACHE_BYTES = 5_000_000
 MAX_REGISTRY_RESPONSE_BYTES = 1_000_000
 NPM_REGISTRY_ORIGIN = "https://registry.npmjs.org"
 GO_PROXY_ORIGIN = "https://proxy.golang.org"
+PYPI_JSON_ORIGIN = "https://pypi.org/pypi"
 ALLOWED_REGISTRY_HOSTS = {
+    "pypi.org",
     "registry.npmjs.org",
     "proxy.golang.org",
 }
@@ -90,6 +95,8 @@ def check_dependency_version_status(
     version: str,
     cache: dict[str, Any],
 ) -> str:
+    if ecosystem == ECOSYSTEM_PYPI:
+        return _check_pypi_version(name, version)
     if ecosystem == ECOSYSTEM_NPM:
         return _check_npm_version(name, version)
     if ecosystem == ECOSYSTEM_GO:
@@ -115,6 +122,8 @@ def _status_checker(status_checker: StatusChecker | None) -> StatusChecker:
 def _collect_manifest_dependencies(root: Path) -> list[dict[str, Any]]:
     dependencies: list[dict[str, Any]] = []
     parsers = {
+        "requirements.txt": parse_requirements_txt,
+        "pyproject.toml": parse_pyproject_toml,
         "package.json": parse_package_json,
         "go.mod": parse_go_mod,
     }
@@ -307,11 +316,41 @@ def _finding(
 
 
 def _registry_label(ecosystem: str) -> str:
+    if ecosystem == ECOSYSTEM_PYPI:
+        return "PyPI"
     if ecosystem == ECOSYSTEM_NPM:
         return "the npm registry"
     if ecosystem == ECOSYSTEM_GO:
         return "the Go module proxy"
     return "the package registry"
+
+
+def _check_pypi_version(name: str, version: str) -> str:
+    package_path = _safe_pypi_package_path(name)
+    if package_path is None:
+        return STATUS_UNKNOWN
+
+    safe_version = quote(version.strip(), safe="")
+    version_url = f"{PYPI_JSON_ORIGIN}/{package_path}/{safe_version}/json"
+    try:
+        _fetch_json(version_url, user_agent="skylos-pypi-dep-scanner/1.0")
+        return STATUS_EXISTS
+    except urllib.error.HTTPError as exc:
+        if exc.code != 404:
+            return STATUS_UNKNOWN
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return STATUS_UNKNOWN
+
+    package_url = f"{PYPI_JSON_ORIGIN}/{package_path}/json"
+    try:
+        _fetch_json(package_url, user_agent="skylos-pypi-dep-scanner/1.0")
+        return STATUS_MISSING_VERSION
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return STATUS_MISSING_PACKAGE
+        return STATUS_UNKNOWN
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return STATUS_UNKNOWN
 
 
 def _check_npm_version(name: str, version: str) -> str:
@@ -370,6 +409,27 @@ def _go_version(version: str) -> str:
     if version.startswith("v"):
         return version
     return f"v{version}"
+
+
+def _safe_pypi_package_path(name: str) -> str | None:
+    raw = name.strip()
+    if not raw:
+        return None
+    if raw.startswith("."):
+        return None
+    if "/" in raw:
+        return None
+    if "\\" in raw:
+        return None
+    if ".." in raw:
+        return None
+    for char in raw:
+        if char.isalnum():
+            continue
+        if char in ("-", "_", "."):
+            continue
+        return None
+    return quote(raw, safe="")
 
 
 def _safe_npm_package_path(name: str) -> str | None:

--- a/skylos/rules/quality/phantom_refs.py
+++ b/skylos/rules/quality/phantom_refs.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import ast
+import builtins
 from collections import defaultdict
 from dataclasses import dataclass
+from difflib import SequenceMatcher
 from pathlib import Path
 
 from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
@@ -11,6 +13,7 @@ from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 @dataclass
 class _ScopeInfo:
     shadowed_names: set[str]
+    bound_names: set[str]
     local_imports: dict[str, list[tuple[int, str]]]
 
 
@@ -45,6 +48,8 @@ def scan_repo_phantom_security_references(
     local_modules = set(module_to_file)
     if not local_modules:
         return []
+
+    builtin_names = set(dir(builtins))
 
     def _store_module_facts(module_name, tree):
         members, has_dynamic_getattr, exported_modules = _collect_module_facts(
@@ -82,6 +87,11 @@ def scan_repo_phantom_security_references(
     findings = []
 
     for file_path, current_module in file_to_module.items():
+        _ensure_module_loaded(current_module)
+
+    repo_member_names = _repo_member_names(module_members)
+
+    for file_path, current_module in file_to_module.items():
         if target_paths and file_path not in target_paths:
             continue
         try:
@@ -95,6 +105,21 @@ def scan_repo_phantom_security_references(
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name):
+                    bare_finding = _bare_call_finding(
+                        file_path=file_path,
+                        node=node.func,
+                        tree=tree,
+                        parent_map=parent_map,
+                        scope_infos=scope_infos,
+                        repo_member_names=repo_member_names,
+                        builtin_names=builtin_names,
+                        phantom_security_names=vibe_dictionary.phantom_security_names,
+                    )
+                    if bare_finding is not None:
+                        findings.append(bare_finding)
+                    continue
+
                 resolved = _resolve_local_module_member(
                     expr=node.func,
                     node=node,
@@ -109,8 +134,6 @@ def scan_repo_phantom_security_references(
                     continue
 
                 target_module, member_name, expr_text = resolved
-                if member_name not in vibe_dictionary.phantom_security_names:
-                    continue
                 if not _ensure_module_loaded(target_module):
                     continue
                 if target_module in dynamic_modules:
@@ -135,7 +158,7 @@ def scan_repo_phantom_security_references(
                 continue
 
             for deco in node.decorator_list:
-                deco_target = deco.func if isinstance(deco, ast.Call) else deco
+                deco_target = _decorator_target(deco)
                 resolved = _resolve_local_module_member(
                     expr=deco_target,
                     node=deco_target,
@@ -170,6 +193,73 @@ def scan_repo_phantom_security_references(
                 )
 
     return findings
+
+
+def _repo_member_names(module_members):
+    names = set()
+    for members in module_members.values():
+        names.update(members)
+    return names
+
+
+def _bare_call_finding(
+    file_path,
+    node,
+    tree,
+    parent_map,
+    scope_infos,
+    repo_member_names,
+    builtin_names,
+    phantom_security_names,
+):
+    name = node.id
+    if name in builtin_names:
+        return None
+    if name in phantom_security_names:
+        return None
+    if _bare_name_is_bound(name, node, tree, parent_map, scope_infos):
+        return None
+    if not _resembles_local_symbol(name, repo_member_names):
+        return None
+    return _build_bare_call_finding(file_path, node, name)
+
+
+def _bare_name_is_bound(name, node, tree, parent_map, scope_infos):
+    for scope in _enclosing_scopes(node, tree, parent_map):
+        info = scope_infos.get(scope)
+        if not info:
+            continue
+        if name in info.bound_names:
+            return True
+    return False
+
+
+def _resembles_local_symbol(name, repo_member_names):
+    for candidate in repo_member_names:
+        if candidate == name:
+            continue
+        if _shared_suffix_token(name, candidate):
+            return True
+        similarity = SequenceMatcher(None, name, candidate).ratio()
+        if similarity >= 0.82:
+            return True
+    return False
+
+
+def _shared_suffix_token(left, right):
+    left_parts = left.split("_")
+    right_parts = right.split("_")
+    if len(left_parts) < 2:
+        return False
+    if len(right_parts) < 2:
+        return False
+    return left_parts[-1] == right_parts[-1]
+
+
+def _decorator_target(decorator):
+    if isinstance(decorator, ast.Call):
+        return decorator.func
+    return decorator
 
 
 def _module_name(root: Path, file_path: Path) -> str:
@@ -230,7 +320,10 @@ def _collect_module_facts(tree, current_module, local_modules):
                     continue
                 bound_name = alias.asname or alias.name
                 members.add(bound_name)
-                full_name = f"{base}.{alias.name}" if base else alias.name
+                if base:
+                    full_name = f"{base}.{alias.name}"
+                else:
+                    full_name = alias.name
                 if full_name in local_modules:
                     exported_modules[bound_name] = full_name
 
@@ -257,10 +350,13 @@ def _build_scope_infos(tree, current_module, local_modules):
 
 def _collect_scope_info(scope_node, current_module, local_modules):
     shadowed = set()
+    bound = set()
     local_imports = defaultdict(list)
 
     if isinstance(scope_node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-        shadowed.update(_extract_args_names(scope_node.args))
+        arg_names = _extract_args_names(scope_node.args)
+        shadowed.update(arg_names)
+        bound.update(arg_names)
 
     class ScopeCollector(ast.NodeVisitor):
         def generic_visit(self, node):
@@ -270,7 +366,11 @@ def _collect_scope_info(scope_node, current_module, local_modules):
         def visit_Import(self, node):
             for alias in node.names:
                 bound_name = alias.asname or alias.name.split(".", 1)[0]
-                full_name = alias.name if alias.asname else alias.name.split(".", 1)[0]
+                bound.add(bound_name)
+                if alias.asname:
+                    full_name = alias.name
+                else:
+                    full_name = alias.name.split(".", 1)[0]
                 if full_name in local_modules:
                     local_imports[bound_name].append((node.lineno, full_name))
 
@@ -279,7 +379,11 @@ def _collect_scope_info(scope_node, current_module, local_modules):
             for alias in node.names:
                 if alias.name == "*":
                     continue
-                full_name = f"{base}.{alias.name}" if base else alias.name
+                bound.add(alias.asname or alias.name)
+                if base:
+                    full_name = f"{base}.{alias.name}"
+                else:
+                    full_name = alias.name
                 if full_name in local_modules:
                     local_imports[alias.asname or alias.name].append(
                         (node.lineno, full_name)
@@ -287,24 +391,34 @@ def _collect_scope_info(scope_node, current_module, local_modules):
 
         def visit_Assign(self, node):
             for target in node.targets:
-                shadowed.update(_extract_target_names(target))
+                names = _extract_target_names(target)
+                shadowed.update(names)
+                bound.update(names)
             self.generic_visit(node.value)
 
         def visit_AnnAssign(self, node):
-            shadowed.update(_extract_target_names(node.target))
+            names = _extract_target_names(node.target)
+            shadowed.update(names)
+            bound.update(names)
             if node.value:
                 self.generic_visit(node.value)
 
         def visit_AugAssign(self, node):
-            shadowed.update(_extract_target_names(node.target))
+            names = _extract_target_names(node.target)
+            shadowed.update(names)
+            bound.update(names)
             self.generic_visit(node.value)
 
         def visit_NamedExpr(self, node):
-            shadowed.update(_extract_target_names(node.target))
+            names = _extract_target_names(node.target)
+            shadowed.update(names)
+            bound.update(names)
             self.generic_visit(node.value)
 
         def visit_For(self, node):
-            shadowed.update(_extract_target_names(node.target))
+            names = _extract_target_names(node.target)
+            shadowed.update(names)
+            bound.update(names)
             self.generic_visit(node.iter)
             for stmt in node.body:
                 self.visit(stmt)
@@ -316,7 +430,9 @@ def _collect_scope_info(scope_node, current_module, local_modules):
         def visit_With(self, node):
             for item in node.items:
                 if item.optional_vars is not None:
-                    shadowed.update(_extract_target_names(item.optional_vars))
+                    names = _extract_target_names(item.optional_vars)
+                    shadowed.update(names)
+                    bound.update(names)
                 self.visit(item.context_expr)
             for stmt in node.body:
                 self.visit(stmt)
@@ -326,6 +442,7 @@ def _collect_scope_info(scope_node, current_module, local_modules):
         def visit_ExceptHandler(self, node):
             if node.name:
                 shadowed.add(node.name)
+                bound.add(node.name)
             if node.type:
                 self.visit(node.type)
             for stmt in node.body:
@@ -333,11 +450,13 @@ def _collect_scope_info(scope_node, current_module, local_modules):
 
         def visit_FunctionDef(self, node):
             shadowed.add(node.name)
+            bound.add(node.name)
 
         visit_AsyncFunctionDef = visit_FunctionDef
 
         def visit_ClassDef(self, node):
             shadowed.add(node.name)
+            bound.add(node.name)
 
         def visit_Lambda(self, node):
             return
@@ -354,6 +473,7 @@ def _collect_scope_info(scope_node, current_module, local_modules):
 
     return _ScopeInfo(
         shadowed_names=shadowed,
+        bound_names=bound,
         local_imports={k: sorted(v) for k, v in local_imports.items()},
     )
 
@@ -455,12 +575,16 @@ def _is_decorator_expression(child, parent):
 
 def _resolve_import_from_base(current_module, node):
     module = node.module or ""
-    cur_pkg = (
-        current_module.rsplit(".", 1)[0] if "." in current_module else current_module
-    )
+    if "." in current_module:
+        cur_pkg = current_module.rsplit(".", 1)[0]
+    else:
+        cur_pkg = current_module
 
     if node.level and node.level > 0:
-        parts = cur_pkg.split(".") if cur_pkg else []
+        if cur_pkg:
+            parts = cur_pkg.split(".")
+        else:
+            parts = []
         up = node.level - 1
 
         if up > len(parts):
@@ -469,7 +593,10 @@ def _resolve_import_from_base(current_module, node):
             base = ".".join(parts[: len(parts) - up])
 
         if module:
-            base = f"{base}.{module}" if base else module
+            if base:
+                base = f"{base}.{module}"
+            else:
+                base = module
         return base
 
     return module
@@ -530,6 +657,30 @@ def _build_call_finding(file_path, node, expr_text, target_module, member_name):
             f"Call to '{expr_text}()' resolves to local module '{target_module}', "
             f"but '{member_name}' is not defined or re-exported there. "
             f"AI-generated code often hallucinates security helpers on local modules."
+        ),
+        "file": str(file_path),
+        "basename": file_path.name,
+        "line": node.lineno,
+        "col": node.col_offset,
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+    }
+
+
+def _build_bare_call_finding(file_path, node, name):
+    return {
+        "rule_id": "SKY-L012",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": "call",
+        "name": name,
+        "simple_name": name,
+        "value": "phantom",
+        "threshold": 0,
+        "message": (
+            f"Call to '{name}()' is not defined or imported, but it resembles "
+            "another local project symbol. AI-generated code often leaves stale "
+            "function names after partial refactors."
         ),
         "file": str(file_path),
         "basename": file_path.name,

--- a/test/test_ai_code_defect_benchmark.py
+++ b/test/test_ai_code_defect_benchmark.py
@@ -428,6 +428,29 @@ def test_ai_code_defect_runner_seeds_dependency_status_cache():
     assert not prepared_paths[0].exists()
 
 
+def test_ai_code_defect_runner_isolates_danger_cases_without_status_cache():
+    prepared_paths = []
+
+    def fake_verify(case_path, **_kwargs):
+        prepared_path = Path(case_path)
+        prepared_paths.append(prepared_path)
+        cache_path = prepared_path / ".skylos" / "cache" / "dependency_versions.json"
+        assert not cache_path.exists()
+        return {"findings": []}
+
+    summary = run_manifest(
+        MANIFEST_PATH,
+        selected_cases={"clean-api-signature"},
+        verify_func=fake_verify,
+    )
+
+    assert summary["case_count"] == 1
+    assert summary["pass_count"] == 1
+    assert prepared_paths
+    assert prepared_paths[0].parent.name.startswith("skylos-ai-defect-")
+    assert not prepared_paths[0].exists()
+
+
 def test_ai_code_defect_runner_reports_missing_expectation(monkeypatch):
     def fake_verify(_case_path, **_kwargs):
         return {"findings": []}

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -2415,7 +2415,10 @@ ignore = []
         real_subprocess_run = subprocess.run
 
         def selective_subprocess_run(*args, **kwargs):
-            cmd = args[0] if args else kwargs.get("args")
+            if args:
+                cmd = args[0]
+            else:
+                cmd = kwargs.get("args")
             if cmd[:4] == ["git", "diff", "HEAD", "--"]:
                 return diff_result
             return real_subprocess_run(*args, **kwargs)
@@ -2833,6 +2836,36 @@ def handler(request):
 
         assert len(quality) == 1
         assert quality[0]["name"] == "security.require_auth"
+
+    def test_analyze_flags_stale_bare_call_resembling_local_symbol(self, tmp_path):
+        pkg = tmp_path / "billing"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "totals.py").write_text(
+            """
+def calculate_total(items):
+    return sum(items)
+""".strip(),
+            encoding="utf-8",
+        )
+        (pkg / "workflow.py").write_text(
+            """
+from billing.totals import calculate_total
+
+def create_invoice(order):
+    return compute_total(order["items"])
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, enable_quality=True))
+        quality = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L012"
+        ]
+
+        assert len(quality) == 1
+        assert quality[0]["name"] == "compute_total"
+        assert quality[0]["vibe_category"] == "hallucinated_reference"
 
     def test_danger_scan_does_not_run_sca_without_enable_sca(
         self, tmp_path, monkeypatch

--- a/test/test_api_signature_hallucination.py
+++ b/test/test_api_signature_hallucination.py
@@ -137,6 +137,108 @@ def test_scan_handles_from_import_aliases(tmp_path, monkeypatch):
     assert any("argument 'wait'" in message for message in messages)
 
 
+def test_scan_flags_module_level_client_resource_method(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    py_file = _write_py(
+        repo / "app.py",
+        "\n".join(
+            [
+                "import sampleapi as api",
+                "",
+                "client = api.Client()",
+                "",
+                "def handler():",
+                "    client.resource.missing()",
+                "",
+            ]
+        ),
+    )
+
+    def surface_loader(_project_root, module_name):
+        assert module_name == "sampleapi"
+        return {
+            "members": {
+                "Client": {
+                    "kind": "class",
+                    "methods": {},
+                    "properties": {
+                        "resource": {
+                            "kind": "property",
+                            "methods": {
+                                "create": {
+                                    "kind": "method",
+                                    "parameters": [],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+    findings = scan_python_api_signature_hallucinations(
+        repo,
+        [py_file],
+        allowed_modules=("sampleapi",),
+        surface_loader=surface_loader,
+    )
+
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == RULE_ID_API_SIGNATURE
+    assert findings[0]["symbol"] == "sampleapi.Client.resource.missing"
+
+
+def test_scan_default_allowlist_flags_openai_resource_method(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    py_file = _write_py(
+        repo / "summarizer.py",
+        "\n".join(
+            [
+                "from openai import OpenAI",
+                "",
+                "client = OpenAI(api_key='test-key')",
+                "",
+                "def summarize(ticket):",
+                "    return client.responses.parse_json(input=ticket)",
+                "",
+            ]
+        ),
+    )
+
+    def surface_loader(_project_root, module_name):
+        assert module_name == "openai"
+        return {
+            "members": {
+                "OpenAI": {
+                    "kind": "class",
+                    "methods": {},
+                    "properties": {
+                        "responses": {
+                            "kind": "property",
+                            "methods": {
+                                "parse": {
+                                    "kind": "method",
+                                    "parameters": [],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+    findings = scan_python_api_signature_hallucinations(
+        repo,
+        [py_file],
+        surface_loader=surface_loader,
+    )
+
+    assert len(findings) == 1
+    assert findings[0]["symbol"] == "openai.OpenAI.responses.parse_json"
+
+
 def test_scan_skips_local_modules_named_like_allowlisted_package(
     tmp_path,
     monkeypatch,

--- a/test/test_manifest_dependency_hallucination.py
+++ b/test/test_manifest_dependency_hallucination.py
@@ -10,7 +10,11 @@ from skylos.rules.danger.danger_hallucination.manifest_dependency_hallucination 
     STATUS_MISSING_VERSION,
     scan_manifest_dependency_hallucinations,
 )
-from skylos.rules.sca.vulnerability_scanner import ECOSYSTEM_GO, ECOSYSTEM_NPM
+from skylos.rules.sca.vulnerability_scanner import (
+    ECOSYSTEM_GO,
+    ECOSYSTEM_NPM,
+    ECOSYSTEM_PYPI,
+)
 
 
 def _status_checker(statuses, calls):
@@ -104,6 +108,34 @@ def test_scan_go_mod_flags_missing_go_module_and_version(tmp_path):
     assert any("github.com/no/module" in message for message in messages)
     assert any("github.com/real/pkg@9.9.9" in message for message in messages)
     assert (ECOSYSTEM_GO, "github.com/real/pkg", "1.2.3") in calls
+
+
+def test_scan_requirements_txt_flags_missing_pypi_version(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text(
+        "\n".join(
+            [
+                "requests==999.0.0",
+                "click==8.1.7",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+    statuses = {
+        (ECOSYSTEM_PYPI, "requests", "999.0.0"): STATUS_MISSING_VERSION,
+    }
+
+    findings = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=_status_checker(statuses, calls),
+    )
+
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == RULE_ID_VERSION_HALLUCINATION
+    assert "requests@999.0.0" in findings[0]["message"]
+    assert (ECOSYSTEM_PYPI, "click", "8.1.7") in calls
 
 
 def test_scan_manifest_dependency_statuses_are_cached(tmp_path):

--- a/test/test_verify_change.py
+++ b/test/test_verify_change.py
@@ -122,6 +122,26 @@ def test_build_verify_change_response_applies_version_hallucination_defaults(tmp
     assert finding["ai_likelihood"] == "high"
 
 
+def test_build_verify_change_response_skips_dependency_import_defaults(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("import requests\n", encoding="utf-8")
+    result = {
+        "danger": [
+            {
+                "rule_id": "SKY-D223",
+                "severity": "MEDIUM",
+                "file": str(app),
+                "line": 1,
+                "message": "Undeclared import 'requests'.",
+            }
+        ]
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    assert payload["findings"] == []
+
+
 def test_build_verify_change_response_filters_target_file_and_range(tmp_path):
     app = tmp_path / "app.py"
     other = tmp_path / "other.py"

--- a/test/test_vibe_rules.py
+++ b/test/test_vibe_rules.py
@@ -1014,6 +1014,28 @@ class TestPhantomCall:
         assert l012[0]["name"] == "security.require_auth"
         assert l012[0]["simple_name"] == "require_auth"
 
+    def test_repo_local_module_attribute_call_phantom_for_stale_helper(self):
+        findings = scan_repo_code(
+            {
+                "billing/__init__.py": "",
+                "billing/totals.py": """
+                    def calculate_total(items):
+                        return sum(items)
+                """,
+                "billing/workflow.py": """
+                    from billing import totals
+
+                    def create_invoice(items):
+                        return totals.compute_total(items)
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 1
+        assert l012[0]["name"] == "totals.compute_total"
+        assert l012[0]["simple_name"] == "compute_total"
+
     def test_repo_dynamic_module_not_flagged(self):
         findings = scan_repo_code(
             {


### PR DESCRIPTION
## Summary

  - improve `skylos verify` detection for stale local references after partial refactors
  - validate installed API method drift more accurately, including OpenAI SDK resource style calls
  - add PyPI manifest version hallucination checks
  - reduce default verify noise from undeclared dependency import findings

  ## Tests

  - `pytest test/test_api_signature_hallucination.py test/test_manifest_dependency_hallucination.py test/test_vibe_rules.py test/test_analyzer.py test/test_verify_change.py test/test_ai_code_defect_benchmark.py test/test_verify_cmd.py`