### PR TITLE
feat(corpus): add pinned framework corpus runner

### DIFF
--- a/benchmarks/dead_code/README.md
+++ b/benchmarks/dead_code/README.md
@@ -100,3 +100,14 @@ pytest fixtures, Pydantic validators, Alembic revisions, importlib plugins, and
 package console-script entrypoints. The cross-language cases currently cover Go
 HTTP handler reachability, Java application entrypoints and stale methods, and
 mixed TypeScript/JavaScript package reachability.
+
+For larger accuracy discovery against pinned upstream framework repositories,
+use `benchmarks/framework_corpus`:
+
+```bash
+python scripts/framework_corpus.py --checkout-root /private/tmp/skylos-biglib-scan
+```
+
+That runner is a manual/nightly drift signal, not the blocking CI suite. Promote
+confirmed real-repo false positives and false negatives into small fixtures here
+so the normal benchmark keeps exact TP/FP/FN/TN coverage.

--- a/benchmarks/dead_code/fixtures/annotation_metadata_scope/app.py
+++ b/benchmarks/dead_code/fixtures/annotation_metadata_scope/app.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+from typing_extensions import deprecated
+
+
+def build_path(
+    value: Annotated[Any | None, deprecated("use route_examples")] = None,
+    deprecated: bool = False,
+):
+    if deprecated:
+        return "legacy"
+    return value
+
+
+RESULT = build_path("demo")
+
+
+def unused_builder():
+    return "stale"

--- a/benchmarks/dead_code/fixtures/explicit_reexports/app.py
+++ b/benchmarks/dead_code/fixtures/explicit_reexports/app.py
@@ -1,0 +1,7 @@
+import json
+import pathlib as pathlib
+from os import PathLike as PathLike
+
+
+def unused_helper():
+    return "stale"

--- a/benchmarks/dead_code/fixtures/local_registration_decorator/app.py
+++ b/benchmarks/dead_code/fixtures/local_registration_decorator/app.py
@@ -1,0 +1,38 @@
+ACTIONS = {}
+STARTUP_CALLBACKS = []
+
+
+def action(name):
+    def decorator(func):
+        ACTIONS[name] = func
+        return func
+
+    return decorator
+
+
+def on_startup(func):
+    STARTUP_CALLBACKS.append(func)
+    return func
+
+
+@action("resize")
+def resize_image(payload):
+    return payload["image"]
+
+
+@action("archive")
+def archive_image(payload):
+    return payload["archive_id"]
+
+
+@on_startup
+def warm_cache():
+    return "ready"
+
+
+def dispatch(name, payload):
+    return ACTIONS[name](payload)
+
+
+def unused_action(payload):
+    return payload.get("stale")

