### PR TITLE
fix(dead-code): reduce Rust and TypeScript false positives

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1200,6 +1200,9 @@ class Skylos:
             if d.type in ("method", "variable") and "." in d.name:
                 parts = d.name.rsplit(".", 1)
                 type_def_lookup[parts[0]].append((parts[1], d))
+                simple_owner = parts[0].split(".")[-1]
+                if simple_owner != parts[0]:
+                    type_def_lookup[simple_owner].append((parts[1], d))
 
         simple_to_keys = defaultdict(list)
         for k, d in non_import_defs.items():
@@ -1247,6 +1250,26 @@ class Skylos:
         for d in self.defs.values():
             if d.type == "method":
                 _methods_by_file_and_name[(str(d.filename), d.simple_name)].append(d)
+
+        def _matching_type_members(
+            type_name: str, member_name: str, ref_file: str
+        ) -> list:
+            matches = [
+                member_def
+                for candidate_member_name, member_def in type_def_lookup.get(
+                    type_name, []
+                )
+                if candidate_member_name == member_name
+            ]
+            if len(matches) <= 1:
+                return matches
+
+            same_file = [
+                member_def
+                for member_def in matches
+                if str(member_def.filename) == str(ref_file)
+            ]
+            return same_file or matches
 
         total_refs = len(self.refs)
         tick_every = int(os.getenv("SKYLOS_MARKREFS_TICK", str(MARKREFS_TICK_DEFAULT)))
@@ -1328,20 +1351,20 @@ class Skylos:
 
             # when ref_mod is a type we know about ..look up members of that type directly
             if ref_mod and ref_mod not in ("self", "cls") and len(candidates) != 1:
-                type_members = type_def_lookup.get(ref_mod)
-                if type_members:
-                    for member_name, member_def in type_members:
-                        if member_name == simple:
-                            member_def.references += 1
+                matched_members = _matching_type_members(ref_mod, simple, ref_file)
+                if matched_members:
+                    for member_def in matched_members:
+                        member_def.references += 1
                     continue
 
                 resolved_type = self._global_type_map.get(ref_mod)
                 if resolved_type:
-                    type_members = type_def_lookup.get(resolved_type)
-                    if type_members:
-                        for member_name, member_def in type_members:
-                            if member_name == simple:
-                                member_def.references += 1
+                    matched_members = _matching_type_members(
+                        resolved_type, simple, ref_file
+                    )
+                    if matched_members:
+                        for member_def in matched_members:
+                            member_def.references += 1
                         continue
 
             non_import_defs_fallback = []

--- a/skylos/visitors/languages/rust/core.py
+++ b/skylos/visitors/languages/rust/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from tree_sitter import Language, Parser
@@ -59,6 +60,210 @@ _IMPLICIT_METHODS = {
     "call_mut",
 }
 
+_ATTR_PATH_REF_RE = re.compile(
+    r'(?:default|serialize_with|deserialize_with|with)\s*=\s*"([A-Za-z_][A-Za-z0-9_:]*)"'
+)
+_RUST_KEYWORDS = {
+    "as",
+    "async",
+    "await",
+    "break",
+    "const",
+    "continue",
+    "crate",
+    "dyn",
+    "else",
+    "enum",
+    "extern",
+    "false",
+    "fn",
+    "for",
+    "if",
+    "impl",
+    "in",
+    "let",
+    "loop",
+    "match",
+    "mod",
+    "move",
+    "mut",
+    "pub",
+    "ref",
+    "return",
+    "self",
+    "Self",
+    "static",
+    "struct",
+    "super",
+    "trait",
+    "true",
+    "type",
+    "unsafe",
+    "use",
+    "where",
+    "while",
+}
+_REGISTRATION_MACROS = {
+    "generate_handler",
+    "tauri::generate_handler",
+    "routes",
+    "router",
+}
+
+_RUST_EXTERNAL_TRAIT_IMPORTS = {
+    "Read": {
+        "sources": ("std::io",),
+        "methods": ("read", "read_exact", "read_to_end", "read_to_string"),
+        "associated": (),
+    },
+    "Write": {
+        "sources": ("std::io",),
+        "methods": ("flush", "write", "write_all", "write_fmt"),
+        "associated": (),
+    },
+    "BufRead": {
+        "sources": ("std::io",),
+        "methods": ("consume", "fill_buf", "lines", "read_line", "split"),
+        "associated": (),
+    },
+    "AsyncReadExt": {
+        "sources": ("tokio::io",),
+        "methods": ("read", "read_exact", "read_to_end", "read_to_string"),
+        "associated": (),
+    },
+    "AsyncWriteExt": {
+        "sources": ("tokio::io",),
+        "methods": ("flush", "shutdown", "write", "write_all"),
+        "associated": (),
+    },
+    "AsyncBufReadExt": {
+        "sources": ("tokio::io",),
+        "methods": ("lines", "read_line", "split"),
+        "associated": (),
+    },
+    "StreamExt": {
+        "sources": ("futures", "futures::stream", "futures_util", "tokio_stream"),
+        "methods": (
+            "buffer_unordered",
+            "chunks",
+            "collect",
+            "filter",
+            "for_each",
+            "map",
+            "next",
+            "then",
+        ),
+        "associated": (),
+    },
+    "TryStreamExt": {
+        "sources": ("futures", "futures::stream", "futures_util", "tokio_stream"),
+        "methods": ("map_err", "map_ok", "try_collect", "try_for_each", "try_next"),
+        "associated": (),
+    },
+    "Row": {
+        "sources": ("sqlx",),
+        "methods": ("columns", "get", "try_get", "try_get_raw"),
+        "associated": (),
+    },
+    "Column": {
+        "sources": ("sqlx",),
+        "methods": ("name", "ordinal", "type_info"),
+        "associated": (),
+    },
+    "TypeInfo": {
+        "sources": ("sqlx",),
+        "methods": ("is_null", "name", "type_compatible"),
+        "associated": (),
+    },
+    "ValueRef": {
+        "sources": ("sqlx",),
+        "methods": ("is_null", "to_owned", "type_info"),
+        "associated": (),
+    },
+    "Executor": {
+        "sources": ("sqlx",),
+        "methods": ("execute", "fetch", "fetch_all", "fetch_one", "fetch_optional"),
+        "associated": (),
+    },
+    "Connection": {
+        "sources": ("sqlx",),
+        "methods": ("close",),
+        "associated": ("connect", "connect_with"),
+    },
+    "Emitter": {
+        "sources": ("tauri",),
+        "methods": ("emit", "emit_filter", "emit_str", "emit_to"),
+        "associated": (),
+    },
+    "Manager": {
+        "sources": ("tauri",),
+        "methods": (
+            "app_handle",
+            "get_webview_window",
+            "manage",
+            "path",
+            "state",
+            "webview_windows",
+        ),
+        "associated": (),
+    },
+    "UpdaterExt": {
+        "sources": ("tauri_plugin_updater",),
+        "methods": ("updater",),
+        "associated": (),
+    },
+    "Watcher": {
+        "sources": ("notify",),
+        "methods": ("unwatch", "watch"),
+        "associated": (),
+    },
+    "Digest": {
+        "sources": ("sha2", "digest"),
+        "methods": ("finalize", "update"),
+        "associated": ("digest", "new"),
+    },
+    "Engine": {
+        "sources": ("base64",),
+        "methods": ("decode", "decode_slice", "encode", "encode_string"),
+        "associated": (),
+    },
+    "FromStr": {
+        "sources": ("std::str",),
+        "methods": (),
+        "associated": ("from_str",),
+    },
+    "BinExt": {
+        "sources": ("gtk::prelude", "gtk4::prelude"),
+        "methods": ("child",),
+        "associated": (),
+    },
+    "Cast": {
+        "sources": ("glib", "glib::prelude", "gtk::prelude", "gtk4::prelude"),
+        "methods": ("downcast", "dynamic_cast", "upcast"),
+        "associated": (),
+    },
+    "GtkWindowExt": {
+        "sources": ("gtk::prelude", "gtk4::prelude"),
+        "methods": ("set_titlebar",),
+        "associated": (),
+    },
+    "HeaderBarExt": {
+        "sources": ("gtk::prelude", "gtk4::prelude"),
+        "methods": ("pack_end", "pack_start", "set_show_close_button"),
+        "associated": (),
+    },
+    "BuilderVerifierExt": {
+        "sources": ("rustls_platform_verifier",),
+        "methods": ("with_platform_verifier",),
+        "associated": (),
+    },
+    "PermissionsExt": {
+        "sources": ("std::os::unix::fs",),
+        "methods": ("mode", "set_mode"),
+        "associated": (),
+    },
+}
+
 
 def _get_parser(lang: Language) -> Parser:
     lang_id = id(lang)
