### PR TITLE
feat(llm): detect excessive agent tool privilege

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -126,6 +126,7 @@ Rule IDs are unified across languages where the same vulnerability exists.
 | D261 | HIGH | Untrusted input to LLM prompt | Python | OWASP LLM01 |
 | D262 | CRITICAL | Unsafe LLM output handling | Python | OWASP LLM05 |
 | D263 | HIGH | Sensitive data sent to LLM | Python | OWASP LLM02 |
+| D264 | HIGH | Excessive agent tool privilege | Python | OWASP LLM06 |
 | D265 | HIGH-CRITICAL | Unsafe ML model deserialization | Python | OWASP LLM04 |
 | D266 | CRITICAL | AI config instruction injection | Agent config and instruction files | OWASP LLM01 |
 | D270 | MEDIUM | Sensitive data in `localStorage` / `sessionStorage` | TS/JS | CWE-922 |
@@ -156,6 +157,7 @@ Finding types:
 | D261 | HIGH | Untrusted input to LLM prompt | Python | Request-controlled data reaches an LLM prompt or message without a clear instruction/data boundary |
 | D262 | CRITICAL | Unsafe LLM output handling | Python | Model output flows into code execution, shell, SQL, or network sinks without validation |
 | D263 | HIGH | Sensitive data sent to LLM | Python | Secrets, credential fields, or sensitive environment values flow into LLM or embedding API input |
