### PR TITLE
fix(verify): surface AI contract diff findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ skylos verify . --file src/app.py --range 40:75 --project-context
 ```
 
 Create a local AI hallucination contract for repo-specific generated-code
-truth, then verify against it:
+truth. `skylos verify` auto-discovers `.skylos/ai-contract.yml`:
 
 ```bash
 skylos contract init
-skylos verify . --contract .skylos/ai-contract.yml
+skylos contract inspect
+skylos verify .
 ```
 
 Create a project config with thresholds, ignores, template hooks, and vibe
@@ -117,7 +118,7 @@ Need more commands? Read the [CLI Reference](https://docs.skylos.dev/cli-referen
 | Selectable terminal triage | `skylos . --tui` | Opens a keyboard-driven category list, finding list, and detail pane | [CLI output modes](./docs/cli-output.md) |
 | IDE/test-script output | `skylos --format concise src/test.py` | Prints only `file:line` findings and exits non-zero when findings exist | [CLI Reference](https://docs.skylos.dev/cli-reference) |
 | In-loop AI-code verification | `skylos verify . --file src/app.py --range 40:75` | Returns narrow JSON for hallucinated helpers, unfinished code, stale references, disabled controls, and API/dependency hallucinations | [AI features](https://docs.skylos.dev/ai-features) |
-| AI hallucination contracts | `skylos verify . --contract .skylos/ai-contract.yml` | Verifies generated code against repo-specific symbols, dependencies, APIs, route guards, and test requirements | [AI Hallucination Contracts](./docs/ai-hallucination-contracts.md) |
+| AI hallucination contracts | `skylos contract init && skylos verify .` | Auto-discovers `.skylos/ai-contract.yml` and verifies generated code against repo-specific symbols, dependencies, APIs, route guards, and test requirements | [AI Hallucination Contracts](./docs/ai-hallucination-contracts.md) |
 | Changed-lines review | `skylos . -a --diff origin/main` | Keeps findings focused on active work instead of legacy debt | [Quality gate docs](https://docs.skylos.dev/quality-gate) |
 | Runtime-assisted dead-code check | `skylos . --trace` | Uses runtime traces to reduce dynamic-code false positives | [Smart tracing](https://docs.skylos.dev/smart-tracing) |
 | Local rule pack | `skylos rules init` | Scaffolds YAML rules for project-specific security and quality checks | [Custom rules](https://docs.skylos.dev/custom-rules) |

--- a/docs/ai-hallucination-contracts.md
+++ b/docs/ai-hallucination-contracts.md
@@ -15,22 +15,37 @@ Create a starter contract:
 ```bash
 skylos contract init
 skylos contract validate .skylos/ai-contract.yml
+skylos contract inspect
 ```
 
-Run verify with the contract:
+Run verify. If `.skylos/ai-contract.yml` exists in the target repo or an
+ancestor directory, `skylos verify` applies it automatically:
 
 ```bash
-skylos verify . --contract .skylos/ai-contract.yml
+skylos verify .
 ```
 
 For agent or editor loops, scope the same check to a file or range:
 
 ```bash
-skylos verify . --file apps/api/routes.py --range 10:40 --project-context --contract .skylos/ai-contract.yml
+skylos verify . --file apps/api/routes.py --range 10:40 --project-context
 ```
 
-MCP clients can pass the same path through the `verify_change` tool as
-`contract_path`.
+Use `--contract` only for a non-default contract path:
+
+```bash
+skylos verify . --contract policies/agent-contract.yml
+```
+
+Use `--no-contract` when a verify run should ignore auto-discovered contracts:
+
+```bash
+skylos verify . --no-contract
+```
+
+MCP clients get the same default discovery through the `verify_change` tool.
+They can pass `contract_path` for a non-default path, or set
+`contract_enabled` to `false` to opt out.
 
 ## Contract Shape
 
@@ -91,7 +106,7 @@ Example clause values:
 This repo includes a deterministic demo fixture:
 
 ```bash
