### PR TITLE
fix(dead-code): reduce Python framework false positives

### DIFF
--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -10,6 +10,9 @@ from skylos.analysis.control_flow import (
     extract_constant_string,
 )
 from skylos.analysis.implicit_refs import pattern_tracker
+from skylos.visitors.registration_decorators import (
+    collect_local_registration_decorators,
+)
 from typing import Any, Optional, Union
 
 PYTHON_BUILTINS = {
@@ -391,6 +394,7 @@ class Visitor(ast.NodeVisitor):
         self._used_attr_names = set()
         self._used_attr_names_with_context = set()
         self._conditional_import_targets = set()
+        self.local_registration_decorators = set()
 
     def add_def(
         self, name: str, t: str, line: int, node: Optional[ast.AST] = None, **extra: Any
@@ -427,6 +431,13 @@ class Visitor(ast.NodeVisitor):
         if self._current_function_qname:
             self.call_graph[self._current_function_qname].add(name)
             self.reverse_call_graph[name].add(self._current_function_qname)
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self.local_registration_decorators.update(
+            collect_local_registration_decorators(node)
+        )
+        for stmt in node.body:
+            self.visit(stmt)
 
     def qual(self, name: str) -> str:
         if name in self.alias:
@@ -485,7 +496,12 @@ class Visitor(ast.NodeVisitor):
                 target = head
 
             self.alias[alias_name] = target
-            self.add_def(target, "import", node.lineno)
+            self.add_def(
+                target,
+                "import",
+                node.lineno,
+                is_exported=a.asname == a.name if a.asname else False,
+            )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         module = node.module
@@ -534,7 +550,12 @@ class Visitor(ast.NodeVisitor):
                 full = a.name
 
             self.alias[alias_name] = full
-            self.add_def(full, "import", node.lineno)
+            self.add_def(
+                full,
+                "import",
+                node.lineno,
+                is_exported=a.asname == a.name if a.asname else False,
+            )
 
     def visit_If(self, node: ast.If) -> None:
         from skylos.analysis.control_flow import (
@@ -841,6 +862,8 @@ class Visitor(ast.NodeVisitor):
                 elif any(
                     keyword in deco_name.lower() for keyword in FRAMEWORK_DECORATORS
                 ):
+                    self.add_ref(qualified_name)
+                elif deco_name in self.local_registration_decorators:
                     self.add_ref(qualified_name)
 
         if self.current_function_scope and self.local_var_maps:
@@ -2157,21 +2180,26 @@ class Visitor(ast.NodeVisitor):
                 self.add_ref(self.qual(tok))
 
     def visit_arguments(self, args: ast.arguments) -> None:
-        for arg in args.args:
-            self.visit_annotation(arg.annotation)
-        for arg in args.posonlyargs:
-            self.visit_annotation(arg.annotation)
-        for arg in args.kwonlyargs:
-            self.visit_annotation(arg.annotation)
-        if args.vararg:
-            self.visit_annotation(args.vararg.annotation)
-        if args.kwarg:
-            self.visit_annotation(args.kwarg.annotation)
-        for default in args.defaults:
-            self.visit(default)
-        for default in args.kw_defaults:
-            if default:
+        current_params = self.current_function_params
+        self.current_function_params = []
+        try:
+            for arg in args.args:
+                self.visit_annotation(arg.annotation)
+            for arg in args.posonlyargs:
+                self.visit_annotation(arg.annotation)
+            for arg in args.kwonlyargs:
+                self.visit_annotation(arg.annotation)
+            if args.vararg:
+                self.visit_annotation(args.vararg.annotation)
+            if args.kwarg:
+                self.visit_annotation(args.kwarg.annotation)
+            for default in args.defaults:
                 self.visit(default)
+            for default in args.kw_defaults:
+                if default:
+                    self.visit(default)
+        finally:
+            self.current_function_params = current_params
 
     def _annotation_to_string(self, node: ast.expr) -> Optional[str]:
         if isinstance(node, ast.Name):

--- a/skylos/visitors/registration_decorators.py
+++ b/skylos/visitors/registration_decorators.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import ast
+
+
+_REGISTRATION_METHOD_NAMES = {
+    "add",
+    "append",
+    "connect",
+    "listen",
+    "register",
+    "register_type_strategy",
+    "setdefault",
+}
+
+
+def collect_local_registration_decorators(node: ast.Module) -> set[str]:
+    decorators = set()
+    for stmt in node.body:
+        if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if _is_registration_decorator(stmt):
+            decorators.add(stmt.name)
+    return decorators
+
+
+def _is_registration_decorator(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    param_names = _positional_param_names(node)
+    if not param_names:
+        return False
+
+    direct_param = param_names[0]
+    if _function_registers_name(node, direct_param):
+        return _function_returns_name(node, direct_param)
+
+    returned_inner_names = _returned_local_function_names(node)
+    if not returned_inner_names:
+        return False
+
+    for stmt in node.body:
+        if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if stmt.name not in returned_inner_names:
+            continue
+        nested_params = _positional_param_names(stmt)
+        if not nested_params:
+            continue
+        registered_param = nested_params[0]
+        if _function_registers_name(stmt, registered_param) and _function_returns_name(
+            stmt, registered_param
+        ):
+            return True
+
+    return False
+
+
+def _positional_param_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    args = []
+    args.extend(node.args.posonlyargs)
+    args.extend(node.args.args)
+    return [arg.arg for arg in args]
+
+
+def _function_returns_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, name: str
+) -> bool:
+    for child in _iter_function_body_nodes(node):
+        if isinstance(child, ast.Return) and isinstance(child.value, ast.Name):
+            if child.value.id == name:
+                return True
+    return False
+
+
+def _returned_local_function_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str]:
+    local_functions = {
+        stmt.name
+        for stmt in node.body
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    returned = set()
+    for stmt in node.body:
+        if not isinstance(stmt, ast.Return):
+            continue
+        if isinstance(stmt.value, ast.Name) and stmt.value.id in local_functions:
+            returned.add(stmt.value.id)
+    return returned
+
+
+def _function_registers_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, name: str
+) -> bool:
+    for child in _iter_function_body_nodes(node):
+        if _is_registration_assignment(child, name):
+            return True
+        if _is_registration_call(child, name):
+            return True
+    return False
+
+
+def _iter_function_body_nodes(node: ast.FunctionDef | ast.AsyncFunctionDef):
+    stack = list(reversed(node.body))
+    while stack:
+        current = stack.pop()
+        yield current
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(current))))
+
+
+def _is_registration_assignment(node: ast.AST, name: str) -> bool:
+    if isinstance(node, ast.Assign):
+        return _assignment_registers_name(node.targets, node.value, name)
+    if isinstance(node, ast.AnnAssign):
+        return _assignment_registers_name([node.target], node.value, name)
+    return False
+
+
+def _assignment_registers_name(
+    targets: list[ast.expr], value: ast.AST | None, name: str
+) -> bool:
+    if value is None:
+        return False
+    if not _expr_mentions_name(value, name):
+        return False
+    return any(_is_registry_target(target) for target in targets)
+
+
+def _is_registry_target(node: ast.AST) -> bool:
+    return isinstance(node, (ast.Subscript, ast.Attribute))
+
+
+def _is_registration_call(node: ast.AST, name: str) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+
+    call_name = _call_name(node.func)
+    simple_name = call_name.rsplit(".", 1)[-1]
+    if simple_name not in _REGISTRATION_METHOD_NAMES:
+        return False
+
+    for arg in node.args:
+        if _expr_mentions_name(arg, name):
+            return True
+    for keyword in node.keywords:
+        if _expr_mentions_name(keyword.value, name):
+            return True
+    return False
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _call_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    if isinstance(node, ast.Call):
+        return _call_name(node.func)
+    return ""
+
+
+def _expr_mentions_name(node: ast.AST, name: str) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name) and child.id == name:
+            return True
+    return False