@@ -108,7 +313,10 @@ class RustCore:
         self.lang: Language | None = RUST_LANG
         self.is_test_file = _is_test_path(file_path)
         self.root_namespace = _module_namespace_for_path(file_path)
+        self.import_aliases: dict[str, set[str]] = {}
+        self._module_scoped_callables: set[str] = set()
         self._seen_refs: set[tuple[str, int]] = set()
+        self._trait_call_usage: tuple[set[str], set[tuple[str, str]]] | None = None
 
         if self.lang:
             self.parser = _get_parser(self.lang)
@@ -151,6 +359,40 @@ class RustCore:
                 return True
         return False
 
+    def _add_attr_refs(self, attrs: list, *, current_callable: str | None) -> None:
+        for attr in attrs:
+            text = self._get_text(attr).strip()
+            if not text:
+                continue
+            path_match = re.match(
+                r"#\[\s*([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)",
+                text,
+            )
+            if path_match:
+                path = path_match.group(1)
+                if path not in {"cfg", "allow", "warn", "deny", "derive"}:
+                    self._add_ref(
+                        path,
+                        attr.start_byte + path_match.start(1),
+                        current_callable=current_callable,
+                        preserve_qualified=True,
+                    )
+            if text.startswith("#[derive"):
+                for name in re.findall(r"\b[A-Z][A-Za-z0-9_]*\b", text):
+                    self._add_ref(
+                        name,
+                        attr.start_byte + text.find(name),
+                        current_callable=current_callable,
+                    )
+            if text.startswith("#[serde"):
+                for path in _ATTR_PATH_REF_RE.findall(text):
+                    self._add_ref(
+                        path,
+                        attr.start_byte + text.find(path),
+                        current_callable=current_callable,
+                        preserve_qualified=True,
+                    )
+
     def _is_test_function(self, name: str, attrs: list, line: int) -> bool:
         if self._has_attr_prefix(
             attrs, ("#[test", "#[tokio::test", "#[async_std::test")
@@ -186,6 +428,34 @@ class RustCore:
             return
         if current_callable and ref_name == current_callable.split(".")[-1]:
             return
+        self._record_ref(ref_name, start_byte, current_callable=current_callable)
+
+        if preserve_qualified:
+            return
+
+        for qualified_ref in self.import_aliases.get(ref_name, ()):
+            if qualified_ref != ref_name:
+                self._record_ref(
+                    qualified_ref,
+                    start_byte,
+                    current_callable=current_callable,
+                )
+
+        sibling_ref = self._sibling_ref(ref_name, current_callable=current_callable)
+        if sibling_ref and sibling_ref != ref_name:
+            self._record_ref(
+                sibling_ref,
+                start_byte,
+                current_callable=current_callable,
+            )
+
+    def _record_ref(
+        self,
+        ref_name: str,
+        start_byte: int,
+        *,
+        current_callable: str | None,
+    ) -> None:
         key = (ref_name, start_byte)
         if key in self._seen_refs:
             return
@@ -193,6 +463,16 @@ class RustCore:
         self.refs.append((ref_name, self.file_path))
         if current_callable:
             self.call_pairs.append((current_callable, ref_name))
+
+    def _sibling_ref(
+        self, ref_name: str, *, current_callable: str | None
+    ) -> str | None:
+        if not current_callable or "." in ref_name:
+            return None
+        if current_callable not in self._module_scoped_callables:
+            return None
+        namespace = current_callable.rsplit(".", 1)[0]
+        return f"{namespace}.{ref_name}" if namespace else None
 
     def scan(self) -> None:
         if not self.root_node:
@@ -251,6 +531,10 @@ class RustCore:
                 )
                 attrs = []
                 continue