--- a/benchmarks/dead_code/manifest.json
+++ b/benchmarks/dead_code/manifest.json
@@ -92,6 +92,97 @@
       }
     },
     {
+      "id": "local-registration-decorator-entrypoints",
+      "path": "fixtures/local_registration_decorator",
+      "description": "Locally defined decorators that register and return functions should keep decorated entrypoints alive while unregistered helpers are still reported.",
+      "taxonomy": ["dynamic_dispatch", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "Apache-2.0",
+        "notes": "Distilled from real Python framework code that registers handlers through project-local decorators."
+      },
+      "scan": {
+        "confidence": 0,
+        "grep_verify": true
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "unused": [
+          {"kind": "function", "file": "app.py", "symbol": "dispatch"},
+          {"kind": "function", "file": "app.py", "symbol": "unused_action"}
+        ],
+        "used": [
+          {"kind": "function", "file": "app.py", "symbol": "action"},
+          {"kind": "function", "file": "app.py", "symbol": "on_startup"},
+          {"kind": "function", "file": "app.py", "symbol": "resize_image"},
+          {"kind": "function", "file": "app.py", "symbol": "archive_image"},
+          {"kind": "function", "file": "app.py", "symbol": "warm_cache"}
+        ]
+      }
+    },
+    {
+      "id": "explicit-same-name-reexports",
+      "path": "fixtures/explicit_reexports",
+      "description": "Python explicit same-name aliases are public re-export signals and should not be reported as unused imports.",
+      "taxonomy": ["package_entrypoint", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pallets/click",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from package API modules that expose imports with `name as name` re-export aliases."
+      },
+      "scan": {
+        "confidence": 0,
+        "grep_verify": true
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "unused": [
+          {"kind": "import", "file": "app.py", "symbol": "json"},
+          {"kind": "function", "file": "app.py", "symbol": "unused_helper"}
+        ],
+        "used": [
+          {"kind": "import", "file": "app.py", "symbol": "pathlib"},
+          {"kind": "import", "file": "app.py", "symbol": "PathLike"}
+        ]
+      }
+    },
+    {
+      "id": "annotation-metadata-import-scope",
+      "path": "fixtures/annotation_metadata_scope",
+      "description": "Annotation metadata should bind to imported decorators even when a function parameter has the same leaf name.",
+      "taxonomy": ["pydantic", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/pydantic/pydantic",
+        "license": "MIT",
+        "notes": "Distilled from Annotated metadata patterns used by Pydantic and FastAPI."
+      },
+      "scan": {
+        "confidence": 0,
+        "grep_verify": true
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "unused": [
+          {"kind": "import", "file": "app.py", "symbol": "json"},
+          {"kind": "function", "file": "app.py", "symbol": "unused_builder"},
+          {"kind": "variable", "file": "app.py", "symbol": "RESULT"}
+        ],
+        "used": [
+          {"kind": "import", "file": "app.py", "symbol": "deprecated"},
+          {"kind": "function", "file": "app.py", "symbol": "build_path"}
+        ]
+      }
+    },
+    {
       "id": "sqlalchemy-mixed-models",
       "path": "fixtures/sqlalchemy_mixed_models",
       "description": "A realistic model module should report only the unreferenced SQLAlchemy model while keeping used models and ORM columns quiet.",

--- a/benchmarks/framework_corpus/README.md
+++ b/benchmarks/framework_corpus/README.md
@@ -1,0 +1,40 @@
+# Framework Corpus
+
+This is the pinned real-repo layer for Skylos dead-code accuracy work.
+
+The normal benchmark in `benchmarks/dead_code` is the blocking CI suite: small,
+labeled fixtures with exact TP/FP/FN/TN scoring. This corpus is deliberately
+larger and slower. It scans pinned upstream framework checkouts, compares the
+dead-code category counts against checked-in baselines, and lets us promote any
+confirmed FP or FN into a small fixture.
+
+The runner treats target repositories as untrusted input. It does not install
+dependencies, run tests, import target packages, or execute package scripts.
+
+## Run
+
+```bash
+python scripts/framework_corpus.py
+python scripts/framework_corpus.py --checkout-root /private/tmp/skylos-biglib-scan
+python scripts/framework_corpus.py --target fastapi --checkout-root /private/tmp/skylos-biglib-scan
+python scripts/framework_corpus.py --json --checkout-root /private/tmp/skylos-biglib-scan
+```
+
+Missing checkouts are skipped by default so this can run in developer
+environments without network access:
+
+```bash
+python scripts/framework_corpus.py --require-checkouts
+```
+
+## Accuracy Loop
+
+1. Pin a popular upstream repo and commit SHA in `manifest.json`.
+2. Scan only source paths, not generated artifacts or dependency directories.
+3. Manually inspect any surprising count change or known symbol anchor.
+4. If the issue is generic, add a distilled fixture under
+   `benchmarks/dead_code/fixtures`.
+5. Keep the real-repo baseline as a nightly/manual drift signal.
+
+This keeps CI deterministic while still using large real repositories to find
+framework conventions that small fixtures would miss.

--- a/benchmarks/framework_corpus/manifest.json
+++ b/benchmarks/framework_corpus/manifest.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "description": "Pinned real-repo framework corpus for manual and nightly Skylos dead-code accuracy checks. Checkouts are static inputs only; the runner does not install dependencies or execute target code.",
+  "targets": [
+    {
+      "id": "fastapi",
+      "repo": "https://github.com/fastapi/fastapi",
+      "ref": "5cdf820c8046edaf83c306ebd7435f038fc4a75a",
+      "checkout": "fastapi",
+      "license": "MIT",
+      "languages": ["python"],
+      "scan_paths": ["fastapi"],
+      "scan": {
+        "confidence": 60,
+        "grep_verify": true
+      },
+      "baseline": {
+        "counts": {
+          "unused_functions": 1,
+          "unused_imports": 0,
+          "unused_classes": 0,
+          "unused_variables": 4,
+          "unused_parameters": 1
+        },
+        "max_delta": 0,
+        "notes": "Baseline captured from the pinned checkout after Python registration-decorator, same-name re-export, and annotation-metadata precision fixes."
+      }
+    },
+    {
+      "id": "starlette",
+      "repo": "https://github.com/encode/starlette",
+      "ref": "70a3bd4276712f0ee11b161c8b14225a84316df1",
+      "checkout": "starlette",
+      "license": "BSD-3-Clause",
+      "languages": ["python"],
+      "scan_paths": ["starlette"],
+      "scan": {
+        "confidence": 60,
+        "grep_verify": true
+      },
+      "baseline": {
+        "counts": {
+          "unused_functions": 2,
+          "unused_imports": 0,
+          "unused_classes": 0,
+          "unused_variables": 0,
+          "unused_parameters": 0
+        },
+        "max_delta": 0,
+        "notes": "Baseline captured from the pinned checkout."
+      }
+    },
+    {
+      "id": "pydantic",
+      "repo": "https://github.com/pydantic/pydantic",
+      "ref": "718ef06e1062892128907f4f28e15f76ff1a38f9",
+      "checkout": "pydantic",
+      "license": "MIT",
+      "languages": ["python"],
+      "scan_paths": ["pydantic"],
+      "scan": {
+        "confidence": 60,
+        "grep_verify": true
+      },
+      "baseline": {
+        "counts": {
+          "unused_functions": 5,
+          "unused_imports": 3,
+          "unused_classes": 1,
+          "unused_variables": 8,
+          "unused_parameters": 2
+        },
+        "max_delta": 0,
+        "notes": "Baseline captured from the pinned checkout after annotation metadata precision fixes."
+      }
+    },
+    {
+      "id": "typer",
+      "repo": "https://github.com/fastapi/typer",
+      "ref": "4e10334990db4e7e1e9a71aff363bcae7f7fc76d",
+      "checkout": "typer",
+      "license": "MIT",
+      "languages": ["python"],
+      "scan_paths": ["typer"],
+      "scan": {
+        "confidence": 60,
+        "grep_verify": true
+      },
+      "baseline": {
+        "counts": {
+          "unused_functions": 1,
+          "unused_imports": 0,
+          "unused_classes": 1,
+          "unused_variables": 26,
+          "unused_parameters": 1
+        },
+        "max_delta": 0,
+        "notes": "Baseline captured from the pinned checkout."
+      }
+    },
+    {
+      "id": "click",
+      "repo": "https://github.com/pallets/click",
+      "ref": "8a1b1a33d739be05b7e91251e3c0dde77c5e152f",
+      "checkout": "click",
+      "license": "BSD-3-Clause",
+      "languages": ["python"],
+      "scan_paths": ["src/click"],
+      "scan": {
+        "confidence": 60,
+        "grep_verify": true
+      },
+      "baseline": {
+        "counts": {
+          "unused_functions": 2,
+          "unused_imports": 1,
+          "unused_classes": 0,
+          "unused_variables": 7,
+          "unused_parameters": 1
+        },
+        "max_delta": 0,
+        "notes": "Baseline captured from the pinned checkout after same-name re-export precision fixes."
+      }
+    }
+  ]
+}

