### PR TITLE
ci(security): harden release and scan gates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      checks: read
     outputs:
       release_tag: ${{ steps.release_ref.outputs.tag }}
 
@@ -113,6 +114,76 @@ jobs:
                   f"release-please manifest version {manifest_version!r} does not match release tag {expected!r}"
               )
           PY
+
+      - name: Verify required release checks
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUIRED_RELEASE_CHECKS: '["test", "analyzer-speed", "corpus", "quality-benchmark", "scan"]'
+        run: |
+          set -euo pipefail
+          release_sha="$(git rev-parse HEAD)"
+
+          for attempt in {1..30}; do
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${GITHUB_REPOSITORY}/commits/${release_sha}/check-runs?per_page=100" \
+              > /tmp/skylos-release-checks.json
+
+            set +e
+            python - "$REQUIRED_RELEASE_CHECKS" /tmp/skylos-release-checks.json <<'PY'
+          import json
+          import sys
+
+          required = json.loads(sys.argv[1])
+          data_path = sys.argv[2]
+          data = json.load(open(data_path, encoding="utf-8"))
+          runs = data.get("check_runs", [])
+
+          failures = []
+          pending = []
+          for name in required:
+              matches = [run for run in runs if run.get("name") == name]
+              if not matches:
+                  pending.append(f"{name}: missing")
+                  continue
+              if any(run.get("conclusion") == "success" for run in matches):
+                  continue
+              active = [run for run in matches if run.get("status") != "completed"]
+              if active:
+                  pending.append(f"{name}: {active[0].get('status')}")
+                  continue
+              conclusions = sorted(
+                  {str(run.get("conclusion") or "unknown") for run in matches}
+              )
+              failures.append(f"{name}: {', '.join(conclusions)}")
+
+          if failures:
+              print("Required release checks failed:")
+              for item in failures:
+                  print(f"- {item}")
+              sys.exit(1)
+          if pending:
+              print("Required release checks are not complete yet:")
+              for item in pending:
+                  print(f"- {item}")
+              sys.exit(2)
+
+          print("Required release checks passed.")
+          PY
+            status=$?
+            set -e
+
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$status" -ne 2 ] || [ "$attempt" -eq 30 ]; then
+              exit "$status"
+            fi
+
+            echo "Required release checks pending; retrying in 20s (attempt ${attempt}/30)."
+            sleep 20
+          done
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,7 @@ jobs:
     uses: ./.github/workflows/publish.yml
     permissions:
       contents: read
+      checks: read
       packages: write
     with:
       ref: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/skylos.yaml
+++ b/.github/workflows/skylos.yaml
@@ -83,6 +83,60 @@ jobs:
         run: |
           .venv/bin/skylos cicd gate --input "$REPORT" --summary --advisory
 
+      - name: Block new high-risk security findings
+        if: steps.scan.outcome == 'success'
+        env:
+          REPORT: ${{ steps.scan.outputs.REPORT }}
+        run: |
+          python - "$REPORT" <<'PY'
+          import json
+          import os
+          import sys
+
+          severity_rank = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+          report_path = sys.argv[1]
+          with open(report_path, encoding="utf-8") as fh:
+              report = json.load(fh)
+
+          blocking = []
+          for category in ("danger", "secrets"):
+              for finding in report.get(category, []) or []:
+                  severity = str(
+                      finding.get("severity") or ("HIGH" if category == "secrets" else "")
+                  ).upper()
+                  if severity_rank.get(severity, 0) >= severity_rank["HIGH"]:
+                      blocking.append((category, severity, finding))
+
+          if not blocking:
+              print("No new high-risk security findings.")
+              sys.exit(0)
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          lines = [
+              "## Blocking Skylos findings",
+              "",
+              "New HIGH/CRITICAL security or secret findings were detected in this diff.",
+              "",
+          ]
+
+          for category, severity, finding in blocking[:20]:
+              file_path = finding.get("file") or finding.get("file_path") or "unknown"
+              line = finding.get("line") or finding.get("line_number") or 1
+              rule = finding.get("rule_id") or finding.get("rule") or category
+              message = finding.get("message") or "High-risk finding"
+              print(f"::error file={file_path},line={line},title=Skylos {rule}::{severity} {message}")
+              lines.append(f"- `{severity}` `{rule}` {file_path}:{line} - {message}")
+
+          if len(blocking) > 20:
+              lines.append(f"- ...and {len(blocking) - 20} more finding(s)")
+
+          if summary:
+              with open(summary, "a", encoding="utf-8") as fh:
+                  fh.write("\n".join(lines) + "\n")
+
+          raise SystemExit(1)
+          PY
+
       - name: GitHub annotations
         if: always()
         env:

