### PR TITLE
fix(analyzer): scope suppression state correctly

### DIFF
--- a/skylos/rules/danger/danger_fs/path_flow.py
+++ b/skylos/rules/danger/danger_fs/path_flow.py
@@ -137,7 +137,7 @@ class _PathFlowChecker(TaintVisitor):
     def __init__(self, file_path, findings, sanitizers=None):
         super().__init__(file_path, findings, sanitizers=sanitizers)
         self.path_like_stack = [{}]
-        self.basename_sanitized_stack = [set()]
+        self.basename_sanitized_stack = [{}]
         self.symlink_sensitive_stack = [{}]
         self.os_open_write_flags_stack = [{}]
         self.safety_stack = [
@@ -155,7 +155,7 @@ class _PathFlowChecker(TaintVisitor):
     def _push(self):
         super()._push()
         self.path_like_stack.append({})
-        self.basename_sanitized_stack.append(set())
+        self.basename_sanitized_stack.append({})
         self.symlink_sensitive_stack.append({})
         self.os_open_write_flags_stack.append({})
         self.safety_stack.append(
@@ -195,15 +195,14 @@ class _PathFlowChecker(TaintVisitor):
 
     def _set_basename_sanitized(self, name, basename_sanitized):
         if not self.basename_sanitized_stack:
-            self.basename_sanitized_stack.append(set())
-        if basename_sanitized:
-            self.basename_sanitized_stack[-1].add(name)
-        else:
-            for env in self.basename_sanitized_stack:
-                env.discard(name)
+            self.basename_sanitized_stack.append({})
+        self.basename_sanitized_stack[-1][name] = bool(basename_sanitized)
 
     def _get_basename_sanitized(self, name):
-        return any(name in env for env in reversed(self.basename_sanitized_stack))
+        for env in reversed(self.basename_sanitized_stack):
+            if name in env:
+                return env[name]
+        return False
 
     def _set_symlink_sensitive(self, name, symlink_sensitive):
         if not self.symlink_sensitive_stack:

--- a/skylos/rules/danger/danger_fs/path_flow.py
+++ b/skylos/rules/danger/danger_fs/path_flow.py
@@ -137,6 +137,7 @@ class _PathFlowChecker(TaintVisitor):
     def __init__(self, file_path, findings, sanitizers=None):
         super().__init__(file_path, findings, sanitizers=sanitizers)
         self.path_like_stack = [{}]
+        self.basename_sanitized_stack = [set()]
         self.symlink_sensitive_stack = [{}]
         self.os_open_write_flags_stack = [{}]
         self.safety_stack = [
@@ -154,6 +155,7 @@ class _PathFlowChecker(TaintVisitor):
     def _push(self):
         super()._push()
         self.path_like_stack.append({})
+        self.basename_sanitized_stack.append(set())
         self.symlink_sensitive_stack.append({})
         self.os_open_write_flags_stack.append({})
         self.safety_stack.append(
@@ -171,6 +173,8 @@ class _PathFlowChecker(TaintVisitor):
         super()._pop()
         if self.path_like_stack:
             self.path_like_stack.pop()
+        if self.basename_sanitized_stack:
+            self.basename_sanitized_stack.pop()
         if self.symlink_sensitive_stack:
             self.symlink_sensitive_stack.pop()
         if self.os_open_write_flags_stack:
@@ -188,6 +192,18 @@ class _PathFlowChecker(TaintVisitor):
             if name in env:
                 return env[name]
         return False
+
+    def _set_basename_sanitized(self, name, basename_sanitized):
+        if not self.basename_sanitized_stack:
+            self.basename_sanitized_stack.append(set())
+        if basename_sanitized:
+            self.basename_sanitized_stack[-1].add(name)
+        else:
+            for env in self.basename_sanitized_stack:
+                env.discard(name)
+
+    def _get_basename_sanitized(self, name):
+        return any(name in env for env in reversed(self.basename_sanitized_stack))
 
     def _set_symlink_sensitive(self, name, symlink_sensitive):
         if not self.symlink_sensitive_stack:
@@ -274,6 +290,32 @@ class _PathFlowChecker(TaintVisitor):
                 return self._is_symlink_sensitive_expr(node.func.value)
         return False
 
+    def _is_basename_sanitized_expr(self, node):
+        if _is_path_name_projection(node):
+            return True
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "name"
+            and isinstance(node.value, ast.Call)
+        ):
+            qn = _qualified_name(node.value)
+            if qn in {"PurePath", "pathlib.PurePath"}:
+                return True
+        if isinstance(node, ast.Name):
+            return self._get_basename_sanitized(node.id)
+        return False
+
+    def _is_fixed_base_with_sanitized_name(self, node):
+        if not isinstance(node, ast.BinOp) or not isinstance(node.op, ast.Div):
+            return False
+        if not self._is_basename_sanitized_expr(node.right):
+            return False
+        return (
+            self._is_path_like_expr(node.left)
+            and not self.is_tainted(node.left)
+            and not self._is_symlink_sensitive_expr(node.left)
+        )
+
     def is_tainted(self, node):
         if _is_path_name_projection(node):
             return False
@@ -293,6 +335,9 @@ class _PathFlowChecker(TaintVisitor):
             if isinstance(tgt, ast.Name):
                 self._set(tgt.id, t)
                 self._set_path_like(tgt.id, path_like)
+                self._set_basename_sanitized(
+                    tgt.id, self._is_basename_sanitized_expr(node.value)
+                )
                 self._set_symlink_sensitive(
                     tgt.id, self._is_symlink_sensitive_expr(node.value)
                 )
@@ -309,6 +354,9 @@ class _PathFlowChecker(TaintVisitor):
             if isinstance(node.target, ast.Name):
                 self._set(node.target.id, t)
                 self._set_path_like(node.target.id, path_like)
+                self._set_basename_sanitized(
+                    node.target.id, self._is_basename_sanitized_expr(node.value)
+                )
                 self._set_symlink_sensitive(
                     node.target.id, self._is_symlink_sensitive_expr(node.value)
                 )
@@ -444,6 +492,8 @@ class _PathFlowChecker(TaintVisitor):
         )
 
     def _flag_symlink_read_if_unsafe(self, node, path_expr):
+        if self._is_fixed_base_with_sanitized_name(path_expr):
+            return
         if not self._path_needs_symlink_protection(path_expr):
             return
         if self._has_symlink_read_guard():

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -413,10 +413,10 @@ class Visitor(ast.NodeVisitor):
                             d.suppression_lines.update(v)
                         else:
                             setattr(d, k, v)
-            if t == "import" and name in self._conditional_import_targets:
-                d.conditional_import = True
-            d.suppression_lines.add(line)
-            break
+                if t == "import" and name in self._conditional_import_targets:
+                    d.conditional_import = True
+                d.suppression_lines.add(line)
+                break
         if not found:
             defn = Definition(name, t, self.file, line, node=node)
             for k, v in extra.items():

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -769,6 +769,24 @@ class TestAnalyze:
         assert "COMPAT_ONE" not in unused_imports
         assert "COMPAT_TWO" not in unused_imports
 
+    def test_noqa_f401_on_second_import_does_not_suppress_first_import(
+        self, tmp_path
+    ):
+        (tmp_path / "app.py").write_text(
+            "import os\n"
+            "import sys  # noqa: F401 - compatibility re-export\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+        unused_imports = {
+            item["simple_name"] for item in result.get("unused_imports", [])
+        }
+        suppressed = {item["name"] for item in result.get("suppressed", [])}
+
+        assert "os" in unused_imports
+        assert "sys" in suppressed
+
     def test_noqa_f401_does_not_suppress_unused_variable(self, tmp_path):
         (tmp_path / "app.py").write_text(
             "unused_value = 1  # noqa: F401\n",

--- a/test/test_dangerous.py
+++ b/test/test_dangerous.py
@@ -180,6 +180,25 @@ def load_sidecar(raw_path):
     assert "SKY-D325" in _rule_ids(out)
 
 
+def test_fixed_base_basename_read_suppresses_symlink_read(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_fixed_base_basename.py",
+        """
+from pathlib import Path
+from flask import request
+
+BASE = Path("/srv/uploads")
+
+def load_upload():
+    safe_name = Path(request.args["name"]).name
+    return (BASE / safe_name).read_text(encoding="utf-8")
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(out)
+    assert "SKY-D325" not in _rule_ids(out)
+
+
 def test_bounded_nofollow_read_is_not_symlink_finding(tmp_path):
     out = _scan_one(
         tmp_path,

--- a/test/test_dangerous.py
+++ b/test/test_dangerous.py
@@ -199,6 +199,31 @@ def load_upload():
     assert "SKY-D325" not in _rule_ids(out)
 
 
+def test_nested_unsanitized_name_does_not_clear_outer_basename_read(tmp_path):
+    out = _scan_one(
+        tmp_path,
+        "a_nested_fixed_base_basename.py",
+        """
+from pathlib import Path
+from flask import request
+
+BASE = Path("/srv/uploads")
+
+def load_upload():
+    safe_name = Path(request.args["name"]).name
+
+    def shadow():
+        safe_name = request.args["other"]
+        return safe_name
+
+    shadow()
+    return (BASE / safe_name).read_text(encoding="utf-8")
+""",
+    )
+    assert "SKY-D215" not in _rule_ids(out)
+    assert "SKY-D325" not in _rule_ids(out)
+
+
 def test_bounded_nofollow_read_is_not_symlink_finding(tmp_path):
     out = _scan_one(
         tmp_path,

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -127,6 +127,17 @@ def test_requests_fixed_host_urljoin_path_ok(tmp_path):
     assert "SKY-D216" not in _rule_ids(out)
 
 
+def test_requests_urljoin_direct_tainted_filename_can_override_host(tmp_path):
+    code = (
+        "from urllib.parse import urljoin\n"
+        "import requests\n"
+        "def f(user_id):\n"
+        "    return requests.get(urljoin('https://cdn.example.com/', f'{user_id}.png'), timeout=3)\n"
+    )
+    out = _scan_one(tmp_path, "ssrf_urljoin_direct_filename.py", code)
+    assert "SKY-D216" in _rule_ids(out)
+
+
 def test_requests_urljoin_bare_tainted_target_flags(tmp_path):
     code = (
         "from urllib.parse import urljoin\n"


### PR DESCRIPTION
Fixed analyzer problem in the last 2 commits.

  - Fixed `Visitor.add_def()` so an existing definition is updated only when the name matches. The last commit, loop will break on the first def and attach a later import's suppression line to the wrong symbol.
  - Changed basename path tracking from a set to scoped name -> bool maps, so nested shadowing does not corrupt outer path safety state.

  ## Tests

  - `pytest test/test_config.py test/test_analyzer.py`