+
+            if attrs:
+                self._add_attr_refs(attrs, current_callable=current_callable)
+                attrs = []
 
             self._scan_refs_in_node(child, current_callable=current_callable)
             self._scan_block(
@@ -322,6 +606,7 @@ class RustCore:
         return sources
 
     def _scan_type_item(self, node, *, namespace: str, attrs: list) -> None:
+        self._add_attr_refs(attrs, current_callable=None)
         name_node = self._child_by_type(node, "type_identifier")
         name = self._node_name_text(name_node)
         if not name:
@@ -333,9 +618,40 @@ class RustCore:
         d.decorators = self._attrs_text(attrs)
         self.defs.append(d)
 
+        if node.type == "type_item":
+            self._scan_type_alias_rhs(node, namespace=namespace)
+
         decl_list = self._child_by_type(node, "declaration_list")
+        if decl_list is None:
+            decl_list = self._child_by_type(node, "field_declaration_list")
         if decl_list is not None and node.type == "trait_item":
             self._scan_trait_members(decl_list, current_type=qualified)
+        elif decl_list is not None:
+            self._scan_block(
+                decl_list,
+                namespace=namespace,
+                current_type=qualified,
+                current_callable=None,
+                pending_attrs=[],
+            )
+
+    def _scan_type_alias_rhs(self, node, *, namespace: str) -> None:
+        seen_equals = False
+        for child in node.children:
+            if child.type == "=":
+                seen_equals = True
+                continue
+            if not seen_equals:
+                continue
+            if child.type == ";":
+                break
+            self._scan_block(
+                child,
+                namespace=namespace,
+                current_type=None,
+                current_callable=None,
+                pending_attrs=[],
+            )
 
     def _scan_trait_members(self, node, *, current_type: str) -> None:
         attrs: list = []
@@ -358,6 +674,12 @@ class RustCore:
             d.is_exported = True
             d.decorators = self._attrs_text(attrs)
             self.defs.append(d)
+            self._scan_signature_refs(
+                child,
+                namespace="",
+                current_type=current_type,
+                current_callable=qualified,
+            )
             body = self._child_by_type(child, "block")
             if body is not None:
                 self._scan_block(
@@ -370,6 +692,7 @@ class RustCore:
             attrs = []
 
     def _scan_impl(self, node, *, namespace: str, attrs: list) -> None:
+        self._add_attr_refs(attrs, current_callable=None)
         type_names = self._impl_header_type_names(node)
         if not type_names:
             return
@@ -438,6 +761,7 @@ class RustCore:
         attrs: list,
         trait_impl: bool,
     ) -> None:
+        self._add_attr_refs(attrs, current_callable=None)
         name_node = self._child_by_type(node, "identifier")
         name = self._node_name_text(name_node)
         if not name:
@@ -452,6 +776,8 @@ class RustCore:
         d = Definition(
             qualified, "method" if current_type else "function", self.file_path, line
         )
+        if current_type is None:
+            self._module_scoped_callables.add(qualified)
         d.is_exported = (
             self._is_public(node)
             or trait_impl
@@ -463,6 +789,13 @@ class RustCore:
         d.decorators = self._attrs_text(attrs)
         self.defs.append(d)
 
+        self._scan_signature_refs(
+            node,
+            namespace=namespace,
+            current_type=current_type,
+            current_callable=qualified,
+        )
+
         body = self._child_by_type(node, "block")
         if body is not None:
             self._scan_block(
@@ -470,6 +803,61 @@ class RustCore:
                 namespace=namespace,
                 current_type=current_type,
                 current_callable=qualified,
+                pending_attrs=[],
+            )
+
+    def _scan_signature_refs(
+        self,
+        node,
+        *,
+        namespace: str,
+        current_type: str | None,
+        current_callable: str,
+    ) -> None:
+        type_parameters = self._child_by_type(node, "type_parameters")
+        if type_parameters is not None:
+            self._scan_block(
+                type_parameters,
+                namespace=namespace,
+                current_type=current_type,
+                current_callable=current_callable,
+                pending_attrs=[],
+            )
+
+        parameters = self._child_by_type(node, "parameters")
+        if parameters is not None:
+            self._scan_block(
+                parameters,
+                namespace=namespace,
+                current_type=current_type,
+                current_callable=current_callable,
+                pending_attrs=[],
+            )
+
+        where_clause = self._child_by_type(node, "where_clause")
+        if where_clause is not None:
+            self._scan_block(
+                where_clause,
+                namespace=namespace,
+                current_type=current_type,
+                current_callable=current_callable,
+                pending_attrs=[],
+            )
+
+        in_return_type = False
+        for child in node.children:
+            if child.type == "->":
+                in_return_type = True
+                continue
+            if not in_return_type:
+                continue
+            if child.type == "block":
+                break
+            self._scan_block(
+                child,
+                namespace=namespace,
+                current_type=current_type,
+                current_callable=current_callable,
                 pending_attrs=[],
             )
 
@@ -483,51 +871,238 @@ class RustCore:
             return
 
         names: list[str] = []
-        for name in self._extract_use_names(node):
-            if not name:
+        for local_name, original_name in self._extract_use_bindings(node):
+            if not local_name:
                 continue
-            d = Definition(name, "import", self.file_path, line)
+            d = Definition(local_name, "import", self.file_path, line)
             d.is_exported = is_public_reexport
             self.defs.append(d)
             self.imports.append(
-                {"name": name, "file": str(self.file_path), "line": line}
+                {"name": local_name, "file": str(self.file_path), "line": line}
             )
-            names.append(name)
+            names.append(local_name)
+            qualified_import = self._qualify_use_import(
+                source,
+                local_name=local_name,
+                original_name=original_name,
+            )
+            if qualified_import:
+                self.import_aliases.setdefault(local_name, set()).add(qualified_import)
+            if self._external_trait_import_is_used(
+                source,
+                local_name=local_name,
+                original_name=original_name,
+            ):
+                self._record_ref(local_name, node.start_byte, current_callable=None)
         self.raw_imports.append({"source": source, "names": names, "line": line})
 
     def _extract_use_names(self, node) -> list[str]:
+        return [local_name for local_name, _ in self._extract_use_bindings(node)]
+
+    def _extract_use_bindings(self, node) -> list[tuple[str, str]]:
         if node.type == "use_as_clause":
-            identifiers = [
-                child for child in node.children if child.type == "identifier"
-            ]
-            if identifiers:
-                return [self._get_text(identifiers[-1]).strip()]
+            return self._extract_use_as_binding(node)
         if node.type == "scoped_use_list":
             use_list = self._child_by_type(node, "use_list")
             if use_list is not None:
-                return self._extract_use_names(use_list)
+                return self._extract_use_bindings(use_list)
         if node.type in {"identifier", "type_identifier"}:
-            return [self._get_text(node).strip()]
+            name = self._get_text(node).strip()
+            return [(name, name)]
         if node.type == "scoped_identifier":
-            identifiers = [
-                child
-                for child in node.children
-                if child.type in {"identifier", "type_identifier"}
-            ]
-            if identifiers:
-                return [self._get_text(identifiers[-1]).strip()]
+            return self._extract_scoped_leaf_binding(node)
 
-        names: list[str] = []
+        bindings: list[tuple[str, str]] = []
         for child in node.children:
-            names.extend(self._extract_use_names(child))
+            bindings.extend(self._extract_use_bindings(child))
+        return self._dedupe_use_bindings(bindings)
+
+    def _extract_use_as_binding(self, node) -> list[tuple[str, str]]:
+        identifiers = [child for child in node.children if child.type == "identifier"]
+        if len(identifiers) >= 2:
+            original = self._get_text(identifiers[0]).strip()
+            alias = self._get_text(identifiers[-1]).strip()
+            return [(alias, original)]
+        if identifiers:
+            name = self._get_text(identifiers[-1]).strip()
+            return [(name, name)]
+        return []
+
+    def _extract_scoped_leaf_binding(self, node) -> list[tuple[str, str]]:
+        identifiers = [
+            child
+            for child in node.children
+            if child.type in {"identifier", "type_identifier"}
+        ]
+        if not identifiers:
+            return []
+        name = self._get_text(identifiers[-1]).strip()
+        return [(name, name)]
+
+    def _dedupe_use_bindings(
+        self, bindings: list[tuple[str, str]]
+    ) -> list[tuple[str, str]]:
         seen: set[str] = set()
-        unique: list[str] = []
-        for name in names:
-            if name in {"crate", "self", "super"} or name in seen:
+        unique: list[tuple[str, str]] = []
+        for local_name, original_name in bindings:
+            if local_name in {"crate", "self", "super"} or local_name in seen:
                 continue
-            seen.add(name)
-            unique.append(name)
+            seen.add(local_name)
+            unique.append((local_name, original_name))
         return unique
+
+    def _qualify_use_import(
+        self,
+        source: str,
+        *,
+        local_name: str,
+        original_name: str,
+    ) -> str | None:
+        target = source.strip()
+        if "{" in target:
+            base = target.split("{", 1)[0].rstrip(":").strip()
+            if not base:
+                return None
+            target = f"{base}::{original_name}"
+        else:
+            target = target.split(" as ", 1)[0].strip()
+        if not target or "::" not in target:
+            return None
+        parts = [part for part in target.split("::") if part and part != local_name]
+        if not parts:
+            return None
+        if parts[-1] != original_name:
+            parts.append(original_name)
+        qualified = self._resolve_rust_path(parts)
+        return qualified if qualified and "." in qualified else None
+
+    def _resolve_rust_path(self, parts: list[str]) -> str | None:
+        if not parts:
+            return None
+
+        namespace_parts = [part for part in self.root_namespace.split(".") if part]
+        resolved: list[str]
+        index = 0
+
+        first = parts[0]
+        if first == "crate":
+            resolved = []
+            index = 1
+        elif first == "self":
+            resolved = list(namespace_parts)
+            index = 1
+        elif first == "super":
+            resolved = list(namespace_parts)
+            while index < len(parts) and parts[index] == "super":
+                if resolved:
+                    resolved.pop()
+                index += 1
+        else:
+            resolved = list(namespace_parts)
+
+        resolved.extend(parts[index:])
+        return ".".join(part for part in resolved if part)
+
+    def _external_trait_import_is_used(
+        self,
+        source: str,
+        *,
+        local_name: str,
+        original_name: str,
+    ) -> bool:
+        trait_name = original_name if original_name != "_" else local_name
+        spec = _RUST_EXTERNAL_TRAIT_IMPORTS.get(trait_name)
+        if not spec:
+            return False
+
+        base = self._use_import_base(source)
+        if not base:
+            return False
+        if base.split("::", 1)[0] in {"crate", "self", "super"}:
+            return False
+        if not self._source_matches_trait_spec(base, spec["sources"]):
+            return False
+
+        method_names, associated_calls = self._collect_trait_call_usage()
+        if set(spec["methods"]) & method_names:
+            return True
+
+        associated_names = set(spec["associated"])
+        if associated_names:
+            for owner, method in associated_calls:
+                if method in associated_names and owner[:1].isupper():
+                    return True
+
+        return False
+
+    def _use_import_base(self, source: str) -> str:
+        target = source.strip()
+        if "{" in target:
+            return target.split("{", 1)[0].rstrip(":").strip()
+        target = target.split(" as ", 1)[0].strip()
+        parts = [part for part in target.split("::") if part]
+        if len(parts) <= 1:
+            return ""
+        return "::".join(parts[:-1])
+
+    def _source_matches_trait_spec(self, base: str, sources: tuple[str, ...]) -> bool:
+        return any(base == source or base.startswith(f"{source}::") for source in sources)
+
+    def _collect_trait_call_usage(self) -> tuple[set[str], set[tuple[str, str]]]:
+        if self._trait_call_usage is not None:
+            return self._trait_call_usage
+
+        method_names: set[str] = set()
+        associated_calls: set[tuple[str, str]] = set()
+
+        if self.root_node is None:
+            self._trait_call_usage = (method_names, associated_calls)
+            return self._trait_call_usage
+
+        for node in self._iter_nodes(self.root_node):
+            method_name = self._trait_method_name_from_node(node)
+            if method_name:
+                method_names.add(method_name)
+                continue
+
+            associated_call = self._trait_associated_call_from_node(node)
+            if associated_call is not None:
+                associated_calls.add(associated_call)
+
+        self._trait_call_usage = (method_names, associated_calls)
+        return self._trait_call_usage
+
+    def _call_parent(self, node):
+        parent = node.parent
+        if parent is not None and parent.type == "generic_function":
+            parent = parent.parent
+        return parent if parent is not None and parent.type == "call_expression" else None
+
+    def _trait_method_name_from_node(self, node) -> str | None:
+        if node.type != "field_expression" or self._call_parent(node) is None:
+            return None
+        name_node = self._child_by_type(node, "field_identifier")
+        name = self._node_name_text(name_node)
+        return name or None
+
+    def _trait_associated_call_from_node(self, node) -> tuple[str, str] | None:
+        if node.type != "scoped_identifier" or self._call_parent(node) is None:
+            return None
+        identifiers = [
+            self._node_name_text(child)
+            for child in node.children
+            if child.type in {"identifier", "type_identifier"}
+        ]
+        if len(identifiers) < 2:
+            return None
+        return identifiers[-2], identifiers[-1]
+
+    def _iter_nodes(self, root_node):
+        stack = [root_node]
+        while stack:
+            node = stack.pop()
+            yield node
+            stack.extend(reversed(node.children))
 
     def _scan_refs_in_node(self, node, *, current_callable: str | None) -> None:
         if node.type == "call_expression":
@@ -537,11 +1112,17 @@ class RustCore:
 
         if node.type == "macro_invocation":
             name_node = self._child_by_type(node, "identifier")
+            macro_name = self._node_name_text(name_node)
             self._add_ref(
-                self._node_name_text(name_node),
+                macro_name,
                 node.start_byte,
                 current_callable=current_callable,
             )
+            if macro_name in _REGISTRATION_MACROS:
+                self._scan_registration_macro_refs(
+                    node,
+                    current_callable=current_callable,
+                )
             return
 
         if node.type == "struct_expression":
@@ -562,11 +1143,36 @@ class RustCore:
             )
             return
 
+        if node.type == "identifier" and self._is_reference_identifier(node):
+            self._add_ref(
+                self._node_name_text(node),
+                node.start_byte,
+                current_callable=current_callable,
+            )
+            return
+
         if node.type == "type_identifier" and not self._is_definition_name(node):
             self._add_ref(
                 self._node_name_text(node),
                 node.start_byte,
                 current_callable=current_callable,
+            )
+
+    def _scan_registration_macro_refs(
+        self, node, *, current_callable: str | None
+    ) -> None:
+        text = self._get_text(node)
+        for match in re.finditer(r"\b[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*\b", text):
+            name = match.group(0)
+            if name in _RUST_KEYWORDS or name == self._node_name_text(
+                self._child_by_type(node, "identifier")
+            ):
+                continue
+            self._add_ref(
+                name,
+                node.start_byte + match.start(),
+                current_callable=current_callable,
+                preserve_qualified=True,
             )
 
     def _add_callee_refs(self, callee, *, current_callable: str | None) -> None:
@@ -615,6 +1221,30 @@ class RustCore:
             ) or self._child_by_type(parent, "identifier")
             return name_node is node
         return False