+| D264 | HIGH | Excessive agent tool privilege | Python | Agent frameworks are granted shell, code execution, unrestricted HTTP, or broad file-management tools |
 | D265 | HIGH-CRITICAL | Unsafe ML model deserialization | Python | Pickle-backed model/checkpoint loading such as `torch.load`, `joblib.load`, or `numpy.load(..., allow_pickle=True)` |
 | D266 | CRITICAL | AI config instruction injection | Agent config and instruction files | D260-style hidden, obfuscated, or instruction-override payloads in AI assistant rule/config files |
 

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -154,6 +154,13 @@ _RULES = (
         aliases=("llm data leakage", "sensitive disclosure"),
     ),
     RuleCatalogEntry(
+        "SKY-D264",
+        "Excessive agent tool privilege",
+        "security",
+        "HIGH",
+        aliases=("excessive agency", "dangerous agent tool"),
+    ),
+    RuleCatalogEntry(
         "SKY-D265",
         "Unsafe ML model deserialization",
         "security",

--- a/skylos/rules/danger/danger.py
+++ b/skylos/rules/danger/danger.py
@@ -15,6 +15,7 @@ from .danger_jwt.jwt_flow import scan as scan_jwt
 from .danger_access.access_flow import scan as scan_access
 from .danger_mcp.mcp_flow import scan as scan_mcp
 from .danger_webhook.webhook_flow import scan as scan_webhook
+from .danger_agent.tool_privilege import scan as scan_agent_tool_privilege
 from .danger_llm.llm_flow import scan as scan_llm
 from .danger_ml.model_deserialization import scan as scan_ml_model_load
 from .danger_hallucination.dependency_hallucination import (
@@ -344,6 +345,25 @@ _LLM_TOKENS = (
     "generatetext",
     "streamtext",
 )
+_AGENT_TOOL_TOKENS = (
+    "agentexecutor",
+    "code_interpreter",
+    "computer_use_preview",
+    "create_openai_functions_agent",
+    "create_openai_tools_agent",
+    "create_react_agent",
+    "create_structured_chat_agent",
+    "crewai",
+    "initialize_agent",
+    "load_tools",
+    "pythonastrepltool",
+    "pythonrepltool",
+    "shelltool",
+    "structuredtool",
+    "tool(",
+    "tools=",
+    "tools =",
+)
 _ML_MODEL_LOAD_TOKENS = (
     "torch.load",
     "weights_only",
@@ -464,6 +484,7 @@ def scan_file_with_tree(tree, file_path, findings, *, source: str | None = None)
         scan_access(tree, file_path, findings)
         scan_mcp(tree, file_path, findings)
         scan_webhook(tree, file_path, findings)
+        scan_agent_tool_privilege(tree, file_path, findings)
         scan_llm(tree, file_path, findings)
         scan_ml_model_load(tree, file_path, findings)
         _PythonCommandExfilChecker(file_path, findings).visit(tree)
@@ -496,6 +517,8 @@ def scan_file_with_tree(tree, file_path, findings, *, source: str | None = None)
         str(file_path).lower(), _WEBHOOK_TOKENS
     ):
         scan_webhook(tree, file_path, findings, source=source)
+    if _has_any(source_lower, _AGENT_TOOL_TOKENS):
+        scan_agent_tool_privilege(tree, file_path, findings)
     if _has_any(source_lower, _LLM_TOKENS):
         scan_llm(tree, file_path, findings)
     if _has_any(source_lower, _ML_MODEL_LOAD_TOKENS):

--- a/skylos/rules/danger/danger_agent/__init__.py
+++ b/skylos/rules/danger/danger_agent/__init__.py
@@ -1,0 +1,2 @@
+"""Agent-framework danger rules."""
+

--- a/skylos/rules/danger/danger_agent/tool_privilege.py
+++ b/skylos/rules/danger/danger_agent/tool_privilege.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import ast
+import sys
+
+from skylos.rules.danger.calls import _qualified_name_from_call, _resolve_expr_name
+
+
+DANGEROUS_TOOL_CONSTRUCTORS = {
+    "ShellTool": "shell execution tool",
+    "PythonREPLTool": "Python REPL tool",
+    "PythonAstREPLTool": "Python AST REPL tool",
+}
+
+DANGEROUS_FUNCTION_REFS = {
+    "compile": "dynamic code compilation",
+    "eval": "dynamic eval",
+    "exec": "dynamic exec",
+    "os.execve": "process replacement",
+    "os.execvp": "process replacement",
+    "os.popen": "shell command execution",
+    "os.system": "shell command execution",
+    "shutil.rmtree": "recursive file deletion",
+    "subprocess.Popen": "subprocess execution",
+    "subprocess.call": "subprocess execution",
+    "subprocess.check_call": "subprocess execution",
+    "subprocess.check_output": "subprocess execution",
+    "subprocess.run": "subprocess execution",
+}
+
+DANGEROUS_LOAD_TOOL_NAMES = {
+    "file_management": "unrestricted file management tool",
+    "python_repl": "Python REPL tool",
+    "python_repl_ast": "Python AST REPL tool",
+    "requests_all": "unrestricted HTTP request tool",
+    "shell": "shell execution tool",
+    "terminal": "terminal execution tool",
+}
+
+DANGEROUS_OPENAI_TOOL_TYPES = {
+    "code_interpreter": "code interpreter tool",
+    "computer_use_preview": "computer-use tool",
+}
+
+AGENT_CALL_SUFFIXES = (
+    ".assistants.create",
+    ".create_openai_functions_agent",
+    ".create_openai_tools_agent",
+    ".create_react_agent",
+    ".create_structured_chat_agent",
+    ".initialize_agent",
+    "Agent",
+    "AgentExecutor",
+    "AgentExecutor.from_agent_and_tools",
+    "create_openai_functions_agent",
+    "create_openai_tools_agent",
+    "create_react_agent",
+    "create_structured_chat_agent",
+    "initialize_agent",
+)
+
+TOOL_FACTORY_SUFFIXES = (
+    ".StructuredTool",
+    ".StructuredTool.from_function",
+    ".Tool",
+    ".Tool.from_function",
+    "StructuredTool",
+    "StructuredTool.from_function",
+    "Tool",
+    "Tool.from_function",
+)
+
+
+class _AgentToolPrivilegeChecker(ast.NodeVisitor):
+    def __init__(self, file_path, findings):
+        self.file_path = file_path
+        self.findings = findings
+        self.aliases: dict[str, str] = {}
+        self._symbol_stack = ["<module>"]
+        self._dangerous_tools_stack: list[dict[str, str]] = [{}]
+        self._dangerous_functions_stack: list[dict[str, str]] = [{}]
+        self._emitted: set[tuple[int, int, str]] = set()
+
+    def _current_symbol(self) -> str:
+        if self._symbol_stack:
+            return self._symbol_stack[-1]
+        return "<module>"
+
+    def _push_scope(self) -> None:
+        self._dangerous_tools_stack.append({})
+        self._dangerous_functions_stack.append({})
+
+    def _pop_scope(self) -> None:
+        if len(self._dangerous_tools_stack) > 1:
+            self._dangerous_tools_stack.pop()
+        if len(self._dangerous_functions_stack) > 1:
+            self._dangerous_functions_stack.pop()
+
+    def _mark_dangerous_tool(self, name: str, detail: str) -> None:
+        self._dangerous_tools_stack[-1][name] = detail
+
+    def _mark_dangerous_function(self, name: str, detail: str) -> None:
+        self._dangerous_functions_stack[-1][name] = detail
+
+    def _dangerous_tool_detail_for_name(self, name: str) -> str | None:
+        for scope in reversed(self._dangerous_tools_stack):
+            detail = scope.get(name)
+            if detail:
+                return detail
+        return None
+
+    def _dangerous_function_detail_for_name(self, name: str) -> str | None:
+        for scope in reversed(self._dangerous_functions_stack):
+            detail = scope.get(name)
+            if detail:
+                return detail
+        return None
+
+    def generic_visit(self, node: ast.AST) -> None:
+        for _, value in ast.iter_fields(node):
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        self.visit(item)
+            elif isinstance(value, ast.AST):
+                self.visit(value)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".", 1)[0]
+            self.aliases[local] = alias.name
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                local = alias.asname or alias.name
+                self.aliases[local] = f"{node.module}.{alias.name}"
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._symbol_stack.append(node.name)
+        self._push_scope()
+        self.generic_visit(node)
+        self._pop_scope()
+        self._symbol_stack.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._symbol_stack.append(node.name)
+        self._push_scope()
+        self.generic_visit(node)
+        self._pop_scope()
+        self._symbol_stack.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._symbol_stack.append(node.name)
+        self.generic_visit(node)
+        self._symbol_stack.pop()
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        tool_detail = self._expr_dangerous_tool_detail(node.value)
+        function_detail = self._expr_dangerous_function_detail(node.value)
+        for target in node.targets:
+            self._mark_target(target, tool_detail, function_detail)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value:
+            tool_detail = self._expr_dangerous_tool_detail(node.value)
+            function_detail = self._expr_dangerous_function_detail(node.value)
+            self._mark_target(node.target, tool_detail, function_detail)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        call_name = _qualified_name_from_call(node, self.aliases)
+        if self._is_agent_call(call_name):
+            detail = self._agent_tool_detail(node)
+            if detail:
+                self._append_finding(node, detail)
+        self.generic_visit(node)
+
+    def _mark_target(
+        self,
+        target: ast.AST,
+        tool_detail: str | None,
+        function_detail: str | None,
+    ) -> None:
+        if not isinstance(target, ast.Name):
+            return
+        if tool_detail:
+            self._mark_dangerous_tool(target.id, tool_detail)
+        if function_detail:
+            self._mark_dangerous_function(target.id, function_detail)
+
+    def _is_agent_call(self, call_name: str | None) -> bool:
+        if not call_name:
+            return False
+        return any(call_name.endswith(suffix) for suffix in AGENT_CALL_SUFFIXES)
+
+    def _agent_tool_detail(self, node: ast.Call) -> str | None:
+        for keyword in node.keywords:
+            if keyword.arg in {"tool", "toolkit", "toolkits", "tools"}:
+                detail = self._expr_dangerous_tool_detail(keyword.value)
+                if detail:
+                    return detail
+
+        for arg in node.args:
+            detail = self._expr_dangerous_tool_detail(arg)
+            if detail:
+                return detail
+        return None
+
+    def _expr_dangerous_tool_detail(self, node: ast.AST | None) -> str | None:
+        if node is None:
+            return None
+        if isinstance(node, ast.Name):
+            return self._dangerous_tool_detail_for_name(node.id)
+        if isinstance(node, ast.Call):
+            return self._call_dangerous_tool_detail(node)
+        if isinstance(node, ast.Dict):
+            return self._dict_dangerous_tool_detail(node)
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            return self._iterable_dangerous_tool_detail(node.elts)
+        return None
+
+    def _iterable_dangerous_tool_detail(self, nodes: list[ast.AST]) -> str | None:
+        for item in nodes:
+            detail = self._expr_dangerous_tool_detail(item)
+            if detail:
+                return detail
+        return None
+
+    def _call_dangerous_tool_detail(self, node: ast.Call) -> str | None:
+        call_name = _qualified_name_from_call(node, self.aliases)
+        short_name = _short_name(call_name)
+        if short_name in DANGEROUS_TOOL_CONSTRUCTORS:
+            return DANGEROUS_TOOL_CONSTRUCTORS[short_name]
+
+        if call_name and call_name.endswith(".load_tools"):
+            return self._load_tools_detail(node)
+        if call_name == "load_tools":
+            return self._load_tools_detail(node)
+
+        if self._is_tool_factory_call(call_name):
+            return self._tool_factory_detail(node)
+        return None
+
+    def _is_tool_factory_call(self, call_name: str | None) -> bool:
+        if not call_name:
+            return False
+        return any(call_name.endswith(suffix) for suffix in TOOL_FACTORY_SUFFIXES)
+
+    def _tool_factory_detail(self, node: ast.Call) -> str | None:
+        for arg in node.args:
+            detail = self._expr_dangerous_function_detail(arg)
+            if detail:
+                return detail
+        for keyword in node.keywords:
+            if keyword.arg not in {"coroutine", "func"}:
+                continue
+            detail = self._expr_dangerous_function_detail(keyword.value)
+            if detail:
+                return detail
+        return None
+
+    def _load_tools_detail(self, node: ast.Call) -> str | None:
+        for value in self._iter_string_constants(node.args):
+            detail = DANGEROUS_LOAD_TOOL_NAMES.get(value.lower())
+            if detail:
+                return detail
+        return None
+
+    def _dict_dangerous_tool_detail(self, node: ast.Dict) -> str | None:
+        tool_type = _dict_string_value(node, "type")
+        if tool_type:
+            return DANGEROUS_OPENAI_TOOL_TYPES.get(tool_type)
+        return None
+
+    def _expr_dangerous_function_detail(self, node: ast.AST | None) -> str | None:
+        if node is None:
+            return None
+        if isinstance(node, ast.Name):
+            marked = self._dangerous_function_detail_for_name(node.id)
+            if marked:
+                return marked
+        name = _resolve_expr_name(node, self.aliases)
+        if name in DANGEROUS_FUNCTION_REFS:
+            return DANGEROUS_FUNCTION_REFS[name]
+        return None
+
+    def _iter_string_constants(self, nodes: list[ast.AST]) -> list[str]:
+        values: list[str] = []
+        for node in nodes:
+            values.extend(_string_constants(node))
+        return values
+
+    def _append_finding(self, node: ast.Call, detail: str) -> None:
+        line = int(getattr(node, "lineno", 1) or 1)
+        col = int(getattr(node, "col_offset", 0) or 0)
+        key = (line, col, detail)
+        if key in self._emitted:
+            return
+        self._emitted.add(key)
+        self.findings.append(
+            {
+                "rule_id": "SKY-D264",
+                "severity": "HIGH",
+                "message": (
+                    "Agent is granted dangerous tool capability "
+                    f"({detail}); restrict tools to allowlisted, scoped "
+                    "functions and require human approval for mutating actions."
+                ),
+                "file": str(self.file_path),
+                "line": line,
+                "col": col,
+                "symbol": self._current_symbol(),
+                "metadata": {"agent_tool_privilege": True},
+            }
+        )
+
+
+def _short_name(call_name: str | None) -> str | None:
+    if not call_name:
+        return None
+    return call_name.rsplit(".", 1)[-1]
+
+
+def _dict_string_value(node: ast.Dict, key_name: str) -> str | None:
+    for key, value in zip(node.keys, node.values):
+        if _constant_string(key) != key_name:
+            continue
+        return _constant_string(value)
+    return None
+
+
+def _constant_string(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _string_constants(node: ast.AST | None) -> list[str]:
+    if node is None:
+        return []
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        values: list[str] = []
+        for item in node.elts:
+            values.extend(_string_constants(item))
+        return values
+    return []
+
+
+def scan(tree, file_path, findings):
+    try:
+        checker = _AgentToolPrivilegeChecker(file_path, findings)
+        checker.visit(tree)
+    except Exception as e:
+        print(
+            f"Agent tool privilege analysis failed for {file_path}: {e}",
+            file=sys.stderr,
+        )

--- a/test/test_agent_tool_privilege.py
+++ b/test/test_agent_tool_privilege.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+
+from skylos.rules.danger.danger import scan_ctx
+
+
+def _write(tmp_path: Path, name: str, code: str) -> Path:
+    file_path = tmp_path / name
+    file_path.write_text(code, encoding="utf-8")
+    return file_path
+
+
+def _scan_one(tmp_path: Path, name: str, code: str):
+    file_path = _write(tmp_path, name, code)
+    return scan_ctx(tmp_path, [file_path])
+
+
+def _rule_ids(findings):
+    return {finding["rule_id"] for finding in findings}
+
+
+def test_shell_tool_registered_to_langchain_agent_flags_d264(tmp_path):
+    findings = _scan_one(
+        tmp_path,
+        "agent_shell_tool.py",
+        """
+from langchain.agents import initialize_agent
+from langchain_community.tools import ShellTool
+
+def build_agent(llm):
+    return initialize_agent([ShellTool()], llm, max_iterations=5)
+""",
+    )
+
+    assert "SKY-D264" in _rule_ids(findings)
+
+
+def test_tool_wrapping_os_system_registered_to_agent_flags_d264(tmp_path):
+    findings = _scan_one(
+        tmp_path,
+        "agent_os_system_tool.py",
+        """
+import os
+from langchain.agents import Tool, initialize_agent
+
+shell_tool = Tool(name="shell", func=os.system, description="run a command")
+
+def build_agent(llm):
+    return initialize_agent([shell_tool], llm, max_iterations=5)
+""",
+    )
+
+    assert "SKY-D264" in _rule_ids(findings)
+
+
+def test_load_tools_terminal_registered_to_agent_flags_d264(tmp_path):
+    findings = _scan_one(
+        tmp_path,
+        "agent_load_tools.py",
+        """
+from langchain.agents import initialize_agent, load_tools
+
+def build_agent(llm):
+    tools = load_tools(["terminal"])
+    return initialize_agent(tools, llm, max_iterations=5)
+""",
+    )
+
+    assert "SKY-D264" in _rule_ids(findings)
+
+
+def test_crewai_agent_with_python_repl_tool_flags_d264(tmp_path):
+    findings = _scan_one(
+        tmp_path,
+        "crewai_agent.py",
+        """
+from crewai import Agent
+from langchain_experimental.tools import PythonREPLTool
+
+agent = Agent(
+    role="ops",
+    goal="operate systems",
+    backstory="operator",
+    tools=[PythonREPLTool()],
+)
+""",
+    )
+
+    assert "SKY-D264" in _rule_ids(findings)
+
+
+def test_tool_wrapper_without_langchain_initialize_token_flags_d264(tmp_path):
+    findings = _scan_one(
+        tmp_path,
+        "generic_agent_tool.py",
+        """
+import os
+from platform_agent import Agent, Tool
+
+shell_tool = Tool(func=os.system, name="shell")
+agent = Agent(tools=[shell_tool])
+""",
+    )
+
+    assert "SKY-D264" in _rule_ids(findings)
+
+
+def test_safe_lookup_tool_registered_to_agent_is_not_d264(tmp_path):
+    findings = _scan_one(
+        tmp_path,
+        "safe_agent_tool.py",
+        """
+from langchain.agents import Tool, initialize_agent
+
+def lookup(query: str) -> str:
+    return "ok"
+
+lookup_tool = Tool(name="lookup", func=lookup, description="read-only lookup")
+
+def build_agent(llm):
+    return initialize_agent([lookup_tool], llm, max_iterations=5)
+""",
+    )
+
+    assert "SKY-D264" not in _rule_ids(findings)


### PR DESCRIPTION
## Summary
  - Add `SKY-D264` for excessive agent tool privilege in Python agent frameworks.
  - Detect dangerous tools registered into agents, including shell or Python REPL tools, `load_tools` dangerous capabilities, OpenAI tool dicts, and `Tool`/`StructuredTool` wrappers around dangerous functions.

  ## Tests
  - `pytest test/test_agent_tool_privilege.py test/test_dangerous.py test/test_deserialization.py test/test_injection_scanner.py`
  - `python scripts/check_rule_docs_parity.py`