--- a/RELEASE_WORKFLOW.md
+++ b/RELEASE_WORKFLOW.md
@@ -32,6 +32,10 @@ These must be enabled for predictable releases:
    - Require status checks to pass.
    - Include PR title validation and core CI checks.
    - Change merge strategy to squash merges for clean release semantics/changelogs.
+   - Keep the publish workflow's required release checks in sync with branch
+     protection. `publish.yml` blocks PyPI/GHCR publish unless `test`,
+     `analyzer-speed`, `corpus`, `quality-benchmark`, and `scan` have passed
+     for the release commit.
 
 2. **PR title policy enabled**
    - Workflow: `.github/workflows/pr-title.yml`

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -19,6 +19,10 @@ def _publish_workflow():
     return yaml.safe_load(Path(".github/workflows/publish.yml").read_text())
 
 
+def _release_please_workflow():
+    return yaml.safe_load(Path(".github/workflows/release-please.yml").read_text())
+
+
 def _tests_workflow():
     return yaml.safe_load(Path(".github/workflows/tests.yaml").read_text())
 
@@ -436,6 +440,30 @@ def test_publish_workflow_validates_strict_semver_release_tags():
     assert "(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)" in resolve_step["run"]
 
 
+def test_publish_workflow_verifies_required_checks_before_publish():
+    workflow = _publish_workflow()
+    release_please = _release_please_workflow()
+
+    assert workflow["jobs"]["build"]["permissions"]["checks"] == "read"
+    assert release_please["jobs"]["publish-release"]["permissions"]["checks"] == "read"
+
+    build_steps = workflow["jobs"]["build"]["steps"]
+    check_step = next(s for s in build_steps if s.get("name") == "Verify required release checks")
+    check_index = build_steps.index(check_step)
+    setup_index = next(
+        i for i, step in enumerate(build_steps) if step.get("name") == "Set up Python"
+    )
+
+    assert check_index < setup_index
+    assert check_step["env"]["REQUIRED_RELEASE_CHECKS"] == (
+        '["test", "analyzer-speed", "corpus", "quality-benchmark", "scan"]'
+    )
+    assert "gh api" in check_step["run"]
+    assert "check-runs?per_page=100" in check_step["run"]
+    assert "Required release checks failed" in check_step["run"]
+    assert "Required release checks are not complete yet" in check_step["run"]
+
+
 def test_tests_workflow_pins_codecov_and_limits_permissions():
     workflow = _tests_workflow()
     assert workflow["permissions"] == {"contents": "read"}
@@ -481,6 +509,18 @@ def test_skylos_pr_workflow_uses_trusted_scanner_package():
     scan_step = next(s for s in steps if s.get("name") == "Run Skylos")
     assert "python -m skylos.cli" not in scan_step["run"]
     assert ".venv/bin/skylos" in scan_step["run"]
+
+    advisory_step = next(s for s in steps if s.get("name") == "Report findings (advisory)")
+    assert "--advisory" in advisory_step["run"]
+
+    blocker_step = next(
+        s for s in steps if s.get("name") == "Block new high-risk security findings"
+    )
+    assert blocker_step["if"] == "steps.scan.outcome == 'success'"
+    assert "HIGH" in blocker_step["run"]
+    assert "CRITICAL" in blocker_step["run"]
+    assert 'for category in ("danger", "secrets")' in blocker_step["run"]
+    assert "raise SystemExit(1)" in blocker_step["run"]
 
 
 def test_composite_action_validates_and_quotes_max_comments_input():


### PR DESCRIPTION
## Summary
  - Gate release publishing on required CI checks before building/publishing artifacts.
  - Fail the Skylos advisory scan workflow on new HIGH/CRITICAL danger or secret findings.
  - Add workflow tests covering the release gate and high-risk scan blocker.

  ## Tests
  - `pytest -q test/test_github_actions_security.py`
  - `pytest -q test/test_cicd_gate.py`