### PR TITLE
feat(secrets): scan Kotlin source files

### DIFF
--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -44,6 +44,8 @@ ALLOWED_FILE_SUFFIXES = (
     ".php",
     ".rs",
     ".dart",
+    ".kt",
+    ".kts",
 )
 
 PROVIDER_PATTERNS = [

--- a/test/test_secrets_nonpy.py
+++ b/test/test_secrets_nonpy.py
@@ -31,6 +31,10 @@ class TestAllowedSuffixes:
     def test_dart_suffix_allowed(self):
         assert ".dart" in ALLOWED_FILE_SUFFIXES
 
+    def test_kotlin_suffixes_allowed(self):
+        assert ".kt" in ALLOWED_FILE_SUFFIXES
+        assert ".kts" in ALLOWED_FILE_SUFFIXES
+
 
 class TestEnvFileScanning:
     def test_detects_aws_key_in_env(self):


### PR DESCRIPTION
## Summary
  - include `.kt` and `.kts` files in secret scanning
  - add suffix coverage tests for Kotlin source files

  ## Tests
  - `pytest test/test_secrets_nonpy.py`