### PR TITLE
fix(analyzer): harden noqa import suppression lines

### DIFF
--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -275,11 +275,31 @@ def _is_alembic_revision_path(filename: str) -> bool:
     return "/versions/" in normalized and normalized.endswith(".py")
 
 
+def _coerce_line_set(value, fallback) -> set[int]:
+    if value is None or isinstance(value, (str, bytes)):
+        return {fallback}
+    try:
+        return {int(line) for line in value}
+    except (TypeError, ValueError):
+        return {fallback}
+
+
 def _check_inline_ignore(def_obj, visitor):
-    if getattr(visitor, "ignore_lines", None) and def_obj.line in visitor.ignore_lines:
+    suppression_lines = _coerce_line_set(
+        getattr(def_obj, "suppression_lines", None),
+        def_obj.line,
+    )
+    ignore_lines = _coerce_line_set(getattr(visitor, "ignore_lines", None), -1)
+    if suppression_lines & ignore_lines:
         return _suppress(def_obj, "inline ignore comment")
     noqa_codes_by_line = getattr(visitor, "noqa_codes_by_line", None) or {}
-    noqa_codes = noqa_codes_by_line.get(def_obj.line)
+    if not isinstance(noqa_codes_by_line, dict):
+        noqa_codes_by_line = {}
+    noqa_codes = None
+    for line in sorted(suppression_lines):
+        if line in noqa_codes_by_line:
+            noqa_codes = noqa_codes_by_line[line]
+            break
     if noqa_codes is None:
         return None
     if not noqa_codes:

--- a/skylos/config.py
+++ b/skylos/config.py
@@ -757,7 +757,7 @@ def get_expired_whitelists(cfg) -> list[tuple[str, str, str]]:
     return expired
 
 
-_NOQA_RE = re.compile(r"#\s*noqa(?::\s*([^#]+))?", re.IGNORECASE)
+_NOQA_RE = re.compile(r"#\s*noqa\b(?::\s*([^#]+))?", re.IGNORECASE)
 
 
 def get_noqa_codes_by_line(source) -> dict[int, set[str]]:
@@ -770,7 +770,10 @@ def get_noqa_codes_by_line(source) -> dict[int, set[str]]:
         if raw_codes is None:
             codes_by_line[i] = set()
             continue
-        codes = {code.upper() for code in re.findall(r"\b[A-Z]+\d+\b", raw_codes)}
+        codes = {
+            code.upper()
+            for code in re.findall(r"\b[A-Z]+\d+\b", raw_codes, re.IGNORECASE)
+        }
         if codes:
             codes_by_line[i] = codes
     return codes_by_line

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -231,6 +231,7 @@ class Definition:
         "conditional_import",
         "suppression_code",
         "folder_role",
+        "suppression_lines",
     )
 
     def __init__(
@@ -272,6 +273,7 @@ class Definition:
         self.conditional_import = False
         self.suppression_code = None
         self.folder_role = None
+        self.suppression_lines = {line}
 
     def to_dict(self) -> dict[str, Any]:
         if self.type == "method" and "." in self.name:
@@ -407,10 +409,14 @@ class Visitor(ast.NodeVisitor):
                     d.node = node
                 for k, v in extra.items():
                     if hasattr(d, k):
-                        setattr(d, k, v)
-                if t == "import" and name in self._conditional_import_targets:
-                    d.conditional_import = True
-                break
+                        if k == "suppression_lines":
+                            d.suppression_lines.update(v)
+                        else:
+                            setattr(d, k, v)
+            if t == "import" and name in self._conditional_import_targets:
+                d.conditional_import = True
+            d.suppression_lines.add(line)
+            break
         if not found:
             defn = Definition(name, t, self.file, line, node=node)
             for k, v in extra.items():
@@ -495,12 +501,14 @@ class Visitor(ast.NodeVisitor):
                 alias_name = head
                 target = head
 
+            line = getattr(a, "lineno", node.lineno)
             self.alias[alias_name] = target
             self.add_def(
                 target,
                 "import",
-                getattr(a, "lineno", node.lineno),
+                line,
                 is_exported=a.asname == a.name if a.asname else False,
+                suppression_lines={line, node.lineno, getattr(node, "end_lineno", line)},
             )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
@@ -549,12 +557,14 @@ class Visitor(ast.NodeVisitor):
             else:
                 full = a.name
 
+            line = getattr(a, "lineno", node.lineno)
             self.alias[alias_name] = full
             self.add_def(
                 full,
                 "import",
-                getattr(a, "lineno", node.lineno),
+                line,
                 is_exported=a.asname == a.name if a.asname else False,
+                suppression_lines={line, node.lineno, getattr(node, "end_lineno", line)},
             )
 
     def visit_If(self, node: ast.If) -> None:

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -721,6 +721,54 @@ class TestAnalyze:
         assert "PLAIN_UNUSED" in unused_imports
         assert "USED_FOR_COMPAT" in suppressed
 
+    def test_noqa_f401_on_multiline_import_statement_suppresses_aliases(
+        self, tmp_path
+    ):
+        (tmp_path / "constants.py").write_text(
+            "COMPAT_ONE = 1\n"
+            "COMPAT_TWO = 2\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "facade.py").write_text(
+            "from constants import (  # noqa: F401 - compatibility re-export\n"
+            "    COMPAT_ONE,\n"
+            "    COMPAT_TWO,\n"
+            ")\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused_imports = {
+            item["simple_name"] for item in result.get("unused_imports", [])
+        }
+
+        assert "COMPAT_ONE" not in unused_imports
+        assert "COMPAT_TWO" not in unused_imports
+
+    def test_noqa_f401_on_multiline_import_close_suppresses_aliases(
+        self, tmp_path
+    ):
+        (tmp_path / "constants.py").write_text(
+            "COMPAT_ONE = 1\n"
+            "COMPAT_TWO = 2\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "facade.py").write_text(
+            "from constants import (\n"
+            "    COMPAT_ONE,\n"
+            "    COMPAT_TWO,\n"
+            ")  # noqa: F401 - compatibility re-export\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused_imports = {
+            item["simple_name"] for item in result.get("unused_imports", [])
+        }
+
+        assert "COMPAT_ONE" not in unused_imports
+        assert "COMPAT_TWO" not in unused_imports
+
     def test_noqa_f401_does_not_suppress_unused_variable(self, tmp_path):
         (tmp_path / "app.py").write_text(
             "unused_value = 1  # noqa: F401\n",

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -875,9 +875,10 @@ lower_confidence = "boom"
     def test_get_noqa_codes_by_line_parses_specific_and_blanket(self):
         source = "\n".join(
             [
-                "import pandas  # noqa: F401, F402 - import ordering",
+                "import pandas  # noqa: f401, F402 - import ordering",
                 "import os  # noqa",
                 "import sys  # noqa: something",
+                "value = 'noquality'",
             ]
         )
 
@@ -886,3 +887,4 @@ lower_confidence = "boom"
         self.assertEqual(codes_by_line[1], {"F401", "F402"})
         self.assertEqual(codes_by_line[2], set())
         self.assertNotIn(3, codes_by_line)
+        self.assertNotIn(4, codes_by_line)


### PR DESCRIPTION
## Summary

  - Harden `noqa` handling for unused import suppressions.
  - Support `# noqa: F401` on multi line import alias lines, import statement headers, and closing parens.
  - Parse `noqa` codes case-insensitively and avoid matching unrelated text like `noquality`.
  - Make suppression line handling defensive for objects without `suppression_lines`.

  ## Tests

  - `pytest test/test_analyzer.py test/test_config.py`
