### PR TITLE
fix(security): move vulnerable app into fixture

### DIFF
--- a/benchmarks/security/fixtures/intentional_vulnerable_flask_app/app.py
+++ b/benchmarks/security/fixtures/intentional_vulnerable_flask_app/app.py
@@ -1,3 +1,9 @@
+"""Deliberately vulnerable Flask fixture.
+
+This file intentionally contains insecure patterns for Skylos demos and
+benchmark coverage. Do not copy these examples into production code.
+"""
+
 from flask import Flask, request
 import sqlite3, os, subprocess, requests, hashlib, pickle, yaml
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ max_args = 5
 max_lines = 50
 model = "gpt-4.1"
 exclude = [
+    # Benchmarks include deliberately vulnerable demo and scanner fixtures.
     "benchmarks",
     "corpus",
     "docs/repo-map",


### PR DESCRIPTION
Closes #590

## Summary

  - Moved the intentionally vulnerable Flask sample from root `app.py` into `benchmarks/security/fixtures/
  intentional_vulnerable_flask_app/app.py`
  - Added comment making clear the insecure patterns are deliberate 

## Why

  Root `app.py` contains deliberate insecure patterns. Keeping it at the repo root makes it look like product code violating
  Skylos own rules. Moved it under excluded benchmark folder. 