### PR TITLE
docs(kotlin): list Kotlin in public metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## What Is Skylos?
 
 Skylos is an open-source static analysis CLI for Python, TypeScript,
-JavaScript, Java, Go, PHP, Rust, Dart, C#, Shell, and deployment config. It
+JavaScript, Java, Go, Kotlin, PHP, Rust, Dart, C#, Shell, and deployment config. It
 runs locally by default and can also be used as a CI/CD PR gate.
 
 Use Skylos when you want one command to check a repo or pull request for:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "skylos"
 version = "4.23.1"
 requires-python = ">=3.10"
-description = "Open-source, local-first static analysis and PR gates for Python, TypeScript/JavaScript, Go, Java, PHP, Rust, Dart, C#, and Shell. Finds dead code, security issues, secrets, quality regressions, and AI-code mistakes."
+description = "Open-source, local-first static analysis and PR gates for Python, TypeScript/JavaScript, Go, Java, Kotlin, PHP, Rust, Dart, C#, and Shell. Finds dead code, security issues, secrets, quality regressions, and AI-code mistakes."
 authors = [{name = "Aaron Oh", email = "aaronoh2015@gmail.com"}]
 readme = "README.md"
 license = "Apache-2.0"

--- a/skylos/agents/center.py
+++ b/skylos/agents/center.py
@@ -46,6 +46,8 @@ SUPPORTED_EXTENSIONS = {
     ".php",
     ".rs",
     ".dart",
+    ".kt",
+    ".kts",
 }
 
 

--- a/skylos/audit/candidates.py
+++ b/skylos/audit/candidates.py
@@ -45,6 +45,8 @@ DEEP_AUDIT_EXTENSIONS = (
     ".rs",
     ".dart",
     ".cs",
+    ".kt",
+    ".kts",
     ".env",
     ".yaml",
     ".yml",

--- a/skylos/audit/types.py
+++ b/skylos/audit/types.py
@@ -88,6 +88,8 @@ def language_for_path(path: str | Path) -> str:
         ".rs": "rust",
         ".dart": "dart",
         ".cs": "csharp",
+        ".kt": "kotlin",
+        ".kts": "kotlin",
         ".env": "env",
         ".yaml": "yaml",
         ".yml": "yaml",

--- a/skylos/benchmarks/dead_code.py
+++ b/skylos/benchmarks/dead_code.py
@@ -74,6 +74,7 @@ SUPPORTED_LANGUAGES = {
     "rust",
     "dart",
     "csharp",
+    "kotlin",
 }
 SCANNER_LANGUAGE_SUPPORT = {
     "skylos": SUPPORTED_LANGUAGES,

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -4228,6 +4228,8 @@ def main() -> None:
                     ".php",
                     ".rs",
                     ".dart",
+                    ".kt",
+                    ".kts",
                 }
                 config_exts = {
                     ".yaml",

--- a/skylos/cli_core/main_parser.py
+++ b/skylos/cli_core/main_parser.py
@@ -8,7 +8,7 @@ def build_main_parser(*, version: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Find dead code, secrets, and risky flows in Python, JS/TS, Go, "
-            "Java, PHP, Rust, Dart, and C#"
+            "Java, Kotlin, PHP, Rust, Dart, and C#"
         ),
         epilog="""
 Run 'skylos commands' for a full list of all available commands.

--- a/skylos/core/result_cache.py
+++ b/skylos/core/result_cache.py
@@ -59,6 +59,8 @@ SOURCE_EXTENSIONS = {
     ".php",
     ".rs",
     ".dart",
+    ".kt",
+    ".kts",
 }
 
 RELEVANT_FILENAMES = {

--- a/skylos/llm/cleanup_orchestrator.py
+++ b/skylos/llm/cleanup_orchestrator.py
@@ -43,6 +43,8 @@ CODE_EXTENSIONS = {
     ".java",
     ".php",
     ".dart",
+    ".kt",
+    ".kts",
 }
 
 MAX_FILE_SIZE = 100_000  # bytes

--- a/skylos/remediation/fixgen.py
+++ b/skylos/remediation/fixgen.py
@@ -44,11 +44,13 @@ _BRACE_LANG_EXTS = {
     ".rs": "rust",
     ".java": "java",
     ".dart": "dart",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
 }
 
 
 def _find_brace_block_end(lines: list[str], start_idx: int) -> int:
-    """Find the end of a brace-delimited block (TS/Go/Java/Rust).
+    """Find the end of a brace-delimited block.
 
     Scans from *start_idx* forward, tracking ``{`` / ``}`` nesting.
     Returns the 0-indexed line of the closing ``}``.
@@ -161,7 +163,7 @@ def _validate_file(file_path: str, content: str) -> list[str]:
         return _validate_go_syntax(file_path, content)
     if ext == ".rs":
         return _validate_rust_syntax(file_path, content)
-    if ext in {".java", ".dart"}:
+    if ext in {".java", ".dart", ".kt", ".kts"}:
         return _check_brace_balance(file_path, content)
     return []
 

--- a/skylos/reporting/grader.py
+++ b/skylos/reporting/grader.py
@@ -66,6 +66,8 @@ _COMMENT_PREFIXES: dict[str, str] = {
     ".php": "//",
     ".rs": "//",
     ".dart": "//",
+    ".kt": "//",
+    ".kts": "//",
 }
 
 


### PR DESCRIPTION
## Summary

  - Add Kotlin to the README supported language list
  - Add Kotlin to the package metadata description in `pyproject.toml`
  - Add Kotlin to the CLI help & parser description

  ## Notes

  This is a metadata and docs follow up for the Kotlin support work.