--- a/scripts/framework_corpus.py
+++ b/scripts/framework_corpus.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from skylos.benchmarks.framework_corpus import (  # noqa: E402
+    format_summary,
+    run_manifest,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the pinned real-repo framework accuracy corpus."
+    )
+    parser.add_argument(
+        "--manifest",
+        default=str(REPO_ROOT / "benchmarks" / "framework_corpus" / "manifest.json"),
+        help="Path to the framework corpus manifest JSON file.",
+    )
+    parser.add_argument(
+        "--checkout-root",
+        default=None,
+        help="Directory containing pinned repo checkouts named by target checkout/id.",
+    )
+    parser.add_argument(
+        "--target",
+        action="append",
+        default=[],
+        help="Run only the specified target id. Repeat for multiple targets.",
+    )
+    parser.add_argument(
+        "--require-checkouts",
+        action="store_true",
+        help="Fail instead of skipping when a target checkout is missing.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of the text summary.",
+    )
+    args = parser.parse_args()
+
+    summary = run_manifest(
+        args.manifest,
+        checkout_root=args.checkout_root,
+        selected_targets=set(args.target),
+        require_checkouts=args.require_checkouts,
+    )
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(format_summary(summary))
+    if summary["failure_count"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skylos/benchmarks/framework_corpus.py
+++ b/skylos/benchmarks/framework_corpus.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from skylos.analyzer import analyze
+from skylos.benchmarks.framework_corpus_schema import (
+    DEAD_CODE_CATEGORIES,
+    FrameworkCorpusFailure,
+    load_manifest,
+    validate_manifest,
+)
+
+DEFAULT_CHECKOUT_ROOT = Path("/private/tmp/skylos-framework-corpus")
+DEFAULT_SCAN = {
+    "confidence": 60,
+    "grep_verify": True,
+}
+
+
+def _default_checkout_root(manifest: dict[str, Any]) -> Path:
+    env_root = os.environ.get("SKYLOS_FRAMEWORK_CORPUS_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve()
+
+    root = manifest.get("checkout_root")
+    if isinstance(root, str) and root.strip():
+        return Path(root).expanduser().resolve()
+
+    return DEFAULT_CHECKOUT_ROOT
+
+
+def _resolve_target_path(target: dict[str, Any], checkout_root: Path) -> Path:
+    checkout = target.get("checkout")
+    if not isinstance(checkout, str) or not checkout.strip():
+        checkout = target["id"]
+
+    path = Path(checkout).expanduser()
+    if path.is_absolute():
+        return path.resolve()
+    return (checkout_root / path).resolve()
+
+
+def _scan_paths(target: dict[str, Any], target_path: Path) -> list[Path]:
+    paths = []
+    raw_paths = target.get("scan_paths") or ["."]
+    for raw_path in raw_paths:
+        paths.append((target_path / raw_path).resolve())
+    return paths
+
+
+def _missing_paths(target: dict[str, Any], target_path: Path) -> list[Path]:
+    paths = []
+    if not target_path.exists():
+        paths.append(target_path)
+        return paths
+
+    for scan_path in _scan_paths(target, target_path):
+        if not scan_path.exists():
+            paths.append(scan_path)
+    return paths
+
+
+def _scan_target(target: dict[str, Any], target_path: Path) -> dict[str, Any]:
+    scan_cfg = dict(DEFAULT_SCAN)
+    scan_cfg.update(target.get("scan") or {})
+
+    scan_paths = _scan_paths(target, target_path)
+    if len(scan_paths) == 1:
+        scan_target: str | list[str] = str(scan_paths[0])
+    else:
+        scan_target = [str(scan_path) for scan_path in scan_paths]
+
+    analyzer_logger = logging.getLogger("Skylos")
+    previous_level = analyzer_logger.level
+    analyzer_logger.setLevel(logging.WARNING)
+    try:
+        raw = analyze(
+            scan_target,
+            conf=int(scan_cfg.get("confidence", DEFAULT_SCAN["confidence"])),
+            enable_quality=False,
+            enable_danger=False,
+            enable_secrets=False,
+            grep_verify=bool(scan_cfg.get("grep_verify", DEFAULT_SCAN["grep_verify"])),
+        )
+    finally:
+        analyzer_logger.setLevel(previous_level)
+    return json.loads(raw)
+
+
+def _category_counts(result: dict[str, Any]) -> dict[str, int]:
+    counts = {}
+    for category in DEAD_CODE_CATEGORIES:
+        findings = result.get(category, [])
+        if isinstance(findings, list):
+            counts[category] = len(findings)
+        else:
+            counts[category] = 0
+    return counts
+
+
+def _norm_rel_path(value: str, project_root: Path) -> str:
+    text = str(value or "").replace("\\", "/")
+    if not text:
+        return ""
+
+    path = Path(text)
+    if path.is_absolute():
+        try:
+            text = path.resolve().relative_to(project_root.resolve()).as_posix()
+        except ValueError:
+            text = path.as_posix()
+
+    if text.startswith("./"):
+        text = text[2:]
+    return text
+
+
+def _finding_symbols(finding: dict[str, Any]) -> set[str]:
+    symbols = set()
+    for key in ("simple_name", "name", "symbol", "full_name", "value"):
+        value = finding.get(key)
+        if isinstance(value, str) and value.strip():
+            symbols.add(value.strip())
+    return symbols
+
+
+def _finding_matches(
+    expectation: dict[str, Any],
+    finding: dict[str, Any],
+    target_path: Path,
+) -> bool:
+    expected_file = expectation.get("file")
+    if isinstance(expected_file, str) and expected_file.strip():
+        actual_file = _norm_rel_path(str(finding.get("file", "")), target_path)
+        if actual_file != expected_file.replace("\\", "/"):
+            return False
+
+    expected_symbol = expectation.get("symbol")
+    if isinstance(expected_symbol, str) and expected_symbol.strip():
+        symbols = _finding_symbols(finding)
+        if expected_symbol not in symbols:
+            return False
+
+    return True
+
+
+def _expectation_label(expectation: dict[str, Any]) -> str:
+    parts = [str(expectation["category"])]
+    file_name = expectation.get("file")
+    symbol = expectation.get("symbol")
+    if isinstance(file_name, str) and file_name.strip():
+        parts.append(file_name)
+    if isinstance(symbol, str) and symbol.strip():
+        parts.append(symbol)
+    return ":".join(parts)
+
+
+def _finding_label(finding: dict[str, Any], target_path: Path) -> str:
+    file_name = _norm_rel_path(str(finding.get("file", "")), target_path)
+    symbols = sorted(_finding_symbols(finding))
+    if symbols:
+        return f"{file_name}:{symbols[0]}"
+    return file_name
+
+
+def _compare_baseline(
+    target: dict[str, Any],
+    counts: dict[str, int],
+) -> list[FrameworkCorpusFailure]:
+    baseline = target.get("baseline", {}) or {}
+    expected_counts = baseline.get("counts", {}) or {}
+    max_delta = int(baseline.get("max_delta", 0))
+    failures = []
+
+    for category, expected in sorted(expected_counts.items()):
+        actual = counts.get(category, 0)
+        delta = abs(actual - int(expected))
+        if delta <= max_delta:
+            continue
+        failures.append(
+            FrameworkCorpusFailure(
+                target_id=target["id"],
+                failure_type="baseline_count",
+                mode=category,
+                expected=f"{expected} +/- {max_delta}",
+                found=[str(actual)],
+            )
+        )
+
+    return failures
+
+
+def _compare_expectations(
+    target: dict[str, Any],
+    result: dict[str, Any],
+    target_path: Path,
+) -> list[FrameworkCorpusFailure]:
+    failures = []
+    expect = target.get("expect", {}) or {}
+    for mode in ("absent", "present"):
+        expectations = expect.get(mode, []) or []
+        for expectation in expectations:
+            category = str(expectation["category"])
+            findings = result.get(category, []) or []
+            matches = []
+            for finding in findings:
+                if not isinstance(finding, dict):
+                    continue
+                if _finding_matches(expectation, finding, target_path):
+                    matches.append(_finding_label(finding, target_path))
+
+            if mode == "absent" and matches:
+                failures.append(
+                    FrameworkCorpusFailure(
+                        target_id=target["id"],
+                        failure_type="expectation",
+                        mode=mode,
+                        expected=_expectation_label(expectation),
+                        found=sorted(matches),
+                    )
+                )
+            if mode == "present" and not matches:
+                failures.append(
+                    FrameworkCorpusFailure(
+                        target_id=target["id"],
+                        failure_type="expectation",
+                        mode=mode,
+                        expected=_expectation_label(expectation),
+                        found=[],
+                    )
+                )
+
+    return failures
+
+
+def _missing_checkout_result(
+    target: dict[str, Any],
+    target_path: Path,
+    missing_paths: list[Path],
+) -> dict[str, Any]:
+    found = [str(path) for path in missing_paths]
+    failure = FrameworkCorpusFailure(
+        target_id=target["id"],
+        failure_type="missing_checkout",
+        mode="path_exists",
+        expected=str(target_path),
+        found=found,
+    )
+    return {
+        "id": target["id"],
+        "repo": target["repo"],
+        "ref": target["ref"],
+        "path": str(target_path),
+        "status": "fail",
+        "counts": {},
+        "failures": [failure.to_dict()],
+    }
+
+
+def run_target(
+    target: dict[str, Any],
+    *,
+    checkout_root: Path,
+    require_checkouts: bool = False,
+) -> dict[str, Any]:
+    target_path = _resolve_target_path(target, checkout_root)
+    missing = _missing_paths(target, target_path)
+    if missing:
+        if require_checkouts:
+            return _missing_checkout_result(target, target_path, missing)
+        return {
+            "id": target["id"],
+            "repo": target["repo"],
+            "ref": target["ref"],
+            "path": str(target_path),
+            "status": "skip",
+            "reason": "checkout or scan path is missing",
+            "missing_paths": [str(path) for path in missing],
+        }
+
+    result = _scan_target(target, target_path)
+    counts = _category_counts(result)
+    failures = []
+    failures.extend(_compare_baseline(target, counts))
+    failures.extend(_compare_expectations(target, result, target_path))
+
+    status = "pass"
+    if failures:
+        status = "fail"
+
+    return {
+        "id": target["id"],
+        "repo": target["repo"],
+        "ref": target["ref"],
+        "path": str(target_path),
+        "status": status,
+        "counts": counts,
+        "failures": [failure.to_dict() for failure in failures],
+    }
+
+
+def _select_targets(
+    targets: list[dict[str, Any]],
+    selected_targets: set[str],
+) -> list[dict[str, Any]]:
+    if not selected_targets:
+        return targets
+
+    selected = []
+    for target in targets:
+        if target["id"] in selected_targets:
+            selected.append(target)
+
+    if not selected:
+        wanted = ", ".join(sorted(selected_targets))
+        raise ValueError(f"no framework corpus target matched: {wanted}")
+    return selected
+
+
+def run_manifest(
+    manifest_path: str | Path,
+    *,
+    checkout_root: str | Path | None = None,
+    selected_targets: set[str] | None = None,
+    require_checkouts: bool = False,
+) -> dict[str, Any]:
+    manifest = load_manifest(manifest_path)
+    targets = validate_manifest(manifest, manifest_path)
+    selected = _select_targets(targets, set(selected_targets or set()))
+
+    if checkout_root is None:
+        resolved_checkout_root = _default_checkout_root(manifest)
+    else:
+        resolved_checkout_root = Path(checkout_root).expanduser().resolve()
+
+    target_results = []
+    skipped_targets = []
+    for target in selected:
+        result = run_target(
+            target,
+            checkout_root=resolved_checkout_root,
+            require_checkouts=require_checkouts,
+        )
+        if result["status"] == "skip":
+            skipped_targets.append(result)
+        else:
+            target_results.append(result)
+
+    failure_count = 0
+    for result in target_results:
+        failure_count += len(result.get("failures", []))
+
+    pass_count = 0
+    for result in target_results:
+        if result["status"] == "pass":
+            pass_count += 1
+
+    return {
+        "manifest": str(Path(manifest_path).resolve()),
+        "checkout_root": str(resolved_checkout_root),
+        "target_count": len(target_results),
+        "skipped_target_count": len(skipped_targets),
+        "pass_count": pass_count,
+        "failure_count": failure_count,
+        "targets": target_results,
+        "skipped_targets": skipped_targets,
+    }
+
+
+def _format_counts(counts: dict[str, int]) -> str:
+    if not counts:
+        return "no counts"
+    parts = []
+    for category in DEAD_CODE_CATEGORIES:
+        if category in counts:
+            parts.append(f"{category}={counts[category]}")
+    return ", ".join(parts)
+
+
+def format_summary(summary: dict[str, Any]) -> str:
+    lines = [
+        f"Framework corpus checkout root: {summary['checkout_root']}",
+        f"Framework corpus targets: {summary['target_count']}",
+        f"Framework corpus skipped targets: {summary['skipped_target_count']}",
+        f"Framework corpus failures: {summary['failure_count']}",
+    ]
+
+    for target in summary.get("targets", []):
+        status = str(target["status"]).upper()
+        counts = _format_counts(target.get("counts", {}))
+        lines.append(f"{status} {target['id']}: {counts}")
+        for failure in target.get("failures", []):
+            found = "none"
+            if failure["found"]:
+                found = ", ".join(failure["found"])
+            lines.append(
+                f"  {failure['failure_type']} {failure['mode']} -> "
+                f"{failure['expected']} (found: {found})"
+            )
+
+    for target in summary.get("skipped_targets", []):
+        reason = target.get("reason", "skipped")
+        lines.append(f"SKIP {target['id']}: {reason}")
+
+    return "\n".join(lines)

--- a/skylos/benchmarks/framework_corpus_schema.py
+++ b/skylos/benchmarks/framework_corpus_schema.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEAD_CODE_CATEGORIES = (
+    "unused_imports",
+    "unused_functions",
+    "unused_classes",
+    "unused_variables",
+    "unused_parameters",
+    "unused_files",
+)
+
+
+@dataclass(frozen=True)
+class FrameworkCorpusFailure:
+    target_id: str
+    failure_type: str
+    mode: str
+    expected: str
+    found: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target_id": self.target_id,
+            "failure_type": self.failure_type,
+            "mode": self.mode,
+            "expected": self.expected,
+            "found": list(self.found),
+        }
+
+
+def load_manifest(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _validate_non_empty_string(
+    target_id: str,
+    target: dict[str, Any],
+    field: str,
+) -> str:
+    value = target.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"framework corpus target {target_id} must declare {field}")
+    return value.strip()
+
+
+def _validate_scan_paths(target_id: str, target: dict[str, Any]) -> None:
+    scan_paths = target.get("scan_paths")
+    if scan_paths is None:
+        return
+    if not isinstance(scan_paths, list) or not scan_paths:
+        raise ValueError(
+            f"framework corpus target {target_id} scan_paths must be a non-empty list"
+        )
+    for scan_path in scan_paths:
+        if not isinstance(scan_path, str) or not scan_path.strip():
+            raise ValueError(
+                f"framework corpus target {target_id} scan_paths must contain strings"
+            )
+
+
+def _validate_scan_config(target_id: str, target: dict[str, Any]) -> None:
+    scan = target.get("scan", {})
+    if not scan:
+        return
+    if not isinstance(scan, dict):
+        raise ValueError(f"framework corpus target {target_id} scan must be an object")
+    confidence = scan.get("confidence")
+    if confidence is None:
+        return
+    if not isinstance(confidence, int) or confidence < 0 or confidence > 100:
+        raise ValueError(
+            f"framework corpus target {target_id} scan.confidence must be 0..100"
+        )
+
+
+def _validate_baseline(target_id: str, target: dict[str, Any]) -> None:
+    baseline = target.get("baseline", {})
+    if not baseline:
+        return
+    if not isinstance(baseline, dict):
+        raise ValueError(
+            f"framework corpus target {target_id} baseline must be an object"
+        )
+
+    counts = baseline.get("counts", {})
+    if not isinstance(counts, dict) or not counts:
+        raise ValueError(
+            f"framework corpus target {target_id} baseline.counts must be non-empty"
+        )
+    for category, expected in counts.items():
+        if category not in DEAD_CODE_CATEGORIES:
+            allowed = ", ".join(DEAD_CODE_CATEGORIES)
+            raise ValueError(
+                f"framework corpus target {target_id} has unsupported category "
+                f"{category}. Allowed: {allowed}"
+            )
+        if not isinstance(expected, int) or expected < 0:
+            raise ValueError(
+                f"framework corpus target {target_id} baseline count {category} "
+                "must be a non-negative integer"
+            )
+
+    max_delta = baseline.get("max_delta", 0)
+    if not isinstance(max_delta, int) or max_delta < 0:
+        raise ValueError(
+            f"framework corpus target {target_id} baseline.max_delta must be >= 0"
+        )
+
+
+def _validate_expectation(
+    target_id: str,
+    mode: str,
+    item: Any,
+) -> None:
+    if not isinstance(item, dict):
+        raise ValueError(
+            f"framework corpus target {target_id} {mode} expectations must be objects"
+        )
+
+    category = item.get("category")
+    if category not in DEAD_CODE_CATEGORIES:
+        allowed = ", ".join(DEAD_CODE_CATEGORIES)
+        raise ValueError(
+            f"framework corpus target {target_id} has unsupported category "
+            f"{category}. Allowed: {allowed}"
+        )
+
+    file_name = item.get("file")
+    symbol = item.get("symbol")
+    has_file = isinstance(file_name, str) and bool(file_name.strip())
+    has_symbol = isinstance(symbol, str) and bool(symbol.strip())
+    if not has_file and not has_symbol:
+        raise ValueError(
+            f"framework corpus target {target_id} {mode} expectations need file or symbol"
+        )
+
+
+def _validate_expectations(target_id: str, target: dict[str, Any]) -> None:
+    expect = target.get("expect", {})
+    if not expect:
+        return
+    if not isinstance(expect, dict):
+        raise ValueError(
+            f"framework corpus target {target_id} expect must be an object"
+        )
+    for mode in ("absent", "present"):
+        items = expect.get(mode, [])
+        if not isinstance(items, list):
+            raise ValueError(
+                f"framework corpus target {target_id} expect.{mode} must be a list"
+            )
+        for item in items:
+            _validate_expectation(target_id, mode, item)
+
+
+def validate_manifest(
+    manifest: dict[str, Any],
+    manifest_path: str | Path,
+) -> list[dict[str, Any]]:
+    if manifest.get("version") != 1:
+        raise ValueError("framework corpus manifest version must be 1")
+
+    targets = manifest.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise ValueError("framework corpus manifest must define targets")
+
+    seen_ids: set[str] = set()
+    for target in targets:
+        if not isinstance(target, dict):
+            raise ValueError("each framework corpus target must be an object")
+
+        target_id = _validate_non_empty_string("<unknown>", target, "id")
+        if target_id in seen_ids:
+            raise ValueError(f"duplicate framework corpus target id: {target_id}")
+        seen_ids.add(target_id)
+
+        repo = _validate_non_empty_string(target_id, target, "repo")
+        if not repo.startswith("https://"):
+            raise ValueError(
+                f"framework corpus target {target_id} repo must be an https URL"
+            )
+        _validate_non_empty_string(target_id, target, "ref")
+        _validate_non_empty_string(target_id, target, "license")
+        _validate_scan_paths(target_id, target)
+        _validate_scan_config(target_id, target)
+        _validate_baseline(target_id, target)
+        _validate_expectations(target_id, target)
+
+    return targets

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -10,6 +10,9 @@ from skylos.analysis.control_flow import (
     extract_constant_string,
 )
 from skylos.analysis.implicit_refs import pattern_tracker
+from skylos.visitors.registration_decorators import (
+    collect_local_registration_decorators,
+)
 from typing import Any, Optional, Union
 
 PYTHON_BUILTINS = {
@@ -391,6 +394,7 @@ class Visitor(ast.NodeVisitor):
         self._used_attr_names = set()
         self._used_attr_names_with_context = set()
         self._conditional_import_targets = set()
+        self.local_registration_decorators = set()
 
     def add_def(
         self, name: str, t: str, line: int, node: Optional[ast.AST] = None, **extra: Any
@@ -427,6 +431,13 @@ class Visitor(ast.NodeVisitor):
         if self._current_function_qname:
             self.call_graph[self._current_function_qname].add(name)
             self.reverse_call_graph[name].add(self._current_function_qname)
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self.local_registration_decorators.update(
+            collect_local_registration_decorators(node)
+        )
+        for stmt in node.body:
+            self.visit(stmt)
 
     def qual(self, name: str) -> str:
         if name in self.alias:
@@ -485,7 +496,12 @@ class Visitor(ast.NodeVisitor):
                 target = head
 
             self.alias[alias_name] = target
-            self.add_def(target, "import", node.lineno)
+            self.add_def(
+                target,
+                "import",
+                node.lineno,
+                is_exported=a.asname == a.name if a.asname else False,
+            )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         module = node.module
@@ -534,7 +550,12 @@ class Visitor(ast.NodeVisitor):
                 full = a.name
 
             self.alias[alias_name] = full
-            self.add_def(full, "import", node.lineno)
+            self.add_def(
+                full,
+                "import",
+                node.lineno,
+                is_exported=a.asname == a.name if a.asname else False,
+            )
 
     def visit_If(self, node: ast.If) -> None:
         from skylos.analysis.control_flow import (
@@ -841,6 +862,8 @@ class Visitor(ast.NodeVisitor):
                 elif any(
                     keyword in deco_name.lower() for keyword in FRAMEWORK_DECORATORS
                 ):
+                    self.add_ref(qualified_name)
+                elif deco_name in self.local_registration_decorators:
                     self.add_ref(qualified_name)
 
         if self.current_function_scope and self.local_var_maps:
@@ -2157,21 +2180,26 @@ class Visitor(ast.NodeVisitor):
                 self.add_ref(self.qual(tok))
 
     def visit_arguments(self, args: ast.arguments) -> None:
-        for arg in args.args:
-            self.visit_annotation(arg.annotation)
-        for arg in args.posonlyargs:
-            self.visit_annotation(arg.annotation)
-        for arg in args.kwonlyargs:
-            self.visit_annotation(arg.annotation)
-        if args.vararg:
-            self.visit_annotation(args.vararg.annotation)
-        if args.kwarg:
-            self.visit_annotation(args.kwarg.annotation)
-        for default in args.defaults:
-            self.visit(default)
-        for default in args.kw_defaults:
-            if default:
+        current_params = self.current_function_params
+        self.current_function_params = []
+        try:
+            for arg in args.args:
+                self.visit_annotation(arg.annotation)
+            for arg in args.posonlyargs:
+                self.visit_annotation(arg.annotation)
+            for arg in args.kwonlyargs:
+                self.visit_annotation(arg.annotation)
+            if args.vararg:
+                self.visit_annotation(args.vararg.annotation)
+            if args.kwarg:
+                self.visit_annotation(args.kwarg.annotation)
+            for default in args.defaults:
                 self.visit(default)
+            for default in args.kw_defaults:
+                if default:
+                    self.visit(default)
+        finally:
+            self.current_function_params = current_params
 
     def _annotation_to_string(self, node: ast.expr) -> Optional[str]:
         if isinstance(node, ast.Name):

--- a/skylos/visitors/registration_decorators.py
+++ b/skylos/visitors/registration_decorators.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import ast
+
+
+_REGISTRATION_METHOD_NAMES = {
+    "add",
+    "append",
+    "connect",
+    "listen",
+    "register",
+    "register_type_strategy",
+    "setdefault",
+}
+
+
+def collect_local_registration_decorators(node: ast.Module) -> set[str]:
+    decorators = set()
+    for stmt in node.body:
+        if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if _is_registration_decorator(stmt):
+            decorators.add(stmt.name)
+    return decorators
+
+
+def _is_registration_decorator(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    param_names = _positional_param_names(node)
+    if not param_names:
+        return False
+
+    direct_param = param_names[0]
+    if _function_registers_name(node, direct_param):
+        return _function_returns_name(node, direct_param)
+
+    returned_inner_names = _returned_local_function_names(node)
+    if not returned_inner_names:
+        return False
+
+    for stmt in node.body:
+        if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if stmt.name not in returned_inner_names:
+            continue
+        nested_params = _positional_param_names(stmt)
+        if not nested_params:
+            continue
+        registered_param = nested_params[0]
+        if _function_registers_name(stmt, registered_param) and _function_returns_name(
+            stmt, registered_param
+        ):
+            return True
+
+    return False
+
+
+def _positional_param_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    args = []
+    args.extend(node.args.posonlyargs)
+    args.extend(node.args.args)
+    return [arg.arg for arg in args]
+
+
+def _function_returns_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, name: str
+) -> bool:
+    for child in _iter_function_body_nodes(node):
+        if isinstance(child, ast.Return) and isinstance(child.value, ast.Name):
+            if child.value.id == name:
+                return True
+    return False
+
+
+def _returned_local_function_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str]:
+    local_functions = {
+        stmt.name
+        for stmt in node.body
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    returned = set()
+    for stmt in node.body:
+        if not isinstance(stmt, ast.Return):
+            continue
+        if isinstance(stmt.value, ast.Name) and stmt.value.id in local_functions:
+            returned.add(stmt.value.id)
+    return returned
+
+
+def _function_registers_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, name: str
+) -> bool:
+    for child in _iter_function_body_nodes(node):
+        if _is_registration_assignment(child, name):
+            return True
+        if _is_registration_call(child, name):
+            return True
+    return False
+
+
+def _iter_function_body_nodes(node: ast.FunctionDef | ast.AsyncFunctionDef):
+    stack = list(reversed(node.body))
+    while stack:
+        current = stack.pop()
+        yield current
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(current))))
+
+
+def _is_registration_assignment(node: ast.AST, name: str) -> bool:
+    if isinstance(node, ast.Assign):
+        return _assignment_registers_name(node.targets, node.value, name)
+    if isinstance(node, ast.AnnAssign):
+        return _assignment_registers_name([node.target], node.value, name)
+    return False
+
+
+def _assignment_registers_name(
+    targets: list[ast.expr], value: ast.AST | None, name: str
+) -> bool:
+    if value is None:
+        return False
+    if not _expr_mentions_name(value, name):
+        return False
+    return any(_is_registry_target(target) for target in targets)
+
+
+def _is_registry_target(node: ast.AST) -> bool:
+    return isinstance(node, (ast.Subscript, ast.Attribute))
+
+
+def _is_registration_call(node: ast.AST, name: str) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+
+    call_name = _call_name(node.func)
+    simple_name = call_name.rsplit(".", 1)[-1]
+    if simple_name not in _REGISTRATION_METHOD_NAMES:
+        return False
+
+    for arg in node.args:
+        if _expr_mentions_name(arg, name):
+            return True
+    for keyword in node.keywords:
+        if _expr_mentions_name(keyword.value, name):
+            return True
+    return False
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _call_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    if isinstance(node, ast.Call):
+        return _call_name(node.func)
+    return ""
+
+
+def _expr_mentions_name(node: ast.AST, name: str) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name) and child.id == name:
+            return True
+    return False

