### PR TITLE
fix(dead-code): resolve Go receiver method refs

### DIFF
--- a/skylos/engines/go/internal/symbols/symbols.go
+++ b/skylos/engines/go/internal/symbols/symbols.go
@@ -365,7 +365,47 @@ func Extract(root string) (*Result, error) {
 		return nil
 	})
 
+	defNames := symbolDefNames(result.Defs)
+	typedRefs, typedCalls := collectTypedSelectorRefs(root, resolvedRoot, modulePath, pkgDirs, defNames)
+	appendUniqueTypedSymbols(result, typedRefs, typedCalls)
+
 	return result, err
+}
+
+func symbolDefNames(defs []Def) map[string]bool {
+	names := map[string]bool{}
+	for _, def := range defs {
+		names[def.Name] = true
+	}
+	return names
+}
+
+func appendUniqueTypedSymbols(result *Result, refs []Ref, calls []CallPair) {
+	seenRefs := map[string]bool{}
+	for _, ref := range result.Refs {
+		seenRefs[ref.File+"\x00"+ref.Name] = true
+	}
+	for _, ref := range refs {
+		key := ref.File + "\x00" + ref.Name
+		if seenRefs[key] {
+			continue
+		}
+		seenRefs[key] = true
+		result.Refs = append(result.Refs, ref)
+	}
+
+	seenCalls := map[string]bool{}
+	for _, call := range result.CallPairs {
+		seenCalls[call.Caller+"\x00"+call.Callee] = true
+	}
+	for _, call := range calls {
+		key := call.Caller + "\x00" + call.Callee
+		if seenCalls[key] {
+			continue
+		}
+		seenCalls[key] = true
+		result.CallPairs = append(result.CallPairs, call)
+	}
 }
 
 func isPathWithinRoot(root, path string) bool {
@@ -439,6 +479,10 @@ func typeExprName(expr ast.Expr) string {
 		if ident, ok := e.X.(*ast.Ident); ok {
 			return ident.Name + "." + e.Sel.Name
 		}
+	case *ast.IndexExpr:
+		return typeExprName(e.X)
+	case *ast.IndexListExpr:
+		return typeExprName(e.X)
 	}
 	return ""
 }

--- a/skylos/engines/go/internal/symbols/symbols.go
+++ b/skylos/engines/go/internal/symbols/symbols.go
@@ -365,11 +365,22 @@ func Extract(root string) (*Result, error) {
 		return nil
 	})
 
-	defNames := symbolDefNames(result.Defs)
-	typedRefs, typedCalls := collectTypedSelectorRefs(root, resolvedRoot, modulePath, pkgDirs, defNames)
-	appendUniqueTypedSymbols(result, typedRefs, typedCalls)
+	if hasMethodDefs(result.Defs) {
+		defNames := symbolDefNames(result.Defs)
+		typedRefs, typedCalls := collectTypedSelectorRefs(root, resolvedRoot, modulePath, pkgDirs, defNames)
+		appendUniqueTypedSymbols(result, typedRefs, typedCalls)
+	}
 
 	return result, err
