### PR TITLE
fix(dead-code): reduce TS and Go false positives

### DIFF
--- a/skylos/analysis/known_patterns.py
+++ b/skylos/analysis/known_patterns.py
@@ -330,6 +330,16 @@ DRF_SERIALIZER_BASES = {
 DRF_PERMISSION_METHODS = {"has_permission", "has_object_permission"}
 DRF_PERMISSION_BASES = {"BasePermission"}
 
+# docutils/Sphinx Directive subclasses declare these as class attributes;
+# the framework reads them, never the user's code.
+DOCUTILS_DIRECTIVE_ATTRS = {
+    "has_content",
+    "required_arguments",
+    "optional_arguments",
+    "final_argument_whitespace",
+    "option_spec",
+}
+
 STARLETTE_MIDDLEWARE_METHODS = {"dispatch"}
 STARLETTE_MIDDLEWARE_BASES = {
     "BaseHTTPMiddleware",

--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -26,6 +26,7 @@ from skylos.analysis.known_patterns import (
     DRF_SERIALIZER_BASES,
     DRF_PERMISSION_METHODS,
     DRF_PERMISSION_BASES,
+    DOCUTILS_DIRECTIVE_ATTRS,
     STARLETTE_MIDDLEWARE_METHODS,
     STARLETTE_MIDDLEWARE_BASES,
     STARLETTE_ENDPOINT_METHODS,
@@ -836,6 +837,17 @@ def _check_data_model_fields(def_obj, analyzer, framework):
                 def_obj,
                 "Enum member" if def_obj.type == "variable" else "Enum method",
             )
+
+    if (
+        def_obj.type == "variable"
+        and "." in def_obj.name
+        and simple_name in DOCUTILS_DIRECTIVE_ATTRS
+    ):
+        prefix = def_obj.name.rsplit(".", 1)[0]
+        parent_simple = prefix.split(".")[-1]
+        class_bases = _class_base_names(parent_simple, framework)
+        if any(base.endswith("Directive") for base in class_bases):
+            return _suppress(def_obj, "docutils directive option")
 
     if def_obj.type == "variable" and "." in def_obj.name:
         parts = def_obj.name.split(".")

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1277,6 +1277,16 @@ class Skylos:
         for i, (ref, ref_file) in enumerate(self.refs, 1):
             if progress_callback and (i == 1 or i % tick_every == 0 or i == total_refs):
                 progress_callback(i, total_refs or 1, Path("PHASE: mark refs"))
+
+            if ref.startswith("~."):
+                # Property access (`x.foo`): dynamic dispatch can reach any
+                # method of this name, so credit them all, then resolve the
+                # bare name normally for functions attached as properties.
+                ref = ref[2:]
+                for d in simple_name_lookup.get(ref, []):
+                    if d.type == "method":
+                        d.references += 1
+
             file_key = f"{ref_file}:{ref}"
 
             if file_key in self.defs:

--- a/skylos/engines/go/internal/symbols/symbols.go
+++ b/skylos/engines/go/internal/symbols/symbols.go
@@ -243,6 +243,11 @@ func Extract(root string) (*Result, error) {
 					}
 				case *ast.TypeSpec:
 					walkExprForRefs(s.Type, pkgDir, importMap, modulePath, root, pkgDirs, path, result)
+					if s.TypeParams != nil {
+						for _, field := range s.TypeParams.List {
+							walkExprForRefs(field.Type, pkgDir, importMap, modulePath, root, pkgDirs, path, result)
+						}
+					}
 				}
 			}
 		}
@@ -260,6 +265,11 @@ func Extract(root string) (*Result, error) {
 				}
 				if funcDecl.Type.Results != nil {
 					for _, field := range funcDecl.Type.Results.List {
+						walkExprForRefs(field.Type, pkgDir, importMap, modulePath, root, pkgDirs, path, result)
+					}
+				}
+				if funcDecl.Type.TypeParams != nil {
+					for _, field := range funcDecl.Type.TypeParams.List {
 						walkExprForRefs(field.Type, pkgDir, importMap, modulePath, root, pkgDirs, path, result)
 					}
 				}

--- a/skylos/engines/go/internal/symbols/symbols_receiver_test.go
+++ b/skylos/engines/go/internal/symbols/symbols_receiver_test.go
@@ -140,6 +140,28 @@ func serve(r runner) {
 	expectNoCall(t, result, "serve", "runner.run")
 }
 
