### PR TITLE
feat(llm): add agent review routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ node_modules
 .mcpregistry_registry_token
 /PR_LOG.md
 /manual/
+/kiv/

--- a/scripts/agent_review_benchmark.py
+++ b/scripts/agent_review_benchmark.py
@@ -29,6 +29,21 @@ def main() -> int:
     parser.add_argument("--api-key", default=None)
     parser.add_argument("--case", action="append", default=[])
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional path to write the full JSON summary.",
+    )
+    parser.add_argument(
+        "--progress-jsonl",
+        default=None,
+        help="Optional path to append per-case progress JSONL.",
+    )
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        help="Print per-case progress to stderr.",
+    )
     args = parser.parse_args()
 
     provider, api_key, base_url, is_local = resolve_llm_runtime(
@@ -52,6 +67,24 @@ def main() -> int:
             print(message)
         return 2
 
+    progress_path = Path(args.progress_jsonl) if args.progress_jsonl else None
+
+    def progress_callback(record: dict) -> None:
+        case = record.get("case", {}) or {}
+        if args.progress:
+            status = "PASS" if not case.get("failures") else "FAIL"
+            print(
+                f"{status} {case.get('id', '<unknown>')} "
+                f"score={case.get('scores', {}).get('overall_score', 0.0)} "
+                f"tokens={case.get('tokens_used', 0)}",
+                file=sys.stderr,
+                flush=True,
+            )
+        if progress_path:
+            progress_path.parent.mkdir(parents=True, exist_ok=True)
+            with progress_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+
     summary = run_manifest(
         args.manifest,
         model=args.model,
@@ -59,7 +92,15 @@ def main() -> int:
         provider=provider,
         base_url=base_url,
         selected_cases=set(args.case),
+        progress_callback=progress_callback
+        if args.progress or progress_path is not None
+        else None,
     )
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
 
     if args.json:
         print(json.dumps(summary, indent=2))

--- a/skylos/benchmarks/agent_review.py
+++ b/skylos/benchmarks/agent_review.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from skylos.core.file_discovery import discover_source_files
-from skylos.llm.analyzer import AnalyzerConfig, SkylosLLM
+from skylos.llm.analyzer import AnalyzerConfig, SECURITY_AUDIT_ISSUE, SkylosLLM
 from skylos.llm.repo_activation import build_repo_activation_index
 
 
@@ -48,6 +49,7 @@ IMPORTANCE_WEIGHTS = {
 
 DEFAULT_SCAN_MAX_FILES = 8
 ALLOWED_SCAN_ISSUE_TYPES = {"quality", "security", "security_audit"}
+ALLOWED_AGENT_ROUTES = {"full", "static_first", "static_only"}
 SCAN_ISSUE_TYPES_FIELD = "issue_types"
 
 
@@ -167,6 +169,13 @@ def validate_manifest(
                 raise ValueError(
                     f"agent review benchmark case {case_id} scan.max_files must be a positive integer"
                 )
+        if isinstance(scan_cfg, dict) and "agent_route" in scan_cfg:
+            route = scan_cfg.get("agent_route")
+            if not isinstance(route, str) or route not in ALLOWED_AGENT_ROUTES:
+                allowed = ", ".join(sorted(ALLOWED_AGENT_ROUTES))
+                raise ValueError(
+                    f"agent review benchmark case {case_id} scan.agent_route must be one of: {allowed}"
+                )
         if isinstance(scan_cfg, dict) and SCAN_ISSUE_TYPES_FIELD in scan_cfg:
             issue_types = scan_cfg.get(SCAN_ISSUE_TYPES_FIELD)
             if not isinstance(issue_types, list) or not issue_types:
@@ -240,6 +249,81 @@ def _normalize_symbol(value: str | None) -> str:
     return value
 
 
+def _is_test_file(path: str | Path) -> bool:
+    path = Path(path)
+    name = path.name.lower()
+    return (
+        name.startswith("test_")
+        or name.endswith("_test.py")
+        or "tests" in path.parts
+    )
+
+
+def _review_target_files(files: list[Path]) -> list[Path]:
+    targets = [path for path in files if not _is_test_file(path)]
+    return targets or files
+
+
+def _case_agent_route(case: dict[str, Any] | None) -> str:
+    if not isinstance(case, dict):
+        return "full"
+    route = str((case.get("scan") or {}).get("agent_route") or "static_first")
+    return route if route in {"full", "static_first", "static_only"} else "full"
+
+
+def _case_issue_types(case: dict[str, Any] | None) -> list[str]:
+    if not isinstance(case, dict):
+        return []
+
+    scan_cfg = case.get("scan") or {}
+    explicit = list(scan_cfg.get(SCAN_ISSUE_TYPES_FIELD) or [])
+    if explicit:
+        return explicit
+
+    expect = case.get("expect", {}) or {}
+    categories = set((expect.get("present", {}) or {}).keys())
+    categories.update((expect.get("absent", {}) or {}).keys())
+
+    issue_types: list[str] = []
+    if "security" in categories:
+        issue_types.append(SECURITY_AUDIT_ISSUE)
+    if categories & {"quality", "bug", "performance", "style", "hallucination"}:
+        issue_types.append("quality")
+    return issue_types
+
+
+def _static_route_target_files(
+    files: list[Path],
+    *,
+    issue_types: list[str],
+) -> list[Path]:
+    analyzer = SkylosLLM(
+        AnalyzerConfig(
+            quiet=True,
+            enable_security=True,
+            enable_quality=True,
+            agent_route="static_first",
+        )
+    )
+    routed = []
+    for path in files:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        static_findings = analyzer._collect_static_agent_findings(
+            source,
+            str(path),
+            issue_types=issue_types or None,
+        )
+        if analyzer._static_route_complete(
+            static_findings,
+            issue_types=issue_types or None,
+        ):
+            routed.append(path)
+    return routed
+
+
 def prepare_case_scan(
     case_path: str | Path,
     *,
@@ -296,8 +380,17 @@ def _scan_case(
 ) -> dict[str, Any]:
     scan_cfg = case.get("scan") if isinstance(case, dict) else {}
     max_files = int((scan_cfg or {}).get("max_files") or DEFAULT_SCAN_MAX_FILES)
-    issue_types = list((scan_cfg or {}).get(SCAN_ISSUE_TYPES_FIELD) or [])
+    issue_types = _case_issue_types(case)
     prepared = prepare_case_scan(case_path, max_files=max_files)
+    reviewed_files = _review_target_files(list(prepared["files"]))
+    route = _case_agent_route(case)
+    if route == "static_only":
+        static_targets = _static_route_target_files(
+            reviewed_files,
+            issue_types=issue_types,
+        )
+        if static_targets:
+            reviewed_files = static_targets
 
     config = AnalyzerConfig(
         model=model,
@@ -311,9 +404,10 @@ def _scan_case(
         full_file_review=prepared["full_file_review"],
         smart_filter=False,
         repo_context_map=prepared["repo_context_map"],
+        agent_route=route,
     )
     analyzer = SkylosLLM(config)
-    result = analyzer.analyze_files(prepared["files"], issue_types=issue_types or None)
+    result = analyzer.analyze_files(reviewed_files, issue_types=issue_types or None)
 
     symbols = {
         _normalize_symbol(getattr(finding, "symbol", None))
@@ -325,7 +419,11 @@ def _scan_case(
         "symbols": sorted(symbols),
         "summary": result.summary,
         "tokens_used": int(result.tokens_used or 0),
-        "reviewed_files": [str(path) for path in prepared["files"]],
+        "reviewed_files": [str(path) for path in reviewed_files],
+        "context_files": [
+            str(path) for path in prepared["files"] if path not in reviewed_files
+        ],
+        "route_counts": dict(getattr(result, "route_counts", {}) or {}),
     }
 
 
@@ -344,13 +442,73 @@ def _dedupe_labels(labels: list[str] | None) -> list[str]:
     return ordered
 
 
+def _normalized_expectation_map(case: dict[str, Any], mode: str) -> dict[str, list[str]]:
+    expect = case.get("expect", {}) or {}
+    expectation_map = expect.get(mode, {}) or {}
+    normalized: dict[str, list[str]] = {}
+    for category, symbols in expectation_map.items():
+        values = [
+            _normalize_symbol(symbol)
+            for symbol in symbols
+            if _normalize_symbol(symbol)
+        ]
+        if values:
+            normalized[category] = values
+    return normalized
+
+
+def _flatten_expectations(expectations: dict[str, list[str]]) -> set[str]:
+    return {symbol for symbols in expectations.values() for symbol in symbols}
+
+
+def _is_clean_precision_guard(case: dict[str, Any]) -> bool:
+    present = case.get("expect", {}).get("present", {}) or {}
+    return "precision_guard" in (case.get("taxonomy") or []) and not present
+
+
+def _expectation_diagnostics(
+    case: dict[str, Any],
+    symbols: set[str],
+    finding_count: int,
+) -> dict[str, Any]:
+    present_by_category = _normalized_expectation_map(case, "present")
+    absent_by_category = _normalized_expectation_map(case, "absent")
+    expected_present = _flatten_expectations(present_by_category)
+    expected_absent = _flatten_expectations(absent_by_category)
+
+    missed_by_category = {
+        category: sorted(set(expected) - symbols)
+        for category, expected in present_by_category.items()
+        if set(expected) - symbols
+    }
+    absent_violations_by_category = {
+        category: sorted(set(expected) & symbols)
+        for category, expected in absent_by_category.items()
+        if set(expected) & symbols
+    }
+
+    precision_guard_noise = (
+        _is_clean_precision_guard(case) and int(finding_count or 0) > 0
+    )
+
+    return {
+        "expected_present": sorted(expected_present),
+        "expected_absent": sorted(expected_absent),
+        "missed_present": sorted(expected_present - symbols),
+        "absent_violations": sorted(expected_absent & symbols),
+        "missed_by_category": missed_by_category,
+        "absent_violations_by_category": absent_violations_by_category,
+        "precision_guard_noise": precision_guard_noise,
+        "finding_count": int(finding_count or 0),
+        "reported_symbol_count": len(symbols),
+    }
+
+
 def _evaluate_expectations(case: dict[str, Any], symbols: set[str], finding_count: int):
     expect = case.get("expect", {})
     present = expect.get("present", {}) or {}
     absent = expect.get("absent", {}) or {}
-    is_clean_precision_guard = "precision_guard" in (
-        case.get("taxonomy") or []
-    ) and not (present)
+    is_clean_precision_guard = _is_clean_precision_guard(case)
 
     failures: list[AgentReviewBenchmarkFailure] = []
     present_total = _count_expectations(present)
@@ -478,12 +636,17 @@ def run_case(
         "importance": case.get("importance", "high"),
         "taxonomy": list(case.get("taxonomy") or []),
         "security_classes": _dedupe_labels(case.get("security_classes")),
+        "scan_issue_types": list(
+            (case.get("scan") or {}).get(SCAN_ISSUE_TYPES_FIELD) or []
+        ),
         "elapsed_seconds": round(elapsed_seconds, 4),
         "finding_count": scan_result["finding_count"],
         "symbols": scan_result["symbols"],
         "summary": scan_result["summary"],
         "tokens_used": scan_result.get("tokens_used", 0),
         "reviewed_files": scan_result.get("reviewed_files", []),
+        "context_files": scan_result.get("context_files", []),
+        "route_counts": scan_result.get("route_counts", {}),
         "scores": _score_case(
             present_total=present_total,
             present_matched=present_matched,
@@ -491,6 +654,11 @@ def run_case(
             absent_violations=absent_violations,
             elapsed_seconds=elapsed_seconds,
             max_seconds=max_seconds,
+        ),
+        "diagnostics": _expectation_diagnostics(
+            case,
+            set(scan_result["symbols"]),
+            scan_result["finding_count"],
         ),
         "failures": [failure.to_dict() for failure in failures],
     }
@@ -545,6 +713,92 @@ def _build_security_scorecard(
     return scorecard
 
 
+def _build_dimension_scorecard(
+    case_results: list[dict[str, Any]],
+    *,
+    field: str,
+    descriptions: dict[str, str],
+) -> dict[str, dict[str, Any]]:
+    totals: dict[str, dict[str, float]] = {}
+
+    for case in case_results:
+        labels = _dedupe_labels(case.get(field))
+        if not labels:
+            continue
+
+        weight = IMPORTANCE_WEIGHTS[case["importance"]]
+        diagnostics = case.get("diagnostics", {}) or {}
+        missed_count = len(diagnostics.get("missed_present", []) or [])
+        noise_count = len(diagnostics.get("absent_violations", []) or [])
+        if diagnostics.get("precision_guard_noise"):
+            noise_count += 1
+
+        for label in labels:
+            bucket = totals.setdefault(
+                label,
+                {
+                    "case_count": 0.0,
+                    "pass_count": 0.0,
+                    "failed_case_count": 0.0,
+                    "weight": 0.0,
+                    "overall_score": 0.0,
+                    "recall": 0.0,
+                    "absence_guard": 0.0,
+                    "latency_score": 0.0,
+                    "tokens": 0.0,
+                    "elapsed_seconds": 0.0,
+                    "missed_present": 0.0,
+                    "noise": 0.0,
+                    "static_only_routes": 0.0,
+                    "full_harness_routes": 0.0,
+                },
+            )
+            failed = bool(case.get("failures"))
+            bucket["case_count"] += 1
+            bucket["pass_count"] += 0.0 if failed else 1.0
+            bucket["failed_case_count"] += 1.0 if failed else 0.0
+            bucket["weight"] += weight
+            bucket["tokens"] += int(case.get("tokens_used", 0) or 0)
+            bucket["elapsed_seconds"] += float(case.get("elapsed_seconds", 0.0) or 0.0)
+            bucket["missed_present"] += missed_count
+            bucket["noise"] += noise_count
+            route_counts = case.get("route_counts", {}) or {}
+            bucket["static_only_routes"] += int(route_counts.get("static_only", 0) or 0)
+            bucket["full_harness_routes"] += int(
+                route_counts.get("full_harness", 0) or 0
+            ) + int(route_counts.get("static_first_escalated", 0) or 0)
+            for score_name in (
+                "overall_score",
+                "recall",
+                "absence_guard",
+                "latency_score",
+            ):
+                bucket[score_name] += case["scores"][score_name] * weight
+
+    scorecard = {}
+    for label, bucket in sorted(totals.items()):
+        case_count = int(bucket["case_count"])
+        weight = bucket["weight"] or 1.0
+        scorecard[label] = {
+            "description": descriptions.get(label, ""),
+            "case_count": case_count,
+            "pass_count": int(bucket["pass_count"]),
+            "failed_case_count": int(bucket["failed_case_count"]),
+            "weighted_score": round(bucket["overall_score"] / weight, 2),
+            "recall": round(bucket["recall"] / weight, 4),
+            "absence_guard": round(bucket["absence_guard"] / weight, 4),
+            "latency_score": round(bucket["latency_score"] / weight, 4),
+            "total_tokens_used": int(bucket["tokens"]),
+            "total_elapsed_seconds": round(bucket["elapsed_seconds"], 4),
+            "missed_present": int(bucket["missed_present"]),
+            "noise": int(bucket["noise"]),
+            "static_only_routes": int(bucket["static_only_routes"]),
+            "full_harness_routes": int(bucket["full_harness_routes"]),
+        }
+
+    return scorecard
+
+
 def run_manifest(
     manifest_path: str | Path,
     *,
@@ -553,6 +807,7 @@ def run_manifest(
     provider: str | None = None,
     base_url: str | None = None,
     selected_cases: set[str] | None = None,
+    progress_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     manifest = load_manifest(manifest_path)
     cases = validate_manifest(manifest, manifest_path)
@@ -581,6 +836,8 @@ def run_manifest(
             base_url=base_url,
         )
         case_results.append(result)
+        if progress_callback is not None:
+            progress_callback({"status": "completed", "case": result})
         weight = IMPORTANCE_WEIGHTS[result["importance"]]
         total_weight += weight
         total_elapsed += result["elapsed_seconds"]
@@ -602,6 +859,10 @@ def run_manifest(
         }
 
     pass_count = sum(1 for case in case_results if not case["failures"])
+    route_counts: dict[str, int] = {}
+    for case in case_results:
+        for route, count in (case.get("route_counts", {}) or {}).items():
+            route_counts[route] = route_counts.get(route, 0) + int(count or 0)
     return {
         "manifest": str(Path(manifest_path).resolve()),
         "model": model,
@@ -613,8 +874,19 @@ def run_manifest(
         "avg_tokens_per_case": round(total_tokens / len(case_results), 2)
         if case_results
         else 0.0,
+        "route_counts": route_counts,
         "scores": scores,
         "security_scorecard": _build_security_scorecard(case_results),
+        "taxonomy_scorecard": _build_dimension_scorecard(
+            case_results,
+            field="taxonomy",
+            descriptions=AGENT_REVIEW_TAXONOMY,
+        ),
+        "security_diagnostics": _build_dimension_scorecard(
+            case_results,
+            field="security_classes",
+            descriptions=SECURITY_BENCHMARK_CLASSES,
+        ),
         "cases": case_results,
     }
 
@@ -635,12 +907,26 @@ def format_summary(summary: dict[str, Any]) -> str:
         f"Agent review benchmark avg tokens/case: {summary.get('avg_tokens_per_case', 0.0)}",
         f"Agent review benchmark total time: {summary['total_elapsed_seconds']:.4f}s",
     ]
+    if summary.get("route_counts"):
+        rendered_routes = ", ".join(
+            f"{name}={count}" for name, count in sorted(summary["route_counts"].items())
+        )
+        lines.append(f"Agent review benchmark routes: {rendered_routes}")
     if summary.get("security_scorecard"):
         lines.append("Security classes:")
         for label, bucket in sorted(summary["security_scorecard"].items()):
             lines.append(
                 f"  {label}: cases={bucket['case_count']} pass={bucket['pass_count']} "
                 f"fail={bucket['failed_case_count']} score={bucket['weighted_score']}"
+            )
+    if summary.get("taxonomy_scorecard"):
+        lines.append("Taxonomy diagnostics:")
+        for label, bucket in sorted(summary["taxonomy_scorecard"].items()):
+            lines.append(
+                f"  {label}: cases={bucket['case_count']} score={bucket['weighted_score']} "
+                f"missed={bucket['missed_present']} noise={bucket['noise']} "
+                f"tokens={bucket['total_tokens_used']} "
+                f"routes=static:{bucket['static_only_routes']}/full:{bucket['full_harness_routes']}"
             )
     for case in summary["cases"]:
         status = "PASS" if not case["failures"] else "FAIL"
@@ -653,6 +939,17 @@ def format_summary(summary: dict[str, Any]) -> str:
         if case.get("reviewed_files"):
             reviewed = ", ".join(Path(path).name for path in case["reviewed_files"])
             lines.append(f"  reviewed files: {reviewed}")
+        diagnostics = case.get("diagnostics") or {}
+        if diagnostics.get("missed_present"):
+            lines.append(
+                f"  missed present: {', '.join(diagnostics['missed_present'])}"
+            )
+        if diagnostics.get("absent_violations"):
+            lines.append(
+                f"  absent violations: {', '.join(diagnostics['absent_violations'])}"
+            )
+        if diagnostics.get("precision_guard_noise"):
+            lines.append("  precision guard noise: yes")
         for failure in case["failures"]:
             found = ", ".join(failure["found"]) if failure["found"] else "none"
             lines.append(

--- a/skylos/llm/agent_review_refuters.py
+++ b/skylos/llm/agent_review_refuters.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+from .schemas import IssueType
+
+
+class AgentReviewRefuterMixin:
+    def _remap_handler_symbols(self, findings, source):
+        import ast
+
+        if not findings:
+            return findings
+
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return findings
+
+        function_nodes = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        weak_symbols = {
+            "archive",
+            "bundle",
+            "file",
+            "filename",
+            "handle",
+            "member",
+            "name",
+            "path",
+            "request",
+            "target",
+            "upload",
+        }
+
+        for finding in findings:
+            if finding.issue_type != IssueType.SECURITY:
+                continue
+            symbol = str(getattr(finding, "symbol", "") or "")
+            if symbol and symbol not in weak_symbols:
+                continue
+            owner = self._function_for_line(function_nodes, finding.location.line)
+            if owner is None:
+                continue
+            if not self._function_has_handler_security_pattern(owner):
+                continue
+            if symbol and symbol != owner.name:
+                finding.metadata["symbol_remapped_from"] = symbol
+            finding.symbol = owner.name
+
+        return findings
+
+    def _function_for_line(self, functions, line):
+        owner = None
+        owner_start = -1
+        for node in functions:
+            start = getattr(node, "lineno", 0)
+            end = getattr(node, "end_lineno", start)
+            if start <= line <= end and start > owner_start:
+                owner = node
+                owner_start = start
+        return owner
+
+    def _function_has_handler_security_pattern(self, node):
+        import ast
+
+        if getattr(node, "decorator_list", None):
+            return True
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call):
+                name = self._call_name(child.func)
+                if name.split(".")[-1] in {"extractall", "extract"}:
+                    return True
+                if name == "open":
+                    return True
+            if self._is_request_files_expr(child):
+                return True
+        return False
+
+    def _filter_refuted_agent_findings(self, findings, source, issue_types=None):
+        import ast
+
+        if not findings:
+            return findings
+
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return findings
+
+        function_nodes = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+
+        filtered = []
+        for finding in findings:
+            if self._is_static_agent_finding(finding):
+                filtered.append(finding)
+                continue
+            if not self._finding_matches_active_modes(finding, issue_types):
+                continue
+            owner = self._owner_function_for_finding(finding, function_nodes)
+            if owner is None:
+                filtered.append(finding)
+                continue
+            if self._refutes_clean_async_owner(finding, owner):
+                continue
+            if self._refutes_safe_subprocess_owner(finding, owner, tree):
+                continue
+            if self._refutes_clean_quality_owner(finding, owner):
+                continue
+            filtered.append(finding)
+        return filtered
+
+    def _is_static_agent_finding(self, finding):
+        return (finding.metadata or {}).get("source") == "static_agent_hint"
+
+    def _finding_matches_active_modes(self, finding, issue_types=None):
+        modes = self._active_review_modes(issue_types)
+        if not modes:
+            return True
+        mode = self._static_route_mode_for_finding(finding)
+        return not mode or mode in modes
+
+    def _owner_function_for_finding(self, finding, functions):
+        symbol = str(getattr(finding, "symbol", "") or "")
+        if symbol:
+            short = symbol.split(".")[-1]
+            for node in functions:
+                if node.name == short:
+                    return node
+        return self._function_for_line(functions, finding.location.line)
+
+    def _refutes_safe_subprocess_owner(self, finding, owner, tree):
+        evidence = self._finding_text(finding)
+        if not any(
+            term in evidence
+            for term in ("command", "shell", "subprocess", "injection", "popen")
+        ):
+            return False
+        return self._function_uses_literal_subprocess_allowlist(owner, tree)
+
+    def _refutes_clean_async_owner(self, finding, owner):
+        import ast
+
+        if finding.issue_type not in {
+            IssueType.QUALITY,
+            IssueType.BUG,
+            IssueType.PERFORMANCE,
+            IssueType.STYLE,
+            IssueType.HALLUCINATION,
+        }:
+            return False
+
+        return isinstance(owner, ast.AsyncFunctionDef) and self._is_clean_async_helper(
+            owner
+        )
+
+    def _function_uses_literal_subprocess_allowlist(self, node, tree):
+        import ast
+
+        saw_safe_subprocess = False
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            if self._call_name(child.func).split(".")[:1] != ["subprocess"]:
+                continue
+            if self._call_has_shell_true(child):
+                return False
+            if not child.args:
+                return False
+            argv = child.args[0]
+            if isinstance(argv, (ast.List, ast.Tuple)):
+                if not self._literal_sequence(argv):
+                    return False
+                saw_safe_subprocess = True
+                continue
+            allowlist = self._subscript_name(argv)
+            if (
+                allowlist
+                and allowlist.isupper()
+                and self._literal_allowlist_is_safe(tree, allowlist)
+            ):
+                saw_safe_subprocess = True
+                continue
+            return False
+        return saw_safe_subprocess
+
+    def _call_has_shell_true(self, node):
+        import ast
+
+        for keyword in node.keywords:
+            if keyword.arg == "shell" and isinstance(keyword.value, ast.Constant):
+                return keyword.value.value is True
+        return False
+
+    def _literal_sequence(self, node):
+        import ast
+
+        return all(isinstance(item, ast.Constant) for item in node.elts)
+
+    def _subscript_name(self, node):
+        import ast
+
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+            return node.value.id
+        return ""
+
+    def _literal_allowlist_is_safe(self, tree, name):
+        bindings = self._literal_allowlist_bindings(tree, name)
+        return (
+            bindings is not None
+            and len(bindings) == 1
+            and self._literal_allowlist_value(bindings[0])
+        )
+
+    def _literal_allowlist_bindings(self, tree, name):
+        import ast
+
+        bindings = []
+        for node in ast.walk(tree):
+            if self._node_mutates_name(node, name):
+                return None
+            if isinstance(node, ast.Assign):
+                target = node.targets[0] if len(node.targets) == 1 else None
+                if isinstance(target, ast.Name) and target.id == name:
+                    bindings.append(node.value)
+        return bindings
+
+    def _node_mutates_name(self, node, name):
+        import ast
+
+        if isinstance(node, ast.Assign):
+            return any(self._target_mutates_name(target, name) for target in node.targets)
+        if isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            return self._assignment_mutates_name(node.target, name)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            return self._call_mutates_name(node.func, name)
+        return False
+
+    def _assignment_mutates_name(self, target, name):
+        import ast
+
+        return (
+            isinstance(target, ast.Name)
+            and target.id == name
+            or self._target_mutates_name(target, name)
+        )
+
+    def _call_mutates_name(self, func, name):
+        mutating_methods = {
+            "append",
+            "clear",
+            "extend",
+            "insert",
+            "pop",
+            "remove",
+            "setdefault",
+            "update",
+        }
+        return (
+            self._call_name(func.value) == name
+            and func.attr in mutating_methods
+        )
+
+    def _target_mutates_name(self, target, name):
+        import ast
+
+        if isinstance(target, ast.Subscript):
+            return self._call_name(target.value) == name
+        if isinstance(target, ast.Attribute):
+            return self._call_name(target.value) == name
+        return False
+
+    def _literal_allowlist_value(self, node):
+        import ast
+
+        if isinstance(node, ast.Dict):
+            return all(
+                isinstance(value, (ast.List, ast.Tuple))
+                and self._literal_sequence(value)
+                for value in node.values
+            )
+        if isinstance(node, (ast.List, ast.Tuple)):
+            return all(
+                isinstance(value, (ast.List, ast.Tuple))
+                and self._literal_sequence(value)
+                for value in node.elts
+            )
+        return False
+
+    def _refutes_clean_quality_owner(self, finding, owner):
+        import ast
+
+        if finding.issue_type not in {
+            IssueType.QUALITY,
+            IssueType.BUG,
+            IssueType.PERFORMANCE,
+        }:
+            return False
+        if isinstance(owner, ast.AsyncFunctionDef):
+            return self._is_clean_async_helper(owner)
+        if self._finding_text_mentions_explicit_issue(finding):
+            return False
+        return self._is_small_safe_helper(owner)
+
+    def _finding_text_mentions_explicit_issue(self, finding):
+        evidence = self._finding_text(finding)
+        explicit_terms = (
+            "shell=true",
+            "subprocess",
+            "inconsistent",
+            "return path",
+            "swallow",
+            "exception",
+            "duplicate condition",
+            "resource leak",
+            "complexity",
+            "branch",
+            "sql injection",
+            "path traversal",
+            "ssrf",
+            "pickle",
+            "eval(",
+            "exec(",
+            "mutable default",
+            "missing await",
+            "unawaited",
+            "blocking",
+            "time.sleep",
+            "requests.",
+        )
+        return any(term in evidence for term in explicit_terms)
+
+    def _is_clean_async_helper(self, node):
+        if self._has_async_blocking_call(node):
+            return False
+        if self._has_exception_handling(node):
+            return False
+        if self._control_flow_count(node) > 1:
+            return False
+        if self._function_parameter_count(node) > 3:
+            return False
+        return self._all_async_calls_are_awaited(node)
+
+    def _all_async_calls_are_awaited(self, node):
+        import ast
+
+        awaited = {
+            id(call)
+            for await_node in ast.walk(node)
+            if isinstance(await_node, ast.Await)
+            for call in ast.walk(await_node.value)
+            if isinstance(call, ast.Call)
+        }
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            name = self._call_name(child.func)
+            if name.startswith(("client.", "session.", "response.")):
+                method = name.split(".")[-1]
+                if method not in {
+                    "delete",
+                    "get",
+                    "json",
+                    "patch",
+                    "post",
+                    "put",
+                    "read",
+                    "request",
+                    "text",
+                }:
+                    continue
+                if id(child) not in awaited:
+                    return False
+        return True
+
+    def _is_small_safe_helper(self, node):
+        if self._has_exception_handling(node):
+            return False
+        if self._control_flow_count(node) > 1:
+            return False
+        if self._function_length(node) > 6:
+            return False
+        if self._has_dangerous_call(node):
+            return False
+        return True
+
+    def _has_dangerous_call(self, node):
+        import ast
+
+        dangerous_roots = {
+            "eval",
+            "exec",
+            "open",
+            "pickle",
+            "requests",
+            "subprocess",
+            "os",
+            "shutil",
+        }
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            name = self._call_name(child.func)
+            if name.split(".", 1)[0] in dangerous_roots:
+                return True
+        return False
+
+    def _finding_text(self, finding):
+        parts = [
+            finding.rule_id,
+            finding.message,
+            finding.explanation,
+            finding.suggestion,
+            finding.code_snippet,
+        ]
+        return " ".join(str(part or "") for part in parts).lower()
+

--- a/skylos/llm/agent_review_routing.py
+++ b/skylos/llm/agent_review_routing.py
@@ -158,6 +158,101 @@ class AgentReviewRoutingMixin(
             "SKY-Q401",
         }
 
+    @staticmethod
+    def _is_static_agent_hint(finding):
+        metadata = getattr(finding, "metadata", None) or {}
+        return metadata.get("source") == "static_agent_hint"
+
+    @staticmethod
+    def _finding_line_set(finding):
+        lines = set()
+        line = getattr(getattr(finding, "location", None), "line", None)
+        if isinstance(line, int) and line > 0:
+            lines.add(line)
+
+        security_details = getattr(finding, "security_details", None) or {}
+        for evidence_line in security_details.get("evidence_lines") or []:
+            if isinstance(evidence_line, int) and evidence_line > 0:
+                lines.add(evidence_line)
+
+        return lines
+
+    @staticmethod
+    def _static_finding_line(static_finding):
+        if not isinstance(static_finding, dict):
+            return 0
+        if "line" in static_finding:
+            return static_finding.get("line", 0) or 0
+        return static_finding.get("lineno", 0) or 0
+
+    @staticmethod
+    def _static_finding_rule(static_finding):
+        if not isinstance(static_finding, dict):
+            return ""
+        return static_finding.get("rule_id") or static_finding.get("code") or ""
+
+    @staticmethod
+    def _lines_overlap(first_lines, second_lines, *, tolerance=2):
+        return any(
+            abs(first - second) <= tolerance
+            for first in first_lines
+            for second in second_lines
+        )
+
+    def _findings_overlap_static_hint(self, hint, other):
+        if getattr(hint, "rule_id", None) != getattr(other, "rule_id", None):
+            return False
+
+        hint_symbol = getattr(hint, "symbol", None)
+        other_symbol = getattr(other, "symbol", None)
+        if hint_symbol and other_symbol and hint_symbol == other_symbol:
+            return True
+
+        return self._lines_overlap(
+            self._finding_line_set(hint),
+            self._finding_line_set(other),
+        )
+
+    def _static_finding_overlaps_hint(self, hint, static_finding):
+        if getattr(hint, "rule_id", None) != self._static_finding_rule(static_finding):
+            return False
+
+        static_line = self._static_finding_line(static_finding)
+        if not isinstance(static_line, int) or static_line <= 0:
+            return False
+
+        return self._lines_overlap(self._finding_line_set(hint), {static_line})
+
+    def _drop_duplicate_static_agent_hints(self, findings, static_findings=None):
+        non_hint_findings = [
+            finding
+            for finding in findings
+            if not self._is_static_agent_hint(finding)
+        ]
+        static_findings = static_findings or []
+        unique = []
+
+        for finding in findings:
+            if not self._is_static_agent_hint(finding):
+                unique.append(finding)
+                continue
+
+            if any(
+                self._findings_overlap_static_hint(finding, other)
+                for other in non_hint_findings
+            ):
+                continue
+
+            if any(
+                self._static_finding_overlaps_hint(finding, static_finding)
+                for static_finding in static_findings
+            ):
+                continue
+
+            unique.append(finding)
+
+        return unique
+
     def _static_route_complete(self, static_agent_findings, issue_types=None):
         if self._agent_route() != "static_first":
             return False
@@ -194,6 +289,9 @@ class AgentReviewRoutingMixin(
         validated = self._filter_refuted_agent_findings(
             validated, source, issue_types=issue_types
         )
+        validated = self._drop_duplicate_static_agent_hints(
+            validated, static_findings=static_findings
+        )
 
         if static_findings:
             validated = merge_findings(validated, static_findings, str(file_path))
@@ -228,4 +326,3 @@ class AgentReviewRoutingMixin(
             "quality" in modes
             and self._should_analyze_quality_function(func_name, def_data)
         )
-

--- a/skylos/llm/agent_review_routing.py
+++ b/skylos/llm/agent_review_routing.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from .agent_review_refuters import AgentReviewRefuterMixin
+from .agent_review_static import AgentReviewStaticFindingMixin
+from .schemas import Confidence, IssueType
+from .validator import deduplicate_findings, merge_findings
+
+
+SECURITY_AUDIT_ISSUE = "security_audit"
+
+
+class AgentReviewRoutingMixin(
+    AgentReviewStaticFindingMixin,
+    AgentReviewRefuterMixin,
+):
+    def _should_analyze_security_function(self, func_name, def_data, graph):
+        taint_paths = graph.find_taint_paths(func_name)
+        if taint_paths:
+            return True
+
+        node = def_data.get("node")
+        if node:
+            complexity = self._estimate_complexity(node)
+            if complexity >= self.config.complexity_threshold:
+                return True
+
+        sensitive = [
+            "auth",
+            "login",
+            "password",
+            "token",
+            "secret",
+            "sql",
+            "query",
+            "execute",
+            "eval",
+            "exec",
+            "shell",
+            "command",
+            "system",
+            "pickle",
+            "yaml",
+            "upload",
+            "file",
+            "path",
+        ]
+        func_lower = func_name.lower()
+        for pattern in sensitive:
+            if pattern in func_lower:
+                return True
+
+        return False
+
+    def _should_analyze_quality_function(self, func_name, def_data):
+        node = def_data.get("node")
+        if node is None:
+            return False
+
+        if self._has_async_blocking_call(node):
+            return True
+
+        complexity = self._estimate_complexity(node)
+        if complexity >= self.config.complexity_threshold:
+            return True
+
+        if self._function_length(node) >= 12:
+            return True
+
+        if self._function_parameter_count(node) >= 4:
+            return True
+
+        if self._return_site_count(node) >= 2:
+            return True
+
+        if self._control_flow_count(node) >= 3:
+            return True
+
+        if self._has_exception_handling(node):
+            return True
+
+        func_lower = func_name.lower()
+        quality_signals = (
+            "build",
+            "format",
+            "normalize",
+            "parse",
+            "render",
+            "resolve",
+            "validate",
+        )
+        return any(token in func_lower for token in quality_signals)
+
+    def _active_review_modes(self, issue_types=None):
+        if not issue_types:
+            modes = set()
+            if self.config.enable_security:
+                modes.add("security")
+            if self.config.enable_quality:
+                modes.add("quality")
+            return modes
+
+        modes = set()
+        for issue_type in issue_types:
+            name = str(issue_type).lower().strip()
+            if name in {"security", SECURITY_AUDIT_ISSUE}:
+                modes.add("security")
+            if name == "quality":
+                modes.add("quality")
+        return modes
+
+    @staticmethod
+    def _normalized_issue_types(issue_types=None):
+        return {str(t).lower().strip() for t in (issue_types or []) if str(t).strip()}
+
+    def _agent_route(self):
+        route = str(getattr(self.config, "agent_route", "full") or "full").strip()
+        return route if route in {"full", "static_first", "static_only"} else "full"
+
+    def _static_route_mode_for_finding(self, finding):
+        metadata = getattr(finding, "metadata", None) or {}
+        route_mode = str(metadata.get("route_mode") or "").strip()
+        if route_mode in {"security", "quality"}:
+            return route_mode
+        if finding.issue_type == IssueType.SECURITY:
+            return "security"
+        if finding.issue_type in {
+            IssueType.QUALITY,
+            IssueType.BUG,
+            IssueType.PERFORMANCE,
+            IssueType.STYLE,
+            IssueType.HALLUCINATION,
+        }:
+            return "quality"
+        return ""
+
+    def _static_route_active_modes(self, issue_types=None):
+        modes = self._active_review_modes(issue_types)
+        if modes:
+            return modes
+        return set()
+
+    def _is_route_complete_static_finding(self, finding):
+        metadata = getattr(finding, "metadata", None) or {}
+        if metadata.get("source") != "static_agent_hint":
+            return False
+        if metadata.get("route_complete") is not True:
+            return False
+        if not metadata.get("route_reason"):
+            return False
+        if getattr(finding, "confidence", None) != Confidence.HIGH:
+            return False
+        if not getattr(finding, "symbol", None):
+            return False
+        return finding.rule_id in {
+            "SKY-D215",
+            "SKY-D326",
+            "SKY-Q301",
+            "SKY-Q401",
+        }
+
+    def _static_route_complete(self, static_agent_findings, issue_types=None):
+        if self._agent_route() != "static_first":
+            return False
+        if not static_agent_findings:
+            return False
+        if not all(
+            self._is_route_complete_static_finding(finding)
+            for finding in static_agent_findings
+        ):
+            return False
+
+        active_modes = self._static_route_active_modes(issue_types)
+        finding_modes = {
+            self._static_route_mode_for_finding(finding)
+            for finding in static_agent_findings
+        }
+        finding_modes.discard("")
+
+        return len(active_modes) == 1 and finding_modes == active_modes
+
+    def _should_use_static_only_route(self):
+        return self._agent_route() == "static_only"
+
+    def _finalize_file_findings(
+        self,
+        findings,
+        source,
+        file_path,
+        static_findings=None,
+        issue_types=None,
+    ):
+        validated, _ = self.validator.validate(findings, source, str(file_path))
+        validated = self._remap_handler_symbols(validated, source)
+        validated = self._filter_refuted_agent_findings(
+            validated, source, issue_types=issue_types
+        )
+
+        if static_findings:
+            validated = merge_findings(validated, static_findings, str(file_path))
+
+        return deduplicate_findings(validated)
+
+    def _should_use_whole_file_review(self, file_norm, issue_types=None):
+        if (
+            self.config.full_file_review
+            or file_norm in self.config.force_full_file_paths
+        ):
+            return True
+        return SECURITY_AUDIT_ISSUE in self._normalized_issue_types(issue_types)
+
+    def _should_analyze_function(
+        self, func_name, def_data, graph, *, issue_types=None, total_functions=0
+    ):
+        if not self.config.smart_filter:
+            return True
+
+        modes = self._active_review_modes(issue_types)
+        if not modes:
+            return True
+
+        if "quality" in modes and total_functions and total_functions <= 3:
+            return True
+
+        return (
+            "security" in modes
+            and self._should_analyze_security_function(func_name, def_data, graph)
+        ) or (
+            "quality" in modes
+            and self._should_analyze_quality_function(func_name, def_data)
+        )
+

--- a/skylos/llm/agent_review_static.py
+++ b/skylos/llm/agent_review_static.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+from .schemas import CodeLocation, Confidence, Finding, IssueType, Severity
+
+
+class AgentReviewStaticFindingMixin:
+    def _estimate_complexity(self, node):
+        import ast
+
+        complexity = 1
+        for child in ast.walk(node):
+            if isinstance(
+                child,
+                (
+                    ast.If,
+                    ast.While,
+                    ast.For,
+                    ast.ExceptHandler,
+                    ast.With,
+                    ast.Assert,
+                    ast.comprehension,
+                ),
+            ):
+                complexity += 1
+            elif isinstance(child, ast.BoolOp):
+                complexity += len(child.values) - 1
+        return complexity
+
+    def _function_length(self, node):
+        start = getattr(node, "lineno", None)
+        end = getattr(node, "end_lineno", None)
+        if start is None:
+            return 0
+        if end is None:
+            end = start
+        return max(end - start + 1, 0)
+
+    def _function_parameter_count(self, node):
+        if node is None:
+            return 0
+
+        args = getattr(node, "args", None)
+        if args is None:
+            return 0
+
+        count = 0
+        for arg in getattr(args, "posonlyargs", []) or []:
+            if getattr(arg, "arg", None) not in ("self", "cls"):
+                count += 1
+        for arg in getattr(args, "args", []) or []:
+            if getattr(arg, "arg", None) not in ("self", "cls"):
+                count += 1
+        count += len(getattr(args, "kwonlyargs", []) or [])
+        return count
+
+    def _return_site_count(self, node):
+        import ast
+
+        if node is None:
+            return 0
+        return sum(1 for child in ast.walk(node) if isinstance(child, ast.Return))
+
+    def _control_flow_count(self, node):
+        import ast
+
+        if node is None:
+            return 0
+        return sum(
+            1
+            for child in ast.walk(node)
+            if isinstance(
+                child,
+                (
+                    ast.If,
+                    ast.For,
+                    ast.AsyncFor,
+                    ast.While,
+                    ast.Try,
+                    ast.With,
+                    ast.Match,
+                ),
+            )
+        )
+
+    def _has_exception_handling(self, node):
+        import ast
+
+        if node is None:
+            return False
+        return any(
+            isinstance(child, (ast.Try, ast.TryStar)) for child in ast.walk(node)
+        )
+
+    def _collect_static_agent_findings(self, source, file_path, issue_types=None):
+        import ast
+
+        modes = self._active_review_modes(issue_types)
+        if not modes:
+            return []
+
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return []
+
+        findings = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if "quality" in modes:
+                findings.extend(self._static_async_blocking_findings(node, file_path))
+                quality = self._static_structural_quality_finding(node, file_path)
+                if quality is not None:
+                    findings.append(quality)
+            if "security" in modes:
+                upload = self._static_upload_traversal_finding(node, file_path)
+                if upload is not None:
+                    findings.append(upload)
+                archive = self._static_archive_extraction_finding(node, file_path)
+                if archive is not None:
+                    findings.append(archive)
+
+        return findings
+
+    def _static_structural_quality_finding(self, node, file_path):
+        complexity = self._estimate_complexity(node)
+        control_flow = self._control_flow_count(node)
+        params = self._function_parameter_count(node)
+        returns = self._return_site_count(node)
+        length = self._function_length(node)
+        has_exception = self._has_exception_handling(node)
+
+        branch_hotspot = control_flow >= 3 and returns >= 3
+        debt_hotspot = (
+            params >= 5 and control_flow >= 4 and returns >= 3 and has_exception
+        )
+        if not branch_hotspot and not debt_hotspot and complexity < 7:
+            return None
+
+        if debt_hotspot:
+            message = f"Technical debt hotspot in '{node.name}'."
+            explanation = (
+                f"Static analysis found a wide, branch-heavy function '{node.name}' "
+                f"with {params} parameters, {control_flow} control-flow nodes, "
+                f"{returns} returns, and exception handling."
+            )
+            severity = Severity.HIGH
+        else:
+            message = f"Branch-heavy control flow in '{node.name}'."
+            explanation = (
+                f"Static analysis found branch-heavy control flow in '{node.name}': "
+                f"complexity={complexity}, control_flow={control_flow}, "
+                f"returns={returns}, length={length}."
+            )
+            severity = Severity.MEDIUM
+
+        return Finding(
+            rule_id="SKY-Q301",
+            issue_type=IssueType.QUALITY,
+            severity=severity,
+            confidence=Confidence.HIGH,
+            message=message,
+            location=CodeLocation(file=str(file_path), line=node.lineno),
+            explanation=explanation,
+            suggestion=(
+                "Split the branch-heavy paths into smaller named helpers and keep "
+                "the top-level function focused on orchestration."
+            ),
+            symbol=node.name,
+            metadata={
+                "source": "static_agent_hint",
+                "route_complete": True,
+                "route_reason": "deterministic_structural_quality_metrics",
+                "route_mode": "quality",
+                "complexity": complexity,
+                "control_flow": control_flow,
+                "returns": returns,
+                "params": params,
+                "has_exception_handling": has_exception,
+            },
+        )
+
+    def _static_async_blocking_findings(self, node, file_path):
+        import ast
+
+        if not isinstance(node, ast.AsyncFunctionDef):
+            return []
+
+        calls = self._async_blocking_calls(node)
+        if not calls:
+            return []
+
+        call_name, line = calls[0]
+        all_calls = ", ".join(name for name, _ in calls[:3])
+        return [
+            Finding(
+                rule_id="SKY-Q401",
+                issue_type=IssueType.PERFORMANCE,
+                severity=Severity.HIGH,
+                confidence=Confidence.HIGH,
+                message=(
+                    f"Blocking call '{call_name}' inside async function "
+                    f"'{node.name}'."
+                ),
+                location=CodeLocation(file=str(file_path), line=line),
+                explanation=(
+                    "Static analysis found blocking synchronous call(s) inside "
+                    f"async function '{node.name}': {all_calls}."
+                ),
+                suggestion=(
+                    "Use async-native alternatives such as asyncio.sleep(), "
+                    "httpx.AsyncClient, aiohttp, or asyncio subprocess APIs."
+                ),
+                symbol=node.name,
+                metadata={
+                    "source": "static_agent_hint",
+                    "route_complete": True,
+                    "route_reason": "blocking_call_inside_async_function",
+                    "route_mode": "quality",
+                    "blocking_calls": [name for name, _ in calls],
+                },
+            )
+        ]
+
+    def _static_upload_traversal_finding(self, node, file_path):
+        if self._function_has_archive_extraction_call(node):
+            return None
+
+        upload_vars, unsafe_filename_vars = self._upload_filename_state(node)
+        if not unsafe_filename_vars:
+            return None
+
+        sink_line = self._upload_traversal_sink_line(
+            node, unsafe_filename_vars, upload_vars
+        )
+        if not sink_line:
+            return None
+
+        return Finding(
+            rule_id="SKY-D215",
+            issue_type=IssueType.SECURITY,
+            severity=Severity.HIGH,
+            confidence=Confidence.HIGH,
+            message="Path traversal risk in file upload handler.",
+            location=CodeLocation(file=str(file_path), line=sink_line),
+            explanation=(
+                "Static analysis found a request upload filename joined into a "
+                "server-side path without basename, resolve, or allowlist validation."
+            ),
+            suggestion=(
+                "Normalize the uploaded filename with basename/secure_filename and "
+                "validate the resolved target stays under the upload root."
+            ),
+            symbol=node.name,
+            metadata={
+                "source": "static_agent_hint",
+                "route_complete": True,
+                "route_reason": "upload_filename_reaches_path_sink",
+                "route_mode": "security",
+                "unsafe_filename_vars": sorted(unsafe_filename_vars),
+                "upload_vars": sorted(upload_vars),
+            },
+            security_details={
+                "attack_path": "attacker controls upload filename used in server path",
+                "impact": "path traversal or arbitrary file overwrite",
+                "fix": "sanitize filename and validate resolved path under upload root",
+                "evidence_lines": [sink_line],
+                "unsafe_if": "uploaded filename is not normalized and root-checked",
+            },
+        )
+
+    def _upload_filename_state(self, node):
+        import ast
+
+        upload_vars = set()
+        unsafe_filename_vars = set()
+
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Assign):
+                continue
+
+            targets = [target for target in child.targets if isinstance(target, ast.Name)]
+            if not targets:
+                continue
+
+            if self._is_request_files_expr(child.value):
+                upload_vars.update(target.id for target in targets)
+            elif not self._is_sanitized_filename_expr(child.value):
+                if self._uses_upload_filename(child.value, upload_vars):
+                    unsafe_filename_vars.update(target.id for target in targets)
+
+        return upload_vars, unsafe_filename_vars
+
+    def _upload_traversal_sink_line(
+        self, node, unsafe_filename_vars, upload_vars
+    ):
+        import ast
+
+        for child in ast.walk(node):
+            if self._unsafe_path_join_line(child, unsafe_filename_vars, upload_vars):
+                return child.lineno
+            if self._unsafe_open_call_line(child, unsafe_filename_vars, upload_vars):
+                return child.lineno
+        return 0
+
+    def _unsafe_path_join_line(self, node, unsafe_filename_vars, upload_vars):
+        import ast
+
+        return (
+            isinstance(node, ast.BinOp)
+            and isinstance(node.op, ast.Div)
+            and self._uses_unsafe_upload_filename(
+                node.right, unsafe_filename_vars, upload_vars
+            )
+        )
+
+    def _unsafe_open_call_line(self, node, unsafe_filename_vars, upload_vars):
+        import ast
+
+        return (
+            isinstance(node, ast.Call)
+            and self._call_name(node.func) == "open"
+            and bool(node.args)
+            and self._uses_unsafe_upload_filename(
+                node.args[0], unsafe_filename_vars, upload_vars
+            )
+        )
+
+    def _static_archive_extraction_finding(self, node, file_path):
+        import ast
+
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            if self._call_name(child.func).split(".")[-1] != "extractall":
+                continue
+            if any(keyword.arg == "members" for keyword in child.keywords):
+                continue
+            return Finding(
+                rule_id="SKY-D326",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                confidence=Confidence.HIGH,
+                message="Unsafe archive extraction without member path validation.",
+                location=CodeLocation(file=str(file_path), line=child.lineno),
+                explanation=(
+                    "Static analysis found extractall() without a validated members "
+                    "list or extraction-root check."
+                ),
+                suggestion=(
+                    "Validate every archive member path against the extraction root "
+                    "before extraction, then pass only validated members."
+                ),
+                symbol=node.name,
+                metadata={
+                    "source": "static_agent_hint",
+                    "route_complete": True,
+                    "route_reason": "archive_extractall_without_members_validation",
+                    "route_mode": "security",
+                },
+                security_details={
+                    "attack_path": "attacker-controlled archive member paths",
+                    "impact": "zip slip / tar slip file write outside extraction root",
+                    "fix": "validate members before extractall",
+                    "evidence_lines": [child.lineno],
+                    "unsafe_if": "archive members are not root-checked before extraction",
+                },
+            )
+
+        return None
+
+    def _function_has_archive_extraction_call(self, node):
+        import ast
+
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            if self._call_name(child.func).split(".")[-1] in {"extract", "extractall"}:
+                return True
+        return False
+
+    def _async_blocking_calls(self, node):
+        import ast
+
+        calls = []
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            name = self._call_name(child.func)
+            if self._is_blocking_call_name(name):
+                calls.append((name, child.lineno))
+        return calls
+
+    def _has_async_blocking_call(self, node):
+        import ast
+
+        if node is None or not isinstance(node, ast.AsyncFunctionDef):
+            return False
+
+        return bool(self._async_blocking_calls(node))
+
+    def _is_blocking_call_name(self, name):
+        if not name:
+            return False
+
+        blocking_roots = {
+            "requests",
+            "urllib",
+            "subprocess",
+            "socket",
+            "os",
+        }
+        blocking_names = {
+            "open",
+        }
+
+        if name == "time.sleep":
+            return True
+        if name in blocking_names:
+            return True
+        if name.split(".", 1)[0] in blocking_roots:
+            return True
+
+        return False
+
+    def _call_name(self, node):
+        import ast
+
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            base = self._call_name(node.value)
+            if base:
+                return base + "." + node.attr
+            return node.attr
+        return ""
+
+    def _is_request_files_expr(self, node):
+        import ast
+
+        if isinstance(node, ast.Subscript):
+            return self._call_name(node.value) == "request.files"
+        if isinstance(node, ast.Call):
+            return self._call_name(node.func) == "request.files.get"
+        return False
+
+    def _is_sanitized_filename_expr(self, node):
+        import ast
+
+        if not isinstance(node, ast.Call):
+            return False
+        name = self._call_name(node.func)
+        return name in {
+            "os.path.basename",
+            "posixpath.basename",
+            "ntpath.basename",
+            "secure_filename",
+            "werkzeug.utils.secure_filename",
+        }
+
+    def _uses_upload_filename(self, node, upload_vars):
+        import ast
+
+        if isinstance(node, ast.Attribute) and node.attr == "filename":
+            return isinstance(node.value, ast.Name) and node.value.id in upload_vars
+        if self._is_request_files_expr(node):
+            return True
+        if self._is_sanitized_filename_expr(node):
+            return False
+        return any(
+            self._uses_upload_filename(child, upload_vars)
+            for child in ast.iter_child_nodes(node)
+        )
+
+    def _uses_unsafe_upload_filename(self, node, unsafe_filename_vars, upload_vars):
+        import ast
+
+        if isinstance(node, ast.Name):
+            return node.id in unsafe_filename_vars
+        if self._uses_upload_filename(node, upload_vars):
+            return True
+        if self._is_sanitized_filename_expr(node):
+            return False
+        return any(
+            self._uses_unsafe_upload_filename(
+                child, unsafe_filename_vars, upload_vars
+            )
+            for child in ast.iter_child_nodes(node)
+        )
+

--- a/skylos/llm/analyzer.py
+++ b/skylos/llm/analyzer.py
@@ -8,13 +8,13 @@ from .agents import AgentConfig, create_agent
 from .finding_evidence import filter_findings_with_evidence
 from .validator import ResultValidator, deduplicate_findings, merge_findings
 from .ui import SkylosUI, estimate_cost
+from .agent_review_routing import AgentReviewRoutingMixin, SECURITY_AUDIT_ISSUE
 
-from .schemas import Confidence, AnalysisResult
+from .schemas import AnalysisResult, Confidence
 from skylos.config import load_config
 from skylos.llm.graph import CodeGraph
 from skylos.core.file_discovery import discover_source_files
 
-SECURITY_AUDIT_ISSUE = "security_audit"
 
 
 def _norm_path(path) -> str:
@@ -64,6 +64,7 @@ class AnalyzerConfig:
         force_full_file_paths=None,
         prompt_templates=None,
         prompt_template_root=None,
+        agent_route="full",
     ):
         self.model = model
         self.api_key = api_key
@@ -97,9 +98,10 @@ class AnalyzerConfig:
         }
         self.prompt_templates = prompt_templates or {}
         self.prompt_template_root = prompt_template_root
+        self.agent_route = agent_route
 
 
-class SkylosLLM:
+class SkylosLLM(AgentReviewRoutingMixin):
     def __init__(self, config=None):
         self.config = config or AnalyzerConfig()
 
@@ -125,12 +127,22 @@ class SkylosLLM:
         self.agent_config.prompt_template_root = self.config.prompt_template_root
 
         self._agents = {}
+        self._route_counts: dict[str, int] = {}
 
     def _reset_usage_counters(self):
         for agent in self._agents.values():
             adapter = getattr(agent, "_adapter", None)
             if adapter and hasattr(adapter, "reset_usage"):
                 adapter.reset_usage()
+
+    def _reset_route_counts(self):
+        self._route_counts = {}
+
+    def _record_route(self, route):
+        self._route_counts[route] = self._route_counts.get(route, 0) + 1
+
+    def _route_counts_snapshot(self):
+        return dict(self._route_counts)
 
     def _total_tokens_used(self):
         total = 0
@@ -146,218 +158,6 @@ class SkylosLLM:
         if agent_type not in self._agents:
             self._agents[agent_type] = create_agent(agent_type, self.agent_config)
         return self._agents[agent_type]
-
-    def _estimate_complexity(self, node):
-        import ast
-
-        complexity = 1
-        for child in ast.walk(node):
-            if isinstance(
-                child,
-                (
-                    ast.If,
-                    ast.While,
-                    ast.For,
-                    ast.ExceptHandler,
-                    ast.With,
-                    ast.Assert,
-                    ast.comprehension,
-                ),
-            ):
-                complexity += 1
-            elif isinstance(child, ast.BoolOp):
-                complexity += len(child.values) - 1
-        return complexity
-
-    def _function_length(self, node):
-        start = getattr(node, "lineno", None)
-        end = getattr(node, "end_lineno", None)
-        if start is None:
-            return 0
-        if end is None:
-            end = start
-        return max(end - start + 1, 0)
-
-    def _function_parameter_count(self, node):
-        if node is None:
-            return 0
-
-        args = getattr(node, "args", None)
-        if args is None:
-            return 0
-
-        count = 0
-        for arg in getattr(args, "posonlyargs", []) or []:
-            if getattr(arg, "arg", None) not in ("self", "cls"):
-                count += 1
-        for arg in getattr(args, "args", []) or []:
-            if getattr(arg, "arg", None) not in ("self", "cls"):
-                count += 1
-        count += len(getattr(args, "kwonlyargs", []) or [])
-        return count
-
-    def _return_site_count(self, node):
-        import ast
-
-        if node is None:
-            return 0
-        return sum(1 for child in ast.walk(node) if isinstance(child, ast.Return))
-
-    def _control_flow_count(self, node):
-        import ast
-
-        if node is None:
-            return 0
-        return sum(
-            1
-            for child in ast.walk(node)
-            if isinstance(
-                child,
-                (
-                    ast.If,
-                    ast.For,
-                    ast.AsyncFor,
-                    ast.While,
-                    ast.Try,
-                    ast.With,
-                    ast.Match,
-                ),
-            )
-        )
-
-    def _has_exception_handling(self, node):
-        import ast
-
-        if node is None:
-            return False
-        return any(
-            isinstance(child, (ast.Try, ast.TryStar)) for child in ast.walk(node)
-        )
-
-    def _should_analyze_security_function(self, func_name, def_data, graph):
-        taint_paths = graph.find_taint_paths(func_name)
-        if taint_paths:
-            return True
-
-        node = def_data.get("node")
-        if node:
-            complexity = self._estimate_complexity(node)
-            if complexity >= self.config.complexity_threshold:
-                return True
-
-        sensitive = [
-            "auth",
-            "login",
-            "password",
-            "token",
-            "secret",
-            "sql",
-            "query",
-            "execute",
-            "eval",
-            "exec",
-            "shell",
-            "command",
-            "system",
-            "pickle",
-            "yaml",
-            "upload",
-            "file",
-            "path",
-        ]
-        func_lower = func_name.lower()
-        for pattern in sensitive:
-            if pattern in func_lower:
-                return True
-
-        return False
-
-    def _should_analyze_quality_function(self, func_name, def_data):
-        node = def_data.get("node")
-        if node is None:
-            return False
-
-        complexity = self._estimate_complexity(node)
-        if complexity >= self.config.complexity_threshold:
-            return True
-
-        if self._function_length(node) >= 12:
-            return True
-
-        if self._function_parameter_count(node) >= 4:
-            return True
-
-        if self._return_site_count(node) >= 2:
-            return True
-
-        if self._control_flow_count(node) >= 3:
-            return True
-
-        if self._has_exception_handling(node):
-            return True
-
-        func_lower = func_name.lower()
-        quality_signals = (
-            "build",
-            "format",
-            "normalize",
-            "parse",
-            "render",
-            "resolve",
-            "validate",
-        )
-        return any(token in func_lower for token in quality_signals)
-
-    def _active_review_modes(self, issue_types=None):
-        if not issue_types:
-            modes = set()
-            if self.config.enable_security:
-                modes.add("security")
-            if self.config.enable_quality:
-                modes.add("quality")
-            return modes
-
-        modes = set()
-        for issue_type in issue_types:
-            name = str(issue_type).lower().strip()
-            if name in {"security", SECURITY_AUDIT_ISSUE}:
-                modes.add("security")
-            if name == "quality":
-                modes.add("quality")
-        return modes
-
-    @staticmethod
-    def _normalized_issue_types(issue_types=None):
-        return {str(t).lower().strip() for t in (issue_types or []) if str(t).strip()}
-
-    def _should_use_whole_file_review(self, file_norm, issue_types=None):
-        if (
-            self.config.full_file_review
-            or file_norm in self.config.force_full_file_paths
-        ):
-            return True
-        return SECURITY_AUDIT_ISSUE in self._normalized_issue_types(issue_types)
-
-    def _should_analyze_function(
-        self, func_name, def_data, graph, *, issue_types=None, total_functions=0
-    ):
-        if not self.config.smart_filter:
-            return True
-
-        modes = self._active_review_modes(issue_types)
-        if not modes:
-            return True
-
-        if "quality" in modes and total_functions and total_functions <= 3:
-            return True
-
-        return (
-            "security" in modes
-            and self._should_analyze_security_function(func_name, def_data, graph)
-        ) or (
-            "quality" in modes
-            and self._should_analyze_quality_function(func_name, def_data)
-        )
 
     def _build_batched_context(self, functions_data, graph, file_path, defs_map=None):
         return self._build_batched_context_for_modes(
@@ -515,7 +315,37 @@ class SkylosLLM:
 
         all_findings = []
         file_norm = _norm_path(file_path)
+        static_agent_findings = self._collect_static_agent_findings(
+            source,
+            str(file_path),
+            issue_types=issue_types,
+        )
+        if self._should_use_static_only_route():
+            self._record_route("static_only")
+            return self._finalize_file_findings(
+                static_agent_findings,
+                source,
+                str(file_path),
+                static_findings=static_findings,
+                issue_types=issue_types,
+            )
+        if self._static_route_complete(
+            static_agent_findings,
+            issue_types=issue_types,
+        ):
+            self._record_route("static_only")
+            return self._finalize_file_findings(
+                static_agent_findings,
+                source,
+                str(file_path),
+                static_findings=static_findings,
+                issue_types=issue_types,
+            )
 
+        if static_agent_findings and self._agent_route() == "static_first":
+            self._record_route("static_first_escalated")
+        else:
+            self._record_route("full_harness")
         if self._should_use_whole_file_review(file_norm, issue_types):
             all_findings = self._analyze_whole_file(
                 source,
@@ -638,14 +468,14 @@ class SkylosLLM:
                     source, str(file_path), defs_map, issue_types=issue_types
                 )
 
-        validated, _ = self.validator.validate(all_findings, source, str(file_path))
-
-        if static_findings:
-            validated = merge_findings(validated, static_findings, str(file_path))
-
-        validated = deduplicate_findings(validated)
-
-        return validated
+        all_findings.extend(static_agent_findings)
+        return self._finalize_file_findings(
+            all_findings,
+            source,
+            str(file_path),
+            static_findings=static_findings,
+            issue_types=issue_types,
+        )
 
     def _count_lines(self, file_path):
         try:
@@ -684,6 +514,7 @@ class SkylosLLM:
         all_findings = []
         total_lines = 0
         self._reset_usage_counters()
+        self._reset_route_counts()
 
         files = [Path(f) for f in files]
 
@@ -760,6 +591,7 @@ class SkylosLLM:
             analysis_time_ms=elapsed_ms,
             model_used=self.config.model,
             tokens_used=self._total_tokens_used(),
+            route_counts=self._route_counts_snapshot(),
         )
         result.summary = self._generate_summary(result)
 

--- a/skylos/llm/prompts.py
+++ b/skylos/llm/prompts.py
@@ -171,6 +171,9 @@ CAPABILITIES:
 - Error handling issues
 - Code smell detection
 - Performance anti-patterns
+- Async correctness/performance issues, including blocking sync calls such as
+  time.sleep(), requests.get/post(), subprocess.run(), or synchronous file/network
+  I/O inside async def handlers
 {_custom_template_section(templates, "quality", template_root)}
 
 RULES:
@@ -207,6 +210,8 @@ GOAL:
 IMPORTANT REVIEW PATTERNS:
 - inconsistent return behavior, especially value-vs-None paths in the same function
 - swallowed exceptions or handlers that silently pass
+- blocking synchronous calls inside async functions, especially time.sleep(),
+  requests.*, subprocess.*, or sync file/network I/O in async web handlers
 - branch-heavy handlers with multiple return paths that are hard to reason about
 - mutable default arguments that retain shared state across calls
 - repo activation evidence such as entrypoints, runtime registrations, import fan-in, and related tests
@@ -291,6 +296,10 @@ FIND SECURITY ISSUES LIKE:
 - Command injection (os.system, subprocess shell=True, etc.)
 - SSRF (requests.get(url_from_user))
 - Path traversal / arbitrary file read
+- File upload traversal, especially request.files/user filenames joined into
+  server-side paths without basename/resolve/allowlist validation
+- Unsafe archive extraction / zip slip / tar slip, especially extractall() or
+  archive member writes without member path validation under the extraction root
 - Insecure deserialization (pickle.loads, yaml.load)
 - eval/exec / dynamic code execution
 - Weak crypto (md5/sha1), missing TLS verification, auth bypass
@@ -305,7 +314,8 @@ RULES:
 4. For each finding, use `explanation` to describe the attack path and likely impact in this code.
 5. Use `suggestion` to describe the concrete secure fix.
 6. Set `security_details` with attack_path, impact, fix, evidence_lines, and unsafe_if.
-7. If no issues found: {{"findings": []}}
+7. For request handlers, upload handlers, and archive handlers, prefer the enclosing handler function as `symbol` over a local variable such as filename, path, member, archive, upload, or request.
+8. If no issues found: {{"findings": []}}
 """
 
 

--- a/skylos/llm/schemas.py
+++ b/skylos/llm/schemas.py
@@ -181,6 +181,7 @@ class AnalysisResult:
         analysis_time_ms: int = 0,
         model_used: str = "",
         tokens_used: int = 0,
+        route_counts: dict[str, int] | None = None,
     ) -> None:
         self.findings = findings or []
         self.summary = summary
@@ -189,6 +190,7 @@ class AnalysisResult:
         self.analysis_time_ms = analysis_time_ms
         self.model_used = model_used
         self.tokens_used = tokens_used
+        self.route_counts = route_counts or {}
 
     def to_dict(self) -> dict[str, Any]:
         out_findings = []
@@ -204,6 +206,7 @@ class AnalysisResult:
                 "analysis_time_ms": self.analysis_time_ms,
                 "model_used": self.model_used,
                 "tokens_used": self.tokens_used,
+                "route_counts": dict(self.route_counts),
             },
         }
 

--- a/skylos/llm/validator.py
+++ b/skylos/llm/validator.py
@@ -36,7 +36,10 @@ class CodeValidator:
             location=location,
             suggestion=finding.suggestion,
             explanation=finding.explanation,
+            code_snippet=getattr(finding, "code_snippet", None),
+            references=list(getattr(finding, "references", None) or []),
             symbol=getattr(finding, "symbol", None),
+            metadata=dict(getattr(finding, "metadata", None) or {}),
             security_details=getattr(finding, "security_details", None),
         )
 

--- a/test/test_agent_review_benchmark.py
+++ b/test/test_agent_review_benchmark.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 import skylos.benchmarks.agent_review as benchmark
 from skylos.benchmarks.agent_review import (
+    ALLOWED_AGENT_ROUTES,
     ALLOWED_SCAN_ISSUE_TYPES,
     AGENT_REVIEW_TAXONOMY,
     SECURITY_BENCHMARK_CLASSES,
@@ -135,6 +136,8 @@ def test_agent_review_runner_reports_symbol_and_budget_failures(tmp_path, monkey
 
     assert summary["failure_count"] == 2
     assert summary["total_tokens_used"] == 17
+    assert summary["cases"][0]["diagnostics"]["missed_present"] == ["demo"]
+    assert summary["cases"][0]["diagnostics"]["absent_violations"] == []
     failures = summary["cases"][0]["failures"]
     assert {failure["failure_type"] for failure in failures} == {
         "expectation",
@@ -157,6 +160,7 @@ def test_format_summary_includes_agent_metrics():
         },
         "total_tokens_used": 99,
         "avg_tokens_per_case": 99.0,
+        "route_counts": {"static_only": 1},
         "security_scorecard": {
             "sql_injection": {
                 "description": SECURITY_BENCHMARK_CLASSES["sql_injection"],
@@ -165,6 +169,17 @@ def test_format_summary_includes_agent_metrics():
                 "failed_case_count": 0,
                 "pass_rate": 1.0,
                 "weighted_score": 100.0,
+            }
+        },
+        "taxonomy_scorecard": {
+            "security": {
+                "case_count": 1,
+                "weighted_score": 100.0,
+                "missed_present": 0,
+                "noise": 0,
+                "total_tokens_used": 99,
+                "static_only_routes": 1,
+                "full_harness_routes": 0,
             }
         },
         "cases": [
@@ -186,7 +201,12 @@ def test_format_summary_includes_agent_metrics():
     assert "Agent review benchmark score: 100.0/100" in rendered
     assert "Agent review benchmark model: gpt-4.1" in rendered
     assert "Agent review benchmark total tokens: 99" in rendered
+    assert "Agent review benchmark routes: static_only=1" in rendered
     assert "sql_injection: cases=1 pass=1 fail=0 score=100.0" in rendered
+    assert (
+        "security: cases=1 score=100.0 missed=0 noise=0 tokens=99 "
+        "routes=static:1/full:0"
+    ) in rendered
     assert "symbols: parse_payload" in rendered
 
 
@@ -247,10 +267,21 @@ def test_run_manifest_builds_security_scorecard(tmp_path, monkeypatch):
     ticks = iter([0.0, 0.1, 0.2, 0.3])
     monkeypatch.setattr(benchmark.time, "perf_counter", lambda: next(ticks))
 
-    summary = run_manifest(manifest_path, model="gpt-4.1", api_key="KEY")
+    progress_records = []
+
+    summary = run_manifest(
+        manifest_path,
+        model="gpt-4.1",
+        api_key="KEY",
+        progress_callback=progress_records.append,
+    )
 
     assert summary["pass_count"] == 1
     assert summary["failure_count"] == 1
+    assert [record["case"]["id"] for record in progress_records] == [
+        "pickle-case",
+        "archive-case",
+    ]
     assert summary["security_scorecard"]["deserialization"] == {
         "description": SECURITY_BENCHMARK_CLASSES["deserialization"],
         "case_count": 1,
@@ -267,6 +298,16 @@ def test_run_manifest_builds_security_scorecard(tmp_path, monkeypatch):
         "pass_rate": 0.5,
         "weighted_score": 75.0,
     }
+    assert summary["cases"][1]["diagnostics"]["missed_present"] == [
+        "extract_bundle"
+    ]
+    assert summary["cases"][1]["diagnostics"]["missed_by_category"] == {
+        "security": ["extract_bundle"]
+    }
+    assert summary["taxonomy_scorecard"]["security"]["missed_present"] == 1
+    assert summary["taxonomy_scorecard"]["security"]["noise"] == 0
+    assert summary["security_diagnostics"]["archive_extraction"]["missed_present"] == 1
+    assert summary["security_diagnostics"]["archive_extraction"]["total_tokens_used"] == 22
 
 
 def test_precision_guard_allows_expected_positive_findings(tmp_path, monkeypatch):
@@ -368,6 +409,11 @@ def test_precision_guard_still_rejects_findings_for_clean_case(tmp_path, monkeyp
 
     assert summary["pass_count"] == 0
     assert summary["failure_count"] == 2
+    assert summary["cases"][0]["diagnostics"]["absent_violations"] == [
+        "normalize_name"
+    ]
+    assert summary["cases"][0]["diagnostics"]["precision_guard_noise"] is True
+    assert summary["taxonomy_scorecard"]["precision_guard"]["noise"] == 2
     assert {failure["mode"] for failure in summary["cases"][0]["failures"]} == {
         "absent",
         "precision_guard",
@@ -427,16 +473,24 @@ def test_scan_case_passes_issue_types_into_analyzer(tmp_path, monkeypatch):
         "prepare_case_scan",
         lambda case_path, max_files=benchmark.DEFAULT_SCAN_MAX_FILES: {
             "project_root": tmp_path,
-            "files": [fixture],
+            "files": [fixture, tmp_path / "tests" / "test_app.py"],
             "repo_context_map": {},
             "full_file_review": True,
         },
     )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_app.py").write_text(
+        "def test_app():\n    pass\n",
+        encoding="utf-8",
+    )
 
     seen: dict[str, object] = {}
 
-    class FakeAnalyzer:
+    RealAnalyzer = benchmark.SkylosLLM
+
+    class FakeAnalyzer(RealAnalyzer):
         def __init__(self, config):
+            super().__init__(config)
             seen["config"] = config
 
         def analyze_files(
@@ -444,7 +498,12 @@ def test_scan_case_passes_issue_types_into_analyzer(tmp_path, monkeypatch):
         ):
             seen["files"] = list(files)
             seen["issue_types"] = list(issue_types or [])
-            return AnalysisResult(findings=[], summary="No issues found", tokens_used=0)
+            return AnalysisResult(
+                findings=[],
+                summary="No issues found",
+                tokens_used=0,
+                route_counts={"static_only": 1},
+            )
 
     monkeypatch.setattr(benchmark, "SkylosLLM", FakeAnalyzer)
 
@@ -460,6 +519,157 @@ def test_scan_case_passes_issue_types_into_analyzer(tmp_path, monkeypatch):
     assert result["finding_count"] == 0
     assert seen["files"] == [fixture]
     assert seen["issue_types"] == ["security_audit"]
+    assert seen["config"].agent_route == "static_first"
+    assert result["context_files"] == [str(tmp_path / "tests" / "test_app.py")]
+    assert result["route_counts"] == {"static_only": 1}
+
+
+def test_scan_case_static_first_keeps_non_test_files(tmp_path, monkeypatch):
+    ledger = tmp_path / "ledger.py"
+    app = tmp_path / "app.py"
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    test_file = tests / "test_app.py"
+
+    ledger.write_text(
+        "def branchy_handler(flag_a, flag_b, flag_c):\n"
+        "    if flag_a:\n"
+        "        if flag_b:\n"
+        "            return 1\n"
+        "        return 2\n"
+        "    if flag_c:\n"
+        "        return 3\n"
+        "    return 4\n",
+        encoding="utf-8",
+    )
+    app.write_text(
+        "from ledger import branchy_handler\n\n"
+        "def handle():\n"
+        "    return branchy_handler(True, False, False)\n",
+        encoding="utf-8",
+    )
+    test_file.write_text("def test_app():\n    pass\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        benchmark,
+        "prepare_case_scan",
+        lambda case_path, max_files=benchmark.DEFAULT_SCAN_MAX_FILES: {
+            "project_root": tmp_path,
+            "files": [app, ledger, test_file],
+            "repo_context_map": {},
+            "full_file_review": True,
+        },
+    )
+
+    seen: dict[str, object] = {}
+    RealAnalyzer = benchmark.SkylosLLM
+
+    class FakeAnalyzer(RealAnalyzer):
+        def __init__(self, config):
+            super().__init__(config)
+            seen["config"] = config
+
+        def analyze_files(
+            self, files, defs_map=None, static_findings=None, issue_types=None
+        ):
+            seen["files"] = list(files)
+            return AnalysisResult(
+                findings=[],
+                summary="No issues found",
+                tokens_used=0,
+                route_counts={"static_only": 1},
+            )
+
+    monkeypatch.setattr(benchmark, "SkylosLLM", FakeAnalyzer)
+
+    benchmark._scan_case(
+        tmp_path,
+        model="gpt-4.1",
+        api_key="KEY",
+        provider=None,
+        base_url=None,
+        case={"scan": {"agent_route": "static_first"}},
+    )
+
+    assert seen["files"] == [app, ledger]
+    assert seen["config"].agent_route == "static_first"
+
+
+def test_scan_case_static_only_routes_to_static_evidence_file(tmp_path, monkeypatch):
+    ledger = tmp_path / "ledger.py"
+    app = tmp_path / "app.py"
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    test_file = tests / "test_app.py"
+
+    ledger.write_text(
+        "def branchy_handler(flag_a, flag_b, flag_c):\n"
+        "    if flag_a:\n"
+        "        if flag_b:\n"
+        "            return 1\n"
+        "        return 2\n"
+        "    if flag_c:\n"
+        "        return 3\n"
+        "    return 4\n",
+        encoding="utf-8",
+    )
+    app.write_text(
+        "from ledger import branchy_handler\n\n"
+        "def handle():\n"
+        "    return branchy_handler(True, False, False)\n",
+        encoding="utf-8",
+    )
+    test_file.write_text("def test_app():\n    pass\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        benchmark,
+        "prepare_case_scan",
+        lambda case_path, max_files=benchmark.DEFAULT_SCAN_MAX_FILES: {
+            "project_root": tmp_path,
+            "files": [app, ledger, test_file],
+            "repo_context_map": {},
+            "full_file_review": True,
+        },
+    )
+
+    seen: dict[str, object] = {}
+    RealAnalyzer = benchmark.SkylosLLM
+
+    class FakeAnalyzer(RealAnalyzer):
+        def __init__(self, config):
+            super().__init__(config)
+            seen["config"] = config
+
+        def analyze_files(
+            self, files, defs_map=None, static_findings=None, issue_types=None
+        ):
+            seen["files"] = list(files)
+            seen["issue_types"] = list(issue_types or [])
+            return AnalysisResult(
+                findings=[],
+                summary="No issues found",
+                tokens_used=0,
+                route_counts={"static_only": 1},
+            )
+
+    monkeypatch.setattr(benchmark, "SkylosLLM", FakeAnalyzer)
+
+    result = benchmark._scan_case(
+        tmp_path,
+        model="gpt-4.1",
+        api_key="KEY",
+        provider=None,
+        base_url=None,
+        case={
+            "scan": {"agent_route": "static_only"},
+            "expect": {"present": {"quality": ["branchy_handler"]}, "absent": {}},
+        },
+    )
+
+    assert seen["files"] == [ledger]
+    assert seen["issue_types"] == ["quality"]
+    assert seen["config"].agent_route == "static_only"
+    assert result["context_files"] == [str(app), str(test_file)]
 
 
 def test_validate_manifest_rejects_unknown_scan_issue_type(tmp_path):
@@ -492,6 +702,40 @@ def test_validate_manifest_rejects_unknown_scan_issue_type(tmp_path):
 
     assert "unsupported scan.issue_types value" in str(exc.value)
     for allowed in ALLOWED_SCAN_ISSUE_TYPES:
+        assert allowed in str(exc.value)
+
+
+def test_validate_manifest_rejects_unknown_agent_route(tmp_path):
+    fixture = tmp_path / "fixture.py"
+    fixture.write_text("def demo():\n    return 1\n", encoding="utf-8")
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {
+                "id": "bad-route",
+                "path": "fixture.py",
+                "taxonomy": ["security"],
+                "importance": "critical",
+                "source": {
+                    "repo": "https://github.com/example/project",
+                    "license": "MIT",
+                    "notes": "test only",
+                },
+                "security_classes": ["command_injection"],
+                "scan": {"agent_route": "cheap-but-wrong"},
+                "expect": {"present": {"security": ["demo"]}, "absent": {}},
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc:
+        validate_manifest(load_manifest(manifest_path), manifest_path)
+
+    assert "scan.agent_route" in str(exc.value)
+    for allowed in ALLOWED_AGENT_ROUTES:
         assert allowed in str(exc.value)
 
 

--- a/test/test_llm_analyzer.py
+++ b/test/test_llm_analyzer.py
@@ -951,6 +951,49 @@ def test_agent_remaps_weak_security_symbol_to_handler(tmp_path, monkeypatch):
     assert "filename" not in symbols
 
 
+def test_agent_static_hint_does_not_duplicate_security_finding(tmp_path, monkeypatch):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "from pathlib import Path\n"
+        "from flask import Flask, request\n\n"
+        "app = Flask(__name__)\n"
+        "UPLOAD_DIR = Path('/srv/uploads')\n\n"
+        "@app.post('/upload')\n"
+        "def upload_file():\n"
+        "    upload = request.files['file']\n"
+        "    filename = upload.filename\n"
+        "    target = UPLOAD_DIR / filename\n"
+        "    with open(target, 'wb') as handle:\n"
+        "        handle.write(upload.read())\n"
+        "    return 'ok'\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True)
+    llm = SkylosLLM(cfg)
+
+    def fake_llm_finding(*args, **kwargs):
+        return [
+            Finding(
+                rule_id="SKY-D215",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.CRITICAL,
+                confidence=Confidence.HIGH,
+                message="Possible path traversal: tainted filesystem path.",
+                location=CodeLocation(file=str(fp), line=13),
+                symbol="upload_file",
+            )
+        ]
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm_finding)
+
+    findings = llm.analyze_file(fp, issue_types=["security_audit"])
+
+    assert [(finding.rule_id, finding.message) for finding in findings] == [
+        ("SKY-D215", "Possible path traversal: tainted filesystem path.")
+    ]
+
+
 def test_small_quality_file_analyzes_all_functions(tmp_path, monkeypatch):
     fp = tmp_path / "quality.py"
     fp.write_text(

--- a/test/test_llm_analyzer.py
+++ b/test/test_llm_analyzer.py
@@ -400,6 +400,557 @@ def render_report(value):
     assert llm._should_analyze_quality_function("render_report", {"node": node}) is True
 
 
+def test_quality_selector_flags_async_blocking_calls():
+    cfg = AnalyzerConfig(quiet=True, enable_security=False, enable_quality=True)
+    llm = SkylosLLM(cfg)
+
+    node = ast.parse(
+        """
+async def fetch_profile(user_id):
+    time.sleep(0.1)
+    response = requests.get(f"https://example.test/users/{user_id}")
+    return response.json()
+"""
+    ).body[0]
+
+    assert llm._should_analyze_quality_function("fetch_profile", {"node": node}) is True
+
+
+def test_agent_static_findings_add_async_blocking_when_llm_misses(tmp_path, monkeypatch):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "import requests\n"
+        "import time\n\n"
+        "async def fetch_profile(user_id):\n"
+        "    time.sleep(0.1)\n"
+        "    response = requests.get(f'https://example.test/users/{user_id}')\n"
+        "    return response.json()\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True, enable_security=False, enable_quality=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", lambda *args, **kwargs: [])
+
+    findings = llm.analyze_file(fp)
+
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-Q401", "fetch_profile")
+    ]
+
+
+def test_agent_static_findings_add_upload_traversal_when_llm_misses(
+    tmp_path, monkeypatch
+):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "from flask import Flask, request\n\n"
+        "app = Flask(__name__)\n"
+        "UPLOAD_DIR = Path('/srv/uploads')\n\n"
+        "@app.post('/upload')\n"
+        "def upload_file():\n"
+        "    upload = request.files['file']\n"
+        "    filename = upload.filename\n"
+        "    target = UPLOAD_DIR / filename\n"
+        "    with open(target, 'wb') as handle:\n"
+        "        handle.write(upload.read())\n"
+        "    return 'ok'\n\n"
+        "@app.post('/upload-safe')\n"
+        "def upload_safe():\n"
+        "    upload = request.files['file']\n"
+        "    safe_name = os.path.basename(upload.filename)\n"
+        "    target = UPLOAD_DIR / safe_name\n"
+        "    with open(target, 'wb') as handle:\n"
+        "        handle.write(upload.read())\n"
+        "    return 'ok'\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", lambda *args, **kwargs: [])
+
+    findings = llm.analyze_file(fp, issue_types=["security_audit"])
+
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-D215", "upload_file")
+    ]
+
+
+def test_agent_static_findings_add_archive_extraction_when_llm_misses(
+    tmp_path, monkeypatch
+):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "import tarfile\n"
+        "from pathlib import Path\n"
+        "from flask import Flask, request\n\n"
+        "app = Flask(__name__)\n"
+        "EXTRACT_ROOT = Path('/srv/bundles')\n\n"
+        "@app.post('/extract-bundle')\n"
+        "def extract_bundle():\n"
+        "    upload = request.files['bundle']\n"
+        "    archive_path = EXTRACT_ROOT / upload.filename\n"
+        "    upload.save(archive_path)\n"
+        "    with tarfile.open(archive_path) as bundle:\n"
+        "        bundle.extractall(EXTRACT_ROOT)\n"
+        "    return 'ok'\n\n"
+        "@app.post('/extract-bundle-safe')\n"
+        "def extract_bundle_safe():\n"
+        "    upload = request.files['bundle']\n"
+        "    archive_path = EXTRACT_ROOT / upload.filename\n"
+        "    upload.save(archive_path)\n"
+        "    root = EXTRACT_ROOT.resolve()\n"
+        "    with tarfile.open(archive_path) as bundle:\n"
+        "        safe_members = [member for member in bundle.getmembers()]\n"
+        "        bundle.extractall(root, members=safe_members)\n"
+        "    return 'ok'\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", lambda *args, **kwargs: [])
+
+    findings = llm.analyze_file(fp, issue_types=["security_audit"])
+
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-D326", "extract_bundle"),
+    ]
+
+
+def test_agent_static_findings_add_branch_hotspot_when_llm_misses(
+    tmp_path, monkeypatch
+):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "def branchy_handler(flag_a, flag_b, flag_c):\n"
+        "    if flag_a:\n"
+        "        if flag_b:\n"
+        "            return 1\n"
+        "        return 2\n"
+        "    if flag_c:\n"
+        "        return 3\n"
+        "    return 4\n\n"
+        "def simple_handler():\n"
+        "    return 1\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True, enable_security=False, enable_quality=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", lambda *args, **kwargs: [])
+
+    findings = llm.analyze_file(fp, issue_types=["quality"])
+
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-Q301", "branchy_handler")
+    ]
+
+
+def test_agent_static_first_route_skips_llm_for_branch_hotspot(tmp_path, monkeypatch):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "def branchy_handler(flag_a, flag_b, flag_c):\n"
+        "    if flag_a:\n"
+        "        if flag_b:\n"
+        "            return 1\n"
+        "        return 2\n"
+        "    if flag_c:\n"
+        "        return 3\n"
+        "    return 4\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(
+        quiet=True,
+        enable_security=False,
+        enable_quality=True,
+        agent_route="static_first",
+    )
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("static route should skip the LLM harness")
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fail_if_called)
+
+    findings = llm.analyze_file(fp, issue_types=["quality"])
+
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-Q301", "branchy_handler")
+    ]
+    assert findings[0].metadata["route_complete"] is True
+    assert findings[0].metadata["route_mode"] == "quality"
+    assert findings[0].metadata["route_reason"]
+    assert llm._route_counts_snapshot() == {"static_only": 1}
+
+
+def test_agent_static_first_escalates_when_multiple_modes_are_in_scope(
+    tmp_path, monkeypatch
+):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "def branchy_handler(flag_a, flag_b, flag_c):\n"
+        "    if flag_a:\n"
+        "        if flag_b:\n"
+        "            return 1\n"
+        "        return 2\n"
+        "    if flag_c:\n"
+        "        return 3\n"
+        "    return 4\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(
+        quiet=True,
+        enable_security=True,
+        enable_quality=True,
+        agent_route="static_first",
+    )
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+    calls = {"count": 0}
+
+    def fake_llm(*args, **kwargs):
+        calls["count"] += 1
+        return []
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm)
+
+    findings = llm.analyze_file(fp)
+
+    assert calls["count"] == 1
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-Q301", "branchy_handler")
+    ]
+    assert llm._route_counts_snapshot() == {"static_first_escalated": 1}
+
+
+def test_agent_full_route_still_calls_llm_with_static_findings(tmp_path, monkeypatch):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "def branchy_handler(flag_a, flag_b, flag_c):\n"
+        "    if flag_a:\n"
+        "        if flag_b:\n"
+        "            return 1\n"
+        "        return 2\n"
+        "    if flag_c:\n"
+        "        return 3\n"
+        "    return 4\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(
+        quiet=True,
+        enable_security=False,
+        enable_quality=True,
+        agent_route="full",
+    )
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+    calls = {"count": 0}
+
+    def fake_llm(*args, **kwargs):
+        calls["count"] += 1
+        return []
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm)
+
+    findings = llm.analyze_file(fp, issue_types=["quality"])
+
+    assert calls["count"] == 1
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-Q301", "branchy_handler")
+    ]
+    assert llm._route_counts_snapshot() == {"full_harness": 1}
+
+
+def test_agent_static_findings_add_debt_hotspot_when_llm_misses(
+    tmp_path, monkeypatch
+):
+    fp = tmp_path / "ledger.py"
+    fp.write_text(
+        "def reconcile_account(\n"
+        "    account,\n"
+        "    mode,\n"
+        "    include_pending=False,\n"
+        "    dry_run=False,\n"
+        "    emit_metrics=False,\n"
+        "    fallback_currency='USD',\n"
+        "):\n"
+        "    actions = []\n"
+        "    try:\n"
+        "        if account is None:\n"
+        "            return actions\n"
+        "        if mode == 'dashboard':\n"
+        "            actions.append('dashboard')\n"
+        "        elif mode == 'nightly':\n"
+        "            actions.append('nightly')\n"
+        "        elif mode == 'close':\n"
+        "            actions.append('close')\n"
+        "        if include_pending and account.get('pending_items'):\n"
+        "            actions.append('pending')\n"
+        "        if emit_metrics and account.get('id'):\n"
+        "            actions.append('metric')\n"
+        "        if dry_run:\n"
+        "            return actions\n"
+        "        return actions\n"
+        "    except Exception:\n"
+        "        return []\n\n"
+        "def summarize_account(account):\n"
+        "    if not account:\n"
+        "        return {'status': 'unknown'}\n"
+        "    return {'status': account.get('status', 'active')}\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True, enable_security=False, enable_quality=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", lambda *args, **kwargs: [])
+
+    findings = llm.analyze_file(fp, issue_types=["quality"])
+
+    assert [(f.rule_id, f.symbol) for f in findings] == [
+        ("SKY-Q301", "reconcile_account")
+    ]
+    assert "params" in findings[0].metadata
+
+
+def test_agent_refutes_clean_async_and_small_helper_noise(tmp_path, monkeypatch):
+    fp = tmp_path / "module.py"
+    fp.write_text(
+        "async def fetch_status(client, user_id):\n"
+        "    response = await client.get(f'/users/{user_id}')\n"
+        "    if response.status == 404:\n"
+        "        return None\n"
+        "    response.raise_for_status()\n"
+        "    return await response.json()\n\n"
+        "def normalize_headers(headers=None):\n"
+        "    current = headers or {}\n"
+        "    return {key.lower(): value for key, value in current.items()}\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True, enable_security=False, enable_quality=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    def fake_llm_findings(*args, **kwargs):
+        return [
+            Finding(
+                rule_id="SKY-L001",
+                issue_type=IssueType.PERFORMANCE,
+                severity=Severity.MEDIUM,
+                confidence=Confidence.MEDIUM,
+                message="Potential missing await or blocking async helper issue",
+                location=CodeLocation(file=str(fp), line=2),
+                symbol="fetch_status",
+            ),
+            Finding(
+                rule_id="SKY-L001",
+                issue_type=IssueType.QUALITY,
+                severity=Severity.MEDIUM,
+                confidence=Confidence.MEDIUM,
+                message="Potential normalization issue",
+                location=CodeLocation(file=str(fp), line=9),
+                symbol="normalize_headers",
+            ),
+            Finding(
+                rule_id="SKY-L212",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.MEDIUM,
+                confidence=Confidence.MEDIUM,
+                message="Potential SSRF issue",
+                location=CodeLocation(file=str(fp), line=2),
+                symbol="fetch_status",
+            ),
+        ]
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm_findings)
+
+    assert llm.analyze_file(fp, issue_types=["quality"]) == []
+
+
+def test_agent_keeps_security_finding_on_clean_async_owner(tmp_path, monkeypatch):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "async def fetch_url(client, url):\n"
+        "    response = await client.get(url)\n"
+        "    return await response.text()\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True, enable_security=True, enable_quality=False)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    def fake_llm_findings(*args, **kwargs):
+        return [
+            Finding(
+                rule_id="SKY-L210",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                confidence=Confidence.HIGH,
+                message="SSRF via user-controlled URL",
+                location=CodeLocation(file=str(fp), line=2),
+                symbol="fetch_url",
+            )
+        ]
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm_findings)
+
+    findings = llm.analyze_file(fp, issue_types=["security_audit"])
+
+    assert [(finding.rule_id, finding.symbol) for finding in findings] == [
+        ("SKY-L210", "fetch_url")
+    ]
+
+
+def test_agent_refutes_safe_subprocess_allowlist_noise(tmp_path, monkeypatch):
+    fp = tmp_path / "hooks.py"
+    fp.write_text(
+        "import subprocess\n\n"
+        "ALLOWED = {\n"
+        "    'status': ['git', 'status', '--short'],\n"
+        "    'fetch': ['git', 'fetch', 'origin'],\n"
+        "}\n\n"
+        "def run_named_hook(name, repo_path):\n"
+        "    cmd = f'cd {repo_path} && {name}'\n"
+        "    return subprocess.run(cmd, shell=True, capture_output=True, text=True)\n\n"
+        "def run_builtin(name):\n"
+        "    return subprocess.run(ALLOWED[name], check=False, capture_output=True, text=True)\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    def fake_llm_findings(*args, **kwargs):
+        return [
+            Finding(
+                rule_id="SKY-L212",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                confidence=Confidence.MEDIUM,
+                message="Command injection via subprocess.run shell=True",
+                location=CodeLocation(file=str(fp), line=10),
+                symbol="run_named_hook",
+            ),
+            Finding(
+                rule_id="SKY-L212",
+                issue_type=IssueType.QUALITY,
+                severity=Severity.MEDIUM,
+                confidence=Confidence.MEDIUM,
+                message="Command injection via subprocess.run",
+                location=CodeLocation(file=str(fp), line=13),
+                symbol="run_builtin",
+            ),
+        ]
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm_findings)
+
+    findings = llm.analyze_file(fp)
+
+    assert [(finding.rule_id, finding.symbol) for finding in findings] == [
+        ("SKY-L212", "run_named_hook")
+    ]
+
+
+def test_agent_keeps_command_injection_when_function_has_mixed_subprocess_calls(
+    tmp_path, monkeypatch
+):
+    fp = tmp_path / "hooks.py"
+    fp.write_text(
+        "import subprocess\n\n"
+        "def run_hook(user_cmd):\n"
+        "    subprocess.run(['git', 'status'], check=False)\n"
+        "    return subprocess.run(user_cmd, shell=True)\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    def fake_llm_findings(*args, **kwargs):
+        return [
+            Finding(
+                rule_id="SKY-L212",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                confidence=Confidence.HIGH,
+                message="Command injection via subprocess.run shell=True",
+                location=CodeLocation(file=str(fp), line=5),
+                symbol="run_hook",
+            )
+        ]
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm_findings)
+
+    findings = llm.analyze_file(fp, issue_types=["security_audit"])
+
+    assert [(finding.rule_id, finding.symbol) for finding in findings] == [
+        ("SKY-L212", "run_hook")
+    ]
+
+
+def test_agent_remaps_weak_security_symbol_to_handler(tmp_path, monkeypatch):
+    fp = tmp_path / "app.py"
+    fp.write_text(
+        "from pathlib import Path\n"
+        "from flask import Flask, request\n\n"
+        "app = Flask(__name__)\n"
+        "UPLOAD_DIR = Path('/srv/uploads')\n\n"
+        "@app.post('/upload')\n"
+        "def upload_file():\n"
+        "    upload = request.files['file']\n"
+        "    filename = upload.filename\n"
+        "    target = UPLOAD_DIR / filename\n"
+        "    return str(target)\n",
+        encoding="utf-8",
+    )
+
+    cfg = AnalyzerConfig(quiet=True)
+    llm = SkylosLLM(cfg)
+    llm.validator = DummyValidator()
+
+    def fake_llm_finding(*args, **kwargs):
+        return [
+            Finding(
+                rule_id="SKY-D215",
+                issue_type=IssueType.SECURITY,
+                severity=Severity.HIGH,
+                confidence=Confidence.HIGH,
+                message="Path traversal through filename",
+                location=CodeLocation(file=str(fp), line=11),
+                symbol="filename",
+            )
+        ]
+
+    monkeypatch.setattr(llm, "_analyze_whole_file", fake_llm_finding)
+
+    findings = llm.analyze_file(fp, issue_types=["security_audit"])
+    symbols = {finding.symbol for finding in findings}
+
+    assert "upload_file" in symbols
+    assert "filename" not in symbols
+
+
 def test_small_quality_file_analyzes_all_functions(tmp_path, monkeypatch):
     fp = tmp_path / "quality.py"
     fp.write_text(

--- a/test/test_llm_prompts.py
+++ b/test/test_llm_prompts.py
@@ -36,6 +36,8 @@ def test_quality_prompt_treats_context_as_untrusted():
     )
     assert "=== BEGIN UNTRUSTED CODE CONTEXT ===" in user
     assert "=== END UNTRUSTED CODE CONTEXT ===" in user
+    assert "blocking sync calls" in system
+    assert "time.sleep()" in system
 
 
 def test_quality_prompt_appends_custom_template_without_replacing_safety(tmp_path):
@@ -92,6 +94,9 @@ def test_security_audit_prompt_treats_context_as_untrusted():
     assert "how an attacker could exploit the shown code" in user
     assert "concrete secure fix" in user
     assert "security_details" in user
+    assert "File upload traversal" in system
+    assert "Unsafe archive extraction" in system
+    assert "enclosing handler function" in system
 
 
 def test_few_shot_examples_match_strict_finding_schema_fields():
@@ -111,6 +116,7 @@ def test_review_prompt_tells_model_how_to_use_review_hints():
 
     assert "expert code reviewer for Python repositories" in system
     assert "mutable default arguments that retain shared state across calls" in system
+    assert "blocking synchronous calls inside async functions" in system
     assert "graph grounding evidence" in system
     assert "allowlisted argv-list subprocess calls" in system
     assert (


### PR DESCRIPTION
## Summary

  - add static first agent review routing with deterministic findings for async blocking, quality hotspots, upload traversal, and unsafe archive extraction
  - split agent review routing, static finding, and refuter logic out of `skylos/llm/analyzer.py`
  
## Tests

  - `pytest test/test_llm_analyzer.py test/test_agent_review_benchmark.py test/test_llm_prompts.py`