### PR TITLE
feat(llm): add replayable verification harness

### DIFF
--- a/.github/workflows/skylos.yaml
+++ b/.github/workflows/skylos.yaml
@@ -124,7 +124,9 @@ jobs:
               line = finding.get("line") or finding.get("line_number") or 1
               rule = finding.get("rule_id") or finding.get("rule") or category
               message = finding.get("message") or "High-risk finding"
-              print(f"::error file={file_path},line={line},title=Skylos {rule}::{severity} {message}")
+              detail = f"{severity} {rule} {file_path}:{line} - {message}"
+              print(detail)
+              print(f"::error file={file_path},line={line},title=Skylos {rule}::{detail}")
               lines.append(f"- `{severity}` `{rule}` {file_path}:{line} - {message}")
 
           if len(blocking) > 20:

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -4449,9 +4449,9 @@ def main() -> None:
 
             console.print("\n[brand]Step 2/2: LLM verification (4-pass)...[/brand]")
 
-            from skylos.llm.verify_orchestrator import run_verification
+            from skylos.llm.harness import run_verification_harness
 
-            result = run_verification(
+            harness_result = run_verification_harness(
                 findings=all_findings,
                 defs_map=defs_map,
                 project_root=str(path if path.is_dir() else path.parent),
@@ -4469,6 +4469,14 @@ def main() -> None:
                 parallel_grep=getattr(agent_args, "parallel_grep", False)
                 or getattr(agent_args, "fix", False),
             )
+            result = harness_result.output
+            harness_summary = harness_result.run.summary_dict()
+            result["harness"] = harness_summary
+            harness_artifact = None
+            if harness_summary.get("state_path"):
+                harness_artifact = str(
+                    pathlib.Path(harness_summary["state_path"]).parent
+                )
 
             stats = result["stats"]
             verified = result["verified_findings"]
@@ -4509,6 +4517,8 @@ def main() -> None:
                 summary_table.add_row("LLM calls", str(stats["llm_calls"]))
                 summary_table.add_row("Time", f"{stats['elapsed_seconds']}s")
                 console.print(summary_table)
+                if harness_artifact:
+                    console.print(f"\n[dim]Harness run: {harness_artifact}[/dim]")
 
                 fps = [f for f in verified if f.get("_llm_verdict") == "FALSE_POSITIVE"]
                 if fps:

--- a/skylos/llm/agents.py
+++ b/skylos/llm/agents.py
@@ -644,9 +644,9 @@ class DeadCodeAgent:
         quiet=False,
         verification_mode="production",
     ):
-        from skylos.llm.verify_orchestrator import run_verification
+        from skylos.llm.harness import run_verification_harness
 
