### PR TITLE
refactor(cli): remove unused feature hints

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>773</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>6828</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>775</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>6876</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>31</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 253</span>
+          <span class="pill"><strong>symbols</strong> 252</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -1112,12 +1112,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/commands command modules used by the cli for focused command behavior. put command-specific behavior here instead of growing skylos/cli.py. skylos/commands/cicd_cmd.py skylos/commands/sync_cmd.py  skylos/commands/clean_cmd.py skylos/commands/suite_cmd.py skylos/commands/defend_cmd.py skylos/commands/rules_cmd.py skylos/commands/verify_cmd.py skylos/commands/key_cmd.py skylos/commands/cache_cmd.py skylos/commands/cicd_cmd.py">
+    <article class="folder-card searchable" data-search="skylos/commands command modules used by the cli for focused command behavior. put command-specific behavior here instead of growing skylos/cli.py. skylos/commands/cicd_cmd.py skylos/commands/sync_cmd.py  skylos/commands/agent_verify_cmd.py skylos/commands/agent_replay_cmd.py skylos/commands/clean_cmd.py skylos/commands/suite_cmd.py skylos/commands/defend_cmd.py skylos/commands/rules_cmd.py skylos/commands/verify_cmd.py skylos/commands/key_cmd.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands" rel="noopener noreferrer">skylos/commands</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 25</span>
-          <span class="pill"><strong>symbols</strong> 121</span>
+          <span class="pill"><strong>files</strong> 27</span>
+          <span class="pill"><strong>symbols</strong> 164</span>
         </div>
       </div>
       <p>Command modules used by the CLI for focused command behavior.</p>
@@ -1131,31 +1131,31 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">skylos/commands/clean_cmd.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">skylos/commands/agent_verify_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">skylos/commands/agent_replay_cmd.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">skylos/commands/clean_cmd.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">skylos/commands/suite_cmd.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">skylos/commands/defend_cmd.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/rules_cmd.py" rel="noopener noreferrer">skylos/commands/rules_cmd.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/verify_cmd.py" rel="noopener noreferrer">skylos/commands/verify_cmd.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py" rel="noopener noreferrer">skylos/commands/key_cmd.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cache_cmd.py" rel="noopener noreferrer">skylos/commands/cache_cmd.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/cicd_cmd.py" rel="noopener noreferrer">skylos/commands/cicd_cmd.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/key_cmd.py" rel="noopener noreferrer">skylos/commands/key_cmd.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">run_analyze</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">add_agent_verify_parser</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">run_agent_verify_command</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">_run_static_dead_code_scan</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">_collect_dead_code_findings</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">_run_verification_harness</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">add_agent_replay_parser</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">run_agent_replay_command</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">harness_replay_payload</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">print_harness_replay</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">_write_replay_output</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">run_analyze</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">run_clean_command</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">_apply_codemod</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">_collect_findings</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">_build_parser</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">run_suite_command</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_parse_csv_selection</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_build_static_upload_result</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_static_upload_failed_quality_gate</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/suite_cmd.py" rel="noopener noreferrer">_build_suite_parser</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">run_defend_command</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">_build_empty_defense_json</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">_build_defend_parser</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/defend_cmd.py" rel="noopener noreferrer">_validate_defend_target</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/clean_cmd.py" rel="noopener noreferrer">_collect_findings</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1490,12 +1490,12 @@
     </article>
     
 
-    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_consumption.py test/test_llm_context.py test/test_llm_finding_evidence.py skylos/llm/security_taskflow.py skylos/llm/verify_orchestrator.py skylos/llm/_grounding.py skylos/llm/finding_evidence.py skylos/llm/prompts.py skylos/llm/threat_trace.py skylos/llm/liveness.py skylos/llm/harness/replay.py">
+    <article class="folder-card searchable" data-search="skylos/llm llm security analysis, evidence grounding, provider runtime resolution, and prompt templates. treat this as high-risk: changes can reduce hallucinations or create scanner false negatives. skylos/llm/analyzer.py skylos/llm/finding_evidence.py skylos/llm/runtime.py test/test_cli_llm_provider.py test/test_litellm_adapter.py test/test_llm_analyzer.py test/test_llm_consumption.py test/test_llm_context.py test/test_llm_finding_evidence.py skylos/llm/security_taskflow.py skylos/llm/verify_orchestrator.py skylos/llm/_grounding.py skylos/llm/finding_evidence.py skylos/llm/prompts.py skylos/llm/threat_trace.py skylos/llm/harness/replay.py skylos/llm/liveness.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 47</span>
-          <span class="pill"><strong>symbols</strong> 505</span>
+          <span class="pill"><strong>symbols</strong> 506</span>
         </div>
       </div>
       <p>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</p>
@@ -1515,8 +1515,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/finding_evidence.py" rel="noopener noreferrer">skylos/llm/finding_evidence.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/prompts.py" rel="noopener noreferrer">skylos/llm/prompts.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/threat_trace.py" rel="noopener noreferrer">skylos/llm/threat_trace.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/liveness.py" rel="noopener noreferrer">skylos/llm/liveness.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/harness/replay.py" rel="noopener noreferrer">skylos/llm/harness/replay.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/harness/replay.py" rel="noopener noreferrer">skylos/llm/harness/replay.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm/liveness.py" rel="noopener noreferrer">skylos/llm/liveness.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1943,7 +1943,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 209</span>
-          <span class="pill"><strong>symbols</strong> 2637</span>
+          <span class="pill"><strong>symbols</strong> 2642</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -1998,7 +1998,7 @@
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>34 / 153</td>
+              <td>34 / 152</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -6744,13 +6744,6 @@
               <td>skylos/cli.py</td>
             </tr>
 
