### PR TITLE
feat(ai-defect): add AI hallucination contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Verify a changed file or range before an agent hands it to review:
 skylos verify . --file src/app.py --range 40:75 --project-context
 ```
 
+Create a local AI hallucination contract for repo-specific generated-code
+truth, then verify against it:
+
+```bash
+skylos contract init
+skylos verify . --contract .skylos/ai-contract.yml
+```
+
 Create a project config with thresholds, ignores, template hooks, and vibe
 dictionary extensions:
 
@@ -109,6 +117,7 @@ Need more commands? Read the [CLI Reference](https://docs.skylos.dev/cli-referen
 | Selectable terminal triage | `skylos . --tui` | Opens a keyboard-driven category list, finding list, and detail pane | [CLI output modes](./docs/cli-output.md) |
 | IDE/test-script output | `skylos --format concise src/test.py` | Prints only `file:line` findings and exits non-zero when findings exist | [CLI Reference](https://docs.skylos.dev/cli-reference) |
 | In-loop AI-code verification | `skylos verify . --file src/app.py --range 40:75` | Returns narrow JSON for hallucinated helpers, unfinished code, stale references, disabled controls, and API/dependency hallucinations | [AI features](https://docs.skylos.dev/ai-features) |
+| AI hallucination contracts | `skylos verify . --contract .skylos/ai-contract.yml` | Verifies generated code against repo-specific symbols, dependencies, APIs, route guards, and test requirements | [AI Hallucination Contracts](./docs/ai-hallucination-contracts.md) |
 | Changed-lines review | `skylos . -a --diff origin/main` | Keeps findings focused on active work instead of legacy debt | [Quality gate docs](https://docs.skylos.dev/quality-gate) |
 | Runtime-assisted dead-code check | `skylos . --trace` | Uses runtime traces to reduce dynamic-code false positives | [Smart tracing](https://docs.skylos.dev/smart-tracing) |
 | Local rule pack | `skylos rules init` | Scaffolds YAML rules for project-specific security and quality checks | [Custom rules](https://docs.skylos.dev/custom-rules) |

--- a/benchmarks/ai_code_defects/fixtures/contract_dependency_clean/.skylos/ai-contract.yml
+++ b/benchmarks/ai_code_defects/fixtures/contract_dependency_clean/.skylos/ai-contract.yml
@@ -1,0 +1,7 @@
+version: 1
+id: benchmark-contract-dependencies-clean
+
+ai:
+  dependencies:
+    reject_nonexistent_packages: true
+    reject_impossible_versions: true

--- a/benchmarks/ai_code_defects/fixtures/contract_dependency_clean/package.json
+++ b/benchmarks/ai_code_defects/fixtures/contract_dependency_clean/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "left-pad": "1.3.0"
+  }
+}

--- a/benchmarks/ai_code_defects/fixtures/contract_dependency_manifest/.skylos/ai-contract.yml
+++ b/benchmarks/ai_code_defects/fixtures/contract_dependency_manifest/.skylos/ai-contract.yml
@@ -1,0 +1,7 @@
+version: 1
+id: benchmark-contract-dependencies
+
+ai:
+  dependencies:
+    reject_nonexistent_packages: true
+    reject_impossible_versions: true

--- a/benchmarks/ai_code_defects/fixtures/contract_dependency_manifest/package.json
+++ b/benchmarks/ai_code_defects/fixtures/contract_dependency_manifest/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "left-pad": "99.99.99",
+    "skylos-contract-ghost-sdk": "1.0.0"
+  }
+}

--- a/benchmarks/ai_code_defects/fixtures/contract_phantom_helper/.skylos/ai-contract.yml
+++ b/benchmarks/ai_code_defects/fixtures/contract_phantom_helper/.skylos/ai-contract.yml
@@ -1,0 +1,7 @@
+version: 1
+id: benchmark-contract-phantom-helper
+
+ai:
+  phantom_symbols:
+    names:
+      - verify_acme_tenant

--- a/benchmarks/ai_code_defects/fixtures/contract_phantom_helper/app.py
+++ b/benchmarks/ai_code_defects/fixtures/contract_phantom_helper/app.py
@@ -1,0 +1,2 @@
+def handler(request):
+    return verify_acme_tenant(request)

--- a/benchmarks/ai_code_defects/fixtures/contract_route_guard_clean/.skylos/ai-contract.yml
+++ b/benchmarks/ai_code_defects/fixtures/contract_route_guard_clean/.skylos/ai-contract.yml
@@ -1,0 +1,9 @@
+version: 1
+id: benchmark-contract-route-guard-clean
+
+security:
+  routes:
+    paths:
+      - "apps/api/**"
+    require_any_decorator:
+      - tenant_admin_required

--- a/benchmarks/ai_code_defects/fixtures/contract_route_guard_clean/apps/api/routes.py
+++ b/benchmarks/ai_code_defects/fixtures/contract_route_guard_clean/apps/api/routes.py
@@ -1,0 +1,13 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+def tenant_admin_required(handler):
+    return handler
+
+
+@app.route("/admin")
+@tenant_admin_required
+def admin_dashboard():
+    return {"ok": True}

--- a/benchmarks/ai_code_defects/fixtures/contract_route_guard_missing/.skylos/ai-contract.yml
+++ b/benchmarks/ai_code_defects/fixtures/contract_route_guard_missing/.skylos/ai-contract.yml
@@ -1,0 +1,9 @@
+version: 1
+id: benchmark-contract-route-guard
+
+security:
+  routes:
+    paths:
+      - "apps/api/**"
+    require_any_decorator:
+      - login_required

--- a/benchmarks/ai_code_defects/fixtures/contract_route_guard_missing/apps/api/routes.py
+++ b/benchmarks/ai_code_defects/fixtures/contract_route_guard_missing/apps/api/routes.py
@@ -1,0 +1,8 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/admin")
+def admin_dashboard():
+    return {"ok": True}

--- a/benchmarks/ai_code_defects/manifest.json
+++ b/benchmarks/ai_code_defects/manifest.json
@@ -665,6 +665,185 @@
       }
     },
     {
+      "id": "contract-phantom-helper",
+      "path": "fixtures/contract_phantom_helper",
+      "description": "Generated handler calls a repo-specific helper listed in the AI contract but never defined.",
+      "taxonomy": ["hallucinated_reference", "contract_guardrail"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic fixture for contract-extended phantom helper verification."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true,
+        "contract_path": ".skylos/ai-contract.yml"
+      },
+      "expect": {
+        "finding_count": 1,
+        "present": [
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference",
+            "contract_clause": "ai.phantom_symbols.names",
+            "file_contains": "app.py",
+            "message_contains": "verify_acme_tenant"
+          }
+        ],
+        "absent": []
+      }
+    },
+    {
+      "id": "contract-route-guard-missing",
+      "path": "fixtures/contract_route_guard_missing",
+      "description": "Generated route is inside a contract-scoped API path but lacks a required auth guard decorator.",
+      "taxonomy": ["contract_guardrail"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic fixture for AI contract route guard enforcement."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true,
+        "contract_path": ".skylos/ai-contract.yml"
+      },
+      "expect": {
+        "finding_count": 1,
+        "present": [
+          {
+            "rule_id": "SKY-A105",
+            "vibe_category": "missing_contract_guardrail",
+            "contract_clause": "security.routes.require_any_decorator",
+            "category": "ai_defect",
+            "severity": "HIGH",
+            "file_contains": "apps/api/routes.py",
+            "message_contains": "@login_required"
+          }
+        ],
+        "absent": []
+      }
+    },
+    {
+      "id": "contract-route-guard-clean",
+      "path": "fixtures/contract_route_guard_clean",
+      "description": "Generated route uses the custom guard decorator required by the contract.",
+      "taxonomy": ["contract_guardrail", "precision_guard"],
+      "importance": "high",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic clean fixture for contract route guard precision."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true,
+        "contract_path": ".skylos/ai-contract.yml"
+      },
+      "expect": {
+        "finding_count": 0,
+        "present": [],
+        "absent": [
+          {
+            "rule_id": "SKY-A105",
+            "vibe_category": "missing_contract_guardrail"
+          }
+        ]
+      }
+    },
+    {
+      "id": "contract-dependency-manifest",
+      "path": "fixtures/contract_dependency_manifest",
+      "description": "Contract enables dependency hallucination checks for a manifest with a fake package and impossible version.",
+      "taxonomy": ["dependency_hallucination", "contract_guardrail"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic fixture for contract-enabled dependency hallucination checks."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true,
+        "contract_path": ".skylos/ai-contract.yml",
+        "dependency_statuses": [
+          {
+            "ecosystem": "npm",
+            "name": "skylos-contract-ghost-sdk",
+            "version": "1.0.0",
+            "status": "missing_package"
+          },
+          {
+            "ecosystem": "npm",
+            "name": "left-pad",
+            "version": "99.99.99",
+            "status": "missing_version"
+          }
+        ]
+      },
+      "expect": {
+        "finding_count": 2,
+        "present": [
+          {
+            "rule_id": "SKY-D222",
+            "vibe_category": "dependency_hallucination",
+            "contract_clause": "ai.dependencies.reject_nonexistent_packages",
+            "file_contains": "package.json",
+            "message_contains": "skylos-contract-ghost-sdk"
+          },
+          {
+            "rule_id": "SKY-D225",
+            "vibe_category": "dependency_hallucination",
+            "contract_clause": "ai.dependencies.reject_impossible_versions",
+            "file_contains": "package.json",
+            "message_contains": "left-pad"
+          }
+        ],
+        "absent": []
+      }
+    },
+    {
+      "id": "contract-dependency-clean",
+      "path": "fixtures/contract_dependency_clean",
+      "description": "Contract-enabled dependency checks stay quiet for known-good dependency versions.",
+      "taxonomy": ["dependency_hallucination", "contract_guardrail", "precision_guard"],
+      "importance": "high",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic clean fixture for contract-enabled dependency hallucination precision."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true,
+        "contract_path": ".skylos/ai-contract.yml",
+        "dependency_statuses": [
+          {
+            "ecosystem": "npm",
+            "name": "left-pad",
+            "version": "1.3.0",
+            "status": "exists"
+          }
+        ]
+      },
+      "expect": {
+        "finding_count": 0,
+        "present": [],
+        "absent": [
+          {
+            "rule_id": "SKY-D222",
+            "vibe_category": "dependency_hallucination"
+          },
+          {
+            "rule_id": "SKY-D225",
+            "vibe_category": "dependency_hallucination"
+          }
+        ]
+      }
+    },
+    {
       "id": "clean-dependency-manifest",
       "path": "fixtures/clean_dependency_manifest",
       "description": "Generated npm and Go manifests use dependency versions known to exist.",

--- a/demo/ai_contract/.skylos/ai-contract.yml
+++ b/demo/ai_contract/.skylos/ai-contract.yml
@@ -1,0 +1,17 @@
+version: 1
+id: demo-ai-contract
+
+ai:
+  phantom_symbols:
+    names:
+      - verify_acme_tenant
+
+security:
+  routes:
+    paths:
+      - "apps/api/**"
+    require_any_decorator:
+      - login_required
+
+tests:
+  high_risk_changes_require_tests: true

--- a/demo/ai_contract/apps/api/routes.py
+++ b/demo/ai_contract/apps/api/routes.py
@@ -1,0 +1,16 @@
+class DemoApp:
+    def route(self, _path):
+        def decorator(handler):
+            return handler
+
+        return decorator
+
+
+app = DemoApp()
+
+
+@app.route("/admin")
+def admin_dashboard(request):
+    if not verify_acme_tenant(request):
+        return {"error": "denied"}, 403
+    return {"status": "ok"}

--- a/dictionary.md
+++ b/dictionary.md
@@ -297,6 +297,7 @@ use the `SKY-A` prefix.
 | A102 | LOW | High-risk change without tests | Diff-aware PR signal |
 | A103 | HIGH | CI permission expansion | GitHub Actions |
 | A104 | MEDIUM | Public CLI surface drift | Diff-aware CLI |
+| A105 | HIGH | Contract route guard missing | Python contract verify |
 | L012 | CRITICAL | Phantom function call / hallucinated security function | Python |
 | L023 | CRITICAL | Phantom decorator | Python |
 | D222 | CRITICAL | Dependency hallucination | Python |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This repository keeps lightweight local docs for features that need examples clo
 |:---|:---|
 | Generated codebase navigator for contributors | [Skylos Repo Map](./repo-map/index.html) |
 | CLI output modes, pretty reports, and TUI controls | [CLI Output Modes](./cli-output.md) |
+| Local contracts for verifying AI-written code | [AI Hallucination Contracts](./ai-hallucination-contracts.md) |
 | Rule ID prefixes and product terminology | [Rule Dictionary](../dictionary.md) |
 
 When GitHub Pages is enabled with the repository's `Repo map pages` workflow,

--- a/docs/ai-hallucination-contracts.md
+++ b/docs/ai-hallucination-contracts.md
@@ -1,0 +1,121 @@
+# AI Hallucination Contracts
+
+AI hallucination contracts are local YAML files that tell `skylos verify` what
+must be true for generated code in this repository. The first version compiles
+contract clauses into existing Skylos checks instead of introducing a general
+rule language.
+
+Use this when a coding agent can invent helpers, packages, versions, API calls,
+or route guardrails that look plausible but are not true for the repo.
+
+## Quickstart
+
+Create a starter contract:
+
+```bash
+skylos contract init
+skylos contract validate .skylos/ai-contract.yml
+```
+
+Run verify with the contract:
+
+```bash
+skylos verify . --contract .skylos/ai-contract.yml
+```
+
+For agent or editor loops, scope the same check to a file or range:
+
+```bash
+skylos verify . --file apps/api/routes.py --range 10:40 --project-context --contract .skylos/ai-contract.yml
+```
+
+MCP clients can pass the same path through the `verify_change` tool as
+`contract_path`.
+
+## Contract Shape
+
+```yaml
+version: 1
+
+ai:
+  phantom_symbols:
+    names:
+      - verify_enterprise_auth
+    decorators:
+      - tenant_admin_required
+
+  dependencies:
+    reject_nonexistent_packages: true
+    reject_impossible_versions: true
+
+  api_surface:
+    reject_unknown_members: true
+    reject_unknown_kwargs: true
+
+security:
+  routes:
+    paths:
+      - "apps/api/**"
+    require_any_decorator:
+      - login_required
+
+tests:
+  high_risk_changes_require_tests: true
+```
+
+## Evidence Fields
+
+Contract-backed verify findings include optional fields:
+
+| Field | Meaning |
+|:---|:---|
+| `contract_id` | Optional `id` from the contract file. |
+| `contract_clause` | Contract clause that explains the finding. |
+| `contract_path` | Contract file used for the run. |
+| `contract_reason` | Human-readable reason for the clause match. |
+
+Example clause values:
+
+| Rule | Clause |
+|:---|:---|
+| `SKY-L012` | `ai.phantom_symbols.names` |
+| `SKY-L023` | `ai.phantom_symbols.decorators` |
+| `SKY-D222` | `ai.dependencies.reject_nonexistent_packages` |
+| `SKY-D225` | `ai.dependencies.reject_impossible_versions` |
+| `SKY-D224` | `ai.api_surface.reject_unknown_members` or `ai.api_surface.reject_unknown_kwargs` |
+| `SKY-A102` | `tests.high_risk_changes_require_tests` |
+| `SKY-A105` | `security.routes.require_any_decorator` |
+
+## Local Demo
+
+This repo includes a deterministic demo fixture:
+
+```bash
+skylos verify demo/ai_contract --file apps/api/routes.py --project-context --contract demo/ai_contract/.skylos/ai-contract.yml
+```
+
+The demo intentionally contains:
+
+- a contract-listed helper that is never defined
+- an API route missing the contract-required guard decorator
+
+Dependency/package and installed-API clauses are covered by deterministic
+benchmark fixtures with offline status caches:
+
+From a source checkout, run:
+
+```bash
+.venv/bin/python scripts/ai_code_defect_benchmark.py --case contract-phantom-helper --case contract-route-guard-missing --case contract-route-guard-clean --case contract-dependency-manifest --case contract-dependency-clean --json
+```
+
+## How This Differs From Generic Rules
+
+Contracts are repo truth for generated code. They are not a replacement for
+Semgrep, CodeQL, Sonar, Snyk, or GitHub Advanced Security. Those tools are
+broad query engines, security analyzers, or platforms. Skylos contracts are a
+local verification layer for agent-written code before review or merge.
+
+Keep the local contract useful and free. Paid product surface should be built
+around organization control: central policy registry, inheritance across repos,
+SSO/RBAC, audit logs, signed verification artifacts, private package/API
+intelligence, and review workflow integrations.

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -78,6 +78,43 @@ logger = logging.getLogger("Skylos")
 PYTHON_SIGNATURE_SUFFIXES = (".py", ".pyi", ".pyw")
 
 
+def _merge_project_config_overrides(project_cfg, overrides):
+    if not isinstance(overrides, dict):
+        return project_cfg
+    if not isinstance(project_cfg, dict):
+        project_cfg = {}
+
+    merged = dict(project_cfg)
+    for key, value in overrides.items():
+        if (
+            isinstance(value, dict)
+            and isinstance(merged.get(key), dict)
+        ):
+            nested = dict(merged[key])
+            for nested_key, nested_value in value.items():
+                existing_value = nested.get(nested_key)
+                if isinstance(existing_value, list) and isinstance(
+                    nested_value, list
+                ):
+                    nested[nested_key] = _merge_ordered_lists(
+                        existing_value, nested_value
+                    )
+                else:
+                    nested[nested_key] = nested_value
+            merged[key] = nested
+        else:
+            merged[key] = value
+    return merged
+
+
+def _merge_ordered_lists(left, right):
+    merged = []
+    for value in list(left) + list(right):
+        if value not in merged:
+            merged.append(value)
+    return merged
+
+
 def _python_signature_files(files):
     py_files = []
     for file_path in files:
@@ -1982,6 +2019,7 @@ class Skylos:
         enable_sca=False,
         trace_file=None,
         config_file=None,
+        project_config_overrides=None,
     ) -> str:
         if not isinstance(path, (str, list, tuple)):
             raise TypeError(
@@ -2012,6 +2050,10 @@ class Skylos:
 
         workspace_inventory = discover_workspace_inventory(project_root)
         project_cfg = load_config(project_root, config_file=config_file)
+        if project_config_overrides:
+            project_cfg = _merge_project_config_overrides(
+                project_cfg, project_config_overrides
+            )
         project_ignore = set(project_cfg.get("ignore", []))
 
         if not files:
@@ -3571,6 +3613,7 @@ def analyze(
     enable_sca=False,
     trace_file=None,
     config_file=None,
+    project_config_overrides=None,
 ) -> str:
     return Skylos().analyze(
         path,
@@ -3589,6 +3632,7 @@ def analyze(
         enable_sca=enable_sca,
         trace_file=trace_file,
         config_file=config_file,
+        project_config_overrides=project_config_overrides,
     )
 
 

--- a/skylos/benchmarks/ai_code_defects.py
+++ b/skylos/benchmarks/ai_code_defects.py
@@ -22,6 +22,7 @@ AI_CODE_DEFECT_TAXONOMY: dict[str, str] = {
     "dependency_hallucination": "Generated manifests cite packages or versions that do not exist.",
     "api_signature_hallucination": "Generated calls use real packages with invented APIs.",
     "assertion_weakening": "Generated test edits weaken assertions instead of preserving behavior.",
+    "contract_guardrail": "Generated code violates project-specific AI contract guardrails.",
     "precision_guard": "Clean generated code should remain free of AI-defect findings.",
 }
 
@@ -339,6 +340,7 @@ def _validate_expectation(expectation: Any, case_id: str, mode: str) -> None:
         "category",
         "severity",
         "ai_likelihood",
+        "contract_clause",
     )
     for key in string_keys:
         value = expectation.get(key)
@@ -372,9 +374,10 @@ def _validate_scan(case: dict[str, Any], case_id: str) -> None:
     if not isinstance(scan, dict):
         raise ValueError(
             f"AI-code-defect benchmark case {case_id} scan config must be an object"
-        )
+    )
     _validate_optional_scan_string(scan, case_id, "file")
     _validate_optional_scan_string(scan, case_id, "range")
+    _validate_optional_scan_string(scan, case_id, "contract_path")
     if "danger" in scan:
         raise ValueError(
             f"AI-code-defect benchmark case {case_id} uses legacy scan.danger; "
@@ -510,6 +513,7 @@ def _run_case(
             include_dependency_hallucinations=_include_dependency_hallucination_scan(
                 scan
             ),
+            contract_path=_contract_path_scan(scan),
         )
         elapsed = time.perf_counter() - started
     finally:
@@ -534,6 +538,13 @@ def _run_case(
 
 def _include_dependency_hallucination_scan(scan: dict[str, Any]) -> bool:
     return bool(scan.get("dependency_hallucinations", False))
+
+
+def _contract_path_scan(scan: dict[str, Any]) -> str | None:
+    contract_path = scan.get("contract_path")
+    if isinstance(contract_path, str):
+        return contract_path
+    return None
 
 
 def _prepared_case_path(
@@ -762,7 +773,7 @@ def _finding_matches(expectation: dict[str, Any], finding: dict[str, Any]) -> bo
         if finding.get("vibe_category") != vibe:
             return False
 
-    for key in ("category", "severity", "ai_likelihood"):
+    for key in ("category", "severity", "ai_likelihood", "contract_clause"):
         value = expectation.get(key)
         if not isinstance(value, str):
             continue

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1562,6 +1562,12 @@ def _handle_rules_command(argv):
     return run_rules_command(argv, console_factory=Console)
 
 
+def _handle_contract_command(argv):
+    from skylos.commands.contract_cmd import run_contract_command
+
+    return run_contract_command(argv, console_factory=Console)
+
+
 def _rules_install(console, rules_dir, pack_or_url):
     from skylos.commands.rules_cmd import install_rules
 

--- a/skylos/cli_core/dispatch.py
+++ b/skylos/cli_core/dispatch.py
@@ -16,6 +16,7 @@ EARLY_COMMAND_HANDLERS = {
     "whitelist": "_run_whitelist_command",
     "clean": "_run_clean_command",
     "cache": "_run_cache_command",
+    "contract": "_handle_contract_command",
     "doctor": "_run_doctor_command",
     "whoami": "_run_whoami_command",
     "login": "_run_login_command",

--- a/skylos/commands/contract_cmd.py
+++ b/skylos/commands/contract_cmd.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from rich.console import Console
+
+from skylos.contracts import (
+    DEFAULT_CONTRACT_PATH,
+    ContractError,
+    starter_contract_text,
+    validate_contract_file,
+)
+from skylos.core.safe_cache_io import write_existing_text_no_symlink
+
+
+def run_contract_command(argv, *, console_factory=Console) -> int:
+    console = console_factory()
+    parser = argparse.ArgumentParser(
+        prog="skylos contract",
+        description="Manage AI hallucination contracts for Skylos verify.",
+    )
+    sub = parser.add_subparsers(dest="contract_cmd")
+
+    p_init = sub.add_parser("init", help="Create a starter AI contract")
+    p_init.add_argument(
+        "--path",
+        default=DEFAULT_CONTRACT_PATH,
+        help=f"Contract path. Default: {DEFAULT_CONTRACT_PATH}",
+    )
+    p_init.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the contract if it already exists.",
+    )
+
+    p_validate = sub.add_parser("validate", help="Validate an AI contract")
+    p_validate.add_argument(
+        "path",
+        nargs="?",
+        default=DEFAULT_CONTRACT_PATH,
+        help=f"Contract path. Default: {DEFAULT_CONTRACT_PATH}",
+    )
+
+    if not argv:
+        parser.print_help()
+        return 0
+
+    args = parser.parse_args(list(argv))
+    if args.contract_cmd == "init":
+        return init_contract(console, args.path, force=bool(args.force))
+    if args.contract_cmd == "validate":
+        return validate_contract(console, args.path)
+
+    parser.print_help()
+    return 0
+
+
+def init_contract(console, path_str: str, *, force: bool = False) -> int:
+    try:
+        dest = _resolve_project_path(path_str)
+        _write_contract_file(dest, starter_contract_text(), force=force)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        return 1
+
+    console.print(f"[green]Created AI contract: {dest}[/green]")
+    console.print(f"[dim]Validate it with: skylos contract validate {dest}[/dim]")
+    return 0
+
+
+def validate_contract(console, path_str: str) -> int:
+    try:
+        contract = validate_contract_file(path_str, project_root=Path.cwd())
+    except ContractError as exc:
+        console.print(f"[red]Invalid contract:[/red] {exc}")
+        return 1
+
+    console.print(
+        "[green]Valid AI contract[/green] "
+        f"[dim](version {contract.version}, path {contract.path})[/dim]"
+    )
+    return 0
+
+
+def _resolve_project_path(path_str: str) -> Path:
+    root = Path.cwd().resolve()
+    candidate = Path(path_str).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+
+    try:
+        resolved = candidate.resolve(strict=False)
+        resolved.relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise ValueError("Contract path must stay inside the current project") from exc
+
+    return resolved
+
+
+def _write_contract_file(dest: Path, text: str, *, force: bool) -> None:
+    if dest.is_symlink():
+        raise ValueError("Contract path must not be a symlink")
+    if dest.exists():
+        if not force:
+            raise ValueError(
+                f"Contract already exists: {dest}. Use --force to overwrite."
+            )
+        if not write_existing_text_no_symlink(dest, text, encoding="utf-8"):
+            raise ValueError(f"Could not safely overwrite contract: {dest}")
+        return
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _write_new_text_no_symlink(dest, text)
+
+
+def _write_new_text_no_symlink(dest: Path, text: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd: int | None = None
+    try:
+        fd = os.open(dest, flags, 0o600)  # skylos: ignore[SKY-D215] path was resolved inside cwd and opened no-follow
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError as exc:
+        raise ValueError(f"Could not safely create contract: {dest}") from exc
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass

--- a/skylos/commands/verify_cmd.py
+++ b/skylos/commands/verify_cmd.py
@@ -84,6 +84,12 @@ def _add_scope_args(parser: argparse.ArgumentParser) -> None:
 
 def _add_runtime_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
+        "--contract",
+        dest="contract_path",
+        default=None,
+        help="AI hallucination contract to apply during verification.",
+    )
+    parser.add_argument(
         "--dependency-hallucinations",
         action="store_true",
         help="Include dependency hallucination checks that may use package metadata caches.",
@@ -127,21 +133,23 @@ def _run_from_args(
     if args.stdin:
         manifest = _read_stdin_manifest(parser)
         _apply_stdin_overrides(args, manifest)
-        return verify_change_stdin_payload_func(
-            manifest,
-            confidence=args.confidence,
-            exclude_folders=exclude_folders,
-        )
+        kwargs = {
+            "confidence": args.confidence,
+            "exclude_folders": exclude_folders,
+        }
+        return verify_change_stdin_payload_func(manifest, **kwargs)
 
-    return verify_change_path_func(
-        args.path,
-        file=args.file,
-        line_range=args.line_range,
-        confidence=args.confidence,
-        exclude_folders=exclude_folders,
-        project_context=args.project_context,
-        include_dependency_hallucinations=args.dependency_hallucinations,
-    )
+    kwargs = {
+        "file": args.file,
+        "line_range": args.line_range,
+        "confidence": args.confidence,
+        "exclude_folders": exclude_folders,
+        "project_context": args.project_context,
+        "include_dependency_hallucinations": args.dependency_hallucinations,
+    }
+    if args.contract_path is not None:
+        kwargs["contract_path"] = args.contract_path
+    return verify_change_path_func(args.path, **kwargs)
 
 
 def _apply_stdin_overrides(args: argparse.Namespace, manifest: dict[str, Any]) -> None:
@@ -152,6 +160,8 @@ def _apply_stdin_overrides(args: argparse.Namespace, manifest: dict[str, Any]) -
         _set_default(manifest, "range", args.line_range)
     if args.dependency_hallucinations:
         _set_default(manifest, "include_dependency_hallucinations", True)
+    if args.contract_path is not None:
+        _set_default(manifest, "contract_path", args.contract_path)
 
 
 def _set_default(payload: dict[str, Any], key: str, value: Any) -> None:

--- a/skylos/contracts/__init__.py
+++ b/skylos/contracts/__init__.py
@@ -1,0 +1,47 @@
+from skylos.contracts.loader import (
+    contract_enables_dependency_hallucinations,
+    contract_project_config_overrides,
+    load_contract,
+    starter_contract_text,
+    validate_contract_file,
+)
+from skylos.contracts.metadata import contract_finding_metadata
+from skylos.contracts.schema import (
+    AIContract,
+    ApiSurfaceContract,
+    DEFAULT_CONTRACT_PATH,
+    DependencyContract,
+    HallucinationContract,
+    PhantomSymbolsContract,
+    RouteContract,
+    SecurityContract,
+    TestsContract,
+    ContractError,
+)
+from skylos.contracts.routes import (
+    RULE_ID_CONTRACT_ROUTE_GUARD,
+    VIBE_CONTRACT_GUARDRAIL,
+    scan_contract_route_guardrails,
+)
+
+__all__ = [
+    "AIContract",
+    "ApiSurfaceContract",
+    "DEFAULT_CONTRACT_PATH",
+    "DependencyContract",
+    "HallucinationContract",
+    "PhantomSymbolsContract",
+    "RouteContract",
+    "SecurityContract",
+    "TestsContract",
+    "ContractError",
+    "contract_enables_dependency_hallucinations",
+    "contract_finding_metadata",
+    "contract_project_config_overrides",
+    "load_contract",
+    "RULE_ID_CONTRACT_ROUTE_GUARD",
+    "VIBE_CONTRACT_GUARDRAIL",
+    "scan_contract_route_guardrails",
+    "starter_contract_text",
+    "validate_contract_file",
+]

--- a/skylos/contracts/loader.py
+++ b/skylos/contracts/loader.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from skylos.contracts.schema import (
+    AIContract,
+    ApiSurfaceContract,
+    CONTRACT_SCHEMA_VERSION,
+    ContractError,
+    DEFAULT_CONTRACT_PATH,
+    DependencyContract,
+    HallucinationContract,
+    PhantomSymbolsContract,
+    RouteContract,
+    SecurityContract,
+    TestsContract,
+)
+from skylos.core.safe_cache_io import read_text_no_symlink
+
+
+MAX_CONTRACT_BYTES = 256 * 1024
+
+
+def starter_contract_text() -> str:
+    return """version: 1
+
+ai:
+  phantom_symbols:
+    names:
+      - verify_enterprise_auth
+      - sanitize_user_input
+    decorators:
+      - tenant_admin_required
+
+  dependencies:
+    reject_nonexistent_packages: true
+    reject_impossible_versions: true
+
+  api_surface:
+    reject_unknown_members: true
+    reject_unknown_kwargs: true
+
+security:
+  routes:
+    paths:
+      - "apps/api/**"
+    require_any_decorator:
+      - require_auth
+      - login_required
+      - jwt_required
+
+tests:
+  high_risk_changes_require_tests: true
+"""
+
+
+def load_contract(
+    path: str | Path,
+    project_root: str | Path | None = None,
+) -> HallucinationContract:
+    candidate_path = _candidate_contract_path(path, project_root)
+    contract_path = _resolve_contract_path_for_read(candidate_path, project_root)
+
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - PyYAML is a runtime dependency.
+        raise ContractError("PyYAML is required to read contract files") from exc
+
+    source = read_text_no_symlink(
+        contract_path,
+        max_bytes=MAX_CONTRACT_BYTES,
+        encoding="utf-8",
+    )
+    if source is None:
+        raise ContractError(
+            "Contract file must be a regular non-symlink file "
+            f"no larger than {MAX_CONTRACT_BYTES} bytes"
+        )
+
+    try:
+        raw = yaml.safe_load(source)
+    except yaml.YAMLError as exc:
+        raise ContractError(f"Invalid YAML: {exc}") from exc
+
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise ContractError("Contract must be a YAML mapping")
+
+    return _parse_contract(raw, contract_path)
+
+
+def validate_contract_file(
+    path: str | Path,
+    project_root: str | Path | None = None,
+) -> HallucinationContract:
+    return load_contract(path, project_root=project_root)
+
+
+def contract_project_config_overrides(
+    contract: HallucinationContract | None,
+) -> dict[str, Any]:
+    if contract is None:
+        return {}
+
+    vibe: dict[str, list[str]] = {}
+    if contract.ai.phantom_symbols.names:
+        vibe["extra_phantom_names"] = list(contract.ai.phantom_symbols.names)
+    if contract.ai.phantom_symbols.decorators:
+        vibe["extra_phantom_decorators"] = list(contract.ai.phantom_symbols.decorators)
+    if not vibe:
+        return {}
+    return {"vibe": vibe}
+
+
+def contract_enables_dependency_hallucinations(
+    contract: HallucinationContract | None,
+) -> bool:
+    if contract is None:
+        return False
+    deps = contract.ai.dependencies
+    api = contract.ai.api_surface
+    return bool(
+        deps.reject_nonexistent_packages
+        or deps.reject_impossible_versions
+        or api.reject_unknown_members
+        or api.reject_unknown_kwargs
+    )
+
+
+def _parse_contract(raw: dict[str, Any], contract_path: Path) -> HallucinationContract:
+    _reject_unknown(raw, {"version", "id", "ai", "security", "tests"}, "")
+    version = _required_int(raw, "version", "version")
+    if version != CONTRACT_SCHEMA_VERSION:
+        raise ContractError(
+            f"version must be {CONTRACT_SCHEMA_VERSION}, got {version}"
+        )
+
+    contract_id = _optional_string(raw.get("id"), "id")
+    ai = _parse_ai(_optional_mapping(raw.get("ai"), "ai"))
+    security = _parse_security(_optional_mapping(raw.get("security"), "security"))
+    tests = _parse_tests(_optional_mapping(raw.get("tests"), "tests"))
+    return HallucinationContract(
+        version=version,
+        path=contract_path,
+        contract_id=contract_id,
+        ai=ai,
+        security=security,
+        tests=tests,
+    )
+
+
+def _parse_ai(raw: dict[str, Any]) -> AIContract:
+    _reject_unknown(raw, {"phantom_symbols", "dependencies", "api_surface"}, "ai")
+    phantom = _parse_phantom_symbols(
+        _optional_mapping(raw.get("phantom_symbols"), "ai.phantom_symbols")
+    )
+    dependencies = _parse_dependencies(
+        _optional_mapping(raw.get("dependencies"), "ai.dependencies")
+    )
+    api_surface = _parse_api_surface(
+        _optional_mapping(raw.get("api_surface"), "ai.api_surface")
+    )
+    return AIContract(
+        phantom_symbols=phantom,
+        dependencies=dependencies,
+        api_surface=api_surface,
+    )
+
+
+def _parse_phantom_symbols(raw: dict[str, Any]) -> PhantomSymbolsContract:
+    _reject_unknown(raw, {"names", "decorators"}, "ai.phantom_symbols")
+    return PhantomSymbolsContract(
+        names=tuple(_string_list(raw.get("names"), "ai.phantom_symbols.names")),
+        decorators=tuple(
+            _string_list(raw.get("decorators"), "ai.phantom_symbols.decorators")
+        ),
+    )
+
+
+def _parse_dependencies(raw: dict[str, Any]) -> DependencyContract:
+    _reject_unknown(
+        raw,
+        {"reject_nonexistent_packages", "reject_impossible_versions"},
+        "ai.dependencies",
+    )
+    return DependencyContract(
+        reject_nonexistent_packages=_bool_value(
+            raw.get("reject_nonexistent_packages", False),
+            "ai.dependencies.reject_nonexistent_packages",
+        ),
+        reject_impossible_versions=_bool_value(
+            raw.get("reject_impossible_versions", False),
+            "ai.dependencies.reject_impossible_versions",
+        ),
+    )
+
+
+def _parse_api_surface(raw: dict[str, Any]) -> ApiSurfaceContract:
+    _reject_unknown(
+        raw,
+        {"reject_unknown_members", "reject_unknown_kwargs"},
+        "ai.api_surface",
+    )
+    return ApiSurfaceContract(
+        reject_unknown_members=_bool_value(
+            raw.get("reject_unknown_members", False),
+            "ai.api_surface.reject_unknown_members",
+        ),
+        reject_unknown_kwargs=_bool_value(
+            raw.get("reject_unknown_kwargs", False),
+            "ai.api_surface.reject_unknown_kwargs",
+        ),
+    )
+
+
+def _parse_security(raw: dict[str, Any]) -> SecurityContract:
+    _reject_unknown(raw, {"routes"}, "security")
+    routes = _parse_routes(_optional_mapping(raw.get("routes"), "security.routes"))
+    return SecurityContract(routes=routes)
+
+
+def _parse_routes(raw: dict[str, Any]) -> RouteContract:
+    _reject_unknown(raw, {"paths", "require_any_decorator"}, "security.routes")
+    paths = tuple(_string_list(raw.get("paths"), "security.routes.paths"))
+    for index, value in enumerate(paths):
+        _validate_glob_path(value, f"security.routes.paths[{index}]")
+    return RouteContract(
+        paths=paths,
+        require_any_decorator=tuple(
+            _string_list(
+                raw.get("require_any_decorator"),
+                "security.routes.require_any_decorator",
+            )
+        ),
+    )
+
+
+def _parse_tests(raw: dict[str, Any]) -> TestsContract:
+    _reject_unknown(raw, {"high_risk_changes_require_tests"}, "tests")
+    return TestsContract(
+        high_risk_changes_require_tests=_bool_value(
+            raw.get("high_risk_changes_require_tests", False),
+            "tests.high_risk_changes_require_tests",
+        )
+    )
+
+
+def _candidate_contract_path(path: str | Path, project_root: str | Path | None) -> Path:
+    candidate = Path(path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    root = Path(project_root).expanduser() if project_root is not None else Path.cwd()
+    return root / candidate
+
+
+def _resolve_contract_path_for_read(
+    candidate_path: Path,
+    project_root: str | Path | None,
+) -> Path:
+    try:
+        if candidate_path.is_symlink():
+            raise ContractError("Contract file must not be a symlink")
+        contract_path = candidate_path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ContractError(f"Contract file not found: {candidate_path}") from exc
+    except OSError as exc:
+        raise ContractError(f"Could not resolve contract file: {exc}") from exc
+
+    if not contract_path.is_file():
+        raise ContractError(f"Contract path is not a file: {contract_path}")
+    if project_root is not None:
+        try:
+            root = Path(project_root).expanduser().resolve(strict=False)
+            contract_path.relative_to(root)
+        except (OSError, ValueError) as exc:
+            raise ContractError("Contract file must stay inside the project") from exc
+    return contract_path
+
+
+def _optional_mapping(value: Any, field: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ContractError(f"{field} must be a mapping")
+    return value
+
+
+def _required_int(raw: dict[str, Any], key: str, field: str) -> int:
+    value = raw.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ContractError(f"{field} must be an integer")
+    return value
+
+
+def _optional_string(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ContractError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _string_list(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ContractError(f"{field} must be a list")
+
+    result: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise ContractError(f"{field}[{index}] must be a non-empty string")
+        result.append(item.strip())
+    return result
+
+
+def _bool_value(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise ContractError(f"{field} must be true or false")
+    return value
+
+
+def _reject_unknown(raw: dict[str, Any], allowed: set[str], field: str) -> None:
+    for key in raw:
+        if key not in allowed:
+            prefix = f"{field}." if field else ""
+            raise ContractError(f"Unknown contract key: {prefix}{key}")
+
+
+def _validate_glob_path(value: str, field: str) -> None:
+    path = Path(value)
+    if path.is_absolute():
+        raise ContractError(f"{field} must be relative")
+    if any(part == ".." for part in path.parts):
+        raise ContractError(f"{field} must stay inside the project")

--- a/skylos/contracts/metadata.py
+++ b/skylos/contracts/metadata.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from skylos.contracts.schema import HallucinationContract
+
+
+@dataclass(frozen=True)
+class _ContractFindingMatch:
+    clause: str
+    reason: str
+
+
+def contract_finding_metadata(
+    contract: HallucinationContract | None,
+    finding: dict[str, Any],
+) -> dict[str, str]:
+    if contract is None:
+        return {}
+
+    match = _contract_finding_match(contract, finding)
+    if match is None:
+        return {}
+
+    metadata = {
+        "contract_clause": match.clause,
+        "contract_path": str(contract.path),
+        "contract_reason": match.reason,
+    }
+    if contract.contract_id:
+        metadata["contract_id"] = contract.contract_id
+    return metadata
+
+
+def _contract_finding_match(
+    contract: HallucinationContract,
+    finding: dict[str, Any],
+) -> _ContractFindingMatch | None:
+    rule_id = str(_finding_value(finding, ("rule_id", "rule"), ""))
+    if rule_id == "SKY-L012":
+        return _phantom_symbol_match(
+            finding,
+            contract.ai.phantom_symbols.names,
+            "ai.phantom_symbols.names",
+        )
+    if rule_id == "SKY-L023":
+        return _phantom_symbol_match(
+            finding,
+            contract.ai.phantom_symbols.decorators,
+            "ai.phantom_symbols.decorators",
+        )
+    if (
+        rule_id == "SKY-D222"
+        and contract.ai.dependencies.reject_nonexistent_packages
+    ):
+        package = _dependency_label(finding)
+        return _ContractFindingMatch(
+            "ai.dependencies.reject_nonexistent_packages",
+            f"Contract rejects nonexistent package dependencies; finding reports {package}.",
+        )
+    if rule_id == "SKY-D225" and contract.ai.dependencies.reject_impossible_versions:
+        package = _dependency_label(finding)
+        return _ContractFindingMatch(
+            "ai.dependencies.reject_impossible_versions",
+            f"Contract rejects impossible dependency versions; finding reports {package}.",
+        )
+    if rule_id == "SKY-D224":
+        return _api_surface_match(contract, finding)
+    if rule_id == "SKY-A102" and contract.tests.high_risk_changes_require_tests:
+        return _ContractFindingMatch(
+            "tests.high_risk_changes_require_tests",
+            "Contract requires tests for high-risk changed code.",
+        )
+    if (
+        rule_id == "SKY-A105"
+        and contract.security.routes.require_any_decorator
+    ):
+        required = ", ".join(
+            f"@{name.lstrip('@')}"
+            for name in contract.security.routes.require_any_decorator
+        )
+        return _ContractFindingMatch(
+            "security.routes.require_any_decorator",
+            f"Contract requires route handlers to use one of: {required}.",
+        )
+    return None
+
+
+def _phantom_symbol_match(
+    finding: dict[str, Any],
+    contract_symbols: tuple[str, ...],
+    clause: str,
+) -> _ContractFindingMatch | None:
+    if not contract_symbols:
+        return None
+
+    finding_symbols = _finding_symbol_candidates(finding)
+    for symbol in contract_symbols:
+        variants = _symbol_variants(symbol)
+        if finding_symbols.isdisjoint(variants):
+            continue
+        display = _first_sorted(variants & finding_symbols) or symbol
+        return _ContractFindingMatch(
+            clause,
+            f"Contract lists '{display}' under {clause}.",
+        )
+    return None
+
+
+def _api_surface_match(
+    contract: HallucinationContract,
+    finding: dict[str, Any],
+) -> _ContractFindingMatch | None:
+    api = contract.ai.api_surface
+    message = str(_finding_value(finding, ("message", "detail", "msg"), ""))
+    is_keyword = "keyword" in message.lower()
+    if is_keyword and api.reject_unknown_kwargs:
+        return _ContractFindingMatch(
+            "ai.api_surface.reject_unknown_kwargs",
+            "Contract rejects calls with keyword arguments absent from the installed API.",
+        )
+    if not is_keyword and api.reject_unknown_members:
+        return _ContractFindingMatch(
+            "ai.api_surface.reject_unknown_members",
+            "Contract rejects members absent from the installed API.",
+        )
+    return None
+
+
+def _dependency_label(finding: dict[str, Any]) -> str:
+    metadata = finding.get("metadata")
+    package_name = None
+    package_version = None
+    if isinstance(metadata, dict):
+        package_name = metadata.get("package_name")
+        package_version = metadata.get("package_version")
+    if package_name:
+        if package_version:
+            return f"'{package_name}@{package_version}'"
+        return f"'{package_name}'"
+
+    symbol = _finding_value(finding, ("symbol", "name", "simple_name"), None)
+    if symbol:
+        return f"'{symbol}'"
+    return "the dependency"
+
+
+def _finding_symbol_candidates(finding: dict[str, Any]) -> set[str]:
+    candidates: set[str] = set()
+    for key in ("simple_name", "symbol", "name"):
+        value = finding.get(key)
+        if isinstance(value, str):
+            candidates.update(_symbol_variants(value))
+    return candidates
+
+
+def _symbol_variants(value: str) -> set[str]:
+    raw = value.strip()
+    if not raw:
+        return set()
+
+    variants = {raw}
+    if raw.startswith("@"):
+        variants.add(raw[1:])
+    if raw.endswith("()"):
+        variants.add(raw[:-2])
+    before_call = raw.split("(", 1)[0].strip()
+    if before_call:
+        variants.add(before_call)
+        if before_call.startswith("@"):
+            variants.add(before_call[1:])
+        if "." in before_call:
+            variants.add(before_call.rsplit(".", 1)[-1])
+    if "." in raw:
+        variants.add(raw.rsplit(".", 1)[-1])
+    return {variant.strip("@") for variant in variants if variant.strip("@")}
+
+
+def _first_sorted(values: set[str]) -> str | None:
+    if not values:
+        return None
+    return sorted(values)[0]
+
+
+def _finding_value(
+    finding: dict[str, Any],
+    keys: tuple[str, ...],
+    default: Any,
+) -> Any:
+    for key in keys:
+        value = finding.get(key)
+        if _has_value(value):
+            return value
+    return default
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str) and not value.strip():
+        return False
+    return True

--- a/skylos/contracts/routes.py
+++ b/skylos/contracts/routes.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import ast
+import fnmatch
+from pathlib import Path
+from typing import Any
+
+from skylos.contracts.schema import HallucinationContract
+from skylos.core.safe_cache_io import read_text_no_symlink
+
+
+RULE_ID_CONTRACT_ROUTE_GUARD = "SKY-A105"
+VIBE_CONTRACT_GUARDRAIL = "missing_contract_guardrail"
+MAX_ROUTE_SOURCE_BYTES = 1_000_000
+
+_ROUTE_METHOD_NAMES = {
+    "route",
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "api_route",
+    "websocket",
+}
+
+
+def scan_contract_route_guardrails(
+    contract: HallucinationContract | None,
+    project_root: str | Path,
+    *,
+    files: list[str | Path] | None = None,
+) -> list[dict[str, Any]]:
+    if not _contract_has_route_guardrail(contract):
+        return []
+
+    assert contract is not None
+    root = _safe_resolve(project_root)
+    findings: list[dict[str, Any]] = []
+    for file_path in _candidate_python_files(root, contract, files=files):
+        findings.extend(_scan_python_file(file_path, root, contract))
+    return findings
+
+
+def _contract_has_route_guardrail(
+    contract: HallucinationContract | None,
+) -> bool:
+    if contract is None:
+        return False
+    routes = contract.security.routes
+    return bool(routes.paths and routes.require_any_decorator)
+
+
+def _candidate_python_files(
+    root: Path,
+    contract: HallucinationContract,
+    *,
+    files: list[str | Path] | None,
+) -> list[Path]:
+    candidates: set[Path] = set()
+    if files is not None:
+        for raw in files:
+            path = _candidate_file_path(root, raw)
+            if _is_scannable_python_file(path) and _path_in_contract_scope(
+                path,
+                root,
+                contract,
+            ):
+                candidates.add(_safe_resolve(path))
+        return sorted(candidates)
+
+    for pattern in contract.security.routes.paths:
+        candidates.update(_glob_contract_pattern(root, pattern, contract))
+    return sorted(candidates)
+
+
+def _candidate_file_path(root: Path, raw: str | Path) -> Path:
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return path
+    root_candidate = root / path
+    if root_candidate.exists():
+        return root_candidate
+    return Path.cwd() / path
+
+
+def _glob_contract_pattern(
+    root: Path,
+    pattern: str,
+    contract: HallucinationContract,
+) -> set[Path]:
+    normalized = _normalize_path(pattern)
+    patterns = [normalized]
+    if not _has_glob(normalized):
+        patterns.append(f"{normalized.rstrip('/')}/**/*.py")
+    elif normalized.endswith("/**"):
+        patterns.append(f"{normalized.rstrip('/')}/**/*.py")
+
+    matches: set[Path] = set()
+    for glob_pattern in patterns:
+        try:
+            paths = root.glob(glob_pattern)
+        except ValueError:
+            continue
+        for path in paths:
+            if _is_scannable_python_file(path) and _path_in_contract_scope(
+                path,
+                root,
+                contract,
+            ):
+                matches.add(_safe_resolve(path))
+    return matches
+
+
+def _is_scannable_python_file(path: Path) -> bool:
+    try:
+        return path.is_file() and not path.is_symlink() and path.suffix == ".py"
+    except OSError:
+        return False
+
+
+def _path_in_contract_scope(
+    path: Path,
+    root: Path,
+    contract: HallucinationContract,
+) -> bool:
+    try:
+        rel = _normalize_path(_safe_resolve(path).relative_to(root))
+    except ValueError:
+        return False
+
+    return any(
+        _path_matches_pattern(rel, pattern)
+        for pattern in contract.security.routes.paths
+    )
+
+
+def _path_matches_pattern(relative_path: str, pattern: str) -> bool:
+    normalized = _normalize_path(pattern)
+    if fnmatch.fnmatchcase(relative_path, normalized):
+        return True
+    if normalized.endswith("/**"):
+        prefix = normalized[:-3].rstrip("/")
+        return relative_path == prefix or relative_path.startswith(f"{prefix}/")
+    if not _has_glob(normalized):
+        prefix = normalized.rstrip("/")
+        return relative_path == prefix or relative_path.startswith(f"{prefix}/")
+    return False
+
+
+def _scan_python_file(
+    file_path: Path,
+    root: Path,
+    contract: HallucinationContract,
+) -> list[dict[str, Any]]:
+    source = read_text_no_symlink(
+        file_path,
+        max_bytes=MAX_ROUTE_SOURCE_BYTES,
+        encoding="utf-8",
+    )
+    if source is None:
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        return []
+
+    required = contract.security.routes.require_any_decorator
+    findings: list[dict[str, Any]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        route_decorators = [
+            decorator
+            for decorator in node.decorator_list
+            if _is_route_decorator(decorator)
+        ]
+        if not route_decorators:
+            continue
+        if _has_required_guard(node, required):
+            continue
+
+        findings.append(_finding(file_path, root, node, route_decorators, required))
+    return findings
+
+
+def _finding(
+    file_path: Path,
+    root: Path,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    route_decorators: list[ast.AST],
+    required: tuple[str, ...],
+) -> dict[str, Any]:
+    route_label = _route_label(route_decorators[0], node.name)
+    required_display = ", ".join(_display_decorator(name) for name in required)
+    return {
+        "rule_id": RULE_ID_CONTRACT_ROUTE_GUARD,
+        "kind": "contract_route_guardrail",
+        "severity": "HIGH",
+        "type": "route",
+        "name": node.name,
+        "simple_name": node.name,
+        "value": required_display,
+        "threshold": 0,
+        "message": (
+            f"Route '{route_label}' is missing a contract-required guard "
+            f"decorator. Add one of: {required_display}."
+        ),
+        "file": str(file_path),
+        "basename": file_path.name,
+        "line": node.lineno,
+        "col": node.col_offset,
+        "category": "ai_defect",
+        "defect_type": VIBE_CONTRACT_GUARDRAIL,
+        "vibe_category": VIBE_CONTRACT_GUARDRAIL,
+        "ai_likelihood": "high",
+        "confidence": 90,
+        "metadata": {
+            "route_path": _route_path(route_decorators[0]),
+            "changed_file": _relative_path(file_path, root),
+            "required_decorators": list(required),
+        },
+    }
+
+
+def _has_required_guard(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    required: tuple[str, ...],
+) -> bool:
+    required_names = _required_name_set(required)
+    for decorator in node.decorator_list:
+        if _decorator_matches_required(decorator, required_names):
+            return True
+        if _is_route_decorator(decorator) and _route_dependency_matches_required(
+            decorator,
+            required_names,
+        ):
+            return True
+    return False
+
+
+def _decorator_matches_required(
+    decorator: ast.AST,
+    required_names: set[str],
+) -> bool:
+    return bool(_name_variants(_decorator_name(decorator)) & required_names)
+
+
+def _route_dependency_matches_required(
+    decorator: ast.AST,
+    required_names: set[str],
+) -> bool:
+    call = decorator if isinstance(decorator, ast.Call) else None
+    if call is None:
+        return False
+    for keyword in call.keywords:
+        if keyword.arg in {"dependencies", "dependency_overrides"}:
+            if _node_mentions_required(keyword.value, required_names):
+                return True
+    return False
+
+
+def _node_mentions_required(node: ast.AST, required_names: set[str]) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name):
+            if _name_variants(child.id) & required_names:
+                return True
+        elif isinstance(child, ast.Attribute):
+            if _name_variants(_dotted_name(child)) & required_names:
+                return True
+        elif isinstance(child, ast.Call):
+            if _name_variants(_dotted_name(child.func)) & required_names:
+                return True
+    return False
+
+
+def _is_route_decorator(decorator: ast.AST) -> bool:
+    name = _decorator_name(decorator)
+    method_name = _last_name_part(name)
+    if method_name not in _ROUTE_METHOD_NAMES:
+        return False
+    if "." in name:
+        return True
+    return method_name in {"route", "api_route"}
+
+
+def _decorator_name(decorator: ast.AST) -> str:
+    if isinstance(decorator, ast.Call):
+        return _dotted_name(decorator.func)
+    return _dotted_name(decorator)
+
+
+def _dotted_name(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        if base:
+            return f"{base}.{node.attr}"
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _dotted_name(node.func)
+    if isinstance(node, ast.Subscript):
+        return _dotted_name(node.value)
+    return ""
+
+
+def _route_label(decorator: ast.AST, fallback: str) -> str:
+    path = _route_path(decorator)
+    name = _decorator_name(decorator) or "route"
+    if path:
+        return f"{name} {path}"
+    return fallback
+
+
+def _route_path(decorator: ast.AST) -> str | None:
+    call = decorator if isinstance(decorator, ast.Call) else None
+    if call is None or not call.args:
+        return None
+    first = call.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
+
+
+def _required_name_set(required: tuple[str, ...]) -> set[str]:
+    names: set[str] = set()
+    for value in required:
+        names.update(_name_variants(value))
+    return names
+
+
+def _name_variants(value: str) -> set[str]:
+    raw = value.strip().lstrip("@")
+    if not raw:
+        return set()
+    variants = {raw}
+    if raw.endswith("()"):
+        variants.add(raw[:-2])
+    before_call = raw.split("(", 1)[0].strip()
+    if before_call:
+        variants.add(before_call)
+    for item in list(variants):
+        if "." in item:
+            variants.add(item.rsplit(".", 1)[-1])
+    return {item.strip().lstrip("@") for item in variants if item.strip().lstrip("@")}
+
+
+def _last_name_part(name: str) -> str:
+    return name.rsplit(".", 1)[-1].lower()
+
+
+def _display_decorator(name: str) -> str:
+    stripped = name.strip()
+    if stripped.startswith("@"):
+        return stripped
+    return f"@{stripped}"
+
+
+def _relative_path(path: Path, root: Path) -> str:
+    try:
+        return _normalize_path(_safe_resolve(path).relative_to(root))
+    except ValueError:
+        return _normalize_path(path)
+
+
+def _normalize_path(path: str | Path) -> str:
+    return str(path).replace("\\", "/").strip("/")
+
+
+def _has_glob(pattern: str) -> bool:
+    for char in "*?[":
+        if char in pattern:
+            return True
+    return False
+
+
+def _safe_resolve(path: str | Path) -> Path:
+    try:
+        return Path(path).expanduser().resolve(strict=False)
+    except OSError:
+        return Path(path).expanduser()

--- a/skylos/contracts/schema.py
+++ b/skylos/contracts/schema.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CONTRACT_SCHEMA_VERSION = 1
+DEFAULT_CONTRACT_PATH = ".skylos/ai-contract.yml"
+
+
+class ContractError(ValueError):
+    """Raised when an AI hallucination contract is invalid."""
+
+
+@dataclass(frozen=True)
+class PhantomSymbolsContract:
+    names: tuple[str, ...] = ()
+    decorators: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class DependencyContract:
+    reject_nonexistent_packages: bool = False
+    reject_impossible_versions: bool = False
+
+
+@dataclass(frozen=True)
+class ApiSurfaceContract:
+    reject_unknown_members: bool = False
+    reject_unknown_kwargs: bool = False
+
+
+@dataclass(frozen=True)
+class AIContract:
+    phantom_symbols: PhantomSymbolsContract = PhantomSymbolsContract()
+    dependencies: DependencyContract = DependencyContract()
+    api_surface: ApiSurfaceContract = ApiSurfaceContract()
+
+
+@dataclass(frozen=True)
+class RouteContract:
+    paths: tuple[str, ...] = ()
+    require_any_decorator: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SecurityContract:
+    routes: RouteContract = RouteContract()
+
+
+@dataclass(frozen=True)
+class TestsContract:
+    high_risk_changes_require_tests: bool = False
+
+
+@dataclass(frozen=True)
+class HallucinationContract:
+    version: int
+    path: Path
+    contract_id: str | None = None
+    ai: AIContract = AIContract()
+    security: SecurityContract = SecurityContract()
+    tests: TestsContract = TestsContract()

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -4,6 +4,8 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from skylos.contracts import contract_finding_metadata
+
 
 SCHEMA_VERSION = 1
 
@@ -15,10 +17,16 @@ AI_VIBE_CATEGORIES = {
     "missing_resilience_control",
     "api_signature_hallucination",
     "assertion_weakening",
+    "dependency_hallucination",
+    "disabled_security_control",
+    "test_impact_gap",
+    "missing_contract_guardrail",
 }
 
 AI_RULE_DEFAULTS = {
     "SKY-A101": ("assertion_weakening", "medium"),
+    "SKY-A102": ("test_impact_gap", "low"),
+    "SKY-A105": ("missing_contract_guardrail", "high"),
     "SKY-L012": ("hallucinated_reference", "high"),
     "SKY-L011": ("disabled_security_control", "medium"),
     "SKY-D222": ("dependency_hallucination", "high"),
@@ -52,6 +60,12 @@ SUGGESTED_FIX_BY_VIBE = {
     "assertion_weakening": (
         "Restore the specific assertion or explain why the weaker test still proves the behavior."
     ),
+    "test_impact_gap": (
+        "Add or update relevant tests, or document why behavior is unchanged."
+    ),
+    "missing_contract_guardrail": (
+        "Add one of the guard decorators required by the Skylos contract."
+    ),
 }
 
 
@@ -83,6 +97,7 @@ def build_verify_change_response(
     target_file: str | Path | None = None,
     line_range: str | tuple[int, int] | None = None,
     scan_target: str | Path | None = None,
+    contract: Any | None = None,
 ) -> dict[str, Any]:
     root = _project_root(project_root)
     parsed_range = _coerce_line_range(line_range)
@@ -94,7 +109,7 @@ def build_verify_change_response(
         if not _matches_line_range(finding, parsed_range):
             continue
 
-        normalized = _normalize_finding(finding, category, root)
+        normalized = _normalize_finding(finding, category, root, contract=contract)
         findings.append(normalized)
 
     findings.sort(
@@ -142,6 +157,8 @@ def _normalize_finding(
     finding: dict[str, Any],
     category: str,
     root: Path,
+    *,
+    contract: Any | None = None,
 ) -> dict[str, Any]:
     rule_id = str(_finding_value(finding, ("rule_id", "rule"), "UNKNOWN"))
     default_vibe, default_likelihood = _rule_defaults(rule_id)
@@ -152,7 +169,7 @@ def _normalize_finding(
     confidence = _confidence(finding.get("confidence"), ai_likelihood)
     severity = str(_finding_value(finding, ("severity",), "MEDIUM")).upper()
 
-    return {
+    normalized = {
         "rule_id": rule_id,
         "vibe_category": vibe_category,
         "ai_likelihood": ai_likelihood,
@@ -163,6 +180,8 @@ def _normalize_finding(
         "severity": severity,
         "category": category,
     }
+    normalized.update(contract_finding_metadata(contract, finding))
+    return normalized
 
 
 def _finding_range(finding: dict[str, Any], root: Path) -> dict[str, Any]:

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -31,6 +31,7 @@ _RULES = (
     RuleCatalogEntry("SKY-A102", "High-risk change without tests", "ai_defect", "LOW"),
     RuleCatalogEntry("SKY-A103", "CI permission expansion", "ai_defect", "HIGH"),
     RuleCatalogEntry("SKY-A104", "Public CLI surface drift", "ai_defect", "MEDIUM"),
+    RuleCatalogEntry("SKY-A105", "Contract route guard missing", "ai_defect", "HIGH"),
     RuleCatalogEntry("SKY-C401", "Duplicated code clone", "quality"),
     RuleCatalogEntry("SKY-CIRC", "Circular dependency", "quality"),
     RuleCatalogEntry("SKY-Q301", "Cyclomatic complexity", "quality"),

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -123,6 +123,15 @@ COMMANDS = [
         "desc": "Install/manage community rule packs",
         "group": "Utility",
     },
+    {
+        "name": "skylos contract",
+        "desc": "Create and validate AI hallucination contracts",
+        "details": [
+            "init: create .skylos/ai-contract.yml",
+            "validate [path]: validate a contract without scanning code",
+        ],
+        "group": "Utility",
+    },
     {"name": "skylos doctor", "desc": "Check installation health", "group": "Utility"},
     {
         "name": "skylos clean [--dry-run|--apply]",

--- a/skylos/verify_change.py
+++ b/skylos/verify_change.py
@@ -6,6 +6,12 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from skylos.contracts import (
+    contract_enables_dependency_hallucinations,
+    contract_project_config_overrides,
+    load_contract,
+    scan_contract_route_guardrails,
+)
 from skylos.core.verify_change_schema import (
     build_verify_change_response,
     parse_line_range,
@@ -28,12 +34,29 @@ def verify_change_path(
     exclude_folders: list[str] | None = None,
     project_context: bool = False,
     include_dependency_hallucinations: bool = False,
+    contract_path: str | Path | None = None,
     analyze_func=None,
 ) -> dict[str, Any]:
     target = Path(path).expanduser()
     target_file = _optional_path(file)
     scan_target = _scan_target(target, target_file, project_context=project_context)
     root = _root_for_verify_target(target)
+    contract_file = (
+        _contract_path_for_verify(contract_path, root) if contract_path else None
+    )
+    contract = None
+    if contract_file is not None:
+        contract = load_contract(
+            contract_file,
+            project_root=_contract_project_root_for_verify(contract_file, root),
+        )
+    include_deps = include_dependency_hallucinations or contract_enables_dependency_hallucinations(
+        contract
+    )
+    changed_files = _changed_files_for_verify(
+        scan_target,
+        target_file,
+    )
 
     if analyze_func is None:
         from skylos.analyzer import analyze as analyze_func
@@ -41,14 +64,18 @@ def verify_change_path(
     analysis_options = _analysis_options(
         confidence=confidence,
         exclude_folders=exclude_folders,
-        include_dependency_hallucinations=include_dependency_hallucinations,
-        changed_files=_changed_files_for_verify(
-            scan_target,
-            target_file,
-        ),
+        include_dependency_hallucinations=include_deps,
+        changed_files=changed_files,
+        project_config_overrides=contract_project_config_overrides(contract),
     )
     raw_result = analyze_func(str(scan_target), **analysis_options)
     analysis_result = _analysis_result_dict(raw_result)
+    _add_contract_route_findings(
+        analysis_result,
+        contract=contract,
+        root=root,
+        changed_files=changed_files,
+    )
 
     return build_verify_change_response(
         analysis_result,
@@ -56,6 +83,7 @@ def verify_change_path(
         target_file=target_file,
         line_range=line_range,
         scan_target=scan_target,
+        contract=contract,
     )
 
 
@@ -76,6 +104,7 @@ def verify_change_stdin_payload(
     manifest_file = _safe_manifest_file(_manifest_value(payload, ("file",), "snippet.py"))
     line_range = _manifest_value(payload, ("line_range", "range"), None)
     include_deps = bool(payload.get("include_dependency_hallucinations", False))
+    contract_path = _manifest_value(payload, ("contract_path", "contract"), None)
 
     with tempfile.TemporaryDirectory(prefix="skylos-verify-") as tmp:
         tmp_root = Path(tmp)
@@ -87,6 +116,7 @@ def verify_change_stdin_payload(
             confidence=confidence,
             exclude_folders=exclude_folders,
             include_dependency_hallucinations=include_deps,
+            contract_path=contract_path,
             analyze_func=analyze_func,
         )
 
@@ -103,6 +133,7 @@ def _analysis_options(
     exclude_folders: list[str] | None,
     include_dependency_hallucinations: bool,
     changed_files: list[str] | None,
+    project_config_overrides: dict[str, Any] | None,
 ) -> dict[str, Any]:
     options = {
         "conf": confidence,
@@ -117,7 +148,78 @@ def _analysis_options(
     }
     if changed_files:
         options["changed_files"] = changed_files
+    if project_config_overrides:
+        options["project_config_overrides"] = project_config_overrides
     return options
+
+
+def _contract_path_for_verify(contract_path: str | Path, root: Path) -> Path:
+    raw = Path(contract_path).expanduser()
+    if raw.is_absolute():
+        return raw
+
+    root_candidate = root / raw
+    if root_candidate.exists():
+        return root_candidate
+
+    cwd_candidate = Path.cwd() / raw
+    if cwd_candidate.exists():
+        return cwd_candidate
+
+    return root_candidate
+
+
+def _contract_project_root_for_verify(
+    contract_path: str | Path,
+    default_root: Path,
+) -> Path:
+    try:
+        resolved = Path(contract_path).expanduser().resolve(strict=False)
+    except OSError:
+        return default_root
+    if resolved.parent.name == ".skylos":
+        return resolved.parent.parent
+    try:
+        resolved.relative_to(default_root)
+    except ValueError:
+        return resolved.parent
+    return default_root
+
+
+def _add_contract_route_findings(
+    analysis_result: dict[str, Any],
+    *,
+    contract,
+    root: Path,
+    changed_files: list[str] | None,
+) -> None:
+    if contract is None:
+        return
+
+    scan_root = _contract_scan_root(contract, root)
+    route_findings = scan_contract_route_guardrails(
+        contract,
+        scan_root,
+        files=changed_files,
+    )
+    if not route_findings:
+        return
+
+    existing = analysis_result.get("ai_defects")
+    if isinstance(existing, list):
+        existing.extend(route_findings)
+    else:
+        analysis_result["ai_defects"] = route_findings
+
+
+def _contract_scan_root(contract, default_root: Path) -> Path:
+    contract_path = getattr(contract, "path", None)
+    if not isinstance(contract_path, Path):
+        return default_root
+    parent = contract_path.parent
+    if parent.name == ".skylos":
+        return parent.parent
+    return parent
 
 
 def _changed_files_for_verify(

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -328,6 +328,7 @@ def _verify_change_impl(
     project_context: bool = False,
     include_dependency_hallucinations: bool = False,
     exclude_folders: str | None = None,
+    contract_path: str | None = None,
 ) -> dict:
     """Core logic for verify_change, extracted for testability."""
     from skylos.verify_change import verify_change_path
@@ -348,6 +349,7 @@ def _verify_change_impl(
         exclude_folders=excl,
         project_context=project_context,
         include_dependency_hallucinations=include_dependency_hallucinations,
+        contract_path=contract_path,
     )
 
 
@@ -1104,6 +1106,7 @@ def _register_tools(mcp):
         project_context: bool = False,
         include_dependency_hallucinations: bool = False,
         exclude_folders: str | None = None,
+        contract_path: str | None = None,
     ) -> str:
         """Verify a changed file/range for AI-code defects.
 
@@ -1125,6 +1128,7 @@ def _register_tools(mcp):
                 project_context=project_context,
                 include_dependency_hallucinations=include_dependency_hallucinations,
                 exclude_folders=exclude_folders,
+                contract_path=contract_path,
             )
             _store_result(result, "verify_change", path)
             return json.dumps(result, indent=2)

--- a/test/test_ai_code_defect_benchmark.py
+++ b/test/test_ai_code_defect_benchmark.py
@@ -41,6 +41,11 @@ EXPECTED_CASE_IDS = {
     "go-module-version-hallucination",
     "mixed-manifest-hallucinations",
     "nested-manifest-workspace",
+    "contract-phantom-helper",
+    "contract-route-guard-missing",
+    "contract-route-guard-clean",
+    "contract-dependency-manifest",
+    "contract-dependency-clean",
     "clean-dependency-manifest",
     "clean-api-signature",
     "clean-range-scope",
@@ -66,6 +71,11 @@ EXPECTED_CASE_PATH_NAMES = [
     "go_module_version_hallucination",
     "mixed_manifest_hallucinations",
     "nested_manifest_workspace",
+    "contract_phantom_helper",
+    "contract_route_guard_missing",
+    "contract_route_guard_clean",
+    "contract_dependency_manifest",
+    "contract_dependency_clean",
     "clean_dependency_manifest",
     "clean_api_signature",
     "range_scoped_mixed_edit",
@@ -83,8 +93,9 @@ def _finding(
     category="quality",
     severity="CRITICAL",
     ai_likelihood="high",
+    contract_clause=None,
 ):
-    return {
+    finding = {
         "rule_id": rule_id,
         "vibe_category": vibe_category,
         "ai_likelihood": ai_likelihood,
@@ -97,6 +108,9 @@ def _finding(
         "severity": severity,
         "category": category,
     }
+    if contract_clause is not None:
+        finding["contract_clause"] = contract_clause
+    return finding
 
 
 def _fake_findings_for_case(case_path, scan_kwargs=None):
@@ -304,6 +318,53 @@ def _fake_findings_for_case(case_path, scan_kwargs=None):
                 severity="HIGH",
             ),
         ]
+    if case_name == "contract_phantom_helper":
+        return [
+            _finding(
+                "SKY-L012",
+                "hallucinated_reference",
+                message="Call to verify_acme_tenant() is never defined.",
+                file_path="app.py",
+                category="ai_defect",
+                contract_clause="ai.phantom_symbols.names",
+            ),
+        ]
+    if case_name == "contract_route_guard_missing":
+        return [
+            _finding(
+                "SKY-A105",
+                "missing_contract_guardrail",
+                message="Route is missing @login_required.",
+                file_path="apps/api/routes.py",
+                category="ai_defect",
+                severity="HIGH",
+                contract_clause="security.routes.require_any_decorator",
+            ),
+        ]
+    if case_name == "contract_route_guard_clean":
+        return []
+    if case_name == "contract_dependency_manifest":
+        return [
+            _finding(
+                "SKY-D222",
+                "dependency_hallucination",
+                message="Hallucinated npm dependency skylos-contract-ghost-sdk",
+                file_path="package.json",
+                category="ai_defect",
+                contract_clause="ai.dependencies.reject_nonexistent_packages",
+            ),
+            _finding(
+                "SKY-D225",
+                "dependency_hallucination",
+                message="Hallucinated npm dependency version left-pad@99.99.99",
+                file_path="package.json",
+                category="ai_defect",
+                severity="HIGH",
+                contract_clause="ai.dependencies.reject_impossible_versions",
+            ),
+        ]
+    if case_name == "contract_dependency_clean":
+        return []
     if case_name == "dependency_version_hallucination":
         return [
             _finding(
@@ -374,8 +435,8 @@ def test_ai_code_defect_runner_scores_expectations(monkeypatch):
 
     summary = run_manifest(MANIFEST_PATH, verify_func=fake_verify)
 
-    assert summary["case_count"] == 21
-    assert summary["pass_count"] == 21
+    assert summary["case_count"] == 26
+    assert summary["pass_count"] == 26
     assert summary["failure_count"] == 0
     assert summary["scores"]["overall_score"] == pytest.approx(100.0)
 
@@ -397,6 +458,18 @@ def test_ai_code_defect_runner_scores_expectations(monkeypatch):
             continue
         assert kwargs["include_dependency_hallucinations"] is True
 
+    contract_case_names = {
+        "contract_phantom_helper",
+        "contract_route_guard_missing",
+        "contract_route_guard_clean",
+        "contract_dependency_manifest",
+        "contract_dependency_clean",
+    }
+    for case_name, kwargs in seen:
+        if case_name not in contract_case_names:
+            continue
+        assert kwargs["contract_path"] == ".skylos/ai-contract.yml"
+
 
 def test_ai_code_defect_runner_empty_selection_runs_all_cases(monkeypatch):
     seen = []
@@ -407,7 +480,7 @@ def test_ai_code_defect_runner_empty_selection_runs_all_cases(monkeypatch):
 
     summary = run_manifest(MANIFEST_PATH, selected_cases=None, verify_func=fake_verify)
 
-    assert summary["case_count"] == 21
+    assert summary["case_count"] == 26
     assert seen == EXPECTED_CASE_PATH_NAMES
 
 

--- a/test/test_contracts.py
+++ b/test/test_contracts.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from rich.console import Console
+
+from skylos import cli
+from skylos.commands import contract_cmd
+from skylos.contracts import (
+    ContractError,
+    contract_enables_dependency_hallucinations,
+    contract_project_config_overrides,
+    load_contract,
+)
+
+
+def test_load_contract_parses_starter_sections(tmp_path):
+    contract_file = tmp_path / ".skylos" / "ai-contract.yml"
+    contract_file.parent.mkdir()
+    contract_file.write_text(contract_cmd.starter_contract_text(), encoding="utf-8")
+
+    contract = load_contract(contract_file)
+
+    assert contract.version == 1
+    assert "verify_enterprise_auth" in contract.ai.phantom_symbols.names
+    assert "tenant_admin_required" in contract.ai.phantom_symbols.decorators
+    assert contract.ai.dependencies.reject_nonexistent_packages is True
+    assert contract.ai.api_surface.reject_unknown_kwargs is True
+    assert contract.tests.high_risk_changes_require_tests is True
+
+
+def test_contract_config_overrides_extend_vibe_dictionary(tmp_path):
+    contract_file = tmp_path / "ai-contract.yml"
+    contract_file.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n"
+        "    decorators: [tenant_admin_required]\n",
+        encoding="utf-8",
+    )
+
+    contract = load_contract(contract_file)
+
+    assert contract_project_config_overrides(contract) == {
+        "vibe": {
+            "extra_phantom_names": ["verify_enterprise_auth"],
+            "extra_phantom_decorators": ["tenant_admin_required"],
+        }
+    }
+    assert contract_enables_dependency_hallucinations(contract) is False
+
+
+def test_contract_dependency_or_api_surface_enables_dependency_scan(tmp_path):
+    contract_file = tmp_path / "ai-contract.yml"
+    contract_file.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  api_surface:\n"
+        "    reject_unknown_members: true\n",
+        encoding="utf-8",
+    )
+
+    contract = load_contract(contract_file)
+
+    assert contract_enables_dependency_hallucinations(contract) is True
+
+
+@pytest.mark.parametrize(
+    ("text", "message"),
+    [
+        ("version: 2\n", "version must be 1"),
+        ("version: true\n", "version must be an integer"),
+        ("version: 1\nunknown: true\n", "Unknown contract key: unknown"),
+        (
+            "version: 1\nsecurity:\n  routes:\n    paths: ['/tmp/app.py']\n",
+            "security.routes.paths[0] must be relative",
+        ),
+        (
+            "version: 1\nsecurity:\n  routes:\n    paths: ['../app.py']\n",
+            "security.routes.paths[0] must stay inside the project",
+        ),
+    ],
+)
+def test_load_contract_rejects_invalid_contracts(tmp_path, text, message):
+    contract_file = tmp_path / "ai-contract.yml"
+    contract_file.write_text(text, encoding="utf-8")
+
+    with pytest.raises(ContractError) as exc:
+        load_contract(contract_file)
+    assert message in str(exc.value)
+
+
+def test_contract_init_creates_valid_starter_contract(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    console = Mock()
+    dest = Path(".skylos") / "ai-contract.yml"
+
+    exit_code = contract_cmd.init_contract(console, str(dest))
+
+    assert exit_code == 0
+    written = tmp_path / dest
+    assert written.exists()
+    assert contract_cmd.validate_contract(console, str(written)) == 0
+
+
+def test_contract_init_refuses_to_overwrite_without_force(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    console = Mock()
+    dest = tmp_path / "ai-contract.yml"
+    dest.write_text("version: 1\n", encoding="utf-8")
+
+    exit_code = contract_cmd.init_contract(console, str(dest))
+
+    assert exit_code == 1
+    assert dest.read_text(encoding="utf-8") == "version: 1\n"
+
+
+def test_contract_init_rejects_paths_outside_project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    console = Mock()
+
+    exit_code = contract_cmd.init_contract(console, "../outside.yml")
+
+    assert exit_code == 1
+    assert not (tmp_path.parent / "outside.yml").exists()
+
+
+def test_run_contract_command_validates_default_contract(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    console = Mock()
+
+    assert contract_cmd.run_contract_command(["init"], console_factory=lambda: console) == 0
+    assert (
+        contract_cmd.run_contract_command(["validate"], console_factory=lambda: console)
+        == 0
+    )
+
+
+def test_cli_contract_dispatch_preserves_argv(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["skylos", "contract", "validate", ".skylos/ai-contract.yml"],
+    )
+
+    with (
+        patch(
+            "skylos.commands.contract_cmd.run_contract_command", return_value=0
+        ) as mock_contract,
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    mock_contract.assert_called_once_with(
+        ["validate", ".skylos/ai-contract.yml"],
+        console_factory=Console,
+    )

--- a/test/test_verify_change.py
+++ b/test/test_verify_change.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from skylos.contracts import load_contract
 from skylos.verify_change import (
     build_verify_change_response,
     parse_line_range,
@@ -122,6 +123,152 @@ def test_build_verify_change_response_applies_version_hallucination_defaults(tmp
     finding = payload["findings"][0]
     assert finding["vibe_category"] == "dependency_hallucination"
     assert finding["ai_likelihood"] == "high"
+
+
+@pytest.mark.parametrize(
+    ("finding", "clause"),
+    [
+        (
+            {
+                "rule_id": "SKY-L012",
+                "simple_name": "verify_enterprise_auth",
+                "message": "Call to verify_enterprise_auth() is never defined.",
+            },
+            "ai.phantom_symbols.names",
+        ),
+        (
+            {
+                "rule_id": "SKY-L023",
+                "simple_name": "tenant_admin_required",
+                "message": "Decorator is never defined.",
+            },
+            "ai.phantom_symbols.decorators",
+        ),
+        (
+            {
+                "rule_id": "SKY-D222",
+                "message": "Package does not exist.",
+                "metadata": {"package_name": "ghostpkg", "package_version": "1.0.0"},
+            },
+            "ai.dependencies.reject_nonexistent_packages",
+        ),
+        (
+            {
+                "rule_id": "SKY-D225",
+                "message": "Version does not exist.",
+                "metadata": {"package_name": "ghostpkg", "package_version": "9.9.9"},
+            },
+            "ai.dependencies.reject_impossible_versions",
+        ),
+        (
+            {
+                "rule_id": "SKY-D224",
+                "message": "Installed API does not accept keyword argument 'timeout'.",
+            },
+            "ai.api_surface.reject_unknown_kwargs",
+        ),
+        (
+            {
+                "rule_id": "SKY-D224",
+                "message": "Installed API does not expose this member.",
+            },
+            "ai.api_surface.reject_unknown_members",
+        ),
+        (
+            {
+                "rule_id": "SKY-A102",
+                "message": "High-risk code changed without tests.",
+            },
+            "tests.high_risk_changes_require_tests",
+        ),
+        (
+            {
+                "rule_id": "SKY-A105",
+                "message": "Route is missing a contract-required guard decorator.",
+            },
+            "security.routes.require_any_decorator",
+        ),
+    ],
+)
+def test_build_verify_change_response_adds_contract_metadata(
+    tmp_path, finding, clause
+):
+    app = tmp_path / "app.py"
+    app.write_text("pass\n", encoding="utf-8")
+    contract_file = tmp_path / "ai-contract.yml"
+    contract_file.write_text(
+        "version: 1\n"
+        "id: enterprise-auth-contract\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n"
+        "    decorators: [tenant_admin_required]\n"
+        "  dependencies:\n"
+        "    reject_nonexistent_packages: true\n"
+        "    reject_impossible_versions: true\n"
+        "  api_surface:\n"
+        "    reject_unknown_members: true\n"
+        "    reject_unknown_kwargs: true\n"
+        "security:\n"
+        "  routes:\n"
+        "    paths: [apps/api/**]\n"
+        "    require_any_decorator: [login_required]\n"
+        "tests:\n"
+        "  high_risk_changes_require_tests: true\n",
+        encoding="utf-8",
+    )
+    contract = load_contract(contract_file)
+    finding = {
+        "severity": "HIGH",
+        "file": str(app),
+        "line": 1,
+        **finding,
+    }
+
+    payload = build_verify_change_response(
+        {"ai_defects": [finding]},
+        project_root=tmp_path,
+        contract=contract,
+    )
+
+    normalized = payload["findings"][0]
+    assert normalized["contract_id"] == "enterprise-auth-contract"
+    assert normalized["contract_clause"] == clause
+    assert normalized["contract_path"] == str(contract.path)
+    assert normalized["contract_reason"]
+
+
+def test_build_verify_change_response_skips_unmatched_contract_metadata(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("pass\n", encoding="utf-8")
+    contract_file = tmp_path / "ai-contract.yml"
+    contract_file.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n",
+        encoding="utf-8",
+    )
+    contract = load_contract(contract_file)
+
+    payload = build_verify_change_response(
+        {
+            "ai_defects": [
+                {
+                    "rule_id": "SKY-L012",
+                    "severity": "HIGH",
+                    "file": str(app),
+                    "line": 1,
+                    "simple_name": "validate_token",
+                    "message": "Call to validate_token() is never defined.",
+                }
+            ]
+        },
+        project_root=tmp_path,
+        contract=contract,
+    )
+
+    assert "contract_clause" not in payload["findings"][0]
 
 
 def test_build_verify_change_response_skips_dependency_import_defaults(tmp_path):
@@ -253,6 +400,203 @@ def test_verify_change_path_can_include_dependency_hallucinations(tmp_path):
     assert seen["kwargs"]["enable_dependency_hallucinations"] is True
     assert seen["kwargs"]["enable_danger"] is False
     assert seen["kwargs"]["changed_files"] == [str(app)]
+
+
+def test_verify_change_path_contract_enables_project_vibe_override(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("def handler(request):\n    return verify_enterprise_auth(request)\n")
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n",
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(app, contract_path=contract)
+
+    assert payload["status"] == "fail"
+    contract_finding = next(
+        finding
+        for finding in payload["findings"]
+        if finding["rule_id"] == "SKY-L012"
+        and finding["vibe_category"] == "hallucinated_reference"
+    )
+    assert contract_finding["contract_clause"] == "ai.phantom_symbols.names"
+    assert contract_finding["contract_path"] == str(contract.resolve())
+    assert (
+        "verify_enterprise_auth" in contract_finding["contract_reason"]
+    )
+    assert any(
+        finding["rule_id"] == "SKY-L012"
+        and finding["vibe_category"] == "hallucinated_reference"
+        for finding in payload["findings"]
+    )
+
+
+def test_verify_change_path_resolves_relative_contract_from_cwd_for_file_target(
+    tmp_path, monkeypatch
+):
+    app_dir = tmp_path / "src"
+    app_dir.mkdir()
+    app = app_dir / "app.py"
+    app.write_text("def handler(request):\n    return verify_enterprise_auth(request)\n")
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    payload = verify_change_path(app, contract_path=".skylos/ai-contract.yml")
+
+    assert payload["status"] == "fail"
+    assert any(finding["rule_id"] == "SKY-L012" for finding in payload["findings"])
+
+
+def test_verify_change_path_contract_options_pass_to_analyzer(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("import requests\n")
+    contract = tmp_path / "ai-contract.yml"
+    contract.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n"
+        "  dependencies:\n"
+        "    reject_impossible_versions: true\n",
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_analyze(*_args, **kwargs):
+        seen["kwargs"] = kwargs
+        return json.dumps({})
+
+    payload = verify_change_path(app, contract_path=contract, analyze_func=fake_analyze)
+
+    assert payload["status"] == "pass"
+    assert seen["kwargs"]["enable_dependency_hallucinations"] is True
+    assert seen["kwargs"]["project_config_overrides"] == {
+        "vibe": {"extra_phantom_names": ["verify_enterprise_auth"]}
+    }
+
+
+def test_verify_change_path_contract_routes_require_guard_decorator(tmp_path):
+    app = tmp_path / "apps" / "api" / "routes.py"
+    app.parent.mkdir(parents=True)
+    app.write_text(
+        "from flask import Flask\n"
+        "app = Flask(__name__)\n\n"
+        "@app.route('/admin')\n"
+        "def admin():\n"
+        "    return {}\n",
+        encoding="utf-8",
+    )
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "security:\n"
+        "  routes:\n"
+        "    paths: [apps/api/**]\n"
+        "    require_any_decorator: [login_required]\n",
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(
+        tmp_path,
+        contract_path=contract,
+        analyze_func=lambda *_args, **_kwargs: {},
+    )
+
+    assert payload["status"] == "fail"
+    finding = next(
+        finding
+        for finding in payload["findings"]
+        if finding["rule_id"] == "SKY-A105"
+    )
+    assert finding["vibe_category"] == "missing_contract_guardrail"
+    assert finding["contract_clause"] == "security.routes.require_any_decorator"
+    assert finding["range"]["file"] == "apps/api/routes.py"
+    assert "@login_required" in finding["message"]
+
+
+def test_verify_change_path_contract_routes_accept_custom_guard_decorator(tmp_path):
+    app = tmp_path / "apps" / "api" / "routes.py"
+    app.parent.mkdir(parents=True)
+    app.write_text(
+        "from flask import Flask\n"
+        "app = Flask(__name__)\n\n"
+        "def tenant_admin_required(fn):\n"
+        "    return fn\n\n"
+        "@app.route('/admin')\n"
+        "@tenant_admin_required\n"
+        "def admin():\n"
+        "    return {}\n",
+        encoding="utf-8",
+    )
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "security:\n"
+        "  routes:\n"
+        "    paths: [apps/api/**]\n"
+        "    require_any_decorator: [tenant_admin_required]\n",
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(
+        tmp_path,
+        contract_path=contract,
+        analyze_func=lambda *_args, **_kwargs: {},
+    )
+
+    assert not any(
+        finding["rule_id"] == "SKY-A105"
+        for finding in payload["findings"]
+    )
+
+
+def test_verify_change_path_contract_routes_respect_path_scope(tmp_path):
+    app = tmp_path / "tools" / "routes.py"
+    app.parent.mkdir(parents=True)
+    app.write_text(
+        "from flask import Flask\n"
+        "app = Flask(__name__)\n\n"
+        "@app.route('/admin')\n"
+        "def admin():\n"
+        "    return {}\n",
+        encoding="utf-8",
+    )
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "security:\n"
+        "  routes:\n"
+        "    paths: [apps/api/**]\n"
+        "    require_any_decorator: [login_required]\n",
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(
+        tmp_path,
+        contract_path=contract,
+        analyze_func=lambda *_args, **_kwargs: {},
+    )
+
+    assert not any(
+        finding["rule_id"] == "SKY-A105"
+        for finding in payload["findings"]
+    )
 
 
 def test_verify_change_path_uses_target_file_for_changed_files(tmp_path):

--- a/test/test_verify_cmd.py
+++ b/test/test_verify_cmd.py
@@ -30,6 +30,8 @@ def test_run_verify_command_prints_json_and_preserves_args(capsys):
             "--range",
             "2:5",
             "--project-context",
+            "--contract",
+            ".skylos/ai-contract.yml",
             "--dependency-hallucinations",
             "--exclude-folder",
             "build",
@@ -51,6 +53,7 @@ def test_run_verify_command_prints_json_and_preserves_args(capsys):
         "exclude_folders": ["venv", "build"],
         "project_context": True,
         "include_dependency_hallucinations": True,
+        "contract_path": ".skylos/ai-contract.yml",
     }
 
 
@@ -105,7 +108,18 @@ def test_run_verify_command_reads_stdin_manifest(monkeypatch, capsys):
     )
 
     exit_code = run_verify_command(
-        ["repo", "--stdin", "--file", "app.py", "--range", "2:2", "-c", "80"],
+        [
+            "repo",
+            "--stdin",
+            "--file",
+            "app.py",
+            "--range",
+            "2:2",
+            "--contract",
+            ".skylos/ai-contract.yml",
+            "-c",
+            "80",
+        ],
         verify_change_path_func=lambda *_args, **_kwargs: None,
         verify_change_stdin_payload_func=fake_stdin,
         parse_exclude_folders_func=lambda **_kwargs: ("venv",),
@@ -119,6 +133,7 @@ def test_run_verify_command_reads_stdin_manifest(monkeypatch, capsys):
         "path": "repo",
         "file": "app.py",
         "range": "2:2",
+        "contract_path": ".skylos/ai-contract.yml",
     }
     assert seen["kwargs"] == {
         "confidence": 80,


### PR DESCRIPTION
## Summary

  Added AI hallucination contracts that let `skylos verify` enforce repo truths for generated code.

  This includes:

  - `skylos contract init|validate`
  - `skylos verify --contract`
  - MCP `verify_change(contract_path=...)`
  - contract backed metadata in verify findings
  - route guardrail enforcement via new `SKY-A105`
  - benchmark coverage for contract backed hallucination checks

  ## Why

  Generic AI-code checks catch broad patterns, but teams also need repo specific guardrails. Contracts help make that repo truth explicit and auditable 

  ## Tests

  - `pytest test/test_ai_code_defect_benchmark.py test/test_contracts.py test/test_verify_cmd.py test/test_verify_change.py test/test_cli_refactor_guardrails.py test/test_mcp_summary.py`