### PR TITLE
fix(dead-code): recognize stdlib callback hooks

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -4,6 +4,7 @@ import sys
 import json
 import logging
 import os
+import re
 import traceback
 from pathlib import Path
 from collections import Counter, defaultdict
@@ -186,6 +187,48 @@ _PYTHON_SOURCE_ROOT_NAMES = {"src", "lib", "python"}
 
 _TRY_NODE_TYPES = (ast.Try, getattr(ast, "TryStar", ast.Try))
 
+_HTML_PARSER_CALLBACKS = {
+    "handle_starttag",
+    "handle_startendtag",
+    "handle_endtag",
+    "handle_data",
+    "handle_entityref",
+    "handle_charref",
+    "handle_comment",
+    "handle_decl",
+    "handle_pi",
+    "unknown_decl",
+}
+
+_URLLIB_REQUEST_HANDLER_BASES = {
+    "BaseHandler",
+    "HTTPDefaultErrorHandler",
+    "HTTPRedirectHandler",
+    "HTTPCookieProcessor",
+    "ProxyHandler",
+    "HTTPPasswordMgr",
+    "HTTPPasswordMgrWithDefaultRealm",
+    "AbstractBasicAuthHandler",
+    "HTTPBasicAuthHandler",
+    "ProxyBasicAuthHandler",
+    "AbstractDigestAuthHandler",
+    "HTTPDigestAuthHandler",
+    "ProxyDigestAuthHandler",
+    "HTTPHandler",
+    "HTTPSHandler",
+    "FileHandler",
+    "FTPHandler",
+    "CacheFTPHandler",
+    "UnknownHandler",
+    "HTTPErrorProcessor",
+    "DataHandler",
+}
+
+_URLLIB_REQUEST_PROTOCOL_HOOK_RE = re.compile(
+    r"^(?:[a-z][a-z0-9+.-]*_(?:open|request|response)|"
+    r"http_error(?:_[0-9]{3})?|default_open|unknown_open|redirect_request)$"
+)
+
 
 def _entrypoint_module_name(qname: str) -> str | None:
     if not isinstance(qname, str) or "." not in qname:
@@ -201,6 +244,17 @@ def _architecture_iad_strict(architecture_cfg) -> bool:
         if key in architecture_cfg:
             return bool(architecture_cfg.get(key))
     return False
+
+
+def _base_class_leaf_names(class_def) -> set[str]:
+    leaves: set[str] = set()
+    for base in getattr(class_def, "base_classes", []):
+        leaves.add(str(base).split(".")[-1])
+    return leaves
+
+
+def _class_has_base_leaf(class_def, leaf_names: set[str]) -> bool:
+    return bool(_base_class_leaf_names(class_def) & leaf_names)
 
 
 def _expand_reexported_entrypoint_modules(
@@ -1573,6 +1627,42 @@ class Skylos:
                 }:
                     definition.references += 1
                     break
+
+        for definition in self.defs.values():
+            if definition.type != "method":
+                continue
+
+            if definition.simple_name not in _HTML_PARSER_CALLBACKS:
+                continue
+
+            if "." not in definition.name:
+                continue
+
+            cls = definition.name.rsplit(".", 1)[0]
+            class_def = self.defs.get(cls)
+            if class_def is None or class_def.type != "class":
+                continue
+
+            if _class_has_base_leaf(class_def, {"HTMLParser"}):
+                definition.references += 1
+
+        for definition in self.defs.values():
+            if definition.type != "method":
+                continue
+
+            if not _URLLIB_REQUEST_PROTOCOL_HOOK_RE.match(definition.simple_name):
+                continue
+
+            if "." not in definition.name:
+                continue
+
+            cls = definition.name.rsplit(".", 1)[0]
+            class_def = self.defs.get(cls)
+            if class_def is None or class_def.type != "class":
+                continue
+
+            if _class_has_base_leaf(class_def, _URLLIB_REQUEST_HANDLER_BASES):
+                definition.references += 1
 
         textual_app_metadata = {"BINDINGS", "CSS", "TITLE", "SUB_TITLE"}
         for definition in self.defs.values():

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -1578,6 +1578,12 @@ class Visitor(ast.NodeVisitor):
             ):
                 self.type_alias_names.add(node.args[0].value)
 
