### PR TITLE
fix(dead-code): handle literal plugin registries

### DIFF
--- a/skylos/deadcode/liveness.py
+++ b/skylos/deadcode/liveness.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
+from skylos.deadcode.plugin_registry import find_literal_plugin_registry_targets
+from skylos.deadcode.python_ast import ParsedPythonFile, parse_python_files
+
 
 SENTINEL_CALLER = "<skylos.deadcode.liveness>"
 DOC_EXTS = {".md", ".rst", ".txt"}
@@ -70,17 +73,19 @@ class LivenessReport:
     rescued: list[LivenessRescue] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "rescued_count": len(self.rescued),
-            "rescued": [
+        rescued_items: list[dict[str, Any]] = []
+        for rescue in self.rescued:
+            rescued_items.append(
                 {
                     "name": rescue.name,
                     "reason": rescue.reason,
                     "file": rescue.file,
                     "line": rescue.line,
                 }
-                for rescue in self.rescued
-            ],
+            )
+        return {
+            "rescued_count": len(self.rescued),
+            "rescued": rescued_items,
         }
 
 
@@ -105,8 +110,9 @@ def apply_dead_code_liveness(
 
     root = Path(project_root).resolve()
     py_files = _python_files(root, files)
+    parsed_files = parse_python_files(py_files)
     docs_text = _read_public_docs(root)
-    attr_calls = _collect_attr_calls(py_files)
+    attr_calls = _collect_attr_calls(parsed_files)
 
     classes: dict[str, Any] = {}
     class_methods: dict[str, list[Any]] = defaultdict(list)
@@ -121,6 +127,8 @@ def apply_dead_code_liveness(
     _rescue_optional_import_fallbacks(definitions, refs, report)
     _rescue_protocol_overrides(classes, class_methods, report)
     _rescue_registration_methods(classes, class_methods, report)
+    for target in find_literal_plugin_registry_targets(definitions, parsed_files):
+        _mark(target, "literal_plugin_registry", report)
     _rescue_documented_public_methods(classes, class_methods, docs_text, report)
     _rescue_unique_external_attr_calls(classes, class_methods, attr_calls, report)
     return report
@@ -149,11 +157,13 @@ def _mark(defn: Any, reason: str, report: LivenessReport) -> None:
 
 
 def _is_live_class(defn: Any) -> bool:
-    return bool(
-        getattr(defn, "references", 0) > 0
-        or getattr(defn, "is_exported", False)
-        or _is_public_name(getattr(defn, "simple_name", ""))
-    )
+    if getattr(defn, "references", 0) > 0:
+        return True
+    if getattr(defn, "is_exported", False):
+        return True
+    if _is_public_name(getattr(defn, "simple_name", "")):
+        return True
+    return False
 
 
 def _is_public_name(name: str) -> bool:
@@ -162,26 +172,46 @@ def _is_public_name(name: str) -> bool:
 
 def _owner_live(classes: dict[str, Any], owner: str) -> bool:
     class_def = classes.get(owner)
-    return bool(class_def and _is_live_class(class_def))
+    if not class_def:
+        return False
+    return _is_live_class(class_def)
 
 
 def _is_support_file(defn: Any) -> bool:
     try:
-        parts = {part.lower() for part in Path(getattr(defn, "filename", "")).parts}
+        path_parts = Path(getattr(defn, "filename", "")).parts
     except TypeError:
         return False
-    return bool(parts & {"test", "tests", "docs", "examples"})
+    for part in path_parts:
+        if part.lower() in {"test", "tests", "docs", "examples"}:
+            return True
+    return False
 
 
 def _python_files(root: Path, files: Iterable[str | Path] | None) -> list[Path]:
     if files is not None:
-        return [Path(f) for f in files if Path(f).suffix == ".py"]
+        explicit_files: list[Path] = []
+        for file in files:
+            path = Path(file)
+            if path.suffix == ".py":
+                explicit_files.append(path)
+        return explicit_files
     if not root.exists():
         return []
     ignored = {".git", ".venv", "venv", "__pycache__"}
-    return [
-        path for path in root.rglob("*.py") if not any(p in ignored for p in path.parts)
-    ]
+    python_files: list[Path] = []
+    for path in root.rglob("*.py"):
+        if _path_has_ignored_part(path, ignored):
+            continue
+        python_files.append(path)
+    return python_files
+
+
+def _path_has_ignored_part(path: Path, ignored: set[str]) -> bool:
+    for part in path.parts:
+        if part in ignored:
+            return True
+    return False
 
 
 def _read_public_docs(root: Path) -> str:
@@ -192,7 +222,7 @@ def _read_public_docs(root: Path) -> str:
     parts: list[str] = []
     seen_bytes = 0
     for path in root.rglob("*"):
-        if not path.is_file() or any(part in ignored for part in path.parts):
+        if not path.is_file() or _path_has_ignored_part(path, ignored):
             continue
         if path.suffix.lower() not in DOC_EXTS and path.stem.upper() not in DOC_NAMES:
             continue
@@ -212,20 +242,16 @@ def _read_public_docs(root: Path) -> str:
     return "\n".join(parts)
 
 
-def _collect_attr_calls(files: Iterable[Path]) -> list[_AttrCall]:
+def _collect_attr_calls(files: Iterable[ParsedPythonFile]) -> list[_AttrCall]:
     calls: list[_AttrCall] = []
-    for path in files:
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        except (OSError, SyntaxError, UnicodeDecodeError):
-            continue
-        for node in ast.walk(tree):
+    for parsed in files:
+        for node in ast.walk(parsed.tree):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
                 calls.append(
                     _AttrCall(
                         node.func.attr,
                         _attr_call_base_name(node.func),
-                        path,
+                        parsed.path,
                         getattr(node, "lineno", 0),
                     )
                 )
@@ -248,16 +274,20 @@ def _rescue_optional_import_fallbacks(
     refs: Iterable[tuple[str, Any]],
     report: LivenessReport,
 ) -> None:
-    conditional_imports = [
-        defn
-        for defn in definitions.values()
-        if getattr(defn, "type", None) == "import"
-        and getattr(defn, "conditional_import", False)
-    ]
+    conditional_imports = []
+    for defn in definitions.values():
+        if getattr(defn, "type", None) != "import":
+            continue
+        if not getattr(defn, "conditional_import", False):
+            continue
+        conditional_imports.append(defn)
     if not conditional_imports:
         return
 
-    referenced_simples = {str(ref).rsplit(".", 1)[-1] for ref, _ref_file in refs}
+    referenced_simples: set[str] = set()
+    for ref, _ref_file in refs:
+        referenced_simples.add(str(ref).rsplit(".", 1)[-1])
+
     conditional_by_file: dict[tuple[str, str], bool] = {}
     for imp in conditional_imports:
         simple = getattr(imp, "simple_name", "")
@@ -284,12 +314,7 @@ def _rescue_protocol_overrides(
         class_def = classes.get(owner)
         if not class_def:
             continue
-        base_names = {
-            base
-            for base in getattr(class_def, "base_classes", [])
-            if isinstance(base, str)
-        }
-        base_names.update(base.rsplit(".", 1)[-1] for base in list(base_names))
+        base_names = _base_names_for_class(class_def)
         live_methods: set[str] = set()
         for base in base_names:
             live_methods.update(PROTOCOL_METHODS_BY_BASE.get(base, set()))
@@ -312,22 +337,49 @@ def _rescue_registration_methods(
             name = getattr(method, "simple_name", "")
             if not _is_public_name(name):
                 continue
-            decorators = {
-                str(deco).rsplit(".", 1)[-1].lower()
-                for deco in getattr(method, "decorators", [])
-            }
-            looks_registered = any(
-                word in name.lower() for word in REGISTRATION_WORDS
-            ) or bool(decorators & {"setupmethod", "route", "command", "receiver"})
-            if looks_registered and _stores_and_returns_callable(method):
-                _mark(method, "registration_api", report)
+            decorators = _decorator_leaf_names(method)
+            if not _looks_registered_method(name, decorators):
+                continue
+            if not _stores_and_returns_callable(method):
+                continue
+            _mark(method, "registration_api", report)
+
+
+def _base_names_for_class(class_def: Any) -> set[str]:
+    base_names: set[str] = set()
+    for base in getattr(class_def, "base_classes", []):
+        if not isinstance(base, str):
+            continue
+        base_names.add(base)
+        base_names.add(base.rsplit(".", 1)[-1])
+    return base_names
+
+
+def _decorator_leaf_names(method: Any) -> set[str]:
+    decorators: set[str] = set()
+    for decorator in getattr(method, "decorators", []):
+        decorators.add(str(decorator).rsplit(".", 1)[-1].lower())
+    return decorators
+
+
+def _looks_registered_method(name: str, decorators: set[str]) -> bool:
+    lowered_name = name.lower()
+    for word in REGISTRATION_WORDS:
+        if word in lowered_name:
+            return True
+    for decorator in decorators:
+        if decorator in {"setupmethod", "route", "command", "receiver"}:
+            return True
+    return False
 
 
 def _stores_and_returns_callable(method: Any) -> bool:
     node = getattr(method, "node", None)
     if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return False
-    params = [arg.arg for arg in node.args.args]
+    params: list[str] = []
+    for arg in node.args.args:
+        params.append(arg.arg)
     if params and params[0] in {"self", "cls"}:
         params = params[1:]
     if not params:
@@ -337,23 +389,35 @@ def _stores_and_returns_callable(method: Any) -> bool:
     returns_param = False
     for child in ast.walk(node):
         if isinstance(child, ast.Call):
-            func = child.func
-            if (
-                isinstance(func, ast.Attribute)
-                and func.attr in REGISTRATION_MUTATORS
-                and isinstance(func.value, ast.Attribute)
-                and isinstance(func.value.value, ast.Name)
-                and func.value.value.id in {"self", "cls"}
-                and any(
-                    isinstance(arg, ast.Name) and arg.id == first_param
-                    for arg in child.args
-                )
-            ):
+            if _call_stores_param_on_self_or_cls(child, first_param):
                 stores_param = True
         elif isinstance(child, ast.Return):
             if isinstance(child.value, ast.Name) and child.value.id == first_param:
                 returns_param = True
     return stores_param and returns_param
+
+
+def _call_stores_param_on_self_or_cls(call: ast.Call, param_name: str) -> bool:
+    func = call.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr not in REGISTRATION_MUTATORS:
+        return False
+    if not isinstance(func.value, ast.Attribute):
+        return False
+    receiver = func.value.value
+    if not isinstance(receiver, ast.Name):
+        return False
+    if receiver.id not in {"self", "cls"}:
+        return False
+    return _call_has_arg_name(call, param_name)
+
+
+def _call_has_arg_name(call: ast.Call, name: str) -> bool:
+    for arg in call.args:
+        if isinstance(arg, ast.Name) and arg.id == name:
+            return True
+    return False
 
 
 def _rescue_documented_public_methods(
@@ -388,7 +452,10 @@ def _docs_reference_method(text: str, class_name: str, method_name: str) -> bool
     ]
     if "_" in method_name and len(method_name) >= 10:
         patterns.append(rf"\.[ \t]*{escaped_method}\(")
-    return any(re.search(pattern, text) for pattern in patterns)
+    for pattern in patterns:
+        if re.search(pattern, text):
+            return True
+    return False
 
 
 def _rescue_unique_external_attr_calls(
@@ -411,26 +478,33 @@ def _rescue_unique_external_attr_calls(
             if _is_public_name(name):
                 method_by_simple[name].append((owner, method))
 
-    call_count = Counter(call.attr for call in attr_calls)
+    call_count: Counter[str] = Counter()
     calls_by_attr: dict[str, list[_AttrCall]] = defaultdict(list)
     for call in attr_calls:
+        call_count[call.attr] += 1
         calls_by_attr[call.attr].append(call)
 
     for method_name, owner_methods in method_by_simple.items():
         if len(owner_methods) != 1:
             continue
-        if (
-            method_name in COMMON_UNTYPED_ATTR_CALLS
-            or call_count.get(method_name, 0) == 0
-        ):
+        if method_name in COMMON_UNTYPED_ATTR_CALLS:
+            continue
+        if call_count.get(method_name, 0) == 0:
             continue
         _owner, method = owner_methods[0]
         method_file = Path(getattr(method, "filename", "")).resolve()
-        external_calls = [
-            call
-            for call in calls_by_attr[method_name]
-            if call.file.resolve() != method_file
-            and call.base_name in FRAMEWORK_PROXY_NAMES
-        ]
-        if external_calls:
+        if _has_external_framework_proxy_call(calls_by_attr[method_name], method_file):
             _mark(method, "unique_external_attr_call", report)
+
+
+def _has_external_framework_proxy_call(
+    calls: list[_AttrCall],
+    method_file: Path,
+) -> bool:
+    for call in calls:
+        if call.file.resolve() == method_file:
+            continue
+        if call.base_name not in FRAMEWORK_PROXY_NAMES:
+            continue
+        return True
+    return False

--- a/skylos/deadcode/plugin_registry.py
+++ b/skylos/deadcode/plugin_registry.py
@@ -1,0 +1,584 @@
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from skylos.deadcode.python_ast import ParsedPythonFile
+
+
+_PLUGIN_TARGET_RE = re.compile(
+    r"^([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*):([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)$"
+)
+_ENTRY_ROOT_NAMES = {"main", "cli", "run", "app", "create_app"}
+_ROOT_EVIDENCE_MARKERS = {
+    "framework_root",
+    "package_entrypoint",
+    "test_entrypoint",
+    "top_level_execution",
+    "coverage_hit",
+    "trace_hit",
+}
+
+
+@dataclass(frozen=True)
+class _ImportContext:
+    name_aliases: dict[str, str]
+    module_aliases: dict[str, str]
+    importlib_names: set[str]
+    import_module_names: set[str]
+
+
+_DefByName = dict[str, Any]
+_DefByFileSimple = dict[tuple[str, str], Any]
+_DefByFileLine = dict[tuple[str, int], Any]
+
+
+def find_literal_plugin_registry_targets(
+    definitions: dict[str, Any],
+    parsed_files: Sequence[ParsedPythonFile],
+) -> list[Any]:
+    definitions_by_name = _definitions_by_name(definitions)
+    definitions_by_file_simple = _definitions_by_file_simple(definitions)
+    definitions_by_file_line = _definitions_by_file_line(definitions)
+
+    registries = _collect_literal_plugin_registries(
+        parsed_files,
+        definitions_by_file_simple,
+        definitions_by_name,
+    )
+    if not registries:
+        return []
+
+    reachable_functions = _reachable_live_functions(definitions)
+    if not reachable_functions:
+        return []
+
+    live_registries = _collect_live_plugin_registry_uses(
+        parsed_files,
+        definitions_by_file_simple,
+        definitions_by_file_line,
+        set(registries),
+        reachable_functions,
+    )
+    if not live_registries:
+        return []
+
+    targets: list[Any] = []
+    seen: set[str] = set()
+    for registry_qname in sorted(live_registries):
+        for target_qname in sorted(registries.get(registry_qname, ())):
+            target = definitions_by_name.get(target_qname)
+            if target is None:
+                continue
+            if getattr(target, "type", None) not in {"class", "function", "method"}:
+                continue
+            target_name = str(getattr(target, "name", ""))
+            if target_name in seen:
+                continue
+            seen.add(target_name)
+            targets.append(target)
+    return targets
+
+
+# Definition indexes
+
+
+def _definitions_by_file_simple(definitions: dict[str, Any]) -> _DefByFileSimple:
+    lookup: _DefByFileSimple = {}
+    for defn in definitions.values():
+        simple = str(getattr(defn, "simple_name", ""))
+        if not simple:
+            continue
+        try:
+            filename = str(Path(getattr(defn, "filename", "")).resolve())
+        except (OSError, TypeError):
+            continue
+        key = (filename, simple)
+        if key not in lookup:
+            lookup[key] = defn
+    return lookup
+
+
+def _definitions_by_name(definitions: dict[str, Any]) -> _DefByName:
+    lookup: _DefByName = {}
+    for defn in definitions.values():
+        name = str(getattr(defn, "name", ""))
+        if not name:
+            continue
+        existing = lookup.get(name)
+        if existing is None:
+            lookup[name] = defn
+            continue
+        existing_type = getattr(existing, "type", None)
+        defn_type = getattr(defn, "type", None)
+        if existing_type == "import" and defn_type != "import":
+            lookup[name] = defn
+    return lookup
+
+
+def _definitions_by_file_line(definitions: dict[str, Any]) -> _DefByFileLine:
+    lookup: _DefByFileLine = {}
+    for defn in definitions.values():
+        if getattr(defn, "type", None) not in {"function", "method"}:
+            continue
+        try:
+            filename = str(Path(getattr(defn, "filename", "")).resolve())
+            line = int(getattr(defn, "line", 0) or 0)
+        except (OSError, TypeError, ValueError):
+            continue
+        if line:
+            lookup[(filename, line)] = defn
+    return lookup
+
+
+# Registry discovery
+
+
+def _collect_literal_plugin_registries(
+    parsed_files: Sequence[ParsedPythonFile],
+    definitions_by_file_simple: _DefByFileSimple,
+    definitions_by_name: _DefByName,
+) -> dict[str, set[str]]:
+    registries: dict[str, set[str]] = {}
+    for parsed in parsed_files:
+        try:
+            file_key = str(parsed.path.resolve())
+        except OSError:
+            continue
+        for stmt in parsed.tree.body:
+            value = _assignment_value(stmt)
+            if value is None:
+                continue
+            targets = _module_assignment_names(stmt)
+            if not targets:
+                continue
+            plugin_targets: set[str] = set()
+            for raw in _literal_strings(value):
+                target = _plugin_target_qname(raw)
+                if target not in definitions_by_name:
+                    continue
+                plugin_targets.add(target)
+            if not plugin_targets:
+                continue
+            for target_name in targets:
+                registry_def = definitions_by_file_simple.get((file_key, target_name))
+                if registry_def is None:
+                    continue
+                registry_qname = str(getattr(registry_def, "name", ""))
+                registries.setdefault(registry_qname, set()).update(plugin_targets)
+    return registries
+
+
+def _assignment_value(node: ast.AST) -> ast.AST | None:
+    if isinstance(node, ast.Assign):
+        return node.value
+    if isinstance(node, ast.AnnAssign):
+        return node.value
+    return None
+
+
+def _module_assignment_names(node: ast.AST) -> list[str]:
+    targets: list[ast.AST] = []
+    if isinstance(node, ast.Assign):
+        targets.extend(node.targets)
+    elif isinstance(node, ast.AnnAssign):
+        targets.append(node.target)
+
+    names: list[str] = []
+    for target in targets:
+        if isinstance(target, ast.Name):
+            names.append(target.id)
+    return names
+
+
+def _literal_strings(node: ast.AST) -> set[str]:
+    strings: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            strings.add(child.value)
+    return strings
+
+
+def _plugin_target_qname(value: str) -> str:
+    match = _PLUGIN_TARGET_RE.match(value.strip())
+    if not match:
+        return ""
+    module_name, member_name = match.groups()
+    return f"{module_name}.{member_name}"
+
+
+# Live registry use detection
+
+
+def _collect_live_plugin_registry_uses(
+    parsed_files: Sequence[ParsedPythonFile],
+    definitions_by_file_simple: _DefByFileSimple,
+    definitions_by_file_line: _DefByFileLine,
+    registry_qnames: set[str],
+    reachable_functions: set[str],
+) -> set[str]:
+    live_registries: set[str] = set()
+    for parsed in parsed_files:
+        try:
+            file_key = str(parsed.path.resolve())
+        except OSError:
+            continue
+        import_ctx = _collect_import_context(parsed.tree)
+        for node in ast.walk(parsed.tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            defn = definitions_by_file_line.get((file_key, node.lineno))
+            if defn is None:
+                continue
+            defn_name = str(getattr(defn, "name", ""))
+            if defn_name not in reachable_functions:
+                continue
+            live_registries.update(
+                _registries_used_by_importlib_getattr_flow(
+                    node,
+                    file_key,
+                    definitions_by_file_simple,
+                    import_ctx,
+                    registry_qnames,
+                )
+            )
+    return live_registries
+
+
+def _collect_import_context(tree: ast.Module) -> _ImportContext:
+    name_aliases: dict[str, str] = {}
+    module_aliases: dict[str, str] = {}
+    importlib_names: set[str] = set()
+    import_module_names: set[str] = set()
+
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Import):
+            for alias in stmt.names:
+                bound_name = alias.asname or alias.name.split(".", 1)[0]
+                if alias.name == "importlib":
+                    importlib_names.add(bound_name)
+                if alias.asname:
+                    module_aliases[bound_name] = alias.name
+                elif "." not in alias.name:
+                    module_aliases[bound_name] = alias.name
+        elif isinstance(stmt, ast.ImportFrom) and stmt.module:
+            for alias in stmt.names:
+                bound_name = alias.asname or alias.name
+                target = f"{stmt.module}.{alias.name}"
+                name_aliases[bound_name] = target
+                if stmt.module == "importlib" and alias.name == "import_module":
+                    import_module_names.add(bound_name)
+
+    return _ImportContext(
+        name_aliases=name_aliases,
+        module_aliases=module_aliases,
+        importlib_names=importlib_names,
+        import_module_names=import_module_names,
+    )
+
+
+def _registries_used_by_importlib_getattr_flow(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    file_key: str,
+    definitions_by_file_simple: _DefByFileSimple,
+    import_ctx: _ImportContext,
+    registry_qnames: set[str],
+) -> set[str]:
+    path_vars: dict[str, str] = {}
+    split_vars: dict[tuple[str, str], str] = {}
+    live_registries: set[str] = set()
+
+    for child in ast.walk(function):
+        for target, value in _iter_simple_assignments(child):
+            registry_qname = _registry_qname_from_lookup(
+                value,
+                file_key,
+                definitions_by_file_simple,
+                import_ctx,
+            )
+            if registry_qname in registry_qnames:
+                path_vars[_target_name(target)] = registry_qname
+
+            split_source = _split_source_var(value)
+            if split_source and split_source in path_vars:
+                module_var, func_var = _split_assignment_pair(target)
+                if module_var and func_var:
+                    split_vars[(module_var, func_var)] = path_vars[split_source]
+
+        if not isinstance(child, ast.Call):
+            continue
+        split_key = _importlib_getattr_split_key(child, import_ctx)
+        if split_key and split_key in split_vars:
+            live_registries.add(split_vars[split_key])
+
+    return live_registries
+
+
+# Reachability
+
+
+def _reachable_live_functions(definitions: dict[str, Any]) -> set[str]:
+    definitions_by_name = _definitions_by_name(definitions)
+    callable_names = _callable_definition_names(definitions_by_name)
+    roots = _root_callable_names(definitions_by_name, callable_names)
+    if not roots:
+        return set()
+    simple_callable_names = _callable_names_by_simple_name(callable_names)
+    return _walk_reachable_functions(
+        roots,
+        definitions_by_name,
+        callable_names,
+        simple_callable_names,
+    )
+
+
+def _callable_definition_names(definitions_by_name: _DefByName) -> set[str]:
+    callable_names: set[str] = set()
+    for name, defn in definitions_by_name.items():
+        if getattr(defn, "type", None) not in {"function", "method"}:
+            continue
+        callable_names.add(name)
+    return callable_names
+
+
+def _callable_names_by_simple_name(
+    callable_names: set[str],
+) -> dict[str, list[str]]:
+    simple_callable_names: dict[str, list[str]] = defaultdict(list)
+    for name in callable_names:
+        simple_callable_names[name.rsplit(".", 1)[-1]].append(name)
+    return simple_callable_names
+
+
+def _root_callable_names(
+    definitions_by_name: _DefByName,
+    callable_names: set[str],
+) -> set[str]:
+    roots: set[str] = set()
+    for name, defn in definitions_by_name.items():
+        if name not in callable_names:
+            continue
+        if not _is_hard_liveness_root(defn):
+            continue
+        roots.add(name)
+    return roots
+
+
+def _walk_reachable_functions(
+    roots: set[str],
+    definitions_by_name: _DefByName,
+    callable_names: set[str],
+    simple_callable_names: dict[str, list[str]],
+) -> set[str]:
+    reachable: set[str] = set()
+    stack = list(roots)
+    while stack:
+        current = stack.pop()
+        if current in reachable:
+            continue
+        reachable.add(current)
+        current_def = definitions_by_name.get(current)
+        if current_def is None:
+            continue
+        callees = _reachable_callees_for_definition(
+            current_def,
+            callable_names,
+            simple_callable_names,
+        )
+        for callee in callees:
+            if callee not in reachable:
+                stack.append(callee)
+    return reachable
+
+
+def _reachable_callees_for_definition(
+    defn: Any,
+    callable_names: set[str],
+    simple_callable_names: dict[str, list[str]],
+) -> list[str]:
+    callees: list[str] = []
+    for raw_callee in getattr(defn, "calls", set()) or ():
+        callee = _resolve_callable_name(
+            str(raw_callee),
+            callable_names,
+            simple_callable_names,
+        )
+        if not callee:
+            continue
+        callees.append(callee)
+    return callees
+
+
+def _is_hard_liveness_root(defn: Any) -> bool:
+    if getattr(defn, "type", None) not in {"function", "method"}:
+        return False
+    filename = str(getattr(defn, "filename", ""))
+    if filename.endswith("__main__.py"):
+        return True
+    if bool(getattr(defn, "is_exported", False)):
+        return True
+    simple_name = str(getattr(defn, "simple_name", ""))
+    if simple_name.startswith("test_") or simple_name in _ENTRY_ROOT_NAMES:
+        return True
+    refs = getattr(defn, "heuristic_refs", {}) or {}
+    if not isinstance(refs, dict):
+        return False
+    for marker in _ROOT_EVIDENCE_MARKERS:
+        if marker in refs:
+            return True
+    return False
+
+
+def _resolve_callable_name(
+    raw_callee: str,
+    callable_names: set[str],
+    simple_callable_names: dict[str, list[str]],
+) -> str:
+    if raw_callee in callable_names:
+        return raw_callee
+    simple = raw_callee.rsplit(".", 1)[-1]
+    candidates = simple_callable_names.get(simple, [])
+    if len(candidates) == 1:
+        return candidates[0]
+    return ""
+
+
+# AST expression helpers
+
+
+def _iter_simple_assignments(node: ast.AST):
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            yield target, node.value
+    elif isinstance(node, ast.AnnAssign):
+        yield node.target, node.value
+
+
+def _target_name(target: ast.AST) -> str:
+    if isinstance(target, ast.Name):
+        return target.id
+    return ""
+
+
+def _split_assignment_pair(target: ast.AST) -> tuple[str | None, str | None]:
+    if not isinstance(target, (ast.Tuple, ast.List)) or len(target.elts) != 2:
+        return None, None
+    left, right = target.elts
+    if isinstance(left, ast.Name) and isinstance(right, ast.Name):
+        return left.id, right.id
+    return None, None
+
+
+def _split_source_var(value: ast.AST | None) -> str:
+    if not isinstance(value, ast.Call):
+        return ""
+    func = value.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and func.attr == "split"
+        and isinstance(func.value, ast.Name)
+    ):
+        return ""
+    if not value.args:
+        return ""
+    sep = value.args[0]
+    if isinstance(sep, ast.Constant) and sep.value == ":":
+        return func.value.id
+    return ""
+
+
+def _registry_qname_from_lookup(
+    value: ast.AST | None,
+    file_key: str,
+    definitions_by_file_simple: _DefByFileSimple,
+    import_ctx: _ImportContext,
+) -> str:
+    registry_expr: ast.AST | None = None
+    if isinstance(value, ast.Subscript):
+        registry_expr = value.value
+    elif (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "get"
+    ):
+        registry_expr = value.func.value
+
+    if registry_expr is None:
+        return ""
+    return _registry_qname_from_expr(
+        registry_expr,
+        file_key,
+        definitions_by_file_simple,
+        import_ctx,
+    )
+
+
+def _registry_qname_from_expr(
+    expr: ast.AST,
+    file_key: str,
+    definitions_by_file_simple: _DefByFileSimple,
+    import_ctx: _ImportContext,
+) -> str:
+    if isinstance(expr, ast.Name):
+        alias = import_ctx.name_aliases.get(expr.id)
+        if alias:
+            return alias
+        local_def = definitions_by_file_simple.get((file_key, expr.id))
+        if local_def is not None:
+            return str(getattr(local_def, "name", ""))
+        return ""
+
+    parts = _attribute_parts(expr)
+    if len(parts) >= 2 and parts[0] in import_ctx.module_aliases:
+        return ".".join([import_ctx.module_aliases[parts[0]], *parts[1:]])
+    return ""
+
+
+def _attribute_parts(expr: ast.AST) -> list[str]:
+    parts: list[str] = []
+    current = expr
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        return list(reversed(parts))
+    return []
+
+
+def _importlib_getattr_split_key(
+    node: ast.Call,
+    import_ctx: _ImportContext,
+) -> tuple[str, str] | None:
+    if not (isinstance(node.func, ast.Name) and node.func.id == "getattr"):
+        return None
+    if len(node.args) < 2:
+        return None
+    module_call, func_arg = node.args[0], node.args[1]
+    if not isinstance(func_arg, ast.Name):
+        return None
+    module_var = _import_module_arg_name(module_call, import_ctx)
+    if not module_var:
+        return None
+    return module_var, func_arg.id
+
+
+def _import_module_arg_name(node: ast.AST, import_ctx: _ImportContext) -> str:
+    if not isinstance(node, ast.Call) or not node.args:
+        return ""
+    first_arg = node.args[0]
+    if not isinstance(first_arg, ast.Name):
+        return ""
+
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == "import_module":
+        value = func.value
+        if isinstance(value, ast.Name) and value.id in import_ctx.importlib_names:
+            return first_arg.id
+    if isinstance(func, ast.Name) and func.id in import_ctx.import_module_names:
+        return first_arg.id
+    return ""

--- a/skylos/deadcode/python_ast.py
+++ b/skylos/deadcode/python_ast.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ParsedPythonFile:
+    path: Path
+    tree: ast.Module
+
+
+def parse_python_files(files: Iterable[Path]) -> list[ParsedPythonFile]:
+    parsed: list[ParsedPythonFile] = []
+    for path in files:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        parsed.append(ParsedPythonFile(path=path, tree=tree))
+    return parsed

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -163,3 +163,152 @@ def test_framework_proxy_attr_call_is_live(tmp_path):
     result = json.loads(analyze(str(tmp_path), grep_verify=False))
 
     assert "app.App.make_shell_context" not in _unused_function_names(result)
+
+
+def test_literal_plugin_registry_targets_are_live(tmp_path):
+    _write(
+        tmp_path / "pyproject.toml",
+        """
+        [project]
+        name = "plugin-registry-fixture"
+        version = "0.0.0"
+
+        [project.scripts]
+        runner = "app:main"
+        """,
+    )
+    _write(
+        tmp_path / "app.py",
+        """
+        from dispatcher import dispatch_event
+
+        def main(event=None):
+            return dispatch_event(event or {"type": "pay", "payload": {}})
+        """,
+    )
+    _write(
+        tmp_path / "registry.py",
+        """
+        HANDLER_PATHS = {
+            "pay": "plugins.payments:charge_card",
+            "invoice": "plugins.payments:archived_invoice",
+        }
+        """,
+    )
+    _write(
+        tmp_path / "dispatcher.py",
+        """
+        import importlib
+
+        from registry import HANDLER_PATHS
+
+        def dispatch_event(event):
+            handler_path = HANDLER_PATHS[event.get("type", "pay")]
+            module_name, func_name = handler_path.split(":")
+            handler = getattr(importlib.import_module(module_name), func_name)
+            return handler(event.get("payload", {}))
+        """,
+    )
+    _write(tmp_path / "plugins" / "__init__.py", "")
+    _write(
+        tmp_path / "plugins" / "payments.py",
+        """
+        def charge_card(payload):
+            return payload
+
+        def archived_invoice(payload):
+            return payload
+
+        def debug_query(payload):
+            return payload
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    unused = _unused_function_names(result)
+
+    assert "plugins.payments.charge_card" not in unused
+    assert "plugins.payments.archived_invoice" not in unused
+    assert "plugins.payments.debug_query" in unused
+    rescues = result["analysis_summary"]["dead_code_liveness"]["rescued"]
+    assert any(item["reason"] == "literal_plugin_registry" for item in rescues)
+
+
+def test_unused_literal_plugin_registry_does_not_rescue_targets(tmp_path):
+    _write(
+        tmp_path / "registry.py",
+        """
+        HANDLER_PATHS = {
+            "pay": "plugins.payments:charge_card",
+        }
+        """,
+    )
+    _write(
+        tmp_path / "dispatcher.py",
+        """
+        import importlib
+
+        from registry import HANDLER_PATHS
+
+        def dispatch_event(event):
+            handler_path = HANDLER_PATHS[event.get("type", "pay")]
+            module_name, func_name = handler_path.split(":")
+            handler = getattr(importlib.import_module(module_name), func_name)
+            return handler(event.get("payload", {}))
+        """,
+    )
+    _write(tmp_path / "plugins" / "__init__.py", "")
+    _write(
+        tmp_path / "plugins" / "payments.py",
+        """
+        def charge_card(payload):
+            return payload
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+
+    assert "plugins.payments.charge_card" in _unused_function_names(result)
+
+
+def test_literal_plugin_registry_requires_importlib_getattr_flow(tmp_path):
+    _write(
+        tmp_path / "pyproject.toml",
+        """
+        [project]
+        name = "plugin-registry-fixture"
+        version = "0.0.0"
+
+        [project.scripts]
+        runner = "app:main"
+        """,
+    )
+    _write(
+        tmp_path / "registry.py",
+        """
+        HANDLER_PATHS = {
+            "pay": "plugins.payments:charge_card",
+        }
+        """,
+    )
+    _write(
+        tmp_path / "app.py",
+        """
+        from registry import HANDLER_PATHS
+
+        def main():
+            return HANDLER_PATHS["pay"]
+        """,
+    )
+    _write(tmp_path / "plugins" / "__init__.py", "")
+    _write(
+        tmp_path / "plugins" / "payments.py",
+        """
+        def charge_card(payload):
+            return payload
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+
+    assert "plugins.payments.charge_card" in _unused_function_names(result)


### PR DESCRIPTION
## Summary

  - Add static liveness support for literal plugin registries that dispatch via reachable `importlib.import_module(...)` + `getattr(...)` flows.
  - Split plugin-registry analysis into `skylos/deadcode/plugin_registry.py` and shared Python AST parsing into `skylos/deadcode/python_ast.py`.
  - Keep `liveness.py` focused on orchestration and rescue marking.

  ## Tests

  - `pytest test/test_dead_code_liveness.py`
  - `pytest test/test_framework_aware.py test/test_dynamic_patterns.py test/test_dead_code_liveness.py test/test_dead_code_evidence.py test/test_dead_code_benchmark.py`