### PR TITLE
fix(quality): reduce quality scan false positives

### DIFF
--- a/editors/vscode/src/types.ts
+++ b/editors/vscode/src/types.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 import type { FindingSource } from "./provenanceCore";
 
 export const SUPPORTED_LANGUAGES = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,15 @@ nesting = 3
 max_args = 5
 max_lines = 50
 model = "gpt-4.1"
-exclude = []
+exclude = [
+    "benchmarks",
+    "corpus",
+    "docs/repo-map",
+    "editors/vscode/out",
+    "manual",
+    "skylos-demo",
+    "test/fixtures",
+]
 ignore = []
 
 [tool.skylos.masking]

--- a/scripts/compare_codex_skylos_demo_deadcode.py
+++ b/scripts/compare_codex_skylos_demo_deadcode.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 import tempfile

--- a/scripts/verify_benchmark.py
+++ b/scripts/verify_benchmark.py
@@ -6,6 +6,9 @@ from skylos.benchmarks.verify_benchmark import (
     format_report,
     main,
 )
+from skylos.benchmarks.verify_benchmark_runner import (
+    tool_environment as _tool_environment,
+)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_benchmark.py
+++ b/scripts/verify_benchmark.py
@@ -6,9 +6,6 @@ from skylos.benchmarks.verify_benchmark import (
     format_report,
     main,
 )
-from skylos.benchmarks.verify_benchmark_runner import (
-    tool_environment as _tool_environment,
-)
 
 
 if __name__ == "__main__":

--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -649,7 +649,7 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
     class_name = parts[-2] if len(parts) >= 2 else None
     if class_name:
         class_def = None