-        result = run_verification(
+        harness_result = run_verification_harness(
             findings=findings,
             defs_map=defs_map,
             project_root=str(project_root),
@@ -659,7 +659,7 @@ class DeadCodeAgent:
             quiet=quiet,
             verification_mode=verification_mode,
         )
-        return result
+        return harness_result.output
 
     def challenge_survivors(
         self,
@@ -669,12 +669,12 @@ class DeadCodeAgent:
         max_challenge=20,
         quiet=False,
     ):
-        from skylos.llm.verify_orchestrator import run_verification
+        from skylos.llm.harness import run_verification_harness
 
         for s in survivors:
             s["_is_survivor"] = True
 
-        result = run_verification(
+        harness_result = run_verification_harness(
             findings=survivors,
             defs_map=defs_map,
             project_root=str(project_root),
@@ -683,11 +683,12 @@ class DeadCodeAgent:
             provider=getattr(self.config, "provider", None),
             base_url=getattr(self.config, "base_url", None),
             max_verify=max_challenge,
+            max_challenge=max_challenge,
             enable_survivor_challenge=True,
             batch_mode=True,
             quiet=quiet,
         )
-        return result
+        return harness_result.output
 
 
 def create_dead_code_agent(

--- a/skylos/llm/harness/__init__.py
+++ b/skylos/llm/harness/__init__.py
@@ -1,0 +1,41 @@
+from .runner import HarnessRunner
+from .replay import (
+    HarnessReplay,
+    HarnessReplayError,
+    HarnessReplayIssue,
+    load_harness_replay,
+)
+from .tools import (
+    HarnessTool,
+    HarnessToolRegistry,
+    default_verification_tool_registry,
+)
+from .types import (
+    HarnessBudget,
+    HarnessBudgetExceeded,
+    HarnessDecision,
+    HarnessResult,
+    HarnessRun,
+    HarnessStep,
+    HarnessToolCall,
+)
+from .verification import run_verification_harness
+
+__all__ = [
+    "HarnessBudget",
+    "HarnessBudgetExceeded",
+    "HarnessDecision",
+    "HarnessReplay",
+    "HarnessReplayError",
+    "HarnessReplayIssue",
+    "HarnessResult",
+    "HarnessRun",
+    "HarnessRunner",
+    "HarnessStep",
+    "HarnessTool",
+    "HarnessToolCall",
+    "HarnessToolRegistry",
+    "default_verification_tool_registry",
+    "load_harness_replay",
+    "run_verification_harness",
+]

--- a/skylos/llm/harness/guards.py
+++ b/skylos/llm/harness/guards.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import time
+from typing import Sized
+
+from .types import HarnessBudget, HarnessBudgetExceeded
+
+
+def enforce_step_budget(steps_started: int, budget: HarnessBudget) -> None:
+    if budget.max_steps is not None and steps_started >= budget.max_steps:
+        raise HarnessBudgetExceeded(
+            f"harness step budget exceeded: {steps_started + 1}>{budget.max_steps}"
+        )
+
+
+def enforce_elapsed_budget(started_monotonic: float, budget: HarnessBudget) -> None:
+    if budget.max_seconds is None:
+        return
+    elapsed = time.monotonic() - started_monotonic
+    if elapsed > budget.max_seconds:
+        raise HarnessBudgetExceeded(
+            f"harness time budget exceeded: {elapsed:.3f}s>{budget.max_seconds:.3f}s"
+        )
+
+
+def enforce_findings_budget(findings: Sized, budget: HarnessBudget) -> None:
+    if budget.max_findings is None:
+        return
+    count = len(findings)
+    if count > budget.max_findings:
+        raise HarnessBudgetExceeded(
+            f"harness findings budget exceeded: {count}>{budget.max_findings}"
+        )
+
+
+def enforce_llm_call_budget(llm_calls: int | None, budget: HarnessBudget) -> None:
+    if budget.max_llm_calls is None or llm_calls is None:
+        return
+    if llm_calls > budget.max_llm_calls:
+        raise HarnessBudgetExceeded(
+            f"harness LLM call budget exceeded: {llm_calls}>{budget.max_llm_calls}"
+        )

--- a/skylos/llm/harness/replay.py
+++ b/skylos/llm/harness/replay.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .trace import EVENTS_FILENAME, STATE_FILENAME, SUMMARY_FILENAME
+
+MAX_REPLAY_EVENTS_BYTES = 5_000_000
+MAX_REPLAY_ARTIFACT_BYTES = 1_000_000
+
+
+class HarnessReplayError(AssertionError):
+    pass
+
+
+@dataclass(frozen=True)
+class HarnessReplayIssue:
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "message": self.message,
+        }
+
+
+@dataclass
+class HarnessReplay:
+    run_dir: Path
+    events: list[dict[str, Any]] = field(default_factory=list)
+    state: dict[str, Any] = field(default_factory=dict)
+    summary: dict[str, Any] = field(default_factory=dict)
+    issues: list[HarnessReplayIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def event_names(self) -> list[str]:
+        return [str(event.get("event", "")) for event in self.events]
+
+    def phase_sequence(self) -> list[str]:
+        steps = self.state.get("steps") if isinstance(self.state, dict) else []
+        if not isinstance(steps, list):
+            return []
+        return [
+            str(step.get("name", ""))
+            for step in steps
+            if isinstance(step, dict)
+        ]
+
+    def tool_sequence(self) -> list[str]:
+        calls = self.state.get("tool_calls") if isinstance(self.state, dict) else []
+        if not isinstance(calls, list):
+            return []
+        return [
+            str(call.get("name", ""))
+            for call in calls
+            if isinstance(call, dict)
+        ]
+
+    def decision_codes(self) -> list[str]:
+        decisions = self.state.get("decisions") if isinstance(self.state, dict) else []
+        if not isinstance(decisions, list):
+            return []
+        return [
+            str(decision.get("code", ""))
+            for decision in decisions
+            if isinstance(decision, dict)
+        ]
+
+    def assert_valid(self) -> None:
+        if self.issues:
+            formatted = "; ".join(
+                f"{issue.code}: {issue.message}" for issue in self.issues
+            )
+            raise HarnessReplayError(formatted)
+
+
+def load_harness_replay(run_dir: str | Path) -> HarnessReplay:
+    path = Path(run_dir)
+    replay = HarnessReplay(run_dir=path)
+    replay.events = _read_events(path / EVENTS_FILENAME, replay.issues)
+    replay.state = _read_json_artifact(path / STATE_FILENAME, replay.issues)
+    replay.summary = _read_json_artifact(path / SUMMARY_FILENAME, replay.issues)
+    if replay.issues:
+        return replay
+    replay.issues.extend(_validate_replay(replay))
+    return replay
+
+
+def _read_events(
+    path: Path,
+    issues: list[HarnessReplayIssue],
+) -> list[dict[str, Any]]:
+    payload = _read_safe_text(
+        path,
+        issues,
+        max_bytes=MAX_REPLAY_EVENTS_BYTES,
+        error_code="invalid_events",
+    )
+    if payload is None:
+        return []
+    events: list[dict[str, Any]] = []
+    try:
+        for index, line in enumerate(payload.splitlines(), 1):
+            if not line.strip():
+                continue
+            event = json.loads(line)
+            if not isinstance(event, dict):
+                issues.append(
+                    HarnessReplayIssue(
+                        "invalid_event",
+                        f"{EVENTS_FILENAME}:{index} is not an object",
+                    )
+                )
+                continue
+            events.append(event)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        issues.append(
+            HarnessReplayIssue(
+                "invalid_events",
+                f"could not read {EVENTS_FILENAME}: {exc}",
+            )
+        )
+    return events
+
+
+def _read_json_artifact(
+    path: Path,
+    issues: list[HarnessReplayIssue],
+) -> dict[str, Any]:
+    payload_text = _read_safe_text(
+        path,
+        issues,
+        max_bytes=MAX_REPLAY_ARTIFACT_BYTES,
+        error_code="invalid_artifact",
+    )
+    if payload_text is None:
+        return {}
+    try:
+        payload = json.loads(payload_text)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        issues.append(
+            HarnessReplayIssue(
+                "invalid_artifact",
+                f"could not read {path.name}: {exc}",
+            )
+        )
+        return {}
+    if not isinstance(payload, dict):
+        issues.append(
+            HarnessReplayIssue(
+                "invalid_artifact",
+                f"{path.name} is not an object",
+            )
+        )
+        return {}
+    return payload
+
+
+def _read_safe_text(
+    path: Path,
+    issues: list[HarnessReplayIssue],
+    *,
+    max_bytes: int,
+    error_code: str,
+) -> str | None:
+    if not _is_safe_file(path, issues, max_bytes=max_bytes):
+        return None
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(  # skylos: ignore[SKY-D215] guarded no-follow replay read
+            path, flags
+        )
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            issues.append(
+                HarnessReplayIssue(
+                    "unsafe_artifact",
+                    f"{path.name} is not a regular file",
+                )
+            )
+            return None
+        if file_stat.st_size > max_bytes:
+            issues.append(
+                HarnessReplayIssue(
+                    "oversized_artifact",
+                    f"{path.name} exceeds {max_bytes} bytes",
+                )
+            )
+            return None
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = None
+            return handle.read()
+    except (OSError, UnicodeError) as exc:
+        issues.append(
+            HarnessReplayIssue(error_code, f"could not read {path.name}: {exc}")
+        )
+        return None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _is_safe_file(
+    path: Path,
+    issues: list[HarnessReplayIssue],
+    *,
+    max_bytes: int,
+) -> bool:
+    try:
+        if path.is_symlink():
+            issues.append(
+                HarnessReplayIssue("unsafe_artifact", f"{path.name} is a symlink")
+            )
+            return False
+        if not path.is_file():
+            issues.append(
+                HarnessReplayIssue("missing_artifact", f"{path.name} is missing")
+            )
+            return False
+        if path.stat().st_size > max_bytes:
+            issues.append(
+                HarnessReplayIssue(
+                    "oversized_artifact",
+                    f"{path.name} exceeds {max_bytes} bytes",
+                )
+            )
+            return False
+    except OSError as exc:
+        issues.append(
+            HarnessReplayIssue("unsafe_artifact", f"could not inspect {path.name}: {exc}")
+        )
+        return False
+    return True
+
+
+def _validate_replay(replay: HarnessReplay) -> list[HarnessReplayIssue]:
+    issues: list[HarnessReplayIssue] = []
+    events = replay.events
+    state = replay.state
+    summary = replay.summary
+
+    if not events:
+        return [HarnessReplayIssue("empty_events", "events.jsonl has no events")]
+    if events[0].get("event") != "run_started":
+        issues.append(
+            HarnessReplayIssue("event_order", "first event is not run_started")
+        )
+
+    run_ids = {
+        str(value)
+        for value in [
+            state.get("run_id"),
+            summary.get("run_id"),
+            *[event.get("run_id") for event in events],
+        ]
+        if value
+    }
+    if len(run_ids) != 1:
+        issues.append(
+            HarnessReplayIssue(
+                "run_id_mismatch",
+                f"artifacts contain multiple run ids: {sorted(run_ids)}",
+            )
+        )
+
+    _validate_run_completion(events, state, summary, issues)
+    _validate_steps(events, state, summary, issues)
+    _validate_tool_calls(events, state, summary, issues)
+    _validate_decisions(state, summary, issues)
+    _validate_budget(state, summary, issues)
+    return issues
+
+
+def _validate_run_completion(
+    events: list[dict[str, Any]],
+    state: dict[str, Any],
+    summary: dict[str, Any],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    completed = [event for event in events if event.get("event") == "run_completed"]
+    if state.get("status") in {"completed", "failed"}:
+        if len(completed) != 1:
+            issues.append(
+                HarnessReplayIssue(
+                    "run_completion",
+                    "finished run must have exactly one run_completed event",
+                )
+            )
+        elif events[-1].get("event") != "run_completed":
+            issues.append(
+                HarnessReplayIssue(
+                    "event_order",
+                    "run_completed is not the final event",
+                )
+            )
+    if state.get("status") != summary.get("status"):
+        issues.append(
+            HarnessReplayIssue(
+                "status_mismatch",
+                "state and summary statuses differ",
+            )
+        )
+
+
+def _validate_steps(
+    events: list[dict[str, Any]],
+    state: dict[str, Any],
+    summary: dict[str, Any],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    steps = _dict_list(state.get("steps"))
+    started = _event_items(events, "step_started")
+    finished = _event_items(events, {"step_completed", "step_failed"})
+
+    _validate_step_sequences(steps, started, finished, issues)
+    _validate_step_statuses(steps, finished, issues)
+    _validate_step_summary(steps, summary, issues)
+
+
+def _validate_step_sequences(
+    steps: list[dict[str, Any]],
+    started: list[dict[str, Any]],
+    finished: list[dict[str, Any]],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    state_names = [str(step.get("name", "")) for step in steps]
+    started_names = [str(event.get("name", "")) for event in started]
+    finished_names = [str(event.get("name", "")) for event in finished]
+    if state_names != started_names:
+        issues.append(
+            HarnessReplayIssue(
+                "step_sequence_mismatch",
+                "state steps do not match step_started events",
+            )
+        )
+    if state_names != finished_names:
+        issues.append(
+            HarnessReplayIssue(
+                "step_sequence_mismatch",
+                "state steps do not match completed/failed step events",
+            )
+        )
+
+
+def _validate_step_statuses(
+    steps: list[dict[str, Any]],
+    finished: list[dict[str, Any]],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    state_statuses = [str(step.get("status", "")) for step in steps]
+    event_statuses = [
+        "completed" if event.get("event") == "step_completed" else "failed"
+        for event in finished
+    ]
+    if state_statuses != event_statuses:
+        issues.append(
+            HarnessReplayIssue(
+                "step_status_mismatch",
+                "state step statuses do not match step events",
+            )
+        )
+
+
+def _validate_step_summary(
+    steps: list[dict[str, Any]],
+    summary: dict[str, Any],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    completed_names = [
+        str(step.get("name", ""))
+        for step in steps
+        if step.get("status") == "completed"
+    ]
+    if completed_names != summary.get("completed_phases"):
+        issues.append(
+            HarnessReplayIssue(
+                "completed_phase_mismatch",
+                "summary completed phases do not match state",
+            )
+        )
+    failed_phase = next(
+        (
+            str(step.get("name", ""))
+            for step in reversed(steps)
+            if step.get("status") == "failed"
+        ),
+        None,
+    )
+    if failed_phase != summary.get("failed_phase"):
+        issues.append(
+            HarnessReplayIssue(
+                "failed_phase_mismatch",
+                "summary failed phase does not match state",
+            )
+        )
+    if len(steps) != summary.get("phase_count"):
+        issues.append(
+            HarnessReplayIssue(
+                "phase_count_mismatch",
+                "summary phase count does not match state",
+            )
+        )
+
+
+def _validate_tool_calls(
+    events: list[dict[str, Any]],
+    state: dict[str, Any],
+    summary: dict[str, Any],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    calls = _dict_list(state.get("tool_calls"))
+    started = _event_items(events, "tool_started")
+    finished = _event_items(events, {"tool_completed", "tool_failed"})
+
+    state_names = [str(call.get("name", "")) for call in calls]
+    started_names = [str(event.get("name", "")) for event in started]
+    finished_names = [str(event.get("name", "")) for event in finished]
+    if state_names != started_names:
+        issues.append(
+            HarnessReplayIssue(
+                "tool_sequence_mismatch",
+                "state tool calls do not match tool_started events",
+            )
+        )
+    if state_names != finished_names:
+        issues.append(
+            HarnessReplayIssue(
+                "tool_sequence_mismatch",
+                "state tool calls do not match completed/failed tool events",
+            )
+        )
+
+    state_statuses = [str(call.get("status", "")) for call in calls]
+    event_statuses = [
+        "completed" if event.get("event") == "tool_completed" else "failed"
+        for event in finished
+    ]
+    if state_statuses != event_statuses:
+        issues.append(
+            HarnessReplayIssue(
+                "tool_status_mismatch",
+                "state tool statuses do not match tool events",
+            )
+        )
+    if len(calls) != summary.get("tool_call_count", 0):
+        issues.append(
+            HarnessReplayIssue(
+                "tool_call_count_mismatch",
+                "summary tool call count does not match state",
+            )
+        )
+
+
+def _validate_decisions(
+    state: dict[str, Any],
+    summary: dict[str, Any],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    decisions = _dict_list(state.get("decisions"))
+    if len(decisions) != summary.get("decision_count"):
+        issues.append(
+            HarnessReplayIssue(
+                "decision_count_mismatch",
+                "summary decision count does not match state",
+            )
+        )
+
+
+def _validate_budget(
+    state: dict[str, Any],
+    summary: dict[str, Any],
+    issues: list[HarnessReplayIssue],
+) -> None:
+    for key in ("budget", "budget_used", "budget_remaining"):
+        if state.get(key) != summary.get(key):
+            issues.append(
+                HarnessReplayIssue(
+                    "budget_mismatch",
+                    f"summary {key} does not match state",
+                )
+            )
+
+
+def _event_items(
+    events: list[dict[str, Any]],
+    event_names: str | set[str],
+) -> list[dict[str, Any]]:
+    names = {event_names} if isinstance(event_names, str) else event_names
+    return [event for event in events if event.get("event") in names]
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]

--- a/skylos/llm/harness/runner.py
+++ b/skylos/llm/harness/runner.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Callable, TypeVar
+from uuid import uuid4
+
+from .guards import enforce_elapsed_budget, enforce_step_budget
+from .trace import (
+    EVENTS_FILENAME,
+    STATE_FILENAME,
+    SUMMARY_FILENAME,
+    default_trace_root,
+    write_json_artifact,
+    write_jsonl_trace,
+)
+from .tools import HarnessToolRegistry
+from .types import (
+    HarnessBudget,
+    HarnessDecision,
+    HarnessRun,
+    HarnessStep,
+    HarnessToolCall,
+    resolved_project_root,
+    sanitize_run_id,
+    utc_now_iso,
+)
+
+T = TypeVar("T")
+
+
+class HarnessRunner:
+    def __init__(
+        self,
+        *,
+        kind: str,
+        project_root: str | Path,
+        budget: HarnessBudget | None = None,
+        run_id: str | None = None,
+        trace_root: str | Path | None = None,
+        metadata: dict[str, Any] | None = None,
+        tool_registry: HarnessToolRegistry | None = None,
+    ):
+        root = resolved_project_root(project_root)
+        self._started_monotonic = time.monotonic()
+        self._events: list[dict[str, Any]] = []
+        self._live_usage_keys: set[str] = set()
+        self._trace_root = Path(trace_root) if trace_root is not None else None
+        self._tool_registry = tool_registry
+        metadata_dict = dict(metadata or {})
+        if self._tool_registry is not None:
+            metadata_dict["registered_tools"] = self._tool_registry.to_dict()
+        self.run = HarnessRun(
+            run_id=sanitize_run_id(run_id) if run_id else self._generate_run_id(),
+            kind=kind,
+            project_root=str(root),
+            budget=budget or HarnessBudget(),
+            metadata=metadata_dict,
+        )
+        if self._trace_root is not None:
+            self._set_artifact_paths()
+        self._record("run_started", self.run.to_dict())
+
+    @classmethod
+    def with_default_trace_root(
+        cls,
+        *,
+        kind: str,
+        project_root: str | Path,
+        budget: HarnessBudget | None = None,
+        run_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        tool_registry: HarnessToolRegistry | None = None,
+    ) -> "HarnessRunner":
+        root = resolved_project_root(project_root)
+        return cls(
+            kind=kind,
+            project_root=root,
+            budget=budget,
+            run_id=run_id,
+            trace_root=default_trace_root(root),
+            metadata=metadata,
+            tool_registry=tool_registry,
+        )
+
+    def run_step(
+        self,
+        name: str,
+        fn: Callable[[], T],
+        *,
+        input_summary: dict[str, Any] | None = None,
+        output_summary: Callable[[T], dict[str, Any]] | None = None,
+    ) -> T:
+        enforce_elapsed_budget(self._started_monotonic, self.run.budget)
+        enforce_step_budget(len(self.run.steps), self.run.budget)
+
+        step = HarnessStep(
+            name=name,
+            status="running",
+            started_at=utc_now_iso(),
+            input_summary=dict(input_summary or {}),
+        )
+        step_started = time.monotonic()
+        self.run.steps.append(step)
+        self._record("step_started", step.to_dict())
+        try:
+            output = fn()
+        except Exception as exc:
+            self._finish_step(
+                step,
+                status="failed",
+                started_monotonic=step_started,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            self.run.status = "failed"
+            self.run.error = step.error
+            self.finish(status="failed", error=step.error)
+            raise
+
+        summary = output_summary(output) if output_summary is not None else {}
+        self._finish_step(
+            step,
+            status="completed",
+            started_monotonic=step_started,
+            output_summary=summary,
+        )
+        return output
+
+    def step(
+        self,
+        name: str,
+        *,
+        input_summary: dict[str, Any] | None = None,
+    ) -> "HarnessStepContext":
+        return HarnessStepContext(
+            self,
+            name=name,
+            input_summary=input_summary,
+        )
+
+    def run_tool(
+        self,
+        name: str,
+        fn: Callable[[], T],
+        *,
+        input_summary: dict[str, Any] | None = None,
+        output_summary: Callable[[T], dict[str, Any]] | None = None,
+    ) -> T:
+        enforce_elapsed_budget(self._started_monotonic, self.run.budget)
+        if self._tool_registry is not None:
+            self._tool_registry.get(name)
+
+        call = HarnessToolCall(
+            name=name,
+            status="running",
+            phase=self.run.current_phase(),
+            started_at=utc_now_iso(),
+            input_summary=dict(input_summary or {}),
+        )
+        call_started = time.monotonic()
+        self.run.tool_calls.append(call)
+        self._record("tool_started", call.to_dict())
+        try:
+            output = fn()
+            summary = output_summary(output) if output_summary is not None else {}
+        except Exception as exc:
+            self._finish_tool(
+                call,
+                status="failed",
+                started_monotonic=call_started,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            raise
+
+        self._finish_tool(
+            call,
+            status="completed",
+            started_monotonic=call_started,
+            output_summary=summary,
+        )
+        return output
+
+    def finish(self, *, status: str = "completed", error: str | None = None) -> None:
+        if self.run.ended_at is not None:
+            return
+        self.run.status = status
+        self.run.error = error
+        self.run.ended_at = utc_now_iso()
+        self.run.duration_ms = _elapsed_ms(self._started_monotonic)
+        self.update_usage(seconds=round(self.run.duration_ms / 1000, 3), persist=False)
+        self._record("run_completed", self.run.to_dict())
+        if self._trace_root is not None:
+            trace_path = write_jsonl_trace(
+                self._trace_root, self.run.run_id, self._events
+            )
+            if trace_path is None:
+                self.run.trace_path = None
+            summary_path = write_json_artifact(
+                self._trace_root,
+                self.run.run_id,
+                SUMMARY_FILENAME,
+                self.run.summary_dict(),
+            )
+            if summary_path is None:
+                self.run.summary_path = None
+            self._persist_state()
+
+    @staticmethod
+    def _generate_run_id() -> str:
+        timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        return f"{timestamp}-{uuid4().hex[:8]}"
+
+    def _finish_step(
+        self,
+        step: HarnessStep,
+        *,
+        status: str,
+        started_monotonic: float,
+        output_summary: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        step.status = status
+        step.ended_at = utc_now_iso()
+        step.duration_ms = _elapsed_ms(started_monotonic)
+        step.output_summary = dict(output_summary or {})
+        step.error = error
+        if status == "completed":
+            self._ingest_usage(step.output_summary)
+        self._record(f"step_{status}", step.to_dict())
+
+    def _finish_tool(
+        self,
+        call: HarnessToolCall,
+        *,
+        status: str,
+        started_monotonic: float,
+        output_summary: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        call.status = status
+        call.ended_at = utc_now_iso()
+        call.duration_ms = _elapsed_ms(started_monotonic)
+        call.output_summary = dict(output_summary or {})
+        call.error = error
+        self._record(f"tool_{status}", call.to_dict())
+
+    def _record(self, event: str, payload: dict[str, Any]) -> None:
+        self._events.append(
+            {
+                "event": event,
+                "run_id": self.run.run_id,
+                "kind": self.run.kind,
+                "timestamp": utc_now_iso(),
+                **payload,
+            }
+        )
+        self._persist_events()
+        self._persist_state()
+
+    def _persist_events(self) -> None:
+        if self._trace_root is None:
+            return
+        trace_path = write_jsonl_trace(
+            self._trace_root,
+            self.run.run_id,
+            self._events,
+        )
+        self.run.trace_path = str(trace_path) if trace_path is not None else None
+
+    def update_usage(
+        self,
+        *,
+        persist: bool = True,
+        live: bool = True,
+        **usage: int | float,
+    ) -> None:
+        for key, value in usage.items():
+            if live:
+                self._live_usage_keys.add(key)
+            current = self.run.usage.get(key, 0)
+            self.run.usage[key] = current + value
+        if persist:
+            self._persist_state()
+
+    def _ingest_usage(self, summary: dict[str, Any]) -> None:
+        llm_calls = summary.get("llm_calls")
+        if (
+            isinstance(llm_calls, int | float)
+            and "llm_calls" not in self._live_usage_keys
+        ):
+            self.update_usage(llm_calls=llm_calls, persist=False, live=False)
+        fixes = summary.get("fixes")
+        if (
+            isinstance(fixes, int | float)
+            and "fixes" not in self._live_usage_keys
+        ):
+            self.update_usage(fixes=fixes, persist=False, live=False)
+
+    def record_decision(
+        self,
+        *,
+        phase: str,
+        code: str,
+        target: dict[str, Any],
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.run.decisions.append(
+            HarnessDecision(
+                phase=phase,
+                code=code,
+                target=dict(target),
+                details=dict(details or {}),
+            )
+        )
+        self._persist_state()
+
+    def _set_artifact_paths(self) -> None:
+        if self._trace_root is None:
+            return
+        run_dir = self._trace_root / self.run.run_id
+        self.run.trace_path = str(run_dir / EVENTS_FILENAME)
+        self.run.state_path = str(run_dir / STATE_FILENAME)
+        self.run.summary_path = str(run_dir / SUMMARY_FILENAME)
+
+    def _persist_state(self) -> None:
+        if self._trace_root is None:
+            return
+        state_path = write_json_artifact(
+            self._trace_root,
+            self.run.run_id,
+            STATE_FILENAME,
+            self.run.state_dict(),
+        )
+        if state_path is None:
+            self.run.state_path = None
+
+
+class HarnessStepContext:
+    def __init__(
+        self,
+        runner: HarnessRunner,
+        *,
+        name: str,
+        input_summary: dict[str, Any] | None = None,
+    ):
+        self._runner = runner
+        self._name = name
+        self._input_summary = dict(input_summary or {})
+        self._output_summary: dict[str, Any] = {}
+        self._step: HarnessStep | None = None
+        self._started_monotonic: float | None = None
+
+    def __enter__(self) -> "HarnessStepContext":
+        enforce_elapsed_budget(
+            self._runner._started_monotonic,
+            self._runner.run.budget,
+        )
+        enforce_step_budget(len(self._runner.run.steps), self._runner.run.budget)
+        self._step = HarnessStep(
+            name=self._name,
+            status="running",
+            started_at=utc_now_iso(),
+            input_summary=self._input_summary,
+        )
+        self._started_monotonic = time.monotonic()
+        self._runner.run.steps.append(self._step)
+        self._runner._record("step_started", self._step.to_dict())
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        if self._step is None or self._started_monotonic is None:
+            return False
+
+        if exc is not None:
+            error = f"{type(exc).__name__}: {exc}"
+            self._runner._finish_step(
+                self._step,
+                status="failed",
+                started_monotonic=self._started_monotonic,
+                error=error,
+            )
+            self._runner.run.status = "failed"
+            self._runner.run.error = error
+            self._runner.finish(status="failed", error=error)
+            return False
+
+        self._runner._finish_step(
+            self._step,
+            status="completed",
+            started_monotonic=self._started_monotonic,
+            output_summary=self._output_summary,
+        )
+        return False
+
+    def set_output_summary(self, **summary: Any) -> None:
+        self._output_summary.update(summary)
+
+
+def _elapsed_ms(started_monotonic: float) -> int:
+    return int(round((time.monotonic() - started_monotonic) * 1000))

--- a/skylos/llm/harness/tools.py
+++ b/skylos/llm/harness/tools.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class HarnessTool:
+    name: str
+    category: str
+    description: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "category": self.category,
+            "description": self.description,
+        }
+
+
+class HarnessToolRegistry:
+    def __init__(self, tools: list[HarnessTool] | None = None):
+        self._tools: dict[str, HarnessTool] = {}
+        for tool in tools or []:
+            self.register_tool(tool)
+
+    def register(
+        self,
+        name: str,
+        *,
+        category: str,
+        description: str = "",
+    ) -> HarnessTool:
+        return self.register_tool(
+            HarnessTool(
+                name=name,
+                category=category,
+                description=description,
+            )
+        )
+
+    def register_tool(self, tool: HarnessTool) -> HarnessTool:
+        if tool.name in self._tools:
+            raise ValueError(f"harness tool already registered: {tool.name}")
+        self._tools[tool.name] = tool
+        return tool
+
+    def has(self, name: str) -> bool:
+        return name in self._tools
+
+    def get(self, name: str) -> HarnessTool:
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise KeyError(f"unknown harness tool: {name}") from exc
+
+    def list(self) -> list[HarnessTool]:
+        return [self._tools[name] for name in sorted(self._tools)]
+
+    def to_dict(self) -> list[dict[str, Any]]:
+        return [tool.to_dict() for tool in self.list()]
+
+
+def default_verification_tool_registry() -> HarnessToolRegistry:
+    registry = HarnessToolRegistry()
+    registry.register(
+        "entry_discovery",
+        category="llm",
+        description="Discover project-specific entry points.",
+    )
+    registry.register(
+        "deterministic_suppression",
+        category="deterministic",
+        description="Apply static dead-code suppression checks.",
+    )
+    registry.register(
+        "haiku_prefilter",
+        category="llm",
+        description="Pre-filter exported symbols with a cheaper verifier.",
+    )
+    registry.register(
+        "batch_verify",
+        category="llm",
+        description="Verify dead-code candidates in batches.",
+    )
+    registry.register(
+        "graph_verify",
+        category="llm",
+        description="Verify one candidate with graph context.",
+    )
+    registry.register(
+        "suppression_audit",
+        category="llm",
+        description="Audit suppressed findings for missed dead code.",
+    )
+    registry.register(
+        "survivor_local_scan",
+        category="deterministic",
+        description="Find local survivor patterns that can be reclassified.",
+    )
+    registry.register(
+        "survivor_discovery",
+        category="deterministic",
+        description="Find survivors with heuristic references to challenge.",
+    )
+    registry.register(
+        "survivor_batch_challenge",
+        category="llm",
+        description="Challenge survivor candidates in batches.",
+    )
+    registry.register(
+        "survivor_challenge",
+        category="llm",
+        description="Challenge one survivor candidate.",
+    )
+    return registry

--- a/skylos/llm/harness/trace.py
+++ b/skylos/llm/harness/trace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -25,50 +26,20 @@ def write_jsonl_trace(
     run_id: str,
     events: list[dict[str, Any]],
 ) -> Path | None:
-    run_dir = _safe_run_dir(trace_root, run_id)
-    if run_dir is None:
-        return None
-    if not _ensure_trace_dir(run_dir):
+    run_dir_fd, run_dir_path = _open_run_dir(trace_root, run_id)
+    if run_dir_fd is None or run_dir_path is None:
         return None
 
-    path = run_dir / EVENTS_FILENAME
-    if _unsafe_existing_path(path):
-        return None
-
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-
-    fd: int | None = None
     try:
-        fd = os.open(  # skylos: ignore[SKY-D215] guarded project-local trace temp path
-            temp_path, flags, 0o600
+        path = _write_artifact_in_dir(
+            run_dir_fd,
+            run_dir_path,
+            EVENTS_FILENAME,
+            lambda handle: _write_jsonl(handle, events),
         )
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            fd = None
-            for event in events:
-                handle.write(json.dumps(event, sort_keys=True, default=str))
-                handle.write("\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-        if _unsafe_existing_path(path):
-            return None
-        os.replace(temp_path, path)
         return path
-    except (OSError, TypeError, ValueError):
-        return None
     finally:
-        if fd is not None:
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        try:
-            if temp_path.exists() and not temp_path.is_symlink():
-                temp_path.unlink()
-        except OSError:
-            pass
+        _close_fd(run_dir_fd)
 
 
 def write_json_artifact(
@@ -77,99 +48,171 @@ def write_json_artifact(
     filename: str,
     payload: dict[str, Any],
 ) -> Path | None:
-    run_dir = _safe_run_dir(trace_root, run_id)
-    if run_dir is None:
-        return None
-    if not _ensure_trace_dir(run_dir):
+    run_dir_fd, run_dir_path = _open_run_dir(trace_root, run_id)
+    if run_dir_fd is None or run_dir_path is None:
         return None
 
-    path = _safe_artifact_path(run_dir, filename)
-    if path is None:
-        return None
-    if _unsafe_existing_path(path):
-        return None
-
-    return _write_json_file(path, payload)
-
-
-def _write_json_file(path: Path, payload: dict[str, Any]) -> Path | None:
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-
-    fd: int | None = None
     try:
-        fd = os.open(  # skylos: ignore[SKY-D215] guarded project-local artifact temp path
-            temp_path, flags, 0o600
+        return _write_artifact_in_dir(
+            run_dir_fd,
+            run_dir_path,
+            filename,
+            lambda handle: _write_json(handle, payload),
         )
+    finally:
+        _close_fd(run_dir_fd)
+
+
+def _write_artifact_in_dir(
+    dir_fd: int,
+    run_dir_path: Path,
+    filename: str,
+    writer: Any,
+) -> Path | None:
+    final_name = _safe_artifact_name(filename)
+    if final_name is None:
+        return None
+    if _unsafe_existing_name(dir_fd, final_name):
+        return None
+
+    temp_name = f".{final_name}.{os.getpid()}.tmp"
+    fd = _open_temp_file(dir_fd, temp_name)
+    if fd is None:
+        return None
+
+    try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             fd = None
-            json.dump(payload, handle, indent=2, sort_keys=True, default=str)
-            handle.write("\n")
+            writer(handle)
             handle.flush()
             os.fsync(handle.fileno())
-        if _unsafe_existing_path(path):
+        if _unsafe_existing_name(dir_fd, final_name):
             return None
-        os.replace(temp_path, path)
-        return path
+        os.replace(temp_name, final_name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        return run_dir_path / final_name
     except (OSError, TypeError, ValueError):
         return None
     finally:
-        if fd is not None:
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        try:
-            if temp_path.exists() and not temp_path.is_symlink():
-                temp_path.unlink()
-        except OSError:
-            pass
+        _close_fd(fd)
+        _unlink_name(dir_fd, temp_name)
 
 
-def _safe_run_dir(trace_root: str | Path, run_id: str) -> Path | None:
+def _write_jsonl(handle: Any, events: list[dict[str, Any]]) -> None:
+    for event in events:
+        handle.write(json.dumps(event, sort_keys=True, default=str))
+        handle.write("\n")
+
+
+def _write_json(handle: Any, payload: dict[str, Any]) -> None:
+    json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+    handle.write("\n")
+
+
+def _open_temp_file(dir_fd: int, temp_name: str) -> int | None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
     try:
-        root = Path(trace_root).resolve()
-        run_dir = root / sanitize_run_id(run_id)
-        run_dir.resolve(strict=False).relative_to(root)
-    except (OSError, ValueError):
+        return os.open(  # skylos: ignore[SKY-D215] dir_fd temp name from _safe_artifact_name
+            temp_name, flags, 0o600, dir_fd=dir_fd
+        )
+    except OSError:
         return None
-    return run_dir
 
 
-def _safe_artifact_path(run_dir: Path, filename: str) -> Path | None:
+def _open_run_dir(trace_root: str | Path, run_id: str) -> tuple[int | None, Path | None]:
+    safe_run_id = sanitize_run_id(run_id)
+    root_path = _absolute_lexical_path(trace_root)
+    if root_path is None:
+        return None, None
+    run_dir_path = root_path / safe_run_id
+    run_fd = _open_or_create_directory(run_dir_path)
+    if run_fd is None:
+        return None, None
+    return run_fd, run_dir_path
+
+
+def _absolute_lexical_path(path: str | Path) -> Path | None:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    if any(part in {"", ".", ".."} for part in candidate.parts[1:]):
+        return None
+    return candidate
+
+
+def _open_or_create_directory(path: Path) -> int | None:
+    parts = path.parts
+    if not parts:
+        return None
+
+    current_fd: int | None = None
+    try:
+        current_fd = os.open(os.sep, _directory_flags(follow_symlinks=True))
+        for part in parts[1:]:
+            if part in {"", ".", ".."}:
+                _close_fd(current_fd)
+                return None
+            _mkdirat(current_fd, part)
+            next_fd = os.open(part, _directory_flags(), dir_fd=current_fd)
+            _close_fd(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except OSError:
+        _close_fd(current_fd)
+        return None
+
+
+def _directory_flags(*, follow_symlinks: bool = False) -> int:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if not follow_symlinks and hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    return flags
+
+
+def _mkdirat(dir_fd: int, name: str) -> None:
+    try:
+        os.mkdir(  # skylos: ignore[SKY-D215] dir_fd path component rejects separators/dotdot
+            name, mode=0o700, dir_fd=dir_fd
+        )
+    except FileExistsError:
+        pass
+
+
+def _safe_artifact_name(filename: str) -> str | None:
     candidate_name = Path(filename).name
     if not candidate_name or candidate_name != filename:
         return None
+    return candidate_name
+
+
+def _unsafe_existing_name(dir_fd: int, name: str) -> bool:
     try:
-        path = run_dir / candidate_name
-        path.resolve(strict=False).relative_to(run_dir.resolve(strict=False))
-    except (OSError, ValueError):
-        return None
-    return path
-
-
-def _ensure_trace_dir(path: Path) -> bool:
-    current = Path(path.anchor) if path.is_absolute() else Path(".")
-    parts = path.parts[1:] if path.is_absolute() else path.parts
-    for part in parts:
-        current = current / part
-        try:
-            if current.is_symlink():
-                return False
-            if current.exists():
-                if not current.is_dir():
-                    return False
-                continue
-            current.mkdir(mode=0o700)
-        except OSError:
-            return False
-    return True
-
-
-def _unsafe_existing_path(path: Path) -> bool:
-    try:
-        return path.exists() and (path.is_symlink() or not path.is_file())
+        metadata = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
     except OSError:
         return True
+    return not stat.S_ISREG(metadata.st_mode)
+
+
+def _unlink_name(dir_fd: int, name: str) -> None:
+    try:
+        os.unlink(  # skylos: ignore[SKY-D215] dir_fd temp cleanup does not follow symlinks
+            name, dir_fd=dir_fd
+        )
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+def _close_fd(fd: int | None) -> None:
+    if fd is None:
+        return
+    try:
+        os.close(fd)
+    except OSError:
+        pass

--- a/skylos/llm/harness/trace.py
+++ b/skylos/llm/harness/trace.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .types import sanitize_run_id
+
+SKYLOS_DIRNAME = ".skylos"
+RUNS_DIRNAME = "runs"
+EVENTS_FILENAME = "events.jsonl"
+STATE_FILENAME = "state.json"
+SUMMARY_FILENAME = "summary.json"
+
+
+def default_trace_root(project_root: str | Path) -> Path:
+    resolved = Path(project_root).resolve()
+    root = resolved.parent if resolved.is_file() else resolved
+    return root / SKYLOS_DIRNAME / RUNS_DIRNAME
+
+
+def write_jsonl_trace(
+    trace_root: str | Path,
+    run_id: str,
+    events: list[dict[str, Any]],
+) -> Path | None:
+    run_dir = _safe_run_dir(trace_root, run_id)
+    if run_dir is None:
+        return None
+    if not _ensure_trace_dir(run_dir):
+        return None
+
+    path = run_dir / EVENTS_FILENAME
+    if _unsafe_existing_path(path):
+        return None
+
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(  # skylos: ignore[SKY-D215] guarded project-local trace temp path
+            temp_path, flags, 0o600
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            for event in events:
+                handle.write(json.dumps(event, sort_keys=True, default=str))
+                handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if _unsafe_existing_path(path):
+            return None
+        os.replace(temp_path, path)
+        return path
+    except (OSError, TypeError, ValueError):
+        return None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            if temp_path.exists() and not temp_path.is_symlink():
+                temp_path.unlink()
+        except OSError:
+            pass
+
+
+def write_json_artifact(
+    trace_root: str | Path,
+    run_id: str,
+    filename: str,
+    payload: dict[str, Any],
+) -> Path | None:
+    run_dir = _safe_run_dir(trace_root, run_id)
+    if run_dir is None:
+        return None
+    if not _ensure_trace_dir(run_dir):
+        return None
+
+    path = _safe_artifact_path(run_dir, filename)
+    if path is None:
+        return None
+    if _unsafe_existing_path(path):
+        return None
+
+    return _write_json_file(path, payload)
+
+
+def _write_json_file(path: Path, payload: dict[str, Any]) -> Path | None:
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(  # skylos: ignore[SKY-D215] guarded project-local artifact temp path
+            temp_path, flags, 0o600
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if _unsafe_existing_path(path):
+            return None
+        os.replace(temp_path, path)
+        return path
+    except (OSError, TypeError, ValueError):
+        return None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            if temp_path.exists() and not temp_path.is_symlink():
+                temp_path.unlink()
+        except OSError:
+            pass
+
+
+def _safe_run_dir(trace_root: str | Path, run_id: str) -> Path | None:
+    try:
+        root = Path(trace_root).resolve()
+        run_dir = root / sanitize_run_id(run_id)
+        run_dir.resolve(strict=False).relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return run_dir
+
+
+def _safe_artifact_path(run_dir: Path, filename: str) -> Path | None:
+    candidate_name = Path(filename).name
+    if not candidate_name or candidate_name != filename:
+        return None
+    try:
+        path = run_dir / candidate_name
+        path.resolve(strict=False).relative_to(run_dir.resolve(strict=False))
+    except (OSError, ValueError):
+        return None
+    return path
+
+
+def _ensure_trace_dir(path: Path) -> bool:
+    current = Path(path.anchor) if path.is_absolute() else Path(".")
+    parts = path.parts[1:] if path.is_absolute() else path.parts
+    for part in parts:
+        current = current / part
+        try:
+            if current.is_symlink():
+                return False
+            if current.exists():
+                if not current.is_dir():
+                    return False
+                continue
+            current.mkdir(mode=0o700)
+        except OSError:
+            return False
+    return True
+
+
+def _unsafe_existing_path(path: Path) -> bool:
+    try:
+        return path.exists() and (path.is_symlink() or not path.is_file())
+    except OSError:
+        return True

--- a/skylos/llm/harness/types.py
+++ b/skylos/llm/harness/types.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+SAFE_RUN_ID_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "._-"
+)
+MAX_RUN_ID_LENGTH = 96
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sanitize_run_id(value: str | None) -> str:
+    cleaned = "".join(
+        char if char in SAFE_RUN_ID_CHARS else "_" for char in str(value or "").strip()
+    )
+    cleaned = cleaned.strip("._-")
+    cleaned = cleaned[:MAX_RUN_ID_LENGTH].strip("._-")
+    if not cleaned or cleaned in {".", ".."}:
+        return f"run-{uuid4().hex[:8]}"
+    return cleaned
+
+
+class HarnessBudgetExceeded(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class HarnessBudget:
+    max_steps: int | None = None
+    max_findings: int | None = None
+    max_llm_calls: int | None = None
+    max_seconds: float | None = None
+    max_fixes: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "max_steps": self.max_steps,
+            "max_findings": self.max_findings,
+            "max_llm_calls": self.max_llm_calls,
+            "max_seconds": self.max_seconds,
+            "max_fixes": self.max_fixes,
+        }
+
+
+@dataclass
+class HarnessStep:
+    name: str
+    status: str
+    started_at: str
+    input_summary: dict[str, Any] = field(default_factory=dict)
+    output_summary: dict[str, Any] = field(default_factory=dict)
+    ended_at: str | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_ms": self.duration_ms,
+            "input_summary": dict(self.input_summary),
+            "output_summary": dict(self.output_summary),
+            "error": self.error,
+        }
+
+
+@dataclass
+class HarnessToolCall:
+    name: str
+    status: str
+    started_at: str
+    input_summary: dict[str, Any] = field(default_factory=dict)
+    output_summary: dict[str, Any] = field(default_factory=dict)
+    phase: str | None = None
+    ended_at: str | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "phase": self.phase,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_ms": self.duration_ms,
+            "input_summary": dict(self.input_summary),
+            "output_summary": dict(self.output_summary),
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class HarnessDecision:
+    phase: str
+    code: str
+    target: dict[str, Any]
+    details: dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(default_factory=utc_now_iso)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase,
+            "code": self.code,
+            "target": dict(self.target),
+            "details": dict(self.details),
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass
+class HarnessRun:
+    run_id: str
+    kind: str
+    project_root: str
+    budget: HarnessBudget = field(default_factory=HarnessBudget)
+    status: str = "running"
+    started_at: str = field(default_factory=utc_now_iso)
+    ended_at: str | None = None
+    duration_ms: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    steps: list[HarnessStep] = field(default_factory=list)
+    tool_calls: list[HarnessToolCall] = field(default_factory=list)
+    decisions: list[HarnessDecision] = field(default_factory=list)
+    usage: dict[str, int | float] = field(default_factory=dict)
+    trace_path: str | None = None
+    state_path: str | None = None
+    summary_path: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "kind": self.kind,
+            "project_root": self.project_root,
+            "status": self.status,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_ms": self.duration_ms,
+            "metadata": dict(self.metadata),
+            "budget": self.budget.to_dict(),
+            "budget_used": self.budget_used(),
+            "budget_remaining": self.budget_remaining(),
+            "steps": [step.to_dict() for step in self.steps],
+            "current_phase": self.current_phase(),
+            "completed_phases": self.completed_phases(),
+            "failed_phase": self.failed_phase(),
+            "tool_calls": [call.to_dict() for call in self.tool_calls],
+            "decisions": [decision.to_dict() for decision in self.decisions],
+            "trace_path": self.trace_path,
+            "state_path": self.state_path,
+            "summary_path": self.summary_path,
+            "error": self.error,
+        }
+
+    def state_dict(self) -> dict[str, Any]:
+        return self.to_dict()
+
+    def summary_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "kind": self.kind,
+            "project_root": self.project_root,
+            "status": self.status,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_ms": self.duration_ms,
+            "budget": self.budget.to_dict(),
+            "budget_used": self.budget_used(),
+            "budget_remaining": self.budget_remaining(),
+            "phase_count": len(self.steps),
+            "completed_phases": self.completed_phases(),
+            "failed_phase": self.failed_phase(),
+            "tool_call_count": len(self.tool_calls),
+            "decision_count": len(self.decisions),
+            "trace_path": self.trace_path,
+            "state_path": self.state_path,
+            "summary_path": self.summary_path,
+            "error": self.error,
+        }
+
+    def current_phase(self) -> str | None:
+        for step in reversed(self.steps):
+            if step.status == "running":
+                return step.name
+        return None
+
+    def completed_phases(self) -> list[str]:
+        return [step.name for step in self.steps if step.status == "completed"]
+
+    def failed_phase(self) -> str | None:
+        for step in reversed(self.steps):
+            if step.status == "failed":
+                return step.name
+        return None
+
+    def budget_remaining(self) -> dict[str, int | float | None]:
+        remaining: dict[str, int | float | None] = {}
+        budget_map = {
+            "steps": self.budget.max_steps,
+            "findings": self.budget.max_findings,
+            "llm_calls": self.budget.max_llm_calls,
+            "seconds": self.budget.max_seconds,
+            "fixes": self.budget.max_fixes,
+        }
+        used_map = self.budget_used()
+        for key, max_value in budget_map.items():
+            if max_value is None:
+                remaining[key] = None
+            else:
+                remaining[key] = max_value - used_map[key]
+        return remaining
+
+    def budget_used(self) -> dict[str, int | float]:
+        return {
+            "steps": len(self.steps),
+            "findings": self.usage.get("findings", 0),
+            "llm_calls": self.usage.get("llm_calls", 0),
+            "seconds": self.usage.get("seconds", 0),
+            "fixes": self.usage.get("fixes", 0),
+        }
+
+
+@dataclass(frozen=True)
+class HarnessResult:
+    output: Any
+    run: HarnessRun
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "output": self.output,
+            "run": self.run.to_dict(),
+        }
+
+
+def resolved_project_root(path: str | Path) -> Path:
+    resolved = Path(path).resolve()
+    return resolved.parent if resolved.is_file() else resolved

--- a/skylos/llm/harness/verification.py
+++ b/skylos/llm/harness/verification.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from skylos.llm.verify_orchestrator import run_verification
+
+from .guards import enforce_findings_budget, enforce_llm_call_budget
+from .runner import HarnessRunner
+from .trace import default_trace_root
+from .tools import default_verification_tool_registry
+from .types import HarnessBudget, HarnessResult
+
+
+def run_verification_harness(
+    *,
+    findings: list[dict[str, Any]],
+    defs_map: dict[str, Any],
+    project_root: str | Path,
+    harness_budget: HarnessBudget | None = None,
+    harness_run_id: str | None = None,
+    harness_trace_root: str | Path | None = None,
+    model: str = "gpt-4.1",
+    api_key: str | None = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    max_verify: int = 50,
+    max_challenge: int = 20,
+    confidence_range: tuple[int, int] = (40, 100),
+    enable_entry_discovery: bool = True,
+    enable_suppression_challenge: bool = True,
+    enable_survivor_challenge: bool = True,
+    batch_mode: bool = True,
+    max_suppression_audit: int = 20,
+    quiet: bool = False,
+    verification_mode: str = "production",
+    grep_workers: int = 4,
+    parallel_grep: bool = False,
+) -> HarnessResult:
+    budget = harness_budget or HarnessBudget()
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=project_root,
+        budget=budget,
+        run_id=harness_run_id,
+        trace_root=(
+            harness_trace_root
+            if harness_trace_root is not None
+            else default_trace_root(project_root)
+        ),
+        metadata={
+            "verification_mode": verification_mode,
+            "batch_mode": batch_mode,
+        },
+        tool_registry=default_verification_tool_registry(),
+    )
+
+    try:
+        runner.update_usage(findings=len(findings))
+        enforce_findings_budget(findings, budget)
+        output = run_verification(
+            findings=findings,
+            defs_map=defs_map,
+            project_root=project_root,
+            model=model,
+            api_key=api_key,
+            provider=provider,
+            base_url=base_url,
+            max_verify=max_verify,
+            max_challenge=max_challenge,
+            confidence_range=confidence_range,
+            enable_entry_discovery=enable_entry_discovery,
+            enable_suppression_challenge=enable_suppression_challenge,
+            enable_survivor_challenge=enable_survivor_challenge,
+            batch_mode=batch_mode,
+            max_suppression_audit=max_suppression_audit,
+            quiet=quiet,
+            verification_mode=verification_mode,
+            grep_workers=grep_workers,
+            parallel_grep=parallel_grep,
+            harness_runner=runner,
+            harness_budget=budget,
+        )
+        llm_calls = _llm_calls(output)
+        enforce_llm_call_budget(llm_calls, budget)
+    except Exception as exc:
+        if runner.run.ended_at is None:
+            runner.finish(status="failed", error=f"{type(exc).__name__}: {exc}")
+        raise
+
+    runner.finish()
+    return HarnessResult(output=output, run=runner.run)
+
+
+def _llm_calls(result: dict[str, Any]) -> int | None:
+    stats = result.get("stats") if isinstance(result, dict) else None
+    if not isinstance(stats, dict):
+        return None
+    value = stats.get("llm_calls")
+    return value if isinstance(value, int) else None

--- a/skylos/llm/verification/__init__.py
+++ b/skylos/llm/verification/__init__.py
@@ -1,0 +1,1 @@
+"""Internal verification orchestration helpers."""

--- a/skylos/llm/verification/candidate_selection.py
+++ b/skylos/llm/verification/candidate_selection.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Any
+
+from skylos.llm.dead_code_verifier import Verdict, _parse_confidence, _parse_int
+
+from .runtime import VerificationRuntime
+
+
+def run_candidate_selection_phase(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    discovered_eps: list[Any],
+    *,
+    max_verify: int,
+    confidence_range: tuple[int, int],
+    judge_all_mode: bool,
+) -> list[dict]:
+    with ctx.phase(
+        "candidate_selection",
+        {
+            "finding_count": len(findings),
+            "max_verify": max_verify,
+            "confidence_low": confidence_range[0],
+            "confidence_high": confidence_range[1],
+        },
+    ) as phase_step:
+        lo, hi = confidence_range
+        to_verify = []
+        for finding in findings:
+            if _should_judge_candidate(finding, judge_all_mode, lo, hi):
+                _select_judged_candidate(
+                    ctx,
+                    finding,
+                    discovered_eps,
+                    judge_all_mode,
+                    to_verify,
+                )
+            else:
+                _mark_candidate_skipped(finding, hi)
+
+        to_verify = to_verify[:max_verify]
+        _record_candidate_selection_decisions(ctx, findings, to_verify)
+        phase_step.set_output_summary(
+            to_verify=len(to_verify),
+            deterministic_suppressed=ctx.stats.deterministic_suppressed,
+            verified_false_positive=ctx.stats.verified_false_positive,
+        )
+    return to_verify
+
+
+def _should_judge_candidate(
+    finding: dict,
+    judge_all_mode: bool,
+    confidence_low: int,
+    confidence_high: int,
+) -> bool:
+    conf = _parse_confidence(finding.get("confidence", 60))
+    refs = _parse_int(finding.get("references", 0))
+    return refs == 0 and (judge_all_mode or confidence_low <= conf <= confidence_high)
+
+
+def _select_judged_candidate(
+    ctx: VerificationRuntime,
+    finding: dict,
+    discovered_eps: list[Any],
+    judge_all_mode: bool,
+    to_verify: list[dict],
+) -> None:
+    matched_ep = _find_discovered_entry_point(finding, discovered_eps)
+    if matched_ep is not None:
+        _handle_discovered_entry_point(ctx, finding, matched_ep, judge_all_mode, to_verify)
+        return
+    _handle_deterministic_candidate(ctx, finding, judge_all_mode, to_verify)
+
+
+def _find_discovered_entry_point(finding: dict, discovered_eps: list[Any]) -> Any | None:
+    full_name = finding.get("full_name", finding.get("name", ""))
+    return next((ep for ep in discovered_eps if ep.name == full_name), None)
+
+
+def _handle_discovered_entry_point(
+    ctx: VerificationRuntime,
+    finding: dict,
+    matched_ep: Any,
+    judge_all_mode: bool,
+    to_verify: list[dict],
+) -> None:
+    if judge_all_mode:
+        finding["_judge_discovered_entry_point"] = (
+            f"{matched_ep.source}: {matched_ep.reason}"
+        )
+        ctx.ops.record_prefilter_fact(
+            finding,
+            code="discovered_entry_point",
+            rationale="Project configuration references this symbol as an entry point",
+            evidence=[f"source={matched_ep.source}", f"reason={matched_ep.reason}"],
+        )
+        to_verify.append(finding)
+        return
+
+    finding["_llm_verdict"] = Verdict.FALSE_POSITIVE.value
+    finding["_llm_rationale"] = "Discovered as entry point in project config"
+    finding["_verified_by_llm"] = True
+    finding["_adjusted_confidence"] = 20
+    ctx.stats.verified_false_positive += 1
+
+
+def _handle_deterministic_candidate(
+    ctx: VerificationRuntime,
+    finding: dict,
+    judge_all_mode: bool,
+    to_verify: list[dict],
+) -> None:
+    decision = _run_deterministic_suppression(ctx, finding)
+    if decision is None:
+        to_verify.append(finding)
+        return
+    if judge_all_mode and not decision.hard:
+        ctx.ops.record_prefilter_fact(
+            finding,
+            code=decision.code,
+            rationale=decision.rationale,
+            evidence=decision.evidence,
+        )
+        to_verify.append(finding)
+        return
+    _apply_deterministic_suppression(ctx, finding, decision)
+
+
+def _run_deterministic_suppression(ctx: VerificationRuntime, finding: dict) -> Any:
+    return ctx.run_tool(
+        "deterministic_suppression",
+        lambda finding=finding: ctx.ops.deterministic_suppress(
+            finding,
+            ctx.source_cache,
+            project_root=ctx.grep_root,
+            repo_facts=ctx.repo_facts,
+            defs_map=ctx.defs_map,
+            grep_cache=ctx.grep_cache,
+        ),
+        input_summary={
+            "name": finding.get("full_name") or finding.get("name"),
+            "file": finding.get("file"),
+            "type": finding.get("type"),
+        },
+        output_summary=lambda result: {
+            "suppressed": result is not None,
+            "code": result.code if result is not None else None,
+            "hard": bool(result.hard) if result is not None else None,
+        },
+    )
+
+
+def _apply_deterministic_suppression(
+    ctx: VerificationRuntime,
+    finding: dict,
+    decision: Any,
+) -> None:
+    finding["_llm_verdict"] = Verdict.FALSE_POSITIVE.value
+    finding["_llm_rationale"] = decision.rationale
+    finding["_suppression_reason"] = decision.code
+    finding["_suppression_evidence"] = list(decision.evidence)
+    finding["_suppression_hard"] = bool(decision.hard)
+    finding["_deterministically_suppressed"] = True
+    finding["_verified_by_llm"] = False
+    finding["_adjusted_confidence"] = 20
+    ctx.stats.deterministic_suppressed += 1
+
+
+def _mark_candidate_skipped(finding: dict, confidence_high: int) -> None:
+    conf = _parse_confidence(finding.get("confidence", 60))
+    refs = _parse_int(finding.get("references", 0))
+    if refs > 0:
+        finding["_llm_verdict"] = "SKIPPED_HAS_REFS"
+        finding["_llm_rationale"] = f"Has {refs} references"
+    elif conf > confidence_high:
+        finding["_llm_verdict"] = "SKIPPED_HIGH_CONF"
+        finding["_llm_rationale"] = "High confidence from static; skipped LLM"
+    else:
+        finding["_llm_verdict"] = "SKIPPED_LOW_CONF"
+        finding["_llm_rationale"] = "Below threshold"
+
+
+def _record_candidate_selection_decisions(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    to_verify: list[dict],
+) -> None:
+    to_verify_ids = {id(finding) for finding in to_verify}
+    for finding in findings:
+        verdict = str(finding.get("_llm_verdict") or "")
+        ctx.record_decision(
+            "candidate_selection",
+            _candidate_selection_code(finding, verdict, to_verify_ids),
+            finding,
+            {"verdict": verdict or None},
+        )
+
+
+def _candidate_selection_code(
+    finding: dict,
+    verdict: str,
+    to_verify_ids: set[int],
+) -> str:
+    if id(finding) in to_verify_ids:
+        return "sent_to_llm"
+    if finding.get("_deterministically_suppressed"):
+        return "deterministically_suppressed"
+    if verdict == Verdict.FALSE_POSITIVE.value:
+        return "discovered_entry_point"
+    if verdict == "SKIPPED_HAS_REFS":
+        return "skipped_has_refs"
+    if verdict == "SKIPPED_HIGH_CONF":
+        return "skipped_high_confidence"
+    if verdict == "SKIPPED_LOW_CONF":
+        return "skipped_low_confidence"
+    return "candidate_unresolved"

--- a/skylos/llm/verification/completion_phases.py
+++ b/skylos/llm/verification/completion_phases.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from skylos.llm.dead_code_verifier import Verdict
+
+from .runtime import VerificationRuntime
+
+
+def run_propagate_alive_phase(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+) -> None:
+    with ctx.phase("propagate_alive", {"finding_count": len(findings)}) as phase_step:
+        fp_names, tp_findings = _partition_alive_findings(findings)
+        findings_by_full_name = {
+            finding.get("full_name", ""): finding for finding in findings
+        }
+
+        propagated = 0
+        for finding in tp_findings:
+            if _propagate_from_alive_callers(ctx, finding, fp_names):
+                propagated += 1
+                continue
+            if _propagate_from_mutual_dependency(
+                ctx,
+                finding,
+                fp_names,
+                findings_by_full_name,
+            ):
+                propagated += 1
+
+        if propagated:
+            ctx.log(
+                "  Transitive alive propagation: "
+                f"{propagated} findings reclassified as FP"
+            )
+        phase_step.set_output_summary(
+            true_positive_inputs=len(tp_findings),
+            propagated=propagated,
+        )
+
+
+def _partition_alive_findings(findings: list[dict]) -> tuple[set[str], list[dict]]:
+    fp_names = set()
+    tp_findings = []
+    for finding in findings:
+        verdict = finding.get("_llm_verdict", "")
+        full_name = finding.get("full_name", finding.get("name", ""))
+        if verdict == "FALSE_POSITIVE":
+            fp_names.add(full_name)
+        elif verdict == "TRUE_POSITIVE":
+            tp_findings.append(finding)
+    return fp_names, tp_findings
+
+
+def _propagate_from_alive_callers(
+    ctx: VerificationRuntime,
+    finding: dict,
+    fp_names: set[str],
+) -> bool:
+    alive_callers = [
+        caller for caller in finding.get("called_by", []) if caller in fp_names
+    ]
+    if not alive_callers:
+        return False
+    _mark_transitive_alive(
+        ctx,
+        finding,
+        fp_names,
+        reason=(
+            "Transitive alive: called by "
+            f"{alive_callers[0]} which is confirmed alive "
+            "(FALSE_POSITIVE). Original rationale: "
+            f"{finding.get('_llm_rationale', '')}"
+        ),
+        decision_detail={"alive_caller": alive_callers[0]},
+    )
+    return True
+
+
+def _propagate_from_mutual_dependency(
+    ctx: VerificationRuntime,
+    finding: dict,
+    fp_names: set[str],
+    findings_by_full_name: dict[str, dict],
+) -> bool:
+    full_name = finding.get("full_name", finding.get("name", ""))
+    for callee in finding.get("calls", []):
+        other_finding = findings_by_full_name.get(callee)
+        if other_finding is None or callee not in fp_names:
+            continue
+        if full_name in other_finding.get("called_by", []):
+            _mark_transitive_alive(
+                ctx,
+                finding,
+                fp_names,
+                reason=(
+                    "Transitive alive: mutual dependency with "
+                    f"{callee} which is alive. Original rationale: "
+                    f"{finding.get('_llm_rationale', '')}"
+                ),
+                decision_detail={"alive_callee": callee},
+            )
+            return True
+    return False
+
+
+def _mark_transitive_alive(
+    ctx: VerificationRuntime,
+    finding: dict,
+    fp_names: set[str],
+    *,
+    reason: str,
+    decision_detail: dict[str, Any],
+) -> None:
+    full_name = finding.get("full_name", finding.get("name", ""))
+    finding["_llm_verdict"] = "FALSE_POSITIVE"
+    finding["_llm_rationale"] = reason
+    finding["_llm_challenged"] = True
+    finding["_adjusted_confidence"] = 50
+    fp_names.add(full_name)
+    ctx.stats.verified_true_positive -= 1
+    ctx.stats.verified_false_positive += 1
+    ctx.record_decision(
+        "propagate_alive",
+        "transitive_alive",
+        finding,
+        decision_detail,
+    )
+
+
+def run_survivor_challenge_phase(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    *,
+    enable_survivor_challenge: bool,
+    max_challenge: int,
+    batch_mode: bool,
+) -> list[dict[str, Any]]:
+    new_dead = []
+    with ctx.phase(
+        "survivor_challenge",
+        {
+            "enabled": enable_survivor_challenge,
+            "max_challenge": max_challenge,
+            "batch_mode": batch_mode,
+        },
+    ) as phase_step:
+        survivor_start_calls = ctx.stats.llm_calls
+        survivor_start_reclassified = ctx.stats.survivors_reclassified_dead
+        survivors: list[dict] = []
+        local_on_emit_survivors: list[dict] = []
+
+        if enable_survivor_challenge:
+            ctx.log("Pass 4: Challenging survivors with heuristic refs...")
+            local_on_emit_survivors = _run_local_survivor_scan(ctx, findings)
+            _append_local_survivor_dead(ctx, local_on_emit_survivors, new_dead)
+            survivors = _run_survivor_discovery(ctx, findings, max_challenge)
+            _challenge_survivors(ctx, survivors, new_dead, batch_mode)
+
+        phase_step.set_output_summary(
+            local_reclassified=len(local_on_emit_survivors),
+            survivors=len(survivors),
+            new_dead=len(new_dead),
+            llm_calls=ctx.stats.llm_calls - survivor_start_calls,
+            reclassified_dead=(
+                ctx.stats.survivors_reclassified_dead
+                - survivor_start_reclassified
+            ),
+        )
+    return new_dead
+
+
+def _run_local_survivor_scan(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+) -> list[dict]:
+    return ctx.run_tool(
+        "survivor_local_scan",
+        lambda: ctx.ops.find_local_on_emit_survivors(
+            ctx.defs_map,
+            findings,
+            ctx.grep_root,
+        ),
+        input_summary={"finding_count": len(findings)},
+        output_summary=lambda result: {"survivors": len(result)},
+    )
+
+
+def _append_local_survivor_dead(
+    ctx: VerificationRuntime,
+    local_on_emit_survivors: list[dict],
+    new_dead: list[dict[str, Any]],
+) -> None:
+    if not local_on_emit_survivors:
+        return
+    ctx.stats.survivors_challenged += len(local_on_emit_survivors)
+    ctx.stats.survivors_reclassified_dead += len(local_on_emit_survivors)
+    for survivor in local_on_emit_survivors:
+        new_dead.append(_local_survivor_dead_finding(survivor))
+        ctx.record_decision(
+            "survivor_challenge",
+            "local_survivor_reclassified",
+            survivor,
+            {"source": "registry_survivor_challenge"},
+        )
+    ctx.log(
+        "  Reclassified "
+        f"{len(local_on_emit_survivors)} local on/emit listeners as dead"
+    )
+
+
+def _local_survivor_dead_finding(survivor: dict) -> dict[str, Any]:
+    owner = survivor.get("_registry_owner", "registry")
+    event_name = survivor.get("_event_name", "")
+    symbol_type = survivor.get("type", "function")
+    return {
+        "name": survivor["name"],
+        "simple_name": survivor["simple_name"],
+        "full_name": survivor["full_name"],
+        "file": survivor["file"],
+        "line": survivor["line"],
+        "type": symbol_type,
+        "confidence": min(95, int(survivor.get("confidence", 50) or 50) + 25),
+        "references": 0,
+        "message": f"Unused {symbol_type}: {survivor['name']}",
+        "_category": "dead_code",
+        "_llm_verdict": "TRUE_POSITIVE",
+        "_llm_rationale": (
+            f"Registered via @{owner}.on('{event_name}') but no "
+            f"{owner}.emit('{event_name}') call exists in app/tests."
+        ),
+        "_source": "registry_survivor_challenge",
+    }
+
+
+def _run_survivor_discovery(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    max_challenge: int,
+) -> list[dict]:
+    survivors = ctx.run_tool(
+        "survivor_discovery",
+        lambda: ctx.ops.find_survivors(ctx.defs_map, findings),
+        input_summary={"finding_count": len(findings)},
+        output_summary=lambda result: {"survivors": len(result)},
+    )
+    survivors = survivors[:max_challenge]
+    ctx.stats.survivors_challenged += len(survivors)
+    return survivors
+
+
+def _challenge_survivors(
+    ctx: VerificationRuntime,
+    survivors: list[dict],
+    new_dead: list[dict[str, Any]],
+    batch_mode: bool,
+) -> None:
+    if not survivors:
+        ctx.log("  No survivors with heuristic refs to challenge.")
+        return
+
+    survivor_cache = ctx.ops.build_source_cache([], ctx.defs_map, survivors)
+    ctx.source_cache.update(survivor_cache)
+    if batch_mode and len(survivors) > 1:
+        _run_batch_survivor_challenge(ctx, survivors, new_dead)
+    else:
+        _run_individual_survivor_challenge(ctx, survivors, new_dead)
+    ctx.log(
+        f"  Challenged {len(survivors)}, "
+        f"reclassified {ctx.stats.survivors_reclassified_dead} as dead"
+    )
+
+
+def _run_batch_survivor_challenge(
+    ctx: VerificationRuntime,
+    survivors: list[dict],
+    new_dead: list[dict[str, Any]],
+) -> None:
+    planned_calls = max(1, (len(survivors) + 4) // 5)
+    ctx.check_llm_budget(planned_calls, "survivor_challenge")
+    batch_results = ctx.run_tool(
+        "survivor_batch_challenge",
+        lambda: ctx.ops.batch_challenge_survivors(
+            ctx.agent,
+            survivors,
+            ctx.defs_map,
+            ctx.source_cache,
+        ),
+        input_summary={
+            "survivors": len(survivors),
+            "planned_llm_calls": planned_calls,
+        },
+        output_summary=lambda result: {"result_count": len(result)},
+    )
+    ctx.add_llm_calls(planned_calls)
+    for survivor, result in zip(survivors, batch_results):
+        _append_llm_survivor_dead(ctx, survivor, result, new_dead)
+
+
+def _run_individual_survivor_challenge(
+    ctx: VerificationRuntime,
+    survivors: list[dict],
+    new_dead: list[dict[str, Any]],
+) -> None:
+    ctx.check_llm_budget(len(survivors), "survivor_challenge")
+    for survivor in survivors:
+        result = _run_survivor_challenge(ctx, survivor)
+        ctx.add_llm_calls(1)
+        _append_llm_survivor_dead(ctx, survivor, result, new_dead)
+
+
+def _run_survivor_challenge(ctx: VerificationRuntime, survivor: dict) -> Any:
+    return ctx.run_tool(
+        "survivor_challenge",
+        lambda survivor=survivor: ctx.ops.challenge_survivor(
+            ctx.agent,
+            survivor,
+            ctx.defs_map,
+            ctx.source_cache,
+        ),
+        input_summary={
+            "name": survivor.get("full_name") or survivor.get("name"),
+            "file": survivor.get("file"),
+        },
+        output_summary=lambda result: {
+            "verdict": result.verdict.value,
+            "suggested_confidence": result.suggested_confidence,
+        },
+    )
+
+
+def _append_llm_survivor_dead(
+    ctx: VerificationRuntime,
+    survivor: dict,
+    result: Any,
+    new_dead: list[dict[str, Any]],
+) -> None:
+    if result.verdict != Verdict.TRUE_POSITIVE:
+        return
+    ctx.stats.survivors_reclassified_dead += 1
+    new_dead.append(_llm_survivor_dead_finding(survivor, result))
+    ctx.record_decision(
+        "survivor_challenge",
+        "llm_survivor_reclassified",
+        survivor,
+        {"source": "llm_survivor_challenge"},
+    )
+
+
+def _llm_survivor_dead_finding(survivor: dict, result: Any) -> dict[str, Any]:
+    symbol_type = survivor.get("type", "function")
+    return {
+        "name": result.name,
+        "full_name": result.full_name,
+        "file": result.file,
+        "line": result.line,
+        "type": symbol_type,
+        "confidence": result.suggested_confidence,
+        "references": 0,
+        "heuristic_refs": result.heuristic_refs,
+        "message": f"Unused {symbol_type}: {result.name}",
+        "_category": "dead_code",
+        "_llm_verdict": "TRUE_POSITIVE",
+        "_llm_rationale": result.rationale,
+        "_source": "llm_survivor_challenge",
+    }
+
+
+def run_finalize_phase(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    new_dead: list[dict[str, Any]],
+    discovered_eps: list[Any],
+    *,
+    start_time: float,
+    verification_mode: str,
+) -> dict[str, Any]:
+    with ctx.phase("finalize", {"finding_count": len(findings)}) as phase_step:
+        ctx.stats.elapsed_seconds = round(time.time() - start_time, 1)
+
+        try:
+            usage = (
+                getattr(ctx.agent.get_adapter(), "total_usage", {}) or {}
+                if ctx.stats.llm_calls
+                else {}
+            )
+        except (AttributeError, ImportError, RuntimeError, TypeError):
+            usage = {}
+        ctx.stats.prompt_tokens = int(usage.get("prompt_tokens") or 0)
+        ctx.stats.completion_tokens = int(usage.get("completion_tokens") or 0)
+        ctx.stats.total_tokens = int(usage.get("total_tokens") or 0)
+
+        ctx.log(
+            f"\nDone in {ctx.stats.elapsed_seconds}s "
+            f"({ctx.stats.llm_calls} LLM calls)"
+        )
+
+        output = ctx.ops.build_verification_output(
+            findings=findings,
+            new_dead=new_dead,
+            discovered_eps=discovered_eps,
+            stats=ctx.stats,
+            verification_mode=verification_mode,
+        )
+
+        ctx.ops.attach_feedback_summary(output, ctx.log)
+
+        ctx.grep_cache.save(ctx.grep_root)
+        phase_step.set_output_summary(
+            verified_findings=len(output.get("verified_findings") or []),
+            new_dead_code=len(output.get("new_dead_code") or []),
+            total_llm_calls=ctx.stats.llm_calls,
+            elapsed_seconds=ctx.stats.elapsed_seconds,
+        )
+    return output

--- a/skylos/llm/verification/phases.py
+++ b/skylos/llm/verification/phases.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from skylos.llm.dead_code_verifier import Verdict, _parse_confidence
+from skylos.llm.verify_llm import HAIKU_PREFILTER_MAX_BATCH
+
+from .candidate_selection import run_candidate_selection_phase
+from .runtime import VerificationOps, VerificationRuntime
+from .suppression_audit import run_suppression_audit_phase
+from .verify_findings import run_verify_findings_phase
+
+logger = logging.getLogger(__name__)
+
+
+def run_entry_discovery_phase(
+    ctx: VerificationRuntime,
+    *,
+    enable_entry_discovery: bool,
+) -> list[Any]:
+    discovered_eps = []
+    if not enable_entry_discovery:
+        return discovered_eps
+
+    with ctx.phase(
+        "entry_discovery",
+        {"definition_count": len(ctx.defs_map)},
+    ) as phase_step:
+        ctx.log("Pass 1: Discovering hidden entry points...")
+        known_eps = []
+        for name, info in ctx.defs_map.items():
+            if isinstance(info, dict) and info.get("type") in (
+                "function",
+                "method",
+            ):
+                known_eps.append(name)
+
+        known_eps = known_eps[:100]
+        planned_llm_calls = ctx.ops.entry_discovery_planned_llm_calls(
+            ctx.config_root,
+            known_eps,
+            ctx.repo_facts,
+        )
+        ctx.check_llm_budget(planned_llm_calls, "entry_discovery")
+        discovered_eps = ctx.run_tool(
+            "entry_discovery",
+            lambda: ctx.ops.discover_entry_points(
+                ctx.agent,
+                ctx.config_root,
+                known_eps,
+            ),
+            input_summary={"known_entry_points": len(known_eps)},
+            output_summary=lambda result: {"entry_points": len(result)},
+        )
+        ctx.stats.entry_points_discovered = len(discovered_eps)
+        ctx.add_llm_calls(planned_llm_calls)
+
+        if discovered_eps:
+            ctx.log(f"  Found {len(discovered_eps)} new entry points:")
+            for ep in discovered_eps:
+                ctx.log(f"    - {ep.name} (from {ep.source})")
+        else:
+            ctx.log("  No new entry points found.")
+        phase_step.set_output_summary(
+            entry_points=len(discovered_eps),
+            planned_llm_calls=planned_llm_calls,
+            llm_calls=planned_llm_calls,
+        )
+    return discovered_eps
+
+
+def run_haiku_prefilter_phase(
+    ctx: VerificationRuntime,
+    to_verify: list[dict],
+    *,
+    config: Any,
+) -> list[dict]:
+    with ctx.phase("haiku_prefilter", {"candidate_count": len(to_verify)}) as phase_step:
+        haiku_start_calls = ctx.stats.llm_calls
+        exported_candidates = []
+        dismissed_count = 0
+        planned_haiku_calls = 0
+        if to_verify:
+            haiku_key = config.api_key or os.environ.get("ANTHROPIC_API_KEY")
+
+            exported_candidates = [
+                finding
+                for finding in to_verify
+                if finding.get("is_exported")
+                and _parse_confidence(finding.get("confidence", 0)) >= 80
+            ]
+            if exported_candidates and haiku_key:
+                planned_haiku_calls = max(
+                    1,
+                    (len(exported_candidates) + HAIKU_PREFILTER_MAX_BATCH - 1)
+                    // HAIKU_PREFILTER_MAX_BATCH,
+                )
+                ctx.check_llm_budget(planned_haiku_calls, "haiku_prefilter")
+                ctx.log(
+                    "Pass 1.5: Haiku pre-filter for "
+                    f"{len(exported_candidates)} exported symbols..."
+                )
+                try:
+                    haiku_agent = ctx.ops.create_haiku_agent(haiku_key)
+                    kept, dismissed = ctx.run_tool(
+                        "haiku_prefilter",
+                        lambda: ctx.ops.haiku_prefilter_exports(
+                            haiku_agent,
+                            exported_candidates,
+                            ctx.source_cache,
+                        ),
+                        input_summary={
+                            "exported_candidates": len(exported_candidates),
+                            "planned_llm_calls": planned_haiku_calls,
+                        },
+                        output_summary=lambda result: {
+                            "kept": len(result[0]),
+                            "dismissed": len(result[1]),
+                        },
+                    )
+                    ctx.stats.haiku_prefiltered = len(dismissed)
+                    ctx.stats.verified_false_positive += len(dismissed)
+                    ctx.add_llm_calls(planned_haiku_calls)
+                    dismissed_count = len(dismissed)
+                    dismissed_set = {id(finding) for finding in dismissed}
+                    for finding in dismissed:
+                        ctx.record_decision(
+                            "haiku_prefilter",
+                            "haiku_public_api_dismissed",
+                            finding,
+                            {"verdict": Verdict.FALSE_POSITIVE.value},
+                        )
+                    to_verify = [
+                        finding
+                        for finding in to_verify
+                        if id(finding) not in dismissed_set
+                    ]
+                    if dismissed:
+                        ctx.log(
+                            "  Haiku dismissed "
+                            f"{len(dismissed)} exported symbols as public API"
+                        )
+                except Exception as exc:
+                    logger.warning(f"Haiku pre-filter setup failed: {exc}")
+        phase_step.set_output_summary(
+            exported_candidates=len(exported_candidates),
+            dismissed=dismissed_count,
+            remaining_to_verify=len(to_verify),
+            planned_llm_calls=planned_haiku_calls,
+            llm_calls=ctx.stats.llm_calls - haiku_start_calls,
+        )
+    return to_verify

--- a/skylos/llm/verification/runtime.py
+++ b/skylos/llm/verification/runtime.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class VerificationOps:
+    discover_entry_points: Any
+    entry_discovery_planned_llm_calls: Any
+    record_prefilter_fact: Any
+    deterministic_suppress: Any
+    create_haiku_agent: Any
+    haiku_prefilter_exports: Any
+    estimate_batches: Any
+    batch_verify_findings: Any
+    build_graph_context: Any
+    verify_with_graph_context: Any
+    should_audit_suppression: Any
+    audit_suppressed_finding: Any
+    find_local_on_emit_survivors: Any
+    find_survivors: Any
+    build_source_cache: Any
+    batch_challenge_survivors: Any
+    challenge_survivor: Any
+    build_verification_output: Any
+    attach_feedback_summary: Any
+
+
+@dataclass
+class VerificationRuntime:
+    agent: Any
+    defs_map: dict[str, Any]
+    grep_root: str
+    config_root: Path
+    grep_cache: Any
+    source_cache: dict[str, str]
+    repo_facts: Any
+    stats: Any
+    log: Any
+    phase: Any
+    check_llm_budget: Any
+    record_decision: Any
+    add_llm_calls: Any
+    run_tool: Any
+    ops: VerificationOps

--- a/skylos/llm/verification/suppression_audit.py
+++ b/skylos/llm/verification/suppression_audit.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any
+
+from skylos.llm.dead_code_verifier import Verdict
+
+from .runtime import VerificationRuntime
+
+
+def run_suppression_audit_phase(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    *,
+    enable_suppression_challenge: bool,
+    max_suppression_audit: int,
+) -> None:
+    with ctx.phase(
+        "suppression_audit",
+        {
+            "enabled": enable_suppression_challenge,
+            "max_suppression_audit": max_suppression_audit,
+        },
+    ) as phase_step:
+        start_calls = ctx.stats.llm_calls
+        start_reclassified = ctx.stats.suppression_reclassified_dead
+        suppression_candidates: list[dict] = []
+
+        if enable_suppression_challenge:
+            suppression_candidates = _suppression_audit_candidates(
+                ctx,
+                findings,
+                max_suppression_audit,
+            )
+            _audit_suppression_candidates(ctx, suppression_candidates)
+            _record_suppression_audit_decisions(ctx, suppression_candidates)
+
+        phase_step.set_output_summary(
+            audited=len(suppression_candidates),
+            llm_calls=ctx.stats.llm_calls - start_calls,
+            reclassified_dead=(
+                ctx.stats.suppression_reclassified_dead - start_reclassified
+            ),
+        )
+
+
+def _suppression_audit_candidates(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    max_suppression_audit: int,
+) -> list[dict]:
+    candidates = [
+        finding
+        for finding in findings
+        if ctx.ops.should_audit_suppression(finding)
+    ][:max_suppression_audit]
+    ctx.stats.suppression_challenged = len(candidates)
+    return candidates
+
+
+def _audit_suppression_candidates(
+    ctx: VerificationRuntime,
+    suppression_candidates: list[dict],
+) -> None:
+    if not suppression_candidates:
+        return
+    ctx.check_llm_budget(len(suppression_candidates), "suppression_audit")
+    ctx.log(
+        "Pass 3: Auditing "
+        f"{len(suppression_candidates)} FALSE_POSITIVE decisions "
+        "for false negatives..."
+    )
+    for finding in suppression_candidates:
+        result = _run_suppression_audit(ctx, finding)
+        ctx.add_llm_calls(1)
+        _apply_suppression_audit_result(ctx, finding, result)
+
+
+def _run_suppression_audit(ctx: VerificationRuntime, finding: dict) -> Any:
+    return ctx.run_tool(
+        "suppression_audit",
+        lambda finding=finding: ctx.ops.audit_suppressed_finding(
+            ctx.agent,
+            finding,
+            ctx.defs_map,
+            ctx.source_cache,
+            project_root=ctx.grep_root,
+            repo_facts=ctx.repo_facts,
+        ),
+        input_summary={
+            "name": finding.get("full_name") or finding.get("name"),
+            "file": finding.get("file"),
+        },
+        output_summary=lambda result: {
+            "verdict": result.verdict.value,
+            "adjusted_confidence": result.adjusted_confidence,
+        },
+    )
+
+
+def _apply_suppression_audit_result(
+    ctx: VerificationRuntime,
+    finding: dict,
+    result: Any,
+) -> None:
+    finding["_suppression_audited"] = True
+    finding["_suppression_audit_verdict"] = result.verdict.value
+    finding["_suppression_audit_rationale"] = result.rationale
+
+    if result.verdict == Verdict.TRUE_POSITIVE:
+        _reopen_suppressed_finding(ctx, finding, result)
+    elif result.verdict == Verdict.FALSE_POSITIVE:
+        _confirm_suppressed_finding(finding)
+
+
+def _reopen_suppressed_finding(
+    ctx: VerificationRuntime,
+    finding: dict,
+    result: Any,
+) -> None:
+    finding["_llm_verdict"] = Verdict.TRUE_POSITIVE.value
+    finding["_llm_rationale"] = f"[suppression-audit] {result.rationale}"
+    finding["_verified_by_llm"] = True
+    finding["_adjusted_confidence"] = result.adjusted_confidence
+    finding["_llm_challenged"] = True
+    finding["_suppression_reopened"] = True
+
+    if finding.get("_deterministically_suppressed"):
+        _overrule_deterministic_suppression(ctx, finding)
+    else:
+        ctx.stats.verified_false_positive -= 1
+
+    ctx.stats.verified_true_positive += 1
+    ctx.stats.suppression_reclassified_dead += 1
+
+
+def _overrule_deterministic_suppression(
+    ctx: VerificationRuntime,
+    finding: dict,
+) -> None:
+    ctx.stats.deterministic_suppressed -= 1
+    finding["_deterministically_suppressed"] = False
+    if finding.get("_suppression_reason"):
+        finding["_suppression_overruled_reason"] = finding.get("_suppression_reason")
+        finding.pop("_suppression_reason", None)
+    if finding.get("_suppression_evidence"):
+        finding["_suppression_overruled_evidence"] = finding.get("_suppression_evidence")
+        finding.pop("_suppression_evidence", None)
+
+
+def _confirm_suppressed_finding(finding: dict) -> None:
+    if finding.get("_deterministically_suppressed"):
+        finding["_verified_by_llm"] = True
+
+
+def _record_suppression_audit_decisions(
+    ctx: VerificationRuntime,
+    suppression_candidates: list[dict],
+) -> None:
+    for finding in suppression_candidates:
+        ctx.record_decision(
+            "suppression_audit",
+            _suppression_audit_decision_code(finding),
+            finding,
+            {"verdict": finding.get("_suppression_audit_verdict")},
+        )
+
+
+def _suppression_audit_decision_code(finding: dict) -> str:
+    if finding.get("_suppression_reopened"):
+        return "suppression_reopened"
+    if finding.get("_suppression_audited"):
+        return "suppression_confirmed"
+    return "suppression_pending"

--- a/skylos/llm/verification/verify_findings.py
+++ b/skylos/llm/verification/verify_findings.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from typing import Any
+
+from skylos.llm.dead_code_verifier import Verdict, _parse_int
+
+from .runtime import VerificationRuntime
+
+
+def run_verify_findings_phase(
+    ctx: VerificationRuntime,
+    to_verify: list[dict],
+    *,
+    batch_mode: bool,
+) -> None:
+    with ctx.phase(
+        "verify_findings",
+        {"candidate_count": len(to_verify), "batch_mode": batch_mode},
+    ) as phase_step:
+        start = _verification_phase_start(ctx)
+        reverify_candidate_count = 0
+
+        if batch_mode and len(to_verify) > 1:
+            batch_results = _run_batch_verification(ctx, to_verify)
+            ctx.add_llm_calls(_batch_verification_llm_calls(batch_results))
+            _apply_verification_results(ctx, to_verify, batch_results)
+            reverify_candidates = _rich_reverify_candidates(ctx, to_verify)
+            reverify_candidate_count = len(reverify_candidates)
+            _run_rich_reverification(ctx, reverify_candidates)
+        else:
+            _run_individual_verification(ctx, to_verify)
+
+        _record_verify_decisions(ctx, to_verify)
+        _set_verify_output_summary(ctx, phase_step, start, reverify_candidate_count)
+
+
+def _verification_phase_start(ctx: VerificationRuntime) -> dict[str, int]:
+    return {
+        "llm_calls": ctx.stats.llm_calls,
+        "true_positive": ctx.stats.verified_true_positive,
+        "false_positive": ctx.stats.verified_false_positive,
+        "uncertain": ctx.stats.uncertain,
+    }
+
+
+def _run_batch_verification(ctx: VerificationRuntime, to_verify: list[dict]) -> list[Any]:
+    planned_verify_calls = ctx.ops.estimate_batches(
+        to_verify,
+        ctx.defs_map,
+        ctx.source_cache,
+        repo_facts=ctx.repo_facts,
+    )
+    ctx.check_llm_budget(planned_verify_calls, "batch_verify")
+    ctx.log(
+        f"Pass 2: Batch-verifying {len(to_verify)} findings "
+        f"({planned_verify_calls} LLM calls)..."
+    )
+    return ctx.run_tool(
+        "batch_verify",
+        lambda: ctx.ops.batch_verify_findings(
+            ctx.agent,
+            to_verify,
+            ctx.defs_map,
+            ctx.source_cache,
+            project_root=ctx.grep_root,
+            repo_facts=ctx.repo_facts,
+        ),
+        input_summary={
+            "candidate_count": len(to_verify),
+            "planned_llm_calls": planned_verify_calls,
+        },
+        output_summary=lambda result: {"result_count": len(result)},
+    )
+
+
+def _batch_verification_llm_calls(batch_results: list[Any]) -> int:
+    skipped_refs_rationale = "Has " "{references} references; skipped"
+    verified_count = len(
+        [
+            result
+            for result in batch_results
+            if result.rationale
+            != skipped_refs_rationale.format(
+                references=_parse_int(result.finding.get("references", 0))
+            )
+        ]
+    )
+    return max(1, (verified_count + 4) // 5)
+
+
+def _apply_verification_results(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+    results: list[Any],
+) -> None:
+    for finding, result in zip(findings, results):
+        _apply_verification_result(ctx, finding, result)
+
+
+def _apply_verification_result(
+    ctx: VerificationRuntime,
+    finding: dict,
+    result: Any,
+) -> None:
+    finding["_llm_verdict"] = result.verdict.value
+    finding["_llm_rationale"] = result.rationale
+    finding["_verified_by_llm"] = result.verdict != Verdict.UNCERTAIN
+    finding["_original_confidence"] = result.original_confidence
+    finding["_adjusted_confidence"] = result.adjusted_confidence
+
+    if result.verdict == Verdict.TRUE_POSITIVE:
+        ctx.stats.verified_true_positive += 1
+    elif result.verdict == Verdict.FALSE_POSITIVE:
+        ctx.stats.verified_false_positive += 1
+        finding["_llm_challenged"] = True
+    else:
+        ctx.stats.uncertain += 1
+
+
+def _rich_reverify_candidates(
+    ctx: VerificationRuntime,
+    findings: list[dict],
+) -> list[dict]:
+    return [
+        finding
+        for finding in findings
+        if finding.get("_llm_verdict") == "TRUE_POSITIVE"
+        and _finding_has_rich_context(ctx, finding)
+    ]
+
+
+def _finding_has_rich_context(ctx: VerificationRuntime, finding: dict) -> bool:
+    ctx_text = ctx.ops.build_graph_context(
+        finding,
+        ctx.defs_map,
+        ctx.source_cache,
+        project_root=ctx.grep_root,
+        repo_facts=ctx.repo_facts,
+        grep_cache=ctx.grep_cache,
+    )
+    lower_context = ctx_text.lower()
+    rich_markers = (
+        "Inheritance Context",
+        "CONFIRMED",
+        "cast(",
+        "pragma: no cover",
+        "Collectible pytest test class: yes",
+        "MkDocs hook registration: yes",
+        "Definition side effect: yes",
+        "Repo-relative file path references",
+    )
+    return "class_usage" in lower_context or any(
+        marker in ctx_text for marker in rich_markers
+    )
+
+
+def _run_rich_reverification(
+    ctx: VerificationRuntime,
+    reverify_candidates: list[dict],
+) -> None:
+    if not reverify_candidates:
+        return
+    ctx.check_llm_budget(len(reverify_candidates), "reverify_findings")
+    ctx.log(
+        "  Re-verifying "
+        f"{len(reverify_candidates)} batch TPs with rich evidence "
+        "(individual mode)..."
+    )
+    for finding in reverify_candidates:
+        result = _run_graph_verify(ctx, finding, mode="reverify")
+        ctx.add_llm_calls(1)
+        _apply_reverify_result(ctx, finding, result)
+
+
+def _run_graph_verify(ctx: VerificationRuntime, finding: dict, *, mode: str) -> Any:
+    return ctx.run_tool(
+        "graph_verify",
+        lambda finding=finding: ctx.ops.verify_with_graph_context(
+            ctx.agent,
+            finding,
+            ctx.defs_map,
+            ctx.source_cache,
+            project_root=ctx.grep_root,
+            repo_facts=ctx.repo_facts,
+        ),
+        input_summary={
+            "name": finding.get("full_name") or finding.get("name"),
+            "file": finding.get("file"),
+            "mode": mode,
+        },
+        output_summary=lambda result: {
+            "verdict": result.verdict.value,
+            "adjusted_confidence": result.adjusted_confidence,
+        },
+    )
+
+
+def _apply_reverify_result(
+    ctx: VerificationRuntime,
+    finding: dict,
+    result: Any,
+) -> None:
+    if result.verdict == Verdict.TRUE_POSITIVE:
+        return
+
+    finding["_llm_verdict"] = result.verdict.value
+    finding["_llm_rationale"] = f"[re-verified] {result.rationale}"
+    finding["_verified_by_llm"] = result.verdict != Verdict.UNCERTAIN
+    finding["_adjusted_confidence"] = result.adjusted_confidence
+    ctx.stats.verified_true_positive -= 1
+
+    if result.verdict == Verdict.FALSE_POSITIVE:
+        ctx.stats.verified_false_positive += 1
+        finding["_llm_challenged"] = True
+        ctx.log(f"    Flipped: {finding.get('full_name', '')} TP → FP")
+    elif result.verdict == Verdict.UNCERTAIN:
+        ctx.stats.uncertain += 1
+
+
+def _run_individual_verification(
+    ctx: VerificationRuntime,
+    to_verify: list[dict],
+) -> None:
+    ctx.check_llm_budget(len(to_verify), "verify_findings")
+    ctx.log(f"Pass 2: Verifying {len(to_verify)} findings with graph context...")
+    for index, finding in enumerate(to_verify):
+        result = _run_graph_verify(ctx, finding, mode="verify")
+        ctx.add_llm_calls(1)
+        _apply_verification_result(ctx, finding, result)
+        if (index + 1) % 10 == 0:
+            ctx.log(f"  Verified {index + 1}/{len(to_verify)}...")
+
+
+def _record_verify_decisions(ctx: VerificationRuntime, to_verify: list[dict]) -> None:
+    for finding in to_verify:
+        verdict = str(finding.get("_llm_verdict") or "")
+        ctx.record_decision(
+            "verify_findings",
+            _verify_decision_code(verdict),
+            finding,
+            {"verdict": verdict or None},
+        )
+
+
+def _verify_decision_code(verdict: str) -> str:
+    if verdict == Verdict.TRUE_POSITIVE.value:
+        return "verified_true_positive"
+    if verdict == Verdict.FALSE_POSITIVE.value:
+        return "verified_false_positive"
+    if verdict == Verdict.UNCERTAIN.value:
+        return "verified_uncertain"
+    return "verification_unresolved"
+
+
+def _set_verify_output_summary(
+    ctx: VerificationRuntime,
+    phase_step: Any,
+    start: dict[str, int],
+    reverify_candidate_count: int,
+) -> None:
+    phase_step.set_output_summary(
+        llm_calls=ctx.stats.llm_calls - start["llm_calls"],
+        verified_true_positive=(
+            ctx.stats.verified_true_positive - start["true_positive"]
+        ),
+        verified_false_positive=(
+            ctx.stats.verified_false_positive - start["false_positive"]
+        ),
+        uncertain=ctx.stats.uncertain - start["uncertain"],
+        reverify_candidates=reverify_candidate_count,
+    )

--- a/skylos/llm/verify_orchestrator.py
+++ b/skylos/llm/verify_orchestrator.py
@@ -48,6 +48,20 @@ from .verify_types import (
     SurvivorVerdict as SurvivorVerdict,
     VerifyStats,
 )
+from .verification.phases import (
+    VerificationOps,
+    VerificationRuntime,
+    run_candidate_selection_phase,
+    run_entry_discovery_phase,
+    run_haiku_prefilter_phase,
+    run_suppression_audit_phase,
+    run_verify_findings_phase,
+)
+from .verification.completion_phases import (
+    run_finalize_phase,
+    run_propagate_alive_phase,
+    run_survivor_challenge_phase,
+)
 
 from skylos.core.grep_verify import (
     _run_grep,
@@ -2477,6 +2491,36 @@ def _attach_feedback_summary(output: dict[str, Any], log) -> None:
         logger.debug(f"Feedback recording failed: {e}")
 
 
+def _entry_discovery_planned_llm_calls(
+    project_root: Path,
+    _known_entry_points: list[str],
+    repo_facts: RepoFacts,
+) -> int:
+    configs = repo_facts.config_files
+    if not configs:
+        return 0
+
+    cache_path = _entry_point_cache_path(project_root)
+    if cache_path.exists():
+        try:
+            from skylos.core.safe_cache_io import load_project_json_cache
+
+            cached = load_project_json_cache(project_root, cache_path)
+            if cached.get("hash") == _config_files_hash(configs):
+                return 0
+        except (
+            OSError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            AttributeError,
+        ) as exc:
+            logger.debug("Ignoring invalid entry point cache %s: %s", cache_path, exc)
+
+    return 1
+
+
+
 def run_verification(
     findings: list[dict],
     defs_map: dict[str, Any],
@@ -2498,6 +2542,8 @@ def run_verification(
     verification_mode: str = VERIFICATION_MODE_PRODUCTION,
     grep_workers: int = 4,
     parallel_grep: bool = False,
+    harness_runner: Any | None = None,
+    harness_budget: Any | None = None,
 ) -> dict[str, Any]:
     from skylos.llm.agents import AgentConfig
 
@@ -2543,372 +2589,138 @@ def run_verification(
     source_cache = _build_source_cache(findings, defs_map)
     repo_facts = _build_repo_facts(config_root)
 
-    discovered_eps = []
-    if enable_entry_discovery:
-        log("Pass 1: Discovering hidden entry points...")
-        known_eps = []
-        for name, info in defs_map.items():
-            if isinstance(info, dict) and info.get("type") in ("function", "method"):
-                known_eps.append(name)
+    def phase(name: str, input_summary: dict[str, Any] | None = None):
+        return _verification_harness_phase(harness_runner, name, input_summary)
 
-        discovered_eps = discover_entry_points(agent, config_root, known_eps[:100])
-        stats.entry_points_discovered = len(discovered_eps)
-        stats.llm_calls += 1
-
-        if discovered_eps:
-            log(f"  Found {len(discovered_eps)} new entry points:")
-            for ep in discovered_eps:
-                log(f"    - {ep.name} (from {ep.source})")
-        else:
-            log("  No new entry points found.")
-
-    lo, hi = confidence_range
-    to_verify = []
-    for f in findings:
-        conf = _parse_confidence(f.get("confidence", 60))
-        refs = _parse_int(f.get("references", 0))
-        should_judge = refs == 0 and (judge_all_mode or lo <= conf <= hi)
-        if should_judge:
-            full_name = f.get("full_name", f.get("name", ""))
-            matched_ep = next(
-                (ep for ep in discovered_eps if ep.name == full_name), None
-            )
-            if matched_ep is not None:
-                if judge_all_mode:
-                    f["_judge_discovered_entry_point"] = (
-                        f"{matched_ep.source}: {matched_ep.reason}"
-                    )
-                    _record_prefilter_fact(
-                        f,
-                        code="discovered_entry_point",
-                        rationale="Project configuration references this symbol as an entry point",
-                        evidence=[
-                            f"source={matched_ep.source}",
-                            f"reason={matched_ep.reason}",
-                        ],
-                    )
-                    to_verify.append(f)
-                else:
-                    f["_llm_verdict"] = Verdict.FALSE_POSITIVE.value
-                    f["_llm_rationale"] = "Discovered as entry point in project config"
-                    f["_verified_by_llm"] = True
-                    f["_adjusted_confidence"] = 20
-                    stats.verified_false_positive += 1
-            else:
-                decision = _deterministic_suppress(
-                    f,
-                    source_cache,
-                    project_root=grep_root,
-                    repo_facts=repo_facts,
-                    defs_map=defs_map,
-                    grep_cache=grep_cache,
-                )
-                if decision is not None:
-                    if judge_all_mode and not decision.hard:
-                        _record_prefilter_fact(
-                            f,
-                            code=decision.code,
-                            rationale=decision.rationale,
-                            evidence=decision.evidence,
-                        )
-                        to_verify.append(f)
-                    else:
-                        f["_llm_verdict"] = Verdict.FALSE_POSITIVE.value
-                        f["_llm_rationale"] = decision.rationale
-                        f["_suppression_reason"] = decision.code
-                        f["_suppression_evidence"] = list(decision.evidence)
-                        f["_suppression_hard"] = bool(decision.hard)
-                        f["_deterministically_suppressed"] = True
-                        f["_verified_by_llm"] = False
-                        f["_adjusted_confidence"] = 20
-                        stats.deterministic_suppressed += 1
-                else:
-                    to_verify.append(f)
-        else:
-            if refs > 0:
-                f["_llm_verdict"] = "SKIPPED_HAS_REFS"
-                f["_llm_rationale"] = f"Has {refs} references"
-            elif conf > hi:
-                f["_llm_verdict"] = "SKIPPED_HIGH_CONF"
-                f["_llm_rationale"] = "High confidence from static; skipped LLM"
-            else:
-                f["_llm_verdict"] = "SKIPPED_LOW_CONF"
-                f["_llm_rationale"] = "Below threshold"
-
-    to_verify = to_verify[:max_verify]
-
-    if to_verify:
-        haiku_key = config.api_key or os.environ.get("ANTHROPIC_API_KEY")
-
-        exported_candidates = [
-            f
-            for f in to_verify
-            if f.get("is_exported") and _parse_confidence(f.get("confidence", 0)) >= 80
-        ]
-        if exported_candidates and haiku_key:
-            log(
-                f"Pass 1.5: Haiku pre-filter for {len(exported_candidates)} exported symbols..."
-            )
-            try:
-                haiku_agent = _create_haiku_agent(haiku_key)
-                kept, dismissed = _haiku_prefilter_exports(
-                    haiku_agent,
-                    exported_candidates,
-                    source_cache,
-                )
-                stats.haiku_prefiltered = len(dismissed)
-                stats.verified_false_positive += len(dismissed)
-                stats.llm_calls += max(
-                    1,
-                    (len(exported_candidates) + HAIKU_PREFILTER_MAX_BATCH - 1)
-                    // HAIKU_PREFILTER_MAX_BATCH,
-                )
-                dismissed_set = {id(f) for f in dismissed}
-                to_verify = [f for f in to_verify if id(f) not in dismissed_set]
-                if dismissed:
-                    log(
-                        f"  Haiku dismissed {len(dismissed)} exported symbols as public API"
-                    )
-            except Exception as e:
-                logger.warning(f"Haiku pre-filter setup failed: {e}")
-
-    if batch_mode and len(to_verify) > 1:
-        log(
-            f"Pass 2: Batch-verifying {len(to_verify)} findings "
-            f"({_estimate_batches(to_verify, defs_map, source_cache, repo_facts=repo_facts)} LLM calls)..."
-        )
-        batch_results = _batch_verify_findings(
-            agent,
-            to_verify,
-            defs_map,
-            source_cache,
-            project_root=grep_root,
-            repo_facts=repo_facts,
-        )
-        stats.llm_calls += max(
-            1,
-            (
-                len(
-                    [
-                        r
-                        for r in batch_results
-                        if r.rationale
-                        != f"Has {_parse_int(r.finding.get('references', 0))} references; skipped"
-                    ]
-                )
-                + 4
-            )
-            // 5,
+    def check_llm_budget(planned_calls: int, phase_name: str) -> None:
+        _enforce_verification_llm_budget(
+            current_calls=stats.llm_calls,
+            planned_calls=planned_calls,
+            harness_budget=harness_budget,
+            phase=phase_name,
         )
 
-        for finding, result in zip(to_verify, batch_results):
-            finding["_llm_verdict"] = result.verdict.value
-            finding["_llm_rationale"] = result.rationale
-            finding["_verified_by_llm"] = result.verdict != Verdict.UNCERTAIN
-            finding["_original_confidence"] = result.original_confidence
-            finding["_adjusted_confidence"] = result.adjusted_confidence
+    def decision_target(finding: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "fingerprint": finding.get("fingerprint"),
+            "name": finding.get("full_name") or finding.get("name"),
+            "file": finding.get("file"),
+            "line": finding.get("line"),
+            "type": finding.get("type"),
+        }
 
-            if result.verdict == Verdict.TRUE_POSITIVE:
-                stats.verified_true_positive += 1
-            elif result.verdict == Verdict.FALSE_POSITIVE:
-                stats.verified_false_positive += 1
-                finding["_llm_challenged"] = True
-            else:
-                stats.uncertain += 1
+    def record_decision(
+        phase_name: str,
+        code: str,
+        finding: dict[str, Any],
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        if harness_runner is None:
+            return
+        harness_runner.record_decision(
+            phase=phase_name,
+            code=code,
+            target=decision_target(finding),
+            details=details or {},
+        )
 
-        reverify_candidates = []
-        for finding in to_verify:
-            if finding.get("_llm_verdict") != "TRUE_POSITIVE":
-                continue
-            ctx = _build_graph_context(
-                finding,
-                defs_map,
-                source_cache,
-                project_root=grep_root,
-                repo_facts=repo_facts,
-                grep_cache=grep_cache,
-            )
-            has_rich_context = (
-                "class_usage" in ctx.lower()
-                or "Inheritance Context" in ctx
-                or "CONFIRMED" in ctx
-                or "cast(" in ctx
-                or "pragma: no cover" in ctx
-                or "Collectible pytest test class: yes" in ctx
-                or "MkDocs hook registration: yes" in ctx
-                or "Definition side effect: yes" in ctx
-                or "Repo-relative file path references" in ctx
-            )
-            if has_rich_context:
-                reverify_candidates.append(finding)
+    def add_llm_calls(count: int) -> None:
+        if count <= 0:
+            return
+        stats.llm_calls += count
+        if harness_runner is not None:
+            harness_runner.update_usage(llm_calls=count)
 
-        if reverify_candidates:
-            log(
-                f"  Re-verifying {len(reverify_candidates)} batch TPs with rich evidence (individual mode)..."
-            )
-            for finding in reverify_candidates:
-                result = verify_with_graph_context(
-                    agent,
-                    finding,
-                    defs_map,
-                    source_cache,
-                    project_root=grep_root,
-                    repo_facts=repo_facts,
-                )
-                stats.llm_calls += 1
-                if result.verdict != Verdict.TRUE_POSITIVE:
-                    finding["_llm_verdict"] = result.verdict.value
-                    finding["_llm_rationale"] = f"[re-verified] {result.rationale}"
-                    finding["_verified_by_llm"] = result.verdict != Verdict.UNCERTAIN
-                    finding["_adjusted_confidence"] = result.adjusted_confidence
-                    if result.verdict == Verdict.FALSE_POSITIVE:
-                        stats.verified_true_positive -= 1
-                        stats.verified_false_positive += 1
-                        finding["_llm_challenged"] = True
-                        log(f"    Flipped: {finding.get('full_name', '')} TP → FP")
-                    elif result.verdict == Verdict.UNCERTAIN:
-                        stats.verified_true_positive -= 1
-                        stats.uncertain += 1
-    else:
-        log(f"Pass 2: Verifying {len(to_verify)} findings with graph context...")
-        for i, finding in enumerate(to_verify):
-            result = verify_with_graph_context(
-                agent,
-                finding,
-                defs_map,
-                source_cache,
-                project_root=grep_root,
-                repo_facts=repo_facts,
-            )
-            stats.llm_calls += 1
+    def run_tool(
+        name: str,
+        fn,
+        *,
+        input_summary: dict[str, Any] | None = None,
+        output_summary=None,
+    ):
+        if harness_runner is None:
+            return fn()
+        return harness_runner.run_tool(
+            name,
+            fn,
+            input_summary=input_summary,
+            output_summary=output_summary,
+        )
 
-            finding["_llm_verdict"] = result.verdict.value
-            finding["_llm_rationale"] = result.rationale
-            finding["_verified_by_llm"] = result.verdict != Verdict.UNCERTAIN
-            finding["_original_confidence"] = result.original_confidence
-            finding["_adjusted_confidence"] = result.adjusted_confidence
+    ops = VerificationOps(
+        discover_entry_points=discover_entry_points,
+        entry_discovery_planned_llm_calls=_entry_discovery_planned_llm_calls,
+        record_prefilter_fact=_record_prefilter_fact,
+        deterministic_suppress=_deterministic_suppress,
+        create_haiku_agent=_create_haiku_agent,
+        haiku_prefilter_exports=_haiku_prefilter_exports,
+        estimate_batches=_estimate_batches,
+        batch_verify_findings=_batch_verify_findings,
+        build_graph_context=_build_graph_context,
+        verify_with_graph_context=verify_with_graph_context,
+        should_audit_suppression=_should_audit_suppression,
+        audit_suppressed_finding=audit_suppressed_finding,
+        find_local_on_emit_survivors=_find_local_on_emit_survivors,
+        find_survivors=_find_survivors,
+        build_source_cache=_build_source_cache,
+        batch_challenge_survivors=_batch_challenge_survivors,
+        challenge_survivor=challenge_survivor,
+        build_verification_output=_build_verification_output,
+        attach_feedback_summary=_attach_feedback_summary,
+    )
 
-            if result.verdict == Verdict.TRUE_POSITIVE:
-                stats.verified_true_positive += 1
-            elif result.verdict == Verdict.FALSE_POSITIVE:
-                stats.verified_false_positive += 1
-                finding["_llm_challenged"] = True
-            else:
-                stats.uncertain += 1
+    ctx = VerificationRuntime(
+        agent=agent,
+        defs_map=defs_map,
+        grep_root=grep_root,
+        config_root=config_root,
+        grep_cache=grep_cache,
+        source_cache=source_cache,
+        repo_facts=repo_facts,
+        stats=stats,
+        log=log,
+        phase=phase,
+        check_llm_budget=check_llm_budget,
+        record_decision=record_decision,
+        add_llm_calls=add_llm_calls,
+        run_tool=run_tool,
+        ops=ops,
+    )
 
-            if (i + 1) % 10 == 0:
-                log(f"  Verified {i + 1}/{len(to_verify)}...")
+    discovered_eps = run_entry_discovery_phase(
+        ctx,
+        enable_entry_discovery=enable_entry_discovery,
+    )
 
-    if enable_suppression_challenge:
-        suppression_candidates = [
-            finding for finding in findings if _should_audit_suppression(finding)
-        ][:max_suppression_audit]
-        stats.suppression_challenged = len(suppression_candidates)
+    to_verify = run_candidate_selection_phase(
+        ctx,
+        findings,
+        discovered_eps,
+        max_verify=max_verify,
+        confidence_range=confidence_range,
+        judge_all_mode=judge_all_mode,
+    )
 
-        if suppression_candidates:
-            log(
-                "Pass 3: Auditing "
-                f"{len(suppression_candidates)} FALSE_POSITIVE decisions for false negatives..."
-            )
-            for finding in suppression_candidates:
-                result = audit_suppressed_finding(
-                    agent,
-                    finding,
-                    defs_map,
-                    source_cache,
-                    project_root=grep_root,
-                    repo_facts=repo_facts,
-                )
-                stats.llm_calls += 1
-                finding["_suppression_audited"] = True
-                finding["_suppression_audit_verdict"] = result.verdict.value
-                finding["_suppression_audit_rationale"] = result.rationale
+    to_verify = run_haiku_prefilter_phase(
+        ctx,
+        to_verify,
+        config=config,
+    )
 
-                if result.verdict == Verdict.TRUE_POSITIVE:
-                    finding["_llm_verdict"] = Verdict.TRUE_POSITIVE.value
-                    finding["_llm_rationale"] = (
-                        f"[suppression-audit] {result.rationale}"
-                    )
-                    finding["_verified_by_llm"] = True
-                    finding["_adjusted_confidence"] = result.adjusted_confidence
-                    finding["_llm_challenged"] = True
-                    finding["_suppression_reopened"] = True
+    run_verify_findings_phase(
+        ctx,
+        to_verify,
+        batch_mode=batch_mode,
+    )
 
-                    if finding.get("_deterministically_suppressed"):
-                        stats.deterministic_suppressed -= 1
-                        finding["_deterministically_suppressed"] = False
-                        if finding.get("_suppression_reason"):
-                            finding["_suppression_overruled_reason"] = finding.get(
-                                "_suppression_reason"
-                            )
-                            finding.pop("_suppression_reason", None)
-                        if finding.get("_suppression_evidence"):
-                            finding["_suppression_overruled_evidence"] = finding.get(
-                                "_suppression_evidence"
-                            )
-                            finding.pop("_suppression_evidence", None)
-                    else:
-                        stats.verified_false_positive -= 1
+    run_suppression_audit_phase(
+        ctx,
+        findings,
+        enable_suppression_challenge=enable_suppression_challenge,
+        max_suppression_audit=max_suppression_audit,
+    )
 
-                    stats.verified_true_positive += 1
-                    stats.suppression_reclassified_dead += 1
-                elif result.verdict == Verdict.FALSE_POSITIVE:
-                    if finding.get("_deterministically_suppressed"):
-                        finding["_verified_by_llm"] = True
-
-    fp_names = set()
-    tp_findings = []
-    for f in findings:
-        verdict = f.get("_llm_verdict", "")
-        full_name = f.get("full_name", f.get("name", ""))
-        if verdict == "FALSE_POSITIVE":
-            fp_names.add(full_name)
-        elif verdict == "TRUE_POSITIVE":
-            tp_findings.append(f)
-
-    propagated = 0
-    for f in tp_findings:
-        full_name = f.get("full_name", f.get("name", ""))
-        called_by = f.get("called_by", [])
-        calls = f.get("calls", [])
-
-        alive_callers = [c for c in called_by if c in fp_names]
-        if alive_callers:
-            f["_llm_verdict"] = "FALSE_POSITIVE"
-            f["_llm_rationale"] = (
-                f"Transitive alive: called by {alive_callers[0]} which is confirmed alive (FALSE_POSITIVE). "
-                f"Original rationale: {f.get('_llm_rationale', '')}"
-            )
-            f["_llm_challenged"] = True
-            f["_adjusted_confidence"] = 50
-            fp_names.add(full_name)
-            stats.verified_true_positive -= 1
-            stats.verified_false_positive += 1
-            propagated += 1
-            continue
-
-        for callee in calls:
-            if callee in fp_names:
-                for other_f in findings:
-                    if other_f.get("full_name", "") == callee:
-                        if full_name in other_f.get("called_by", []):
-                            f["_llm_verdict"] = "FALSE_POSITIVE"
-                            f["_llm_rationale"] = (
-                                f"Transitive alive: mutual dependency with {callee} which is alive. "
-                                f"Original rationale: {f.get('_llm_rationale', '')}"
-                            )
-                            f["_llm_challenged"] = True
-                            f["_adjusted_confidence"] = 50
-                            fp_names.add(full_name)
-                            stats.verified_true_positive -= 1
-                            stats.verified_false_positive += 1
-                            propagated += 1
-                            break
-                if f.get("_llm_verdict") == "FALSE_POSITIVE":
-                    break
-
-    if propagated:
-        log(f"  Transitive alive propagation: {propagated} findings reclassified as FP")
+    run_propagate_alive_phase(ctx, findings)
 
     haiku_note = (
         f", {stats.haiku_prefiltered} haiku-prefiltered"
@@ -2923,142 +2735,22 @@ def run_verification(
         f"{stats.uncertain} uncertain"
     )
 
-    new_dead = []
-    if enable_survivor_challenge:
-        log("Pass 4: Challenging survivors with heuristic refs...")
-
-        local_on_emit_survivors = _find_local_on_emit_survivors(
-            defs_map,
-            findings,
-            grep_root,
-        )
-        if local_on_emit_survivors:
-            stats.survivors_challenged += len(local_on_emit_survivors)
-            stats.survivors_reclassified_dead += len(local_on_emit_survivors)
-            for surv in local_on_emit_survivors:
-                owner = surv.get("_registry_owner", "registry")
-                event_name = surv.get("_event_name", "")
-                new_dead.append(
-                    {
-                        "name": surv["name"],
-                        "simple_name": surv["simple_name"],
-                        "full_name": surv["full_name"],
-                        "file": surv["file"],
-                        "line": surv["line"],
-                        "type": surv.get("type", "function"),
-                        "confidence": min(
-                            95, int(surv.get("confidence", 50) or 50) + 25
-                        ),
-                        "references": 0,
-                        "message": f"Unused {surv.get('type', 'function')}: {surv['name']}",
-                        "_category": "dead_code",
-                        "_llm_verdict": "TRUE_POSITIVE",
-                        "_llm_rationale": (
-                            f"Registered via @{owner}.on('{event_name}') but no "
-                            f"{owner}.emit('{event_name}') call exists in app/tests."
-                        ),
-                        "_source": "registry_survivor_challenge",
-                    }
-                )
-            log(
-                f"  Reclassified {len(local_on_emit_survivors)} local on/emit listeners as dead"
-            )
-
-        survivors = _find_survivors(defs_map, findings)
-        survivors = survivors[:max_challenge]
-        stats.survivors_challenged += len(survivors)
-
-        if survivors:
-            survivor_cache = _build_source_cache([], defs_map, survivors)
-            source_cache.update(survivor_cache)
-
-            if batch_mode and len(survivors) > 1:
-                batch_results = _batch_challenge_survivors(
-                    agent, survivors, defs_map, source_cache
-                )
-                stats.llm_calls += max(1, (len(survivors) + 4) // 5)
-
-                for surv, sv in zip(survivors, batch_results):
-                    if sv.verdict == Verdict.TRUE_POSITIVE:
-                        stats.survivors_reclassified_dead += 1
-                        new_dead.append(
-                            {
-                                "name": sv.name,
-                                "full_name": sv.full_name,
-                                "file": sv.file,
-                                "line": sv.line,
-                                "type": surv.get("type", "function"),
-                                "confidence": sv.suggested_confidence,
-                                "references": 0,
-                                "heuristic_refs": sv.heuristic_refs,
-                                "message": f"Unused {surv.get('type', 'function')}: {sv.name}",
-                                "_category": "dead_code",
-                                "_llm_verdict": "TRUE_POSITIVE",
-                                "_llm_rationale": sv.rationale,
-                                "_source": "llm_survivor_challenge",
-                            }
-                        )
-            else:
-                for surv in survivors:
-                    sv = challenge_survivor(agent, surv, defs_map, source_cache)
-                    stats.llm_calls += 1
-
-                    if sv.verdict == Verdict.TRUE_POSITIVE:
-                        stats.survivors_reclassified_dead += 1
-                        new_dead.append(
-                            {
-                                "name": sv.name,
-                                "full_name": sv.full_name,
-                                "file": sv.file,
-                                "line": sv.line,
-                                "type": surv.get("type", "function"),
-                                "confidence": sv.suggested_confidence,
-                                "references": 0,
-                                "heuristic_refs": sv.heuristic_refs,
-                                "message": f"Unused {surv.get('type', 'function')}: {sv.name}",
-                                "_category": "dead_code",
-                                "_llm_verdict": "TRUE_POSITIVE",
-                                "_llm_rationale": sv.rationale,
-                                "_source": "llm_survivor_challenge",
-                            }
-                        )
-
-            log(
-                f"  Challenged {len(survivors)}, "
-                f"reclassified {stats.survivors_reclassified_dead} as dead"
-            )
-        else:
-            log("  No survivors with heuristic refs to challenge.")
-
-    stats.elapsed_seconds = round(time.time() - start_time, 1)
-
-    try:
-        usage = (
-            getattr(agent.get_adapter(), "total_usage", {}) or {}
-            if stats.llm_calls
-            else {}
-        )
-    except (AttributeError, ImportError, RuntimeError, TypeError):
-        usage = {}
-    stats.prompt_tokens = int(usage.get("prompt_tokens") or 0)
-    stats.completion_tokens = int(usage.get("completion_tokens") or 0)
-    stats.total_tokens = int(usage.get("total_tokens") or 0)
-
-    log(f"\nDone in {stats.elapsed_seconds}s ({stats.llm_calls} LLM calls)")
-
-    output = _build_verification_output(
-        findings=findings,
-        new_dead=new_dead,
-        discovered_eps=discovered_eps,
-        stats=stats,
-        verification_mode=verification_mode,
+    new_dead = run_survivor_challenge_phase(
+        ctx,
+        findings,
+        enable_survivor_challenge=enable_survivor_challenge,
+        max_challenge=max_challenge,
+        batch_mode=batch_mode,
     )
 
-    _attach_feedback_summary(output, log)
-
-    grep_cache.save(grep_root)
-
-    return output
+    return run_finalize_phase(
+        ctx,
+        findings,
+        new_dead,
+        discovered_eps,
+        start_time=start_time,
+        verification_mode=verification_mode,
+    )
 
 
 def _estimate_batches(
@@ -3107,3 +2799,47 @@ def _logger(quiet: bool):
         print(msg, file=sys.stderr)
 
     return _log
+
+
+class _NoopHarnessPhase:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def set_output_summary(self, **summary: Any) -> None:
+        return None
+
+
+def _verification_harness_phase(
+    harness_runner: Any | None,
+    name: str,
+    input_summary: dict[str, Any] | None = None,
+):
+    if harness_runner is None:
+        return _NoopHarnessPhase()
+    return harness_runner.step(name, input_summary=input_summary)
+
+
+def _enforce_verification_llm_budget(
+    *,
+    current_calls: int,
+    planned_calls: int,
+    harness_budget: Any | None,
+    phase: str,
+) -> None:
+    if planned_calls <= 0:
+        return
+    max_calls = getattr(harness_budget, "max_llm_calls", None)
+    if max_calls is None:
+        return
+    if current_calls + planned_calls <= max_calls:
+        return
+
+    from skylos.llm.harness.types import HarnessBudgetExceeded
+
+    raise HarnessBudgetExceeded(
+        "harness LLM call budget exceeded before "
+        f"{phase}: {current_calls}+{planned_calls}>{max_calls}"
+    )

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -371,7 +371,9 @@ def test_agent_scan_can_opt_into_dead_code_verification(tmp_path):
 
 def test_agent_verify_json_uses_harness_and_writes_metadata(tmp_path):
     sample = tmp_path / "sample.py"
-    sample.write_text("def old_func():\n    pass\n")
+    sample.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        "def old_func():\n    pass\n"
+    )
     output_path = tmp_path / "verify.json"
     finding = {
         "name": "old_func",

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import re
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -366,6 +367,93 @@ def test_agent_scan_can_opt_into_dead_code_verification(tmp_path):
     assert exc.value.code == 0
     args = mock_pipeline.call_args.kwargs["agent_args"]
     assert args.skip_verification is False
+
+
+def test_agent_verify_json_uses_harness_and_writes_metadata(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("def old_func():\n    pass\n")
+    output_path = tmp_path / "verify.json"
+    finding = {
+        "name": "old_func",
+        "full_name": "sample.old_func",
+        "file": str(sample),
+        "line": 1,
+        "confidence": 75,
+        "references": 0,
+        "type": "function",
+    }
+    verification_output = {
+        "verified_findings": [finding],
+        "new_dead_code": [],
+        "entry_points": [],
+        "stats": {
+            "total_findings": 1,
+            "verified_true_positive": 1,
+            "verified_false_positive": 0,
+            "uncertain": 0,
+            "entry_points_discovered": 0,
+            "survivors_challenged": 0,
+            "survivors_reclassified_dead": 0,
+            "llm_calls": 1,
+            "elapsed_seconds": 0.1,
+        },
+    }
+    run_summary = {
+        "run_id": "cli-run",
+        "status": "completed",
+        "state_path": str(tmp_path / ".skylos" / "runs" / "cli-run" / "state.json"),
+        "summary_path": str(
+            tmp_path / ".skylos" / "runs" / "cli-run" / "summary.json"
+        ),
+        "trace_path": str(
+            tmp_path / ".skylos" / "runs" / "cli-run" / "events.jsonl"
+        ),
+    }
+
+    with (
+        patch("skylos.analyzer.analyze", return_value=json.dumps({"definitions": {}})),
+        patch(
+            "skylos.deadcode.collect.collect_dead_code_findings",
+            return_value=[finding],
+        ),
+        patch("skylos.llm.harness.run_verification_harness") as mock_harness,
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "verify",
+                str(sample),
+                "--format",
+                "json",
+                "--output",
+                str(output_path),
+            ],
+        ),
+    ):
+        mock_harness.return_value = SimpleNamespace(
+            output=verification_output,
+            run=SimpleNamespace(summary_dict=lambda: run_summary),
+        )
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+    payload = json.loads(output_path.read_text())
+    assert payload["harness"]["run_id"] == "cli-run"
+    assert payload["harness"]["state_path"].endswith("state.json")
+    mock_harness.assert_called_once()
+    kwargs = mock_harness.call_args.kwargs
+    assert kwargs["findings"] == [finding]
+    assert kwargs["project_root"] == str(sample.parent)
+    assert kwargs["api_key"] == "fake-key"
+    assert kwargs["verification_mode"] == "judge_all"
 
 
 def test_agent_analyze_strict_exits_one_when_findings_exist(tmp_path):

--- a/test/test_llm_harness.py
+++ b/test/test_llm_harness.py
@@ -1,0 +1,742 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from skylos.llm.harness import (
+    HarnessBudget,
+    HarnessBudgetExceeded,
+    HarnessReplayError,
+    HarnessRunner,
+    HarnessToolRegistry,
+    default_verification_tool_registry,
+    load_harness_replay,
+    run_verification_harness,
+)
+from skylos.llm.agents import AgentConfig, DeadCodeAgent
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_runner_records_step_and_writes_jsonl_trace(tmp_path):
+    trace_root = tmp_path / "runs"
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        run_id="run-one",
+        trace_root=trace_root,
+    )
+
+    output = runner.run_step(
+        "verify",
+        lambda: {"verified_findings": [{"name": "old"}]},
+        input_summary={"finding_count": 1},
+        output_summary=lambda result: {
+            "verified_findings": len(result["verified_findings"])
+        },
+    )
+    runner.finish()
+
+    assert output == {"verified_findings": [{"name": "old"}]}
+    assert runner.run.status == "completed"
+    assert runner.run.steps[0].output_summary == {"verified_findings": 1}
+
+    trace_path = trace_root / "run-one" / "events.jsonl"
+    events = _read_jsonl(trace_path)
+    assert [event["event"] for event in events] == [
+        "run_started",
+        "step_started",
+        "step_completed",
+        "run_completed",
+    ]
+    assert events[-1]["status"] == "completed"
+    assert events[-1]["trace_path"] == str(trace_path)
+
+    state = _read_json(trace_root / "run-one" / "state.json")
+    summary = _read_json(trace_root / "run-one" / "summary.json")
+    assert state["current_phase"] is None
+    assert state["completed_phases"] == ["verify"]
+    assert summary["status"] == "completed"
+    assert summary["completed_phases"] == ["verify"]
+
+
+def test_runner_records_registered_tool_call(tmp_path):
+    trace_root = tmp_path / "runs"
+    registry = HarnessToolRegistry()
+    registry.register(
+        "grep_refs",
+        category="deterministic",
+        description="Find static references.",
+    )
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        run_id="tool-run",
+        trace_root=trace_root,
+        tool_registry=registry,
+    )
+
+    with runner.step("candidate_selection") as step:
+        result = runner.run_tool(
+            "grep_refs",
+            lambda: ["app.py:1: old()"],
+            input_summary={"query": "old"},
+            output_summary=lambda matches: {"matches": len(matches)},
+        )
+        step.set_output_summary(to_verify=1)
+        live_events = _read_jsonl(trace_root / "tool-run" / "events.jsonl")
+        assert [event["event"] for event in live_events] == [
+            "run_started",
+            "step_started",
+            "tool_started",
+            "tool_completed",
+        ]
+    runner.finish()
+
+    assert result == ["app.py:1: old()"]
+    events = _read_jsonl(trace_root / "tool-run" / "events.jsonl")
+    assert [event["event"] for event in events] == [
+        "run_started",
+        "step_started",
+        "tool_started",
+        "tool_completed",
+        "step_completed",
+        "run_completed",
+    ]
+
+    state = _read_json(trace_root / "tool-run" / "state.json")
+    summary = _read_json(trace_root / "tool-run" / "summary.json")
+    assert state["metadata"]["registered_tools"] == [
+        {
+            "name": "grep_refs",
+            "category": "deterministic",
+            "description": "Find static references.",
+        }
+    ]
+    assert state["tool_calls"][0]["name"] == "grep_refs"
+    assert state["tool_calls"][0]["phase"] == "candidate_selection"
+    assert state["tool_calls"][0]["status"] == "completed"
+    assert state["tool_calls"][0]["input_summary"] == {"query": "old"}
+    assert state["tool_calls"][0]["output_summary"] == {"matches": 1}
+    assert summary["tool_call_count"] == 1
+
+
+def test_runner_rejects_unknown_registered_tool(tmp_path):
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        tool_registry=HarnessToolRegistry(),
+    )
+
+    with pytest.raises(KeyError, match="unknown harness tool"):
+        runner.run_tool("missing", lambda: None)
+
+    assert runner.run.tool_calls == []
+
+
+def test_runner_live_usage_survives_failed_step_without_double_counting(tmp_path):
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        run_id="failed-live-usage",
+        trace_root=tmp_path / "runs",
+    )
+
+    with pytest.raises(RuntimeError, match="after call"):
+        with runner.step("verify_findings") as step:
+            runner.update_usage(llm_calls=1)
+            step.set_output_summary(llm_calls=1)
+            raise RuntimeError("after call")
+
+    state = _read_json(tmp_path / "runs" / "failed-live-usage" / "state.json")
+    summary = _read_json(tmp_path / "runs" / "failed-live-usage" / "summary.json")
+    assert state["status"] == "failed"
+    assert state["budget_used"]["llm_calls"] == 1
+    assert summary["budget_used"]["llm_calls"] == 1
+
+
+def test_default_verification_tool_registry_lists_expected_tools():
+    registry = default_verification_tool_registry()
+
+    assert {
+        "entry_discovery",
+        "deterministic_suppression",
+        "batch_verify",
+        "graph_verify",
+        "suppression_audit",
+        "survivor_challenge",
+    }.issubset({tool.name for tool in registry.list()})
+
+
+def test_runner_artifacts_form_replayable_golden_trace(tmp_path):
+    trace_root = tmp_path / "runs"
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        run_id="golden-replay",
+        trace_root=trace_root,
+        metadata={"fixture": "golden"},
+    )
+    runner.update_usage(findings=2)
+
+    target = {
+        "fingerprint": "fp-old",
+        "name": "app.old",
+        "file": "app.py",
+        "line": 1,
+        "type": "function",
+    }
+    with runner.step(
+        "candidate_selection",
+        input_summary={"finding_count": 2, "max_verify": 1},
+    ) as step:
+        runner.record_decision(
+            phase="candidate_selection",
+            code="sent_to_llm",
+            target=target,
+            details={"verdict": None},
+        )
+        step.set_output_summary(to_verify=1, llm_calls=0)
+
+    with runner.step(
+        "verify_findings",
+        input_summary={"candidate_count": 1, "batch_mode": False},
+    ) as step:
+        runner.record_decision(
+            phase="verify_findings",
+            code="verified_true_positive",
+            target=target,
+            details={"verdict": "TRUE_POSITIVE"},
+        )
+        step.set_output_summary(llm_calls=1, verified_true_positive=1)
+
+    runner.finish()
+
+    run_dir = trace_root / "golden-replay"
+    events = _read_jsonl(run_dir / "events.jsonl")
+    state = _read_json(run_dir / "state.json")
+    summary = _read_json(run_dir / "summary.json")
+
+    replay = {
+        "events": [event["event"] for event in events],
+        "phases": [step["name"] for step in state["steps"]],
+        "completed_phases": summary["completed_phases"],
+        "decisions": [
+            {
+                "phase": decision["phase"],
+                "code": decision["code"],
+                "name": decision["target"]["name"],
+                "verdict": decision["details"]["verdict"],
+            }
+            for decision in state["decisions"]
+        ],
+        "budget_used": {
+            key: summary["budget_used"][key]
+            for key in ("steps", "findings", "llm_calls", "fixes")
+        },
+    }
+
+    assert replay == {
+        "events": [
+            "run_started",
+            "step_started",
+            "step_completed",
+            "step_started",
+            "step_completed",
+            "run_completed",
+        ],
+        "phases": ["candidate_selection", "verify_findings"],
+        "completed_phases": ["candidate_selection", "verify_findings"],
+        "decisions": [
+            {
+                "phase": "candidate_selection",
+                "code": "sent_to_llm",
+                "name": "app.old",
+                "verdict": None,
+            },
+            {
+                "phase": "verify_findings",
+                "code": "verified_true_positive",
+                "name": "app.old",
+                "verdict": "TRUE_POSITIVE",
+            },
+        ],
+        "budget_used": {
+            "steps": 2,
+            "findings": 2,
+            "llm_calls": 1,
+            "fixes": 0,
+        },
+    }
+
+
+def test_harness_replay_validates_runner_artifacts(tmp_path):
+    trace_root = tmp_path / "runs"
+    registry = HarnessToolRegistry()
+    registry.register("grep_refs", category="deterministic")
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        run_id="replay-ok",
+        trace_root=trace_root,
+        tool_registry=registry,
+    )
+
+    with runner.step("candidate_selection"):
+        runner.run_tool(
+            "grep_refs",
+            lambda: ["app.py:1: old()"],
+            output_summary=lambda matches: {"matches": len(matches)},
+        )
+    runner.finish()
+
+    replay = load_harness_replay(trace_root / "replay-ok")
+
+    assert replay.ok
+    replay.assert_valid()
+    assert replay.event_names() == [
+        "run_started",
+        "step_started",
+        "tool_started",
+        "tool_completed",
+        "step_completed",
+        "run_completed",
+    ]
+    assert replay.phase_sequence() == ["candidate_selection"]
+    assert replay.tool_sequence() == ["grep_refs"]
+
+
+def test_harness_replay_reports_corrupted_summary(tmp_path):
+    trace_root = tmp_path / "runs"
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        run_id="replay-corrupt",
+        trace_root=trace_root,
+    )
+    runner.run_step("verify", lambda: {})
+    runner.finish()
+
+    summary_path = trace_root / "replay-corrupt" / "summary.json"
+    summary = _read_json(summary_path)
+    summary["phase_count"] = 99
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+    replay = load_harness_replay(trace_root / "replay-corrupt")
+
+    assert not replay.ok
+    assert any(issue.code == "phase_count_mismatch" for issue in replay.issues)
+    with pytest.raises(HarnessReplayError, match="phase_count_mismatch"):
+        replay.assert_valid()
+
+
+def test_runner_enforces_step_budget(tmp_path):
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        budget=HarnessBudget(max_steps=0),
+    )
+
+    with pytest.raises(HarnessBudgetExceeded, match="step budget"):
+        runner.run_step("verify", lambda: {})
+
+
+def test_runner_sanitizes_trace_run_id(tmp_path):
+    runner = HarnessRunner(
+        kind="verification",
+        project_root=tmp_path,
+        run_id="../bad/id",
+        trace_root=tmp_path / "runs",
+    )
+
+    runner.finish()
+
+    assert runner.run.run_id == "bad_id"
+    assert (tmp_path / "runs" / "bad_id" / "events.jsonl").exists()
+    assert (tmp_path / "runs" / "bad_id" / "state.json").exists()
+    assert (tmp_path / "runs" / "bad_id" / "summary.json").exists()
+
+
+def test_verification_harness_wraps_existing_verifier(tmp_path):
+    finding = {
+        "name": "old_func",
+        "file": str(tmp_path / "app.py"),
+        "line": 1,
+        "references": 0,
+    }
+    result = {
+        "verified_findings": [finding],
+        "new_dead_code": [],
+        "entry_points": [],
+        "stats": {"total_findings": 1, "llm_calls": 2},
+    }
+
+    with patch(
+        "skylos.llm.harness.verification.run_verification",
+        return_value=result,
+    ) as mock_run:
+        harness_result = run_verification_harness(
+            findings=[finding],
+            defs_map={"app.old_func": {"name": "app.old_func"}},
+            project_root=tmp_path,
+            harness_run_id="verify-one",
+            harness_trace_root=tmp_path / "runs",
+            harness_budget=HarnessBudget(max_findings=2, max_llm_calls=2),
+            model="test-model",
+            api_key="test-key",
+            max_verify=10,
+            max_challenge=5,
+            quiet=True,
+        )
+
+    assert harness_result.output == result
+    assert harness_result.run.kind == "verification"
+    assert harness_result.run.status == "completed"
+    assert harness_result.run.trace_path is not None
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["harness_runner"] is not None
+    assert mock_run.call_args.kwargs["harness_budget"].max_llm_calls == 2
+
+
+def test_verification_harness_writes_default_project_trace(tmp_path):
+    result = {
+        "verified_findings": [],
+        "new_dead_code": [],
+        "entry_points": [],
+        "stats": {"total_findings": 0, "llm_calls": 0},
+    }
+
+    with patch(
+        "skylos.llm.harness.verification.run_verification",
+        return_value=result,
+    ):
+        harness_result = run_verification_harness(
+            findings=[],
+            defs_map={},
+            project_root=tmp_path,
+            harness_run_id="default-trace",
+            quiet=True,
+        )
+
+    trace_path = tmp_path / ".skylos" / "runs" / "default-trace" / "events.jsonl"
+    assert harness_result.run.trace_path == str(trace_path)
+    events = _read_jsonl(trace_path)
+    assert events[-1]["event"] == "run_completed"
+    assert events[-1]["status"] == "completed"
+
+
+def test_verification_harness_rejects_findings_over_budget(tmp_path):
+    findings = [
+        {"name": "one", "file": str(tmp_path / "a.py"), "line": 1},
+        {"name": "two", "file": str(tmp_path / "b.py"), "line": 1},
+    ]
+
+    with patch("skylos.llm.harness.verification.run_verification") as mock_run:
+        with pytest.raises(HarnessBudgetExceeded, match="findings budget"):
+            run_verification_harness(
+                findings=findings,
+                defs_map={},
+                project_root=tmp_path,
+                harness_run_id="too-many-findings",
+                harness_budget=HarnessBudget(max_findings=1),
+                quiet=True,
+            )
+
+    mock_run.assert_not_called()
+    events = _read_jsonl(tmp_path / ".skylos" / "runs" / "too-many-findings" / "events.jsonl")
+    assert events[-1]["status"] == "failed"
+    assert "findings budget" in events[-1]["error"]
+    state = _read_json(tmp_path / ".skylos" / "runs" / "too-many-findings" / "state.json")
+    summary = _read_json(tmp_path / ".skylos" / "runs" / "too-many-findings" / "summary.json")
+    assert state["budget_used"]["findings"] == 2
+    assert summary["status"] == "failed"
+
+
+def test_verification_harness_rejects_llm_calls_over_budget(tmp_path):
+    result = {
+        "verified_findings": [],
+        "new_dead_code": [],
+        "entry_points": [],
+        "stats": {"total_findings": 1, "llm_calls": 3},
+    }
+
+    with patch(
+        "skylos.llm.harness.verification.run_verification",
+        return_value=result,
+    ):
+        with pytest.raises(HarnessBudgetExceeded, match="LLM call budget"):
+            run_verification_harness(
+                findings=[{"name": "old", "file": str(tmp_path / "a.py"), "line": 1}],
+                defs_map={},
+                project_root=tmp_path,
+                harness_run_id="over-budget",
+                harness_trace_root=tmp_path / "runs",
+                harness_budget=HarnessBudget(max_llm_calls=2),
+                quiet=True,
+            )
+
+    events = _read_jsonl(tmp_path / "runs" / "over-budget" / "events.jsonl")
+    assert events[-1]["status"] == "failed"
+    assert "LLM call budget" in events[-1]["error"]
+
+
+def test_verification_harness_traces_verifier_exception(tmp_path):
+    with patch(
+        "skylos.llm.harness.verification.run_verification",
+        side_effect=RuntimeError("verifier exploded"),
+    ):
+        with pytest.raises(RuntimeError, match="verifier exploded"):
+            run_verification_harness(
+                findings=[],
+                defs_map={},
+                project_root=tmp_path,
+                harness_run_id="verifier-failed",
+                quiet=True,
+            )
+
+    events = _read_jsonl(tmp_path / ".skylos" / "runs" / "verifier-failed" / "events.jsonl")
+    assert [event["event"] for event in events] == [
+        "run_started",
+        "run_completed",
+    ]
+    assert events[-1]["status"] == "failed"
+    assert "RuntimeError: verifier exploded" in events[-1]["error"]
+
+
+def test_verification_harness_blocks_entry_discovery_before_llm_call(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+
+    with patch("skylos.llm.verify_orchestrator.DeadCodeVerifierAgent") as MockAgent:
+        with pytest.raises(HarnessBudgetExceeded, match="before entry_discovery"):
+            run_verification_harness(
+                findings=[],
+                defs_map={},
+                project_root=project,
+                harness_run_id="blocked-entry",
+                harness_budget=HarnessBudget(max_llm_calls=0),
+                model="test-model",
+                api_key="test-key",
+                quiet=True,
+            )
+
+    MockAgent.return_value._call_llm.assert_not_called()
+    events = _read_jsonl(project / ".skylos" / "runs" / "blocked-entry" / "events.jsonl")
+    assert [event["event"] for event in events] == [
+        "run_started",
+        "step_started",
+        "step_failed",
+        "run_completed",
+    ]
+    assert events[2]["name"] == "entry_discovery"
+    assert "before entry_discovery" in events[-1]["error"]
+    state = _read_json(project / ".skylos" / "runs" / "blocked-entry" / "state.json")
+    summary = _read_json(project / ".skylos" / "runs" / "blocked-entry" / "summary.json")
+    assert state["failed_phase"] == "entry_discovery"
+    assert state["budget_used"]["llm_calls"] == 0
+    assert summary["failed_phase"] == "entry_discovery"
+    assert summary["budget_remaining"]["llm_calls"] == 0
+
+
+def test_verification_harness_allows_no_config_entry_discovery_with_zero_llm_budget(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with patch("skylos.llm.verify_orchestrator.DeadCodeVerifierAgent") as MockAgent:
+        harness_result = run_verification_harness(
+            findings=[],
+            defs_map={},
+            project_root=project,
+            harness_run_id="no-config-entry",
+            harness_budget=HarnessBudget(max_llm_calls=0),
+            model="test-model",
+            api_key="test-key",
+            quiet=True,
+        )
+
+    MockAgent.return_value._call_llm.assert_not_called()
+    assert harness_result.output["stats"]["llm_calls"] == 0
+    state = _read_json(project / ".skylos" / "runs" / "no-config-entry" / "state.json")
+    summary = _read_json(project / ".skylos" / "runs" / "no-config-entry" / "summary.json")
+    assert state["status"] == "completed"
+    assert state["budget_used"]["llm_calls"] == 0
+    assert summary["budget_remaining"]["llm_calls"] == 0
+
+
+def test_verification_harness_runs_real_verifier_with_mocked_agent(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    source_file = project / "main.py"
+    source_file.write_text("def old_func():\n    pass\n")
+
+    findings = [
+        {
+            "name": "old_func",
+            "full_name": "main.old_func",
+            "file": str(source_file),
+            "line": 1,
+            "confidence": 75,
+            "references": 0,
+            "type": "function",
+            "calls": [],
+            "called_by": [],
+        }
+    ]
+    defs_map = {
+        "main.old_func": {
+            "name": "main.old_func",
+            "file": str(source_file),
+            "line": 1,
+            "type": "function",
+        }
+    }
+
+    def mock_llm(system, user):
+        if "entry point" in system.lower() or "entry point" in user.lower():
+            return json.dumps({"entry_points": []})
+        if "survivor" in system.lower() or "heuristic" in system.lower():
+            return json.dumps(
+                {
+                    "is_dead": True,
+                    "rationale": "spurious match",
+                    "heuristic_assessment": "spurious",
+                }
+            )
+        return json.dumps({"verdict": "TRUE_POSITIVE", "rationale": "no callers"})
+
+    with patch("skylos.llm.verify_orchestrator.DeadCodeVerifierAgent") as MockAgent:
+        MockAgent.return_value._call_llm.side_effect = mock_llm
+        harness_result = run_verification_harness(
+            findings=findings,
+            defs_map=defs_map,
+            project_root=project,
+            harness_run_id="real-verifier",
+            model="test-model",
+            api_key="test-key",
+            max_verify=10,
+            max_challenge=5,
+            quiet=True,
+        )
+
+    assert harness_result.output["stats"]["total_findings"] == 1
+    assert harness_result.output["verified_findings"][0]["_llm_verdict"] == "TRUE_POSITIVE"
+    step_names = [step.name for step in harness_result.run.steps]
+    assert step_names == [
+        "entry_discovery",
+        "candidate_selection",
+        "haiku_prefilter",
+        "verify_findings",
+        "suppression_audit",
+        "propagate_alive",
+        "survivor_challenge",
+        "finalize",
+    ]
+    assert harness_result.run.steps[-1].output_summary["verified_findings"] == 1
+    tool_names = [call.name for call in harness_result.run.tool_calls]
+    assert {
+        "entry_discovery",
+        "deterministic_suppression",
+        "graph_verify",
+        "survivor_local_scan",
+        "survivor_discovery",
+    }.issubset(set(tool_names))
+    events = _read_jsonl(project / ".skylos" / "runs" / "real-verifier" / "events.jsonl")
+    assert events[-1]["status"] == "completed"
+    replay = load_harness_replay(project / ".skylos" / "runs" / "real-verifier")
+    replay.assert_valid()
+    assert replay.phase_sequence() == step_names
+    assert replay.tool_sequence() == tool_names
+    state = _read_json(project / ".skylos" / "runs" / "real-verifier" / "state.json")
+    summary = _read_json(project / ".skylos" / "runs" / "real-verifier" / "summary.json")
+    assert state["current_phase"] is None
+    assert state["completed_phases"] == step_names
+    assert [call["name"] for call in state["tool_calls"]] == tool_names
+    assert state["budget_used"]["findings"] == 1
+    assert state["budget_used"]["llm_calls"] == 2
+    assert summary["completed_phases"] == step_names
+    assert summary["tool_call_count"] == len(tool_names)
+    assert summary["decision_count"] >= 2
+    decision_codes = {decision["code"] for decision in state["decisions"]}
+    assert "sent_to_llm" in decision_codes
+    assert "verified_true_positive" in decision_codes
+
+
+def test_dead_code_agent_verify_candidates_uses_harness(tmp_path):
+    expected = {"verified_findings": [], "new_dead_code": [], "stats": {}}
+    agent = DeadCodeAgent(AgentConfig(model="test-model", api_key="test-key"))
+
+    with patch("skylos.llm.harness.run_verification_harness") as mock_harness:
+        mock_harness.return_value = SimpleNamespace(output=expected)
+        result = agent.verify_candidates(
+            findings=[],
+            defs_map={},
+            project_root=tmp_path,
+            max_verify=3,
+            batch_mode=False,
+            quiet=True,
+            verification_mode="judge_all",
+        )
+
+    assert result == expected
+    mock_harness.assert_called_once()
+    kwargs = mock_harness.call_args.kwargs
+    assert kwargs["project_root"] == str(tmp_path)
+    assert kwargs["model"] == "test-model"
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["max_verify"] == 3
+    assert kwargs["batch_mode"] is False
+    assert kwargs["quiet"] is True
+    assert kwargs["verification_mode"] == "judge_all"
+
+
+def test_dead_code_agent_challenge_survivors_uses_harness(tmp_path):
+    expected = {"verified_findings": [], "new_dead_code": [], "stats": {}}
+    config = AgentConfig(model="test-model", api_key="test-key")
+    config.provider = "test-provider"
+    config.base_url = "https://example.test/v1"
+    agent = DeadCodeAgent(config)
+    survivors = [
+        {
+            "name": "maybe_used",
+            "full_name": "app.maybe_used",
+            "file": str(tmp_path / "app.py"),
+            "line": 1,
+            "type": "function",
+        }
+    ]
+
+    with patch("skylos.llm.harness.run_verification_harness") as mock_harness:
+        mock_harness.return_value = SimpleNamespace(output=expected)
+        result = agent.challenge_survivors(
+            survivors=survivors,
+            defs_map={"app.maybe_used": {"name": "app.maybe_used"}},
+            project_root=tmp_path,
+            max_challenge=7,
+            quiet=True,
+        )
+
+    assert result == expected
+    assert survivors[0]["_is_survivor"] is True
+    mock_harness.assert_called_once()
+    kwargs = mock_harness.call_args.kwargs
+    assert kwargs["findings"] == survivors
+    assert kwargs["project_root"] == str(tmp_path)
+    assert kwargs["model"] == "test-model"
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["provider"] == "test-provider"
+    assert kwargs["base_url"] == "https://example.test/v1"
+    assert kwargs["max_verify"] == 7
+    assert kwargs["max_challenge"] == 7
+    assert kwargs["enable_survivor_challenge"] is True
+    assert kwargs["batch_mode"] is True
+    assert kwargs["quiet"] is True

--- a/test/test_llm_harness.py
+++ b/test/test_llm_harness.py
@@ -330,7 +330,9 @@ def test_harness_replay_reports_corrupted_summary(tmp_path):
     summary_path = trace_root / "replay-corrupt" / "summary.json"
     summary = _read_json(summary_path)
     summary["phase_count"] = 99
-    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    summary_path.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        json.dumps(summary), encoding="utf-8"
+    )
 
     replay = load_harness_replay(trace_root / "replay-corrupt")
 
@@ -410,7 +412,9 @@ def test_trace_writer_rejects_existing_artifact_symlink(tmp_path):
     run_dir = trace_root / "run-one"
     run_dir.mkdir(parents=True)
     target = tmp_path / "target.json"
-    target.write_text("do-not-overwrite", encoding="utf-8")
+    target.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        "do-not-overwrite", encoding="utf-8"
+    )
     os.symlink(target, run_dir / "state.json")
 
     result = write_json_artifact(
@@ -573,7 +577,9 @@ def test_verification_harness_traces_verifier_exception(tmp_path):
 def test_verification_harness_blocks_entry_discovery_before_llm_call(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
-    (project / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    (project / "pyproject.toml").write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        "[project]\nname = 'demo'\n"
+    )
 
     with patch("skylos.llm.verify_orchestrator.DeadCodeVerifierAgent") as MockAgent:
         with pytest.raises(HarnessBudgetExceeded, match="before entry_discovery"):
@@ -634,9 +640,13 @@ def test_verification_harness_allows_no_config_entry_discovery_with_zero_llm_bud
 def test_verification_harness_runs_real_verifier_with_mocked_agent(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
-    (project / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    (project / "pyproject.toml").write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        "[project]\nname = 'demo'\n"
+    )
     source_file = project / "main.py"
-    source_file.write_text("def old_func():\n    pass\n")
+    source_file.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        "def old_func():\n    pass\n"
+    )
 
     findings = [
         {

--- a/test/test_llm_harness.py
+++ b/test/test_llm_harness.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -15,6 +16,7 @@ from skylos.llm.harness import (
     load_harness_replay,
     run_verification_harness,
 )
+from skylos.llm.harness.trace import write_json_artifact, write_jsonl_trace
 from skylos.llm.agents import AgentConfig, DeadCodeAgent
 
 
@@ -363,6 +365,63 @@ def test_runner_sanitizes_trace_run_id(tmp_path):
     assert (tmp_path / "runs" / "bad_id" / "events.jsonl").exists()
     assert (tmp_path / "runs" / "bad_id" / "state.json").exists()
     assert (tmp_path / "runs" / "bad_id" / "summary.json").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink not supported")
+def test_trace_writer_rejects_symlinked_trace_root_component(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.symlink(outside, repo_root / ".skylos")
+
+    result = write_json_artifact(
+        repo_root / ".skylos" / "runs",
+        "run-one",
+        "state.json",
+        {"status": "bad"},
+    )
+
+    assert result is None
+    assert not (outside / "runs" / "run-one" / "state.json").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink not supported")
+def test_trace_writer_rejects_symlinked_run_directory(tmp_path):
+    trace_root = tmp_path / "runs"
+    trace_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.symlink(outside, trace_root / "run-one")
+
+    result = write_jsonl_trace(
+        trace_root,
+        "run-one",
+        [{"event": "run_started", "run_id": "run-one"}],
+    )
+
+    assert result is None
+    assert not (outside / "events.jsonl").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink not supported")
+def test_trace_writer_rejects_existing_artifact_symlink(tmp_path):
+    trace_root = tmp_path / "runs"
+    run_dir = trace_root / "run-one"
+    run_dir.mkdir(parents=True)
+    target = tmp_path / "target.json"
+    target.write_text("do-not-overwrite", encoding="utf-8")
+    os.symlink(target, run_dir / "state.json")
+
+    result = write_json_artifact(
+        trace_root,
+        "run-one",
+        "state.json",
+        {"status": "bad"},
+    )
+
+    assert result is None
+    assert target.read_text(encoding="utf-8") == "do-not-overwrite"
 
 
 def test_verification_harness_wraps_existing_verifier(tmp_path):


### PR DESCRIPTION
 ## Summary

  - Add replayable LLM verification harness
  - Wire the harness into `run_verification`, `DeadCodeAgent`, and `skylos agent verify` output.
  - Split verification orchestration into focused phase modules
  - Add replay validation and safety checks for trace artifact reads/writes.

  ## Tests

  - `pytest .`