### PR TITLE
feat(dead-code): add Kotlin grep verification support

### DIFF
--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -18,6 +18,7 @@ _JAVA_EXTS = {".java"}
 _PHP_EXTS = {".php"}
 _RUST_EXTS = {".rs"}
 _DART_EXTS = {".dart"}
+_KOTLIN_EXTS = {".kt", ".kts"}
 
 _ALL_SOURCE_GLOBS = [
     "*.py",
@@ -33,6 +34,8 @@ _ALL_SOURCE_GLOBS = [
     "*.php",
     "*.rs",
     "*.dart",
+    "*.kt",
+    "*.kts",
     "*.rst",
     "*.md",
     "*.yaml",
@@ -51,6 +54,7 @@ _LANG_GLOBS: dict[str, list[str]] = {
     "php": ["*.php"],
     "rust": ["*.rs"],
     "dart": ["*.dart"],
+    "kotlin": ["*.kt", "*.kts"],
 }
 
 _IGNORED_GREP_PATH_PARTS = (
@@ -95,6 +99,8 @@ def detect_language(file_path: str) -> str:
         return "rust"
     if ext in _DART_EXTS:
         return "dart"
+    if ext in _KOTLIN_EXTS:
+        return "kotlin"
     return "python"
 
 
@@ -274,6 +280,21 @@ def module_candidates(file_path: str, project_root: str | Path) -> list[str]:
             parts = parts[1:]
         return ["::".join(parts)] if parts else []
 
+    elif lang == "kotlin":
+        if rel.endswith(".kts"):
+            stem = rel[:-4]
+        elif rel.endswith(".kt"):
+            stem = rel[:-3]
+        else:
+            return []
+        parts = [p for p in stem.split("/") if p]
+        for prefix in ("src/main/kotlin", "src/test/kotlin", "src"):
+            prefix_parts = prefix.split("/")
+            if parts[: len(prefix_parts)] == prefix_parts:
+                parts = parts[len(prefix_parts) :]
+                break
+        return [".".join(parts)] if parts else []
+
     return []
 
 
@@ -357,6 +378,13 @@ def is_definition_line(grep_line: str, finding: dict) -> bool:
         f"trait {simple_name}",
         f"pub trait {simple_name}",
         f"impl {simple_name}",
+        # Kotlin
+        f"fun {simple_name}",
+        f"private fun {simple_name}",
+        f"class {simple_name}",
+        f"object {simple_name}",
+        f"interface {simple_name}",
+        f"enum class {simple_name}",
     ]
     for pattern in definition_patterns:
         if pattern in content:

--- a/skylos/core/grep_verify_language_strategies.py
+++ b/skylos/core/grep_verify_language_strategies.py
@@ -82,6 +82,18 @@ def _deterministic_suppress_rust(finding: dict) -> bool:
     return False
 
 
+def _deterministic_suppress_kotlin(finding: dict) -> bool:
+    decorators = finding.get("decorators", [])
+    if not isinstance(decorators, list):
+        return False
+
+    root_annotations = {"@Test", "@Override", "@Composable"}
+    for decorator in decorators:
+        if str(decorator).strip() in root_annotations:
+            return True
+    return False
+
+
 def _deterministic_suppress_multilang(finding: dict) -> bool:
     lang = detect_language(finding.get("file", ""))
     if lang == "typescript":
@@ -94,6 +106,8 @@ def _deterministic_suppress_multilang(finding: dict) -> bool:
         return _deterministic_suppress_php(finding)
     elif lang == "rust":
         return _deterministic_suppress_rust(finding)
+    elif lang == "kotlin":
+        return _deterministic_suppress_kotlin(finding)
     return False
 
 

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -618,6 +618,10 @@ class TestDetectLanguage:
     def test_rust(self):
         assert detect_language("lib.rs") == "rust"
 
+    def test_kotlin(self):
+        assert detect_language("Main.kt") == "kotlin"
+        assert detect_language("build.gradle.kts") == "kotlin"
+
     def test_unknown_defaults_python(self):
         assert detect_language("data.csv") == "python"
         assert detect_language("") == "python"
@@ -760,6 +764,15 @@ class TestDeterministicSuppressMultiLang:
         }
         assert _deterministic_suppress_multilang(finding)
 
+    def test_kotlin_test_annotation(self):
+        finding = {
+            "file": "UserTest.kt",
+            "simple_name": "loadsUser",
+            "type": "function",
+            "decorators": ["@Test"],
+        }
+        assert _deterministic_suppress_multilang(finding)
+
     def test_python_not_suppressed(self):
         finding = {
             "file": "main.py",
@@ -787,6 +800,11 @@ class TestSourceGlobs:
     def test_php_globs(self):
         globs = source_globs_for_language("php")
         assert "*.php" in globs
+
+    def test_kotlin_globs(self):
+        globs = source_globs_for_language("kotlin")
+        assert "*.kt" in globs
+        assert "*.kts" in globs
 
     def test_unknown_defaults_python(self):
         globs = source_globs_for_language("unknown")


### PR DESCRIPTION
## Summary
  - add Kotlin `.kt` / `.kts` detection to grep verification
  - add Kotlin source globs and module candidates for `src/main/kotlin` and `src/test/kotlin`
  - recognise Kotlin definition lines for functions, classes, objects, interfaces, and enum classes
  - suppress Kotlin framework/test roots such as `@Test`, `@Override`, and `@Composable`

  ## Tests
  - `pytest .`