+        if callee in {"typing.cast", "typing_extensions.cast"} and node.args:
+            first_arg = node.args[0]
+            annotation_str = self._annotation_string_value(first_arg)
+            if annotation_str is not None:
+                self.visit_string_annotation(annotation_str)
+
         if (
             isinstance(node.func, ast.Name)
             and node.func.id in ("getattr", "hasattr", "setattr", "delattr")

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -495,6 +495,80 @@ class TestHeuristics:
 
         assert mock_method.references == 1
 
+    def test_html_parser_callbacks_get_references(self, mock_definition):
+        """HTMLParser.feed() dispatches handle_* callbacks dynamically."""
+        skylos = Skylos()
+        mock_class = mock_definition(
+            name="HtmlRouteExtractor",
+            simple_name="HtmlRouteExtractor",
+            type="class",
+            references=1,
+        )
+        mock_class.base_classes = ["html.parser.HTMLParser"]
+        mock_start = mock_definition(
+            name="HtmlRouteExtractor.handle_starttag",
+            simple_name="handle_starttag",
+            type="method",
+            references=0,
+        )
+        mock_data = mock_definition(
+            name="HtmlRouteExtractor.handle_data",
+            simple_name="handle_data",
+            type="method",
+            references=0,
+        )
+        mock_helper = mock_definition(
+            name="HtmlRouteExtractor.helper",
+            simple_name="helper",
+            type="method",
+            references=0,
+        )
+        skylos.defs = {
+            "HtmlRouteExtractor": mock_class,
+            "HtmlRouteExtractor.handle_starttag": mock_start,
+            "HtmlRouteExtractor.handle_data": mock_data,
+            "HtmlRouteExtractor.helper": mock_helper,
+        }
+
+        skylos._apply_heuristics()
+
+        assert mock_start.references == 1
+        assert mock_data.references == 1
+        assert mock_helper.references == 0
+
+    def test_urllib_request_handler_hooks_get_references(self, mock_definition):
+        """urllib opener dispatches protocol hook methods by naming convention."""
+        skylos = Skylos()
+        mock_class = mock_definition(
+            name="_PinnedHTTPHandler",
+            simple_name="_PinnedHTTPHandler",
+            type="class",
+            references=1,
+        )
+        mock_class.base_classes = ["urllib.request.HTTPHandler"]
+        mock_open = mock_definition(
+            name="_PinnedHTTPHandler.http_open",
+            simple_name="http_open",
+            type="method",
+            references=0,
+        )
+        mock_helper = mock_definition(
+            name="_PinnedHTTPHandler.connection_factory",
+            simple_name="connection_factory",
+            type="method",
+            references=0,
+        )
+        skylos.defs = {
+            "_PinnedHTTPHandler": mock_class,
+            "_PinnedHTTPHandler.http_open": mock_open,
+            "_PinnedHTTPHandler.connection_factory": mock_helper,
+        }
+
+        skylos._apply_heuristics()
+
+        assert mock_open.references == 1
+        assert mock_helper.references == 0
+
     def test_textual_app_runtime_hooks_get_references(self, mock_definition):
         """Textual App subclasses consume metadata and action methods dynamically."""
         skylos = Skylos()
@@ -566,6 +640,22 @@ class TestAnalyze:
 
         assert ("api.py", "action") not in unused
         assert ("payload.py", "action") not in unused
+
+    def test_cast_string_type_reference_keeps_import_live(self, tmp_path):
+        (tmp_path / "app.py").write_text(
+            "from typing import cast\n"
+            "from models import AgentActionName\n\n"
+            "def normalize(action):\n"
+            "    return cast(\"AgentActionName\", action)\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused_imports = {
+            item["simple_name"] for item in result.get("unused_imports", [])
+        }
+
+        assert "AgentActionName" not in unused_imports
 
     def test_mcp_decorated_tools_and_resources_are_live(self, tmp_path):
         (tmp_path / "server.py").write_text(


### PR DESCRIPTION
## Summary

  - Treat `HTMLParser` subclass callback methods as live when they match stdlib dispatch names. Eg. `handle_starttag`, `handle_endtag`, and `handle_data`.
  - Treat `urllib.request` handler protocol hooks as live for handler subclasses, including methods like `http_open` and `https_open`.
  - Count string type references in `typing.cast("TypeName", value)` /`typing_extensions.cast(...)` as real type references
  
  ## Tests

  - `pytest test/test_analyzer.py`