--- a/test/test_changes_analyzer.py
+++ b/test/test_changes_analyzer.py
@@ -170,6 +170,38 @@ def regular_func(_param: str):
             "Parameter in test file should be suppressed"
         )
 
+    def test_explicit_same_name_import_alias_is_exported(self):
+        code = """
+from os import PathLike as PathLike
+import pathlib as pathlib
+import json
+"""
+        result = self._analyze(code)
+
+        import_names = {i["simple_name"] for i in result["unused_imports"]}
+
+        assert "PathLike" not in import_names
+        assert "pathlib" not in import_names
+        assert "json" in import_names
+
+    def test_annotation_metadata_uses_import_over_parameter_name(self):
+        code = """
+from __future__ import annotations
+from typing import Annotated, Any
+from typing_extensions import deprecated
+
+def path(
+    example: Annotated[Any | None, deprecated("use examples")] = None,
+    deprecated: bool = False,
+):
+    return deprecated
+"""
+        result = self._analyze(code)
+
+        import_names = {i["simple_name"] for i in result["unused_imports"]}
+
+        assert "deprecated" not in import_names
+
     def _analyze(self, code: str, filename: str = "example.py") -> dict:
         with tempfile.TemporaryDirectory() as temp_dir:
             file_path = Path(temp_dir) / filename

