### PR TITLE
fix(dead-code): reduce language false positives

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -3310,6 +3310,19 @@ class Skylos:
         from skylos.visitors.languages.typescript.resolve import MonorepoResolver
 
         monorepo_resolver = MonorepoResolver(str(self._project_root))
+        try:
+            from skylos.deadcode.browser_refs import collect_mdx_ts_imports
+
+            mdx_raw_imports = collect_mdx_ts_imports(
+                Path(root),
+                files,
+                exclude_folders=exclude_folders,
+            )
+            ts_raw_imports.update(mdx_raw_imports)
+        except Exception:
+            if os.getenv("SKYLOS_DEBUG"):
+                logger.error("MDX component import graph scan failed", exc_info=True)
+
         self._build_ts_import_graph(ts_raw_imports, monorepo_resolver)
 
         self._global_type_map = {}

--- a/skylos/deadcode/browser_refs.py
+++ b/skylos/deadcode/browser_refs.py
@@ -23,6 +23,9 @@ _HTML_TEMPLATE_SUFFIXES = {
     ".svelte",
     ".astro",
 }
+_MDX_SUFFIXES = {
+    ".mdx",
+}
 
 _QUOTED_EVENT_HANDLER_RE = re.compile(
     r"""\bon[a-zA-Z]+\s*=\s*\\?(?P<quote>["'])(?P<handler>.*?)\\?(?P=quote)""",
@@ -43,6 +46,22 @@ _LEGACY_STRING_DISPATCH_RE = re.compile(
 _ACTION_PROPERTY_RE = re.compile(
     r"""\b[A-Za-z_$][\w$]*Action\s*:\s*(?P<quote>["'])(?P<name>[A-Za-z_$][\w$]*)(?P=quote)"""
 )
+_MDX_IMPORT_RE = re.compile(
+    r"""^\s*import\s+(?P<clause>[\s\S]*?)\s+from\s+"""
+    r"""(?P<quote>["'])(?P<source>[^"']+)(?P=quote)\s*;?""",
+    re.MULTILINE,
+)
+_MDX_NAMED_IMPORT_RE = re.compile(r"""\{(?P<body>[^}]*)\}""", re.DOTALL)
+_MDX_NAMESPACE_IMPORT_RE = re.compile(
+    r"""\*\s+as\s+(?P<name>[A-Za-z_$][\w$]*)"""
+)
+_MDX_COMPONENT_TAG_RE = re.compile(
+    r"""</?\s*(?P<name>[A-Z][A-Za-z0-9_$]*)(?:\s|/|>|[.])"""
+)
+_MARKDOWN_CODE_BLOCK_RE = re.compile(
+    r"""(```[\s\S]*?```|~~~[\s\S]*?~~~)"""
+)
+_MARKDOWN_INLINE_CODE_RE = re.compile(r"""`[^`\n]*`""")
 _SCRIPT_TAG_RE = re.compile(r"""<script\b(?P<attrs>[^>]*)>""", re.IGNORECASE)
 _SRC_ATTR_RE = re.compile(
     r"""\bsrc\s*=\s*(?P<quote>["'])(?P<value>.*?)(?P=quote)""",
@@ -79,6 +98,87 @@ def extract_browser_event_handler_names(source: str) -> set[str]:
     return names
 
 
+def extract_mdx_component_refs(
+    root: Path,
+    mdx_file: Path,
+    source: str,
+    monorepo_resolver,
+) -> list[tuple[str, Path]]:
+    clean_source = _strip_markdown_code(source)
+    rendered_components = _extract_mdx_rendered_components(clean_source)
+    if not rendered_components:
+        return []
+
+    imported_components = _extract_mdx_imported_components(clean_source)
+    refs: list[tuple[str, Path]] = []
+    seen: set[tuple[str, Path]] = set()
+    for name in sorted(rendered_components):
+        imported = imported_components.get(name)
+        if not imported:
+            continue
+        import_source, exported_name = imported
+
+        target_file = _resolve_mdx_component_file(
+            root,
+            mdx_file,
+            import_source,
+            monorepo_resolver,
+        )
+        if target_file is None:
+            continue
+
+        key = (exported_name, target_file)
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append(key)
+    return refs
+
+
+def collect_mdx_ts_imports(
+    project_root: Path,
+    source_files,
+    *,
+    exclude_folders=None,
+) -> dict[Path, list[dict[str, object]]]:
+    root = Path(project_root).resolve()
+    source_cache: dict[Path, str] = {}
+    raw_imports: dict[Path, list[dict[str, object]]] = {}
+
+    for file_path in _iter_mdx_reference_files(root, source_files, exclude_folders):
+        source = _read_text(root, file_path, source_cache)
+        if source is None:
+            continue
+
+        clean_source = _strip_markdown_code(source)
+        rendered_components = _extract_mdx_rendered_components(clean_source)
+        if not rendered_components:
+            continue
+
+        imported_components = _extract_mdx_imported_components(clean_source)
+        imports_by_source: dict[str, list[str]] = {}
+        for local_name in sorted(rendered_components):
+            imported = imported_components.get(local_name)
+            if not imported:
+                continue
+            import_source, exported_name = imported
+            imports_by_source.setdefault(import_source, []).append(exported_name)
+
+        entries: list[dict[str, object]] = []
+        for import_source, names in imports_by_source.items():
+            entries.append(
+                {
+                    "source": import_source,
+                    "names": names,
+                    "line": 1,
+                }
+            )
+        if entries:
+            raw_imports[file_path] = entries
+
+    return raw_imports
+
+
 def collect_browser_event_handler_refs(
     project_root: Path,
     source_files,
@@ -91,6 +191,7 @@ def collect_browser_event_handler_refs(
     seen_names: set[str] = set()
     source_cache: dict[Path, str] = {}
     template_files: list[Path] = []
+    monorepo_resolver = _build_ts_monorepo_resolver(root)
 
     reference_files = list(
         _iter_browser_reference_files(root, source_files, exclude_folders)
@@ -102,6 +203,15 @@ def collect_browser_event_handler_refs(
 
         if file_path.suffix.lower() in _HTML_TEMPLATE_SUFFIXES:
             template_files.append(file_path)
+
+        if file_path.suffix.lower() in _MDX_SUFFIXES:
+            for name, target_file in extract_mdx_component_refs(
+                root,
+                file_path,
+                source,
+                monorepo_resolver,
+            ):
+                _append_ref(refs, seen_refs, name, target_file)
 
         for name in extract_browser_event_handler_names(source):
             seen_names.add(name)
@@ -117,6 +227,111 @@ def collect_browser_event_handler_refs(
                 _append_ref(refs, seen_refs, name, script_file)
 
     return refs
+
+
+def _strip_markdown_code(source: str) -> str:
+    without_blocks = _MARKDOWN_CODE_BLOCK_RE.sub("", source)
+    return _MARKDOWN_INLINE_CODE_RE.sub("", without_blocks)
+
+
+def _extract_mdx_rendered_components(source: str) -> set[str]:
+    names: set[str] = set()
+    for match in _MDX_COMPONENT_TAG_RE.finditer(source):
+        names.add(match.group("name"))
+    return names
+
+
+def _extract_mdx_imported_components(source: str) -> dict[str, tuple[str, str]]:
+    imported: dict[str, tuple[str, str]] = {}
+    for match in _MDX_IMPORT_RE.finditer(source):
+        clause = match.group("clause").strip()
+        import_source = match.group("source").strip()
+        for local_name, exported_name in _extract_import_clause_local_names(
+            clause
+        ).items():
+            imported[local_name] = (import_source, exported_name)
+    return imported
+
+
+def _extract_import_clause_local_names(clause: str) -> dict[str, str]:
+    names: dict[str, str] = {}
+
+    namespace_match = _MDX_NAMESPACE_IMPORT_RE.search(clause)
+    if namespace_match:
+        namespace_name = namespace_match.group("name")
+        names[namespace_name] = namespace_name
+
+    named_spans: list[tuple[int, int]] = []
+    for match in _MDX_NAMED_IMPORT_RE.finditer(clause):
+        named_spans.append(match.span())
+        for part in match.group("body").split(","):
+            parsed = _names_from_import_part(part)
+            if parsed:
+                local_name, exported_name = parsed
+                names[local_name] = exported_name
+
+    default_clause = clause
+    for start, end in reversed(named_spans):
+        default_clause = default_clause[:start] + default_clause[end:]
+    default_clause = default_clause.split(",", 1)[0].strip()
+    if default_clause and not default_clause.startswith("*"):
+        parsed = _names_from_import_part(default_clause)
+        if parsed:
+            local_name, exported_name = parsed
+            names[local_name] = exported_name
+
+    return names
+
+
+def _names_from_import_part(part: str) -> tuple[str, str] | None:
+    cleaned = part.strip()
+    if not cleaned:
+        return None
+
+    pieces = re.split(r"\s+as\s+", cleaned)
+    exported_name = pieces[0].strip()
+    local_name = pieces[-1].strip()
+    if not re.fullmatch(r"[A-Za-z_$][\w$]*", exported_name):
+        return None
+    if re.fullmatch(r"[A-Za-z_$][\w$]*", local_name):
+        return local_name, exported_name
+    return None
+
+
+def _resolve_mdx_component_file(
+    root: Path,
+    mdx_file: Path,
+    import_source: str,
+    monorepo_resolver,
+) -> Path | None:
+    if import_source.startswith(("http://", "https://", "//")):
+        return None
+
+    try:
+        from skylos.visitors.languages.typescript.analysis import resolve_ts_module
+    except ImportError:
+        return None
+
+    resolved = resolve_ts_module(
+        import_source,
+        str(mdx_file),
+        monorepo_resolver=monorepo_resolver,
+    )
+    if not resolved:
+        return None
+
+    target_file = Path(resolved)
+    if target_file.suffix.lower() not in _JS_SOURCE_SUFFIXES:
+        return None
+    return _resolve_readable_project_file(root, target_file)
+
+
+def _build_ts_monorepo_resolver(root: Path):
+    try:
+        from skylos.visitors.languages.typescript.resolve import MonorepoResolver
+    except ImportError:
+        return None
+    return MonorepoResolver(str(root))
 
 
 def _iter_event_handler_values(source: str):
@@ -346,6 +561,43 @@ def _iter_browser_reference_files(
         exclude_folders=exclude_folders,
     )
     for file_path in template_files:
+        if file_path in seen:
+            continue
+        seen.add(file_path)
+        yield file_path
+
+    for file_path in _iter_mdx_reference_files(root, source_files, exclude_folders):
+        if file_path in seen:
+            continue
+        seen.add(file_path)
+        yield file_path
+
+
+def _iter_mdx_reference_files(
+    root: Path,
+    source_files,
+    exclude_folders,
+):
+    seen: set[Path] = set()
+
+    for raw_file in source_files:
+        file_path = Path(raw_file).resolve()
+        if file_path.suffix.lower() not in _MDX_SUFFIXES:
+            continue
+        if file_path in seen:
+            continue
+        seen.add(file_path)
+        yield file_path
+
+    if not root.exists() or not root.is_dir():
+        return
+
+    mdx_files = discover_source_files(
+        root,
+        _MDX_SUFFIXES,
+        exclude_folders=exclude_folders,
+    )
+    for file_path in mdx_files:
         if file_path in seen:
             continue
         seen.add(file_path)

--- a/skylos/visitors/languages/java/core.py
+++ b/skylos/visitors/languages/java/core.py
@@ -52,6 +52,17 @@ _LIFECYCLE_METHODS: set[str] = {
     "onViewCreated",
 }
 
+_SERIALIZATION_HOOKS_WITHOUT_ARGS: set[str] = {
+    "readObjectNoData",
+    "readResolve",
+    "writeReplace",
+}
+
+_SERIALIZATION_HOOKS_WITH_STREAM: dict[str, str] = {
+    "readObject": "ObjectInputStream",
+    "writeObject": "ObjectOutputStream",
+}
+
 _DEFS_PATTERN = """
 (class_declaration name: (identifier) @class_def)
 (interface_declaration name: (identifier) @iface_def)
@@ -156,6 +167,17 @@ class JavaCore:
                 name_node = current.child_by_field_name("name")
                 if name_node:
                     return self._get_text(name_node)
+            current = current.parent
+        return None
+
+    def _find_containing_method(self, node) -> str | None:
+        current = node.parent
+        while current:
+            if current.type == "method_declaration":
+                name_node = current.child_by_field_name("name")
+                if name_node:
+                    return self._get_text(name_node)
+                return None
             current = current.parent
         return None
 
@@ -278,6 +300,45 @@ class JavaCore:
                             return True
         return False
 
+    def _method_parameter_texts(self, method_node) -> list[str]:
+        parameters = method_node.child_by_field_name(
+            "parameters"
+        ) or self._find_child_by_type(method_node, "formal_parameters")
+        if parameters is None:
+            return []
+
+        result: list[str] = []
+        for child in parameters.children:
+            if child.type in {"formal_parameter", "spread_parameter"}:
+                result.append(self._get_text(child))
+        return result
+
+    def _is_java_serialization_hook(self, name: str, name_node) -> bool:
+        method_node = name_node.parent
+        if method_node is None or method_node.type != "method_declaration":
+            return False
+
+        parameters = self._method_parameter_texts(method_node)
+        if name in _SERIALIZATION_HOOKS_WITHOUT_ARGS:
+            return len(parameters) == 0
+
+        stream_type = _SERIALIZATION_HOOKS_WITH_STREAM.get(name)
+        if stream_type is None or len(parameters) != 1:
+            return False
+        return stream_type in parameters[0]
+
+    def _is_abstract_method(self, name_node) -> bool:
+        method_node = name_node.parent
+        if method_node is None or method_node.type != "method_declaration":
+            return False
+
+        modifiers = method_node.child_by_field_name(
+            "modifiers"
+        ) or self._find_child_by_type(method_node, "modifiers")
+        if modifiers is None:
+            return False
+        return "abstract" in self._get_text(modifiers)
+
     def scan(self) -> None:
         if not self.root_node:
             self.raw_imports: list[dict] = []
@@ -288,6 +349,7 @@ class JavaCore:
 
         self._scan_defs()
         self._scan_refs()
+        self._scan_reflection_refs()
         self._scan_imports()
         self.raw_imports = []
         self._build_call_graph()
@@ -324,6 +386,12 @@ class JavaCore:
         name = self._get_text(node)
 
         if type_name == "method" and name in _LIFECYCLE_METHODS:
+            return
+
+        if type_name == "method" and self._is_java_serialization_hook(name, node):
+            return
+
+        if type_name == "method" and self._is_abstract_method(node):
             return
 
         if type_name == "method":
@@ -383,10 +451,28 @@ class JavaCore:
         for node in c.get("ref", []):
             name = self._get_text(node)
             if not self._is_self_ref(node, name):
+                if node.parent and node.parent.type == "method_invocation":
+                    object_node = node.parent.child_by_field_name("object")
+                    if object_node is not None:
+                        object_name = self._get_text(object_node)
+                        if object_name not in {"this", "super"}:
+                            qualified_ref = f"{object_name}.{name}"
+                            key = (qualified_ref, node.start_byte)
+                            if key not in seen:
+                                seen.add(key)
+                                self.refs.append((qualified_ref, self.file_path))
+                            continue
+
                 key = (name, node.start_byte)
                 if key not in seen:
                     seen.add(key)
                     self.refs.append((name, self.file_path))
+                    if node.parent and node.parent.type == "method_invocation":
+                        class_name = self._find_containing_class(node)
+                        method_name = self._find_containing_method(node)
+                        if class_name and method_name != name:
+                            qualified_name = f"{class_name}.{name}"
+                            self.refs.append((qualified_name, self.file_path))
 
         for node in c.get("type_ref", []):
             parent = node.parent
@@ -413,6 +499,48 @@ class JavaCore:
             if key not in seen:
                 seen.add(key)
                 self.refs.append((name, self.file_path))
+
+    def _scan_reflection_refs(self) -> None:
+        if self.root_node is None:
+            return
+
+        for node in self._walk_nodes(self.root_node):
+            if node.type != "method_invocation":
+                continue
+
+            name_node = node.child_by_field_name("name")
+            object_node = node.child_by_field_name("object")
+            if name_node is None or object_node is None:
+                continue
+            if self._get_text(name_node) != "forName":
+                continue
+            if self._get_text(object_node) != "Class":
+                continue
+
+            class_name = self._first_string_argument(node)
+            if class_name:
+                self.refs.append((class_name, self.file_path))
+
+    def _first_string_argument(self, invocation_node) -> str | None:
+        arguments = invocation_node.child_by_field_name(
+            "arguments"
+        ) or self._find_child_by_type(invocation_node, "argument_list")
+        if arguments is None:
+            return None
+
+        for child in self._walk_nodes(arguments):
+            if child.type != "string_literal":
+                continue
+            raw = self._get_text(child).strip()
+            if len(raw) < 2:
+                continue
+            if raw[0] not in {'"', "'"} or raw[-1] != raw[0]:
+                continue
+            value = raw[1:-1].strip()
+            if value:
+                return value
+            return None
+        return None
 
     def _scan_imports(self) -> None:
         c = self._defs_captures

--- a/skylos/visitors/languages/rust/core.py
+++ b/skylos/visitors/languages/rust/core.py
@@ -476,6 +476,7 @@ class RustCore:
     def _scan_use_imports(self, node) -> None:
         line = node.start_point[0] + 1
         source = self._get_text(node).strip()
+        is_public_reexport = self._is_public(node)
         source = source.removeprefix("use").strip().rstrip(";")
         if "*" in source:
             self.raw_imports.append({"source": source, "names": ["*"], "line": line})
@@ -486,6 +487,7 @@ class RustCore:
             if not name:
                 continue
             d = Definition(name, "import", self.file_path, line)
+            d.is_exported = is_public_reexport
             self.defs.append(d)
             self.imports.append(
                 {"name": name, "file": str(self.file_path), "line": line}

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -973,6 +973,28 @@ class TestAnalyze:
         }
         mock_log_info.assert_any_call("Analyzing 2 files...")
 
+    def test_analyze_rust_public_reexports_stay_live(self, tmp_path):
+        (tmp_path / "lib.rs").write_text(
+            """
+mod internal {
+    pub fn public_api() {}
+    pub fn stale_api() {}
+}
+
+pub use crate::internal::public_api;
+use crate::internal::stale_api;
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unused_imports = {item["simple_name"] for item in result["unused_imports"]}
+
+        assert "public_api" not in unused_imports
+        assert "stale_api" in unused_imports
+
     @patch("skylos.analyzer.logger.info")
     def test_analyze_mixed_languages_includes_csharp_in_summary(self, mock_log_info):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -2483,6 +2505,165 @@ public class Api {
 
         assert "Api.publicEndpoint" not in unreachable
         assert "Api.privateHelper" in unreachable
+
+    def test_analyze_java_serialization_hooks_stay_live(self, tmp_path):
+        (tmp_path / "SerializableValue.java").write_text(
+            """
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
+
+public class SerializableValue {
+    private Object writeReplace() throws ObjectStreamException {
+        return this;
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException {
+        throw new InvalidObjectException("unsupported");
+    }
+
+    private String staleHelper() {
+        return "stale";
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "SerializableValue.writeReplace" not in unreachable
+        assert "SerializableValue.readObject" not in unreachable
+        assert "SerializableValue.staleHelper" in unreachable
+
+    def test_analyze_java_abstract_methods_stay_live(self, tmp_path):
+        (tmp_path / "RecordStrategy.java").write_text(
+            """
+public abstract class RecordStrategy {
+    abstract String componentName(Class<?> raw);
+
+    private String staleHelper() {
+        return "stale";
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "RecordStrategy.componentName" not in unreachable
+        assert "RecordStrategy.staleHelper" in unreachable
+
+    def test_analyze_java_method_call_disambiguates_field_with_same_name(
+        self, tmp_path
+    ):
+        (tmp_path / "Adapter.java").write_text(
+            """
+public class Adapter {
+    public static void main(String[] args) {
+        new Worker().read();
+    }
+}
+
+class Worker {
+    private String delegate;
+
+    void read() {
+        delegate();
+    }
+
+    private String delegate() {
+        return delegate;
+    }
+
+    private String staleHelper() {
+        return "stale";
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "Worker.delegate" not in unreachable
+        assert "Worker.staleHelper" in unreachable
+
+    def test_analyze_java_class_for_name_marks_literal_class_live(self, tmp_path):
+        (tmp_path / "App.java").write_text(
+            """
+public class App {
+    public static void main(String[] args) throws Exception {
+        Class.forName("com.example.Plugin");
+    }
+}
+
+class Plugin {
+    void run() {
+    }
+}
+
+class StalePlugin {
+    void run() {
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+
+        assert "Plugin" not in unreachable_classes
+        assert "StalePlugin" in unreachable_classes
+
+    def test_analyze_java_qualified_call_does_not_rescue_same_class_method(
+        self, tmp_path
+    ):
+        (tmp_path / "App.java").write_text(
+            """
+public class App {
+    public static void main(String[] args) {
+        new Worker().read();
+    }
+}
+
+class Other {
+    static void delegate() {
+    }
+}
+
+class Worker {
+    void read() {
+        Other.delegate();
+    }
+
+    private void delegate() {
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["name"] for item in result["unused_functions"]}
+
+        assert "Worker.delegate" in unreachable
 
     def test_analyze_typescript_transitive_dead_uses_file_scoped_callers(
         self, tmp_path

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -510,6 +510,67 @@ function unusedHelper() {
         assert "cancelNFZ" not in unused
         assert "unusedHelper" in unused
 
+    def test_mdx_imported_components_mark_target_tsx_file_live(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        (tmp_path / "tsconfig.json").write_text(
+            '{"compilerOptions":{"paths":{"@/*":["./*"]}}}',
+            encoding="utf-8",
+        )
+        (tmp_path / "content").mkdir()
+        (tmp_path / "components").mkdir()
+        (tmp_path / "content" / "page.mdx").write_text(
+            """
+import { UsedPanel } from "@/components/used";
+
+<UsedPanel />
+
+```mdx
+<DeadPanel />
+```
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "components" / "used.tsx").write_text(
+            """
+export function UsedPanel() {
+    return null;
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "components" / "duplicate.tsx").write_text(
+            """
+export function UsedPanel() {
+    return null;
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "components" / "dead.tsx").write_text(
+            """
+export function DeadPanel() {
+    return null;
+}
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused = {
+            (Path(item["file"]).name, item["name"])
+            for item in result.get("unused_functions", [])
+        }
+        unused_files = {
+            Path(item["file"]).name for item in result.get("unused_files", [])
+        }
+
+        assert ("used.tsx", "UsedPanel") not in unused
+        assert ("duplicate.tsx", "UsedPanel") in unused
+        assert ("dead.tsx", "DeadPanel") in unused
+        assert "used.tsx" not in unused_files
+        assert "duplicate.tsx" in unused_files
+
     def test_generated_inline_handlers_mark_js_functions_live(self, tmp_path):
         from skylos.analyzer import analyze
 


### PR DESCRIPTION
## Summary
  - reduce Java dead-code FPs for serialization hooks, abstract contract methods, `Class.forName(...)` reflection, and same class method calls hidden by same-name fields
  - treat Rust `pub use` imports as public re-exports so public API imports are not reported as unused
  - add MDX component liveness and MDX import graph support for TSX docs components

  ## Tests
  - Scanned Gson, Zod, and ripgrep
  - `pytest .`