### PR TITLE
fix(java): reduce annotation dead-code false positives

### DIFF
--- a/skylos/visitors/languages/java/core.py
+++ b/skylos/visitors/languages/java/core.py
@@ -63,6 +63,92 @@ _SERIALIZATION_HOOKS_WITH_STREAM: dict[str, str] = {
     "writeObject": "ObjectOutputStream",
 }
 
+_CLASS_ENTRYPOINT_ANNOTATIONS: set[str] = {
+    "ApplicationPath",
+    "ApplicationScoped",
+    "Component",
+    "Configuration",
+    "ConfigurationProperties",
+    "Controller",
+    "ControllerAdvice",
+    "DataJpaTest",
+    "Dependent",
+    "Document",
+    "Embeddable",
+    "Entity",
+    "ExtendWith",
+    "Factory",
+    "HiltAndroidApp",
+    "MappedSuperclass",
+    "MessageDriven",
+    "MicronautTest",
+    "Named",
+    "Path",
+    "QuarkusTest",
+    "Repository",
+    "RequestScoped",
+    "RestController",
+    "RestControllerAdvice",
+    "RunWith",
+    "Service",
+    "SessionScoped",
+    "SpringBootApplication",
+    "SpringBootTest",
+    "Stateful",
+    "Stateless",
+    "Testcontainers",
+    "WebFilter",
+    "WebListener",
+    "WebMvcTest",
+    "WebServlet",
+}
+
+_METHOD_ENTRYPOINT_ANNOTATIONS: set[str] = {
+    "After",
+    "AfterAll",
+    "AfterClass",
+    "AfterEach",
+    "Bean",
+    "Before",
+    "BeforeAll",
+    "BeforeClass",
+    "BeforeEach",
+    "DeleteMapping",
+    "DgsData",
+    "DgsMutation",
+    "DgsQuery",
+    "EventListener",
+    "ExceptionHandler",
+    "GET",
+    "GetMapping",
+    "GraphQLMutation",
+    "GraphQLQuery",
+    "JmsListener",
+    "KafkaListener",
+    "MessageMapping",
+    "MutationMapping",
+    "PATCH",
+    "POST",
+    "PUT",
+    "ParameterizedTest",
+    "PatchMapping",
+    "Path",
+    "PostConstruct",
+    "PostMapping",
+    "PreDestroy",
+    "PutMapping",
+    "QueryMapping",
+    "RabbitListener",
+    "RepeatedTest",
+    "RequestMapping",
+    "Scheduled",
+    "SchemaMapping",
+    "SubscribeMapping",
+    "Test",
+    "TestFactory",
+    "TestTemplate",
+}
+
 _DEFS_PATTERN = """
 (class_declaration name: (identifier) @class_def)
 (interface_declaration name: (identifier) @iface_def)
@@ -274,31 +360,74 @@ class JavaCore:
                 return child
         return None
 
-    def _has_annotation(self, node, annotation_name: str) -> bool:
-        decl = node.parent
+    _ANNOTATED_DECL_TYPES: set[str] = {
+        "annotation_type_declaration",
+        "class_declaration",
+        "enum_declaration",
+        "field_declaration",
+        "interface_declaration",
+        "method_declaration",
+        "constructor_declaration",
+        "record_declaration",
+    }
+
+    def _declaration_for_node(self, node):
+        decl = node
         while decl:
-            if decl.type in (
-                "class_declaration",
-                "method_declaration",
-                "field_declaration",
-                "constructor_declaration",
-            ):
-                break
+            if decl.type in self._ANNOTATED_DECL_TYPES:
+                return decl
             decl = decl.parent
+        return None
+
+    def _annotation_names(self, node) -> set[str]:
+        decl = self._declaration_for_node(node)
         if not decl:
-            return False
+            return set()
+
+        names: set[str] = set()
         for child in decl.children:
             if child.type == "modifiers":
                 for mod_child in child.children:
-                    if mod_child.type == "marker_annotation":
+                    if (
+                        mod_child.type == "marker_annotation"
+                        or "annotation" in mod_child.type
+                    ):
                         name = mod_child.child_by_field_name("name")
-                        if name and self._get_text(name) == annotation_name:
-                            return True
-                    elif mod_child.type == "annotation":
-                        name = mod_child.child_by_field_name("name")
-                        if name and self._get_text(name) == annotation_name:
-                            return True
+                        if name:
+                            annotation = self._get_text(name)
+                            names.add(annotation)
+                            names.add(annotation.rsplit(".", 1)[-1])
+        return names
+
+    def _has_annotation(self, node, annotation_name: str) -> bool:
+        return annotation_name in self._annotation_names(node)
+
+    def _has_any_annotation(self, node, annotation_names: set[str]) -> bool:
+        return bool(self._annotation_names(node) & annotation_names)
+
+    def _class_contains_annotated_method(
+        self, class_node, annotation_names: set[str]
+    ) -> bool:
+        for child in self._walk_nodes(class_node):
+            if child is class_node:
+                continue
+            if child.type == "class_declaration":
+                continue
+            if child.type == "method_declaration" and self._has_any_annotation(
+                child, annotation_names
+            ):
+                return True
         return False
+
+    def _is_java_class_entrypoint(self, name_node) -> bool:
+        class_node = self._declaration_for_node(name_node)
+        if class_node is None:
+            return False
+        if self._has_any_annotation(class_node, _CLASS_ENTRYPOINT_ANNOTATIONS):
+            return True
+        return self._class_contains_annotated_method(
+            class_node, _METHOD_ENTRYPOINT_ANNOTATIONS
+        )
 
     def _method_parameter_texts(self, method_node) -> list[str]:
         parameters = method_node.child_by_field_name(
@@ -389,6 +518,9 @@ class JavaCore:
     def _add_def(self, node, type_name: str) -> None:
         name = self._get_text(node)
 
+        if type_name == "class" and self._is_java_class_entrypoint(node):
+            return
+
         if type_name == "method" and name in _LIFECYCLE_METHODS:
             return
 
@@ -401,40 +533,8 @@ class JavaCore:
         if type_name == "method":
             if self._has_annotation(node, "Override"):
                 return
-            if self._has_annotation(node, "Bean"):
+            if self._has_any_annotation(node, _METHOD_ENTRYPOINT_ANNOTATIONS):
                 return
-            if self._has_annotation(node, "Test"):
-                return
-            if self._has_annotation(node, "Before"):
-                return
-            if self._has_annotation(node, "After"):
-                return
-            if self._has_annotation(node, "BeforeEach"):
-                return
-            if self._has_annotation(node, "AfterEach"):
-                return
-            if self._has_annotation(node, "PostConstruct"):
-                return
-            if self._has_annotation(node, "PreDestroy"):
-                return
-            if self._has_annotation(node, "EventListener"):
-                return
-            if self._has_annotation(node, "Scheduled"):
-                return
-            if self._has_annotation(node, "ExceptionHandler"):
-                return
-
-        if type_name == "method":
-            for ann in (
-                "GetMapping",
-                "PostMapping",
-                "PutMapping",
-                "DeleteMapping",
-                "PatchMapping",
-                "RequestMapping",
-            ):
-                if self._has_annotation(node, ann):
-                    return
 
         if type_name == "method":
             class_name = self._find_containing_class(node)

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -2715,6 +2715,88 @@ class Worker {
 
         assert "Worker.delegate" in unreachable
 
+    def test_analyze_java_framework_annotations_mark_classes_live(self, tmp_path):
+        (tmp_path / "Components.java").write_text(
+            """
+import jakarta.persistence.Entity;
+import jakarta.ws.rs.Path;
+import org.springframework.stereotype.Service;
+
+@Service
+class PackagePrivateService {
+    void staleHelper() {
+    }
+}
+
+@Entity
+class AuditRecord {
+    private Long id;
+}
+
+@Path("/orders")
+class OrderResource {
+}
+
+class TrulyUnused {
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+        unreachable_functions = {
+            item["name"] for item in result["unused_functions"]
+        }
+
+        assert "PackagePrivateService" not in unreachable_classes
+        assert "AuditRecord" not in unreachable_classes
+        assert "OrderResource" not in unreachable_classes
+        assert "TrulyUnused" in unreachable_classes
+        assert "PackagePrivateService.staleHelper" in unreachable_functions
+
+    def test_analyze_java_junit5_annotations_mark_tests_live(self, tmp_path):
+        (tmp_path / "BillingTest.java").write_text(
+            """
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BillingTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"basic", "pro"})
+    void acceptsPlan(String plan) {
+        plan.trim();
+    }
+
+    @AfterAll
+    static void cleanup() {
+    }
+}
+
+class LegacySuite {
+    void stale() {
+    }
+}
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+        unreachable_functions = {
+            item["name"] for item in result["unused_functions"]
+        }
+
+        assert "BillingTest" not in unreachable_classes
+        assert "BillingTest.acceptsPlan" not in unreachable_functions
+        assert "BillingTest.cleanup" not in unreachable_functions
+        assert "LegacySuite" in unreachable_classes
+
     def test_analyze_typescript_transitive_dead_uses_file_scoped_callers(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

  Fixes Java dead-code false positives for annotation-driven entrypoints.

  ## What Changed

  - Treat common Java class annotations as live roots, including Spring, Jakarta/JPA, servlet, CDI, Micronaut, Quarkus, and test annotations.
  - Treat common Java method annotations as live roots, including JUnit lifecycle/test annotations, Spring mappings, scheduled jobs, and GraphQL/JMS/Kafka/Rabbit handlers.
  - Normalize fully qualified annotation names to their leaf names before matching.

  ## Why

  Java frameworks commonly discover classes and methods through annotations rather than direct static calls. The previous scanner could report such symbols as dead code, especially when classes were package-private.

  ## Validation

  - `pytest test/test_analyzer.py`
  - `pytest test/test_java_security.py`
