### PR TITLE
feat(dead-code): add Kotlin thin scanner layer

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -44,6 +44,7 @@ from skylos.visitors.languages.go import scan_go_file, clear_go_cache
 from skylos.visitors.languages.java import scan_java_file
 from skylos.visitors.languages.rust import scan_rust_file
 from skylos.visitors.languages.csharp import scan_csharp_file
+from skylos.visitors.languages.kotlin import scan_kotlin_file
 
 from skylos.rules.secrets import scan_ctx as _secrets_scan_ctx
 
@@ -182,6 +183,7 @@ _PHP_SOURCE_EXTS = (".php",)
 _RUST_SOURCE_EXTS = (".rs",)
 _DART_SOURCE_EXTS = (".dart",)
 _CSHARP_SOURCE_EXTS = (".cs",)
+_KOTLIN_SOURCE_EXTS = (".kt", ".kts")
 _SHELL_SOURCE_EXTS = SHELL_SOURCE_EXTS
 _PYTHON_SOURCE_ROOT_NAMES = {"src", "lib", "python"}
 
@@ -655,6 +657,8 @@ class Skylos:
         ".rs": "Rust",
         ".dart": "Dart",
         ".cs": "C#",
+        ".kt": "Kotlin",
+        ".kts": "Kotlin",
         ".sh": "Shell",
         ".bash": "Shell",
         ".zsh": "Shell",
@@ -689,6 +693,7 @@ class Skylos:
             *(_RUST_SOURCE_EXTS),
             *(_DART_SOURCE_EXTS),
             *(_CSHARP_SOURCE_EXTS),
