### PR TITLE
fix(upload): require explicit scan uploads

### DIFF
--- a/skylos/api/__init__.py
+++ b/skylos/api/__init__.py
@@ -1322,6 +1322,7 @@ def upload_report_v2(
         artifact_result = _upload_report_artifacts(
             artifacts,
             init_result["artifact_instructions"],
+            init_result.get("skipped_artifacts"),
         )
         if not artifact_result.get("success", True):
             return artifact_result
@@ -1356,14 +1357,27 @@ def _start_report_artifact_upload(
     strict: bool,
     is_forced: bool,
 ) -> dict[str, Any]:
-    init_response, last_err = _post_json_with_retries(
-        REPORT_INIT_URL,
-        _build_auth_headers(token),
-        _build_report_init_payload(prepared, artifacts),
-        quiet=quiet,
-        initial_message="Uploading scan results...",
-        accepted_statuses=(200, 201, 401, 402, 404, 405, 501),
-    )
+    skipped_artifacts = []
+    initial_message = "Uploading scan results..."
+
+    while True:
+        init_response, last_err = _post_json_with_retries(
+            REPORT_INIT_URL,
+            _build_auth_headers(token),
+            _build_report_init_payload(prepared, artifacts),
+            quiet=quiet,
+            initial_message=initial_message,
+            accepted_statuses=(200, 201, 400, 401, 402, 404, 405, 501),
+        )
+        if _retry_artifact_init_without_optional_artifact(
+            init_response,
+            artifacts,
+            skipped_artifacts,
+        ):
+            initial_message = None
+            continue
+        break
+
     if init_response is None:
         if _looks_like_server_error(last_err):
             return {
@@ -1376,6 +1390,11 @@ def _start_report_artifact_upload(
         }
     if init_response.status_code in (404, 405, 501):
         return {"complete": True, "result": _build_large_upload_protocol_error(prepared)}
+    if init_response.status_code == 400:
+        return {
+            "complete": True,
+            "result": _build_report_init_error(init_response),
+        }
     if init_response.status_code in (401, 402):
         return {
             "complete": True,
@@ -1401,15 +1420,91 @@ def _start_report_artifact_upload(
         "complete": False,
         "init_data": init_data,
         "artifact_instructions": artifact_instructions,
+        "skipped_artifacts": skipped_artifacts,
     }
+
+
+def _retry_artifact_init_without_optional_artifact(
+    init_response,
+    artifacts: dict,
+    skipped_artifacts: list,
+) -> bool:
+    artifact_name = _unsupported_optional_artifact_name(init_response, artifacts)
+    if artifact_name is None:
+        return False
+
+    artifact = artifacts.pop(artifact_name)
+    artifact.cleanup()
+    _append_skipped_artifact(skipped_artifacts, artifact_name, "unsupported")
+    return True
+
+
+def _unsupported_optional_artifact_name(init_response, artifacts: dict) -> str | None:
+    if init_response is None:
+        return None
+    if init_response.status_code != 400:
+        return None
+
+    message = _report_init_error_message(init_response)
+    if "Unsupported artifact" not in message:
+        return None
+
+    for artifact_name, artifact in artifacts.items():
+        if artifact.required:
+            continue
+        single_quoted_name = f"'{artifact_name}'"
+        double_quoted_name = f'"{artifact_name}"'
+        if single_quoted_name in message or double_quoted_name in message:
+            return artifact_name
+    return None
+
+
+def _report_init_error_message(response) -> str:
+    parts = []
+    try:
+        data = response.json()
+    except (TypeError, ValueError):
+        data = {}
+
+    if isinstance(data, dict):
+        error = data.get("error")
+        if isinstance(error, str):
+            parts.append(error)
+        code = data.get("code")
+        if isinstance(code, str):
+            parts.append(code)
+
+    text = getattr(response, "text", "")
+    if isinstance(text, str):
+        parts.append(text)
+    return " ".join(parts)
+
+
+def _build_report_init_error(response) -> dict[str, Any]:
+    error = f"Server Error {response.status_code}: {response.text}"
+    result = {
+        "success": False,
+        "error": error,
+    }
+    try:
+        data = response.json()
+    except (TypeError, ValueError):
+        data = {}
+    if isinstance(data, dict) and isinstance(data.get("code"), str):
+        result["code"] = data["code"]
+    return result
 
 
 def _upload_report_artifacts(
     artifacts: dict,
     artifact_instructions: dict,
+    skipped_artifacts: list | None = None,
 ) -> dict[str, Any]:
     uploaded_artifacts = {}
-    skipped_artifacts = []
+    if skipped_artifacts is None:
+        skipped_artifacts = []
+    else:
+        skipped_artifacts = list(skipped_artifacts)
     for artifact_name, artifact in artifacts.items():
         result = _upload_one_report_artifact(
             artifact_name,

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -24,7 +24,6 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
     _build_main_parser = cli_module._build_main_parser
     _build_main_scan_context = cli_module._build_main_scan_context
     _concise_scan_exit_code = cli_module._concise_scan_exit_code
-    _detect_link_file = cli_module._detect_link_file
     _emit_github_annotations = cli_module._emit_github_annotations
     _format_concise_results = cli_module._format_concise_results
     _formatted_output_gate_exit_code = cli_module._formatted_output_gate_exit_code
@@ -822,12 +821,6 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             nudge = pick_nudge(result, args, project_root)
             if nudge:
                 console.print(f"\n  {nudge}")
-
-    if not args.upload and not getattr(args, "no_upload", False) and not args.json:
-        is_linked = _detect_link_file(project_root) is not None
-        has_env_token = bool(os.getenv("SKYLOS_TOKEN"))
-        if is_linked or has_env_token:
-            args.upload = True
 
     forgotten = result.get("forgotten", [])
     if forgotten:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1157,6 +1157,85 @@ class TestSkylosApi(unittest.TestCase):
     @patch("skylos.api.get_git_root", return_value=None)
     @patch("skylos.api.get_project_info", return_value={})
     @patch("skylos.api.detect_ai_code", return_value={"detected": False})
+    @patch("requests.put")
+    @patch("requests.post")
+    def test_upload_report_retries_without_unsupported_optional_definitions(
+        self,
+        mock_post,
+        mock_put,
+        _mock_ai,
+        _mock_info,
+        _mock_root,
+        _mock_git_info,
+        mock_token,
+    ):
+        mock_token.return_value = "token"
+
+        unsupported_resp = MagicMock()
+        unsupported_resp.status_code = 400
+        unsupported_resp.text = (
+            '{"error":"Unsupported artifact \'definitions\'.","code":"BAD_REQUEST"}'
+        )
+        unsupported_resp.json.return_value = {
+            "error": "Unsupported artifact 'definitions'.",
+            "code": "BAD_REQUEST",
+        }
+        init_resp = MagicMock()
+        init_resp.status_code = 201
+        init_resp.json.return_value = {
+            "scanId": "scan_artifact",
+            "upload_id": "upload-1",
+            "artifacts": {
+                "scan_report": {
+                    "artifact_id": "artifact-scan",
+                    "key": "scan-key",
+                    "upload": {
+                        "method": "PUT",
+                        "url": "https://uploads.skylos.dev/report",
+                    },
+                }
+            },
+        }
+        complete_resp = MagicMock()
+        complete_resp.status_code = 200
+        complete_resp.json.return_value = {"scanId": "scan_artifact"}
+        mock_post.side_effect = [unsupported_resp, init_resp, complete_resp]
+
+        ok_upload = MagicMock()
+        ok_upload.status_code = 200
+        ok_upload.headers = {}
+        ok_upload.text = "OK"
+        mock_put.return_value = ok_upload
+
+        with patch("skylos.api._legacy_inline_upload_limit_bytes", return_value=10):
+            result = upload_report(
+                {
+                    "danger": [{"file": "app.py", "line": 5, "message": "oops"}],
+                    "definitions": {"app.func": {"file": "app.py", "line": 5}},
+                },
+                quiet=True,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(mock_put.call_count, 1)
+
+        first_init_payload = mock_post.call_args_list[0].kwargs["json"]
+        second_init_payload = mock_post.call_args_list[1].kwargs["json"]
+        self.assertIn("definitions", first_init_payload["artifacts"])
+        self.assertNotIn("definitions", second_init_payload["artifacts"])
+
+        complete_payload = mock_post.call_args_list[2].kwargs["json"]
+        self.assertIn("scan_report", complete_payload["artifacts"])
+        self.assertEqual(
+            complete_payload["skipped_artifacts"],
+            [{"name": "definitions", "reason": "unsupported"}],
+        )
+
+    @patch("skylos.api.get_project_token")
+    @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
+    @patch("skylos.api.get_git_root", return_value=None)
+    @patch("skylos.api.get_project_info", return_value={})
+    @patch("skylos.api.detect_ai_code", return_value={"detected": False})
     @patch("requests.post")
     def test_upload_report_large_payload_fails_cleanly_when_artifacts_unsupported(
         self,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1091,6 +1091,40 @@ def test_main_json_upload_calls_upload_report_quiet(monkeypatch):
     assert "provenance_summary" in printed_payload
 
 
+def test_main_linked_repo_does_not_upload_without_upload_flag(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+
+    monkeypatch.setattr(cli.sys, "argv", ["skylos", "."])
+    monkeypatch.setenv("SKYLOS_TOKEN", "token")
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.render_results"),
+        patch("skylos.cli.print_badge"),
+        patch("skylos.cli._detect_link_file", return_value=".skylos/link.json"),
+        patch("skylos.cli.upload_report") as mock_upload,
+    ):
+        cli.main()
+
+    mock_upload.assert_not_called()
+
+
 def test_main_json_gate_failure_exits_nonzero(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},


### PR DESCRIPTION
## Summary
  - Stop regular scans from auto-uploading just because a repo is linked or `SKYLOS_TOKEN` is present
  - Keep uploads opt-in through `--upload`
  - Retry large scan artifact init without optional `definitions` when Skylos Cloud rejects that artifact

  ## Tests
  - `pytest test/test_api.py test/test_cli_uncovered_paths.py test/test_cli.py`