+
+    def _is_reference_identifier(self, node) -> bool:
+        name = self._node_name_text(node)
+        if not name or name in _RUST_KEYWORDS:
+            return False
+        if self._is_definition_name(node):
+            return False
+        parent = node.parent
+        if parent is None:
+            return False
+        if parent.type in {
+            "use_declaration",
+            "field_declaration",
+            "field_identifier",
+            "let_declaration",
+            "parameter",
+            "self_parameter",
+            "for",
+            "visibility_modifier",
+        }:
+            return False
+        if parent.type in _DEF_CONTAINER_TYPES:
+            return False
+        return True
 
     def _build_call_graph(self) -> None:
         name_to_def: dict[str, Definition] = {}

--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -66,6 +66,11 @@ _PLAYWRIGHT_CONFIG_FILES = frozenset(
         "playwright.config.js",
         "playwright.config.mts",
         "playwright.config.mjs",
+        "tsup.config.ts",
+        "tsup.config.mts",
+        "tsup.config.js",
+        "tsup.config.mjs",
+        "tsup.config.cjs",
     }
 )
 
@@ -81,7 +86,7 @@ except Exception:
 
 _ENTRY_PARSER_CACHE: dict[int, Parser] = {}
 _CONFIG_OBJECT_CALLS = frozenset({"defineConfig", "defineProject", "defineWorkspace"})
