### PR TITLE
refactor(reporting): extract result builder

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -16,10 +16,7 @@ except ImportError:
 
 from skylos.visitors.base import Visitor
 
-from skylos.analysis.circular_deps import (
-    CircularDependencyRule,
-    _resolve_from_import_targets,
-)
+from skylos.analysis.circular_deps import _resolve_from_import_targets
 
 from skylos.constants import (
     AUTO_CALLED,
@@ -64,8 +61,6 @@ from skylos.rules.quality.clones import (
     detect_pairs,
     group_pairs,
 )
-from skylos.reporting.rollups import attach_directory_rollups
-
 from skylos.analysis.penalties import apply_penalties
 from skylos.analysis.file_processing import (
     collect_python_raw_imports,
@@ -1816,359 +1811,35 @@ class Skylos:
         pyproject_entrypoint_modules=None,
         config_file=None,
     ):
-        """Assemble the final result dict from analysis outputs."""
-        architecture_main_guard_modules = set(architecture_main_guard_modules or ())
-        pyproject_entrypoint_qnames = set(pyproject_entrypoint_qnames or ())
-        pyproject_entrypoint_modules = set(pyproject_entrypoint_modules or ())
+        from skylos.reporting.result_builder import build_analysis_result
 
-        evidence_root = getattr(self, "_project_root", None)
-        if evidence_root is None:
-            evidence_root = Path(path[0] if isinstance(path, (list, tuple)) else path)
-            if evidence_root.is_file():
-                evidence_root = evidence_root.parent
-        from skylos.deadcode.evidence import build_dead_code_evidence
-
-        dead_code_ledger = build_dead_code_evidence(
-            self.defs,
-            project_root=evidence_root,
+        return build_analysis_result(
+            self,
+            files,
+            thr,
+            exclude_folders,
+            enable_secrets,
+            enable_danger,
+            enable_quality,
+            enable_sca,
+            all_secrets,
+            all_dangers,
+            all_quality,
+            all_sca,
+            all_suppressed,
+            empty_files,
+            modmap,
+            all_raw_imports,
+            path,
+            unused_ts_exports=unused_ts_exports,
+            workspace_inventory=workspace_inventory,
+            architecture_abstractness=architecture_abstractness,
+            architecture_loc=architecture_loc,
+            architecture_main_guard_modules=architecture_main_guard_modules,
             pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
-        )
-        dead_code_evidence = dead_code_ledger.to_dict(evidence_root)
-        evidence_by_name = {
-            entry["qualified_name"]: entry
-            for entry in dead_code_evidence.get("symbols", [])
-        }
-
-        def attach_evidence(target: dict, definition) -> None:
-            entry = evidence_by_name.get(getattr(definition, "name", ""))
-            if not entry:
-                return
-            target["dead_code_classification"] = entry["classification"]
-            target["dead_code_evidence"] = list(entry.get("evidence") or [])
-
-        unused = []
-        dead_class_keys = {
-            key
-            for key, definition in self.defs.items()
-            if definition.type in ("class", "type")
-            and definition.references == 0
-            and not definition.is_exported
-            and definition.confidence > 0
-            and definition.confidence >= thr
-        }
-        class_key_by_name_file = {}
-        for key, definition in self.defs.items():
-            if definition.type in ("class", "type"):
-                class_key_by_name_file[
-                    (definition.name, str(Path(definition.filename).resolve()))
-                ] = key
-
-        for definition in self.defs.values():
-            if (
-                definition.references == 0
-                and not definition.is_exported
-                and definition.confidence > 0
-                and definition.confidence >= thr
-            ):
-                if definition.type == "method" and "." in definition.name:
-                    owner = definition.name.rsplit(".", 1)[0]
-                    owner_key = class_key_by_name_file.get(
-                        (owner, str(Path(definition.filename).resolve()))
-                    )
-                    if owner_key in dead_class_keys:
-                        continue
-                item = definition.to_dict()
-                attach_evidence(item, definition)
-                unused.append(item)
-
-        context_map = {}
-        for name, d in self.defs.items():
-            if d.type in ("class", "function", "method") and not name.startswith("_"):
-                loc = 1
-                node = getattr(d, "node", None)
-                if node is not None:
-                    start = getattr(node, "lineno", None)
-                    end = getattr(node, "end_lineno", None)
-                    if start is not None and end is not None:
-                        loc = max(1, end - start + 1)
-
-                is_dead = (
-                    d.references == 0
-                    and not d.is_exported
-                    and d.confidence > 0
-                    and d.confidence >= thr
-                )
-
-                context_entry = {
-                    "name": d.name,
-                    "file": str(d.filename),
-                    "line": d.line,
-                    "type": d.type,
-                    "loc": loc,
-                    "complexity": getattr(d, "complexity", 1),
-                    "calls": sorted(d.calls) if d.calls else [],
-                    "called_by": sorted(d.called_by) if d.called_by else [],
-                    "dead": is_dead,
-                }
-                attach_evidence(context_entry, d)
-                context_map[name] = context_entry
-
-        whitelisted = []
-        for d in self.defs.values():
-            reason = getattr(d, "skip_reason", None)
-            if reason:
-                entry = {
-                    "name": d.simple_name,
-                    "file": str(d.filename),
-                    "line": d.line,
-                    "reason": d.skip_reason,
-                    "category": "dead_code",
-                    "suppression_code": getattr(d, "suppression_code", None),
-                    "folder_role": getattr(d, "folder_role", None),
-                }
-                whitelisted.append(entry)
-                if reason == "inline ignore comment":
-                    all_suppressed.append(entry)
-
-        result = {
-            "definitions": context_map,
-            "unused_functions": [],
-            "unused_imports": [],
-            "unused_classes": [],
-            "unused_variables": [],
-            "unused_parameters": [],
-            "unused_files": [],
-            "whitelisted": whitelisted,
-            "suppressed": all_suppressed,
-            "dead_code_evidence": dead_code_evidence,
-            "analysis_summary": {
-                "total_files": len(files),
-                "excluded_folders": exclude_folders or [],
-                "languages": self._count_languages(files),
-                "dead_code_evidence": dead_code_ledger.summary(),
-            },
-        }
-
-        liveness_report = getattr(self, "_dead_code_liveness_report", None)
-        if liveness_report is not None:
-            result["analysis_summary"]["dead_code_liveness"] = liveness_report.to_dict()
-
-        grep_verify_report = getattr(self, "_grep_verify_report", None)
-        if grep_verify_report is not None:
-            result["analysis_summary"]["grep_verify"] = dict(grep_verify_report)
-
-        if workspace_inventory is not None:
-            project_root = (
-                self._project_root
-                if hasattr(self, "_project_root")
-                else Path(
-                    path[0] if isinstance(path, (list, tuple)) else path
-                ).resolve()
-            )
-            result["workspaces"] = workspace_inventory.to_dict(project_root)
-            result["analysis_summary"]["monorepo_detected"] = (
-                workspace_inventory.is_monorepo
-            )
-            result["analysis_summary"]["workspace_count"] = len(
-                workspace_inventory.packages
-            )
-            result["analysis_summary"]["workspace_total_packages"] = (
-                workspace_inventory.total_packages
-            )
-            result["analysis_summary"]["workspace_diagnostic_count"] = len(
-                workspace_inventory.diagnostics
-            )
-
-        if enable_secrets and all_secrets:
-            result["secrets"] = all_secrets
-            result["analysis_summary"]["secrets_count"] = len(all_secrets)
-
-        if enable_danger and all_dangers:
-            result["danger"] = all_dangers
-            result["analysis_summary"]["danger_count"] = len(all_dangers)
-
-        if enable_sca:
-            result["dependency_vulnerabilities"] = all_sca
-            result["analysis_summary"]["sca_count"] = len(all_sca)
-
-        if enable_quality and all_quality:
-            custom_hits = []
-            core_quality = []
-
-            for f in all_quality:
-                rid = str(f.get("rule_id", ""))
-                if rid.startswith("CUSTOM-"):
-                    custom_hits.append(f)
-                else:
-                    core_quality.append(f)
-
-            if core_quality:
-                from skylos.rules.quality.standards import enrich_finding
-
-                for f in core_quality:
-                    enrich_finding(f)
-                result["quality"] = core_quality
-                result["analysis_summary"]["quality_count"] = len(core_quality)
-
-            if custom_hits:
-                result["custom_rules"] = custom_hits
-                result["analysis_summary"]["custom_rules_count"] = len(custom_hits)
-
-        if empty_files:
-            result["unused_files"] = empty_files
-            result["analysis_summary"]["unused_files_count"] = len(empty_files)
-
-        if enable_danger and result.get("danger"):
-            from skylos.rules.compliance import enrich_findings_with_compliance
-
-            result["danger"] = enrich_findings_with_compliance(result["danger"])
-
-        for u in unused:
-            if u["type"] in ("function", "method"):
-                result["unused_functions"].append(u)
-            elif u["type"] == "import":
-                result["unused_imports"].append(u)
-            elif u["type"] in ("class", "type"):
-                result["unused_classes"].append(u)
-            elif u["type"] in ("variable", "constant"):
-                result["unused_variables"].append(u)
-            elif u["type"] == "parameter":
-                result["unused_parameters"].append(u)
-
-        if unused_ts_exports:
-            if "unused_exports" not in result:
-                result["unused_exports"] = []
-            result["unused_exports"].extend(unused_ts_exports)
-            result["analysis_summary"]["unused_exports_count"] = len(unused_ts_exports)
-
-        project_cfg = load_config(
-            path[0] if isinstance(path, (list, tuple)) else path,
+            pyproject_entrypoint_modules=pyproject_entrypoint_modules,
             config_file=config_file,
         )
-        if project_cfg.get("check_circular", True):
-            circular_rule = CircularDependencyRule()
-
-            for file in files:
-                if not str(file).endswith(".py"):
-                    continue
-                mod = modmap.get(file, "")
-                raw_imp = all_raw_imports.get(file, [])
-                circular_rule.add_file_imports(str(file), mod, raw_imp)
-
-            try:
-                circular_findings = circular_rule.analyze()
-                if circular_findings:
-                    result["circular_dependencies"] = circular_findings
-
-                if enable_quality:
-                    try:
-                        from skylos.analysis.architecture import (
-                            get_architecture_findings,
-                        )
-
-                        dep_graph = dict(
-                            circular_rule._analyzer.architecture_dependencies
-                        )
-                        mod_files = dict(circular_rule._analyzer.modules)
-                        entrypoint_modules = (
-                            pyproject_entrypoint_modules
-                            | architecture_main_guard_modules
-                        )
-                        entrypoint_modules = _expand_reexported_entrypoint_modules(
-                            pyproject_entrypoint_qnames,
-                            entrypoint_modules,
-                            all_raw_imports,
-                            modmap,
-                            mod_files,
-                        )
-                        package_boundary_modules = _find_package_boundary_modules(
-                            all_raw_imports,
-                            modmap,
-                            mod_files,
-                        )
-
-                        mod_trees = {}
-                        if not architecture_abstractness:
-                            for file in files:
-                                if not str(file).endswith(".py"):
-                                    continue
-                                mod = modmap.get(file, "")
-                                try:
-                                    src = Path(file).read_text(
-                                        encoding="utf-8", errors="ignore"
-                                    )
-                                    mod_trees[mod] = ast.parse(src)
-                                except (OSError, SyntaxError):
-                                    pass
-
-                        arch_findings, arch_summary = get_architecture_findings(
-                            dependency_graph=dep_graph,
-                            module_files=mod_files,
-                            module_trees=mod_trees,
-                            module_abstractness=architecture_abstractness,
-                            module_loc=architecture_loc,
-                            entrypoint_modules=entrypoint_modules,
-                            package_boundary_modules=package_boundary_modules,
-                            layer_policy=project_cfg.get("architecture"),
-                            iad_findings_advisory=not _architecture_iad_strict(
-                                project_cfg.get("architecture")
-                            ),
-                        )
-                        ignored_rules = set(project_cfg.get("ignore", []))
-                        if arch_findings:
-                            arch_findings = [
-                                f
-                                for f in arch_findings
-                                if f.get("rule_id") not in ignored_rules
-                            ]
-                        if arch_findings:
-                            all_quality.extend(arch_findings)
-                            from skylos.rules.quality.standards import enrich_finding
-
-                            for finding in arch_findings:
-                                enrich_finding(finding)
-                            result.setdefault("quality", []).extend(arch_findings)
-                            result["analysis_summary"]["quality_count"] = len(
-                                result.get("quality", []) or []
-                            )
-                        if arch_summary:
-                            result["architecture_metrics"] = arch_summary
-                    except Exception:
-                        if os.getenv("SKYLOS_DEBUG"):
-                            traceback.print_exc()
-
-            except Exception:
-                if os.getenv("SKYLOS_DEBUG"):
-                    traceback.print_exc()
-
-        try:
-            from skylos.reporting.grader import count_lines_of_code, compute_grade
-
-            total_loc = count_lines_of_code(files)
-            grade_categories = []
-            if enable_danger:
-                grade_categories.append("security")
-            if enable_quality:
-                grade_categories.append("quality")
-            grade_categories.append("dead_code")
-            if enable_sca:
-                grade_categories.append("dependencies")
-            if enable_secrets:
-                grade_categories.append("secrets")
-            result["analysis_summary"]["total_loc"] = total_loc
-            result["analysis_summary"]["grade_categories"] = grade_categories
-            result["grade"] = compute_grade(
-                result,
-                total_loc,
-                included_categories=grade_categories,
-            )
-        except Exception:
-            if os.getenv("SKYLOS_DEBUG"):
-                traceback.print_exc()
-
-        attach_directory_rollups(result, getattr(self, "_project_root", None))
-
-        return result
 
     def analyze(
         self,

--- a/skylos/reporting/architecture_result.py
+++ b/skylos/reporting/architecture_result.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import ast
+import os
+import traceback
+from pathlib import Path
+
+from skylos.analysis.circular_deps import CircularDependencyRule
+
+_MAX_ARCHITECTURE_SOURCE_BYTES = 2_000_000
+
+
+def attach_circular_and_architecture(
+    result,
+    project_cfg,
+    files,
+    modmap,
+    all_raw_imports,
+    enable_quality,
+    all_quality,
+    architecture_abstractness,
+    architecture_loc,
+    architecture_main_guard_modules,
+    pyproject_entrypoint_qnames,
+    pyproject_entrypoint_modules,
+):
+    if not project_cfg.get("check_circular", True):
+        return
+    circular_rule = _build_circular_rule(files, modmap, all_raw_imports)
+    try:
+        circular_findings = circular_rule.analyze()
+    except Exception:
+        _debug_traceback()
+        return
+    if circular_findings:
+        result["circular_dependencies"] = circular_findings
+    if enable_quality:
+        _attach_architecture(
+            result,
+            project_cfg,
+            files,
+            modmap,
+            all_raw_imports,
+            all_quality,
+            circular_rule,
+            architecture_abstractness,
+            architecture_loc,
+            architecture_main_guard_modules,
+            pyproject_entrypoint_qnames,
+            pyproject_entrypoint_modules,
+        )
+
+
+def _build_circular_rule(files, modmap, all_raw_imports):
+    circular_rule = CircularDependencyRule()
+    for file in files:
+        if not str(file).endswith(".py"):
+            continue
+        mod = modmap.get(file, "")
+        raw_imp = all_raw_imports.get(file, [])
+        circular_rule.add_file_imports(str(file), mod, raw_imp)
+    return circular_rule
+
+
+def _debug_traceback():
+    if os.getenv("SKYLOS_DEBUG"):
+        traceback.print_exc()
+
+
+def _attach_architecture(
+    result,
+    project_cfg,
+    files,
+    modmap,
+    all_raw_imports,
+    all_quality,
+    circular_rule,
+    architecture_abstractness,
+    architecture_loc,
+    architecture_main_guard_modules,
+    pyproject_entrypoint_qnames,
+    pyproject_entrypoint_modules,
+):
+    try:
+        findings, summary = _architecture_findings(
+            project_cfg,
+            files,
+            modmap,
+            all_raw_imports,
+            circular_rule,
+            architecture_abstractness,
+            architecture_loc,
+            architecture_main_guard_modules,
+            pyproject_entrypoint_qnames,
+            pyproject_entrypoint_modules,
+        )
+    except Exception:
+        _debug_traceback()
+        return
+    _attach_architecture_findings(result, project_cfg, all_quality, findings)
+    if summary:
+        result["architecture_metrics"] = summary
+
+
+def _architecture_findings(
+    project_cfg,
+    files,
+    modmap,
+    all_raw_imports,
+    circular_rule,
+    architecture_abstractness,
+    architecture_loc,
+    architecture_main_guard_modules,
+    pyproject_entrypoint_qnames,
+    pyproject_entrypoint_modules,
+):
+    from skylos.analysis.architecture import get_architecture_findings
+    from skylos.analyzer import _architecture_iad_strict
+
+    dep_graph = dict(circular_rule._analyzer.architecture_dependencies)
+    mod_files = dict(circular_rule._analyzer.modules)
+    entrypoint_modules = _architecture_entrypoint_modules(
+        pyproject_entrypoint_qnames,
+        pyproject_entrypoint_modules,
+        architecture_main_guard_modules,
+        all_raw_imports,
+        modmap,
+        mod_files,
+    )
+    package_modules = _package_boundary_modules(all_raw_imports, modmap, mod_files)
+    mod_trees = _architecture_module_trees(files, modmap, architecture_abstractness)
+    return get_architecture_findings(
+        dependency_graph=dep_graph,
+        module_files=mod_files,
+        module_trees=mod_trees,
+        module_abstractness=architecture_abstractness,
+        module_loc=architecture_loc,
+        entrypoint_modules=entrypoint_modules,
+        package_boundary_modules=package_modules,
+        layer_policy=project_cfg.get("architecture"),
+        iad_findings_advisory=not _architecture_iad_strict(
+            project_cfg.get("architecture")
+        ),
+    )
+
+
+def _architecture_entrypoint_modules(
+    pyproject_entrypoint_qnames,
+    pyproject_entrypoint_modules,
+    architecture_main_guard_modules,
+    all_raw_imports,
+    modmap,
+    mod_files,
+):
+    from skylos.analyzer import _expand_reexported_entrypoint_modules
+
+    entrypoint_modules = pyproject_entrypoint_modules | architecture_main_guard_modules
+    return _expand_reexported_entrypoint_modules(
+        pyproject_entrypoint_qnames,
+        entrypoint_modules,
+        all_raw_imports,
+        modmap,
+        mod_files,
+    )
+
+
+def _package_boundary_modules(all_raw_imports, modmap, mod_files):
+    from skylos.analyzer import _find_package_boundary_modules
+
+    return _find_package_boundary_modules(all_raw_imports, modmap, mod_files)
+
+
+def _architecture_module_trees(files, modmap, architecture_abstractness):
+    if architecture_abstractness:
+        return {}
+    source_root = _source_root(files)
+    mod_trees = {}
+    for file in files:
+        if not str(file).endswith(".py"):
+            continue
+        mod = modmap.get(file, "")
+        _add_module_tree(mod_trees, mod, file, source_root)
+    return mod_trees
+
+
+def _source_root(files):
+    resolved = []
+    for file in files:
+        try:
+            resolved.append(Path(file).resolve())
+        except OSError:
+            continue
+    if not resolved:
+        return Path(".").resolve()
+    root = Path(os.path.commonpath(resolved))
+    if root.is_file():
+        return root.parent
+    return root
+
+
+def _safe_source_path(file, source_root):
+    source_path = Path(file)
+    if source_path.is_symlink():
+        return None
+    try:
+        resolved_path = source_path.resolve()
+        resolved_path.relative_to(source_root)
+    except (OSError, ValueError):
+        return None
+    return resolved_path
+
+
+def _add_module_tree(mod_trees, mod, file, source_root):
+    source_path = _safe_source_path(file, source_root)
+    if source_path is None:
+        return
+    try:
+        stat = source_path.stat()
+    except OSError:
+        return
+    if not source_path.is_file():
+        return
+    if stat.st_size > _MAX_ARCHITECTURE_SOURCE_BYTES:
+        return
+    try:
+        src = source_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return
+    try:
+        mod_trees[mod] = ast.parse(src)
+    except SyntaxError:
+        return
+
+
+def _attach_architecture_findings(result, project_cfg, all_quality, arch_findings):
+    if not arch_findings:
+        return
+    ignored_rules = set(project_cfg.get("ignore", []))
+    kept = []
+    for finding in arch_findings:
+        if finding.get("rule_id") not in ignored_rules:
+            kept.append(finding)
+    if not kept:
+        return
+    all_quality.extend(kept)
+    from skylos.rules.quality.standards import enrich_finding
+
+    for finding in kept:
+        enrich_finding(finding)
+    result.setdefault("quality", []).extend(kept)
+    result["analysis_summary"]["quality_count"] = len(result.get("quality", []) or [])

--- a/skylos/reporting/dead_code_result.py
+++ b/skylos/reporting/dead_code_result.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _primary_path(path):
+    if not isinstance(path, (list, tuple)):
+        return path
+
+    for item in path:
+        return item
+
+    return "."
+
+
+def _sorted_values(values):
+    if not values:
+        return []
+    return sorted(values)
+
+
+def dead_code_evidence(analyzer, path, pyproject_entrypoint_qnames):
+    evidence_root = getattr(analyzer, "_project_root", None)
+    if evidence_root is None:
+        evidence_root = Path(_primary_path(path))
+        if evidence_root.is_file():
+            evidence_root = evidence_root.parent
+
+    from skylos.deadcode.evidence import build_dead_code_evidence
+
+    ledger = build_dead_code_evidence(
+        analyzer.defs,
+        project_root=evidence_root,
+        pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
+    )
+    return ledger, ledger.to_dict(evidence_root)
+
+
+def _evidence_by_name(dead_code_evidence_payload):
+    by_name = {}
+    for entry in dead_code_evidence_payload.get("symbols", []):
+        by_name[entry["qualified_name"]] = entry
+    return by_name
+
+
+def _attach_evidence(target: dict, definition, evidence_by_name) -> None:
+    entry = evidence_by_name.get(getattr(definition, "name", ""))
+    if not entry:
+        return
+    target["dead_code_classification"] = entry["classification"]
+    target["dead_code_evidence"] = list(entry.get("evidence") or [])
+
+
+def _is_dead_definition(definition, thr):
+    if definition.references != 0:
+        return False
+    if definition.is_exported:
+        return False
+    if definition.confidence <= 0:
+        return False
+    return definition.confidence >= thr
+
+
+def _dead_class_keys(analyzer, thr):
+    keys = set()
+    for key, definition in analyzer.defs.items():
+        if definition.type not in ("class", "type"):
+            continue
+        if _is_dead_definition(definition, thr):
+            keys.add(key)
+    return keys
+
+
+def _class_key_by_name_file(analyzer):
+    by_name_file = {}
+    for key, definition in analyzer.defs.items():
+        if definition.type not in ("class", "type"):
+            continue
+        filename = str(Path(definition.filename).resolve())
+        by_name_file[(definition.name, filename)] = key
+    return by_name_file
+
+
+def _method_owner_key(definition, class_keys):
+    if definition.type != "method":
+        return None
+    if "." not in definition.name:
+        return None
+    owner = definition.name.rsplit(".", 1)[0]
+    filename = str(Path(definition.filename).resolve())
+    return class_keys.get((owner, filename))
+
+
+def unused_definitions(analyzer, thr, dead_code_evidence_payload):
+    evidence_by_name = _evidence_by_name(dead_code_evidence_payload)
+    unused = []
+    dead_classes = _dead_class_keys(analyzer, thr)
+    class_keys = _class_key_by_name_file(analyzer)
+    for definition in analyzer.defs.values():
+        if not _is_dead_definition(definition, thr):
+            continue
+        owner_key = _method_owner_key(definition, class_keys)
+        if owner_key in dead_classes:
+            continue
+        item = definition.to_dict()
+        _attach_evidence(item, definition, evidence_by_name)
+        unused.append(item)
+    return unused
+
+
+def _definition_loc(definition):
+    node = getattr(definition, "node", None)
+    if node is None:
+        return 1
+    start = getattr(node, "lineno", None)
+    end = getattr(node, "end_lineno", None)
+    if start is None or end is None:
+        return 1
+    return max(1, end - start + 1)
+
+
+def _context_entry(definition, thr, evidence_by_name):
+    entry = {
+        "name": definition.name,
+        "file": str(definition.filename),
+        "line": definition.line,
+        "type": definition.type,
+        "loc": _definition_loc(definition),
+        "complexity": getattr(definition, "complexity", 1),
+        "calls": _sorted_values(definition.calls),
+        "called_by": _sorted_values(definition.called_by),
+        "dead": _is_dead_definition(definition, thr),
+    }
+    _attach_evidence(entry, definition, evidence_by_name)
+    return entry
+
+
+def definition_context(analyzer, thr, dead_code_evidence_payload):
+    evidence_by_name = _evidence_by_name(dead_code_evidence_payload)
+    context = {}
+    for name, definition in analyzer.defs.items():
+        if definition.type not in ("class", "function", "method"):
+            continue
+        if name.startswith("_"):
+            continue
+        context[name] = _context_entry(definition, thr, evidence_by_name)
+    return context
+
+
+def whitelisted_definitions(analyzer, all_suppressed):
+    whitelisted = []
+    for definition in analyzer.defs.values():
+        reason = getattr(definition, "skip_reason", None)
+        if not reason:
+            continue
+        entry = _whitelist_entry(definition)
+        whitelisted.append(entry)
+        if reason == "inline ignore comment":
+            all_suppressed.append(entry)
+    return whitelisted
+
+
+def _whitelist_entry(definition):
+    return {
+        "name": definition.simple_name,
+        "file": str(definition.filename),
+        "line": definition.line,
+        "reason": definition.skip_reason,
+        "category": "dead_code",
+        "suppression_code": getattr(definition, "suppression_code", None),
+        "folder_role": getattr(definition, "folder_role", None),
+    }

--- a/skylos/reporting/result_builder.py
+++ b/skylos/reporting/result_builder.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.config import load_config
+from skylos.reporting.architecture_result import attach_circular_and_architecture
+from skylos.reporting.dead_code_result import (
+    dead_code_evidence,
+    definition_context,
+    unused_definitions,
+    whitelisted_definitions,
+)
+from skylos.reporting.rollups import attach_directory_rollups
+
+
+def _primary_path(path):
+    if not isinstance(path, (list, tuple)):
+        return path
+
+    for item in path:
+        return item
+
+    return "."
+
+
+def _normal_set(values):
+    return set(values or ())
+
+
+def build_analysis_result(
+    analyzer,
+    files,
+    thr,
+    exclude_folders,
+    enable_secrets,
+    enable_danger,
+    enable_quality,
+    enable_sca,
+    all_secrets,
+    all_dangers,
+    all_quality,
+    all_sca,
+    all_suppressed,
+    empty_files,
+    modmap,
+    all_raw_imports,
+    path,
+    unused_ts_exports=None,
+    workspace_inventory=None,
+    architecture_abstractness=None,
+    architecture_loc=None,
+    architecture_main_guard_modules=None,
+    pyproject_entrypoint_qnames=None,
+    pyproject_entrypoint_modules=None,
+    config_file=None,
+):
+    """Assemble the final result dict from analysis outputs."""
+    architecture_main_guard_modules = _normal_set(architecture_main_guard_modules)
+    pyproject_entrypoint_qnames = _normal_set(pyproject_entrypoint_qnames)
+    pyproject_entrypoint_modules = _normal_set(pyproject_entrypoint_modules)
+
+    ledger, evidence = dead_code_evidence(
+        analyzer,
+        path,
+        pyproject_entrypoint_qnames,
+    )
+    unused = unused_definitions(analyzer, thr, evidence)
+    context_map = definition_context(analyzer, thr, evidence)
+    whitelisted = whitelisted_definitions(analyzer, all_suppressed)
+
+    result = _base_result(
+        analyzer,
+        files,
+        exclude_folders,
+        context_map,
+        whitelisted,
+        all_suppressed,
+        evidence,
+        ledger,
+    )
+    _attach_analysis_reports(analyzer, result)
+    _attach_workspace(analyzer, result, workspace_inventory, path)
+    _attach_findings(
+        result,
+        enable_secrets,
+        enable_danger,
+        enable_sca,
+        all_secrets,
+        all_dangers,
+        all_sca,
+    )
+    _attach_quality(result, enable_quality, all_quality)
+    _attach_empty_files(result, empty_files)
+    _enrich_danger(result, enable_danger)
+    _bucket_unused_definitions(result, unused)
+    _attach_unused_ts_exports(result, unused_ts_exports)
+
+    project_cfg = load_config(_primary_path(path), config_file=config_file)
+    attach_circular_and_architecture(
+        result,
+        project_cfg,
+        files,
+        modmap,
+        all_raw_imports,
+        enable_quality,
+        all_quality,
+        architecture_abstractness,
+        architecture_loc,
+        architecture_main_guard_modules,
+        pyproject_entrypoint_qnames,
+        pyproject_entrypoint_modules,
+    )
+    _attach_grade(
+        result,
+        files,
+        enable_danger,
+        enable_quality,
+        enable_sca,
+        enable_secrets,
+    )
+    attach_directory_rollups(result, getattr(analyzer, "_project_root", None))
+    return result
+
+
+def _base_result(
+    analyzer,
+    files,
+    exclude_folders,
+    context_map,
+    whitelisted,
+    all_suppressed,
+    dead_code_evidence,
+    dead_code_ledger,
+):
+    return {
+        "definitions": context_map,
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "unused_parameters": [],
+        "unused_files": [],
+        "whitelisted": whitelisted,
+        "suppressed": all_suppressed,
+        "dead_code_evidence": dead_code_evidence,
+        "analysis_summary": {
+            "total_files": len(files),
+            "excluded_folders": exclude_folders or [],
+            "languages": analyzer._count_languages(files),
+            "dead_code_evidence": dead_code_ledger.summary(),
+        },
+    }
+
+
+def _attach_analysis_reports(analyzer, result):
+    liveness_report = getattr(analyzer, "_dead_code_liveness_report", None)
+    if liveness_report is not None:
+        result["analysis_summary"]["dead_code_liveness"] = liveness_report.to_dict()
+
+    grep_verify_report = getattr(analyzer, "_grep_verify_report", None)
+    if grep_verify_report is not None:
+        result["analysis_summary"]["grep_verify"] = dict(grep_verify_report)
+
+
+def _attach_workspace(analyzer, result, workspace_inventory, path):
+    if workspace_inventory is None:
+        return
+    if hasattr(analyzer, "_project_root"):
+        project_root = analyzer._project_root
+    else:
+        project_root = Path(_primary_path(path)).resolve()
+    summary = result["analysis_summary"]
+    result["workspaces"] = workspace_inventory.to_dict(project_root)
+    summary["monorepo_detected"] = workspace_inventory.is_monorepo
+    summary["workspace_count"] = len(workspace_inventory.packages)
+    summary["workspace_total_packages"] = workspace_inventory.total_packages
+    summary["workspace_diagnostic_count"] = len(workspace_inventory.diagnostics)
+
+
+def _attach_findings(
+    result,
+    enable_secrets,
+    enable_danger,
+    enable_sca,
+    all_secrets,
+    all_dangers,
+    all_sca,
+):
+    summary = result["analysis_summary"]
+    if enable_secrets and all_secrets:
+        result["secrets"] = all_secrets
+        summary["secrets_count"] = len(all_secrets)
+    if enable_danger and all_dangers:
+        result["danger"] = all_dangers
+        summary["danger_count"] = len(all_dangers)
+    if enable_sca:
+        result["dependency_vulnerabilities"] = all_sca
+        summary["sca_count"] = len(all_sca)
+
+
+def _split_quality_findings(all_quality):
+    custom_hits = []
+    core_quality = []
+    for finding in all_quality:
+        rule_id = str(finding.get("rule_id", ""))
+        if rule_id.startswith("CUSTOM-"):
+            custom_hits.append(finding)
+        else:
+            core_quality.append(finding)
+    return core_quality, custom_hits
+
+
+def _attach_quality(result, enable_quality, all_quality):
+    if not enable_quality or not all_quality:
+        return
+    core_quality, custom_hits = _split_quality_findings(all_quality)
+    if core_quality:
+        from skylos.rules.quality.standards import enrich_finding
+
+        for finding in core_quality:
+            enrich_finding(finding)
+        result["quality"] = core_quality
+        result["analysis_summary"]["quality_count"] = len(core_quality)
+    if custom_hits:
+        result["custom_rules"] = custom_hits
+        result["analysis_summary"]["custom_rules_count"] = len(custom_hits)
+
+
+def _attach_empty_files(result, empty_files):
+    if not empty_files:
+        return
+    result["unused_files"] = empty_files
+    result["analysis_summary"]["unused_files_count"] = len(empty_files)
+
+
+def _enrich_danger(result, enable_danger):
+    if not enable_danger or not result.get("danger"):
+        return
+    from skylos.rules.compliance import enrich_findings_with_compliance
+
+    result["danger"] = enrich_findings_with_compliance(result["danger"])
+
+
+def _bucket_unused_definitions(result, unused):
+    buckets = {
+        "function": "unused_functions",
+        "method": "unused_functions",
+        "import": "unused_imports",
+        "class": "unused_classes",
+        "type": "unused_classes",
+        "variable": "unused_variables",
+        "constant": "unused_variables",
+        "parameter": "unused_parameters",
+    }
+    for item in unused:
+        bucket = buckets.get(item["type"])
+        if bucket:
+            result[bucket].append(item)
+
+
+def _attach_unused_ts_exports(result, unused_ts_exports):
+    if not unused_ts_exports:
+        return
+    result.setdefault("unused_exports", []).extend(unused_ts_exports)
+    result["analysis_summary"]["unused_exports_count"] = len(unused_ts_exports)
+def _attach_grade(
+    result,
+    files,
+    enable_danger,
+    enable_quality,
+    enable_sca,
+    enable_secrets,
+):
+    try:
+        from skylos.reporting.grader import count_lines_of_code, compute_grade
+
+        total_loc = count_lines_of_code(files)
+        categories = _grade_categories(
+            enable_danger,
+            enable_quality,
+            enable_sca,
+            enable_secrets,
+        )
+        result["analysis_summary"]["total_loc"] = total_loc
+        result["analysis_summary"]["grade_categories"] = categories
+        result["grade"] = compute_grade(
+            result,
+            total_loc,
+            included_categories=categories,
+        )
+    except Exception:
+        _debug_traceback()
+
+
+def _grade_categories(enable_danger, enable_quality, enable_sca, enable_secrets):
+    categories = []
+    if enable_danger:
+        categories.append("security")
+    if enable_quality:
+        categories.append("quality")
+    categories.append("dead_code")
+    if enable_sca:
+        categories.append("dependencies")
+    if enable_secrets:
+        categories.append("secrets")
+    return categories


### PR DESCRIPTION
## Summary
  - extract analyzer result assembly out of `skylos/analyzer.py`
  - add reporting helpers for result building, dead-code result shaping, and architecture result attachment

  ## Tests
  - `pytest  .`