--- a/test/test_dynamic_patterns.py
+++ b/test/test_dynamic_patterns.py
@@ -316,6 +316,74 @@ p = Permission.READ | Permission.WRITE
         assert "EXECUTE" not in unused
 
 
+class TestLocalRegistrationDecorators:
+    def _get_unused_functions(self, code):
+        from skylos.analyzer import Skylos
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir) / "mod.py"
+            p.write_text(code)
+            s = Skylos()
+            result = json.loads(s.analyze(tmpdir, thr=0, grep_verify=False))
+            return {item["simple_name"] for item in result["unused_functions"]}
+
+    def test_decorator_factory_registration_marks_function_used(self):
+        unused = self._get_unused_functions("""
+RESOLVERS = {}
+
+def resolves(kind):
+    def inner(func):
+        RESOLVERS[kind] = func
+        return func
+    return inner
+
+@resolves(str)
+def resolve_string(value):
+    return str(value)
+
+def unused_helper():
+    return None
+""")
+
+        assert "resolve_string" not in unused
+        assert "unused_helper" in unused
+
+    def test_direct_registration_decorator_marks_function_used(self):
+        unused = self._get_unused_functions("""
+COMMANDS = {}
+
+def command(func):
+    COMMANDS[func.__name__] = func
+    return func
+
+@command
+def serve():
+    return "ok"
+
+def unused_helper():
+    return None
+""")
+
+        assert "serve" not in unused
+        assert "unused_helper" in unused
+
+    def test_plain_wrapper_decorator_does_not_mask_unused_function(self):
+        unused = self._get_unused_functions("""
+def wraps(flag):
+    def inner(func):
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+    return inner
+
+@wraps(True)
+def still_dead():
+    return None
+""")
+
+        assert "still_dead" in unused
+
+
 class TestDefinitionReasonFields:
     def test_definition_has_new_fields(self):
         d = Definition("test.func", "function", "test.py", 1)

