### PR TITLE
fix(dead-code): recognize numba overload implementations

### DIFF
--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -75,6 +75,12 @@ OVERRIDE_DECORATORS = {
     "typing_extensions.override",
 }
 
+NUMBA_OVERLOAD_DECORATORS = {
+    "numba.extending.overload",
+    "numba.extending.overload_method",
+    "numba.extending.overload_attribute",
+}
+
 IMPLICIT_DUNDERS = {
     "__init__",
     "__new__",
@@ -718,6 +724,53 @@ class Visitor(ast.NodeVisitor):
             return self._get_decorator_name(deco.func)
         return None
 
+    def _local_binding_shadows_alias(
+        self, name: str, current_definition: str | None = None
+    ) -> bool:
+        if self.current_function_scope and self.local_var_maps:
+            for scope_map in reversed(self.local_var_maps):
+                if scope_map.get(name) != current_definition and name in scope_map:
+                    return True
+
+        candidates = []
+        if self.cls:
+            candidates.append(".".join(filter(None, [self.mod, self.cls, name])))
+        candidates.append(f"{self.mod}.{name}" if self.mod else name)
+
+        return any(
+            d.name in candidates
+            and d.name != current_definition
+            and d.type != "import"
+            for d in self.defs
+        )
+
+    def _resolve_alias_prefix(
+        self, name: str, current_definition: str | None = None
+    ) -> str:
+        head = name.split(".", 1)[0]
+        if self._local_binding_shadows_alias(head, current_definition):
+            return name
+        if name in self.alias:
+            return self.alias[name]
+        if "." not in name:
+            return name
+        _, rest = name.split(".", 1)
+        target = self.alias.get(head)
+        if target:
+            return f"{target}.{rest}"
+        return name
+
+    def _is_numba_overload_decorator(
+        self, name: str, current_definition: str | None = None
+    ) -> bool:
+        head = name.split(".", 1)[0]
+        if self._local_binding_shadows_alias(head, current_definition):
+            return False
+        return (
+            self._resolve_alias_prefix(name, current_definition)
+            in NUMBA_OVERLOAD_DECORATORS
+        )
+
     def _analyze_decorator_args(self, deco: ast.expr) -> None:
         if not isinstance(deco, ast.Call):
             return
@@ -871,6 +924,10 @@ class Visitor(ast.NodeVisitor):
                         )
                 elif any(
                     keyword in deco_name.lower() for keyword in FRAMEWORK_DECORATORS
+                ):
+                    self.add_ref(qualified_name)
+                elif isinstance(d, ast.Call) and self._is_numba_overload_decorator(
+                    deco_name, current_definition=qualified_name
                 ):
                     self.add_ref(qualified_name)
                 elif deco_name in self.local_registration_decorators:

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -13,6 +13,95 @@ def _unused_function_names(result):
     return {item["full_name"] for item in result.get("unused_functions", [])}
 
 
+def test_numba_overload_implementation_is_live(tmp_path):
+    _write(
+        tmp_path / "skylos_false_positive.py",
+        """
+        import numba.extending
+        from numba import njit
+
+        def select_method(x):
+            return x
+
+        @numba.extending.overload(select_method)
+        def _select_method(x):
+            def temp(x):
+                return x
+            return temp
+
+        @njit()
+        def jitted_harness():
+            return select_method(0.0)
+
+        jitted_harness()
+        """,
+    )
+    _write(
+        tmp_path / "aliased_overload.py",
+        """
+        from numba.extending import overload as nb_overload
+        import numba.extending as ne
+
+        def select_alias(x):
+            return x
+
+        @nb_overload(select_alias)
+        def _select_alias(x):
+            def impl(x):
+                return x
+            return impl
+
+        @ne.overload(select_alias)
+        def _select_module_alias(x):
+            def impl(x):
+                return x
+            return impl
+
+        @ne.overload_method(object, "work")
+        def _select_method_alias(x):
+            def impl(x):
+                return x
+            return impl
+
+        @ne.overload_attribute(object, "value")
+        def _select_attribute_alias(x):
+            def impl(x):
+                return x
+            return impl
+        """,
+    )
+    _write(
+        tmp_path / "shadowed_alias.py",
+        """
+        from numba.extending import overload as nb_overload
+
+        def nb_overload(target):
+            def decorator(func):
+                return func
+            return decorator
+
+        @nb_overload(None)
+        def _shadowed_helper(x):
+            return x
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    unused = _unused_function_names(result)
+
+    assert "skylos_false_positive._select_method" not in unused
+    assert "skylos_false_positive._select_method.temp" not in unused
+    assert "aliased_overload._select_alias" not in unused
+    assert "aliased_overload._select_alias.impl" not in unused
+    assert "aliased_overload._select_module_alias" not in unused
+    assert "aliased_overload._select_module_alias.impl" not in unused
+    assert "aliased_overload._select_method_alias" not in unused
+    assert "aliased_overload._select_method_alias.impl" not in unused
+    assert "aliased_overload._select_attribute_alias" not in unused
+    assert "aliased_overload._select_attribute_alias.impl" not in unused
+    assert "shadowed_alias._shadowed_helper" in unused
+
+
 def test_optional_import_fallback_is_live(tmp_path):
     _write(
         tmp_path / "pkg" / "mod.py",


### PR DESCRIPTION
Solves #627 

## Summary

  - Recognize Numba overload decorators as live registration roots in dead-code analysis
  - Support direct, imported, and module alias forms for `numba.extending.overload`
  - Covers `overload_method`, `overload_attribute`, nested returned implementations, and shadowed alias cases

  ## Tests

  - `pytest test/test_dead_code_liveness.py`
  - `pytest test/test_dead_code.py test/test_framework_aware.py test/test_dynamic_patterns.py`