-_RUNNER_CONFIG_TOOLS = frozenset({"vite", "vitest", "playwright"})
+_RUNNER_CONFIG_TOOLS = frozenset({"vite", "vitest", "playwright", "tsup"})
 _STRING_FRAGMENT_TYPES = frozenset({"string_fragment", "escape_sequence"})
 
 
@@ -318,6 +323,10 @@ def demote_unconsumed_ts_exports(defs, consumed_exports, lifecycle_entry_points=
         if not str(defn.filename).endswith(_TS_JS_EXTENSIONS):
             continue
         if defn.type == "import":
+            continue
+        if str(defn.filename).endswith(".d.ts"):
+            continue
+        if "ambient declaration" in getattr(defn, "framework_signals", ()):
             continue
         if (
             os.path.realpath(str(defn.filename)) in lifecycle_entry_points
@@ -813,6 +822,26 @@ def _discover_vitest_config_entries(
     return matches
 
 
+def _discover_tsup_config_entries(
+    config_path: str, ts_files: set[str], default_base_dir: str
+) -> set[str]:
+    source, root_node = _load_entry_config_ast(config_path)
+    if source is None or root_node is None:
+        return set()
+
+    objects = _find_config_root_objects(source, root_node)
+    if not objects:
+        return set()
+
+    base_dir = _resolve_config_root_base(source, objects, default_base_dir)
+    return _literal_entries_from_nodes(
+        source,
+        _find_object_path_values(source, objects, ("entry",)),
+        base_dir,
+        ts_files,
+    )
+
+
 def _discover_playwright_config_entries(
     config_path: str, ts_files: set[str]
 ) -> set[str]:
@@ -1028,7 +1057,13 @@ def _iter_entry_discoveries(
                     "playwright"
                     if os.path.basename(candidate) in _PLAYWRIGHT_CONFIG_FILES
                     else (
-                        "vitest" if "vitest" in os.path.basename(candidate) else "vite"
+                        "vitest"
+                        if "vitest" in os.path.basename(candidate)
+                        else (
+                            "tsup"
+                            if os.path.basename(candidate).startswith("tsup.config.")
+                            else "vite"
+                        )
                     ),
                     str(package_root),
                 )
@@ -1051,6 +1086,10 @@ def _iter_entry_discoveries(
             )
         elif tool == "playwright":
             entry_files = _discover_playwright_config_entries(config_path, ts_files)
+        elif tool == "tsup":
+            entry_files = _discover_tsup_config_entries(
+                config_path, ts_files, base_dir
+            )
         else:
             entry_files = _discover_vite_config_entries(config_path, ts_files, base_dir)
         for entry_file in sorted(entry_files):

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -358,11 +358,17 @@ class TypeScriptCore:
         name = self._get_text(node)
 
         if type_name == "method":
-            if self._is_object_literal_method(node):
+            object_node = self._containing_object_literal(node)
+            if object_node is not None:
+                if self._is_bundler_plugin_object(object_node) and (
+                    name not in _BUNDLER_PLUGIN_HOOK_METHODS
+                ):
+                    pass
+                else:
+                    return
+            elif name in _LIFECYCLE_METHODS:
                 return
-            if name in _LIFECYCLE_METHODS:
-                return
-            if name in _BUNDLER_PLUGIN_HOOK_METHODS:
+            elif name in _BUNDLER_PLUGIN_HOOK_METHODS:
                 return
 
         if type_name == "method":
@@ -498,15 +504,48 @@ class TypeScriptCore:
             return False
         return False
 
-    def _is_object_literal_method(self, node) -> bool:
+    def _containing_object_literal(self, node):
         current = node.parent
         while current:
             if current.type == "object":
-                return True
+                return current
             if current.type in {"class_body", "class_declaration", "program"}:
-                return False
+                return None
             current = current.parent
+        return None
+
+    def _is_bundler_plugin_object(self, object_node) -> bool:
+        has_name = False
+        has_hook = False
+
+        for child in object_node.named_children:
+            if child.type == "pair" and self._pair_has_string_name(child):
+                has_name = True
+            elif child.type == "method_definition":
+                name_node = child.child_by_field_name("name")
+                if (
+                    name_node
+                    and self._get_text(name_node) in _BUNDLER_PLUGIN_HOOK_METHODS
+                ):
+                    has_hook = True
+
+            if has_name and has_hook:
+                return True
+
         return False
+
+    def _pair_has_string_name(self, pair_node) -> bool:
+        if len(pair_node.named_children) < 2:
+            return False
+
+        key_node = pair_node.named_children[0]
+        value_node = pair_node.named_children[1]
+        if key_node.type not in {"property_identifier", "identifier", "string"}:
+            return False
+
+        raw_key = self._get_text(key_node)
+        key = raw_key.strip("'\"")
+        return key == "name" and value_node.type == "string"
 
     def _is_exported(self, node) -> bool:
         try:

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -29,7 +29,9 @@ _LIFECYCLE_METHODS: set[str] = {
     "componentDidUpdate",
     "shouldComponentUpdate",
     "getDerivedStateFromProps",
+    "getDerivedStateFromError",
     "getSnapshotBeforeUpdate",
+    "componentDidCatch",
     "ngOnInit",
     "ngOnDestroy",
     "ngOnChanges",
@@ -103,12 +105,15 @@ _REFS_PATTERN = """
 (binary_expression right: (identifier) @ref)
 (binary_expression left: (identifier) @ref)
 (assignment_expression right: (identifier) @ref)
+(assignment_pattern right: (identifier) @ref)
+(update_expression (identifier) @ref)
 (spread_element (identifier) @ref)
 (member_expression object: (identifier) @ref)
 (subscript_expression object: (identifier) @ref)
 (subscript_expression index: (identifier) @ref)
 (pair value: (identifier) @ref)
 (unary_expression (identifier) @ref)
+(await_expression (identifier) @ref)
 (template_substitution (identifier) @ref)
 (shorthand_property_identifier) @ref
 (decorator (identifier) @ref)
@@ -167,6 +172,7 @@ class TypeScriptCore:
 
         self._suffix = Path(str(file_path)).suffix.lower()
         self._uses_jsx_parser = self._suffix in _JSX_EXTENSIONS
+        self._is_declaration_file = str(file_path).endswith(".d.ts")
 
         if self._uses_jsx_parser and TSX_LANG:
             self.lang: Language | None = TSX_LANG
@@ -322,6 +328,22 @@ class TypeScriptCore:
                 continue
             self._add_ref(node)
 
+        self._scan_default_parameter_refs()
+
+    def _scan_default_parameter_refs(self) -> None:
+        if not self.root_node:
+            return
+        for node in self._iter_nodes(self.root_node):
+            if node.type != "required_parameter":
+                continue
+            seen_default = False
+            for child in node.children:
+                if child.type == "=":
+                    seen_default = True
+                    continue
+                if seen_default and child.type == "identifier":
+                    self._add_ref(child)
+
     def _find_containing_class(self, node) -> str | None:
         current = node.parent
         while current:
@@ -336,11 +358,12 @@ class TypeScriptCore:
         name = self._get_text(node)
 
         if type_name == "method":
+            if self._is_object_literal_method(node):
+                return
             if name in _LIFECYCLE_METHODS:
                 return
             if name in _BUNDLER_PLUGIN_HOOK_METHODS:
-                if self._is_object_literal_method(node):
-                    return
+                return
 
         if type_name == "method":
             class_name = self._find_containing_class(node)
@@ -349,10 +372,13 @@ class TypeScriptCore:
 
         line = node.start_point[0] + 1
 
-        is_exported = self._is_exported(node)
+        is_ambient = self._is_ambient_declaration(node)
+        is_exported = self._is_exported(node) or self._is_declaration_file or is_ambient
 
         d = Definition(name, type_name, self.file_path, line)
         d.is_exported = is_exported
+        if self._is_declaration_file or is_ambient:
+            d.framework_signals.append("ambient declaration")
         if (
             type_name == "function"
             and d.is_exported
@@ -495,12 +521,50 @@ class TypeScriptCore:
             pass
         return False
 
+    def _is_ambient_declaration(self, node) -> bool:
+        current = node.parent
+        while current:
+            if current.type == "ambient_declaration":
+                return True
+            if current.type == "program":
+                return False
+            current = current.parent
+        return False
+
     def _scan_imports(self) -> None:
         c = self._imports_captures
 
         for node in c.get("import_name", []):
+            if self._is_aliased_import_original(node):
+                continue
             name = self._get_text(node)
             line = node.start_point[0] + 1
+            d = Definition(name, "import", self.file_path, line)
+            self.defs.append(d)
+            self.imports.append(
+                {"name": name, "file": str(self.file_path), "line": line}
+            )
+        self._scan_aliased_imports()
+
+    def _is_aliased_import_original(self, node) -> bool:
+        parent = node.parent
+        if parent is None or parent.type != "import_specifier":
+            return False
+        identifiers = [child for child in parent.children if child.type == "identifier"]
+        return len(identifiers) >= 2 and identifiers[0] == node
+
+    def _scan_aliased_imports(self) -> None:
+        if not self.root_node:
+            return
+        for node in self._iter_nodes(self.root_node):
+            if node.type != "import_specifier":
+                continue
+            identifiers = [child for child in node.children if child.type == "identifier"]
+            if len(identifiers) < 2:
+                continue
+            alias_node = identifiers[-1]
+            name = self._get_text(alias_node)
+            line = alias_node.start_point[0] + 1
             d = Definition(name, "import", self.file_path, line)
             self.defs.append(d)
             self.imports.append(
@@ -517,13 +581,14 @@ class TypeScriptCore:
             import_stmt = src_node.parent
             if import_stmt:
                 names = self._extract_import_names_from_stmt(import_stmt)
-                self.raw_imports.append(
-                    {
-                        "source": source_path,
-                        "names": names,
-                        "line": src_node.start_point[0] + 1,
-                    }
-                )
+                raw_import = {
+                    "source": source_path,
+                    "names": names,
+                    "line": src_node.start_point[0] + 1,
+                }
+                if any(name.startswith("* as ") for name in names):
+                    raw_import["consume_all_exports"] = True
+                self.raw_imports.append(raw_import)
 
         for src_node in c.get("export_src", []):
             source_path = self._get_text(src_node).strip("'\"")
@@ -560,7 +625,18 @@ class TypeScriptCore:
                     elif clause_child.type == "identifier":
                         names.append(self._get_text(clause_child))
                     elif clause_child.type == "namespace_import":
-                        names.append("*")
+                        alias_node = next(
+                            (
+                                ns_child
+                                for ns_child in clause_child.children
+                                if ns_child.type == "identifier"
+                            ),
+                            None,
+                        )
+                        if alias_node is not None:
+                            names.append(f"* as {self._get_text(alias_node)}")
+                        else:
+                            names.append("*")
         return names
 
     def _extract_export_names_from_stmt(self, export_stmt) -> list[str]:

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -997,6 +997,54 @@ use crate::internal::stale_api;
         assert "public_api" not in unused_imports
         assert "stale_api" in unused_imports
 
+    def test_analyze_rust_namespaced_associated_constructor_is_live(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "tls.rs").write_text(
+            """
+struct VerifyCaCertVerifier;
+
+impl VerifyCaCertVerifier {
+    fn new() -> Self { Self }
+}
+
+fn build_verifier() {
+    VerifyCaCertVerifier::new();
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(src_dir), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable = {item["full_name"] for item in result["unused_functions"]}
+
+        assert "tls.VerifyCaCertVerifier.new" not in unreachable
+        assert "tls.build_verifier" in unreachable
+
+    def test_analyze_rust_external_trait_import_methods_are_live(self, tmp_path):
+        (tmp_path / "lib.rs").write_text(
+            """
+use futures::StreamExt;
+use crate::traits::WidgetExt;
+
+fn run(stream: StreamLike, widget: Widget) {
+    stream.next();
+    widget.next();
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unused_imports = {item["simple_name"] for item in result["unused_imports"]}
+
+        assert "StreamExt" not in unused_imports
+        assert "WidgetExt" in unused_imports
+
     @patch("skylos.analyzer.logger.info")
     def test_analyze_mixed_languages_includes_csharp_in_summary(self, mock_log_info):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/test/test_rust.py
+++ b/test/test_rust.py
@@ -249,6 +249,192 @@ fn main() {
     assert {"api", "route"} <= ref_names
 
 
+def test_rust_use_imports_emit_project_qualified_refs(tmp_path):
+    file_path = tmp_path / "src" / "drivers" / "mysql" / "query.rs"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text(
+        """
+use super::helpers::{escape_identifier as escape, is_wkt_geometry};
+
+fn run() {
+    escape("table");
+    is_wkt_geometry("point");
+}
+""",
+        encoding="utf-8",
+    )
+
+    _, refs, *_ = scan_rust_file(str(file_path), {})
+    ref_names = {r[0] for r in refs}
+
+    assert "drivers.mysql.helpers.escape_identifier" in ref_names
+    assert "drivers.mysql.helpers.is_wkt_geometry" in ref_names
+
+
+def test_rust_function_signatures_scan_type_parameters_and_return_types(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use tauri::{AppHandle, Runtime};
+use crate::models::RoutineInfo;
+
+pub async fn get_routines<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<Vec<RoutineInfo>, String> {
+    todo!()
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert {"Runtime", "AppHandle", "RoutineInfo"} <= ref_names
+
+
+def test_rust_trait_signatures_and_attribute_macros_are_refs(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use async_trait::async_trait;
+use crate::models::{ConnectionParams, RoutineInfo};
+
+#[async_trait]
+pub trait DatabaseDriver {
+    async fn get_routines(
+        &self,
+        params: &ConnectionParams,
+    ) -> Result<Vec<RoutineInfo>, String>;
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert {"async_trait", "ConnectionParams", "RoutineInfo"} <= ref_names
+
+
+def test_rust_impl_attribute_macros_are_refs(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use async_trait::async_trait;
+
+trait Service {
+    fn run(&self);
+}
+
+struct Driver;
+
+#[async_trait]
+impl Service for Driver {
+    fn run(&self) {}
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert "async_trait" in ref_names
+
+
+def test_rust_external_trait_import_method_usage_marks_import_live(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use futures::StreamExt;
+use sqlx::{Column, Row, ValueRef};
+use std::io::{Read, Write};
+use tauri::{Emitter, Manager};
+
+fn run(stream: &mut Stream, row: RowLike, column: ColumnLike, value: ValueLike) {
+    stream.next();
+    row.try_get_raw(0);
+    column.type_info();
+    value.is_null();
+    file.read_to_end(&mut bytes);
+    out.write_all(&bytes);
+    app.emit("event", ());
+    app.path();
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert {"StreamExt", "Row", "Column", "ValueRef", "Read", "Write"} <= ref_names
+    assert {"Emitter", "Manager"} <= ref_names
+
+
+def test_rust_generic_trait_method_calls_mark_trait_import_live(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use sqlx::Row;
+
+fn run(row: RowLike, index: usize) {
+    row.try_get::<Vec<u8>, _>(index);
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert "Row" in ref_names
+
+
+def test_rust_type_alias_rhs_is_scanned_for_trait_objects(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use tokio_postgres::types::ToSql;
+
+type PgParam = Box<dyn ToSql + Send + Sync>;
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert "ToSql" in ref_names
+
+
+def test_rust_local_extension_trait_import_not_rescued_by_method_name(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use crate::traits::WidgetExt;
+
+fn run(widget: Widget) {
+    widget.next();
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert "next" in ref_names
+    assert "WidgetExt" not in ref_names
+
+
+def test_rust_inline_module_calls_emit_sibling_refs(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+mod tls_tests {
+    fn params_with_ssl() {}
+
+    #[test]
+    fn test_tls_connector_disable() {
+        params_with_ssl();
+    }
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert "tls_tests.params_with_ssl" in ref_names
+
+
 def test_rust_restricted_visibility_is_not_exported(tmp_path):
     defs, *_ = _scan_rust(
         tmp_path,
@@ -351,3 +537,65 @@ use crate::handlers::*;
 
     assert {d.type for d in defs} == set()
     assert raw_imports == [{"source": "crate::handlers::*", "names": ["*"], "line": 2}]
+
+
+def test_rust_serde_attrs_and_field_types_are_references(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ModelList {
+    models: Vec<Model>,
+    #[serde(default = "default_true")]
+    enabled: bool,
+}
+
+#[derive(Deserialize)]
+struct Model {
+    id: String,
+}
+
+fn default_true() -> bool { true }
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert {"Serialize", "Deserialize", "Model", "default_true"} <= ref_names
+
+
+def test_rust_callback_methods_and_registration_macros_are_references(tmp_path):
+    _, refs, *_ = _scan_rust(
+        tmp_path,
+        """
+struct StatementStream;
+
+impl StatementStream {
+    fn next_statement(&mut self) -> Option<String> { None }
+}
+
+fn parse_json_number(_: &serde_json::Value) -> Option<f64> { None }
+fn refresh_and_collect_system_stats() {}
+fn is_debug_mode() -> bool { true }
+fn close_devtools() {}
+
+fn run(value: Option<&serde_json::Value>, stream: &mut StatementStream) {
+    value.and_then(parse_json_number);
+    tokio::task::spawn_blocking(refresh_and_collect_system_stats);
+    stream.next_statement();
+    tauri::generate_handler![is_debug_mode, close_devtools];
+}
+""",
+    )
+
+    ref_names = {r[0] for r in refs}
+
+    assert {
+        "parse_json_number",
+        "refresh_and_collect_system_stats",
+        "next_statement",
+        "is_debug_mode",
+        "close_devtools",
+    } <= ref_names

--- a/test/test_ts_exports.py
+++ b/test/test_ts_exports.py
@@ -11,6 +11,7 @@ from skylos.visitors.languages.typescript.workspace import (
 )
 from skylos.visitors.languages.typescript.analysis import (
     build_ts_import_graph,
+    demote_unconsumed_ts_exports,
     find_unused_ts_exports,
     find_dead_ts_files,
     _is_nextjs_convention_file,
@@ -27,6 +28,33 @@ def _make_def(name, typ, filename, line=1, exported=False):
 
 def _scan_raw_imports(*paths: Path) -> dict[str, list[dict]]:
     return {str(path): scan_typescript_file(str(path))[12] for path in paths}
+
+
+# ---------- Export demotion exceptions ----------
+
+
+class TestExportDemotion:
+    def test_declaration_file_exports_are_not_demoted(self, tmp_path):
+        types_file = tmp_path / "types.d.ts"
+        ambient = _make_def("Window", "class", str(types_file), exported=True)
+
+        demoted = demote_unconsumed_ts_exports(
+            {f"{types_file}:Window": ambient},
+            {},
+        )
+
+        assert demoted == []
+        assert ambient.is_exported is True
+
+    def test_ambient_declaration_exports_are_not_demoted(self, tmp_path):
+        host_file = tmp_path / "host.ts"
+        ambient = _make_def("Window", "class", str(host_file), exported=True)
+        ambient.framework_signals.append("ambient declaration")
+
+        demoted = demote_unconsumed_ts_exports({f"{host_file}:Window": ambient}, {})
+
+        assert demoted == []
+        assert ambient.is_exported is True
 
 
 # ---------- Aliased import consumption ----------
@@ -334,6 +362,44 @@ class TestWildcardPassthrough:
         assert "helper" in consumed[str(mod_file)]
 
 
+class TestNamespaceImportConsumption:
+    def test_namespace_import_conservatively_consumes_source_exports(self, tmp_path):
+        api_file = tmp_path / "pluginApi.ts"
+        host_file = tmp_path / "PluginSlotProvider.tsx"
+
+        api_file.write_text(
+            """
+export function defineSlot() {}
+export function usePluginToast() {}
+""",
+            encoding="utf-8",
+        )
+        host_file.write_text(
+            """
+import * as pluginApi from "./pluginApi";
+
+(window as unknown as Record<string, unknown>).__TABULARIS_API__ = pluginApi;
+""",
+            encoding="utf-8",
+        )
+
+        defs = {
+            f"{api_file}:defineSlot": _make_def(
+                "defineSlot", "function", str(api_file), exported=True
+            ),
+            f"{api_file}:usePluginToast": _make_def(
+                "usePluginToast", "function", str(api_file), exported=True
+            ),
+        }
+
+        raw_imports = _scan_raw_imports(host_file)
+        consumed, _, _ = build_ts_import_graph(raw_imports, defs)
+
+        assert {"defineSlot", "usePluginToast"} <= consumed[str(api_file)]
+        assert defs[f"{api_file}:defineSlot"].references >= 1
+        assert defs[f"{api_file}:usePluginToast"].references >= 1
+
+
 class TestTypeScriptDeadFiles:
     def test_main_tsx_is_treated_as_entrypoint(self, tmp_path):
         main_file = tmp_path / "src" / "main.tsx"
@@ -570,6 +636,44 @@ export default defineConfig({
             [vite_config, lib_entry, worker_entry, helper_file],
             [],
             {str(helper_file): {str(lib_entry)}},
+            {},
+            project_root=str(tmp_path),
+            workspace_inventory=inventory,
+        )
+
+        assert dead_files == []
+
+    def test_tsup_config_is_config_entry_and_keeps_entries_live(self, tmp_path):
+        tsup_config = tmp_path / "packages" / "create-plugin" / "tsup.config.ts"
+        cli_file = tmp_path / "packages" / "create-plugin" / "src" / "cli.ts"
+
+        (tmp_path / "package.json").write_text(
+            '{"name":"@repo/root","workspaces":["packages/*"]}',
+            encoding="utf-8",
+        )
+        tsup_config.parent.mkdir(parents=True, exist_ok=True)
+        cli_file.parent.mkdir(parents=True, exist_ok=True)
+        (tsup_config.parent / "package.json").write_text(
+            '{"name":"@repo/create-plugin","scripts":{"build":"tsup"}}',
+            encoding="utf-8",
+        )
+        tsup_config.write_text(
+            """
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: { cli: "src/cli.ts" },
+});
+""",
+            encoding="utf-8",
+        )
+        cli_file.write_text("export function main() {}\n", encoding="utf-8")
+
+        inventory = discover_workspace_inventory(tmp_path)
+        dead_files = find_dead_ts_files(
+            [tsup_config, cli_file],
+            [],
+            {},
             {},
             project_root=str(tmp_path),
             workspace_inventory=inventory,

--- a/test/test_typescript.py
+++ b/test/test_typescript.py
@@ -113,3 +113,174 @@ def test_typescript_scan_result_is_parallel_worker_picklable(tmp_path):
     result = scan_typescript_file(str(p), {}, enable_quality_rules=False)
 
     pickle.dumps(result)
+
+
+def test_react_error_boundary_lifecycle_methods_are_not_dead_defs(tmp_path):
+    p = tmp_path / "Boundary.tsx"
+    p.write_text(
+        """
+import { Component } from "react";
+
+class Boundary extends Component {
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error(error);
+  }
+
+  render() {
+    return null;
+  }
+}
+""",
+        encoding="utf-8",
+    )
+
+    defs, *_ = scan_typescript_file(str(p))
+    def_names = {d.name for d in defs}
+
+    assert "Boundary.getDerivedStateFromError" not in def_names
+    assert "Boundary.componentDidCatch" not in def_names
+
+
+def test_declaration_file_defs_are_treated_as_public_ambient_api(tmp_path):
+    p = tmp_path / "types.d.ts"
+    p.write_text(
+        """
+declare global {
+  interface Window {
+    __APP_API__?: unknown;
+  }
+}
+
+declare module "external-lib" {
+  export class MultiPoint {}
+}
+""",
+        encoding="utf-8",
+    )
+
+    defs, *_ = scan_typescript_file(str(p))
+    exported = {d.name for d in defs if d.is_exported}
+
+    assert {"Window", "MultiPoint"} <= exported
+
+
+def test_regular_ts_ambient_declaration_defs_are_public_api(tmp_path):
+    p = tmp_path / "host.ts"
+    p.write_text(
+        """
+export function registerHost() {}
+
+declare global {
+  interface Window {
+    __APP_API__?: unknown;
+  }
+}
+""",
+        encoding="utf-8",
+    )
+
+    defs, *_ = scan_typescript_file(str(p))
+    exported = {d.name for d in defs if d.is_exported}
+
+    assert "Window" in exported
+
+
+def test_object_literal_methods_are_not_reported_as_standalone_defs(tmp_path):
+    p = tmp_path / "dragState.ts"
+    p.write_text(
+        """
+let table: string | null = null;
+
+export const dragState = {
+  get table() { return table; },
+  start(name: string) { table = name; },
+  clear() { table = null; },
+};
+
+dragState.clear();
+""",
+        encoding="utf-8",
+    )
+
+    defs, refs, *_ = scan_typescript_file(str(p))
+
+    assert "clear" not in {d.name for d in defs}
+    assert "clear" in {r[0] for r in refs}
+
+
+def test_default_parameter_and_update_expression_identifiers_are_refs(tmp_path):
+    p = tmp_path / "helpers.ts"
+    p.write_text(
+        """
+const MAX_HISTORY_SIZE = 10;
+let idCounter = 0;
+
+export function addHistoryEntry(maxSize = MAX_HISTORY_SIZE) {
+  return maxSize;
+}
+
+export function generateId() {
+  return `custom-${idCounter++}`;
+}
+""",
+        encoding="utf-8",
+    )
+
+    _, refs, *_ = scan_typescript_file(str(p))
+    ref_names = {r[0] for r in refs}
+
+    assert {"MAX_HISTORY_SIZE", "idCounter"} <= ref_names
+
+
+def test_aliased_named_import_defs_use_local_binding(tmp_path):
+    p = tmp_path / "icons.tsx"
+    p.write_text(
+        """
+import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
+import { Image as ImageIcon } from "lucide-react";
+
+export function pick() {
+  openFileDialog();
+  return <ImageIcon />;
+}
+""",
+        encoding="utf-8",
+    )
+
+    defs, refs, *_ = scan_typescript_file(str(p))
+    import_names = {d.name for d in defs if d.type == "import"}
+    ref_names = {r[0] for r in refs}
+
+    assert {"openFileDialog", "ImageIcon"} <= import_names
+    assert "open" not in import_names
+    assert "Image" not in import_names
+    assert {"openFileDialog", "ImageIcon"} <= ref_names
+
+
+def test_awaited_generic_call_identifier_is_ref_in_tsx(tmp_path):
+    p = tmp_path / "CellNameAiButton.tsx"
+    p.write_text(
+        """
+import { invoke } from "@tauri-apps/api/core";
+
+export function Button() {
+  async function handleGenerate() {
+    const name = await invoke<string>("generate_cell_name");
+    return name.trim();
+  }
+  return <button onClick={handleGenerate} />;
+}
+""",
+        encoding="utf-8",
+    )
+
+    defs, refs, *_ = scan_typescript_file(str(p))
+    import_names = {d.name for d in defs if d.type == "import"}
+    ref_names = {r[0] for r in refs}
+
+    assert "invoke" in import_names
+    assert "invoke" in ref_names

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -464,6 +464,17 @@ class TestTSDeadCodeFalsePositives:
         assert "closeBundle" not in names
         assert "orphanHook" in names
 
+    def test_regular_object_literal_methods_remain_untracked(self, tmp_path):
+        code = (
+            "const helpers = {\n"
+            "    formatName(value) {\n"
+            "        return value.trim();\n"
+            "    },\n"
+            "};\n"
+        )
+        defs, _, _, _ = _scan_ts(tmp_path, code)
+        assert "formatName" not in _def_names(defs)
+
     def test_html_inline_handlers_mark_global_js_functions_live(self, tmp_path):
         from skylos.analyzer import analyze
 


### PR DESCRIPTION
## Summary

  - Reduce dead code FPs in Rust and TS scanners
  - Improve Rust reference tracking for attributes, signatures, type aliases, imports, namespaced helpers, associated calls, and external trait method imports.
  - Improve TS liveness for ambient declarations, declaration files, aliased imports, object-literal methods, React lifecycle methods, config entrypoints, and awaited generic calls.

  ## Tests

  - `pytest test/test_rust.py test/test_typescript.py test/test_ts_exports.py`
  - `pytest test/test_dead_code.py test/test_dead_code_liveness.py test/test_dead_code_evidence.py test/test_analyzer.py`