+}
+
+func hasMethodDefs(defs []Def) bool {
+	for _, def := range defs {
+		if def.Type == "method" {
+			return true
+		}
+	}
+	return false
 }
 
 func symbolDefNames(defs []Def) map[string]bool {

--- a/skylos/engines/go/internal/symbols/symbols_receiver_test.go
+++ b/skylos/engines/go/internal/symbols/symbols_receiver_test.go
@@ -140,6 +140,21 @@ func serve(r runner) {
 	expectNoCall(t, result, "serve", "runner.run")
 }
 
+func TestHasMethodDefsOnlyMatchesMethods(t *testing.T) {
+	defs := []Def{
+		{Name: "main", Type: "function"},
+		{Name: "unused", Type: "function"},
+	}
+	if hasMethodDefs(defs) {
+		t.Fatal("function-only package should not require typed selector resolution")
+	}
+
+	defs = append(defs, Def{Name: "worker.run", Type: "method"})
+	if !hasMethodDefs(defs) {
+		t.Fatal("method package should use typed selector resolution")
+	}
+}
+
 func TestExtractRespectsImportedSelectorWhenLocalNameIsNotTyped(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")

--- a/skylos/engines/go/internal/symbols/symbols_receiver_test.go
+++ b/skylos/engines/go/internal/symbols/symbols_receiver_test.go
@@ -1,0 +1,223 @@
+package symbols
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractResolvesReceiverMethodRefsFromTypedSelectors(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+	writeTestFile(t, root, "demo.go", `package demo
+
+type Context struct {
+	writermem responseWriter
+}
+
+type Pool struct{}
+type responseWriter struct{}
+
+func (*Pool) Get() any { return &Context{} }
+func (c *Context) reset() {}
+func (w *responseWriter) reset(_ any) {}
+
+func serve(pool *Pool, writer any) {
+	c := pool.Get().(*Context)
+	c.reset()
+	c.writermem.reset(writer)
+}
+`)
+
+	result, err := Extract(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRef(t, result, "Context.reset")
+	expectRef(t, result, "responseWriter.reset")
+	expectCall(t, result, "serve", "Context.reset")
+	expectCall(t, result, "serve", "responseWriter.reset")
+}
+
+func TestExtractResolvesPromotedEmbeddedMethodRef(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+	writeTestFile(t, root, "demo.go", `package demo
+
+type inner struct{}
+type outer struct {
+	inner
+}
+
+func (i inner) run() {}
+
+func serve(o outer) {
+	o.run()
+}
+`)
+
+	result, err := Extract(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRef(t, result, "inner.run")
+	expectCall(t, result, "serve", "inner.run")
+}
+
+func TestExtractResolvesMethodExpressionRef(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+	writeTestFile(t, root, "demo.go", `package demo
+
+type Context struct{}
+
+func (c *Context) reset() {}
+
+func serve() {
+	reset := (*Context).reset
+	reset(&Context{})
+}
+`)
+
+	result, err := Extract(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRef(t, result, "Context.reset")
+}
+
+func TestExtractResolvesGenericReceiverMethodRef(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+	writeTestFile(t, root, "demo.go", `package demo
+
+type Box[T any] struct{}
+
+func (b *Box[T]) reset() {}
+
+func serve() {
+	var b Box[int]
+	b.reset()
+}
+`)
+
+	result, err := Extract(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRef(t, result, "Box.reset")
+	expectCall(t, result, "serve", "Box.reset")
+}
+
+func TestExtractDoesNotEmitPhantomInterfaceMethodRefs(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+	writeTestFile(t, root, "demo.go", `package demo
+
+type runner interface {
+	run()
+}
+
+type worker struct{}
+
+func (w worker) run() {}
+
+func serve(r runner) {
+	r.run()
+}
+`)
+
+	result, err := Extract(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectNoRef(t, result, "runner.run")
+	expectNoCall(t, result, "serve", "runner.run")
+}
+
+func TestExtractRespectsImportedSelectorWhenLocalNameIsNotTyped(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+	writeTestFile(t, root, "demo.go", `package demo
+
+import "example.com/demo/helper"
+
+func serve() {
+	helper.Run()
+}
+`)
+	if err := os.Mkdir(filepath.Join(root, "helper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, root, filepath.Join("helper", "helper.go"), `package helper
+
+func Run() {}
+`)
+
+	result, err := Extract(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRef(t, result, "helper.Run")
+	expectCall(t, result, "serve", "helper.Run")
+}
+
+func writeTestFile(t *testing.T, root string, relPath string, content string) {
+	t.Helper()
+
+	path := filepath.Join(root, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func expectRef(t *testing.T, result *Result, name string) {
+	t.Helper()
+
+	for _, ref := range result.Refs {
+		if ref.Name == name {
+			return
+		}
+	}
+	t.Fatalf("expected ref %q in %#v", name, result.Refs)
+}
+
+func expectCall(t *testing.T, result *Result, caller string, callee string) {
+	t.Helper()
+
+	for _, call := range result.CallPairs {
+		if call.Caller == caller && call.Callee == callee {
+			return
+		}
+	}
+	t.Fatalf("expected call %q -> %q in %#v", caller, callee, result.CallPairs)
+}
+
+func expectNoRef(t *testing.T, result *Result, name string) {
+	t.Helper()
+
+	for _, ref := range result.Refs {
+		if ref.Name == name {
+			t.Fatalf("did not expect ref %q in %#v", name, result.Refs)
+		}
+	}
+}
+
+func expectNoCall(t *testing.T, result *Result, caller string, callee string) {
+	t.Helper()
+
+	for _, call := range result.CallPairs {
+		if call.Caller == caller && call.Callee == callee {
+			t.Fatalf("did not expect call %q -> %q in %#v", caller, callee, result.CallPairs)
+		}
+	}
+}

--- a/skylos/engines/go/internal/symbols/typed_selectors.go
+++ b/skylos/engines/go/internal/symbols/typed_selectors.go
@@ -1,0 +1,293 @@
+package symbols
+
+import (
+	"go/ast"
+	"go/build"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type parsedPackage struct {
+	files      []*ast.File
+	fset       *token.FileSet
+	importPath string
+	pkgDir     string
+}
+
+func collectTypedSelectorRefs(
+	root string,
+	resolvedRoot string,
+	modulePath string,
+	pkgDirs map[string]string,
+	defNames map[string]bool,
+) ([]Ref, []CallPair) {
+	packages := collectParsedPackages(root, resolvedRoot, modulePath)
+	refs := []Ref{}
+	calls := []CallPair{}
+
+	for _, pkg := range packages {
+		pkgRefs, pkgCalls := resolveTypedSelectors(pkg, modulePath, root, pkgDirs, defNames)
+		refs = append(refs, pkgRefs...)
+		calls = append(calls, pkgCalls...)
+	}
+
+	return refs, calls
+}
+
+func collectParsedPackages(root, resolvedRoot, modulePath string) []parsedPackage {
+	fset := token.NewFileSet()
+	packagesByKey := map[string]*parsedPackage{}
+
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			name := info.Name()
+			if defaultSkipDirs[name] || (strings.HasPrefix(name, ".") && name != ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		resolvedPath, resolveErr := filepath.EvalSymlinks(path)
+		if resolveErr != nil || !isPathWithinRoot(resolvedRoot, resolvedPath) {
+			return nil
+		}
+		if !matchesCurrentBuild(resolvedPath) {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, resolvedPath, nil, 0)
+		if parseErr != nil {
+			return nil
+		}
+
+		pkgDir := pkgDirKey(root, resolvedPath)
+		key := pkgDir + "\x00" + file.Name.Name
+		pkg := packagesByKey[key]
+		if pkg == nil {
+			pkg = &parsedPackage{
+				files:      []*ast.File{},
+				fset:       fset,
+				importPath: packageImportPath(modulePath, pkgDir, file.Name.Name),
+				pkgDir:     pkgDir,
+			}
+			packagesByKey[key] = pkg
+		}
+		pkg.files = append(pkg.files, file)
+
+		return nil
+	})
+
+	packages := []parsedPackage{}
+	keys := make([]string, 0, len(packagesByKey))
+	for key := range packagesByKey {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		packages = append(packages, *packagesByKey[key])
+	}
+	return packages
+}
+
+func matchesCurrentBuild(path string) bool {
+	ok, err := build.Default.MatchFile(filepath.Dir(path), filepath.Base(path))
+	if err != nil {
+		return true
+	}
+	return ok
+}
+
+func packageImportPath(modulePath, pkgDir, pkgName string) string {
+	if modulePath == "" {
+		if pkgDir == "." {
+			return pkgName
+		}
+		return pkgDir
+	}
+	if pkgDir == "." {
+		return modulePath
+	}
+	return modulePath + "/" + pkgDir
+}
+
+func resolveTypedSelectors(
+	pkg parsedPackage,
+	modulePath string,
+	root string,
+	pkgDirs map[string]string,
+	defNames map[string]bool,
+) ([]Ref, []CallPair) {
+	info := &types.Info{
+		Selections: map[*ast.SelectorExpr]*types.Selection{},
+		Uses:       map[*ast.Ident]types.Object{},
+	}
+	conf := types.Config{
+		Importer: importer.Default(),
+		Error: func(error) {
+		},
+	}
+	_, _ = conf.Check(pkg.importPath, pkg.fset, pkg.files, info)
+	if len(info.Selections) == 0 {
+		return nil, nil
+	}
+
+	refs := []Ref{}
+	calls := []CallPair{}
+
+	for _, file := range pkg.files {
+		for _, decl := range file.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok || funcDecl.Body == nil {
+				continue
+			}
+
+			fileRefs, fileCalls := resolveFuncTypedSelectors(
+				funcDecl,
+				pkg,
+				info,
+				modulePath,
+				root,
+				pkgDirs,
+				defNames,
+			)
+			refs = append(refs, fileRefs...)
+			calls = append(calls, fileCalls...)
+		}
+	}
+
+	return refs, calls
+}
+
+func resolveFuncTypedSelectors(
+	funcDecl *ast.FuncDecl,
+	pkg parsedPackage,
+	info *types.Info,
+	modulePath string,
+	root string,
+	pkgDirs map[string]string,
+	defNames map[string]bool,
+) ([]Ref, []CallPair) {
+	callerName := typedCallerName(funcDecl, pkg.pkgDir)
+	refs := []Ref{}
+	calls := []CallPair{}
+
+	ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			refName := typedSelectionName(node, info, pkg, modulePath, root, pkgDirs, defNames)
+			if refName != "" {
+				refs = append(refs, Ref{
+					Name: refName,
+					File: pkg.fset.Position(node.Pos()).Filename,
+				})
+			}
+		case *ast.CallExpr:
+			selector, ok := node.Fun.(*ast.SelectorExpr)
+			if !ok {
+				break
+			}
+
+			calleeName := typedSelectionName(selector, info, pkg, modulePath, root, pkgDirs, defNames)
+			if calleeName != "" {
+				calls = append(calls, CallPair{
+					Caller: callerName,
+					Callee: calleeName,
+				})
+			}
+		}
+		return true
+	})
+
+	return refs, calls
+}
+
+func typedCallerName(funcDecl *ast.FuncDecl, pkgDir string) string {
+	if funcDecl.Recv != nil && len(funcDecl.Recv.List) > 0 {
+		recv := receiverTypeName(funcDecl.Recv.List[0].Type)
+		return qname(pkgDir, recv, funcDecl.Name.Name)
+	}
+	return qname(pkgDir, funcDecl.Name.Name)
+}
+
+func typedSelectionName(
+	selector *ast.SelectorExpr,
+	info *types.Info,
+	pkg parsedPackage,
+	modulePath string,
+	root string,
+	pkgDirs map[string]string,
+	defNames map[string]bool,
+) string {
+	selection := info.Selections[selector]
+	if selection == nil {
+		return ""
+	}
+	if selection.Kind() != types.MethodVal && selection.Kind() != types.MethodExpr {
+		return ""
+	}
+
+	receiverPkgPath, receiverName := receiverNameFromMethod(selection.Obj())
+	if receiverName == "" {
+		return ""
+	}
+
+	targetPkgDir := pkg.pkgDir
+	if receiverPkgPath != "" && receiverPkgPath != pkg.importPath {
+		resolvedPkgDir := resolveImportToPkgDir(receiverPkgPath, modulePath, root, pkgDirs)
+		if resolvedPkgDir == "" {
+			return ""
+		}
+		targetPkgDir = resolvedPkgDir
+	}
+
+	name := qname(targetPkgDir, receiverName, selection.Obj().Name())
+	if !defNames[name] {
+		return ""
+	}
+	return name
+}
+
+func receiverNameFromMethod(obj types.Object) (string, string) {
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return "", ""
+	}
+
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return "", ""
+	}
+
+	return receiverNameFromType(sig.Recv().Type())
+}
+
+func receiverNameFromType(t types.Type) (string, string) {
+	switch typ := t.(type) {
+	case *types.Pointer:
+		return receiverNameFromType(typ.Elem())
+	case *types.Named:
+		obj := typ.Obj()
+		if obj == nil {
+			return "", ""
+		}
+		pkg := obj.Pkg()
+		pkgPath := ""
+		if pkg != nil {
+			pkgPath = pkg.Path()
+		}
+		return pkgPath, obj.Name()
+	}
+	return "", ""
+}

--- a/skylos/scale/parallel_static.py
+++ b/skylos/scale/parallel_static.py
@@ -60,30 +60,36 @@ def run_proc_file_parallel(
         jobs = 1
 
     if jobs <= 1:
-        outs = []
-        total = len(files)
-        for i, f in enumerate(files, 1):
-            if progress_callback:
-                progress_callback(i, total or 1, f)
+        return _run_proc_files_serial(
+            files,
+            modmap,
+            extra_visitors=extra_visitors,
+            progress_callback=progress_callback,
+            changed_files=changed_files,
+            collect_clone_fragments=collect_clone_fragments,
+            clone_cfg=clone_cfg,
+            collect_architecture_metrics=collect_architecture_metrics,
+            enable_quality_rules=enable_quality_rules,
+            enable_danger_rules=enable_danger_rules,
+            config_file=config_file,
+        )
 
-            from skylos.analyzer import proc_file
-
-            full_scan = changed_files is None or str(f) in changed_files
-            out = proc_file(
-                f,
-                modmap[f],
-                extra_visitors=extra_visitors,
-                full_scan=full_scan,
-                collect_clone_fragments=collect_clone_fragments,
-                clone_cfg=clone_cfg,
-                collect_architecture_metrics=collect_architecture_metrics,
-                enable_quality_rules=enable_quality_rules,
-                enable_danger_rules=enable_danger_rules,
-                config_file=config_file,
-            )
-            outs.append(out)
-
-        return outs
+    if any(str(f).endswith(".go") for f in files):
+        return _run_mixed_files_with_serial_go(
+            files,
+            modmap,
+            extra_visitors=extra_visitors,
+            jobs=jobs,
+            progress_callback=progress_callback,
+            custom_rules_data=custom_rules_data,
+            changed_files=changed_files,
+            collect_clone_fragments=collect_clone_fragments,
+            clone_cfg=clone_cfg,
+            collect_architecture_metrics=collect_architecture_metrics,
+            enable_quality_rules=enable_quality_rules,
+            enable_danger_rules=enable_danger_rules,
+            config_file=config_file,
+        )
 
     pending = []
     for f in files:
@@ -160,3 +166,114 @@ def run_proc_file_parallel(
         ordered.append(results.get(str(f)))
 
     return ordered
+
+
+def _run_mixed_files_with_serial_go(
+    files,
+    modmap,
+    extra_visitors=None,
+    jobs=0,
+    progress_callback=None,
+    custom_rules_data=None,
+    changed_files=None,
+    collect_clone_fragments=False,
+    clone_cfg=None,
+    collect_architecture_metrics=False,
+    enable_quality_rules=True,
+    enable_danger_rules=True,
+    config_file=None,
+):
+    go_files = []
+    other_files = []
+    for f in files:
+        if str(f).endswith(".go"):
+            go_files.append(f)
+        else:
+            other_files.append(f)
+
+    completed = 0
+    total = len(files)
+
+    def child_progress(_done, _total, file_path):
+        nonlocal completed
+        completed += 1
+        if progress_callback:
+            progress_callback(completed, total or 1, file_path)
+
+    results = {}
+    if other_files:
+        other_outs = run_proc_file_parallel(
+            other_files,
+            modmap,
+            extra_visitors=extra_visitors,
+            jobs=jobs,
+            progress_callback=child_progress,
+            custom_rules_data=custom_rules_data,
+            changed_files=changed_files,
+            collect_clone_fragments=collect_clone_fragments,
+            clone_cfg=clone_cfg,
+            collect_architecture_metrics=collect_architecture_metrics,
+            enable_quality_rules=enable_quality_rules,
+            enable_danger_rules=enable_danger_rules,
+            config_file=config_file,
+        )
+        for f, out in zip(other_files, other_outs):
+            results[str(f)] = out
+
+    if go_files:
+        go_outs = _run_proc_files_serial(
+            go_files,
+            modmap,
+            extra_visitors=extra_visitors,
+            progress_callback=child_progress,
+            changed_files=changed_files,
+            collect_clone_fragments=collect_clone_fragments,
+            clone_cfg=clone_cfg,
+            collect_architecture_metrics=collect_architecture_metrics,
+            enable_quality_rules=enable_quality_rules,
+            enable_danger_rules=enable_danger_rules,
+            config_file=config_file,
+        )
+        for f, out in zip(go_files, go_outs):
+            results[str(f)] = out
+
+    return [results.get(str(f)) for f in files]
+
+
+def _run_proc_files_serial(
+    files,
+    modmap,
+    extra_visitors=None,
+    progress_callback=None,
+    changed_files=None,
+    collect_clone_fragments=False,
+    clone_cfg=None,
+    collect_architecture_metrics=False,
+    enable_quality_rules=True,
+    enable_danger_rules=True,
+    config_file=None,
+):
+    outs = []
+    total = len(files)
+    for i, f in enumerate(files, 1):
+        if progress_callback:
+            progress_callback(i, total or 1, f)
+
+        from skylos.analyzer import proc_file
+
+        full_scan = changed_files is None or str(f) in changed_files
+        out = proc_file(
+            f,
+            modmap[f],
+            extra_visitors=extra_visitors,
+            full_scan=full_scan,
+            collect_clone_fragments=collect_clone_fragments,
+            clone_cfg=clone_cfg,
+            collect_architecture_metrics=collect_architecture_metrics,
+            enable_quality_rules=enable_quality_rules,
+            enable_danger_rules=enable_danger_rules,
+            config_file=config_file,
+        )
+        outs.append(out)
+
+    return outs

--- a/test/test_parallel_static.py
+++ b/test/test_parallel_static.py
@@ -49,6 +49,11 @@ class ExplodingExecutor:
         return fut
 
 
+class ShouldNotRunExecutor:
+    def __init__(self, max_workers=None):
+        raise AssertionError("parallel executor should not be used")
+
+
 def fake_as_completed(futs):
     fs = list(futs)
     fs.reverse()
@@ -77,6 +82,60 @@ def test_parallel_path_preserves_order(monkeypatch, tmp_path):
     assert out[0] == ("ok", str(files[0]), "mx")
     assert out[1] == ("ok", str(files[1]), "my")
     assert out[2] == ("ok", str(files[2]), "mz")
+
+
+def test_go_files_use_serial_path_to_keep_module_cache_effective(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "ProcessPoolExecutor", ShouldNotRunExecutor)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    calls = []
+
+    def fake_proc_file(file_path, mod, extra_visitors=None, full_scan=True, **kwargs):
+        calls.append(str(file_path))
+        return ("go-ok", str(file_path), mod)
+
+    import skylos.analyzer
+
+    monkeypatch.setattr(skylos.analyzer, "proc_file", fake_proc_file)
+
+    files = [tmp_path / "a.go", tmp_path / "b.go"]
+    modmap = {files[0]: "m", files[1]: "m"}
+
+    out = ps.run_proc_file_parallel(files, modmap, jobs=2)
+
+    assert out == [("go-ok", str(files[0]), "m"), ("go-ok", str(files[1]), "m")]
+    assert calls == [str(files[0]), str(files[1])]
+
+
+def test_mixed_files_keep_non_go_parallel_and_preserve_order(monkeypatch, tmp_path):
+    monkeypatch.setattr(ps, "ProcessPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(ps, "as_completed", fake_as_completed)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    def fake_proc_file(file_path, mod, extra_visitors=None, full_scan=True, **kwargs):
+        return ("mixed-ok", str(file_path), mod)
+
+    import skylos.analyzer
+
+    monkeypatch.setattr(skylos.analyzer, "proc_file", fake_proc_file)
+
+    files = [tmp_path / "a.py", tmp_path / "b.go", tmp_path / "c.ts"]
+    modmap = {files[0]: "py", files[1]: "go", files[2]: "ts"}
+    progress = []
+
+    out = ps.run_proc_file_parallel(
+        files,
+        modmap,
+        jobs=2,
+        progress_callback=lambda done, total, path: progress.append(
+            (done, total, path.name)
+        ),
+    )
+
+    assert out[0] == ("mixed-ok", str(files[0]), "py")
+    assert out[1] == ("mixed-ok", str(files[1]), "go")
+    assert out[2] == ("mixed-ok", str(files[2]), "ts")
+    assert progress == [(1, 3, "c.ts"), (2, 3, "a.py"), (3, 3, "b.go")]
 
 
 def test_parallel_path_retries_parent_process_when_worker_result_fails(


### PR DESCRIPTION
## Summary
  - add a Go type-aware selector resolver using `go/types` to emit accurate method refs and call pairs
  - fix Go dead-code FPs for receiver calls like `c.reset()`, field receiver calls
  like `c.writermem.reset()`, promoted embedded methods, method expressions, and generic receivers
  - run Go files in the static worker path so Go analysis reuses the cache

  ## Tests
  - `go test ./...`
  - `pytest test/test_parallel_static.py test/test_go_runner.py test/test_go_security.py`