### PR TITLE
fix(analyzer): make noqa suppressions code-specific

### DIFF
--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -200,6 +200,12 @@ _FUTURE_IMPORTS = {
     "generator_stop",
 }
 
+_NOQA_DEAD_CODE_CODES_BY_TYPE = {
+    "import": {"F401"},
+    "variable": {"F841"},
+    "constant": {"F841"},
+}
+
 
 def _suppress(def_obj, reason=None, code=None, folder_role=None):
     def_obj.confidence = 0
@@ -272,6 +278,19 @@ def _is_alembic_revision_path(filename: str) -> bool:
 def _check_inline_ignore(def_obj, visitor):
     if getattr(visitor, "ignore_lines", None) and def_obj.line in visitor.ignore_lines:
         return _suppress(def_obj, "inline ignore comment")
+    noqa_codes_by_line = getattr(visitor, "noqa_codes_by_line", None) or {}
+    noqa_codes = noqa_codes_by_line.get(def_obj.line)
+    if noqa_codes is None:
+        return None
+    if not noqa_codes:
+        return _suppress(def_obj, "inline ignore comment", code="noqa")
+    matching_codes = _NOQA_DEAD_CODE_CODES_BY_TYPE.get(def_obj.type, set())
+    if noqa_codes & matching_codes:
+        return _suppress(
+            def_obj,
+            "inline ignore comment",
+            code="noqa:" + ",".join(sorted(noqa_codes & matching_codes)),
+        )
     return None
 
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -41,7 +41,7 @@ from skylos.rules.secrets import scan_ctx as _secrets_scan_ctx
 from skylos.rules.danger.calls import DangerousCallsRule
 
 