-            <tr class="searchable" data-search="_print_feature_hints def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_print_feature_hints</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
             <tr class="searchable" data-search="interactive_selection def skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">interactive_selection</a></td>
               <td>def</td>
@@ -7731,6 +7724,48 @@
               <td>skylos/cloud/upload_manifest.py</td>
             </tr>
 
+            <tr class="searchable" data-search="add_agent_replay_parser def skylos/commands/agent_replay_cmd.py command modules used by the cli for focused command behavior.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">add_agent_replay_parser</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/commands/agent_replay_cmd.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="run_agent_replay_command def skylos/commands/agent_replay_cmd.py command modules used by the cli for focused command behavior.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">run_agent_replay_command</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/commands/agent_replay_cmd.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="harness_replay_payload def skylos/commands/agent_replay_cmd.py command modules used by the cli for focused command behavior.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">harness_replay_payload</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/commands/agent_replay_cmd.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="print_harness_replay def skylos/commands/agent_replay_cmd.py command modules used by the cli for focused command behavior.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_replay_cmd.py" rel="noopener noreferrer">print_harness_replay</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/commands/agent_replay_cmd.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="add_agent_verify_parser def skylos/commands/agent_verify_cmd.py command modules used by the cli for focused command behavior.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">add_agent_verify_parser</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/commands/agent_verify_cmd.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="run_agent_verify_command def skylos/commands/agent_verify_cmd.py command modules used by the cli for focused command behavior.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/agent_verify_cmd.py" rel="noopener noreferrer">run_agent_verify_command</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/commands/agent_verify_cmd.py</td>
+            </tr>
+
             <tr class="searchable" data-search="run_badge_command def skylos/commands/badge_cmd.py command modules used by the cli for focused command behavior.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands/badge_cmd.py" rel="noopener noreferrer">run_badge_command</a></td>
               <td>def</td>
@@ -8366,41 +8401,6 @@
               <td>class</td>
               <td><span class="ok">public</span></td>
               <td>skylos/core/linter.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="load_python_api_surface_cache def skylos/core/python_api_surface.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">load_python_api_surface_cache</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/core/python_api_surface.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="save_python_api_surface_cache def skylos/core/python_api_surface.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">save_python_api_surface_cache</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/core/python_api_surface.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="cached_python_api_surface def skylos/core/python_api_surface.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">cached_python_api_surface</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/core/python_api_surface.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="cache_python_api_surface def skylos/core/python_api_surface.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">cache_python_api_surface</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/core/python_api_surface.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="build_python_api_surface def skylos/core/python_api_surface.py small shared core types and helpers used across scan paths.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">build_python_api_surface</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/core/python_api_surface.py</td>
             </tr></tbody>
       </table>
     </section>

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1170,58 +1170,6 @@ def _print_upload_cta(console: Console, project_root: Path):
         )
 
 
-def _print_feature_hints(console: Console, args):
-    """Print contextual hints about features the user hasn't used yet."""
-    if _is_ci():
-        return
-
-    hints = []
-
-    ran_all = getattr(args, "all_checks", False)
-    ran_danger = getattr(args, "danger", False)
-    ran_secrets = getattr(args, "secrets", False)
-    ran_quality = getattr(args, "quality", False)
-
-    if not ran_all and not (ran_danger and ran_secrets and ran_quality):
-        extras = []
-        if not ran_danger:
-            extras.append("security")
-        if not ran_secrets:
-            extras.append("secrets")
-        if not ran_quality:
-            extras.append("quality")
-        hints.append(
-            f"[dim]Add {' + '.join(extras)} scanning:[/dim] [bold]skylos . -a[/bold]"
-        )
-
-    hint_file = Path.home() / ".skylos" / ".hint_index"
-    try:
-        idx = int(hint_file.read_text().strip()) if hint_file.exists() else 0
-    except (ValueError, OSError):
-        idx = 0
-
-    rotating_hints = [
-        "[dim]Run the full local bundle:[/dim] [bold]skylos suite .[/bold]",
-        "[dim]Scan for AI/LLM guardrails:[/dim] [bold]skylos defend .[/bold]",
-        "[dim]Map LLM integrations:[/dim] [bold]skylos discover .[/bold]",
-        "[dim]LLM-verified dead code (100% accuracy):[/dim] [bold]skylos agent verify .[/bold]",
-        "[dim]Auto-fix dead code interactively:[/dim] [bold]skylos . -i[/bold]",
-    ]
-
-    hints.append(rotating_hints[idx % len(rotating_hints)])
-
-    try:
-        hint_file.parent.mkdir(parents=True, exist_ok=True)
-        hint_file.write_text(str(idx + 1))
-    except OSError:
-        pass
-
-    if hints:
-        console.print()
-        for hint in hints:
-            console.print(f"  {hint}")
-
-
 def interactive_selection(
     console: Console, unused_functions, unused_imports, root_path=None
 ):


### PR DESCRIPTION
## Summary

  - Remove the unused `_print_feature_hints` helper from `skylos/cli.py`
