### PR TITLE
fix(analyzer): recognize django and gunicorn liveness

### DIFF
--- a/corpus/fixtures/django_error_handlers/pyproject.toml
+++ b/corpus/fixtures/django_error_handlers/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "skylos-corpus-django-error-handlers"
+version = "0.0.0"
+dependencies = ["Django"]

--- a/corpus/fixtures/django_error_handlers/urls.py
+++ b/corpus/fixtures/django_error_handlers/urls.py
@@ -1,0 +1,32 @@
+"""Django root URLconf error handlers are looked up by name."""
+
+from django.http import (  # skylos: ignore[SKY-D223] corpus fixture dependency
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseNotFound,
+    HttpResponseServerError,
+)
+
+
+def _bad_request(request, exception):
+    return HttpResponseBadRequest("Bad request")
+
+
+def _not_found(request, exception):
+    return HttpResponseNotFound("Not found")
+
+
+def _forbidden(request, exception):
+    return HttpResponseForbidden("Forbidden")
+
+
+def _server_error(request, exception=None):
+    return HttpResponseServerError("Server error")
+
+
+handler400 = _bad_request
+handler404 = _not_found
+handler403 = _forbidden
+handler500 = _server_error
+
+urlpatterns = []

--- a/corpus/fixtures/django_path_converter/pyproject.toml
+++ b/corpus/fixtures/django_path_converter/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "skylos-corpus-django-path-converter"
+version = "0.0.0"
+dependencies = ["Django"]

--- a/corpus/fixtures/django_path_converter/urls.py
+++ b/corpus/fixtures/django_path_converter/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path, register_converter  # skylos: ignore[SKY-D223] corpus fixture dependency
+
+
+class FourDigitYearConverter:
+    regex = "[0-9]{4}"
+
+    def to_python(self, value):
+        return int(value)
+
+    def to_url(self, value):
+        return "%04d" % value
+
+
+register_converter(FourDigitYearConverter, "yyyy")
+urlpatterns = []

--- a/corpus/fixtures/gunicorn_config.py
+++ b/corpus/fixtures/gunicorn_config.py
@@ -1,0 +1,15 @@
+bind = "0.0.0.0:80"
+forwarded_allow_ips = "*"
+secure_scheme_headers = {"X-FORWARDED-PROTO": "https"}
+workers = 4
+threads = 1
+worker_class = "sync"
+timeout = 15
+graceful_timeout = 10
+chdir = "/usr/src/app"
+preload_app = True
+control_socket_disable = True
+
+
+def worker_exit(server, worker):
+    server.log.info("worker %s exiting", worker.pid)