+            *(_KOTLIN_SOURCE_EXTS),
             *(_SHELL_SOURCE_EXTS),
         }
         ext_list = [
@@ -707,6 +712,8 @@ class Skylos:
             "rs",
             "dart",
             "cs",
+            "kt",
+            "kts",
             "sh",
             "bash",
             "zsh",
@@ -845,7 +852,9 @@ class Skylos:
             for def_name, def_obj in self.defs.items():
                 if def_obj.type not in ("function", "method"):
                     continue
-                if str(def_obj.filename).endswith((".java",) + _CSHARP_SOURCE_EXTS):
+                if str(def_obj.filename).endswith(
+                    (".java",) + _CSHARP_SOURCE_EXTS + _KOTLIN_SOURCE_EXTS
+                ):
                     continue
                 if "." not in def_obj.name:
                     continue
@@ -3546,6 +3555,16 @@ def proc_file(
 
     if str(file).endswith(".cs"):
         out = scan_csharp_file(
+            file,
+            cfg,
+            enable_danger_rules=enable_danger_rules,
+        )
+        if isinstance(out, tuple) and len(out) < 13:
+            return (*out, *([None] * (13 - len(out))))
+        return out[:13]
+
+    if str(file).endswith(_KOTLIN_SOURCE_EXTS):
+        out = scan_kotlin_file(
             file,
             cfg,
             enable_danger_rules=enable_danger_rules,

--- a/skylos/visitors/languages/kotlin/__init__.py
+++ b/skylos/visitors/languages/kotlin/__init__.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.core.safe_cache_io import read_text_no_symlink
+
+from .core import scan_symbols
+
+MAX_KOTLIN_SOURCE_BYTES = 2_000_000
+
+
+class DummyVisitor:
+    def __init__(
+        self,
+        *,
+        is_test_file: bool = False,
+        test_decorated_lines: set[int] | None = None,
+    ) -> None:
+        self.is_test_file: bool = is_test_file
+        self.test_decorated_lines: set[int] = test_decorated_lines or set()
+        self.dataclass_fields: set[str] = set()
+        self.pydantic_models: set[str] = set()
+        self.class_defs: dict = {}
+        self.first_read_lineno: dict = {}
+        self.framework_decorated_lines: set[int] = set()
+        self.detected_frameworks: set[str] = set()
+
+
+def _empty_result(config: dict) -> tuple:
+    return (
+        [],
+        [],
+        set(),
+        set(),
+        DummyVisitor(),
+        DummyVisitor(),
+        [],
+        [],
+        [],
+        None,
+        None,
+        config,
+        [],
+    )
+
+
+def scan_kotlin_file(
+    file_path: str,
+    config: dict | None = None,
+    *,
+    enable_danger_rules: bool = True,
+) -> tuple:
+    if config is None:
+        config = {}
+
+    try:
+        path = Path(file_path)
+        if path.suffix.lower() not in {".kt", ".kts"}:
+            raise ValueError("unsupported Kotlin path")
+        source = read_text_no_symlink(
+            path,
+            max_bytes=MAX_KOTLIN_SOURCE_BYTES,
+            encoding="utf-8",
+            errors="ignore",
+        )
+        if source is None:
+            raise ValueError("unreadable Kotlin source path")
+    except Exception:
+        return _empty_result(config)
+
+    defs, refs, raw_imports = scan_symbols(str(path), source)
+    test_decorated_lines = {
+        definition.line
+        for definition in defs
+        if "@Test" in getattr(definition, "decorators", [])
+    }
+    visitor = DummyVisitor(
+        is_test_file=_is_test_path(path),
+        test_decorated_lines=test_decorated_lines,
+    )
+
+    return (
+        defs,
+        refs,
+        set(),
+        set(),
+        visitor,
+        DummyVisitor(),
+        [],
+        [],
+        [],
+        None,
+        None,
+        config,
+        raw_imports,
+    )
+
+
+def _is_test_path(path: Path) -> bool:
+    normalized = str(path).lower().replace("\\", "/")
+    return "/test/" in normalized or normalized.endswith("test.kt")
+
+
+__all__ = ["scan_kotlin_file"]

--- a/skylos/visitors/languages/kotlin/_lex.py
+++ b/skylos/visitors/languages/kotlin/_lex.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import re
+
+_TOKEN_RE = re.compile(
+    r'''
+    //[^\n]*
+    |/\*.*?\*/
+    |"""[\s\S]*?"""
+    |"(?:\\.|[^"\\])*"
+    |'(?:\\.|[^'\\])*'
+    ''',
+    re.DOTALL | re.VERBOSE,
+)
+
+
+def matching_brace(text: str, open_brace: int) -> int:
+    depth = 0
+    for index in range(open_brace, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+def mask_comments_and_strings(source: str) -> str:
+    return _TOKEN_RE.sub(_mask_token, source)
+
+
+def _mask_token(match: re.Match[str]) -> str:
+    return "".join("\n" if char == "\n" else " " for char in match.group(0))

--- a/skylos/visitors/languages/kotlin/core.py
+++ b/skylos/visitors/languages/kotlin/core.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from skylos.visitors.base import Definition
+from skylos.visitors.languages.kotlin._lex import mask_comments_and_strings
+from skylos.visitors.languages.kotlin._lex import matching_brace
+
+_IDENT = r"(?:`[^`]+`|[A-Za-z_]\w*)"
+_ANNOTATION_PREFIX = (
+    r"(?P<annotations>"
+    r"(?:(?:@[^\n]+\n\s*)|(?:@[A-Za-z_][\w.]*(?:\([^()\n]*\))?\s+))*"
+    r")"
+)
+_MODIFIER = (
+    "public|private|protected|internal|data|sealed|open|abstract|final|value|"
+    "annotation|inner|companion|override|suspend|inline|tailrec|operator|infix|"
+    "external|expect|actual"
+)
+_TYPE_RE = re.compile(
+    rf"(?m)^\s*{_ANNOTATION_PREFIX}"
+    rf"(?P<mods>(?:(?:{_MODIFIER})\s+)*)"
+    rf"(?P<kind>enum\s+class|class|interface|object)\s+"
+    rf"(?P<name>{_IDENT})"
+)
+_FUNCTION_RE = re.compile(
+    rf"(?m)^\s*{_ANNOTATION_PREFIX}"
+    rf"(?P<mods>(?:(?:{_MODIFIER})\s+)*)"
+    rf"fun\s+(?:<[^>\n]+>\s*)?"
+    rf"(?:(?:{_IDENT})(?:<[^>\n]+>)?\s*\.\s*)?"
+    rf"(?P<name>{_IDENT})\s*\("
+)
+_IMPORT_RE = re.compile(
+    rf"(?m)^\s*import\s+(?P<path>[A-Za-z_][\w.]*(?:\.\*)?|\*)"
+    rf"(?:\s+as\s+(?P<alias>{_IDENT}))?"
+)
+_CALL_RE = re.compile(rf"\b(?P<name>{_IDENT})\s*\(")
+_ANNOTATION_RE = re.compile(r"@(?:[A-Za-z_]\w*:)?(?P<name>[A-Za-z_][\w.]*)")
+
+_CLASS_KIND = "class"
+_NON_CALL_KEYWORDS = {
+    "catch",
+    "constructor",
+    "else",
+    "for",
+    "if",
+    "return",
+    "super",
+    "this",
+    "throw",
+    "try",
+    "when",
+    "while",
+}
+_ROOT_ANNOTATIONS = {
+    "Bean",
+    "Composable",
+    "Controller",
+    "GetMapping",
+    "PostMapping",
+    "RestController",
+    "Test",
+}
+_LIFECYCLE_METHODS = {
+    "main",
+    "onCreate",
+    "onStart",
+    "onResume",
+    "onPause",
+    "onStop",
+    "onDestroy",
+    "onRestart",
+    "onCreateView",
+    "onViewCreated",
+}
+
+
+@dataclass
+class _RefState:
+    file_path: str
+    refs: list[tuple[str, str]] = field(default_factory=list)
+    seen: set[tuple[str, int]] = field(default_factory=set)
+
+
+def scan_symbols(
+    file_path: str, source: str
+) -> tuple[list[Definition], list[tuple[str, str]], list[dict]]:
+    masked = mask_comments_and_strings(source)
+    type_ranges = _type_ranges(masked)
+    type_defs = _type_defs(file_path, source, masked)
+    function_defs, declaration_offsets = _function_defs(
+        file_path,
+        source,
+        masked,
+        type_ranges,
+    )
+    import_defs, raw_imports = _import_defs(file_path, source, masked)
+    declaration_offsets.update(_type_declaration_offsets(masked))
+    refs = _refs(file_path, masked, declaration_offsets)
+    return type_defs + function_defs + import_defs, refs, raw_imports
+
+
+def _type_defs(file_path: str, source: str, masked: str) -> list[Definition]:
+    defs: list[Definition] = []
+    for match in _TYPE_RE.finditer(masked):
+        name = _clean_identifier(match.group("name"))
+        line = _line_for_offset(source, match.start("name"))
+        definition = Definition(name, _CLASS_KIND, file_path, line)
+        definition.decorators = _decorators(match.group("annotations"))
+        definition.is_exported = _is_visible_outside_file(match.group("mods"))
+        if definition.is_exported:
+            definition.references = 1
+        defs.append(definition)
+    return defs
+
+
+def _function_defs(
+    file_path: str,
+    source: str,
+    masked: str,
+    type_ranges: list[tuple[int, int, str]],
+) -> tuple[list[Definition], set[int]]:
+    defs: list[Definition] = []
+    declaration_offsets: set[int] = set()
+    for match in _FUNCTION_RE.finditer(masked):
+        name = _clean_identifier(match.group("name"))
+        if name in _NON_CALL_KEYWORDS:
+            continue
+
+        declaration_offsets.add(match.start("name"))
+        owner = _containing_type(type_ranges, match.start())
+        kind = "method" if owner else "function"
+        full_name = f"{owner}.{name}" if owner else name
+        line = _line_for_offset(source, match.start("name"))
+        definition = Definition(full_name, kind, file_path, line)
+        definition.decorators = _decorators(match.group("annotations"))
+        definition.is_exported = _is_function_exported(
+            name,
+            match.group("mods"),
+            definition.decorators,
+        )
+        if definition.is_exported:
+            definition.references = 1
+        defs.append(definition)
+    return defs, declaration_offsets
+
+
+def _import_defs(
+    file_path: str,
+    source: str,
+    masked: str,
+) -> tuple[list[Definition], list[dict]]:
+    defs: list[Definition] = []
+    raw_imports: list[dict] = []
+    for match in _IMPORT_RE.finditer(masked):
+        import_path = match.group("path")
+        alias = match.group("alias")
+        names = _imported_names(import_path, alias)
+        line = _line_for_offset(source, match.start())
+        for name in names:
+            defs.append(Definition(name, "import", file_path, line))
+        raw_imports.append({"source": import_path, "names": names, "line": line})
+    return defs, raw_imports
+
+
+def _refs(
+    file_path: str,
+    masked: str,
+    declaration_offsets: set[int],
+) -> list[tuple[str, str]]:
+    state = _RefState(file_path=file_path)
+    for match in _CALL_RE.finditer(masked):
+        name = _clean_identifier(match.group("name"))
+        if _skip_call_ref(name, match.start("name"), declaration_offsets):
+            continue
+        _append_ref(name, match.start("name"), state)
+    for match in _ANNOTATION_RE.finditer(masked):
+        name = match.group("name").split(".")[-1]
+        _append_ref(name, match.start("name"), state)
+    return state.refs
+
+
+def _type_declaration_offsets(masked: str) -> set[int]:
+    offsets: set[int] = set()
+    for match in _TYPE_RE.finditer(masked):
+        offsets.add(match.start("name"))
+    return offsets
+
+
+def _type_ranges(masked: str) -> list[tuple[int, int, str]]:
+    ranges: list[tuple[int, int, str]] = []
+    for match in _TYPE_RE.finditer(masked):
+        open_brace = masked.find("{", match.end())
+        if open_brace == -1:
+            continue
+        close_brace = matching_brace(masked, open_brace)
+        if close_brace == -1:
+            continue
+        ranges.append((open_brace, close_brace, _clean_identifier(match.group("name"))))
+    return ranges
+
+
+def _containing_type(ranges: list[tuple[int, int, str]], offset: int) -> str | None:
+    candidates = []
+    for start, end, name in ranges:
+        if start <= offset <= end:
+            candidates.append((start, end, name))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[2]
+
+
+def _decorators(annotation_text: str | None) -> list[str]:
+    if not annotation_text:
+        return []
+    names: list[str] = []
+    for match in _ANNOTATION_RE.finditer(annotation_text):
+        names.append("@" + match.group("name").split(".")[-1])
+    return names
+
+
+def _is_function_exported(
+    name: str,
+    modifiers: str | None,
+    decorators: list[str],
+) -> bool:
+    decorator_names = {decorator.lstrip("@") for decorator in decorators}
+    if decorator_names & _ROOT_ANNOTATIONS:
+        return True
+    if "Override" in decorator_names:
+        return True
+    if name in _LIFECYCLE_METHODS:
+        return True
+    return _is_visible_outside_file(modifiers)
+
+
+def _is_visible_outside_file(modifiers: str | None) -> bool:
+    modifier_set = set((modifiers or "").split())
+    return "private" not in modifier_set
+
+
+def _imported_names(import_path: str, alias: str | None) -> list[str]:
+    if alias:
+        return [_clean_identifier(alias)]
+    if import_path.endswith(".*") or import_path == "*":
+        return []
+    leaf = import_path.rsplit(".", 1)[-1]
+    if not leaf:
+        return []
+    return [_clean_identifier(leaf)]
+
+
+def _skip_call_ref(
+    name: str,
+    offset: int,
+    declaration_offsets: set[int],
+) -> bool:
+    return offset in declaration_offsets or name in _NON_CALL_KEYWORDS
+
+
+def _append_ref(
+    name: str,
+    offset: int,
+    state: _RefState,
+) -> None:
+    if not name:
+        return
+    key = (name, offset)
+    if key in state.seen:
+        return
+    state.seen.add(key)
+    state.refs.append((name, state.file_path))
+
+
+def _clean_identifier(name: str) -> str:
+    cleaned = name.strip()
+    if cleaned.startswith("`") and cleaned.endswith("`"):
+        return cleaned[1:-1]
+    return cleaned
+
+
+def _line_for_offset(source: str, offset: int) -> int:
+    return source.count("\n", 0, max(offset, 0)) + 1

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -247,6 +247,8 @@ class TestSkylos:
                 ".rs",
                 ".dart",
                 ".cs",
+                ".kt",
+                ".kts",
                 *SHELL_SOURCE_EXTS,
             },
             exclude_folders=None,

--- a/test/test_kotlin.py
+++ b/test/test_kotlin.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skylos.analyzer import analyze, proc_file
+from skylos.visitors.languages.kotlin import scan_kotlin_file
+
+
+def _scan_kotlin(tmp_path: Path, code: str, filename: str = "src/main/App.kt") -> tuple:
+    file_path = tmp_path / filename
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(code, encoding="utf-8")
+    return scan_kotlin_file(str(file_path), {})
+
+
+def test_kotlin_scanner_collects_defs_refs_and_raw_imports(tmp_path):
+    defs, refs, _, _, visitor, _, quality, danger, _, _, _, _, raw_imports = (
+        _scan_kotlin(
+            tmp_path,
+            """
+package demo
+
+import com.acme.Service
+import com.acme.Legacy as OldService
+
+class Controller {
+    fun publicApi() {
+        privateUsed()
+    }
+
+    private fun privateUsed() {}
+    private fun privateDead() {}
+}
+
+fun main() {
+    Controller().publicApi()
+    topUsed()
+}
+
+private fun topUsed() {}
+private fun topDead() {}
+""",
+        )
+    )
+
+    def_names = {definition.name for definition in defs}
+    ref_names = {ref[0] for ref in refs}
+    exported = {definition.name for definition in defs if definition.is_exported}
+
+    assert "Service" in def_names
+    assert "OldService" in def_names
+    assert "Controller" in def_names
+    assert "Controller.publicApi" in def_names
+    assert "Controller.privateUsed" in def_names
+    assert "Controller.privateDead" in def_names
+    assert "main" in def_names
+    assert "topUsed" in def_names
+    assert "topDead" in def_names
+
+    assert "Controller" in ref_names
+    assert "publicApi" in ref_names
+    assert "privateUsed" in ref_names
+    assert "topUsed" in ref_names
+
+    assert "Controller" in exported
+    assert "Controller.publicApi" in exported
+    assert "main" in exported
+    assert "Controller.privateDead" not in exported
+    assert "topDead" not in exported
+
+    assert visitor.is_test_file is False
+    assert quality == []
+    assert danger == []
+    assert raw_imports == [
+        {"source": "com.acme.Service", "names": ["Service"], "line": 3},
+        {"source": "com.acme.Legacy", "names": ["OldService"], "line": 5},
+    ]
+
+
+def test_kotlin_test_annotation_marks_function_as_test_entrypoint(tmp_path):
+    defs, refs, _, _, visitor, _, _, _, _, _, _, _, _ = _scan_kotlin(
+        tmp_path,
+        """
+import kotlin.test.Test
+
+class ControllerTest {
+    @Test
+    fun loadsUser() {}
+}
+""",
+        filename="src/test/ControllerTest.kt",
+    )
+
+    test_method = next(definition for definition in defs if _is_loads_user(definition))
+
+    assert test_method.is_exported is True
+    assert visitor.is_test_file is True
+    assert visitor.test_decorated_lines == {test_method.line}
+    assert ("Test", str(tmp_path / "src/test/ControllerTest.kt")) in refs
+
+
+def test_proc_file_dispatches_kotlin_to_kotlin_scanner(tmp_path):
+    file_path = tmp_path / "Main.kt"
+    file_path.write_text("fun main() {}\n", encoding="utf-8")
+
+    out = proc_file(str(file_path))
+    defs = out[0]
+
+    assert any(definition.name == "main" for definition in defs)
+
+
+def test_analyze_kotlin_reports_language_summary_and_dead_code(tmp_path):
+    file_path = tmp_path / "Main.kt"
+    file_path.write_text(
+        """
+fun main() {
+    used()
+}
+
+private fun used() {}
+private fun unusedPrivate() {}
+""",
+        encoding="utf-8",
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=60, grep_verify=False))
+    unused = {item["full_name"] for item in result["unused_functions"]}
+
+    assert result["analysis_summary"]["languages"] == {"Kotlin": 1}
+    assert "unusedPrivate" in unused
+    assert "used" not in unused
+
+
+def _is_loads_user(definition) -> bool:
+    return definition.name == "ControllerTest.loadsUser"


### PR DESCRIPTION
## Summary
  - add a very thin Kotlin dead code scanner for `.kt` and `.kts` files
  - collect Kotlin classes, objects, interfaces, functions, methods, imports, calls, constructors, and annotation refs
  - wire Kotlin into analyzer discovery, language summaries, and `proc_file` dispatch
  - add Kotlin scanner and analyzer dispatch tests