### PR TITLE
fix(security): reduce browser scanner noise

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -20,7 +20,11 @@ from skylos.analysis.circular_deps import (
     _resolve_from_import_targets,
 )
 
-from skylos.constants import AUTO_CALLED, MARKREFS_TICK_DEFAULT
+from skylos.constants import (
+    AUTO_CALLED,
+    DEFAULT_EXCLUDE_FOLDERS,
+    MARKREFS_TICK_DEFAULT,
+)
 
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.visitors.test_aware import TestAwareVisitor
@@ -3038,7 +3042,13 @@ class Skylos:
                                 _add_injection_candidate(candidate)
                         if injection_root.is_dir():
                             pending_dirs = [injection_root]
-                            excluded_dirs = set(exclude_folders or [])
+                            excluded_dirs = {
+                                folder
+                                for folder in DEFAULT_EXCLUDE_FOLDERS
+                                if "*" not in folder
+                            }
+                            excluded_dirs.add("site-packages")
+                            excluded_dirs.update(exclude_folders or [])
                             while (
                                 pending_dirs
                                 and len(injection_candidates)

--- a/skylos/security/injection_scanner.py
+++ b/skylos/security/injection_scanner.py
@@ -107,6 +107,18 @@ _PROMPT_KEYS_RE = re.compile(
 )
 
 
+def _is_allowed_json_bom(
+    source: str, ext: str, char_hex: str, line_no: int, is_agent_instruction: bool
+) -> bool:
+    return (
+        not is_agent_instruction
+        and ext == ".json"
+        and char_hex == "U+FEFF"
+        and line_no == 1
+        and source.startswith("\ufeff")
+    )
+
+
 def scan_file(
     filepath: str | Path, *, scan_path: str | Path | None = None
 ) -> list[dict]:
@@ -146,6 +158,10 @@ def scan_file(
 
     _, zero_width_hits = strip_zero_width(source, max_hits=MAX_ZERO_WIDTH_HITS)
     for char_hex, line_no in zero_width_hits:
+        if _is_allowed_json_bom(
+            source, ext, char_hex, line_no, is_agent_instruction
+        ):
+            continue
         findings.append(
             _make_finding(
                 filepath,

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -201,6 +201,85 @@ _ERROR_DISCLOSURE_PROPS = {"stack", "sql", "sqlMessage", "sqlState"}
 
 _RESPONSE_METHODS = {"json", "send", "write", "end"}
 
+_HTML_EXECUTABLE_RE = re.compile(
+    r"<\s*(?:script|iframe|object|embed)\b|"
+    r"\bon[a-z0-9_-]+\s*=|"
+    r"javascript\s*:",
+    re.IGNORECASE,
+)
+
+_SAFE_HTML_SANITIZER_CALLEES = {
+    "DOMPurify.sanitize",
+    "sanitizeHtml",
+    "sanitizeHTML",
+}
+
+_RANDOM_SECURITY_TERMS = (
+    "token",
+    "nonce",
+    "csrf",
+    "xsrf",
+    "session",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "apikey",
+    "privatekey",
+    "jwt",
+    "bearer",
+    "cookie",
+    "signature",
+    "hmac",
+    "salt",
+    "otpcode",
+    "otptoken",
+    "otpsecret",
+    "totp",
+    "hotp",
+    "mfacode",
+    "mfatoken",
+    "authorization",
+    "oauth",
+    "resetcode",
+    "resetlink",
+    "invitecode",
+    "magiclink",
+    "verificationcode",
+)
+
+_SERVER_PATH_HINTS = (
+    "/api/",
+    "/app/",
+    "/pages/api/",
+    "/server/",
+    "/backend/",
+    "/routes/",
+    "/controllers/",
+    "/handlers/",
+    "/lambda/",
+    "/functions/",
+)
+
+_BROWSER_PATH_HINTS = (
+    "/public/",
+    "/static/",
+    "/assets/",
+    "/client/",
+    "/browser/",
+    "/frontend/",
+    "/js/",
+)
+
+_BROWSER_GLOBAL_RE = re.compile(
+    r"\b(?:document|window|navigator|localStorage|sessionStorage)\b"
+)
+
+_SERVER_GLOBAL_RE = re.compile(
+    r"\b(?:process\.env|require\s*\(|module\.exports|exports\.|"
+    r"createServer|express\s*\(|fastify\s*\(|app\.(?:get|post|put|patch|delete))\b"
+)
+
 _WEBHOOK_PROVIDER_HINTS = (
     "stripe",
     "github",
@@ -331,6 +410,154 @@ def _first_static_call_arg(call_node, source_bytes: bytes) -> str | None:
     if args is None:
         return None
     return _static_string_value(_first_real_arg(args), source_bytes)
+
+
+def _callee_name(call_node, source_bytes: bytes) -> str | None:
+    if call_node is None or call_node.type != "call_expression":
+        return None
+
+    function_node = call_node.child_by_field_name("function")
+    if function_node is None:
+        return None
+    if function_node.type == "identifier":
+        return _get_text(source_bytes, function_node)
+    if function_node.type != "member_expression":
+        return None
+
+    object_node = function_node.child_by_field_name("object")
+    property_node = function_node.child_by_field_name("property")
+    if object_node is None or property_node is None:
+        return None
+
+    object_name = _get_text(source_bytes, object_node)
+    property_name = _get_text(source_bytes, property_node)
+    return f"{object_name}.{property_name}"
+
+
+def _is_safe_html_sanitizer_call(node, source_bytes: bytes) -> bool:
+    unwrapped = _unwrap_ts_expression(node)
+    if unwrapped.type != "call_expression":
+        return False
+
+    callee = _callee_name(unwrapped, source_bytes)
+    return callee in _SAFE_HTML_SANITIZER_CALLEES
+
+
+def _html_literal_can_execute(value: str) -> bool:
+    return bool(_HTML_EXECUTABLE_RE.search(value))
+
+
+def _html_assignment_rhs_requires_finding(rhs_node, source_bytes: bytes) -> bool:
+    if rhs_node is None:
+        return True
+
+    unwrapped = _unwrap_ts_expression(rhs_node)
+    literal_value = _static_string_value(unwrapped, source_bytes)
+    if literal_value is not None:
+        return _html_literal_can_execute(literal_value)
+
+    if _is_safe_html_sanitizer_call(unwrapped, source_bytes):
+        return False
+
+    return True
+
+
+def _assignment_rhs_for_property_capture(prop_node):
+    member_node = prop_node.parent
+    current = member_node.parent if member_node is not None else None
+    while current is not None:
+        if current.type == "assignment_expression":
+            return current.child_by_field_name("right")
+        if current.type in {
+            "expression_statement",
+            "call_expression",
+            "statement_block",
+            "program",
+        }:
+            return None
+        current = current.parent
+    return None
+
+
+def _html_property_capture_requires_finding(prop_node, source_bytes: bytes) -> bool:
+    rhs_node = _assignment_rhs_for_property_capture(prop_node)
+    return _html_assignment_rhs_requires_finding(rhs_node, source_bytes)
+
+
+def _document_write_requires_finding(prop_node, source_bytes: bytes) -> bool:
+    member_node = prop_node.parent
+    call_node = member_node.parent if member_node is not None else None
+    if call_node is None or call_node.type != "call_expression":
+        return True
+
+    args_node = call_node.child_by_field_name("arguments")
+    first_arg = _first_real_arg(args_node) if args_node is not None else None
+    return _html_assignment_rhs_requires_finding(first_arg, source_bytes)
+
+
+def _nearest_statement_text(node, source_bytes: bytes) -> str:
+    current = node
+    while current is not None:
+        if current.type in {
+            "expression_statement",
+            "lexical_declaration",
+            "variable_declaration",
+            "return_statement",
+            "assignment_expression",
+        }:
+            return _get_text(source_bytes, current)
+        current = current.parent
+    return _get_text(source_bytes, node)
+
+
+def _text_has_random_security_context(text: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", text.lower())
+    return any(term in normalized for term in _RANDOM_SECURITY_TERMS)
+
+
+def _node_name_text(node, source_bytes: bytes) -> str | None:
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        return _get_text(source_bytes, name_node)
+    return None
+
+
+def _math_random_requires_finding(prop_node, source_bytes: bytes) -> bool:
+    statement_text = _nearest_statement_text(prop_node, source_bytes)
+    if _text_has_random_security_context(statement_text):
+        return True
+
+    current = prop_node.parent
+    while current is not None:
+        if current.type in {
+            "function_declaration",
+            "function_expression",
+            "method_definition",
+            "variable_declarator",
+        }:
+            name = _node_name_text(current, source_bytes)
+            if name and _text_has_random_security_context(name):
+                return True
+        current = current.parent
+
+    return False
+
+
+def _collect_static_string_bindings(root_node, source_bytes: bytes) -> dict[str, str]:
+    bindings: dict[str, str] = {}
+    stack = [root_node]
+    while stack:
+        node = stack.pop()
+        if node.type == "variable_declarator":
+            name_node = node.child_by_field_name("name")
+            value_node = node.child_by_field_name("value")
+            if name_node is not None and value_node is not None:
+                if name_node.type == "identifier":
+                    value = _static_string_value(value_node, source_bytes)
+                    if value is not None:
+                        bindings[_get_text(source_bytes, name_node)] = value
+        stack.extend(reversed(node.children))
+    return bindings
 
 
 def _child_process_aliases(root_node, lang: Language, source_bytes: bytes) -> set[str]:
@@ -471,9 +698,38 @@ def _prefix_has_fixed_http_host(prefix: str) -> bool:
     return bool(match and match.group(1))
 
 
-def _url_arg_is_ssrf_relevant(node, source_bytes: bytes) -> bool:
+def _has_server_path_hint(file_path: str) -> bool:
+    normalized = str(file_path).replace(os.sep, "/").lower()
+    return any(hint in normalized for hint in _SERVER_PATH_HINTS)
+
+
+def _is_likely_browser_asset(file_path: str, source_bytes: bytes) -> bool:
+    if _has_server_path_hint(file_path):
+        return False
+
+    normalized = str(file_path).replace(os.sep, "/").lower()
+    if any(hint in normalized for hint in _BROWSER_PATH_HINTS):
+        return True
+
+    source_text = source_bytes.decode("utf-8", errors="replace")
+    if _SERVER_GLOBAL_RE.search(source_text):
+        return False
+
+    return bool(_BROWSER_GLOBAL_RE.search(source_text))
+
+
+def _url_arg_is_ssrf_relevant(
+    node,
+    source_bytes: bytes,
+    file_path: str | None = None,
+    static_string_bindings: dict[str, str] | None = None,
+) -> bool:
     if node.type == "string":
         return False
+    if node.type == "identifier" and static_string_bindings is not None:
+        name = _get_text(source_bytes, node)
+        if name in static_string_bindings:
+            return False
     if node.type == "template_string" and not _has_dynamic_url_part(node):
         return False
 
@@ -487,6 +743,9 @@ def _url_arg_is_ssrf_relevant(node, source_bytes: bytes) -> bool:
             return False
         if lower_prefix.startswith(("http://", "https://", "//")):
             return True
+        return False
+
+    if file_path and _is_likely_browser_asset(file_path, source_bytes):
         return False
 
     return True
@@ -526,12 +785,25 @@ def scan_danger(
     jsx_captures = _run_batch(root_node, lang, "danger_jsx", _JSX_PATTERN)
     complex_captures = _run_batch(root_node, lang, "danger_complex", _COMPLEX_PATTERN)
     child_process_aliases = _child_process_aliases(root_node, lang, source_bytes)
+    static_string_bindings = _collect_static_string_bindings(root_node, source_bytes)
 
     for k, v in jsx_captures.items():
         simple_captures.setdefault(k, []).extend(v)
 
     for cap_name, (rule_id, severity, message) in _SIMPLE_MAP.items():
         for node in simple_captures.get(cap_name, []):
+            if cap_name in {"innerHTML", "outerHTML"} and not (
+                _html_property_capture_requires_finding(node, source_bytes)
+            ):
+                continue
+            if cap_name == "doc_write" and not _document_write_requires_finding(
+                node, source_bytes
+            ):
+                continue
+            if cap_name == "math_random" and not _math_random_requires_finding(
+                node, source_bytes
+            ):
+                continue
             findings.append(
                 {
                     "rule_id": rule_id,
@@ -638,7 +910,9 @@ def scan_danger(
     # --- fetch SSRF (SKY-D216) ---
     for node in complex_captures.get("fetch_args", []):
         first_arg = _first_real_arg(node)
-        if first_arg and _url_arg_is_ssrf_relevant(first_arg, source_bytes):
+        if first_arg and _url_arg_is_ssrf_relevant(
+            first_arg, source_bytes, str(file_path), static_string_bindings
+        ):
             findings.append(
                 {
                     "rule_id": "SKY-D216",
@@ -653,7 +927,9 @@ def scan_danger(
     # --- axios SSRF (SKY-D216) ---
     for node in complex_captures.get("axios_args", []):
         first_arg = _first_real_arg(node)
-        if first_arg and _url_arg_is_ssrf_relevant(first_arg, source_bytes):
+        if first_arg and _url_arg_is_ssrf_relevant(
+            first_arg, source_bytes, str(file_path), static_string_bindings
+        ):
             findings.append(
                 {
                     "rule_id": "SKY-D216",

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3216,6 +3216,28 @@ def create_invoice(order):
         assert any(f.get("file") == str(app) for f in injection_findings)
         assert any(f.get("file") == str(prompt_doc) for f in injection_findings)
 
+    def test_prompt_injection_scan_skips_default_excluded_dirs(self, tmp_path):
+        app = tmp_path / "app.py"
+        app.write_text("print('ok')\n", encoding="utf-8")
+        venv_file = tmp_path / "venv" / "lib" / "python3.14" / "site-packages"
+        venv_file.mkdir(parents=True)
+        dependency_file = venv_file / "dependency.py"
+        dependency_file.write_text("# ignore previous instructions\n", encoding="utf-8")
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                enable_danger=True,
+                grep_verify=False,
+            )
+        )
+        injection_findings = [
+            f for f in result.get("danger", []) if f.get("rule_id") == "SKY-D260"
+        ]
+
+        assert all(f.get("file") != str(dependency_file) for f in injection_findings)
+
     def test_prompt_injection_scan_prioritizes_docs_inside_file_cap(
         self, tmp_path, monkeypatch
     ):

--- a/test/test_injection_scanner.py
+++ b/test/test_injection_scanner.py
@@ -324,6 +324,15 @@ class TestScanMarkdown:
         assert d266[0]["severity"] == "CRITICAL"
         assert "SKY-D260" not in {f["rule_id"] for f in findings}
 
+    def test_agent_instruction_bom_still_uses_d266(self, tmp_path):
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("\ufeff# Instructions\n", encoding="utf-8")
+
+        findings = scan_file(agents)
+        hidden = [f for f in findings if f["type"] == "hidden_char"]
+        assert hidden
+        assert hidden[0]["rule_id"] == "SKY-D266"
+
     def test_injection_in_matched_fenced_block_is_ignored(self):
         path = _write_temp(
             "# README\n\n```\nignore previous instructions\n```\n",
@@ -375,6 +384,16 @@ class TestScanYAML:
             assert len(d260) == 0
         finally:
             os.unlink(path)
+
+
+class TestScanJSON:
+    def test_leading_json_bom_is_not_hidden_prompt_injection(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text('\ufeff{"name": "demo"}\n', encoding="utf-8")
+
+        findings = scan_file(path)
+        hidden = [f for f in findings if f["type"] == "hidden_char"]
+        assert hidden == []
 
 
 class TestScanEnv:

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -47,10 +47,28 @@ class TestTSDangerRules:
         assert "SKY-D201" in ids
 
     def test_innerhtml_detected(self, tmp_path):
-        code = 'document.getElementById("x")!.innerHTML = "<b>xss</b>";'
+        code = "const msg = req.query.msg;\ndocument.getElementById('x')!.innerHTML = msg;"
         _, _, _, danger = _scan_ts(tmp_path, code)
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D226" in ids
+
+    def test_static_innerhtml_is_not_flagged(self, tmp_path):
+        code = 'document.getElementById("x")!.innerHTML = "<b>status</b>";'
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D226" not in ids
+
+    def test_innerhtml_static_executable_markup_is_flagged(self, tmp_path):
+        code = 'document.getElementById("x")!.innerHTML = "<img src=x onerror=alert(1)>";'
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D226" in ids
+
+    def test_innerhtml_sanitizer_is_not_flagged(self, tmp_path):
+        code = "el.innerHTML = DOMPurify.sanitize(userHtml);"
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D226" not in ids
 
     def test_new_function_detected(self, tmp_path):
         code = 'const f = new Function("return 1");'
@@ -71,7 +89,7 @@ class TestTSDangerRules:
         assert "SKY-D202" in ids
 
     def test_outerhtml_detected(self, tmp_path):
-        code = 'document.getElementById("x")!.outerHTML = "<div>replaced</div>";'
+        code = "document.getElementById('x')!.outerHTML = renderUserHtml(user);"
         _, _, _, danger = _scan_ts(tmp_path, code)
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D226" in ids
@@ -163,6 +181,17 @@ class TestTSDangerRules:
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D216" not in ids
 
+    def test_fetch_static_url_identifier_is_safe(self, tmp_path):
+        code = (
+            "const SITE_REGISTRY_URL = '/data/sites.json';\n"
+            "export function fetchSites() {\n"
+            "  return fetch(SITE_REGISTRY_URL);\n"
+            "}\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D216" not in ids
+
     def test_fetch_split_fixed_host_variable_path_is_safe(self, tmp_path):
         code = (
             "export function fetchAvatar(userId: string) {\n"
@@ -223,6 +252,16 @@ class TestTSDangerRules:
         _, _, _, danger = _scan_ts(tmp_path, code)
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D216" in ids
+
+    def test_browser_asset_fetch_variable_url_is_not_ssrf(self, tmp_path):
+        code = (
+            "const site = getSelectedSite();\n"
+            "document.addEventListener('DOMContentLoaded', () => {});\n"
+            "fetch(site.config);\n"
+        )
+        _, _, _, danger = _scan_ts_file(tmp_path, "public/app.js", code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D216" not in ids
 
 
 class TestTSQualityRules:
@@ -1685,17 +1724,52 @@ class TestNewQualityRules:
 class TestInsecureRandomness:
     """SKY-D250: Math.random() is not cryptographically secure."""
 
-    def test_math_random_flagged(self, tmp_path):
-        code = "const id = Math.random().toString(36);\n"
+    def test_math_random_security_token_flagged(self, tmp_path):
+        code = "const sessionToken = Math.random().toString(36);\n"
         _, _, _, danger = _scan_ts(tmp_path, code)
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D250" in ids
 
-    def test_math_random_in_expression(self, tmp_path):
-        code = "const roll = Math.floor(Math.random() * 6) + 1;\n"
+    def test_math_random_cookie_value_flagged(self, tmp_path):
+        code = "document.cookie = 'sid=' + Math.random().toString(36);\n"
         _, _, _, danger = _scan_ts(tmp_path, code)
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D250" in ids
+
+    def test_math_random_otp_code_flagged(self, tmp_path):
+        code = "const otpCode = Math.floor(Math.random() * 1000000);\n"
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D250" in ids
+
+    def test_math_random_inside_token_generator_flagged(self, tmp_path):
+        code = (
+            "function generateSessionToken() {\n"
+            "  return Math.random().toString(36);\n"
+            "}\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D250" in ids
+
+    def test_math_random_in_non_security_expression_is_safe(self, tmp_path):
+        code = "const roll = Math.floor(Math.random() * 6) + 1;\n"
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D250" not in ids
+
+    def test_math_random_visual_coordinate_expression_is_safe(self, tmp_path):
+        code = (
+            "ctx.fillRect(\n"
+            "  x0 + Math.random() * wPix,\n"
+            "  py(zTop) + Math.random() * (py(zBot) - py(zTop)),\n"
+            "  2,\n"
+            "  2,\n"
+            ");\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D250" not in ids
 
     def test_crypto_random_safe(self, tmp_path):
         """crypto.getRandomValues() should NOT trigger SKY-D250."""


### PR DESCRIPTION
## Summary

  - Tighten TS/JS security scanning to reduce browser app noise
  - Keep dynamic `innerHTML`/`outerHTML` findings, but skip harmless static markup and known sanitizer calls.
  - Make `Math.random()` findings security context aware
  - Avoid noise from leading JSON BOMs and already excluded dependency folders.

  ## Tests

  - `pytest test/test_typescript_expanded.py`
  - `pytest test/test_injection_scanner.py`