--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -151,6 +151,73 @@
       }
     },
     {
+      "id": "django-error-handlers",
+      "path": "fixtures/django_error_handlers",
+      "description": "Django root URLconf error handler aliases should not be flagged as dead variables.",
+      "source": {
+        "repo": "https://github.com/daveisfera/skylos-repro",
+        "license": "Unlicense",
+        "notes": "Distilled from issue #619's Django error handler false-positive repro."
+      },
+      "expect": {
+        "absent": {
+          "unused_variables": [
+            "handler400",
+            "handler403",
+            "handler404",
+            "handler500"
+          ]
+        },
+        "present": {}
+      }
+    },
+    {
+      "id": "django-path-converter",
+      "path": "fixtures/django_path_converter",
+      "description": "Django custom path converter protocol members should stay alive when the converter class is registered in URLconf.",
+      "source": {
+        "repo": "https://github.com/django/django",
+        "license": "BSD-3-Clause",
+        "notes": "Distilled from the official Django custom path converter documentation and issue #619."
+      },
+      "expect": {
+        "absent": {
+          "unused_functions": ["to_python", "to_url"],
+          "unused_variables": ["regex"]
+        },
+        "present": {}
+      }
+    },
+    {
+      "id": "gunicorn-config",
+      "path": "fixtures/gunicorn_config.py",
+      "description": "Gunicorn config settings and lifecycle hooks should not be flagged as dead code.",
+      "source": {
+        "repo": "https://github.com/daveisfera/skylos-repro",
+        "license": "Unlicense",
+        "notes": "Distilled from issue #619's Gunicorn config false-positive repro."
+      },
+      "expect": {
+        "absent": {
+          "unused_functions": ["worker_exit"],
+          "unused_variables": [
+            "bind",
+            "forwarded_allow_ips",
+            "secure_scheme_headers",
+            "workers",
+            "threads",
+            "worker_class",
+            "timeout",
+            "graceful_timeout",
+            "chdir",
+            "preload_app",
+            "control_socket_disable"
+          ]
+        },
+        "present": {}
+      }
+    },
+    {
       "id": "django-class-based-view",
       "path": "fixtures/django_cbv.py",
       "description": "Django class-based views should not be treated as dead framework classes.",

--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -154,6 +154,119 @@ _DJANGO_MODULE_VARS = {
     "default_app_config",
 }
 
+_DJANGO_URLCONF_HANDLER_VARS = {
+    "handler400",
+    "handler403",
+    "handler404",
+    "handler500",
+}
+
+_DJANGO_PATH_CONVERTER_METHODS = {
+    "to_python",
+    "to_url",
+}
+
+_GUNICORN_CONFIG_SETTINGS = {
+    "access_log_format",
+    "accesslog",
+    "backlog",
+    "bind",
+    "ca_certs",
+    "capture_output",
+    "cert_reqs",
+    "certfile",
+    "chdir",
+    "check_config",
+    "child_exit",
+    "ciphers",
+    "config",
+    "control_socket_disable",
+    "daemon",
+    "default_proc_name",
+    "disable_redirect_access_to_syslog",
+    "do_handshake_on_connect",
+    "enable_stdio_inheritance",
+    "env",
+    "errorlog",
+    "forwarded_allow_ips",
+    "graceful_timeout",
+    "group",
+    "initgroups",
+    "keepalive",
+    "keyfile",
+    "limit_request_field_size",
+    "limit_request_fields",
+    "limit_request_line",
+    "logconfig",
+    "logconfig_dict",
+    "logconfig_json",
+    "logger_class",
+    "loglevel",
+    "max_requests",
+    "max_requests_jitter",
+    "nworkers_changed",
+    "on_exit",
+    "on_reload",
+    "on_starting",
+    "paste",
+    "pidfile",
+    "post_fork",
+    "post_request",
+    "post_worker_init",
+    "pre_exec",
+    "pre_fork",
+    "pre_request",
+    "preload_app",
+    "proc_name",
+    "pythonpath",
+    "raw_env",
+    "reload",
+    "reload_engine",
+    "reload_extra_files",
+    "reuse_port",
+    "secure_scheme_headers",
+    "sendfile",
+    "spew",
+    "ssl_context",
+    "statsd_host",
+    "statsd_prefix",
+    "strip_header_spaces",
+    "suppress_ragged_eofs",
+    "threads",
+    "timeout",
+    "tmp_upload_dir",
+    "umask",
+    "user",
+    "when_ready",
+    "worker_abort",
+    "worker_class",
+    "worker_connections",
+    "worker_exit",
+    "worker_int",
+    "worker_tmp_dir",
+    "workers",
+    "wsgi_app",
+}
+
+_GUNICORN_CONFIG_HOOKS = {
+    "child_exit",
+    "nworkers_changed",
+    "on_exit",
+    "on_reload",
+    "on_starting",
+    "post_fork",
+    "post_request",
+    "post_worker_init",
+    "pre_exec",
+    "pre_fork",
+    "pre_request",
+    "ssl_context",
+    "when_ready",
+    "worker_abort",
+    "worker_exit",
+    "worker_int",
+}
+
 _DJANGO_COMMAND_ATTRS = {
     "help",
     "missing_args_message",
@@ -440,6 +553,97 @@ def _check_alembic_migration(def_obj):
     return None
 
 
+def _is_likely_module_level(def_obj):
+    parts = str(def_obj.name).split(".")
+    if len(parts) < 2:
+        return True
+    owner = parts[-2]
+    return not (owner and owner[0].isupper())
+
+
+def _parent_simple_name(def_obj):
+    if "." not in str(def_obj.name):
+        return None
+    parent = str(def_obj.name).rsplit(".", 1)[0]
+    return parent.split(".")[-1]
+
+
+def _class_declares_django_path_converter_protocol(analyzer, class_name):
+    has_regex = False
+    has_to_python = False
+    has_to_url = False
+
+    for candidate in getattr(analyzer, "defs", {}).values():
+        if "." not in str(getattr(candidate, "name", "")):
+            continue
+        if _parent_simple_name(candidate) != class_name:
+            continue
+        if candidate.type == "variable" and candidate.simple_name == "regex":
+            has_regex = True
+        elif candidate.type == "method" and candidate.simple_name == "to_python":
+            has_to_python = True
+        elif candidate.type == "method" and candidate.simple_name == "to_url":
+            has_to_url = True
+
+    return has_regex and has_to_python and has_to_url
+
+
+def _check_django_path_converter(def_obj, analyzer, framework):
+    converter_classes = set(
+        getattr(analyzer, "_global_django_path_converter_classes", set())
+    )
+    converter_classes.update(getattr(framework, "django_path_converter_classes", set()))
+    if not converter_classes:
+        return None
+
+    if def_obj.type == "class":
+        class_name = def_obj.simple_name
+    else:
+        class_name = _parent_simple_name(def_obj)
+    if class_name not in converter_classes:
+        return None
+    if not _class_declares_django_path_converter_protocol(analyzer, class_name):
+        return None
+
+    if def_obj.type == "class":
+        return _suppress(def_obj, "Django path converter class")
+    if def_obj.type == "variable" and def_obj.simple_name == "regex":
+        return _suppress(def_obj, "Django path converter regex")
+    if (
+        def_obj.type == "method"
+        and def_obj.simple_name in _DJANGO_PATH_CONVERTER_METHODS
+    ):
+        return _suppress(def_obj, "Django path converter method")
+    return None
+
+
+def _is_gunicorn_config_path(filename):
+    normalized = (
+        Path(str(filename))
+        .stem.lower()
+        .replace(".", "_")
+        .replace("-", "_")
+    )
+    parts = set(filter(None, normalized.split("_")))
+    if normalized == "gunicorn":
+        return True
+    return "gunicorn" in parts and bool(parts & {"conf", "config"})
+
+
+def _check_gunicorn_config(def_obj):
+    if not _is_gunicorn_config_path(def_obj.filename):
+        return None
+    if not _is_likely_module_level(def_obj):
+        return None
+
+    simple_name = def_obj.simple_name
+    if def_obj.type == "variable" and simple_name in _GUNICORN_CONFIG_SETTINGS:
+        return _suppress(def_obj, "Gunicorn config setting")
+    if def_obj.type == "function" and simple_name in _GUNICORN_CONFIG_HOOKS:
+        return _suppress(def_obj, "Gunicorn lifecycle hook")
+    return None
+
+
 def _check_django_drf_structural(def_obj, framework):
     detected = getattr(framework, "detected_frameworks", set())
     simple_name = def_obj.simple_name
@@ -460,6 +664,14 @@ def _check_django_drf_structural(def_obj, framework):
 
     if def_obj.type == "variable" and simple_name in _DJANGO_MODULE_VARS:
         return _suppress(def_obj)
+
+    if (
+        def_obj.type == "variable"
+        and simple_name in _DJANGO_URLCONF_HANDLER_VARS
+        and "django" in detected
+        and _is_likely_module_level(def_obj)
+    ):
+        return _suppress(def_obj, "Django URLconf error handler")
 
     if def_obj.type == "variable" and simple_name in _MIGRATION_ATTRS:
         fname = str(def_obj.filename)
@@ -1144,6 +1356,12 @@ def apply_penalties(
         return
 
     if _check_alembic_migration(def_obj) is True:
+        return
+
+    if _check_gunicorn_config(def_obj) is True:
+        return
+
+    if _check_django_path_converter(def_obj, analyzer, framework) is True:
         return
 
     if _check_django_drf_structural(def_obj, framework) is True:

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2612,6 +2612,7 @@ class Skylos:
         self._global_abc_implementers = {}
         self._global_protocol_implementers = {}
         self._global_protocol_method_names = {}
+        self._global_django_path_converter_classes = set()
 
         for defs, test_flags, framework_flags, file, mod, cfg in file_contexts:
             self._global_abc_classes.update(
@@ -2648,6 +2649,10 @@ class Skylos:
                 if cls not in self._global_protocol_method_names:
                     self._global_protocol_method_names[cls] = set()
                 self._global_protocol_method_names[cls].update(methods)
+
+            self._global_django_path_converter_classes.update(
+                getattr(framework_flags, "django_path_converter_classes", set())
+            )
 
         self._duck_typed_implementers = set()
 

--- a/skylos/visitors/framework_aware.py
+++ b/skylos/visitors/framework_aware.py
@@ -174,6 +174,12 @@ class FrameworkAwareVisitor:
         self.objects_with_routes = defaultdict(list)
         self.objects_passed_as_args = set()
         self.objects_created_by_call = set()
+        self.django_path_converter_classes = set()
+        self._django_register_converter_names = set()
+        self._django_urls_aliases = set()
+        self._django_root_aliases = set()
+        self._function_depth = 0
+        self._class_depth = 0
 
         if filename:
             self._check_framework_imports_in_file(filename)
@@ -195,6 +201,15 @@ class FrameworkAwareVisitor:
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             name = alias.name.lower()
+            bound_name = alias.asname or alias.name.split(".", 1)[0]
+
+            if name == "django":
+                self._django_root_aliases.add(bound_name)
+            elif name == "django.urls":
+                if alias.asname:
+                    self._django_urls_aliases.add(alias.asname)
+                else:
+                    self._django_root_aliases.add("django")
 
             for fw in FRAMEWORK_IMPORTS:
                 if fw in name:
@@ -211,6 +226,17 @@ class FrameworkAwareVisitor:
             if module_name in FRAMEWORK_IMPORTS:
                 self.is_framework_file = True
                 self.detected_frameworks.add(module_name)
+
+            if node.module == "django.urls":
+                for alias in node.names:
+                    if alias.name == "register_converter":
+                        self._django_register_converter_names.add(
+                            alias.asname or alias.name
+                        )
+            elif node.module == "django":
+                for alias in node.names:
+                    if alias.name == "urls":
+                        self._django_urls_aliases.add(alias.asname or alias.name)
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -247,7 +273,11 @@ class FrameworkAwareVisitor:
 
         if is_route:
             self._collect_annotation_type_refs(node)
-        self.generic_visit(node)
+        self._function_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self._function_depth -= 1
 
     visit_AsyncFunctionDef = visit_FunctionDef
 
@@ -289,7 +319,11 @@ class FrameworkAwareVisitor:
                     self.declarative_classes.add(node.name)
                     break
 
-        self.generic_visit(node)
+        self._class_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self._class_depth -= 1
 
     def visit_Assign(self, node: ast.Assign) -> None:
         if isinstance(node.value, ast.Call):
@@ -322,6 +356,19 @@ class FrameworkAwareVisitor:
         if callback_target is not None:
             self._mark_view_from_url_pattern(callback_target)
             self.is_framework_file = True
+
+        if (
+            self._function_depth == 0
+            and self._class_depth == 0
+            and self._is_django_register_converter_call(node.func)
+            and node.args
+        ):
+            cls_name = self._simple_name(node.args[0])
+            if cls_name:
+                self.django_path_converter_classes.add(cls_name)
+                self._mark_classes.add(cls_name)
+                self.is_framework_file = True
+                self.detected_frameworks.add("django")
 
         if isinstance(node.func, ast.Attribute) and node.func.attr == "register":
             if len(node.args) >= 2:
@@ -452,6 +499,31 @@ class FrameworkAwareVisitor:
 
         parts.reverse()
         return ".".join(parts)
+
+    def _expr_to_str(self, node: ast.AST) -> str:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            return self._attr_to_str(node)
+        return ""
+
+    def _is_django_register_converter_call(self, func: ast.AST) -> bool:
+        if isinstance(func, ast.Name):
+            return func.id in self._django_register_converter_names
+
+        if not isinstance(func, ast.Attribute) or func.attr != "register_converter":
+            return False
+
+        receiver = self._expr_to_str(func.value)
+        if receiver in self._django_urls_aliases:
+            return True
+        if receiver == "django.urls":
+            return True
+
+        for django_alias in self._django_root_aliases:
+            if receiver == f"{django_alias}.urls":
+                return True
+        return False
 
     def _base_names(self, node: ast.ClassDef) -> list[str]:
         out = []

--- a/test/test_dead_code_evidence.py
+++ b/test/test_dead_code_evidence.py
@@ -27,6 +27,13 @@ def _event_roles(entry):
     return {event["role"] for event in entry["evidence"]}
 
 
+def _unused_full_names(result, bucket):
+    return {
+        item.get("full_name") or item.get("name")
+        for item in result.get(bucket, [])
+    }
+
+
 def test_evidence_ledger_uses_paper_classification_precedence():
     symbol = SymbolKey(
         file="app.py",
@@ -241,6 +248,276 @@ def test_dynamic_pattern_evidence_is_reported_from_analyzer(tmp_path):
     assert by_name["app.handle_login"]["classification"] == "alive"
     assert _event_kinds(by_name["app.handle_login"]) >= {"dynamic_pattern"}
     assert "reachable_from_root" not in _event_kinds(by_name["app.handle_login"])
+
+
+def test_gunicorn_config_settings_and_hooks_are_not_reported_dead(tmp_path):
+    gunicorn_project = tmp_path / "gunicorn_project"
+    ordinary_project = tmp_path / "ordinary_project"
+    gunicorn_project.mkdir()
+    ordinary_project.mkdir()
+
+    (gunicorn_project / "gunicorn_config.py").write_text(
+        "\n".join(
+            [
+                'bind = "0.0.0.0:80"',
+                'forwarded_allow_ips = "*"',
+                "workers = 4",
+                "preload_app = True",
+                "control_socket_disable = True",
+                "",
+                "def worker_exit(server, worker):",
+                "    server.log.info('worker %s exiting', worker.pid)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (ordinary_project / "ordinary.py").write_text(
+        "\n".join(
+            [
+                'bind = "127.0.0.1:8000"',
+                "",
+                "def worker_exit(server, worker):",
+                "    return server, worker",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(gunicorn_project), conf=60, grep_verify=False, trace_file=False)
+    )
+
+    unused_functions = _unused_full_names(result, "unused_functions")
+    unused_variables = _unused_full_names(result, "unused_variables")
+
+    assert "gunicorn_config.worker_exit" not in unused_functions
+    assert "gunicorn_config.bind" not in unused_variables
+    assert "gunicorn_config.forwarded_allow_ips" not in unused_variables
+    assert "gunicorn_config.workers" not in unused_variables
+    assert "gunicorn_config.preload_app" not in unused_variables
+    assert "gunicorn_config.control_socket_disable" not in unused_variables
+
+    by_name = _entries_by_name(result)
+    gunicorn_bind = by_name["gunicorn_config.bind"]
+    assert gunicorn_bind["classification"] == "uncertain"
+    assert any(
+        event["reason"] == "Gunicorn config setting"
+        for event in gunicorn_bind["evidence"]
+    )
+
+    ordinary_result = json.loads(
+        analyze(str(ordinary_project), conf=60, grep_verify=False, trace_file=False)
+    )
+    assert "ordinary.worker_exit" in _unused_full_names(
+        ordinary_result,
+        "unused_functions",
+    )
+    assert "ordinary.bind" in _unused_full_names(ordinary_result, "unused_variables")
+
+
+def test_django_urlconf_error_handler_aliases_are_not_reported_dead(tmp_path):
+    django_project = tmp_path / "django_project"
+    plain_project = tmp_path / "plain_project"
+    django_project.mkdir()
+    plain_project.mkdir()
+
+    (django_project / "urls.py").write_text(
+        "\n".join(
+            [
+                "from django.http import HttpResponseBadRequest, HttpResponseNotFound",
+                "",
+                "def _bad_request(request, exception):",
+                '    return HttpResponseBadRequest("Bad request")',
+                "",
+                "def _not_found(request, exception):",
+                '    return HttpResponseNotFound("Not found")',
+                "",
+                "handler400 = _bad_request",
+                "handler404 = _not_found",
+                "urlpatterns = []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (plain_project / "plain.py").write_text(
+        "\n".join(
+            [
+                "def fallback():",
+                "    return 404",
+                "",
+                "handler404 = fallback",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(django_project), conf=60, grep_verify=False, trace_file=False)
+    )
+
+    unused_variables = _unused_full_names(result, "unused_variables")
+
+    assert "urls.handler400" not in unused_variables
+    assert "urls.handler404" not in unused_variables
+
+    by_name = _entries_by_name(result)
+    handler = by_name["urls.handler404"]
+    assert handler["classification"] == "uncertain"
+    assert any(
+        event["reason"] == "Django URLconf error handler"
+        for event in handler["evidence"]
+    )
+
+    plain_result = json.loads(
+        analyze(str(plain_project), conf=60, grep_verify=False, trace_file=False)
+    )
+    assert "plain.handler404" in _unused_full_names(
+        plain_result,
+        "unused_variables",
+    )
+
+
+def test_django_registered_path_converter_protocol_is_not_reported_dead(tmp_path):
+    django_project = tmp_path / "django_project"
+    ordinary_project = tmp_path / "ordinary_project"
+    wrapped_project = tmp_path / "wrapped_project"
+    django_project.mkdir()
+    ordinary_project.mkdir()
+    wrapped_project.mkdir()
+
+    (django_project / "converters.py").write_text(
+        "\n".join(
+            [
+                "class FourDigitYearConverter:",
+                '    regex = "[0-9]{4}"',
+                "",
+                "    def to_python(self, value):",
+                "        return int(value)",
+                "",
+                "    def to_url(self, value):",
+                '        return "%04d" % value',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (django_project / "urls.py").write_text(
+        "\n".join(
+            [
+                "import converters",
+                "from django.urls import path, register_converter",
+                "",
+                'register_converter(converters.FourDigitYearConverter, "yyyy")',
+                "urlpatterns = []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    (ordinary_project / "converters.py").write_text(
+        "\n".join(
+            [
+                "class FourDigitYearConverter:",
+                '    regex = "[0-9]{4}"',
+                "",
+                "    def to_python(self, value):",
+                "        return int(value)",
+                "",
+                "    def to_url(self, value):",
+                '        return "%04d" % value',
+                "",
+                "converter = FourDigitYearConverter()",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (wrapped_project / "converters.py").write_text(
+        "\n".join(
+            [
+                "class FourDigitYearConverter:",
+                '    regex = "[0-9]{4}"',
+                "",
+                "    def to_python(self, value):",
+                "        return int(value)",
+                "",
+                "    def to_url(self, value):",
+                '        return "%04d" % value',
+                "",
+                "converter = FourDigitYearConverter()",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (wrapped_project / "urls.py").write_text(
+        "\n".join(
+            [
+                "import converters",
+                "from django.urls import register_converter",
+                "",
+                "def configure_converters():",
+                '    register_converter(converters.FourDigitYearConverter, "yyyy")',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(django_project), conf=60, grep_verify=False, trace_file=False)
+    )
+    unused_functions = _unused_full_names(result, "unused_functions")
+    unused_variables = _unused_full_names(result, "unused_variables")
+
+    assert "converters.FourDigitYearConverter.to_python" not in unused_functions
+    assert "converters.FourDigitYearConverter.to_url" not in unused_functions
+    assert "converters.FourDigitYearConverter.regex" not in unused_variables
+
+    by_name = _entries_by_name(result)
+    regex = by_name["converters.FourDigitYearConverter.regex"]
+    assert regex["classification"] == "uncertain"
+    assert any(
+        event["reason"] == "Django path converter regex"
+        for event in regex["evidence"]
+    )
+
+    ordinary_result = json.loads(
+        analyze(str(ordinary_project), conf=60, grep_verify=False, trace_file=False)
+    )
+    assert "converters.FourDigitYearConverter.to_python" in _unused_full_names(
+        ordinary_result,
+        "unused_functions",
+    )
+    assert "converters.FourDigitYearConverter.to_url" in _unused_full_names(
+        ordinary_result,
+        "unused_functions",
+    )
+    assert "converters.FourDigitYearConverter.regex" in _unused_full_names(
+        ordinary_result,
+        "unused_variables",
+    )
+
+    wrapped_result = json.loads(
+        analyze(str(wrapped_project), conf=60, grep_verify=False, trace_file=False)
+    )
+    assert "converters.FourDigitYearConverter.to_python" in _unused_full_names(
+        wrapped_result,
+        "unused_functions",
+    )
+    assert "converters.FourDigitYearConverter.to_url" in _unused_full_names(
+        wrapped_result,
+        "unused_functions",
+    )
+    assert "converters.FourDigitYearConverter.regex" in _unused_full_names(
+        wrapped_result,
+        "unused_variables",
+    )
 
 
 def test_trace_and_coverage_evidence_are_reported_from_analyzer(tmp_path):


### PR DESCRIPTION
Fixes #619

## Summary
  - Fixed Gunicorn config module settings and lifecycle hooks as live framework and runtime symbols.
  - Fixed Django URLconf error handler aliases (`handler400`, `handler403` etc) as live.
  - Fixed Django custom path converter protocol members when the converter class is registered via `django.urls.register_converter(...)`.

  ## Tests
  - `pytest test/test_dead_code_evidence.py`
  - `pytest test/test_framework_aware.py test/test_analyzer.py`
  - Also scanned issue #619 repro repo to check FPs are fixed
  
 ## Scope
  We left 2 repro findings are intentionally untouched but will include it down the road:
  - `load_m3u8_from_s3`. Not a Django or Gunicorn entrypoint.
  - local `register_converter`. Not in the documented Django convention.