-skylos verify demo/ai_contract --file apps/api/routes.py --project-context --contract demo/ai_contract/.skylos/ai-contract.yml
+skylos verify demo/ai_contract --file apps/api/routes.py --project-context
 ```
 
 The demo intentionally contains:

--- a/skylos/commands/contract_cmd.py
+++ b/skylos/commands/contract_cmd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 from pathlib import Path
 
@@ -9,6 +10,8 @@ from rich.console import Console
 from skylos.contracts import (
     DEFAULT_CONTRACT_PATH,
     ContractError,
+    contract_enables_dependency_hallucinations,
+    contract_project_config_overrides,
     starter_contract_text,
     validate_contract_file,
 )
@@ -43,6 +46,23 @@ def run_contract_command(argv, *, console_factory=Console) -> int:
         help=f"Contract path. Default: {DEFAULT_CONTRACT_PATH}",
     )
 
+    p_inspect = sub.add_parser(
+        "inspect",
+        aliases=["explain"],
+        help="Explain an AI contract",
+    )
+    p_inspect.add_argument(
+        "path",
+        nargs="?",
+        default=DEFAULT_CONTRACT_PATH,
+        help=f"Contract path. Default: {DEFAULT_CONTRACT_PATH}",
+    )
+    p_inspect.add_argument(
+        "--json",
+        action="store_true",
+        help="Print a machine-readable contract summary.",
+    )
+
     if not argv:
         parser.print_help()
         return 0
@@ -52,6 +72,8 @@ def run_contract_command(argv, *, console_factory=Console) -> int:
         return init_contract(console, args.path, force=bool(args.force))
     if args.contract_cmd == "validate":
         return validate_contract(console, args.path)
+    if args.contract_cmd in {"inspect", "explain"}:
+        return inspect_contract(console, args.path, output_json=bool(args.json))
 
     parser.print_help()
     return 0
@@ -81,6 +103,43 @@ def validate_contract(console, path_str: str) -> int:
         "[green]Valid AI contract[/green] "
         f"[dim](version {contract.version}, path {contract.path})[/dim]"
     )
+    return 0
+
+
+def inspect_contract(console, path_str: str, *, output_json: bool = False) -> int:
+    try:
+        contract = validate_contract_file(path_str, project_root=Path.cwd())
+    except ContractError as exc:
+        console.print(f"[red]Invalid contract:[/red] {exc}")
+        return 1
+
+    summary = _contract_summary(contract)
+    if output_json:
+        console.print(json.dumps(summary, indent=2), markup=False)
+        return 0
+
+    console.print(
+        "[green]AI contract[/green] "
+        f"[dim](version {contract.version}, path {contract.path})[/dim]"
+    )
+    if contract.contract_id:
+        console.print(f"[dim]id:[/dim] {contract.contract_id}")
+    console.print("[bold]Clauses[/bold]")
+    for clause, detail in summary["clauses"].items():
+        console.print(f"- {clause}: {_format_clause_detail(detail)}")
+    console.print("[bold]Analyzer effects[/bold]")
+    effects = summary["analyzer_effects"]
+    dependency_status = (
+        "enabled" if effects["dependency_hallucination_scan"] else "disabled"
+    )
+    console.print(f"- dependency hallucination scan: {dependency_status}")
+    overrides = effects["project_config_overrides"]
+    if overrides:
+        console.print(
+            f"- project config overrides: {json.dumps(overrides, sort_keys=True)}"
+        )
+    else:
+        console.print("- project config overrides: none")
     return 0
 
 
@@ -136,3 +195,62 @@ def _write_new_text_no_symlink(dest: Path, text: str) -> None:
                 os.close(fd)
             except OSError:
                 pass
+
+
+def _contract_summary(contract) -> dict:
+    return {
+        "schema_version": contract.version,
+        "id": contract.contract_id,
+        "path": str(contract.path),
+        "clauses": {
+            "ai.phantom_symbols.names": {
+                "enabled": bool(contract.ai.phantom_symbols.names),
+                "values": list(contract.ai.phantom_symbols.names),
+            },
+            "ai.phantom_symbols.decorators": {
+                "enabled": bool(contract.ai.phantom_symbols.decorators),
+                "values": list(contract.ai.phantom_symbols.decorators),
+            },
+            "ai.dependencies.reject_nonexistent_packages": {
+                "enabled": contract.ai.dependencies.reject_nonexistent_packages,
+            },
+            "ai.dependencies.reject_impossible_versions": {
+                "enabled": contract.ai.dependencies.reject_impossible_versions,
+            },
+            "ai.api_surface.reject_unknown_members": {
+                "enabled": contract.ai.api_surface.reject_unknown_members,
+            },
+            "ai.api_surface.reject_unknown_kwargs": {
+                "enabled": contract.ai.api_surface.reject_unknown_kwargs,
+            },
+            "security.routes.paths": {
+                "enabled": bool(contract.security.routes.paths),
+                "values": list(contract.security.routes.paths),
+            },
+            "security.routes.require_any_decorator": {
+                "enabled": bool(contract.security.routes.require_any_decorator),
+                "values": list(contract.security.routes.require_any_decorator),
+            },
+            "tests.high_risk_changes_require_tests": {
+                "enabled": contract.tests.high_risk_changes_require_tests,
+            },
+        },
+        "analyzer_effects": {
+            "dependency_hallucination_scan": contract_enables_dependency_hallucinations(
+                contract
+            ),
+            "project_config_overrides": contract_project_config_overrides(contract),
+        },
+    }
+
+
+def _format_clause_detail(detail: dict) -> str:
+    if not detail["enabled"]:
+        result = "disabled"
+    else:
+        values = detail.get("values")
+        if not values:
+            result = "enabled"
+        else:
+            result = ", ".join(str(value) for value in values)
+    return result

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -193,6 +193,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 "unused_parameters",
                 "unused_files",
                 "danger",
+                "ai_defects",
                 "quality",
                 "secrets",
                 "custom_rules",
@@ -205,6 +206,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                         if str((project_root / item.get("file", "")).resolve())
                         in changed_files
                     ]
+            result_json = json.dumps(result)
 
         if getattr(args, "diff", None):
             from skylos.cicd.review import (
@@ -228,6 +230,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                     "unused_parameters",
                     "unused_files",
                     "danger",
+                    "ai_defects",
                     "quality",
                     "secrets",
                     "custom_rules",
@@ -333,6 +336,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
 
                 _finding_categories = [
                     "danger",
+                    "ai_defects",
                     "quality",
                     "secrets",
                     "custom_rules",
@@ -784,6 +788,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             "unused_classes",
             "unused_parameters",
             "danger",
+            "ai_defects",
             "quality",
             "secrets",
             "custom_rules",

--- a/skylos/commands/verify_cmd.py
+++ b/skylos/commands/verify_cmd.py
@@ -87,7 +87,17 @@ def _add_runtime_args(parser: argparse.ArgumentParser) -> None:
         "--contract",
         dest="contract_path",
         default=None,
-        help="AI hallucination contract to apply during verification.",
+        help=(
+            "AI hallucination contract to apply during verification. "
+            "Defaults to auto-discovering .skylos/ai-contract.yml."
+        ),
+    )
+    parser.add_argument(
+        "--no-contract",
+        dest="contract_enabled",
+        action="store_false",
+        default=True,
+        help="Do not auto-discover or apply an AI hallucination contract.",
     )
     parser.add_argument(
         "--dependency-hallucinations",
@@ -130,6 +140,7 @@ def _run_from_args(
     verify_change_path_func,
     verify_change_stdin_payload_func,
 ) -> dict[str, Any]:
+    _validate_contract_args(args, parser)
     if args.stdin:
         manifest = _read_stdin_manifest(parser)
         _apply_stdin_overrides(args, manifest)
@@ -149,6 +160,8 @@ def _run_from_args(
     }
     if args.contract_path is not None:
         kwargs["contract_path"] = args.contract_path
+    if not args.contract_enabled:
+        kwargs["contract_enabled"] = False
     return verify_change_path_func(args.path, **kwargs)
 
 
@@ -162,6 +175,19 @@ def _apply_stdin_overrides(args: argparse.Namespace, manifest: dict[str, Any]) -
         _set_default(manifest, "include_dependency_hallucinations", True)
     if args.contract_path is not None:
         _set_default(manifest, "contract_path", args.contract_path)
+    if not args.contract_enabled:
+        _set_default(manifest, "contract_enabled", False)
+
+
+def _validate_contract_args(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> None:
+    if args.contract_enabled:
+        return
+    if args.contract_path is None:
+        return
+    parser.error("--contract cannot be used with --no-contract")
 
 
 def _set_default(payload: dict[str, Any], key: str, value: Any) -> None:

--- a/skylos/contracts/__init__.py
+++ b/skylos/contracts/__init__.py
@@ -1,6 +1,7 @@
 from skylos.contracts.loader import (
     contract_enables_dependency_hallucinations,
     contract_project_config_overrides,
+    discover_contract_path,
     load_contract,
     starter_contract_text,
     validate_contract_file,
@@ -38,6 +39,7 @@ __all__ = [
     "contract_enables_dependency_hallucinations",
     "contract_finding_metadata",
     "contract_project_config_overrides",
+    "discover_contract_path",
     "load_contract",
     "RULE_ID_CONTRACT_ROUTE_GUARD",
     "VIBE_CONTRACT_GUARDRAIL",

--- a/skylos/contracts/loader.py
+++ b/skylos/contracts/loader.py
@@ -98,6 +98,25 @@ def validate_contract_file(
     return load_contract(path, project_root=project_root)
 
 
+def discover_contract_path(start: str | Path) -> Path | None:
+    candidate = Path(start).expanduser()
+    if candidate.is_file():
+        current = candidate.parent
+    else:
+        current = candidate
+
+    try:
+        current = current.resolve(strict=False)
+    except OSError:
+        current = current.absolute()
+
+    for directory in (current, *current.parents):
+        contract_path = directory / DEFAULT_CONTRACT_PATH
+        if contract_path.exists() or contract_path.is_symlink():
+            return contract_path
+    return None
+
+
 def contract_project_config_overrides(
     contract: HallucinationContract | None,
 ) -> dict[str, Any]:

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -17,15 +17,19 @@ AI_VIBE_CATEGORIES = {
     "missing_resilience_control",
     "api_signature_hallucination",
     "assertion_weakening",
+    "ci_permission_expansion",
     "dependency_hallucination",
     "disabled_security_control",
     "test_impact_gap",
     "missing_contract_guardrail",
+    "public_api_surface_drift",
 }
 
 AI_RULE_DEFAULTS = {
     "SKY-A101": ("assertion_weakening", "medium"),
     "SKY-A102": ("test_impact_gap", "low"),
+    "SKY-A103": ("ci_permission_expansion", "high"),
+    "SKY-A104": ("public_api_surface_drift", "medium"),
     "SKY-A105": ("missing_contract_guardrail", "high"),
     "SKY-L012": ("hallucinated_reference", "high"),
     "SKY-L011": ("disabled_security_control", "medium"),
@@ -62,6 +66,12 @@ SUGGESTED_FIX_BY_VIBE = {
     ),
     "test_impact_gap": (
         "Add or update relevant tests, or document why behavior is unchanged."
+    ),
+    "ci_permission_expansion": (
+        "Restore the narrower workflow permissions or document why the broader CI trust boundary is required."
+    ),
+    "public_api_surface_drift": (
+        "Restore the public option or document the compatibility break."
     ),
     "missing_contract_guardrail": (
         "Add one of the guard decorators required by the Skylos contract."

--- a/skylos/verify_change.py
+++ b/skylos/verify_change.py
@@ -9,6 +9,7 @@ from typing import Any
 from skylos.contracts import (
     contract_enables_dependency_hallucinations,
     contract_project_config_overrides,
+    discover_contract_path,
     load_contract,
     scan_contract_route_guardrails,
 )
@@ -35,14 +36,19 @@ def verify_change_path(
     project_context: bool = False,
     include_dependency_hallucinations: bool = False,
     contract_path: str | Path | None = None,
+    contract_enabled: bool = True,
     analyze_func=None,
 ) -> dict[str, Any]:
     target = Path(path).expanduser()
     target_file = _optional_path(file)
     scan_target = _scan_target(target, target_file, project_context=project_context)
     root = _root_for_verify_target(target)
-    contract_file = (
-        _contract_path_for_verify(contract_path, root) if contract_path else None
+    contract_file = _contract_path_for_verify_target(
+        target=target,
+        scan_target=scan_target,
+        root=root,
+        contract_path=contract_path,
+        contract_enabled=contract_enabled,
     )
     contract = None
     if contract_file is not None:
@@ -105,6 +111,12 @@ def verify_change_stdin_payload(
     line_range = _manifest_value(payload, ("line_range", "range"), None)
     include_deps = bool(payload.get("include_dependency_hallucinations", False))
     contract_path = _manifest_value(payload, ("contract_path", "contract"), None)
+    contract_enabled = _manifest_contract_enabled(payload)
+    contract_path = _manifest_contract_path(
+        payload,
+        contract_path=contract_path,
+        contract_enabled=contract_enabled,
+    )
 
     with tempfile.TemporaryDirectory(prefix="skylos-verify-") as tmp:
         tmp_root = Path(tmp)
@@ -117,6 +129,7 @@ def verify_change_stdin_payload(
             exclude_folders=exclude_folders,
             include_dependency_hallucinations=include_deps,
             contract_path=contract_path,
+            contract_enabled=contract_enabled,
             analyze_func=analyze_func,
         )
 
@@ -151,6 +164,27 @@ def _analysis_options(
     if project_config_overrides:
         options["project_config_overrides"] = project_config_overrides
     return options
+
+
+def _contract_path_for_verify_target(
+    *,
+    target: Path,
+    scan_target: Path,
+    root: Path,
+    contract_path: str | Path | None,
+    contract_enabled: bool,
+) -> Path | None:
+    if not contract_enabled:
+        if contract_path is not None:
+            raise ValueError("contract_path cannot be used when contracts are disabled")
+        return None
+    if contract_path is not None:
+        return _contract_path_for_verify(contract_path, root)
+
+    discovered = discover_contract_path(scan_target)
+    if discovered is not None:
+        return discovered
+    return discover_contract_path(target)
 
 
 def _contract_path_for_verify(contract_path: str | Path, root: Path) -> Path:
@@ -346,6 +380,35 @@ def _manifest_value(
         if _has_manifest_value(value):
             return value
     return default
+
+
+def _manifest_contract_enabled(payload: dict[str, Any]) -> bool:
+    value = payload.get("contract_enabled", True)
+    if isinstance(value, bool):
+        return value
+    raise ValueError("stdin manifest contract_enabled must be true or false")
+
+
+def _manifest_contract_path(
+    payload: dict[str, Any],
+    *,
+    contract_path: Any,
+    contract_enabled: bool,
+) -> Any:
+    if not contract_enabled or _has_manifest_value(contract_path):
+        return contract_path
+
+    discovered = discover_contract_path(_manifest_contract_discovery_start(payload))
+    if discovered is None:
+        return contract_path
+    return discovered
+
+
+def _manifest_contract_discovery_start(payload: dict[str, Any]) -> Path:
+    target = Path(_manifest_target_path(payload)).expanduser()
+    if target.is_absolute():
+        return target
+    return Path.cwd() / target
 
 
 def _has_manifest_value(value: Any) -> bool:

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -329,6 +329,7 @@ def _verify_change_impl(
     include_dependency_hallucinations: bool = False,
     exclude_folders: str | None = None,
     contract_path: str | None = None,
+    contract_enabled: bool = True,
 ) -> dict:
     """Core logic for verify_change, extracted for testability."""
     from skylos.verify_change import verify_change_path
@@ -350,6 +351,7 @@ def _verify_change_impl(
         project_context=project_context,
         include_dependency_hallucinations=include_dependency_hallucinations,
         contract_path=contract_path,
+        contract_enabled=contract_enabled,
     )
 
 
@@ -1107,6 +1109,7 @@ def _register_tools(mcp):
         include_dependency_hallucinations: bool = False,
         exclude_folders: str | None = None,
         contract_path: str | None = None,
+        contract_enabled: bool = True,
     ) -> str:
         """Verify a changed file/range for AI-code defects.
 
@@ -1129,6 +1132,7 @@ def _register_tools(mcp):
                 include_dependency_hallucinations=include_dependency_hallucinations,
                 exclude_folders=exclude_folders,
                 contract_path=contract_path,
+                contract_enabled=contract_enabled,
             )
             _store_result(result, "verify_change", path)
             return json.dumps(result, indent=2)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1988,6 +1988,20 @@ class TestDiffFlag:
                     "message": "eval",
                 },
             ],
+            "ai_defects": [
+                {
+                    "rule_id": "SKY-A103",
+                    "file": "src/app.py",
+                    "line": 12,
+                    "message": "CI permission expanded",
+                },
+                {
+                    "rule_id": "SKY-A104",
+                    "file": "src/app.py",
+                    "line": 50,
+                    "message": "CLI flag removed",
+                },
+            ],
             "quality": [],
             "secrets": [],
         }
@@ -2019,6 +2033,58 @@ class TestDiffFlag:
         assert output["unused_functions"][0]["name"] == "foo"
         assert len(output["danger"]) == 1
         assert output["danger"][0]["line"] == 12
+        assert len(output["ai_defects"]) == 1
+        assert output["ai_defects"][0]["rule_id"] == "SKY-A103"
+
+    def test_diff_base_filters_ai_defects_to_changed_files(self, monkeypatch):
+        """--diff-base filters ai_defects to changed files."""
+        monkeypatch.setattr(
+            cli.sys,
+            "argv",
+            ["skylos", ".", "--diff-base", "origin/main", "--json", "--no-provenance"],
+        )
+
+        result = {
+            "analysis_summary": {"total_files": 2},
+            "unused_functions": [],
+            "unused_imports": [],
+            "unused_variables": [],
+            "unused_classes": [],
+            "unused_parameters": [],
+            "danger": [],
+            "ai_defects": [
+                {
+                    "rule_id": "SKY-A103",
+                    "file": "src/app.py",
+                    "line": 12,
+                    "message": "CI permission expanded",
+                },
+                {
+                    "rule_id": "SKY-A104",
+                    "file": "legacy/app.py",
+                    "line": 20,
+                    "message": "CLI flag removed",
+                },
+            ],
+            "quality": [],
+            "secrets": [],
+        }
+
+        captured_output = []
+
+        with (
+            patch("skylos.cli.Progress", return_value=_progress_ctx()),
+            patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+            patch("skylos.cli.load_config", return_value={}),
+            patch("skylos.cli.subprocess.run") as mock_git,
+            patch("builtins.print", side_effect=lambda x: captured_output.append(x)),
+        ):
+            mock_git.return_value = Mock(returncode=0, stdout="src/app.py\n")
+            cli.main()
+
+        output = json.loads(captured_output[0])
+        assert len(output["ai_defects"]) == 1
+        assert output["ai_defects"][0]["file"] == "src/app.py"
 
 
 if __name__ == "__main__":

--- a/test/test_contracts.py
+++ b/test/test_contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -132,11 +133,44 @@ def test_run_contract_command_validates_default_contract(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     console = Mock()
 
-    assert contract_cmd.run_contract_command(["init"], console_factory=lambda: console) == 0
+    assert (
+        contract_cmd.run_contract_command(["init"], console_factory=lambda: console)
+        == 0
+    )
     assert (
         contract_cmd.run_contract_command(["validate"], console_factory=lambda: console)
         == 0
     )
+
+
+def test_run_contract_command_inspects_contract_as_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    console = Mock()
+    contract = Path("ai-contract.yml")
+    contract.write_text(
+        "version: 1\n"
+        "id: enterprise-auth-contract\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n"
+        "  dependencies:\n"
+        "    reject_nonexistent_packages: true\n",
+        encoding="utf-8",
+    )
+
+    exit_code = contract_cmd.run_contract_command(
+        ["inspect", str(contract), "--json"],
+        console_factory=lambda: console,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(console.print.call_args.args[0])
+    assert payload["id"] == "enterprise-auth-contract"
+    assert payload["clauses"]["ai.phantom_symbols.names"] == {
+        "enabled": True,
+        "values": ["verify_enterprise_auth"],
+    }
+    assert payload["analyzer_effects"]["dependency_hallucination_scan"] is True
 
 
 def test_cli_contract_dispatch_preserves_argv(monkeypatch):

--- a/test/test_verify_change.py
+++ b/test/test_verify_change.py
@@ -57,6 +57,42 @@ def test_build_verify_change_response_filters_to_ai_findings(tmp_path):
     assert finding["suggested_fix"]
 
 
+def test_build_verify_change_response_keeps_diff_backed_ai_rules(tmp_path):
+    app = tmp_path / ".github" / "workflows" / "ci.yml"
+    app.parent.mkdir(parents=True)
+    app.write_text("permissions: write-all\n", encoding="utf-8")
+
+    payload = build_verify_change_response(
+        {
+            "ai_defects": [
+                {
+                    "rule_id": "SKY-A103",
+                    "vibe_category": "ci_permission_expansion",
+                    "severity": "HIGH",
+                    "file": str(app),
+                    "line": 1,
+                    "message": "CI permissions expanded.",
+                },
+                {
+                    "rule_id": "SKY-A104",
+                    "vibe_category": "public_api_surface_drift",
+                    "severity": "MEDIUM",
+                    "file": str(app),
+                    "line": 1,
+                    "message": "Public CLI flag removed.",
+                },
+            ],
+        },
+        project_root=tmp_path,
+    )
+
+    assert payload["status"] == "fail"
+    assert {finding["rule_id"] for finding in payload["findings"]} == {
+        "SKY-A103",
+        "SKY-A104",
+    }
+
+
 def test_build_verify_change_response_applies_rule_defaults(tmp_path):
     app = tmp_path / "app.py"
     app.write_text("requests.get(url, verify=False)\n")
@@ -436,6 +472,74 @@ def test_verify_change_path_contract_enables_project_vibe_override(tmp_path):
     )
 
 
+def test_verify_change_path_auto_discovers_default_contract_from_parent(tmp_path):
+    app = tmp_path / "src" / "app.py"
+    app.parent.mkdir()
+    app.write_text("def handler(request):\n    return verify_enterprise_auth(request)\n")
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n",
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_analyze(*_args, **kwargs):
+        seen["kwargs"] = kwargs
+        return json.dumps({})
+
+    payload = verify_change_path(app, analyze_func=fake_analyze)
+
+    assert payload["status"] == "pass"
+    assert seen["kwargs"]["project_config_overrides"] == {
+        "vibe": {"extra_phantom_names": ["verify_enterprise_auth"]}
+    }
+
+
+def test_verify_change_path_can_disable_auto_discovered_contract(tmp_path):
+    app = tmp_path / "src" / "app.py"
+    app.parent.mkdir()
+    app.write_text("import requests\n")
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  dependencies:\n"
+        "    reject_impossible_versions: true\n",
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_analyze(*_args, **kwargs):
+        seen["kwargs"] = kwargs
+        return json.dumps({})
+
+    payload = verify_change_path(
+        app,
+        contract_enabled=False,
+        analyze_func=fake_analyze,
+    )
+
+    assert payload["status"] == "pass"
+    assert seen["kwargs"]["enable_dependency_hallucinations"] is False
+    assert "project_config_overrides" not in seen["kwargs"]
+
+
+def test_verify_change_path_rejects_explicit_contract_when_disabled(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text("pass\n")
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text("version: 1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="contracts are disabled"):
+        verify_change_path(app, contract_path=contract, contract_enabled=False)
+
+
 def test_verify_change_path_resolves_relative_contract_from_cwd_for_file_target(
     tmp_path, monkeypatch
 ):
@@ -635,6 +739,39 @@ def test_verify_change_stdin_payload_uses_manifest_file_for_schema():
     assert payload["target"]["file"] == "src/app.py"
     assert payload["target"]["range"] == {"start_line": 2, "end_line": 2}
     assert any(f["range"]["file"] == "src/app.py" for f in payload["findings"])
+
+
+def test_verify_change_stdin_payload_discovers_contract_from_manifest_path(tmp_path):
+    app = tmp_path / "src" / "app.py"
+    app.parent.mkdir()
+    contract = tmp_path / ".skylos" / "ai-contract.yml"
+    contract.parent.mkdir()
+    contract.write_text(
+        "version: 1\n"
+        "ai:\n"
+        "  phantom_symbols:\n"
+        "    names: [verify_enterprise_auth]\n",
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_analyze(*_args, **kwargs):
+        seen["kwargs"] = kwargs
+        return json.dumps({})
+
+    payload = verify_change_stdin_payload(
+        {
+            "path": str(tmp_path),
+            "file": "src/app.py",
+            "code": "def handler(request):\n    return verify_enterprise_auth(request)\n",
+        },
+        analyze_func=fake_analyze,
+    )
+
+    assert payload["status"] == "pass"
+    assert seen["kwargs"]["project_config_overrides"] == {
+        "vibe": {"extra_phantom_names": ["verify_enterprise_auth"]}
+    }
 
 
 def test_verify_change_stdin_payload_rejects_absolute_manifest_file():

--- a/test/test_verify_cmd.py
+++ b/test/test_verify_cmd.py
@@ -57,6 +57,32 @@ def test_run_verify_command_prints_json_and_preserves_args(capsys):
     }
 
 
+def test_run_verify_command_can_disable_contract_discovery(capsys):
+    seen = {}
+
+    def fake_verify(path, **kwargs):
+        seen["path"] = path
+        seen["kwargs"] = kwargs
+        return {
+            "schema_version": 1,
+            "tool": "verify_change",
+            "status": "pass",
+            "target": {"path": path, "file": None, "range": None},
+            "findings": [],
+            "summary": "No AI-code issues found",
+        }
+
+    exit_code = run_verify_command(
+        ["repo", "--no-contract"],
+        verify_change_path_func=fake_verify,
+        parse_exclude_folders_func=lambda **_kwargs: (),
+    )
+
+    _ = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert seen["kwargs"]["contract_enabled"] is False
+
+
 def test_run_verify_command_fails_on_findings_unless_disabled(capsys):
     def fake_verify(_path, **_kwargs):
         return {
@@ -139,3 +165,35 @@ def test_run_verify_command_reads_stdin_manifest(monkeypatch, capsys):
         "confidence": 80,
         "exclude_folders": ["venv"],
     }
+
+
+def test_run_verify_command_sets_stdin_contract_opt_out(monkeypatch, capsys):
+    seen = {}
+
+    def fake_stdin(payload, **kwargs):
+        seen["payload"] = payload
+        seen["kwargs"] = kwargs
+        return {
+            "schema_version": 1,
+            "tool": "verify_change",
+            "status": "pass",
+            "target": {"path": payload["path"], "file": None, "range": None},
+            "findings": [],
+            "summary": "No AI-code issues found",
+        }
+
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"code": "pass\n"})),
+    )
+
+    exit_code = run_verify_command(
+        ["repo", "--stdin", "--no-contract"],
+        verify_change_stdin_payload_func=fake_stdin,
+        parse_exclude_folders_func=lambda **_kwargs: (),
+    )
+
+    _ = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert seen["payload"]["contract_enabled"] is False


### PR DESCRIPTION
## Summary

  Fixes two AI contract / AI-defect workflow regressions

  - `skylos verify` surfaces `SKY-A103` and `SKY-A104` findings
  - stdin verify discovers `.skylos/ai-contract.yml` from the manifest project path
  - diff-scoped scans filter `ai_defects` for both `--diff` and `--diff-base`, including JSON output.