-        for dname, dobj in all_defs.items():
+        for dobj in all_defs.values():
             if (
                 dobj.type == "class"
                 and dobj.simple_name == class_name

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1454,6 +1454,12 @@ class Skylos:
                     class_methods[cls].append(definition)
 
         for cls, methods in class_methods.items():
+            class_def = self.defs[cls]
+            base_classes = getattr(class_def, "base_classes", [])
+            is_textual_app = any(
+                str(base).split(".")[-1] == "App" for base in base_classes
+            )
+
             if self.defs[cls].references > 0:
                 for method in methods:
                     if method.simple_name in AUTO_CALLED:
@@ -1468,6 +1474,85 @@ class Skylos:
 
                     if method.simple_name == "format" and cls.endswith("Formatter"):
                         method.references += 1
+
+            if is_textual_app:
+                for method in methods:
+                    if method.simple_name == "compose":
+                        method.references += 1
+                    elif method.simple_name.startswith("action_"):
+                        method.references += 1
+
+        referenced_class_prefixes = tuple(
+            f"{name}."
+            for name, definition in self.defs.items()
+            if definition.type == "class" and definition.references > 0
+        )
+        for definition in self.defs.values():
+            if definition.type not in ("method", "variable"):
+                continue
+
+            if definition.references > 0:
+                continue
+
+            if not (
+                definition.simple_name.startswith("visit_")
+                or definition.simple_name.startswith("leave_")
+                or definition.simple_name.startswith("transform_")
+            ):
+                continue
+
+            if referenced_class_prefixes and definition.name.startswith(
+                referenced_class_prefixes
+            ):
+                definition.references += 1
+
+        http_handler_metadata = {
+            "protocol_version",
+            "server_version",
+            "sys_version",
+        }
+        for definition in self.defs.values():
+            if definition.type != "variable":
+                continue
+
+            if definition.simple_name not in http_handler_metadata:
+                continue
+
+            if "." not in definition.name:
+                continue
+
+            cls = definition.name.rsplit(".", 1)[0]
+            class_def = self.defs.get(cls)
+            if class_def is None or class_def.type != "class":
+                continue
+
+            base_classes = getattr(class_def, "base_classes", [])
+            for base in base_classes:
+                if str(base).split(".")[-1] == "BaseHTTPRequestHandler":
+                    definition.references += 1
+                    break
+
+        textual_app_metadata = {"BINDINGS", "CSS", "TITLE", "SUB_TITLE"}
+        for definition in self.defs.values():
+            if definition.type != "variable":
+                continue
+
+            if definition.simple_name not in textual_app_metadata:
+                continue
+
+            if "." not in definition.name:
+                continue
+
+            cls = definition.name.rsplit(".", 1)[0]
+            class_def = self.defs.get(cls)
+            if class_def is None or class_def.type != "class":
+                continue
+
+            base_classes = getattr(class_def, "base_classes", [])
+            for base in base_classes:
+                if str(base).split(".")[-1] == "App":
+                    definition.references += 1
+                    break
 
         registry_bases = set()
         for name, defn in self.defs.items():
@@ -2684,10 +2769,7 @@ class Skylos:
             if class_name in self._global_protocol_implementers:
                 continue
 
-            for (
-                protocol_name,
-                protocol_methods,
-            ) in self._global_protocol_method_names.items():
+            for protocol_methods in self._global_protocol_method_names.values():
                 if not protocol_methods or len(protocol_methods) < 3:
                     continue
 

--- a/skylos/api/_artifacts.py
+++ b/skylos/api/_artifacts.py
@@ -179,7 +179,7 @@ def upload_artifact(
     timeout = instruction.get("timeout_seconds") or UPLOAD_TIMEOUT
     last_err = None
 
-    for _attempt in range(3):
+    for _ in range(3):
         try:
             response = _send_artifact_upload(
                 artifact,

--- a/skylos/llm/_grounding.py
+++ b/skylos/llm/_grounding.py
@@ -154,7 +154,8 @@ def _parse_file(file_path: Path, module: str, root: Path) -> _ParsedFile | None:
 
 def _collect_defs(parsed: _ParsedFile, tree: ast.AST) -> dict[str, str]:
     symbols: dict[str, str] = {}
-    for name, _line, _end_line, _kind in _iter_defs(parsed, tree):
+    for definition in _iter_defs(parsed, tree):
+        name = definition[0]
         short = name.removeprefix(f"{parsed.module}.")
         symbols[short] = name
         symbols[short.split(".")[-1]] = name

--- a/skylos/llm/security_taskflow.py
+++ b/skylos/llm/security_taskflow.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import hashlib
-import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path

--- a/skylos/rules/quality/logic_foundation.py
+++ b/skylos/rules/quality/logic_foundation.py
@@ -308,7 +308,7 @@ class DuplicateBranchRule(SkylosRule):
         seen = {}
         findings = []
 
-        for condition, _body, line in branches:
+        for condition, _, line in branches:
             if condition is None:
                 continue
             key = _semantic_ast_key(condition)
@@ -342,7 +342,7 @@ class DuplicateBranchRule(SkylosRule):
         seen = {}
         findings = []
 
-        for _condition, body, line in branches:
+        for _, body, line in branches:
             if _is_empty_branch_body(body):
                 continue
             if _substantive_branch_statement_count(body) < 2:

--- a/skylos/rules/quality/logic_maintainability.py
+++ b/skylos/rules/quality/logic_maintainability.py
@@ -1,5 +1,6 @@
 import ast
 import math
+import re
 from pathlib import Path
 
 from skylos.audit.redaction import REDACTION, redact_text
@@ -63,6 +64,219 @@ def _duplicate_string_display(value: str) -> str:
     return value if len(value) <= 40 else value[:37] + "..."
 
 
+_DUPLICATE_STRING_PATH_PREFIXES = (
+    "benchmarks/",
+    "corpus/",
+    "docs/",
+    "editors/",
+    "scripts/",
+    "skylos/",
+    "test/",
+    "tests/",
+)
+
+_DUPLICATE_STRING_PATH_SUFFIXES = (
+    ".cfg",
+    ".css",
+    ".go",
+    ".html",
+    ".ini",
+    ".java",
+    ".js",
+    ".json",
+    ".md",
+    ".php",
+    ".py",
+    ".rs",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".xml",
+    ".yaml",
+    ".yml",
+)
+
+_DUPLICATE_STRING_SCHEMA_VALUES = frozenset(
+    {
+        "ai",
+        "ai_agent",
+        "ai_authored",
+        "basename",
+        "category",
+        "col",
+        "confidence",
+        "CRITICAL",
+        "cwe",
+        "dead_code",
+        "debt",
+        "dismissed",
+        "error",
+        "failed",
+        "FAIL",
+        "file",
+        "findings",
+        "fingerprint",
+        "HIGH",
+        "INFO",
+        "kind",
+        "line",
+        "LOW",
+        "MEDIUM",
+        "message",
+        "name",
+        "PASS",
+        "passed",
+        "primary_dimension",
+        "priority_score",
+        "quality",
+        "rule_id",
+        "security",
+        "secrets",
+        "severity",
+        "signal_count",
+        "signals",
+        "simple_name",
+        "snoozed",
+        "snoozed_until",
+        "standard_refs",
+        "success",
+        "system",
+        "threshold",
+        "triage",
+        "type",
+        "value",
+        "WARN",
+    }
+)
+
+
+def _is_rule_identifier_literal(value: str) -> bool:
+    return re.fullmatch(r"(?:SKY-[A-Z]\d{3,4}|CUSTOM-[A-Z0-9_-]+)", value) is not None
+
+
+def _looks_like_filesystem_path_literal(value: str) -> bool:
+    stripped = value.strip()
+    normalized = stripped.replace("\\", "/")
+
+    if "/" not in normalized:
+        return False
+
+    if normalized.startswith(("http://", "https://")):
+        return False
+
+    if normalized.startswith("/"):
+        return normalized.endswith(_DUPLICATE_STRING_PATH_SUFFIXES)
+
+    if normalized.endswith("/"):
+        return True
+
+    if normalized.startswith(_DUPLICATE_STRING_PATH_PREFIXES):
+        return True
+
+    last_segment = normalized.rsplit("/", 1)[-1]
+    return last_segment.endswith(_DUPLICATE_STRING_PATH_SUFFIXES)
+
+
+def _looks_like_markup_fragment(value: str) -> bool:
+    stripped = value.strip()
+    if re.search(r"</?[A-Za-z][^>]*>", stripped):
+        return True
+    return bool(re.search(r"\sdata-[A-Za-z0-9_-]+\s*=", stripped))
+
+
+def _is_duplicate_string_noise(value: str) -> bool:
+    stripped = value.strip()
+
+    if stripped in _DUPLICATE_STRING_SCHEMA_VALUES:
+        return True
+
+    if _is_rule_identifier_literal(stripped):
+        return True
+
+    if _looks_like_filesystem_path_literal(stripped):
+        return True
+
+    return _looks_like_markup_fragment(value)
+
+
+def _target_names(target: ast.AST) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: set[str] = set()
+        for element in target.elts:
+            names.update(_target_names(element))
+        return names
+
+    return set()
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+
+    if isinstance(node, ast.Attribute):
+        base = _call_name(node.value)
+        if base:
+            return f"{base}.{node.attr}"
+        return node.attr
+
+    return ""
+
+
+def _is_container_literal(node: ast.AST) -> bool:
+    if isinstance(node, (ast.Dict, ast.List, ast.Tuple, ast.Set)):
+        return True
+
+    if isinstance(node, ast.Call):
+        call_name = _call_name(node.func)
+        return call_name in {"dict", "frozenset", "list", "set", "tuple"}
+
+    return False
+
+
+def _target_names_are_constant_like(target_names: set[str]) -> bool:
+    return any(name.isupper() or name.startswith("_") for name in target_names)
+
+
+def _is_module_level_assignment(parent: ast.AST, parent_map: dict[int, ast.AST]) -> bool:
+    grandparent = parent_map.get(id(parent))
+    return isinstance(grandparent, ast.Module)
+
+
+def _assignment_targets(parent: ast.Assign | ast.AnnAssign) -> set[str]:
+    if isinstance(parent, ast.Assign):
+        target_names: set[str] = set()
+        for target in parent.targets:
+            target_names.update(_target_names(target))
+        return target_names
+
+    return _target_names(parent.target)
+
+
+def _assignment_value(parent: ast.Assign | ast.AnnAssign) -> ast.AST | None:
+    return parent.value
+
+
+def _is_declarative_assignment(parent: ast.Assign | ast.AnnAssign) -> bool:
+    value = _assignment_value(parent)
+    if value is None:
+        return False
+
+    if _is_container_literal(value):
+        return True
+
+    return _target_names_are_constant_like(_assignment_targets(parent))
+
+
+def _is_local_scope_node(node: ast.AST) -> bool:
+    return isinstance(
+        node,
+        (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
+    )
+
+
 class DuplicateStringLiteralRule(SkylosRule):
     rule_id = "SKY-L027"
     name = "Duplicate String Literal"
@@ -121,6 +335,24 @@ class DuplicateStringLiteralRule(SkylosRule):
 
             current = parent
 
+    def _is_module_level_declarative_literal(self, node, parent_map):
+        current = node
+
+        while True:
+            parent = parent_map.get(id(current))
+            if parent is None:
+                return False
+
+            if _is_local_scope_node(parent):
+                return False
+
+            if isinstance(parent, (ast.Assign, ast.AnnAssign)):
+                if not _is_module_level_assignment(parent, parent_map):
+                    return False
+                return _is_declarative_assignment(parent)
+
+            current = parent
+
     def visit_node(self, node, context):
         if not isinstance(node, ast.Module):
             return None
@@ -146,6 +378,10 @@ class DuplicateStringLiteralRule(SkylosRule):
                 if self._is_structural_key_literal(child, parent_map):
                     continue
                 if self._is_annotation_literal(child, parent_map):
+                    continue
+                if self._is_module_level_declarative_literal(child, parent_map):
+                    continue
+                if _is_duplicate_string_noise(child.value):
                     continue
                 key = child.value
                 if key not in string_occurrences:

--- a/skylos/rules/quality/logic_security.py
+++ b/skylos/rules/quality/logic_security.py
@@ -186,12 +186,6 @@ class SecurityTodoRule(SkylosRule):
         return findings if findings else None
 
 
-_DISABLED_SECURITY_PATTERNS = DEFAULT_VIBE_DICTIONARY.disabled_security_patterns
-_DANGEROUS_CALLS = DEFAULT_VIBE_DICTIONARY.dangerous_calls
-_DANGEROUS_DECORATORS = DEFAULT_VIBE_DICTIONARY.dangerous_decorators
-_DANGEROUS_ASSIGNMENTS = DEFAULT_VIBE_DICTIONARY.dangerous_assignments
-
-
 class DisabledSecurityRule(SkylosRule):
     rule_id = "SKY-L011"
     name = "Disabled Security Control"
@@ -344,9 +338,6 @@ class DisabledSecurityRule(SkylosRule):
         return findings if findings else None
 
 
-_PHANTOM_SECURITY_NAMES = DEFAULT_VIBE_DICTIONARY.phantom_security_names
-
-
 class PhantomCallRule(SkylosRule):
     rule_id = "SKY-L012"
     name = "Phantom Function Call"
@@ -430,9 +421,6 @@ class PhantomCallRule(SkylosRule):
                 "ai_likelihood": "high",
             }
         ]
-
-
-_PHANTOM_SECURITY_DECORATORS = DEFAULT_VIBE_DICTIONARY.phantom_security_decorators
 
 
 class PhantomDecoratorRule(SkylosRule):
@@ -716,9 +704,6 @@ class UndefinedConfigRule(SkylosRule):
         return None
 
 
-_WELL_KNOWN_ENV_VARS = DEFAULT_VIBE_DICTIONARY.well_known_env_vars
-
-
 class StaleMockRule(SkylosRule):
     rule_id = "SKY-L024"
     name = "Stale Mock"
@@ -898,10 +883,6 @@ class StaleMockRule(SkylosRule):
         return None
 
 
-_SECURITY_VAR_KEYWORDS = DEFAULT_VIBE_DICTIONARY.security_var_keywords
-_INSECURE_RANDOM_FUNCS = DEFAULT_VIBE_DICTIONARY.insecure_random_funcs
-
-
 def _var_name_is_security(name, vibe_dictionary=None):
     vibe_dictionary = vibe_dictionary or DEFAULT_VIBE_DICTIONARY
     lower = name.lower()
@@ -983,14 +964,10 @@ class InsecureRandomRule(SkylosRule):
         return None
 
 
-_CREDENTIAL_VAR_NAMES = DEFAULT_VIBE_DICTIONARY.credential_var_names
-_CREDENTIAL_VAR_SUFFIXES = DEFAULT_VIBE_DICTIONARY.credential_var_suffixes
-
 _CREDENTIAL_DSN_RE = re.compile(
     r"[a-zA-Z][a-zA-Z0-9+.-]*://[^:]+:[^@]+@",
 )
 
-_PLACEHOLDER_VALUES = DEFAULT_VIBE_DICTIONARY.placeholder_values
 _MOCK_CONTEXT_WORDS = {
     "mock",
     "fake",
@@ -1541,10 +1518,6 @@ class ErrorDisclosureRule(SkylosRule):
             "line": node.lineno,
             "col": node.col_offset,
         }
-
-
-_SENSITIVE_FILE_KEYWORDS = DEFAULT_VIBE_DICTIONARY.sensitive_file_keywords
-_NETWORK_TIMEOUT_CALLS = DEFAULT_VIBE_DICTIONARY.network_timeout_calls
 
 
 def _is_sensitive_filename(name, vibe_dictionary=None):

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -771,6 +771,9 @@ class Visitor(ast.NodeVisitor):
             "endpoint",
             "hook",
             "signal",
+            "tool",
+            "resource",
+            "prompt",
             "event",
             "job",
             "worker",
@@ -962,7 +965,6 @@ class Visitor(ast.NodeVisitor):
     def _visit_comprehension_scope(
         self,
         node: Union[ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp],
-        comp_type: str,
     ) -> None:
         self._comprehension_scope_stack.append({})
 
@@ -991,16 +993,16 @@ class Visitor(ast.NodeVisitor):
                 self._bind_comprehension_target(elt, lineno)
 
     def visit_ListComp(self, node: ast.ListComp) -> None:
-        self._visit_comprehension_scope(node, "listcomp")
+        self._visit_comprehension_scope(node)
 
     def visit_SetComp(self, node: ast.SetComp) -> None:
-        self._visit_comprehension_scope(node, "setcomp")
+        self._visit_comprehension_scope(node)
 
     def visit_DictComp(self, node: ast.DictComp) -> None:
-        self._visit_comprehension_scope(node, "dictcomp")
+        self._visit_comprehension_scope(node)
 
     def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
-        self._visit_comprehension_scope(node, "genexp")
+        self._visit_comprehension_scope(node)
 
     def visit_Match(self, node: ast.Match) -> None:
         self.visit(node.subject)

--- a/skylos/visitors/languages/java/danger.py
+++ b/skylos/visitors/languages/java/danger.py
@@ -222,10 +222,6 @@ _JAVA_SQL_SINK_ARGS = {
 _JAVA_LDAP_SINK_ARGS = {
     ".search(": (1,),
 }
-_JAVA_XPATH_SINK_ARGS = {
-    ".evaluate(": (0,),
-    ".compile(": (0,),
-}
 _JAVA_XSS_WRITER_METHODS = (".print(", ".println(", ".printf(", ".format(", ".write(")
 _JAVA_XSS_SANITIZER_HINTS = (
     "encodeForHTML(",

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -944,8 +944,6 @@ _AUTH_EVIDENCE_PATTERNS = tuple(
 
 _MUTATING_METHODS = frozenset({"POST", "PUT", "DELETE", "PATCH"})
 
-_NEXTJS_ROUTE_PATTERNS = ("/app/", "/pages/api/")
-
 _SERVER_ACTION_SQL_CALL_PATTERN = re.compile(
     r"\.(\$?(?:query|exec|execute|raw|sql|queryRaw|executeRaw|queryRawUnsafe|executeRawUnsafe))\s*"
     r"\(\s*`([^`]*\$\{[^`]*)`",

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -49,6 +49,7 @@ def mock_definition():
         mock.complexity = 1
         mock.why_confidence_reduced = []
         mock.conditional_import = False
+        mock.base_classes = []
         mock.to_dict.return_value = {
             "name": name,
             "type": type,
@@ -412,6 +413,96 @@ class TestHeuristics:
         assert mock_init.references == 1
         assert mock_enter.references == 1
 
+    def test_visitor_alias_hooks_get_references(self, mock_definition):
+        """class-level NodeVisitor aliases are dispatch hooks, not dead variables."""
+        skylos = Skylos()
+        mock_class = mock_definition(
+            name="ScopeCollector",
+            simple_name="ScopeCollector",
+            type="class",
+            references=1,
+        )
+        mock_alias = mock_definition(
+            name="ScopeCollector._collect_scope_info.visit_AsyncFor",
+            simple_name="visit_AsyncFor",
+            type="variable",
+            references=0,
+        )
+        mock_method = mock_definition(
+            name="ScopeCollector._collect_scope_info.visit_Import",
+            simple_name="visit_Import",
+            type="method",
+            references=0,
+        )
+        skylos.defs = {
+            "ScopeCollector": mock_class,
+            "ScopeCollector._collect_scope_info.visit_AsyncFor": mock_alias,
+            "ScopeCollector._collect_scope_info.visit_Import": mock_method,
+        }
+
+        skylos._apply_heuristics()
+
+        assert mock_alias.references == 1
+        assert mock_method.references == 1
+
+    def test_http_handler_metadata_gets_references(self, mock_definition):
+        """BaseHTTPRequestHandler reads metadata attributes dynamically."""
+        skylos = Skylos()
+        mock_class = mock_definition(
+            name="AgentServiceHandler",
+            simple_name="AgentServiceHandler",
+            type="class",
+            references=0,
+        )
+        mock_class.base_classes = ["http.server.BaseHTTPRequestHandler"]
+        mock_variable = mock_definition(
+            name="AgentServiceHandler.server_version",
+            simple_name="server_version",
+            type="variable",
+            references=0,
+        )
+        skylos.defs = {
+            "AgentServiceHandler": mock_class,
+            "AgentServiceHandler.server_version": mock_variable,
+        }
+
+        skylos._apply_heuristics()
+
+        assert mock_variable.references == 1
+
+    def test_textual_app_runtime_hooks_get_references(self, mock_definition):
+        """Textual App subclasses consume metadata and action methods dynamically."""
+        skylos = Skylos()
+        mock_class = mock_definition(
+            name="SkylosApp",
+            simple_name="SkylosApp",
+            type="class",
+            references=0,
+        )
+        mock_class.base_classes = ["textual.app.App"]
+        mock_binding = mock_definition(
+            name="SkylosApp.BINDINGS",
+            simple_name="BINDINGS",
+            type="variable",
+            references=0,
+        )
+        mock_action = mock_definition(
+            name="SkylosApp.action_go_category",
+            simple_name="action_go_category",
+            type="method",
+            references=0,
+        )
+        skylos.defs = {
+            "SkylosApp": mock_class,
+            "SkylosApp.BINDINGS": mock_binding,
+            "SkylosApp.action_go_category": mock_action,
+        }
+
+        skylos._apply_heuristics()
+
+        assert mock_binding.references == 1
+        assert mock_action.references == 1
+
 
 class TestAnalyze:
     def test_architecture_iad_strict_requires_explicit_iad_opt_in(self):
@@ -450,6 +541,39 @@ class TestAnalyze:
 
         assert ("api.py", "action") not in unused
         assert ("payload.py", "action") not in unused
+
+    def test_mcp_decorated_tools_and_resources_are_live(self, tmp_path):
+        (tmp_path / "server.py").write_text(
+            "class FakeMCP:\n"
+            "    def tool(self):\n"
+            "        def decorate(fn):\n"
+            "            return fn\n"
+            "        return decorate\n\n"
+            "    def resource(self, _uri):\n"
+            "        def decorate(fn):\n"
+            "            return fn\n"
+            "        return decorate\n\n"
+            "mcp = FakeMCP()\n\n"
+            "@mcp.tool()\n"
+            "def registered_tool():\n"
+            "    return 'tool'\n\n"
+            "@mcp.resource('skylos://latest')\n"
+            "def registered_resource():\n"
+            "    return 'resource'\n\n"
+            "def plain_dead():\n"
+            "    return 'dead'\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused = {
+            (Path(item["file"]).name, item["simple_name"])
+            for item in result.get("unused_functions", [])
+        }
+
+        assert ("server.py", "registered_tool") not in unused
+        assert ("server.py", "registered_resource") not in unused
+        assert ("server.py", "plain_dead") in unused
 
     def test_package_scan_resolves_relative_and_module_import_styles(self, tmp_path):
         package = tmp_path / "pkg"

--- a/test/test_quality_standards.py
+++ b/test/test_quality_standards.py
@@ -193,6 +193,82 @@ y = "hello world"
 """
         assert self._run(code) is None
 
+    def test_skips_filesystem_paths(self):
+        code = """
+a = "skylos/analyzer.py"
+b = "skylos/analyzer.py"
+c = "skylos/analyzer.py"
+d = "test/"
+e = "test/"
+f = "test/"
+"""
+        assert self._run(code) is None
+
+    def test_skips_markup_fragments(self):
+        code = """
+a = "</li>"
+b = "</li>"
+c = "</li>"
+d = '" data-search="'
+e = '" data-search="'
+f = '" data-search="'
+"""
+        assert self._run(code) is None
+
+    def test_skips_schema_vocabulary_and_rule_ids(self):
+        code = """
+a = "rule_id"
+b = "rule_id"
+c = "rule_id"
+d = "SKY-Q802"
+e = "SKY-Q802"
+f = "SKY-Q802"
+g = "CRITICAL"
+h = "CRITICAL"
+i = "CRITICAL"
+"""
+        assert self._run(code) is None
+
+    def test_route_like_strings_still_report(self):
+        code = """
+a = "/api/users"
+b = "/api/users"
+c = "/api/users"
+"""
+        results = self._run(code)
+        assert results is not None
+        assert results[0]["name"] == "/api/users"
+
+    def test_skips_module_level_declarative_tables(self):
+        code = """
+RULE_METADATA = {
+    "one": ("detector", "detector"),
+    "two": ("detector", "detector"),
+    "three": ("detector", "detector"),
+}
+"""
+        assert self._run(code) is None
+
+    def test_skips_module_level_constants(self):
+        code = """
+FIRST_LABEL = "same label"
+SECOND_LABEL = "same label"
+THIRD_LABEL = "same label"
+"""
+        assert self._run(code) is None
+
+    def test_function_local_duplicates_still_report(self):
+        code = """
+def build_messages():
+    first = "same label"
+    second = "same label"
+    third = "same label"
+    return first, second, third
+"""
+        results = self._run(code)
+        assert results is not None
+        assert results[0]["name"] == "same label"
+
 
 # ---------------------------------------------------------------------------
 # TooManyReturnsRule (SKY-L028)


### PR DESCRIPTION
## Summary
  - Reduce Skylos noise by excluding benchmark, demo, generated, fixture paths from quality scans
  - Mark dynamic runtime hooks as live for MCP tools, Textual apps, AST visitor aliases, and HTTP handler metadata
  - Tune `SKY-L027` duplicate string detection to skip noisy declarative values like paths, markup fragments, schema vocabulary, rule IDs, and module-level metadata tables
  - Remove small confirmed stale imports and unused loop variables

  ## Tests
  - `pytest test/test_analyzer.py test/test_quality_standards.py test/test_defend.py test/
  test_cmd_injection.py`
  - `pytest test/test_verify_benchmark.py`
  - `pytest test/test_quality_standards.py test/test_quality_rules.py`