+func TestExtractDoesNotExportMethodsJustBecauseInterfaceDeclaresSameName(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+	writeTestFile(t, root, "demo.go", `package demo
+
+type runner interface {
+	run()
+}
+
+type worker struct{}
+
+func (w worker) run() {}
+`)
+
+	result, err := Extract(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectDefExported(t, result, "worker.run", false)
+}
+
 func TestHasMethodDefsOnlyMatchesMethods(t *testing.T) {
 	defs := []Def{
 		{Name: "main", Type: "function"},
@@ -235,4 +257,18 @@ func expectNoCall(t *testing.T, result *Result, caller string, callee string) {
 			t.Fatalf("did not expect call %q -> %q in %#v", caller, callee, result.CallPairs)
 		}
 	}
+}
+
+func expectDefExported(t *testing.T, result *Result, name string, exported bool) {
+	t.Helper()
+
+	for _, def := range result.Defs {
+		if def.Name == name {
+			if def.IsExported != exported {
+				t.Fatalf("expected def %q exported=%v, got %v", name, exported, def.IsExported)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected def %q in %#v", name, result.Defs)
 }

--- a/skylos/visitors/languages/typescript/__init__.py
+++ b/skylos/visitors/languages/typescript/__init__.py
@@ -19,6 +19,39 @@ class DummyVisitor:
         self.framework_decorated_lines: set[int] = set()
 
 
+_MINIFIED_LINE_THRESHOLD = 3000
+
+
+def _empty_typescript_scan_result(config: dict) -> tuple:
+    return (
+        [],
+        [],
+        set(),
+        set(),
+        DummyVisitor(),
+        DummyVisitor(),
+        [],
+        [],
+        [],
+        None,
+        None,
+        config,
+        [],
+    )
+
+
+def is_minified_js_source(file_path: str, source: bytes) -> bool:
+    base = file_path.rsplit("/", 1)[-1]
+    if ".min." in base:
+        return True
+    if len(source) < 5000:
+        return False
+    for line in source.split(b"\n", 200)[:200]:
+        if len(line) > _MINIFIED_LINE_THRESHOLD:
+            return True
+    return False
+
+
 def scan_typescript_file(
     file_path: str,
     config: dict | None = None,
@@ -33,20 +66,10 @@ def scan_typescript_file(
         with open(file_path, "rb") as f:
             source = f.read()
     except Exception:
-        return (
-            [],
-            [],
-            set(),
-            set(),
-            DummyVisitor(),
-            DummyVisitor(),
-            [],
-            [],
-            [],
-            None,
-            None,
-            config,
-        )
+        return _empty_typescript_scan_result(config)
+
+    if is_minified_js_source(str(file_path), source):
+        return _empty_typescript_scan_result(config)
 
     complexity_limit: int = config.get("complexity", 10)
 

--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -312,6 +312,13 @@ def _resolve_namespace_reexports(
 _VSCODE_EXTENSION_LIFECYCLE_EXPORTS = frozenset({"activate", "deactivate"})
 
 
+# The automatic/precompile JSX transforms emit calls to these in *user* code,
+# so a jsx-runtime module's exports are protocol surface, never dead.
+_JSX_RUNTIME_PROTOCOL_EXPORTS = frozenset(
+    {"jsx", "jsxs", "jsxDEV", "jsxTemplate", "jsxAttr", "jsxEscape", "Fragment", "JSX"}
+)
+
+
 def demote_unconsumed_ts_exports(defs, consumed_exports, lifecycle_entry_points=None):
     lifecycle_entry_points = {
         os.path.realpath(str(path)) for path in lifecycle_entry_points or ()
@@ -326,7 +333,16 @@ def demote_unconsumed_ts_exports(defs, consumed_exports, lifecycle_entry_points=
             continue
         if str(defn.filename).endswith(".d.ts"):
             continue
-        if "ambient declaration" in getattr(defn, "framework_signals", ()):
+        signals = getattr(defn, "framework_signals", ())
+        if "ambient declaration" in signals:
+            continue
+        if "deprecated export" in signals:
+            continue
+        if "type-only declaration" in signals:
+            continue
+        if defn.simple_name in _JSX_RUNTIME_PROTOCOL_EXPORTS and os.path.basename(
+            str(defn.filename)
+        ).startswith(("jsx-runtime.", "jsx-dev-runtime.")):
             continue
         if (
             os.path.realpath(str(defn.filename)) in lifecycle_entry_points
@@ -432,9 +448,17 @@ _TS_ENTRY_FILES = frozenset(
 def _is_ts_entry_or_infra(sf: str) -> bool:
     if sf.endswith(_TEST_SUFFIXES) or "/__tests__/" in sf:
         return True
-    if "/test/" in sf or "/tests/" in sf:
+    if "/test/" in sf or "/tests/" in sf or "/testdata/" in sf:
+        return True
+    if "/integration/" in sf:
+        return True
+    if "/_static/" in sf or "/static/" in sf or "/public/" in sf:
         return True
     if "/bench/" in sf or "/benchmark/" in sf or "/benchmarks/" in sf:
+        return True
+    if "/perf/" in sf or "/perf-measures/" in sf or "/performance/" in sf:
+        return True
+    if "/example/" in sf or "/examples/" in sf:
         return True
     if sf.endswith(".d.ts"):
         return True
@@ -453,9 +477,17 @@ def _is_ts_entry_or_infra(sf: str) -> bool:
 def _is_ts_dev_or_test_root(sf: str) -> bool:
     if sf.endswith(_TEST_SUFFIXES) or "/__tests__/" in sf:
         return True
-    if "/test/" in sf or "/tests/" in sf:
+    if "/test/" in sf or "/tests/" in sf or "/testdata/" in sf:
+        return True
+    if "/integration/" in sf:
+        return True
+    if "/_static/" in sf or "/static/" in sf or "/public/" in sf:
         return True
     if "/bench/" in sf or "/benchmark/" in sf or "/benchmarks/" in sf:
+        return True
+    if "/perf/" in sf or "/perf-measures/" in sf or "/performance/" in sf:
+        return True
+    if "/example/" in sf or "/examples/" in sf:
         return True
     if sf.endswith(".d.ts"):
         return True

--- a/skylos/visitors/languages/typescript/core.py
+++ b/skylos/visitors/languages/typescript/core.py
@@ -97,7 +97,7 @@ _DEFS_TS_ONLY_PATTERN = "(method_definition name: (identifier) @method_ident_def
 _REFS_PATTERN = """
 (call_expression function: (identifier) @ref)
 (new_expression constructor: (identifier) @ref)
-(member_expression property: (property_identifier) @ref)
+(member_expression property: (property_identifier) @prop_ref)
 (arguments (identifier) @ref)
 (variable_declarator value: (identifier) @ref)
 (array (identifier) @ref)
@@ -115,6 +115,13 @@ _REFS_PATTERN = """
 (unary_expression (identifier) @ref)
 (await_expression (identifier) @ref)
 (template_substitution (identifier) @ref)
+(for_in_statement right: (identifier) @ref)
+(computed_property_name (identifier) @ref)
+(augmented_assignment_expression left: (identifier) @ref)
+(augmented_assignment_expression right: (identifier) @ref)
+(type_query (identifier) @ref)
+(nested_type_identifier module: (identifier) @ref)
+(public_field_definition value: (identifier) @ref)
 (shorthand_property_identifier) @ref
 (decorator (identifier) @ref)
 (decorator (call_expression function: (identifier) @ref))
@@ -262,13 +269,13 @@ class TypeScriptCore:
             self._add_def(node, "class")
 
         for node in c.get("iface_def", []):
-            self._add_def(node, "class")
+            self._add_def(node, "class", extra_signal="type-only declaration")
 
         for node in c.get("enum_def", []):
             self._add_def(node, "class")
 
         for node in c.get("type_def", []):
-            self._add_def(node, "class")
+            self._add_def(node, "class", extra_signal="type-only declaration")
 
         for node in c.get("dec_ident", []):
             class_node = node.parent
@@ -322,6 +329,17 @@ class TypeScriptCore:
         for node in c.get("ref", []):
             self._add_ref(node)
 
+        # `x.foo` / `x[k].foo()` — emit the plain name (so functions/exports
+        # attached as properties still resolve) AND a `~.` marker so the
+        # analyzer also credits same-named methods on any class, since the
+        # receiver type is unknown and dispatch may reach any of them.
+        for node in c.get("prop_ref", []):
+            name = self._get_text(node)
+            if self._is_self_ref(node, name):
+                continue
+            self.refs.append((name, self.file_path))
+            self.refs.append((f"~.{name}", self.file_path))
+
         for node in c.get("type_ref", []):
             parent = node.parent
             if parent and parent.type in self._TYPE_DEF_PARENTS:
@@ -354,27 +372,37 @@ class TypeScriptCore:
             current = current.parent
         return None
 
-    def _add_def(self, node, type_name: str) -> None:
+    def _has_deprecated_jsdoc(self, node) -> bool:
+        current = node
+        while current.parent and current.parent.type != "program":
+            current = current.parent
+        sibling = current.prev_named_sibling
+        if sibling is not None and sibling.type == "comment":
+            return "@deprecated" in self._get_text(sibling)
+        return False
+
+    def _should_skip_method_def(self, node, name: str) -> bool:
+        object_node = self._containing_object_literal(node)
+        if object_node is not None:
+            return not (
+                self._is_bundler_plugin_object(object_node)
+                and name not in _BUNDLER_PLUGIN_HOOK_METHODS
+            )
+        return name in _LIFECYCLE_METHODS or name in _BUNDLER_PLUGIN_HOOK_METHODS
+
+    def _qualified_method_name(self, node, name: str) -> str:
+        class_name = self._find_containing_class(node)
+        if class_name:
+            return f"{class_name}.{name}"
+        return name
+
+    def _add_def(self, node, type_name: str, extra_signal: str | None = None) -> None:
         name = self._get_text(node)
 
         if type_name == "method":
-            object_node = self._containing_object_literal(node)
-            if object_node is not None:
-                if self._is_bundler_plugin_object(object_node) and (
-                    name not in _BUNDLER_PLUGIN_HOOK_METHODS
-                ):
-                    pass
-                else:
-                    return
-            elif name in _LIFECYCLE_METHODS:
+            if self._should_skip_method_def(node, name):
                 return
-            elif name in _BUNDLER_PLUGIN_HOOK_METHODS:
-                return
-
-        if type_name == "method":
-            class_name = self._find_containing_class(node)
-            if class_name:
-                name = f"{class_name}.{name}"
+            name = self._qualified_method_name(node, name)
 
         line = node.start_point[0] + 1
 
@@ -385,6 +413,10 @@ class TypeScriptCore:
         d.is_exported = is_exported
         if self._is_declaration_file or is_ambient:
             d.framework_signals.append("ambient declaration")
+        if extra_signal:
+            d.framework_signals.append(extra_signal)
+        if is_exported and self._has_deprecated_jsdoc(node):
+            d.framework_signals.append("deprecated export")
         if (
             type_name == "function"
             and d.is_exported
@@ -786,6 +818,14 @@ class TypeScriptCore:
             line = node.start_point[0] + 1
 
             if function_node.type == "import":
+                for source_path in self._string_sources_from_node(first_arg):
+                    self._append_raw_import(source_path, line, consume_all_exports=True)
+                continue
+
+            if (
+                function_node.type == "identifier"
+                and self._get_text(function_node) == "require"
+            ):
                 for source_path in self._string_sources_from_node(first_arg):
                     self._append_raw_import(source_path, line, consume_all_exports=True)
                 continue

--- a/test/test_typescript.py
+++ b/test/test_typescript.py
@@ -115,6 +115,17 @@ def test_typescript_scan_result_is_parallel_worker_picklable(tmp_path):
     pickle.dumps(result)
 
 
+def test_minified_js_scan_result_keeps_tuple_shape(tmp_path):
+    p = tmp_path / "app.min.js"
+    p.write_text("function run(){return 1}\n", encoding="utf-8")
+
+    result = scan_typescript_file(str(p))
+
+    assert len(result) == 13
+    assert result[0] == []
+    assert result[12] == []
+
+
 def test_react_error_boundary_lifecycle_methods_are_not_dead_defs(tmp_path):
     p = tmp_path / "Boundary.tsx"
     p.write_text(


### PR DESCRIPTION
## Summary

  - Treat docutils/Sphinx `Directive` class attributes as framework consumed.
  - Suppress intentionally unused underscore prefixed parameters.
  - Keep TS property accesses, computed property refs, public field values, and `require()` imports visible to reachability analysis.
  - Skip minified JS sources
  - Add Go generic type parameter refs without marking unrelated methods exported

  ## Tests

  - `pytest test/test_typescript.py test/test_typescript_expanded.py test/test_ts_exports.py test/test_typescript_resolve.py test/test_typescript_framework.py test/test_typescript_workspace.py`
  - `pytest test/test_go_runner.py test/test_go_quality.py test/test_go_security.py`
  - `go test ./...` from `skylos/engines/go`