### PR TITLE
feat(dead-code): add configurable entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,16 @@ extra_phantom_decorators = ["tenant_admin_required"]
 extra_credential_names = ["tenant_signing_secret"]
 extra_network_timeout_calls = ["vendor_sdk.fetch"]
 
+[tool.skylos.dead_code]
+entrypoints = []
+
+[[tool.skylos.dead_code.entrypoints]]
+type = "method"
+name = ["create", "pre_hook", "post_hook"]
+parent = { name = "Main", base_classes = ["Application"] }
+path = "src/**"
+reason = "project framework lifecycle hook"
+
 [tool.skylos.contribution]
 collect_local_signals = false
 contribute_public_corpus = false
@@ -204,6 +214,11 @@ Template files extend Skylos' built-in prompts; they do not replace the
 JSON-only output contract or untrusted-code safety rules. Vibe dictionary
 extensions let teams teach Skylos about local fake-auth helpers, project
 credential names, sensitive files, and network calls that must set timeouts.
+Dead-code entrypoints let teams mark proprietary framework classes, lifecycle
+methods, and decorator-registered functions as live using precise rules for
+type, name, path, decorators, base classes, and parent classes.
+Rules must include a symbol selector such as `name`, `decorators`,
+`base_classes`, or `parent`; `path` and `module` only narrow the match.
 Contribution signals are off by default; when enabled, Skylos records local
 structural accept/dismiss/learn events under `.skylos/contribution/` without raw
 source.

--- a/editors/vscode/out/ai.js
+++ b/editors/vscode/out/ai.js
@@ -1,4 +1,37 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AIAnalyzer = void 0;
 exports.extractFunctions = extractFunctions;
@@ -6,8 +39,8 @@ exports.callLLMStreamingWithCallback = callLLMStreamingWithCallback;
 exports.fixWithAI = fixWithAI;
 exports.callOpenAIStreaming = callOpenAIStreaming;
 exports.callAnthropicStreaming = callAnthropicStreaming;
-const vscode = require("vscode");
-const crypto = require("crypto");
+const vscode = __importStar(require("vscode"));
+const crypto = __importStar(require("crypto"));
 const config_1 = require("./config");
 const scanner_1 = require("./scanner");
 const verifyCore_1 = require("./verifyCore");
