### PR TITLE
fix(sca): skip non-PyPI pyproject sources

### DIFF
--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -7,6 +7,14 @@ import time
 import logging
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:  # pragma: no cover - dependency missing
+        tomllib = None
+
 from skylos.core.safe_cache_io import (
     load_project_json_cache,
     read_text_no_symlink,
@@ -31,6 +39,11 @@ ECOSYSTEM_GO = "Go"
 
 _VERSION_RE = re.compile(r"([=~!<>]=?)\s*([A-Za-z0-9._*+-]+)")
 _REQ_LINE_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
+_DIRECT_REFERENCE_RE = re.compile(
+    r"\s@\s*(?:[A-Za-z][A-Za-z0-9+.-]*:|[A-Za-z0-9+.-]+\+|/|\.{1,2}/)"
+)
+_NON_PYPI_SOURCE_KEYS = frozenset({"git", "url", "path", "workspace", "index"})
+_POETRY_NON_PYPI_SOURCE_KEYS = frozenset({"git", "url", "path", "source"})
 
 
 def _extract_pinned_version(spec: str) -> str | None:
@@ -41,6 +54,107 @@ def _extract_pinned_version(spec: str) -> str | None:
         if op in ("~=", ">="):
             return ver
     return None
+
+
+def _normalize_dependency_name(name: str) -> str:
+    normalized = str(name).strip().lower()
+    normalized = re.sub(r"[-_.]+", "-", normalized)
+    return normalized
+
+
+def _load_toml(text: str) -> dict:
+    if tomllib is None:
+        return {}
+
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    return data
+
+
+def _has_non_pypi_source_key(source: object, keys: frozenset[str]) -> bool:
+    if isinstance(source, dict):
+        for key in source:
+            if key in keys:
+                return True
+        return False
+
+    if isinstance(source, list):
+        for candidate in source:
+            if _has_non_pypi_source_key(candidate, keys):
+                return True
+        return False
+
+    return False
+
+
+def _source_names_with_keys(
+    sources: dict,
+    keys: frozenset[str],
+    *,
+    skip_python: bool = False,
+) -> set[str]:
+    names: set[str] = set()
+
+    for raw_name, source in sources.items():
+        if skip_python and str(raw_name).strip() == "python":
+            continue
+
+        if _has_non_pypi_source_key(source, keys):
+            name = _normalize_dependency_name(str(raw_name))
+            if name:
+                names.add(name)
+
+    return names
+
+
+def _uv_non_pypi_source_names(tool: dict) -> set[str]:
+    uv = tool.get("uv")
+    if not isinstance(uv, dict):
+        return set()
+
+    sources = uv.get("sources")
+    if not isinstance(sources, dict):
+        return set()
+
+    return _source_names_with_keys(sources, _NON_PYPI_SOURCE_KEYS)
+
+
+def _poetry_non_pypi_source_names(tool: dict) -> set[str]:
+    poetry = tool.get("poetry")
+    if not isinstance(poetry, dict):
+        return set()
+
+    dependencies = poetry.get("dependencies")
+    if not isinstance(dependencies, dict):
+        return set()
+
+    return _source_names_with_keys(
+        dependencies,
+        _POETRY_NON_PYPI_SOURCE_KEYS,
+        skip_python=True,
+    )
+
+
+def _pyproject_non_pypi_source_names(text: str) -> set[str]:
+    data = _load_toml(text)
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return set()
+
+    names = set()
+    names.update(_uv_non_pypi_source_names(tool))
+    names.update(_poetry_non_pypi_source_names(tool))
+    return names
+
+
+def _is_direct_reference_requirement(requirement: str) -> bool:
+    return bool(_DIRECT_REFERENCE_RE.search(requirement))
 
 
 def parse_requirements_txt(path: Path) -> list[dict]:
@@ -97,15 +211,22 @@ def parse_pyproject_toml(path: Path) -> list[dict]:
     if txt is None:
         return deps
 
+    non_pypi_source_names = _pyproject_non_pypi_source_names(txt)
     dep_block = _extract_toml_array(txt, "dependencies")
     if dep_block:
         items = re.findall(r"""['"]([^'"]+)['"]""", dep_block)
         for item in items:
+            if _is_direct_reference_requirement(item):
+                continue
+
             m = _REQ_LINE_RE.match(item.strip())
             if not m:
                 continue
 
             name = m.group(1)
+            if _normalize_dependency_name(name) in non_pypi_source_names:
+                continue
+
             rest = item[m.end() :]
             version = _extract_pinned_version(rest)
             if not version:
@@ -140,6 +261,8 @@ def parse_pyproject_toml(path: Path) -> list[dict]:
         key = parts[0].strip()
         val = parts[1].strip()
         if key == "python":
+            continue
+        if _normalize_dependency_name(key) in non_pypi_source_names:
             continue
 
         ver_match = re.search(r"""['"]?\^?~?([0-9][A-Za-z0-9._*+-]*)""", val)

--- a/test/test_hallucination_dependency.py
+++ b/test/test_hallucination_dependency.py
@@ -89,6 +89,39 @@ dependencies = [
     assert "google-genai" in deps
 
 
+def test_uv_source_dependency_counts_as_declared_for_d223(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        """
+[project]
+dependencies = [
+  "private-pkg>=1.0.0",
+]
+
+[tool.uv.sources]
+private-pkg = { git = "https://github.com/example/private-pkg" }
+""".strip(),
+        encoding="utf-8",
+    )
+    source = _write_py(repo / "app.py", "import private_pkg\n")
+
+    monkeypatch.setattr(dep, "_get_stdlib_modules", lambda: set())
+    monkeypatch.setattr(dep, "_collect_local_modules", lambda root: set())
+    monkeypatch.setattr(dep, "_load_private_allowlist", lambda: set())
+    monkeypatch.setattr(dep, "_build_installed_module_mapping", lambda: {})
+    monkeypatch.setattr(dep, "_load_import_to_dist_mapping", lambda: {})
+
+    def fail_pypi_check(name, cache):
+        raise AssertionError(f"{name} should be treated as declared")
+
+    monkeypatch.setattr(dep, "_check_pypi_status", fail_pypi_check)
+
+    findings = dep.scan_python_dependency_hallucinations(repo, [source])
+
+    assert _extract_single(findings, dep.RULE_ID_UNDECLARED) == []
+
+
 def test_parse_pyproject_toml_poetry_block(tmp_path):
     py = tmp_path / "pyproject.toml"
     py.write_text(

--- a/test/test_manifest_dependency_hallucination.py
+++ b/test/test_manifest_dependency_hallucination.py
@@ -138,6 +138,104 @@ def test_scan_requirements_txt_flags_missing_pypi_version(tmp_path):
     assert (ECOSYSTEM_PYPI, "click", "8.1.7") in calls
 
 
+def test_scan_pyproject_skips_uv_non_pypi_sources(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "uv-source-demo"',
+                "dependencies = [",
+                '  "git-pkg>=1.0.0",',
+                '  "url-pkg==2.0.0",',
+                '  "path-pkg>=3.0.0",',
+                '  "workspace-pkg>=4.0.0",',
+                '  "index-pkg>=5.0.0",',
+                '  "normal-pkg>=6.0.0",',
+                "]",
+                "",
+                "[tool.uv.sources]",
+                'git-pkg = { git = "https://github.com/example/git-pkg" }',
+                'url-pkg = { url = "https://example.com/url-pkg.whl" }',
+                'path-pkg = { path = "../path-pkg" }',
+                "workspace-pkg = { workspace = true }",
+                'index-pkg = { index = "internal" }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+
+    findings = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=_status_checker({}, calls),
+    )
+
+    assert findings == []
+    assert calls == [(ECOSYSTEM_PYPI, "normal-pkg", "6.0.0")]
+
+
+def test_scan_pyproject_skips_pep508_direct_references(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "direct-ref-demo"',
+                "dependencies = [",
+                '  "direct-git @ git+https://github.com/example/direct-git@v1.0.0",',
+                '  "direct-url @ https://example.com/direct-url-1.0.0.whl",',
+                '  "direct-path @ ../direct-path",',
+                '  "normal-pkg==2.0.0",',
+                "]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+
+    findings = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=_status_checker({}, calls),
+    )
+
+    assert findings == []
+    assert calls == [(ECOSYSTEM_PYPI, "normal-pkg", "2.0.0")]
+
+
+def test_scan_pyproject_skips_poetry_non_pypi_sources(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[tool.poetry.dependencies]",
+                'python = "^3.11"',
+                'git-pkg = { git = "https://github.com/example/git-pkg", rev = "1.0.0" }',
+                'path-pkg = { path = "../path-pkg" }',
+                'url-pkg = { url = "https://example.com/url-pkg-1.0.0.whl" }',
+                'source-pkg = { version = "1.2.3", source = "internal" }',
+                'normal-pkg = "^6.0.0"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+
+    findings = scan_manifest_dependency_hallucinations(
+        repo,
+        status_checker=_status_checker({}, calls),
+    )
+
+    assert findings == []
+    assert calls == [(ECOSYSTEM_PYPI, "normal-pkg", "6.0.0")]
+
+
 def test_scan_manifest_dependency_statuses_are_cached(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
Fixes #606.

## Summary

  - Skip pypi hallucination checks for pyproject dependencies which relied on uv `git`, `url`, `path`, `workspace`, or custom `index` sources
  - Skip PEP 508 referenced dependencies and Poetry `git`, `path`, `url`, or `source` dependencies from pypi registry checks

  ## Tests

  - `pytest test/test_manifest_dependency_hallucination.py test/test_hallucination_dependency.py test/test_sca_cache.py`