--- a/test/test_changes_analyzer.py
+++ b/test/test_changes_analyzer.py
@@ -170,6 +170,38 @@ def regular_func(_param: str):
             "Parameter in test file should be suppressed"
         )
 
+    def test_explicit_same_name_import_alias_is_exported(self):
+        code = """
+from os import PathLike as PathLike
+import pathlib as pathlib
+import json
+"""
+        result = self._analyze(code)
+
+        import_names = {i["simple_name"] for i in result["unused_imports"]}
+
+        assert "PathLike" not in import_names
+        assert "pathlib" not in import_names
+        assert "json" in import_names
+
+    def test_annotation_metadata_uses_import_over_parameter_name(self):
+        code = """
+from __future__ import annotations
+from typing import Annotated, Any
+from typing_extensions import deprecated
+
+def path(
+    example: Annotated[Any | None, deprecated("use examples")] = None,
+    deprecated: bool = False,
+):
+    return deprecated
+"""
+        result = self._analyze(code)
+
+        import_names = {i["simple_name"] for i in result["unused_imports"]}
+
+        assert "deprecated" not in import_names
+
     def _analyze(self, code: str, filename: str = "example.py") -> dict:
         with tempfile.TemporaryDirectory() as temp_dir:
             file_path = Path(temp_dir) / filename