@@ -574,7 +607,7 @@ async function runPostFixValidation(command) {
     const ws = vscode.workspace.workspaceFolders?.[0];
     if (!ws)
         return { success: false, output: "No workspace folder" };
-    const { exec } = await Promise.resolve().then(() => require("child_process"));
+    const { exec } = await import("child_process");
     return new Promise((resolve) => {
         exec(command, { cwd: ws.uri.fsPath, timeout: 30000 }, (err, stdout, stderr) => {
             if (err) {

--- a/editors/vscode/out/autoremediate.js
+++ b/editors/vscode/out/autoremediate.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AutoRemediator = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const ai_1 = require("./ai");
 const config_1 = require("./config");
 const scanner_1 = require("./scanner");

--- a/editors/vscode/out/chatview.js
+++ b/editors/vscode/out/chatview.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosChatViewProvider = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const config_1 = require("./config");
 const scanner_1 = require("./scanner");
 const webviewSecurity_1 = require("./webviewSecurity");
@@ -222,7 +255,7 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
         }
         const doc = editor.document;
         const line = Math.max(0, this.currentFinding.line - 1);
-        const { extractFunctions } = await Promise.resolve().then(() => require("./ai"));
+        const { extractFunctions } = await import("./ai.js");
         const functions = extractFunctions(doc.getText(), doc.languageId);
         const targetFn = functions.find((fn) => line >= fn.startLine && line <= fn.endLine);
         if (targetFn) {

--- a/editors/vscode/out/codelens.js
+++ b/editors/vscode/out/codelens.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosCodeLensProvider = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const types_1 = require("./types");
 const config_1 = require("./config");
 const findingCore_1 = require("./findingCore");

--- a/editors/vscode/out/commandcenter.js
+++ b/editors/vscode/out/commandcenter.js
@@ -1,10 +1,43 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosCommandCenterProvider = exports.ActionNode = void 0;
-const fs = require("fs/promises");
-const path = require("path");
+const fs = __importStar(require("fs/promises"));
+const path = __importStar(require("path"));
 const child_process_1 = require("child_process");
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const config_1 = require("./config");
 const scanner_1 = require("./scanner");
 const automationCore_1 = require("./automationCore");

--- a/editors/vscode/out/config.js
+++ b/editors/vscode/out/config.js
@@ -1,4 +1,37 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getSkylosBin = getSkylosBin;
 exports.getConfidenceThreshold = getConfidenceThreshold;
@@ -36,7 +69,7 @@ exports.isShowDeadParams = isShowDeadParams;
 exports.getDiffBase = getDiffBase;
 exports.isFixPreviewFirst = isFixPreviewFirst;
 exports.getPostFixCommand = getPostFixCommand;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const types_1 = require("./types");
 const configCore_1 = require("./configCore");
 function cfg() {

--- a/editors/vscode/out/dashboard.js
+++ b/editors/vscode/out/dashboard.js
@@ -1,8 +1,41 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosDashboard = void 0;
 exports.computeSecurityScore = computeSecurityScore;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const config_1 = require("./config");
 const webviewSecurity_1 = require("./webviewSecurity");
 const GRADE_COLOR = {

--- a/editors/vscode/out/decorations.js
+++ b/editors/vscode/out/decorations.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.DecorationsManager = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const config_1 = require("./config");
 const provenanceCore_1 = require("./provenanceCore");
 const deadCodeType = () => ({

--- a/editors/vscode/out/detail.js
+++ b/editors/vscode/out/detail.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FindingDetailPanel = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const rules_1 = require("./rules");
 const reviewCore_1 = require("./reviewCore");
 const provenanceCore_1 = require("./provenanceCore");

--- a/editors/vscode/out/diagnostics.js
+++ b/editors/vscode/out/diagnostics.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.DiagnosticsManager = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const config_1 = require("./config");
 const diagnosticCore_1 = require("./diagnosticCore");
 const provenanceCore_1 = require("./provenanceCore");

--- a/editors/vscode/out/export.js
+++ b/editors/vscode/out/export.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.exportReport = exportReport;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const dashboard_1 = require("./dashboard");
 const rules_1 = require("./rules");
 async function exportReport(store) {

--- a/editors/vscode/out/extension.js
+++ b/editors/vscode/out/extension.js
@@ -1,8 +1,41 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.activate = activate;
 exports.deactivate = deactivate;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const store_1 = require("./store");
 const scanner_1 = require("./scanner");
 const diagnostics_1 = require("./diagnostics");
@@ -439,7 +472,7 @@ function activate(context) {
             return;
         }
         const skylosBin = (0, config_1.getSkylosBin)();
-        const { spawn: spawnProc } = await Promise.resolve().then(() => require("child_process"));
+        const { spawn: spawnProc } = await import("child_process");
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Skylos: Generating dead code removal plan..." }, () => new Promise((resolve, reject) => {
             const args = ["agent", "verify", root, "--fix", "--format", "json", "--quiet"];
             const proc = spawnProc(skylosBin, args, { cwd: root });

--- a/editors/vscode/out/filedecorations.js
+++ b/editors/vscode/out/filedecorations.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosFileDecorationProvider = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const config_1 = require("./config");
 class SkylosFileDecorationProvider {
     constructor(store) {

--- a/editors/vscode/out/findingCore.js
+++ b/editors/vscode/out/findingCore.js
@@ -1,12 +1,45 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.normalizeReportCore = normalizeReportCore;
 exports.canonicalRuleId = canonicalRuleId;
 exports.isDeadCodeRule = isDeadCodeRule;
 exports.normalizeSeverity = normalizeSeverity;
 exports.makeFingerprint = makeFingerprint;
-const crypto = require("crypto");
-const path = require("path");
+const crypto = __importStar(require("crypto"));
+const path = __importStar(require("path"));
 const DEAD_CODE_RULES = {
     unused_functions: { ruleId: "SKY-U001", legacyRuleId: "DEAD-FUNC", itemType: "function", label: "function" },
     unused_imports: { ruleId: "SKY-U002", legacyRuleId: "DEAD-IMPORT", itemType: "import", label: "import" },

--- a/editors/vscode/out/findingCore.js
+++ b/editors/vscode/out/findingCore.js
@@ -3,8 +3,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.normalizeReportCore = normalizeReportCore;
 exports.canonicalRuleId = canonicalRuleId;
 exports.isDeadCodeRule = isDeadCodeRule;
-exports.isUnusedImportRule = isUnusedImportRule;
-exports.isUnusedFunctionRule = isUnusedFunctionRule;
 exports.normalizeSeverity = normalizeSeverity;
 exports.makeFingerprint = makeFingerprint;
 const crypto = require("crypto");
@@ -65,12 +63,6 @@ function canonicalRuleId(ruleId) {
 }
 function isDeadCodeRule(ruleId) {
     return canonicalRuleId(ruleId).startsWith("SKY-U");
-}
-function isUnusedImportRule(ruleId) {
-    return canonicalRuleId(ruleId) === "SKY-U002";
-}
-function isUnusedFunctionRule(ruleId) {
-    return canonicalRuleId(ruleId) === "SKY-U001";
 }
 function normalizeSeverity(value) {
     const normalized = String(value ?? "").toUpperCase();

--- a/editors/vscode/out/hover.js
+++ b/editors/vscode/out/hover.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosHoverProvider = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const rules_1 = require("./rules");
 const types_1 = require("./types");
 const config_1 = require("./config");

--- a/editors/vscode/out/navigator.js
+++ b/editors/vscode/out/navigator.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FindingNavigator = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const config_1 = require("./config");
 class FindingNavigator {
     constructor(store) {

--- a/editors/vscode/out/quickfix.js
+++ b/editors/vscode/out/quickfix.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosQuickFixProvider = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const types_1 = require("./types");
 const findingCore_1 = require("./findingCore");
 class SkylosQuickFixProvider {

--- a/editors/vscode/out/scanner.js
+++ b/editors/vscode/out/scanner.js
@@ -1,4 +1,37 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosScanError = exports.buildScanErrorMessage = exports.out = void 0;
 exports.cancelScan = cancelScan;
@@ -6,9 +39,9 @@ exports.scanWorkspace = scanWorkspace;
 exports.scanFile = scanFile;
 exports.doctorSkylos = doctorSkylos;
 exports.normalizeReport = normalizeReport;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const child_process_1 = require("child_process");
-const path = require("path");
+const path = __importStar(require("path"));
 const config_1 = require("./config");
 const scanCore_1 = require("./scanCore");
 const findingCore_1 = require("./findingCore");

--- a/editors/vscode/out/sidebar.js
+++ b/editors/vscode/out/sidebar.js
@@ -1,8 +1,41 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosTreeProvider = exports.FindingNode = void 0;
-const vscode = require("vscode");
-const path = require("path");
+const vscode = __importStar(require("vscode"));
+const path = __importStar(require("path"));
 const config_1 = require("./config");
 const reviewCore_1 = require("./reviewCore");
 const provenanceCore_1 = require("./provenanceCore");

--- a/editors/vscode/out/statusbar.js
+++ b/editors/vscode/out/statusbar.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SkylosStatusBar = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const dashboard_1 = require("./dashboard");
 const config_1 = require("./config");
 class SkylosStatusBar {

--- a/editors/vscode/out/store.js
+++ b/editors/vscode/out/store.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FindingsStore = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 const provenanceCore_1 = require("./provenanceCore");
 const reviewCore_1 = require("./reviewCore");
 class FindingsStore {

--- a/editors/vscode/out/streaming.js
+++ b/editors/vscode/out/streaming.js
@@ -1,7 +1,40 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.StreamingDecorationManager = exports.StreamingJsonParser = void 0;
-const vscode = require("vscode");
+const vscode = __importStar(require("vscode"));
 /**
  * Parses streaming LLM output to extract complete JSON issue objects
  * as they arrive chunk by chunk.

--- a/editors/vscode/src/chatview.ts
+++ b/editors/vscode/src/chatview.ts
@@ -266,7 +266,7 @@ Reference OWASP, CWE, PCI DSS when relevant. Be concise.${contextBlock}`;
     const doc = editor.document;
     const line = Math.max(0, this.currentFinding.line - 1);
 
-    const { extractFunctions } = await import("./ai");
+    const { extractFunctions } = await import("./ai.js");
     const functions = extractFunctions(doc.getText(), doc.languageId);
     const targetFn = functions.find(
       (fn) => line >= fn.startLine && line <= fn.endLine,

--- a/editors/vscode/src/findingCore.ts
+++ b/editors/vscode/src/findingCore.ts
@@ -197,14 +197,6 @@ export function isDeadCodeRule(ruleId: string): boolean {
   return canonicalRuleId(ruleId).startsWith("SKY-U");
 }
 
-export function isUnusedImportRule(ruleId: string): boolean {
-  return canonicalRuleId(ruleId) === "SKY-U002";
-}
-
-export function isUnusedFunctionRule(ruleId: string): boolean {
-  return canonicalRuleId(ruleId) === "SKY-U001";
-}
-
 export function normalizeSeverity(value?: string): CoreSeverity {
   const normalized = String(value ?? "").toUpperCase();
   if (normalized === "CRITICAL") return "CRITICAL";

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "Node16",
     "target": "es2020",
     "lib": ["es2020"],
     "outDir": "out",
     "rootDir": "src",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "types": ["node", "vscode"],
     "strict": true,
     "skipLibCheck": true

--- a/skylos/analysis/known_patterns.py
+++ b/skylos/analysis/known_patterns.py
@@ -346,15 +346,6 @@ STARLETTE_MIDDLEWARE_BASES = {
     "HTTPMiddleware",
 }
 
-FASTAPI_CBVROUTER_METHODS = {
-    "get",
-    "post",
-    "put",
-    "patch",
-    "delete",
-    "head",
-    "options",
-}
 FASTAPI_CBVROUTER_BASES = {"APIRouter", "CBVRouter"}
 
 CELERY_TASK_METHODS = {"run"}

--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -2,6 +2,7 @@ import ast
 from typing import Any, Optional
 from skylos.constants import PENALTIES, get_non_library_dir_kind, is_test_path
 from skylos.config import is_whitelisted
+from skylos.deadcode.config_entrypoints import configured_entrypoint_reason
 from skylos.analysis.known_patterns import (
     HARD_ENTRYPOINTS,
     PYTEST_HOOKS,
@@ -316,6 +317,13 @@ def _check_config_whitelist(def_obj, cfg):
         return _suppress(def_obj, reason)
     if conf_reduction > 0:
         return -conf_reduction
+    return None
+
+
+def _check_configured_entrypoint(def_obj, analyzer, cfg):
+    reason = configured_entrypoint_reason(def_obj, analyzer, cfg)
+    if reason:
+        return _suppress(def_obj, reason, code="configured_entrypoint")
     return None
 
 
@@ -1080,6 +1088,9 @@ def apply_penalties(
         return
     if isinstance(result, int):
         confidence += result
+
+    if _check_configured_entrypoint(def_obj, analyzer, cfg) is True:
+        return
 
     if _check_hard_entrypoint(def_obj) is True:
         return

--- a/skylos/audit/polyglot.py
+++ b/skylos/audit/polyglot.py
@@ -23,17 +23,6 @@ class PolyglotSignalRule:
     regex: re.Pattern[str]
 
 
-POLYGLOT_LANGUAGES = {
-    "typescript",
-    "javascript",
-    "go",
-    "java",
-    "php",
-    "rust",
-    "dart",
-    "csharp",
-}
-
 _TS_JS_RULES = (
     PolyglotSignalRule(
         rule_id="SKY-D201",

--- a/skylos/cicd/review.py
+++ b/skylos/cicd/review.py
@@ -61,7 +61,7 @@ def run_pr_review(
         return
 
     if grade and previous_grade is None:
-        previous_grade = _fetch_previous_grade(repo, diff_base)
+        previous_grade = _fetch_previous_grade(diff_base)
 
     all_findings = _flatten_findings(results)
 
@@ -73,7 +73,6 @@ def run_pr_review(
     if not summary_only:
         changed_ranges = get_changed_line_ranges(diff_base)
         findings = filter_findings_to_diff(all_findings, changed_ranges)
-        # Regression findings ARE the diff — no need to filter them
         findings.extend(regression_findings)
     else:
         findings = all_findings + regression_findings
@@ -850,7 +849,7 @@ def _post_summary_comment(
         console.print(f"[yellow]Failed to post summary comment: {e.stderr}[/yellow]")
 
 
-def _fetch_previous_grade(repo: str, base_branch: str = "origin/main") -> dict | None:
+def _fetch_previous_grade(base_branch: str = "origin/main") -> dict | None:
     try:
         from skylos.api import BASE_URL, get_project_token
 

--- a/skylos/cloud/login.py
+++ b/skylos/cloud/login.py
@@ -429,10 +429,6 @@ def _parse_callback_request(path: str, *, expected_state: str | None):
     )
 
 
-def _whoami_url(base_url: str) -> str:
-    return _safe_whoami_url(base_url)
-
-
 def _safe_whoami_url(base_url: str) -> str:
     normalized = (base_url or DEFAULT_BASE_URL).strip().rstrip("/")
     parsed = urlparse(normalized)

--- a/skylos/commands/init_cmd.py
+++ b/skylos/commands/init_cmd.py
@@ -26,6 +26,22 @@ names = []
 decorators = []
 bases = []
 
+[tool.skylos.dead_code]
+entrypoints = []
+
+# [[tool.skylos.dead_code.entrypoints]]
+# type = "class"
+# name = "Main"
+# path = "**/main.py"
+# base_classes = ["Application"]
+# reason = "framework entrypoint"
+#
+# [[tool.skylos.dead_code.entrypoints]]
+# type = "method"
+# name = ["create", "pre_hook", "post_hook"]
+# parent = { name = "Main", base_classes = ["Application"] }
+# reason = "framework lifecycle method"
+
 [tool.skylos.templates]
 # security = ".skylos/templates/security.md"
 # quality = ".skylos/templates/quality.md"

--- a/skylos/config.py
+++ b/skylos/config.py
@@ -42,6 +42,9 @@ DEFAULTS = {
         "bases": [],
         "keep_docstring": True,
     },
+    "dead_code": {
+        "entrypoints": [],
+    },
     "templates": {
         "security": None,
         "quality": None,
@@ -360,6 +363,7 @@ def _merge_user_config(base_cfg: dict, user_cfg: dict | None) -> dict:
             "vibe",
             "architecture",
             "contribution",
+            "dead_code",
         ) and isinstance(value, dict):
             merged_section = {}
             current_section = final_cfg.get(key)
@@ -422,6 +426,7 @@ def _sanitize_config(cfg: dict) -> dict:
     )
     safe["masking"] = _sanitize_masking_section(safe.get("masking"))
     safe["templates"] = _sanitize_templates_section(safe.get("templates"))
+    safe["dead_code"] = _sanitize_dead_code_section(safe.get("dead_code"))
     safe["contribution"] = _sanitize_contribution_section(safe.get("contribution"))
     safe["vibe"] = _sanitize_vibe_section(safe.get("vibe"))
     safe["architecture"] = _sanitize_architecture_section(safe.get("architecture"))
@@ -534,6 +539,85 @@ def _sanitize_templates_section(value):
         candidate = raw.get(key)
         if candidate is None or isinstance(candidate, str):
             safe[key] = candidate
+    return safe
+
+
+def _sanitize_dead_code_section(value):
+    if isinstance(value, dict):
+        raw = value
+    else:
+        raw = {}
+    return {
+        "entrypoints": _safe_dead_code_entrypoints(raw.get("entrypoints")),
+    }
+
+
+def _safe_string_or_list(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return None
+
+
+def _safe_dead_code_rule_dict(value):
+    if not isinstance(value, dict):
+        return None
+
+    safe = {}
+    for key in (
+        "type",
+        "name",
+        "full_name",
+        "module",
+        "path",
+        "decorator",
+        "decorators",
+        "base_class",
+        "base_classes",
+        "reason",
+    ):
+        item = _safe_string_or_list(value.get(key))
+        if item is not None:
+            safe[key] = item
+
+    parent = value.get("parent")
+    if not isinstance(parent, dict):
+        parent = value.get("parent_class")
+    if isinstance(parent, dict):
+        safe_parent = {}
+        for key in ("name", "full_name", "module", "path", "base_class", "base_classes"):
+            item = _safe_string_or_list(parent.get(key))
+            if item is not None:
+                safe_parent[key] = item
+        if safe_parent:
+            safe["parent"] = safe_parent
+
+    if not any(
+        key in safe
+        for key in (
+            "name",
+            "full_name",
+            "decorator",
+            "decorators",
+            "base_class",
+            "base_classes",
+            "parent",
+        )
+    ):
+        return None
+
+    return safe
+
+
+def _safe_dead_code_entrypoints(value):
+    if not isinstance(value, list):
+        return []
+    safe = []
+    for item in value:
+        rule = _safe_dead_code_rule_dict(item)
+        if rule:
+            safe.append(rule)
     return safe
 
 

--- a/skylos/deadcode/config_entrypoints.py
+++ b/skylos/deadcode/config_entrypoints.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_REASON = "configured dead-code entrypoint"
+
+
+def configured_entrypoint_reason(
+    def_obj: Any,
+    analyzer: Any,
+    cfg: dict | None,
+) -> str | None:
+
+    rules = _entrypoint_rules(cfg)
+    if not rules:
+        return None
+
+    for rule in rules:
+        if _has_specific_selector(rule) and _matches_rule(def_obj, analyzer, rule):
+            reason = rule.get("reason")
+            matched_reason = DEFAULT_REASON
+            if isinstance(reason, str) and reason:
+                matched_reason = reason
+            return matched_reason
+    return None
+
+
+def _entrypoint_rules(cfg: dict | None) -> list[dict]:
+    if not isinstance(cfg, dict):
+        return []
+    dead_code = cfg.get("dead_code")
+    if not isinstance(dead_code, dict):
+        return []
+    rules = dead_code.get("entrypoints")
+    if not isinstance(rules, list):
+        return []
+    entrypoint_rules: list[dict] = []
+    for rule in rules:
+        if isinstance(rule, dict):
+            entrypoint_rules.append(rule)
+    return entrypoint_rules
+
+
+def _matches_rule(def_obj: Any, analyzer: Any, rule: dict) -> bool:
+    if not _matches_values(rule.get("type"), [str(getattr(def_obj, "type", ""))]):
+        return False
+    if not _matches_values(
+        rule.get("name"),
+        [
+            str(getattr(def_obj, "simple_name", "")),
+            _display_name(def_obj),
+        ],
+    ):
+        return False
+    if not _matches_values(rule.get("full_name"), [str(getattr(def_obj, "name", ""))]):
+        return False
+    decorator_patterns = _combined_values(rule, "decorator", "decorators")
+    if decorator_patterns and not _matches_values(
+        decorator_patterns, _decorator_candidates(def_obj)
+    ):
+        return False
+    base_patterns = _combined_values(rule, "base_class", "base_classes")
+    if base_patterns and not _matches_values(
+        base_patterns, _base_class_candidates(def_obj)
+    ):
+        return False
+
+    parent = rule.get("parent")
+    if isinstance(parent, dict) and not _matches_parent(def_obj, analyzer, parent):
+        return False
+    path_patterns = _as_list(rule.get("path"))
+    if path_patterns and not _matches_values(
+        path_patterns, _path_candidates(def_obj, analyzer)
+    ):
+        return False
+    module_patterns = _as_list(rule.get("module"))
+    if module_patterns and not _matches_values(
+        module_patterns, _module_candidates(def_obj, analyzer)
+    ):
+        return False
+
+    return True
+
+
+def _has_specific_selector(rule: dict) -> bool:
+    for key in (
+        "name",
+        "full_name",
+        "decorator",
+        "decorators",
+        "base_class",
+        "base_classes",
+    ):
+        if _as_list(rule.get(key)):
+            return True
+    has_parent_selector = isinstance(rule.get("parent"), dict)
+    return has_parent_selector
+
+
+def _display_name(def_obj: Any) -> str:
+    name = str(getattr(def_obj, "name", ""))
+    if getattr(def_obj, "type", None) == "method" and "." in name:
+        parts = name.split(".")
+        if len(parts) >= 2:
+            display_name = ".".join(parts[-2:])
+            return display_name
+    display_name = str(getattr(def_obj, "simple_name", ""))
+    return display_name
+
+
+def _matches_parent(def_obj: Any, analyzer: Any, rule: dict) -> bool:
+    parent = _parent_definition(def_obj, analyzer)
+    if parent is None:
+        return False
+
+    if not _matches_values(
+        rule.get("name"),
+        [
+            str(getattr(parent, "simple_name", "")),
+            str(getattr(parent, "name", "")).rsplit(".", 1)[-1],
+        ],
+    ):
+        return False
+    if not _matches_values(rule.get("full_name"), [str(getattr(parent, "name", ""))]):
+        return False
+    base_patterns = _combined_values(rule, "base_class", "base_classes")
+    if base_patterns and not _matches_values(
+        base_patterns, _base_class_candidates(parent)
+    ):
+        return False
+    path_patterns = _as_list(rule.get("path"))
+    if path_patterns and not _matches_values(
+        path_patterns, _path_candidates(parent, analyzer)
+    ):
+        return False
+    module_patterns = _as_list(rule.get("module"))
+    if module_patterns and not _matches_values(
+        module_patterns, _module_candidates(parent, analyzer)
+    ):
+        return False
+    return True
+
+
+def _parent_definition(def_obj: Any, analyzer: Any) -> Any | None:
+    name = str(getattr(def_obj, "name", ""))
+    if "." not in name:
+        return None
+
+    parent_name = name.rsplit(".", 1)[0]
+    defs = getattr(analyzer, "defs", {})
+    if isinstance(defs, dict):
+        direct = defs.get(parent_name)
+        if direct is not None and getattr(direct, "type", None) == "class":
+            return direct
+
+        parent_simple = parent_name.rsplit(".", 1)[-1]
+        filename = str(getattr(def_obj, "filename", ""))
+        for candidate in defs.values():
+            if getattr(candidate, "type", None) != "class":
+                continue
+            if str(getattr(candidate, "simple_name", "")) != parent_simple:
+                continue
+            if str(getattr(candidate, "filename", "")) == filename:
+                return candidate
+    return None
+
+
+def _matches_values(patterns: Any, candidates: list[str]) -> bool:
+    normalized_patterns = _as_list(patterns)
+    if not normalized_patterns:
+        return True
+
+    normalized_candidates: list[str] = []
+    for candidate in candidates:
+        if candidate:
+            normalized_candidates.append(candidate)
+    if not normalized_candidates:
+        return False
+
+    for pattern in normalized_patterns:
+        for candidate in normalized_candidates:
+            if fnmatch.fnmatchcase(candidate, pattern):
+                return True
+    return False
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        strings: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                strings.append(item)
+        return strings
+    return []
+
+
+def _combined_values(rule: dict, singular: str, plural: str) -> list[str]:
+    values: list[str] = []
+    values.extend(_as_list(rule.get(singular)))
+    values.extend(_as_list(rule.get(plural)))
+    return values
+
+
+def _decorator_candidates(def_obj: Any) -> list[str]:
+    candidates: list[str] = []
+    for decorator in _string_attribute_values(def_obj, "decorators"):
+        text = str(decorator).lstrip("@")
+        if not text:
+            continue
+        candidates.append(text)
+        candidates.append(text.rsplit(".", 1)[-1])
+    return candidates
+
+
+def _base_class_candidates(def_obj: Any) -> list[str]:
+    candidates: list[str] = []
+    for base in _string_attribute_values(def_obj, "base_classes"):
+        text = str(base)
+        if not text:
+            continue
+        candidates.append(text)
+        candidates.append(text.rsplit(".", 1)[-1])
+    return candidates
+
+
+def _string_attribute_values(def_obj: Any, name: str) -> list[str]:
+    value = getattr(def_obj, name, [])
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        strings: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                strings.append(item)
+        return strings
+    return []
+
+
+def _path_candidates(def_obj: Any, analyzer: Any) -> list[str]:
+    filename = str(getattr(def_obj, "filename", ""))
+    if not filename:
+        return []
+
+    path = Path(filename)
+    candidates = [filename.replace("\\", "/"), path.name]
+    root = getattr(analyzer, "_project_root", None)
+    if root:
+        try:
+            rel = path.resolve().relative_to(Path(root).resolve())
+            candidates.append(str(rel).replace("\\", "/"))
+        except (OSError, ValueError):
+            pass
+    return _dedupe(candidates)
+
+
+def _module_candidates(def_obj: Any, analyzer: Any) -> list[str]:
+    candidates: list[str] = []
+    path_modules = _module_candidates_from_path(def_obj, analyzer)
+    candidates.extend(path_modules)
+
+    full_name = str(getattr(def_obj, "name", ""))
+    for module in path_modules:
+        if full_name == module or full_name.startswith(f"{module}."):
+            candidates.append(module)
+    return _dedupe(candidates)
+
+
+def _module_candidates_from_path(def_obj: Any, analyzer: Any) -> list[str]:
+    filename = str(getattr(def_obj, "filename", ""))
+    if not filename:
+        return []
+
+    path = Path(filename)
+    root = getattr(analyzer, "_project_root", None)
+    if root:
+        try:
+            rel = path.resolve().relative_to(Path(root).resolve())
+        except (OSError, ValueError):
+            rel = path
+    else:
+        rel = path
+
+    if rel.suffix not in {".py", ".pyi", ".pyw"}:
+        return []
+
+    rel_no_suffix = rel.with_suffix("")
+    parts = list(rel_no_suffix.parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    module = ".".join(part for part in parts if part and part != ".")
+    modules: list[str] = []
+    if module:
+        modules.append(module)
+    return modules
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result

--- a/skylos/discover/detector.py
+++ b/skylos/discover/detector.py
@@ -215,17 +215,6 @@ OUTPUT_VALIDATION_CALLS = {
     "ast.literal_eval",
 }
 
-OUTPUT_VALIDATION_SIMPLE = {
-    "loads",
-    "load",
-    "validate",
-    "model_validate",
-    "parse_obj",
-    "parse_raw",
-    "validate_python",
-    "validate_json",
-    "literal_eval",
-}
 
 LENGTH_CHECK_FUNCTIONS = {"len", "length", "size"}
 

--- a/skylos/llm/prompts.py
+++ b/skylos/llm/prompts.py
@@ -367,31 +367,6 @@ REQUIREMENTS:
 Output ONLY the JSON, no markdown formatting."""
 
 
-def user_audit(context):
-    return f"""Perform a comprehensive security audit.
-
-=== BEGIN UNTRUSTED CODE CONTEXT ===
-{context}
-=== END UNTRUSTED CODE CONTEXT ===
-
-Look for:
-1. Security vulnerabilities (SQL injection, XSS, hardcoded secrets, command injection)
-2. Logic errors and bugs
-3. HALLUCINATIONS: Function/method calls to things that DON'T EXIST in:
-   - The [PROJECT INDEX] above
-   - Python standard library
-   - Imported third-party packages
-   If code calls a function not in these sources, flag as issue_type="hallucination"
-
-OUTPUT: JSON object with findings. Format:
-{{"findings": [{{"rule_id": "SKY-XXXX", "issue_type": "...", "severity": "...", "message": "...", "line": N, "confidence": "...", "suggestion": "..."}}]}}
-
-issue_type must be one of: security, quality, bug, performance, hallucination
-Use SKY-D* for security, SKY-Q*/SKY-C*/SKY-L*/SKY-P* for quality, SKY-S* for secrets
-
-If code is clean, output: {{"findings": []}}"""
-
-
 def build_security_prompt(
     context, include_examples=True, templates=None, template_root=None
 ):
@@ -531,13 +506,3 @@ def _string_field(item: dict, key: str) -> str:
 
 def _markdown_table_text(value: str) -> str:
     return value.replace("|", "\\|").replace("\n", " ")
-
-
-RULE_RANGES = {
-    "security": ("SKY-D200", "SKY-D299"),
-    "quality": ("SKY-Q301", "SKY-Q499"),
-    "logic": ("SKY-L001", "SKY-L009"),
-    "performance": ("SKY-P401", "SKY-P499"),
-    "secrets": ("SKY-S101", "SKY-S199"),
-    "structure": ("SKY-C303", "SKY-C399"),
-}

--- a/skylos/visitors/languages/rust/core.py
+++ b/skylos/visitors/languages/rust/core.py
@@ -896,9 +896,6 @@ class RustCore:
                 self._record_ref(local_name, node.start_byte, current_callable=None)
         self.raw_imports.append({"source": source, "names": names, "line": line})
 
-    def _extract_use_names(self, node) -> list[str]:
-        return [local_name for local_name, _ in self._extract_use_bindings(node)]
-
     def _extract_use_bindings(self, node) -> list[tuple[str, str]]:
         if node.type == "use_as_clause":
             return self._extract_use_as_binding(node)

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.analysis.penalties import apply_penalties
+from skylos.deadcode.config_entrypoints import configured_entrypoint_reason
 
 from skylos.analyzer import (
     Skylos,
@@ -2016,6 +2017,155 @@ class TestApplyPenalties:
             skylos, mock_def, mock_test_aware_visitor, mock_framework_aware_visitor
         )
         assert mock_def.confidence == 0
+
+
+class TestConfiguredDeadCodeEntrypoints:
+    @patch("skylos.analysis.penalties.detect_framework_usage")
+    def test_configured_class_entrypoint_matches_path_and_base(
+        self,
+        mock_detect_framework,
+        mock_definition,
+        mock_test_aware_visitor,
+        mock_framework_aware_visitor,
+    ):
+        mock_detect_framework.return_value = None
+        skylos = Skylos()
+        skylos._project_root = Path("/repo")
+        cfg = {
+            "dead_code": {
+                "entrypoints": [
+                    {
+                        "type": "class",
+                        "name": "_Main",
+                        "path": "app/main.py",
+                        "base_classes": ["Application"],
+                        "reason": "custom app entrypoint",
+                    }
+                ]
+            }
+        }
+        mock_def = mock_definition(
+            name="app.main._Main",
+            simple_name="_Main",
+            type="class",
+            confidence=100,
+        )
+        mock_def.filename = Path("/repo/app/main.py")
+        mock_def.base_classes = ["framework.Application"]
+
+        apply_penalties(
+            skylos,
+            mock_def,
+            mock_test_aware_visitor,
+            mock_framework_aware_visitor,
+            cfg,
+        )
+
+        assert mock_def.confidence == 0
+        assert mock_def.skip_reason == "custom app entrypoint"
+        assert mock_def.suppression_code == "configured_entrypoint"
+
+    def test_configured_method_entrypoint_matches_parent_base(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            """
+[tool.skylos]
+ignore = []
+
+[[tool.skylos.dead_code.entrypoints]]
+type = "method"
+name = ["create"]
+parent = { name = "Main", base_classes = ["Application"] }
+reason = "custom framework lifecycle method"
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "main.py").write_text(
+            """
+class Application:
+    pass
+
+class Main(Application):
+    def create(self):
+        return None
+
+    def stale(self):
+        return None
+
+app = Main()
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0))
+        unused_methods = {
+            item["full_name"].rsplit(".", 1)[-1]
+            for item in result["unused_functions"]
+        }
+
+        assert "create" not in unused_methods
+        assert "stale" in unused_methods
+
+    def test_configured_function_entrypoint_matches_decorator(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            """
+[tool.skylos]
+ignore = []
+
+[[tool.skylos.dead_code.entrypoints]]
+type = "function"
+decorators = ["runtime_hook"]
+reason = "custom decorator entrypoint"
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "hooks.py").write_text(
+            """
+def runtime_hook(fn):
+    return fn
+
+@runtime_hook
+def boot():
+    return None
+
+def orphan():
+    return None
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0))
+        unused_functions = {
+            item["simple_name"] for item in result["unused_functions"]
+        }
+
+        assert "boot" not in unused_functions
+        assert "orphan" in unused_functions
+
+    def test_malformed_entrypoint_rule_does_not_suppress_broadly(
+        self, mock_definition
+    ):
+        skylos = Skylos()
+        skylos._project_root = Path("/repo")
+        cfg = {
+            "dead_code": {
+                "entrypoints": [
+                    {
+                        "type": "function",
+                        "path": "main.py",
+                        "reason": "too broad",
+                    }
+                ]
+            }
+        }
+        mock_def = mock_definition(
+            name="main.orphan",
+            simple_name="orphan",
+            type="function",
+            confidence=100,
+        )
+        mock_def.filename = Path("/repo/main.py")
+
+        assert configured_entrypoint_reason(mock_def, skylos, cfg) is None
 
 
 class TestIgnorePragmas:


### PR DESCRIPTION
## Summary
  - Add `[[tool.skylos.dead_code.entrypoints]]` config for project specific dead-code entrypoints
  - Match configured entrypoints by type, name, full name, path, module, decorators, base classes, and parent class metadata
  - Suppress matching definitions with a `configured_entrypoint` suppression code

  ## Tests

  - `pytest -q test/test_analyzer.py test/test_config.py test/test_dead_code.py test/
  test_dead_code_liveness.py test/test_dead_code_evidence.py test/test_framework_aware.py test/
  test_dynamic_patterns.py`
  - Manual stress: `700 defs x 1200 rules -> 300 matches in 0.9s`