### PR TITLE
fix(dead-code): track browser handler liveness

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1511,6 +1511,20 @@ class Skylos:
             "server_version",
             "sys_version",
         }
+        http_handler_override_methods = {
+            "do_CONNECT",
+            "do_DELETE",
+            "do_GET",
+            "do_HEAD",
+            "do_OPTIONS",
+            "do_PATCH",
+            "do_POST",
+            "do_PUT",
+            "end_headers",
+            "log_message",
+            "send_error",
+            "version_string",
+        }
         for definition in self.defs.values():
             if definition.type != "variable":
                 continue
@@ -1529,6 +1543,30 @@ class Skylos:
             base_classes = getattr(class_def, "base_classes", [])
             for base in base_classes:
                 if str(base).split(".")[-1] == "BaseHTTPRequestHandler":
+                    definition.references += 1
+                    break
+
+        for definition in self.defs.values():
+            if definition.type != "method":
+                continue
+
+            if definition.simple_name not in http_handler_override_methods:
+                continue
+
+            if "." not in definition.name:
+                continue
+
+            cls = definition.name.rsplit(".", 1)[0]
+            class_def = self.defs.get(cls)
+            if class_def is None or class_def.type != "class":
+                continue
+
+            base_classes = getattr(class_def, "base_classes", [])
+            for base in base_classes:
+                if str(base).split(".")[-1] in {
+                    "BaseHTTPRequestHandler",
+                    "SimpleHTTPRequestHandler",
+                }:
                     definition.references += 1
                     break
 
@@ -3181,6 +3219,21 @@ class Skylos:
         self._all_used_attr_context = all_used_attr_context
         self._param_method_refs = all_param_method_refs
         self._call_arg_types = all_call_arg_types
+
+        try:
+            from skylos.deadcode.browser_refs import (
+                collect_browser_event_handler_refs,
+            )
+
+            browser_handler_refs = collect_browser_event_handler_refs(
+                Path(root),
+                files,
+                exclude_folders=exclude_folders,
+            )
+            self.refs.extend(browser_handler_refs)
+        except Exception:
+            if os.getenv("SKYLOS_DEBUG"):
+                logger.error("Browser event handler liveness scan failed", exc_info=True)
 
         for top_level_ref in all_top_level_refs:
             defn = self.defs.get(top_level_ref)