--- a/test/test_dynamic_patterns.py
+++ b/test/test_dynamic_patterns.py
@@ -316,6 +316,74 @@ p = Permission.READ | Permission.WRITE
         assert "EXECUTE" not in unused
 
 
+class TestLocalRegistrationDecorators:
+    def _get_unused_functions(self, code):
+        from skylos.analyzer import Skylos
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "mod.py"
+            p.write_text(code)
+            s = Skylos()
+            result = json.loads(s.analyze(tmpdir, thr=0, grep_verify=False))
+            return {item["simple_name"] for item in result["unused_functions"]}
+
+    def test_decorator_factory_registration_marks_function_used(self):
+        unused = self._get_unused_functions("""
+RESOLVERS = {}
+
+def resolves(kind):
+    def inner(func):
+        RESOLVERS[kind] = func
+        return func
+    return inner
+
+@resolves(str)
+def resolve_string(value):
+    return str(value)
+
+def unused_helper():
+    return None
+""")
+
+        assert "resolve_string" not in unused
+        assert "unused_helper" in unused
+
+    def test_direct_registration_decorator_marks_function_used(self):
+        unused = self._get_unused_functions("""
+COMMANDS = {}
+
+def command(func):
+    COMMANDS[func.__name__] = func
+    return func
+
+@command
+def serve():
+    return "ok"
+
+def unused_helper():
+    return None
+""")
+
+        assert "serve" not in unused
+        assert "unused_helper" in unused
+
+    def test_plain_wrapper_decorator_does_not_mask_unused_function(self):
+        unused = self._get_unused_functions("""
+def wraps(flag):
+    def inner(func):
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+    return inner
+
+@wraps(True)
+def still_dead():
+    return None
+""")
+
+        assert "still_dead" in unused
+
+
 class TestDefinitionReasonFields:
     def test_definition_has_new_fields(self):
         d = Definition("test.func", "function", "test.py", 1)


### PR DESCRIPTION
## Summary

  - Detect local registration decorators that store decorated functions in registries, covering patterns like Pydantic's `@resolves(...)`
  - Treat same name aliases like `from x import Y as Y` as public re-exports
  - Fix default expression scoping so imports used in `Annotated[..., helper(...)]` are not shadowed by same named parameters

  ## Tests

  - `pytest test/test_changes_analyzer.py test/test_dynamic_patterns.py`