--- a/test/test_framework_corpus.py
+++ b/test/test_framework_corpus.py
@@ -1,0 +1,161 @@
+import json
+from pathlib import Path
+
+import skylos.benchmarks.framework_corpus as framework_corpus
+from skylos.benchmarks.framework_corpus import (
+    format_summary,
+    load_manifest,
+    run_manifest,
+    validate_manifest,
+)
+
+
+MANIFEST_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "benchmarks"
+    / "framework_corpus"
+    / "manifest.json"
+)
+
+
+def _write_manifest(tmp_path, manifest):
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest_path
+
+
+def _sample_manifest():
+    return {
+        "version": 1,
+        "targets": [
+            {
+                "id": "demo",
+                "repo": "https://github.com/example/demo",
+                "ref": "0123456789abcdef",
+                "checkout": "demo",
+                "license": "MIT",
+                "scan_paths": ["pkg"],
+                "baseline": {
+                    "counts": {
+                        "unused_functions": 1,
+                        "unused_imports": 0,
+                    },
+                    "max_delta": 0,
+                },
+                "expect": {
+                    "present": [
+                        {
+                            "category": "unused_functions",
+                            "file": "pkg/app.py",
+                            "symbol": "stale",
+                        }
+                    ],
+                    "absent": [
+                        {
+                            "category": "unused_functions",
+                            "file": "pkg/app.py",
+                            "symbol": "live",
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+
+def test_checked_in_framework_corpus_manifest_validates():
+    manifest = load_manifest(MANIFEST_PATH)
+    targets = validate_manifest(manifest, MANIFEST_PATH)
+
+    assert {target["id"] for target in targets} >= {
+        "fastapi",
+        "starlette",
+        "pydantic",
+        "typer",
+        "click",
+    }
+
+
+def test_framework_corpus_skips_missing_checkout_by_default(tmp_path):
+    manifest_path = _write_manifest(tmp_path, _sample_manifest())
+
+    summary = run_manifest(manifest_path, checkout_root=tmp_path / "checkouts")
+
+    assert summary["target_count"] == 0
+    assert summary["skipped_target_count"] == 1
+    assert summary["failure_count"] == 0
+    assert summary["skipped_targets"][0]["id"] == "demo"
+
+
+def test_framework_corpus_can_require_checkouts(tmp_path):
+    manifest_path = _write_manifest(tmp_path, _sample_manifest())
+
+    summary = run_manifest(
+        manifest_path,
+        checkout_root=tmp_path / "checkouts",
+        require_checkouts=True,
+    )
+
+    assert summary["target_count"] == 1
+    assert summary["failure_count"] == 1
+    assert summary["targets"][0]["status"] == "fail"
+    assert "missing_checkout" in format_summary(summary)
+
+
+def test_framework_corpus_passes_baseline_and_expectations(tmp_path, monkeypatch):
+    checkout = tmp_path / "checkouts" / "demo" / "pkg"
+    checkout.mkdir(parents=True)
+    (checkout / "app.py").write_text("def stale():\n    pass\n", encoding="utf-8")
+    manifest_path = _write_manifest(tmp_path, _sample_manifest())
+
+    def fake_scan_target(target, target_path):
+        return {
+            "unused_functions": [
+                {
+                    "file": str(target_path / "pkg" / "app.py"),
+                    "simple_name": "stale",
+                }
+            ],
+            "unused_imports": [],
+        }
+
+    monkeypatch.setattr(framework_corpus, "_scan_target", fake_scan_target)
+
+    summary = run_manifest(manifest_path, checkout_root=tmp_path / "checkouts")
+
+    assert summary["target_count"] == 1
+    assert summary["pass_count"] == 1
+    assert summary["failure_count"] == 0, format_summary(summary)
+    assert summary["targets"][0]["counts"]["unused_functions"] == 1
+
+
+def test_framework_corpus_reports_count_and_anchor_drift(tmp_path, monkeypatch):
+    checkout = tmp_path / "checkouts" / "demo" / "pkg"
+    checkout.mkdir(parents=True)
+    (checkout / "app.py").write_text("def stale():\n    pass\n", encoding="utf-8")
+    manifest = _sample_manifest()
+    manifest["targets"][0]["baseline"]["counts"]["unused_functions"] = 0
+    manifest["targets"][0]["expect"]["absent"][0]["symbol"] = "stale"
+    manifest_path = _write_manifest(tmp_path, manifest)
+
+    def fake_scan_target(target, target_path):
+        return {
+            "unused_functions": [
+                {
+                    "file": str(target_path / "pkg" / "app.py"),
+                    "simple_name": "stale",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(framework_corpus, "_scan_target", fake_scan_target)
+
+    summary = run_manifest(manifest_path, checkout_root=tmp_path / "checkouts")
+
+    assert summary["target_count"] == 1
+    assert summary["failure_count"] == 2
+    failure_types = {
+        failure["failure_type"]
+        for failure in summary["targets"][0]["failures"]
+    }
+    assert failure_types == {"baseline_count", "expectation"}


### PR DESCRIPTION
## Summary

  - Added CI fixtures for local registration decorators, same-name re-exports, and `Annotated[...]` metadata imports.
  - Added pinned corpus runner for FastAPI, Starlette, Pydantic, Typer, and Click.
  - Add baseline checks, docs, and tests for the corpus workflow.

  ## Tests

  - `pytest test/test_dead_code_benchmark.py test/test_framework_corpus.py`