--- a/skylos/deadcode/browser_refs.py
+++ b/skylos/deadcode/browser_refs.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from skylos.core.file_discovery import discover_source_files
+from skylos.core.safe_cache_io import read_text_no_symlink
+
+_JS_SOURCE_SUFFIXES = {
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
+}
+_HTML_TEMPLATE_SUFFIXES = {
+    ".html",
+    ".htm",
+    ".vue",
+    ".svelte",
+    ".astro",
+}
+
+_QUOTED_EVENT_HANDLER_RE = re.compile(
+    r"""\bon[a-zA-Z]+\s*=\s*\\?(?P<quote>["'])(?P<handler>.*?)\\?(?P=quote)""",
+    re.DOTALL,
+)
+_UNQUOTED_EVENT_HANDLER_RE = re.compile(
+    r"""\bon[a-zA-Z]+\s*=\s*(?P<handler>[^\s>]+)""",
+    re.DOTALL,
+)
+_WINDOW_CALL_RE = re.compile(r"""\bwindow\s*\.\s*(?P<name>[A-Za-z_$][\w$]*)\s*\(""")
+_DIRECT_CALL_RE = re.compile(r"""(?<![.\w$])(?P<name>[A-Za-z_$][\w$]*)\s*\(""")
+_WINDOW_LITERAL_DISPATCH_RE = re.compile(
+    r"""\bwindow\s*\[\s*(?P<quote>["'])(?P<name>[A-Za-z_$][\w$]*)(?P=quote)\s*\]\s*\("""
+)
+_LEGACY_STRING_DISPATCH_RE = re.compile(
+    r"""\b(?:callLegacy|legacyClick|legacyKeyDown)\s*\(\s*(?P<quote>["'])(?P<name>[A-Za-z_$][\w$]*)(?P=quote)"""
+)
+_ACTION_PROPERTY_RE = re.compile(
+    r"""\b[A-Za-z_$][\w$]*Action\s*:\s*(?P<quote>["'])(?P<name>[A-Za-z_$][\w$]*)(?P=quote)"""
+)
+_SCRIPT_TAG_RE = re.compile(r"""<script\b(?P<attrs>[^>]*)>""", re.IGNORECASE)
+_SRC_ATTR_RE = re.compile(
+    r"""\bsrc\s*=\s*(?P<quote>["'])(?P<value>.*?)(?P=quote)""",
+    re.IGNORECASE | re.DOTALL,
+)
+_TYPE_ATTR_RE = re.compile(
+    r"""\btype\s*=\s*(?P<quote>["'])(?P<value>.*?)(?P=quote)""",
+    re.IGNORECASE | re.DOTALL,
+)
+_JS_CONTROL_WORDS = {
+    "catch",
+    "do",
+    "for",
+    "function",
+    "if",
+    "switch",
+    "while",
+    "with",
+}
+_MAX_REFERENCE_FILE_BYTES = 512_000
+
+
+def extract_browser_event_handler_names(source: str) -> set[str]:
+    names: set[str] = set()
+
+    for handler in _iter_event_handler_values(source):
+        normalized = _normalize_handler_source(handler)
+        for name in _extract_call_names(normalized):
+            names.add(name)
+
+    for name in _extract_string_dispatch_names(source):
+        names.add(name)
+
+    return names
+
+
+def collect_browser_event_handler_refs(
+    project_root: Path,
+    source_files,
+    *,
+    exclude_folders=None,
+) -> list[tuple[str, str]]:
+    root = Path(project_root).resolve()
+    refs: list[tuple[str, str]] = []
+    seen_refs: set[tuple[str, str]] = set()
+    seen_names: set[str] = set()
+    source_cache: dict[Path, str] = {}
+    template_files: list[Path] = []
+
+    reference_files = list(
+        _iter_browser_reference_files(root, source_files, exclude_folders)
+    )
+    for file_path in reference_files:
+        source = _read_text(root, file_path, source_cache)
+        if source is None:
+            continue
+
+        if file_path.suffix.lower() in _HTML_TEMPLATE_SUFFIXES:
+            template_files.append(file_path)
+
+        for name in extract_browser_event_handler_names(source):
+            seen_names.add(name)
+            _append_ref(refs, seen_refs, name, file_path)
+
+    global_scripts = _collect_non_module_script_files(root, template_files, source_cache)
+    for script_file in global_scripts:
+        source = _read_text(root, script_file, source_cache)
+        if source is None:
+            continue
+        for name in seen_names:
+            if _source_defines_top_level_browser_name(source, name):
+                _append_ref(refs, seen_refs, name, script_file)
+
+    return refs
+
+
+def _iter_event_handler_values(source: str):
+    quoted_spans: list[tuple[int, int]] = []
+
+    for match in _QUOTED_EVENT_HANDLER_RE.finditer(source):
+        quoted_spans.append(match.span())
+        yield match.group("handler")
+
+    for match in _UNQUOTED_EVENT_HANDLER_RE.finditer(source):
+        if _span_overlaps(match.span(), quoted_spans):
+            continue
+        yield match.group("handler")
+
+
+def _normalize_handler_source(handler: str) -> str:
+    return (
+        handler.replace(r"\"", '"')
+        .replace(r"\'", "'")
+        .replace("&quot;", '"')
+        .replace("&#34;", '"')
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+    )
+
+
+def _extract_call_names(handler: str) -> set[str]:
+    names: set[str] = set()
+
+    for match in _WINDOW_CALL_RE.finditer(handler):
+        names.add(match.group("name"))
+
+    for match in _DIRECT_CALL_RE.finditer(handler):
+        name = match.group("name")
+        if name in _JS_CONTROL_WORDS:
+            continue
+        names.add(name)
+
+    return names
+
+
+def _extract_string_dispatch_names(source: str) -> set[str]:
+    names: set[str] = set()
+
+    for match in _WINDOW_LITERAL_DISPATCH_RE.finditer(source):
+        names.add(match.group("name"))
+
+    for match in _LEGACY_STRING_DISPATCH_RE.finditer(source):
+        names.add(match.group("name"))
+
+    if _source_uses_legacy_dispatch(source):
+        for match in _ACTION_PROPERTY_RE.finditer(source):
+            names.add(match.group("name"))
+
+    return names
+
+
+def _source_uses_legacy_dispatch(source: str) -> bool:
+    for helper in ("callLegacy", "legacyClick", "legacyKeyDown"):
+        if helper in source:
+            return True
+    return False
+
+
+def _append_ref(
+    refs: list[tuple[str, str]],
+    seen_refs: set[tuple[str, str]],
+    name: str,
+    file_path: Path,
+) -> None:
+    ref = (name, str(file_path))
+    if ref in seen_refs:
+        return
+    seen_refs.add(ref)
+    refs.append(ref)
+
+
+def _read_text(
+    root: Path,
+    file_path: Path,
+    source_cache: dict[Path, str],
+) -> str | None:
+    resolved = _resolve_readable_project_file(root, file_path)
+    if resolved is None:
+        return None
+    if resolved in source_cache:
+        return source_cache[resolved]
+    source = read_text_no_symlink(
+        resolved,
+        max_bytes=_MAX_REFERENCE_FILE_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if source is None:
+        return None
+    source_cache[resolved] = source
+    return source
+
+
+def _resolve_readable_project_file(root: Path, file_path: Path) -> Path | None:
+    try:
+        if file_path.is_symlink():
+            return None
+        resolved = file_path.resolve(strict=True)
+        resolved.relative_to(root)
+        stat_result = resolved.stat()
+    except (OSError, ValueError):
+        return None
+
+    if not resolved.is_file():
+        return None
+    if stat_result.st_size > _MAX_REFERENCE_FILE_BYTES:
+        return None
+    return resolved
+
+
+def _collect_non_module_script_files(
+    root: Path,
+    template_files: list[Path],
+    source_cache: dict[Path, str],
+) -> set[Path]:
+    script_files: set[Path] = set()
+
+    for template_file in template_files:
+        source = _read_text(root, template_file, source_cache)
+        if source is None:
+            continue
+
+        for match in _SCRIPT_TAG_RE.finditer(source):
+            attrs = match.group("attrs")
+            if _script_attrs_are_module(attrs):
+                continue
+            src = _script_src(attrs)
+            if not src:
+                continue
+            script_file = _resolve_script_src(root, template_file.parent, src)
+            if script_file is not None:
+                script_files.add(script_file)
+
+    return script_files
+
+
+def _script_attrs_are_module(attrs: str) -> bool:
+    match = _TYPE_ATTR_RE.search(attrs)
+    if not match:
+        return False
+    return match.group("value").strip().lower() == "module"
+
+
+def _script_src(attrs: str) -> str | None:
+    match = _SRC_ATTR_RE.search(attrs)
+    if not match:
+        return None
+    return match.group("value").strip()
+
+
+def _resolve_script_src(root: Path, template_dir: Path, src: str) -> Path | None:
+    clean_src = src.split("#", 1)[0].split("?", 1)[0].strip()
+    if not clean_src:
+        return None
+    if clean_src.startswith(("http://", "https://", "//")):
+        return None
+    if ":" in clean_src:
+        return None
+
+    if clean_src.startswith("/"):
+        candidate = root / clean_src.lstrip("/")
+    else:
+        candidate = template_dir / clean_src
+
+    if candidate.suffix.lower() not in _JS_SOURCE_SUFFIXES:
+        return None
+
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
+def _source_defines_top_level_browser_name(source: str, name: str) -> bool:
+    escaped = re.escape(name)
+    patterns = (
+        rf"^(?:export\s+)?(?:async\s+)?function\s+{escaped}\b",
+        rf"^(?:export\s+)?(?:const|let|var)\s+{escaped}\s*=",
+    )
+    for pattern in patterns:
+        if re.search(pattern, source, re.MULTILINE):
+            return True
+    return False
+
+
+def _span_overlaps(span: tuple[int, int], occupied: list[tuple[int, int]]) -> bool:
+    start, end = span
+    for occupied_start, occupied_end in occupied:
+        if start < occupied_end and end > occupied_start:
+            return True
+    return False
+
+
+def _iter_browser_reference_files(
+    root: Path,
+    source_files,
+    exclude_folders,
+):
+    seen: set[Path] = set()
+
+    for raw_file in source_files:
+        file_path = Path(raw_file).resolve()
+        if file_path.suffix.lower() not in _JS_SOURCE_SUFFIXES:
+            continue
+        if file_path in seen:
+            continue
+        seen.add(file_path)
+        yield file_path
+
+    if not root.exists() or not root.is_dir():
+        return
+
+    template_files = discover_source_files(
+        root,
+        _HTML_TEMPLATE_SUFFIXES,
+        exclude_folders=exclude_folders,
+    )
+    for file_path in template_files:
+        if file_path in seen:
+            continue
+        seen.add(file_path)
+        yield file_path

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -36,6 +36,29 @@ _LIFECYCLE_METHODS: set[str] = {
     "ngAfterViewInit",
 }
 
+_BUNDLER_PLUGIN_HOOK_METHODS: set[str] = {
+    "buildEnd",
+    "buildStart",
+    "closeBundle",
+    "closeWatcher",
+    "configurePreviewServer",
+    "configureServer",
+    "generateBundle",
+    "handleHotUpdate",
+    "load",
+    "moduleParsed",
+    "options",
+    "renderChunk",
+    "renderError",
+    "renderStart",
+    "resolveDynamicImport",
+    "resolveFileUrl",
+    "resolveId",
+    "transform",
+    "watchChange",
+    "writeBundle",
+}
+
 _ROUTE_ATTACHMENT_METHODS: set[str] = {
     "all",
     "delete",
@@ -82,6 +105,8 @@ _REFS_PATTERN = """
 (assignment_expression right: (identifier) @ref)
 (spread_element (identifier) @ref)
 (member_expression object: (identifier) @ref)
+(subscript_expression object: (identifier) @ref)
+(subscript_expression index: (identifier) @ref)
 (pair value: (identifier) @ref)
 (unary_expression (identifier) @ref)
 (template_substitution (identifier) @ref)
@@ -310,8 +335,12 @@ class TypeScriptCore:
     def _add_def(self, node, type_name: str) -> None:
         name = self._get_text(node)
 
-        if type_name == "method" and name in _LIFECYCLE_METHODS:
-            return
+        if type_name == "method":
+            if name in _LIFECYCLE_METHODS:
+                return
+            if name in _BUNDLER_PLUGIN_HOOK_METHODS:
+                if self._is_object_literal_method(node):
+                    return
 
         if type_name == "method":
             class_name = self._find_containing_class(node)
@@ -441,6 +470,16 @@ class TypeScriptCore:
                 current = current.parent
                 continue
             return False
+        return False
+
+    def _is_object_literal_method(self, node) -> bool:
+        current = node.parent
+        while current:
+            if current.type == "object":
+                return True
+            if current.type in {"class_body", "class_declaration", "program"}:
+                return False
+            current = current.parent
         return False
 
     def _is_exported(self, node) -> bool:

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -470,6 +470,31 @@ class TestHeuristics:
 
         assert mock_variable.references == 1
 
+    def test_http_handler_override_methods_get_references(self, mock_definition):
+        """SimpleHTTPRequestHandler calls override methods dynamically."""
+        skylos = Skylos()
+        mock_class = mock_definition(
+            name="NoCacheHandler",
+            simple_name="NoCacheHandler",
+            type="class",
+            references=0,
+        )
+        mock_class.base_classes = ["http.server.SimpleHTTPRequestHandler"]
+        mock_method = mock_definition(
+            name="NoCacheHandler.log_message",
+            simple_name="log_message",
+            type="method",
+            references=0,
+        )
+        skylos.defs = {
+            "NoCacheHandler": mock_class,
+            "NoCacheHandler.log_message": mock_method,
+        }
+
+        skylos._apply_heuristics()
+
+        assert mock_method.references == 1
+
     def test_textual_app_runtime_hooks_get_references(self, mock_definition):
         """Textual App subclasses consume metadata and action methods dynamically."""
         skylos = Skylos()

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -394,6 +394,287 @@ class TestTSDeadCodeFalsePositives:
         defs, refs, _, _ = _scan_ts(tmp_path, code)
         assert "helper" not in _unused(defs, refs)
 
+    def test_bracket_lookup_counts_object_reference(self, tmp_path):
+        code = (
+            "const STAT_LABEL = { ready: 'READY' };\n"
+            "function statusLabel(status) {\n"
+            "    return STAT_LABEL[status] || status.toUpperCase();\n"
+            "}\n"
+            "statusLabel('ready');\n"
+        )
+        defs, refs, _, _ = _scan_ts(tmp_path, code)
+        assert "STAT_LABEL" not in _unused(defs, refs)
+
+    def test_bundler_plugin_hook_object_methods_are_framework_live(self, tmp_path):
+        code = (
+            "function copyLegacyAssets() {\n"
+            "    return {\n"
+            "        name: 'copy-legacy-assets',\n"
+            "        closeBundle() {\n"
+            "            return true;\n"
+            "        },\n"
+            "        orphanHook() {\n"
+            "            return false;\n"
+            "        },\n"
+            "    };\n"
+            "}\n"
+            "copyLegacyAssets();\n"
+        )
+        defs, _, _, _ = _scan_ts_file(tmp_path, "vite.config.js", code)
+        names = _def_names(defs)
+        assert "closeBundle" not in names
+        assert "orphanHook" in names
+
+    def test_html_inline_handlers_mark_global_js_functions_live(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        (tmp_path / "index.html").write_text(
+            """
+<button onclick="switchSite('base')">Switch</button>
+<select onchange="set3DDensity(this.value)"></select>
+<button onclick="return confirmNFZ()">Confirm</button>
+<button onclick="window.cancelNFZ()">Cancel</button>
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "app.js").write_text(
+            """
+function switchSite(siteId) {
+    return siteId;
+}
+
+const set3DDensity = (value) => {
+    return value;
+};
+
+function confirmNFZ() {
+    return true;
+}
+
+function cancelNFZ() {
+    return false;
+}
+
+function unusedHelper() {
+    return 1;
+}
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused = {item["name"] for item in result.get("unused_functions", [])}
+
+        assert "switchSite" not in unused
+        assert "set3DDensity" not in unused
+        assert "confirmNFZ" not in unused
+        assert "cancelNFZ" not in unused
+        assert "unusedHelper" in unused
+
+    def test_generated_inline_handlers_mark_js_functions_live(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        (tmp_path / "app.js").write_text(
+            """
+function deployDroneTo(id) {
+    return id;
+}
+
+function toggleDroneFeed(id) {
+    return id;
+}
+
+function renderMenu(id) {
+    menu.innerHTML = `
+        <button onclick="deployDroneTo('${id}')">Deploy</button>
+        <button onclick="toggleDroneFeed('${id}')">Feed</button>
+    `;
+}
+
+renderMenu("drone-1");
+
+function orphanedHandler() {
+    return "unused";
+}
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused = {item["name"] for item in result.get("unused_functions", [])}
+
+        assert "deployDroneTo" not in unused
+        assert "toggleDroneFeed" not in unused
+        assert "orphanedHandler" in unused
+
+    def test_legacy_string_dispatch_marks_global_js_functions_live(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        legacy_dir = tmp_path / "src" / "legacy"
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "actions.js").write_text(
+            """
+export function callLegacy(name, ...args) {
+    const fn = window[name];
+    return fn(...args);
+}
+
+export function legacyClick(name, ...args) {
+    return () => callLegacy(name, ...args);
+}
+""",
+            encoding="utf-8",
+        )
+        components_dir = tmp_path / "src" / "components"
+        components_dir.mkdir()
+        (components_dir / "Header.jsx").write_text(
+            """
+import { callLegacy, legacyClick } from "../legacy/actions";
+
+export function Header() {
+    return (
+        <>
+            <button onClick={legacyClick('toggleFleetPanel')}>Fleet</button>
+            <select onChange={(event) => callLegacy('switchSite', event.target.value)} />
+        </>
+    );
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "app.js").write_text(
+            """
+function switchSite(siteId) {
+    return siteId;
+}
+
+function toggleFleetPanel() {
+    return true;
+}
+
+function unusedLegacyAction() {
+    return false;
+}
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused = {item["name"] for item in result.get("unused_functions", [])}
+
+        assert "switchSite" not in unused
+        assert "toggleFleetPanel" not in unused
+        assert "unusedLegacyAction" in unused
+
+    def test_legacy_action_config_marks_global_js_functions_live(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        (tmp_path / "index.html").write_text(
+            '<script src="/app.js"></script>',
+            encoding="utf-8",
+        )
+        legacy_dir = tmp_path / "src" / "legacy"
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "actions.js").write_text(
+            """
+export function legacyClick(name) {
+    return () => window[name]();
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "src" / "Toolbar.jsx").write_text(
+            """
+import { legacyClick } from "./legacy/actions";
+
+const config = {
+    confirmAction: 'confirmNFZ',
+    cancelAction: 'cancelNFZ',
+};
+
+export function Toolbar() {
+    return (
+        <>
+            <button onClick={legacyClick(config.confirmAction)}>Confirm</button>
+            <button onClick={legacyClick(config.cancelAction)}>Cancel</button>
+        </>
+    );
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "app.js").write_text(
+            """
+function confirmNFZ() {
+    return true;
+}
+
+function cancelNFZ() {
+    return false;
+}
+
+function unusedToolbarAction() {
+    return false;
+}
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused = {item["name"] for item in result.get("unused_functions", [])}
+
+        assert "confirmNFZ" not in unused
+        assert "cancelNFZ" not in unused
+        assert "unusedToolbarAction" in unused
+
+    def test_legacy_dispatch_prefers_top_level_loaded_script_function(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        (tmp_path / "index.html").write_text(
+            """
+<script src="/app.js"></script>
+<script src="/map2d.js"></script>
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "src" / "Header.jsx").parent.mkdir()
+        (tmp_path / "src" / "Header.jsx").write_text(
+            """
+import { legacyClick } from "./legacy/actions";
+
+export function Header() {
+    return <button onClick={legacyClick('toggleSatellite')}>Satellite</button>;
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "app.js").write_text(
+            """
+function toggleSatellite() {
+    return true;
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "map2d.js").write_text(
+            """
+(function () {
+    function toggleSatellite() {
+        return false;
+    }
+})();
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused = {
+            (item["name"], Path(item["file"]).name)
+            for item in result.get("unused_functions", [])
+        }
+
+        assert ("toggleSatellite", "app.js") not in unused
+
     def test_stored_in_array(self, tmp_path):
         code = (
             "function a() { return 1; }\n"


### PR DESCRIPTION
## Summary

  - Fix dead code FPs for browser JS handlers.
  - Track liveness from inline HTML handlers, generated innerHTML handlers, and React legacy dispatch helpers like legacyClick(...) / callLegacy(...).
  - Add framework liveness for Vite object hook methods and http.server handler overrides.
  - Count JS/TS bracket lookups like STAT_LABEL[key] as references.

  ## Tests

  - `pytest .`