-from skylos.config import get_all_ignore_lines, load_config
+from skylos.config import get_noqa_codes_by_line, get_skylos_ignore_lines, load_config
 from skylos.core.file_discovery import (
     discover_source_files,
     find_git_root,
@@ -3087,7 +3087,8 @@ def proc_file(
 
     try:
         source = Path(file).read_text(encoding="utf-8")
-        ignore_lines = get_all_ignore_lines(source)
+        ignore_lines = get_skylos_ignore_lines(source)
+        noqa_codes_by_line = get_noqa_codes_by_line(source)
 
         tree = ast.parse(source)
 
@@ -3174,6 +3175,7 @@ def proc_file(
         tv = TestAwareVisitor(filename=file)
         tv.visit(tree)
         tv.ignore_lines = ignore_lines
+        tv.noqa_codes_by_line = noqa_codes_by_line
 
         fv = FrameworkAwareVisitor(filename=file)
         fv.visit(tree)

--- a/skylos/config.py
+++ b/skylos/config.py
@@ -1,6 +1,7 @@
 import copy
 import fnmatch
 import os
+import re
 from pathlib import Path
 
 CONFIG_FILE_ENV_VAR = "SKYLOS_CONFIG_FILE"
@@ -756,7 +757,26 @@ def get_expired_whitelists(cfg) -> list[tuple[str, str, str]]:
     return expired
 
 
-def get_all_ignore_lines(source) -> set[int]:
+_NOQA_RE = re.compile(r"#\s*noqa(?::\s*([^#]+))?", re.IGNORECASE)
+
+
+def get_noqa_codes_by_line(source) -> dict[int, set[str]]:
+    codes_by_line: dict[int, set[str]] = {}
+    for i, line in enumerate(source.splitlines(), start=1):
+        match = _NOQA_RE.search(line)
+        if not match:
+            continue
+        raw_codes = match.group(1)
+        if raw_codes is None:
+            codes_by_line[i] = set()
+            continue
+        codes = {code.upper() for code in re.findall(r"\b[A-Z]+\d+\b", raw_codes)}
+        if codes:
+            codes_by_line[i] = codes
+    return codes_by_line
+
+
+def _collect_ignore_lines(source, *, include_code_specific_noqa: bool) -> set[int]:
     ignore_lines = set()
     in_ignore_block = False
 
@@ -789,16 +809,32 @@ def get_all_ignore_lines(source) -> set[int]:
                 "#skylos:ignore",
                 "# noqa: skylos",
                 "pragma: no skylos",
-                "# noqa",
-                "#noqa",
             ]
         ):
             ignore_lines.add(i)
             stripped = line.strip()
             if stripped.startswith("@"):
                 ignore_lines.add(i + 1)
+            continue
+
+        match = _NOQA_RE.search(line)
+        if not match:
+            continue
+        if include_code_specific_noqa or match.group(1) is None:
+            ignore_lines.add(i)
+            stripped = line.strip()
+            if stripped.startswith("@"):
+                ignore_lines.add(i + 1)
 
     return ignore_lines
+
+
+def get_all_ignore_lines(source) -> set[int]:
+    return _collect_ignore_lines(source, include_code_specific_noqa=True)
+
+
+def get_skylos_ignore_lines(source) -> set[int]:
+    return _collect_ignore_lines(source, include_code_specific_noqa=False)
 
 
 def suggest_pattern(name) -> str | None:

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -499,7 +499,7 @@ class Visitor(ast.NodeVisitor):
             self.add_def(
                 target,
                 "import",
-                node.lineno,
+                getattr(a, "lineno", node.lineno),
                 is_exported=a.asname == a.name if a.asname else False,
             )
 
@@ -553,7 +553,7 @@ class Visitor(ast.NodeVisitor):
             self.add_def(
                 full,
                 "import",
-                node.lineno,
+                getattr(a, "lineno", node.lineno),
                 is_exported=a.asname == a.name if a.asname else False,
             )
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -693,6 +693,47 @@ class TestAnalyze:
 
         assert "AgentActionName" not in unused_imports
 
+    def test_noqa_f401_suppresses_only_matching_unused_import(self, tmp_path):
+        (tmp_path / "constants.py").write_text(
+            "USED_FOR_COMPAT = 1\n"
+            "PLAIN_UNUSED = 2\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "facade.py").write_text(
+            "from constants import (\n"
+            "    USED_FOR_COMPAT,  # noqa: F401 - compatibility re-export\n"
+            "    PLAIN_UNUSED,\n"
+            ")\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused_imports = {
+            item["simple_name"] for item in result.get("unused_imports", [])
+        }
+        suppressed = {
+            item["name"]
+            for item in result.get("suppressed", [])
+            if item.get("suppression_code") == "noqa:F401"
+        }
+
+        assert "USED_FOR_COMPAT" not in unused_imports
+        assert "PLAIN_UNUSED" in unused_imports
+        assert "USED_FOR_COMPAT" in suppressed
+
+    def test_noqa_f401_does_not_suppress_unused_variable(self, tmp_path):
+        (tmp_path / "app.py").write_text(
+            "unused_value = 1  # noqa: F401\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused_variables = {
+            item["simple_name"] for item in result.get("unused_variables", [])
+        }
+
+        assert "unused_value" in unused_variables
+
     def test_mcp_decorated_tools_and_resources_are_live(self, tmp_path):
         (tmp_path / "server.py").write_text(
             "class FakeMCP:\n"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -11,6 +11,8 @@ from skylos.config import (
     is_whitelisted,
     get_expired_whitelists,
     get_all_ignore_lines,
+    get_noqa_codes_by_line,
+    get_skylos_ignore_lines,
     suggest_pattern,
 )
 from skylos.core.contribution_settings import load_contribution_settings
@@ -854,3 +856,33 @@ lower_confidence = "boom"
 
         self.assertIn(1, ignore_lines)
         self.assertNotIn(2, ignore_lines)
+
+    def test_get_skylos_ignore_lines_excludes_code_specific_noqa(self):
+        source = "\n".join(
+            [
+                "import pandas  # noqa: F401",
+                "import os  # noqa",
+                "x = 1  # skylos: ignore",
+            ]
+        )
+
+        ignore_lines = get_skylos_ignore_lines(source)
+
+        self.assertNotIn(1, ignore_lines)
+        self.assertIn(2, ignore_lines)
+        self.assertIn(3, ignore_lines)
+
+    def test_get_noqa_codes_by_line_parses_specific_and_blanket(self):
+        source = "\n".join(
+            [
+                "import pandas  # noqa: F401, F402 - import ordering",
+                "import os  # noqa",
+                "import sys  # noqa: something",
+            ]
+        )
+
+        codes_by_line = get_noqa_codes_by_line(source)
+
+        self.assertEqual(codes_by_line[1], {"F401", "F402"})
+        self.assertEqual(codes_by_line[2], set())
+        self.assertNotIn(3, codes_by_line)


### PR DESCRIPTION
## Summary

  - Make `# noqa` handling code-specific instead of treating all `# noqa: <code>` comments as blanket Skylos ignores.
  - Map `F401` to unused-import suppression and `F841` to unused variable suppression.
  - Keep blanket behavior for plain `# noqa`, `# noqa: skylos`, and `# skylos: ignore`.

  ## Tests

  - `pytest test/test_config.py test/test_analyzer.py`
