### PR TITLE
fix(cli): unify exclude options

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ container usage, and optional dependencies.
 Run `skylos init` to add these sections to `pyproject.toml`:
 
 ```toml
+[tool.skylos]
+exclude = ["node_modules", "dist"]
+
 [tool.skylos.templates]
 # security = ".skylos/templates/security.md"
 # quality = ".skylos/templates/quality.md"
@@ -228,7 +231,10 @@ By default Skylos discovers `[tool.skylos]` in `pyproject.toml` by walking up
 from the scan path. To use a dedicated TOML config, pass `--config-file PATH`
 or set `SKYLOS_CONFIG_FILE`; standalone files may use either `[tool.skylos]`
 or top-level `[skylos]`. Synced Skylos Cloud policy keeps its protected
-precedence over repository-controlled config.
+precedence over repository-controlled config. The top-level
+`[tool.skylos].exclude` list applies to the main scan and commands such as
+`skylos debt` and `skylos clean`; pass `--exclude` for command-local additions
+or `--include-folder` to override an excluded folder.
 
 ## Language Support
 

--- a/skylos/cli_core/main_parser.py
+++ b/skylos/cli_core/main_parser.py
@@ -157,13 +157,19 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
     parser.add_argument("--dry-run", action="store_true", help="Show what would be removed")
 
     parser.add_argument(
-        "--exclude-folder",
+        "--exclude",
         action="append",
         dest="exclude_folders",
         help=(
-            "Exclude a folder from analysis (can be used multiple times). By default, common folders like __pycache__, "
+            "Exclude folders from analysis. Can be repeated. By default, common folders like __pycache__, "
             ".git, venv are excluded. Use --no-default-excludes to disable default exclusions."
         ),
+    )
+    parser.add_argument(
+        "--exclude-folder",
+        action="append",
+        dest="exclude_folders",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--include-folder",
@@ -177,7 +183,7 @@ Run 'skylos tour' for a guided walkthrough of capabilities.
     parser.add_argument(
         "--no-default-excludes",
         action="store_true",
-        help="Do not exclude default folders (__pycache__, .git, venv, etc.). Only exclude folders with --exclude-folder.",
+        help="Do not exclude default folders (__pycache__, .git, venv, etc.). Only exclude folders from config or --exclude.",
     )
     parser.add_argument(
         "--list-default-excludes",

--- a/skylos/commands/clean_cmd.py
+++ b/skylos/commands/clean_cmd.py
@@ -6,6 +6,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
 
+from skylos.config import load_config
+from skylos.constants import parse_exclude_folders
 from skylos.remediation.codemods import (
     comment_out_unused_function_cst,
     comment_out_unused_import_cst,
@@ -90,6 +92,26 @@ def _build_parser():
         action="store_true",
         help="Use comment-out transforms instead of removal in noninteractive mode.",
     )
+    parser.add_argument(
+        "--exclude",
+        "--exclude-folder",
+        nargs="+",
+        action="extend",
+        dest="exclude_folders",
+        default=None,
+        help="Additional folders to exclude from analysis.",
+    )
+    parser.add_argument(
+        "--include-folder",
+        action="append",
+        dest="include_folders",
+        help="Force include a folder that would otherwise be excluded.",
+    )
+    parser.add_argument(
+        "--no-default-excludes",
+        action="store_true",
+        help="Do not exclude default folders; only exclude folders from config or --exclude.",
+    )
     return parser
 
 
@@ -121,10 +143,11 @@ def _effective_confidence(args, noninteractive):
     return None
 
 
-def _analyze(path, confidence):
-    if confidence is None:
-        return json.loads(run_analyze(path))
-    return json.loads(run_analyze(path, conf=confidence))
+def _analyze(path, confidence, exclude_folders):
+    kwargs = {"exclude_folders": sorted(exclude_folders)}
+    if confidence is not None:
+        kwargs["conf"] = confidence
+    return json.loads(run_analyze(path, **kwargs))
 
 
 def _collect_all_findings(result):
@@ -344,6 +367,12 @@ def run_clean_command(argv: list[str]) -> int:
     scan_root = Path(path).resolve()
     if scan_root.is_file():
         scan_root = scan_root.parent
+    exclude_folders = parse_exclude_folders(
+        user_exclude_folders=args.exclude_folders,
+        config_exclude_folders=load_config(scan_root).get("exclude"),
+        use_defaults=not args.no_default_excludes,
+        include_folders=args.include_folders,
+    )
 
     console.print(
         Panel(
@@ -354,7 +383,7 @@ def run_clean_command(argv: list[str]) -> int:
     console.print(f"Scanning [bold]{path}[/bold]...\n")
 
     confidence = _effective_confidence(args, noninteractive)
-    result = _analyze(path, confidence)
+    result = _analyze(path, confidence, exclude_folders)
     all_findings = _collect_all_findings(result)
 
     if not all_findings:

--- a/skylos/commands/debt_cmd.py
+++ b/skylos/commands/debt_cmd.py
@@ -181,9 +181,22 @@ def run_debt_command(
     )
     debt_parser.add_argument(
         "--exclude",
+        "--exclude-folder",
         nargs="+",
+        action="extend",
         default=None,
         help="Additional folders to exclude",
+    )
+    debt_parser.add_argument(
+        "--include-folder",
+        action="append",
+        dest="include_folders",
+        help="Force include a folder that would otherwise be excluded",
+    )
+    debt_parser.add_argument(
+        "--no-default-excludes",
+        action="store_true",
+        help="Do not exclude default folders; only exclude folders from config or --exclude.",
     )
     debt_args = debt_parser.parse_args(argv)
     console = console_factory()
@@ -265,12 +278,12 @@ def run_debt_command(
 
     exclude = set(
         parse_exclude_folders_func(
-            use_defaults=True,
+            use_defaults=not debt_args.no_default_excludes,
             config_exclude_folders=load_config_func(target).get("exclude"),
+            user_exclude_folders=debt_args.exclude,
+            include_folders=debt_args.include_folders,
         )
     )
-    if debt_args.exclude:
-        exclude.update(debt_args.exclude)
 
     policy = None
     try:

--- a/skylos/core/cli_shared.py
+++ b/skylos/core/cli_shared.py
@@ -34,6 +34,7 @@ _SAFE_ADDOPTS_VALUE_OPTIONS = frozenset(
         "--format",
         "--confidence",
         "-c",
+        "--exclude",
         "--exclude-folder",
         "--include-folder",
         "--diff-base",

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -132,6 +132,7 @@ COMMANDS = [
             "--apply: apply matching cleanup edits without prompting",
             "--confidence N: minimum confidence, default 80 in noninteractive mode",
             "--types import,function: comma-separated cleanup types",
+            "--exclude FOLDER: exclude a folder from analysis",
             "--comment-out: comment out findings instead of removing them",
         ],
         "group": "Utility",

--- a/test/test_clean_cmd.py
+++ b/test/test_clean_cmd.py
@@ -182,7 +182,10 @@ def test_clean_command_dry_run_writes_nothing_and_uses_default_confidence(tmp_pa
         exit_code = clean_cmd.run_clean_command([str(tmp_path), "--dry-run"])
 
     assert exit_code == 0
-    analyze.assert_called_once_with(str(tmp_path), conf=80)
+    analyze.assert_called_once()
+    assert analyze.call_args.args == (str(tmp_path),)
+    assert analyze.call_args.kwargs["conf"] == 80
+    assert ".git" in analyze.call_args.kwargs["exclude_folders"]
     remove_import.assert_not_called()
     assert target.read_text(encoding="utf-8") == original
     printed = " ".join(
@@ -190,6 +193,45 @@ def test_clean_command_dry_run_writes_nothing_and_uses_default_confidence(tmp_pa
     )
     assert "Dry run" in printed
     assert "os" in printed
+
+
+def test_clean_command_merges_config_and_cli_excludes(tmp_path):
+    result = {
+        "unused_imports": [],
+        "unused_functions": [],
+    }
+    console = Mock()
+
+    with (
+        patch("skylos.commands.clean_cmd.Console", return_value=console),
+        patch(
+            "skylos.commands.clean_cmd.load_config",
+            return_value={"exclude": ["generated", "vendor"]},
+        ),
+        patch(
+            "skylos.commands.clean_cmd.run_analyze", return_value=json.dumps(result)
+        ) as analyze,
+    ):
+        exit_code = clean_cmd.run_clean_command(
+            [
+                str(tmp_path),
+                "--dry-run",
+                "--no-default-excludes",
+                "--exclude",
+                "build",
+                "--exclude-folder",
+                "legacy",
+                "--include-folder",
+                "vendor",
+            ]
+        )
+
+    assert exit_code == 0
+    assert set(analyze.call_args.kwargs["exclude_folders"]) == {
+        "build",
+        "generated",
+        "legacy",
+    }
 
 
 def test_clean_command_apply_removes_without_prompt(tmp_path):

--- a/test/test_cli_addopts_safety.py
+++ b/test/test_cli_addopts_safety.py
@@ -22,6 +22,8 @@ def test_sanitize_addopts_keeps_safe_scan_options_only():
             "--confidence",
             "80",
             "--severity=high",
+            "--exclude",
+            "generated",
             "--exclude-folder",
             "vendor",
             "--trace",
@@ -41,9 +43,24 @@ def test_sanitize_addopts_keeps_safe_scan_options_only():
         "--confidence",
         "80",
         "--severity=high",
+        "--exclude",
+        "generated",
         "--exclude-folder",
         "vendor",
     ]
+
+
+def test_parse_main_cli_args_accepts_uniform_exclude_flag_and_compat_alias():
+    parser = build_main_parser(version="test")
+
+    args = parse_main_cli_args(
+        parser,
+        [".", "--exclude", "generated", "--exclude-folder", "vendor"],
+        addopts_loader=list,
+    )
+
+    assert args.path == ["."]
+    assert args.exclude_folders == ["generated", "vendor"]
 
 
 def test_parse_main_cli_args_never_gets_command_from_addopts():

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -307,6 +307,7 @@ def test_cli_guardrail_clean_help_lists_noninteractive_flags(monkeypatch, capsys
     assert "skylos clean [--dry-run|--apply]" in output
     assert "--confidence N" in output
     assert "--types import,function" in output
+    assert "--exclude FOLDER" in output
     assert "--comment-out" in output
 
 
@@ -1270,6 +1271,50 @@ def test_cli_guardrail_debt_changed_json_keeps_project_scope(tmp_path, monkeypat
     assert payload["summary"]["scope"]["score"] == "project"
     assert payload["summary"]["scope"]["hotspots"] == "changed"
     assert payload["hotspots"][0]["priority_score"] == 38.87
+
+
+def test_cli_guardrail_debt_uses_uniform_exclude_flags_and_config(
+    tmp_path, monkeypatch
+):
+    snapshot = _debt_snapshot(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "skylos",
+            "debt",
+            str(tmp_path),
+            "--no-default-excludes",
+            "--exclude",
+            "build",
+            "dist",
+            "--exclude-folder",
+            "legacy",
+            "--include-folder",
+            "vendor",
+        ],
+    )
+
+    with (
+        patch(
+            "skylos.cli.load_config",
+            return_value={"exclude": ["generated", "vendor"]},
+        ),
+        patch("skylos.debt.run_debt_analysis", return_value=snapshot) as mock_debt,
+        patch("skylos.debt.load_policy", return_value=None),
+        patch("skylos.debt.format_debt_table", return_value="ok"),
+        patch("skylos.cli.Console", return_value=Mock()),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    assert set(mock_debt.call_args.kwargs["exclude_folders"]) == {
+        "build",
+        "dist",
+        "generated",
+        "legacy",
+    }
 
 
 def test_cli_guardrail_debt_subdir_save_baseline_rejected(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #601

## Summary

  Unifies Skylos exclusion options across scan, debt, and clean command surfaces.

## Changes

  - Adds `--exclude` to `skylos` scan command while preserving `--exclude-folder`
  - Adds exclusion to `skylos clean`, including:
    - `--exclude`
    - `--exclude-folder`
    - `--include-folder`
    - `--no-default-excludes`
    - `[tool.skylos].exclude` from `pyproject.toml`
  - Allows `--exclude` in `[tool.skylos].addopts`.

  ## Tests

  - `pytest test/test_clean_cmd.py test/test_cli_addopts_safety.py test/test_cli_refactor_guardrails.py`