### PR TITLE
feat(verify): add language-aware verification coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Verify a changed file or range before an agent hands it to review:
 skylos verify . --file src/app.py --range 40:75 --project-context
 ```
 
+`skylos verify` schema version 2 returns `pass`, `fail`, or `incomplete`.
+`incomplete` means a requested proof could not be established, such as a
+third-party TS/JS import or computed namespace member that Skylos did not
+resolve; it exits `2` unless `--no-fail` is set. The `coverage` object lists
+completed checks, skipped checks, checked references, and skip reasons.
+
+For TypeScript and JavaScript, verification checks named imports, default and
+type-only imports, static namespace members, re-exports, and CommonJS exports
+against local and workspace package surfaces without executing Node.js.
+
 Create a local AI hallucination contract for repo-specific generated-code
 truth. `skylos verify` auto-discovers `.skylos/ai-contract.yml`:
 
@@ -338,9 +348,9 @@ or `--include-folder` to override an excluded folder.
 | Language | Dead Code | Security | Quality | Notes |
 |:---|:---:|:---:|:---:|:---|
 | Python | Yes | Yes | Yes | strongest coverage; framework-aware static analysis and optional tracing |
-| TypeScript / JavaScript | Yes | Yes | Yes | Tree-sitter parsing, package graph reachability, framework conventions |
+| TypeScript / JavaScript | Yes | Yes | Yes | Tree-sitter parsing, package graph reachability, framework conventions, local/workspace API hallucination checks |
 | Java | Yes | Yes | Yes | Tree-sitter parsing and structured security-flow analysis |
-| Go | Yes | Partial | Partial | dead-code and selected security benchmark coverage |
+| Go | Yes | Partial | Partial | native engine availability is reported in scan JSON and `skylos doctor --format json` |
 | PHP | Yes | Yes | Partial | PHP parser coverage plus taint-style security sinks and sources |
 | Rust | Yes | Yes | Partial | Rust parser coverage plus security sink/source checks |
 | Dart | Yes | Yes | Partial | Dart parser coverage plus selected security sinks and sources |

--- a/benchmarks/ai_code_defects/README.md
+++ b/benchmarks/ai_code_defects/README.md
@@ -18,9 +18,15 @@ harder cases:
 - nested workspace manifests with dependency hallucinations below the scan root
 - clean dependency manifests for package/version precision
 - installed-package API member and keyword-argument hallucinations
+- local TypeScript named, default, type-only, namespace, re-export, and
+  CommonJS API-surface hallucinations, plus a clean precision control
 - diff-aware assertion weakening in tests
 - exact finding-count expectations to catch noisy over-reporting
 - a clean generated-code absence guard
+
+Every checked-in case carries an explicit `language` label. Benchmark JSON
+reports per-language case counts and language-label coverage under
+`metadata.languages`.
 
 Registry-dependent dependency cases seed Skylos' normal dependency-version cache
 inside a temporary fixture copy, so benchmark results do not depend on live npm

--- a/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/package.json
+++ b/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "clean-typescript-local-api-surface",
+  "private": true
+}

--- a/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/app.ts
+++ b/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/app.ts
@@ -1,0 +1,14 @@
+import createClient, { verifyToken, type User } from "./security";
+import * as security from "./security";
+
+const { validateLegacy } = require("./legacy.cjs");
+const legacy = require("./legacy.cjs");
+
+createClient();
+verifyToken();
+security.verifyToken();
+validateLegacy();
+legacy.validateLegacy();
+
+const user: User = { id: "user-1" };
+console.log(user);

--- a/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/legacy.cjs
+++ b/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/legacy.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  validateLegacy: () => true
+};

--- a/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/security.ts
+++ b/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/security.ts
@@ -1,0 +1,5 @@
+export { verifyToken } from "./token";
+export type { User } from "./types";
+export default function createClient() {
+  return { ready: true };
+}

--- a/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/token.ts
+++ b/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/token.ts
@@ -1,0 +1,3 @@
+export function verifyToken() {
+  return true;
+}

--- a/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/types.ts
+++ b/benchmarks/ai_code_defects/fixtures/clean_typescript_local_api_surface/src/types.ts
@@ -1,0 +1,3 @@
+export interface User {
+  id: string;
+}

--- a/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/package.json
+++ b/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "typescript-local-api-hallucination",
+  "private": true
+}

--- a/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/app.ts
+++ b/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/app.ts
@@ -1,0 +1,20 @@
+import createClient, {
+  verifyToken,
+  verifyTenant,
+  type User,
+  type MissingUser
+} from "./security";
+import * as security from "./security";
+
+const { validateLegacy, validateLegacyAdmin } = require("./legacy.cjs");
+
+createClient();
+verifyToken();
+security.verifyToken();
+security.authorizeAdmin();
+validateLegacy();
+validateLegacyAdmin();
+
+const user: User = { id: "user-1" };
+const missing: MissingUser = user;
+console.log(user, missing);

--- a/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/legacy.cjs
+++ b/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/legacy.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  validateLegacy: () => true
+};

--- a/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/security.ts
+++ b/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/security.ts
@@ -1,0 +1,5 @@
+export { verifyToken } from "./token";
+export type { User } from "./types";
+export default function createClient() {
+  return { ready: true };
+}

--- a/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/token.ts
+++ b/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/token.ts
@@ -1,0 +1,3 @@
+export function verifyToken() {
+  return true;
+}

--- a/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/types.ts
+++ b/benchmarks/ai_code_defects/fixtures/typescript_local_api_hallucination/src/types.ts
@@ -1,0 +1,3 @@
+export interface User {
+  id: string;
+}

--- a/benchmarks/ai_code_defects/manifest.json
+++ b/benchmarks/ai_code_defects/manifest.json
@@ -3,6 +3,7 @@
   "cases": [
     {
       "id": "hallucinated-reference",
+      "language": "python",
       "path": "fixtures/hallucinated_reference",
       "description": "Generated handler calls a plausible helper that was never defined.",
       "taxonomy": ["hallucinated_reference"],
@@ -29,6 +30,7 @@
     },
     {
       "id": "repo-local-phantom-reference",
+      "language": "python",
       "path": "fixtures/repo_local_phantom_reference",
       "description": "Generated handler calls a plausible method on a real local module, but the method was never implemented.",
       "taxonomy": ["hallucinated_reference"],
@@ -56,6 +58,7 @@
     },
     {
       "id": "multiple-phantom-references",
+      "language": "python",
       "path": "fixtures/multiple_phantom_references",
       "description": "Generated request handler chains several plausible security helpers that do not exist.",
       "taxonomy": ["hallucinated_reference"],
@@ -83,6 +86,7 @@
     },
     {
       "id": "range-scoped-mixed-edit",
+      "language": "python",
       "path": "fixtures/range_scoped_mixed_edit",
       "description": "A generated file contains multiple AI defects, but verify is scoped to only the changed handler range.",
       "taxonomy": ["hallucinated_reference"],
@@ -124,6 +128,7 @@
     },
     {
       "id": "file-scoped-multi-module",
+      "language": "python",
       "path": "fixtures/file_scoped_multi_module",
       "description": "A generated package contains defects in multiple modules, but verify is scoped to the edited route file.",
       "taxonomy": ["hallucinated_reference", "precision_guard"],
@@ -160,6 +165,7 @@
     },
     {
       "id": "assertion-weakening",
+      "language": "python",
       "path": "fixtures/assertion_weakening",
       "description": "Generated test edit weakens a specific status assertion into a broad null check.",
       "taxonomy": ["assertion_weakening"],
@@ -195,6 +201,7 @@
     },
     {
       "id": "bad-test-expected-broadening",
+      "language": "python",
       "path": "fixtures/bad_test_expected_broadening",
       "description": "Generated test edit replaces a specific expected value with a broad ANY matcher.",
       "taxonomy": ["assertion_weakening"],
@@ -230,6 +237,7 @@
     },
     {
       "id": "clean-test-expected-change",
+      "language": "python",
       "path": "fixtures/clean_test_expected_change",
       "description": "A test keeps an exact expected value while the fixture value changes.",
       "taxonomy": ["assertion_weakening", "precision_guard"],
@@ -260,6 +268,7 @@
     },
     {
       "id": "incomplete-generation",
+      "language": "python",
       "path": "fixtures/incomplete_generation",
       "description": "Generated business function is left as a pass-body stub.",
       "taxonomy": ["incomplete_generation"],
@@ -286,6 +295,7 @@
     },
     {
       "id": "unfinished-generated-class",
+      "language": "python",
       "path": "fixtures/unfinished_generated_class",
       "description": "Generated workflow mixes pass, ellipsis, and NotImplementedError placeholders.",
       "taxonomy": ["incomplete_generation"],
@@ -313,6 +323,7 @@
     },
     {
       "id": "api-signature-hallucination",
+      "language": "python",
       "path": "fixtures/api_signature_hallucination",
       "description": "Generated code calls real installed package APIs that do not exist.",
       "taxonomy": ["api_signature_hallucination"],
@@ -342,6 +353,7 @@
     },
     {
       "id": "api-keyword-hallucination",
+      "language": "python",
       "path": "fixtures/api_keyword_hallucination",
       "description": "Generated code passes invented keyword arguments to real installed package APIs.",
       "taxonomy": ["api_signature_hallucination"],
@@ -381,6 +393,7 @@
     },
     {
       "id": "dependency-package-hallucination",
+      "language": "javascript",
       "path": "fixtures/dependency_package_hallucination",
       "description": "Generated package manifest adds a package that does not exist.",
       "taxonomy": ["dependency_hallucination"],
@@ -422,6 +435,7 @@
     },
     {
       "id": "compound-ai-failure-edit",
+      "language": "multi",
       "path": "fixtures/compound_ai_failure_edit",
       "description": "One generated edit combines phantom helpers, unfinished code, invented package APIs, and hallucinated dependencies.",
       "taxonomy": [
@@ -492,6 +506,7 @@
     },
     {
       "id": "compound-api-range-scope",
+      "language": "multi",
       "path": "fixtures/compound_ai_failure_edit",
       "description": "A compound generated edit is scoped down to only the invented installed-package API call.",
       "taxonomy": [
@@ -558,6 +573,7 @@
     },
     {
       "id": "dependency-version-hallucination",
+      "language": "javascript",
       "path": "fixtures/dependency_version_hallucination",
       "description": "Generated package manifest pins a dependency/version that should be verified against the registry.",
       "taxonomy": ["dependency_hallucination"],
@@ -593,6 +609,7 @@
     },
     {
       "id": "repo-level-security-regression",
+      "language": "python",
       "path": "fixtures/repo_level_security_regression",
       "description": "Generated repo-level edit introduces string-built SQL and unsafe pickle deserialization.",
       "taxonomy": ["security_regression"],
@@ -632,6 +649,7 @@
     },
     {
       "id": "slopsquat-dependency",
+      "language": "python",
       "path": "fixtures/slopsquat_dependency",
       "description": "Generated requirements file pins a suspicious existing near-miss of a popular package.",
       "taxonomy": ["dependency_hallucination"],
@@ -681,6 +699,7 @@
     },
     {
       "id": "disabled-security-control",
+      "language": "python",
       "path": "fixtures/disabled_security_control",
       "description": "Generated integration disables TLS verification while calling an external service.",
       "taxonomy": ["security_regression", "incomplete_generation"],
@@ -717,6 +736,7 @@
     },
     {
       "id": "missing-auth-route",
+      "language": "python",
       "path": "fixtures/missing_auth_route",
       "description": "Generated mutating FastAPI route has no auth, permission, or security dependency guard.",
       "taxonomy": ["security_regression"],
@@ -748,6 +768,7 @@
     },
     {
       "id": "clean-auth-route",
+      "language": "python",
       "path": "fixtures/clean_auth_route",
       "description": "Generated mutating FastAPI route uses an explicit admin dependency guard.",
       "taxonomy": ["security_regression", "precision_guard"],
@@ -774,6 +795,7 @@
     },
     {
       "id": "async-swallowed-error",
+      "language": "python",
       "path": "fixtures/async_swallowed_error",
       "description": "Generated async integration swallows broad exceptions and returns None.",
       "taxonomy": ["incomplete_generation", "security_regression"],
@@ -805,6 +827,7 @@
     },
     {
       "id": "clean-async-error-handling",
+      "language": "python",
       "path": "fixtures/clean_async_error_handling",
       "description": "Generated async integration re-raises a narrow timeout instead of swallowing errors.",
       "taxonomy": ["incomplete_generation", "precision_guard"],
@@ -831,6 +854,7 @@
     },
     {
       "id": "clean-repo-level-security",
+      "language": "python",
       "path": "fixtures/clean_repo_level_security",
       "description": "Clean repo-level security edit uses parameterized SQL and JSON parsing.",
       "taxonomy": ["security_regression", "precision_guard"],
@@ -862,6 +886,7 @@
     },
     {
       "id": "go-module-version-hallucination",
+      "language": "go",
       "path": "fixtures/go_module_version_hallucination",
       "description": "Generated Go module manifest pins a real module to an invented version.",
       "taxonomy": ["dependency_hallucination"],
@@ -898,6 +923,7 @@
     },
     {
       "id": "mixed-manifest-hallucinations",
+      "language": "javascript",
       "path": "fixtures/mixed_manifest_hallucinations",
       "description": "A generated manifest mixes multiple missing packages with an invented version in one dependency edit.",
       "taxonomy": ["dependency_hallucination"],
@@ -956,6 +982,7 @@
     },
     {
       "id": "nested-manifest-workspace",
+      "language": "javascript",
       "path": "fixtures/nested_manifest_workspace",
       "description": "Generated dependency hallucinations live in a nested workspace manifest instead of the scan root.",
       "taxonomy": ["dependency_hallucination"],
@@ -1005,6 +1032,7 @@
     },
     {
       "id": "contract-phantom-helper",
+      "language": "python",
       "path": "fixtures/contract_phantom_helper",
       "description": "Generated handler calls a repo-specific helper listed in the AI contract but never defined.",
       "taxonomy": ["hallucinated_reference", "contract_guardrail"],
@@ -1035,6 +1063,7 @@
     },
     {
       "id": "contract-route-guard-missing",
+      "language": "python",
       "path": "fixtures/contract_route_guard_missing",
       "description": "Generated route is inside a contract-scoped API path but lacks a required auth guard decorator.",
       "taxonomy": ["contract_guardrail"],
@@ -1067,6 +1096,7 @@
     },
     {
       "id": "contract-route-guard-clean",
+      "language": "python",
       "path": "fixtures/contract_route_guard_clean",
       "description": "Generated route uses the custom guard decorator required by the contract.",
       "taxonomy": ["contract_guardrail", "precision_guard"],
@@ -1094,6 +1124,7 @@
     },
     {
       "id": "contract-dependency-manifest",
+      "language": "javascript",
       "path": "fixtures/contract_dependency_manifest",
       "description": "Contract enables dependency hallucination checks for a manifest with a fake package and impossible version.",
       "taxonomy": ["dependency_hallucination", "contract_guardrail"],
@@ -1145,6 +1176,7 @@
     },
     {
       "id": "contract-dependency-clean",
+      "language": "javascript",
       "path": "fixtures/contract_dependency_clean",
       "description": "Contract-enabled dependency checks stay quiet for known-good dependency versions.",
       "taxonomy": ["dependency_hallucination", "contract_guardrail", "precision_guard"],
@@ -1184,6 +1216,7 @@
     },
     {
       "id": "clean-dependency-manifest",
+      "language": "multi",
       "path": "fixtures/clean_dependency_manifest",
       "description": "Generated npm and Go manifests use dependency versions known to exist.",
       "taxonomy": ["precision_guard", "dependency_hallucination"],
@@ -1229,6 +1262,7 @@
     },
     {
       "id": "clean-api-signature",
+      "language": "python",
       "path": "fixtures/clean_api_signature",
       "description": "Generated code calls real installed package APIs with accepted keyword arguments.",
       "taxonomy": [
@@ -1259,6 +1293,7 @@
     },
     {
       "id": "clean-dynamic-api-surface",
+      "language": "python",
       "path": "fixtures/clean_dynamic_api_surface",
       "description": "Generated code uses dynamic access and keyword expansion around real installed package APIs without inventing members.",
       "taxonomy": [
@@ -1289,6 +1324,7 @@
     },
     {
       "id": "clean-range-scope",
+      "language": "python",
       "path": "fixtures/range_scoped_mixed_edit",
       "description": "A generated file has later AI defects, but the selected clean range must stay quiet.",
       "taxonomy": [
@@ -1323,7 +1359,86 @@
       }
     },
     {
+      "id": "typescript-local-api-hallucination",
+      "language": "typescript",
+      "path": "fixtures/typescript_local_api_hallucination",
+      "description": "Generated TypeScript invents named, type-only, namespace, and CommonJS exports on local modules.",
+      "taxonomy": ["hallucinated_reference"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic multi-shape fixture for deterministic local TypeScript and JavaScript API-surface truth."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true
+      },
+      "expect": {
+        "finding_count": 4,
+        "present": [
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference",
+            "min_count": 2,
+            "file_contains": "src/app.ts",
+            "metadata": {
+              "language": "typescript",
+              "reference_kind": "named_import"
+            }
+          },
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference",
+            "file_contains": "src/app.ts",
+            "metadata": {
+              "language": "typescript",
+              "reference_kind": "namespace_member"
+            }
+          },
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference",
+            "file_contains": "src/app.ts",
+            "metadata": {
+              "language": "typescript",
+              "reference_kind": "commonjs_destructure"
+            }
+          }
+        ],
+        "absent": []
+      }
+    },
+    {
+      "id": "clean-typescript-local-api-surface",
+      "language": "typescript",
+      "path": "fixtures/clean_typescript_local_api_surface",
+      "description": "Generated TypeScript uses real default, named, type-only, namespace, re-exported, and CommonJS local APIs.",
+      "taxonomy": ["hallucinated_reference", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic clean control for deterministic local TypeScript and JavaScript API-surface precision."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true
+      },
+      "expect": {
+        "finding_count": 0,
+        "present": [],
+        "absent": [
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference"
+          }
+        ]
+      }
+    },
+    {
       "id": "clean-generated-code",
+      "language": "python",
       "path": "fixtures/clean_generated_code",
       "description": "Generated code defines the helper it calls and contains no unfinished body.",
       "taxonomy": ["precision_guard"],

--- a/dictionary.md
+++ b/dictionary.md
@@ -302,7 +302,7 @@ use the `SKY-A` prefix.
 | A103 | HIGH | CI permission expansion | GitHub Actions |
 | A104 | MEDIUM | Public CLI surface drift | Diff-aware CLI |
 | A105 | HIGH | Contract route guard missing | Python contract verify |
-| L012 | CRITICAL | Phantom function call / hallucinated security function | Python |
+| L012 | CRITICAL | Phantom function, import, or module-member reference | Python, TS/JS |
 | L023 | CRITICAL | Phantom decorator | Python |
 | D222 | CRITICAL | Dependency hallucination | Python |
 | D224 | HIGH | API signature hallucination | Python |

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -482,9 +482,13 @@ def _resolve_analysis_root(path_like: Path) -> Path:
 
     start = current
     home = Path.home().resolve()
+    workspace_root = _declared_js_workspace_root(start, home=home)
+    if workspace_root is not None:
+        return workspace_root
+
     probe = current
     for _ in range(20):
-        if (probe / "pyproject.toml").exists():
+        if (probe / "pyproject.toml").exists() or (probe / "package.json").exists():
             if probe == home and start != home:
                 break
             return probe
@@ -510,6 +514,70 @@ def _resolve_analysis_root(path_like: Path) -> Path:
         pass
 
     return current
+
+
+def _declared_js_workspace_root(start: Path, *, home: Path) -> Path | None:
+    from skylos.visitors.languages.typescript.workspace import (
+        discover_workspace_inventory,
+    )
+
+    probe = start
+    for _ in range(20):
+        if _may_declare_js_workspace(probe):
+            inventory = discover_workspace_inventory(probe)
+            for package in inventory.packages:
+                if _path_is_within(start, package.root):
+                    return probe
+        if probe == home and start != home:
+            break
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+    return None
+
+
+def _may_declare_js_workspace(path: Path) -> bool:
+    return any(
+        (path / marker).is_file()
+        for marker in (
+            "package.json",
+            "pnpm-workspace.yaml",
+            "lerna.json",
+            "rush.json",
+            "tsconfig.json",
+        )
+    )
+
+
+def _path_is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _go_engine_analysis_report(files) -> dict | None:
+    go_file_count = sum(1 for file_path in files if str(file_path).endswith(".go"))
+    if not go_file_count:
+        return None
+
+    from skylos.engines.go_runner import get_go_engine_status
+
+    engine_status = get_go_engine_status()
+    available = engine_status.get("status") == "available"
+    report = {
+        "status": "available" if available else "partial",
+        "file_count": go_file_count,
+        "engine": dict(engine_status),
+        "completed_checks": ["quality"],
+        "skipped_checks": [],
+    }
+    if available:
+        report["completed_checks"].extend(["dead_code", "security"])
+    else:
+        report["skipped_checks"] = ["dead_code", "security"]
+    return report
 
 
 def _no_source_danger_targets(
@@ -2043,6 +2111,10 @@ class Skylos:
             project_root = _resolve_analysis_root(project_root)
 
         files, root = self._discover_files(path, exclude_folders)
+        self._language_engine_reports = {}
+        go_engine_report = _go_engine_analysis_report(files)
+        if go_engine_report is not None:
+            self._language_engine_reports["go"] = go_engine_report
 
         from skylos.visitors.languages.typescript.workspace import (
             discover_workspace_inventory,
@@ -2196,6 +2268,7 @@ class Skylos:
         all_dangers = []
         all_quality = []
         all_ai_defects = []
+        self._ai_verification_checks = [] if enable_ai_defects else None
         all_suppressed = []
         empty_files = []
         file_contexts = []
@@ -3214,6 +3287,45 @@ class Skylos:
         except Exception:
             if os.getenv("SKYLOS_DEBUG"):
                 logger.error("MDX component import graph scan failed", exc_info=True)
+
+        if enable_ai_defects:
+            from skylos.core.verification_coverage import reconcile_check_findings
+            from skylos.rules.ai_defect.js_api_hallucination import (
+                failed_js_api_check,
+                scan_js_local_api_hallucinations,
+                skipped_js_api_check,
+            )
+
+            if "SKY-L012" in project_ignore:
+                self._ai_verification_checks.append(
+                    skipped_js_api_check("rule_ignored")
+                )
+            else:
+                try:
+                    js_findings, js_check = scan_js_local_api_hallucinations(
+                        project_root,
+                        files,
+                        ts_raw_imports,
+                        monorepo_resolver=monorepo_resolver,
+                    )
+                    before_count = len(all_ai_defects)
+                    _extend_unsuppressed_ai_defect_findings(
+                        js_findings,
+                        project_ignore=project_ignore,
+                        per_file_ignore_lines=per_file_ignore_lines,
+                        all_ai_defects=all_ai_defects,
+                        all_suppressed=all_suppressed,
+                    )
+                    accepted_count = len(all_ai_defects) - before_count
+                    self._ai_verification_checks.append(
+                        reconcile_check_findings(js_check, accepted_count)
+                    )
+                except Exception:
+                    self._ai_verification_checks.append(
+                        failed_js_api_check("detector_error")
+                    )
+                    if os.getenv("SKYLOS_DEBUG"):
+                        logger.error("JS API hallucination scan failed", exc_info=True)
 
         self._build_ts_import_graph(ts_raw_imports, monorepo_resolver)
 

--- a/skylos/benchmarks/ai_code_defects.py
+++ b/skylos/benchmarks/ai_code_defects.py
@@ -40,6 +40,13 @@ IMPORTANCE_WEIGHTS = {
     "high": 2.0,
     "critical": 3.0,
 }
+BENCHMARK_LANGUAGES = {
+    "go",
+    "javascript",
+    "multi",
+    "python",
+    "typescript",
+}
 DEPENDENCY_STATUS_VALUES = {
     LEGACY_STATUS_EXISTS,
     *(state.value for state in DependencyTruthState),
@@ -259,6 +266,7 @@ def _validate_case(
         )
 
     _validate_taxonomy(case, case_id)
+    _validate_language(case, case_id)
     _validate_importance(case, case_id)
     _validate_source(case, case_id)
     _validate_expectations(case, case_id)
@@ -298,6 +306,17 @@ def _validate_importance(case: dict[str, Any], case_id: str) -> None:
     raise ValueError(
         f"AI-code-defect benchmark case {case_id} importance must be one of: {allowed}"
     )
+
+
+def _validate_language(case: dict[str, Any], case_id: str) -> None:
+    language = case.get("language")
+    if language is None:
+        return
+    if not isinstance(language, str) or language not in BENCHMARK_LANGUAGES:
+        allowed = ", ".join(sorted(BENCHMARK_LANGUAGES))
+        raise ValueError(
+            f"AI-code-defect benchmark case {case_id} language must be one of: {allowed}"
+        )
 
 
 def _validate_source(case: dict[str, Any], case_id: str) -> None:
@@ -659,6 +678,7 @@ def _run_case(
     case_summary = {
         "id": case["id"],
         "path": case["path"],
+        "language": case.get("language", "unlabelled"),
         "taxonomy": list(case["taxonomy"]),
         "importance": case.get("importance", "high"),
         "elapsed_seconds": elapsed,
@@ -942,7 +962,25 @@ def _benchmark_metadata(summary_cases: list[dict[str, Any]]) -> dict[str, Any]:
         metadata["external_comparisons"] = comparisons
     metadata["evidence_contracts"] = _evidence_contract_metadata(summary_cases)
     metadata["runtime"] = _runtime_metadata(summary_cases)
+    metadata["languages"] = _language_metadata(summary_cases)
     return metadata
+
+
+def _language_metadata(summary_cases: list[dict[str, Any]]) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    labelled = 0
+    for case in summary_cases:
+        language = str(case.get("language") or "unlabelled")
+        counts[language] = counts.get(language, 0) + 1
+        if language != "unlabelled":
+            labelled += 1
+    total = len(summary_cases)
+    return {
+        "case_counts": dict(sorted(counts.items())),
+        "labelled_cases": labelled,
+        "total_cases": total,
+        "coverage_rate": (labelled / total) if total else 1.0,
+    }
 
 
 def _challenge_benchmark_metadata(summary_cases: list[dict[str, Any]]) -> dict[str, Any]:

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1644,10 +1644,10 @@ def _run_whitelist_command(argv):
     return run_whitelist_command(argv)
 
 
-def _run_doctor_command(_argv):
+def _run_doctor_command(argv):
     from skylos.commands.doctor_cmd import run_doctor_command
 
-    return run_doctor_command()
+    return run_doctor_command(argv)
 
 
 def _run_whoami_command(_argv):

--- a/skylos/commands/doctor_cmd.py
+++ b/skylos/commands/doctor_cmd.py
@@ -1,3 +1,5 @@
+import argparse
+import json
 import platform
 from pathlib import Path
 
@@ -35,122 +37,204 @@ def _interactive_available() -> bool:
         return False
 
 
-def run_doctor_command() -> int:
-    console = Console()
+def _go_engine_status() -> dict[str, str]:
+    from skylos.engines.go_runner import get_go_engine_status
 
-    console.print()
-    console.print(Panel.fit("[bold]Skylos Doctor[/bold]", border_style="cyan"))
-    console.print()
+    return get_go_engine_status()
 
-    py_ver = platform.python_version()
-    py_ok = tuple(int(x) for x in py_ver.split(".")[:2]) >= (3, 10)
+
+def _doctor_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="skylos doctor", add_help=False)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def _doctor_json_report(py_ver: str, py_ok: bool, go_status: dict) -> dict:
+    rust_available = _rust_available()
+    llm_available = _llm_available()
+    interactive_available = _interactive_available()
+    degraded = go_status.get("status") != "available"
+    return {
+        "schema_version": 1,
+        "tool": "doctor",
+        "status": "fail" if not py_ok else ("degraded" if degraded else "ok"),
+        "checks": {
+            "python": {
+                "status": "ok" if py_ok else "fail",
+                "version": py_ver,
+                "minimum_version": "3.10",
+            },
+            "skylos": {"status": "ok", "version": str(skylos.__version__)},
+            "go_engine": dict(go_status),
+            "rust_acceleration": {
+                "status": "available" if rust_available else "unavailable"
+            },
+            "llm_support": {"status": "available" if llm_available else "unavailable"},
+            "interactive": {
+                "status": "available" if interactive_available else "unavailable"
+            },
+        },
+    }
+
+
+def _print_availability(
+    console: Console,
+    available: bool,
+    available_message: str,
+    unavailable_message: str,
+) -> None:
+    console.print(available_message if available else unavailable_message)
+
+
+def _print_runtime_status(
+    console: Console,
+    py_ver: str,
+    py_ok: bool,
+    go_status: dict[str, str],
+) -> None:
     console.print(
         f"  {'[green]OK[/green]' if py_ok else '[red]FAIL[/red]'}  Python {py_ver}"
         + ("" if py_ok else " [red](requires 3.10+)[/red]")
     )
-
     console.print(f"  [green]OK[/green]  Skylos {skylos.__version__}")
+    _print_availability(
+        console,
+        go_status.get("status") == "available",
+        "  [green]OK[/green]  Go engine available",
+        "  [yellow]--[/yellow]  Go engine unavailable "
+        "[dim](Go dead-code and security checks will be incomplete)[/dim]",
+    )
 
-    if _rust_available():
-        console.print(
-            "  [green]OK[/green]  skylos\\[fast] installed (Rust acceleration)"
-        )
-    else:
-        console.print(
-            "  [yellow]--[/yellow]  skylos\\[fast] not installed [dim](optional: pip install skylos\\[fast])[/dim]"
-        )
 
-    if _llm_available():
-        console.print("  [green]OK[/green]  LLM support available")
-    else:
-        console.print(
-            "  [yellow]--[/yellow]  LLM support not available [dim](optional: pip install litellm)[/dim]"
-        )
+def _print_optional_status(console: Console) -> None:
+    _print_availability(
+        console,
+        _rust_available(),
+        "  [green]OK[/green]  skylos\\[fast] installed (Rust acceleration)",
+        "  [yellow]--[/yellow]  skylos\\[fast] not installed "
+        "[dim](optional: pip install skylos\\[fast])[/dim]",
+    )
+    _print_availability(
+        console,
+        _llm_available(),
+        "  [green]OK[/green]  LLM support available",
+        "  [yellow]--[/yellow]  LLM support not available "
+        "[dim](optional: pip install litellm)[/dim]",
+    )
+    _print_availability(
+        console,
+        _interactive_available(),
+        "  [green]OK[/green]  Interactive mode available",
+        "  [yellow]--[/yellow]  Interactive mode not available "
+        "[dim](optional: pip install inquirer)[/dim]",
+    )
 
-    if _interactive_available():
-        console.print("  [green]OK[/green]  Interactive mode available")
-    else:
-        console.print(
-            "  [yellow]--[/yellow]  Interactive mode not available [dim](optional: pip install inquirer)[/dim]"
-        )
 
+def _print_credit_status(console: Console, token: str) -> None:
+    try:
+        from skylos.api import get_credit_balance
+
+        balance_data = get_credit_balance(token)
+    except Exception:
+        console.print("  [yellow]--[/yellow]  Cloud credit balance unavailable")
+        return
+    if not balance_data:
+        return
+    plan = balance_data.get("plan", "free")
+    balance = balance_data.get("balance", 0)
+    if plan == "enterprise":
+        console.print(f"  [green]OK[/green]  Plan: {plan} (unlimited credits)")
+        return
+    color = "green" if balance > 0 else "red"
+    console.print(f"  [{color}]OK[/{color}]  Plan: {plan} | Credits: {balance:,}")
+
+
+def _print_cloud_status(console: Console) -> None:
     from skylos.api import get_project_token
 
     token = get_project_token()
-    if token:
-        console.print("  [green]OK[/green]  Cloud connected (SKYLOS_TOKEN set)")
-        try:
-            from skylos.api import get_credit_balance
-
-            balance_data = get_credit_balance(token)
-            if balance_data:
-                plan = balance_data.get("plan", "free")
-                balance = balance_data.get("balance", 0)
-                if plan == "enterprise":
-                    console.print(
-                        f"  [green]OK[/green]  Plan: {plan} (unlimited credits)"
-                    )
-                else:
-                    color = "green" if balance > 0 else "red"
-                    console.print(
-                        f"  [{color}]OK[/{color}]  Plan: {plan} | Credits: {balance:,}"
-                    )
-        except Exception:
-            pass
-    else:
+    if not token:
         console.print(
             "  [yellow]--[/yellow]  Cloud not connected [dim](optional: skylos login)[/dim]"
         )
+        return
+    console.print("  [green]OK[/green]  Cloud connected (SKYLOS_TOKEN set)")
+    _print_credit_status(console, token)
 
-    cwd = Path.cwd()
+
+def _print_project_config(console: Console, cwd: Path) -> None:
     pyproject = cwd / "pyproject.toml"
-    if pyproject.exists():
-        try:
-            config = load_config(cwd)
-            has_skylos_config = bool(
-                config.get("whitelist")
-                or config.get("exclude")
-                or config.get("gate")
-                or config.get("masking")
-            )
-            if has_skylos_config:
-                console.print(
-                    "  [green]OK[/green]  pyproject.toml [tool.skylos] config found"
-                )
-            else:
-                console.print(
-                    "  [yellow]--[/yellow]  pyproject.toml exists but no [tool.skylos] section"
-                )
-        except Exception:
-            console.print(
-                "  [yellow]--[/yellow]  pyproject.toml exists but could not parse config"
-            )
-    else:
+    if not pyproject.exists():
         console.print("  [yellow]--[/yellow]  No pyproject.toml in current directory")
+        return
+    try:
+        config = load_config(cwd)
+    except Exception:
+        console.print(
+            "  [yellow]--[/yellow]  pyproject.toml exists but could not parse config"
+        )
+        return
+    has_skylos_config = bool(
+        config.get("whitelist")
+        or config.get("exclude")
+        or config.get("gate")
+        or config.get("masking")
+    )
+    _print_availability(
+        console,
+        has_skylos_config,
+        "  [green]OK[/green]  pyproject.toml [tool.skylos] config found",
+        "  [yellow]--[/yellow]  pyproject.toml exists but no [tool.skylos] section",
+    )
 
+
+def _print_workflow_status(console: Console, cwd: Path) -> None:
     workflow = cwd / ".github" / "workflows" / "skylos.yml"
-    if workflow.exists():
-        console.print("  [green]OK[/green]  GitHub Actions workflow found")
-    else:
-        console.print(
-            "  [yellow]--[/yellow]  No CI/CD workflow [dim](run: skylos cicd init)[/dim]"
-        )
+    _print_availability(
+        console,
+        workflow.exists(),
+        "  [green]OK[/green]  GitHub Actions workflow found",
+        "  [yellow]--[/yellow]  No CI/CD workflow [dim](run: skylos cicd init)[/dim]",
+    )
 
+
+def _print_rule_status(console: Console) -> None:
     rules_dir = Path.home() / ".skylos" / "rules"
-    if rules_dir.exists():
-        rule_files = list(rules_dir.glob("*.yml"))
-        if rule_files:
-            console.print(
-                f"  [green]OK[/green]  {len(rule_files)} community rule pack(s) installed"
-            )
-        else:
-            console.print(
-                "  [yellow]--[/yellow]  No community rules [dim](optional: skylos rules install <pack>)[/dim]"
-            )
-    else:
+    rule_files = list(rules_dir.glob("*.yml")) if rules_dir.exists() else []
+    if rule_files:
         console.print(
-            "  [yellow]--[/yellow]  No community rules [dim](optional: skylos rules install <pack>)[/dim]"
+            f"  [green]OK[/green]  {len(rule_files)} community rule pack(s) installed"
         )
+        return
+    console.print(
+        "  [yellow]--[/yellow]  No community rules "
+        "[dim](optional: skylos rules install <pack>)[/dim]"
+    )
 
+
+def _print_local_status(console: Console) -> None:
+    cwd = Path.cwd()
+    _print_project_config(console, cwd)
+    _print_workflow_status(console, cwd)
+    _print_rule_status(console)
+
+
+def run_doctor_command(argv: list[str] | None = None) -> int:
+    args = _doctor_parser().parse_args(argv or [])
+    py_ver = platform.python_version()
+    py_ok = tuple(int(x) for x in py_ver.split(".")[:2]) >= (3, 10)
+    go_status = _go_engine_status()
+    if args.format == "json":
+        print(json.dumps(_doctor_json_report(py_ver, py_ok, go_status), indent=2))
+        return 0
+
+    console = Console()
+    console.print()
+    console.print(Panel.fit("[bold]Skylos Doctor[/bold]", border_style="cyan"))
+    console.print()
+    _print_runtime_status(console, py_ver, py_ok, go_status)
+    _print_optional_status(console)
+    _print_cloud_status(console)
+    _print_local_status(console)
     console.print()
     return 0

--- a/skylos/commands/verify_cmd.py
+++ b/skylos/commands/verify_cmd.py
@@ -233,6 +233,8 @@ def _exit_code(payload: dict[str, Any], *, no_fail: bool) -> int:
         return 0
     if payload.get("status") == "fail":
         return 1
+    if payload.get("status") == "incomplete":
+        return 2
     return 0
 
 

--- a/skylos/core/js_api_surface.py
+++ b/skylos/core/js_api_surface.py
@@ -10,16 +10,16 @@ from skylos.core.api_symbol_truth import (
     cache_api_symbol_surface,
 )
 from skylos.core.js_api_surface_exports import collect_js_exports_from_file
+from skylos.core.js_api_surface_members import _add_export_member
 from skylos.core.js_api_surface_utils import (
     EXCLUDED_JS_API_DIRS,
-    JS_SOURCE_SUFFIXES,
     MAX_JS_API_ENTRYPOINTS_PER_PACKAGE,
     MAX_JS_API_PACKAGE_JSON_BYTES,
     MAX_JS_API_PACKAGES,
-    has_js_source_suffix as _has_js_source_suffix,
     path_has_excluded_part as _path_has_excluded_part,
     relative_posix as _relative_posix,
     resolve_entrypoint_target as _resolve_entrypoint_target,
+    _safe_source_file,
     safe_name as _safe_name,
     utc_timestamp as _utc_timestamp,
 )
@@ -47,13 +47,16 @@ def build_js_api_surfaces(project_root: str | Path) -> list[dict[str, Any]]:
         ):
             members: dict[str, dict[str, Any]] = {}
             visited: set[Path] = set()
+            diagnostics: set[str] = set()
             collect_js_exports_from_file(
                 root,
                 entrypoint,
                 members,
                 visited,
                 depth=0,
+                diagnostics=diagnostics,
             )
+            _add_commonjs_default_facade(root, entrypoint, members)
             if not members:
                 continue
 
@@ -68,6 +71,8 @@ def build_js_api_surfaces(project_root: str | Path) -> list[dict[str, Any]]:
                 "metadata": {
                     "package_dir": _relative_posix(root, package_dir),
                     "entrypoint": _relative_posix(root, entrypoint),
+                    "complete": not diagnostics,
+                    "incomplete_reasons": sorted(diagnostics),
                 },
             }
             version = package_data.get("version")
@@ -76,6 +81,279 @@ def build_js_api_surfaces(project_root: str | Path) -> list[dict[str, Any]]:
             surfaces.append(surface)
 
     return surfaces
+
+
+def inspect_js_file_api_surface(
+    project_root: str | Path,
+    file_path: str | Path,
+    *,
+    name: str | None = None,
+) -> dict[str, Any] | None:
+    root = _safe_project_root(project_root)
+    if root is None:
+        return None
+
+    candidate = Path(file_path)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    entrypoint = _safe_source_file(root, candidate)
+    if entrypoint is None:
+        return None
+
+    members: dict[str, dict[str, Any]] = {}
+    diagnostics: set[str] = set()
+    collect_js_exports_from_file(
+        root,
+        entrypoint,
+        members,
+        set(),
+        depth=0,
+        diagnostics=diagnostics,
+    )
+    _add_commonjs_default_facade(root, entrypoint, members)
+    surface_name = _safe_name(name) or _relative_posix(root, entrypoint)
+    return {
+        "kind": SURFACE_KIND_JS_MODULE,
+        "name": surface_name,
+        "source": "js_api_surface",
+        "origin": _relative_posix(root, entrypoint),
+        "captured_at": _utc_timestamp(),
+        "exports": sorted(members),
+        "members": members,
+        "metadata": {
+            "entrypoint": _relative_posix(root, entrypoint),
+            "complete": not diagnostics,
+            "incomplete_reasons": sorted(diagnostics),
+        },
+    }
+
+
+def inspect_js_package_api_surface(
+    project_root: str | Path,
+    module_source: str,
+    *,
+    resolution_mode: str,
+) -> tuple[dict[str, Any] | None, str | None, bool]:
+    root = _safe_project_root(project_root)
+    safe_source = _safe_name(module_source)
+    if root is None or safe_source is None:
+        return None, "invalid_package_reference", False
+    if resolution_mode not in {"import", "require", "types"}:
+        return None, "unsupported_package_resolution_mode", False
+
+    for package_json in _discover_package_json_files(root):
+        package_data = _read_package_json(package_json)
+        package_name = _safe_name(package_data.get("name"))
+        if package_name is None:
+            continue
+        subpath = _package_source_subpath(package_name, safe_source)
+        if subpath is None:
+            continue
+
+        targets, target_reason = _package_targets_for_mode(
+            package_data,
+            subpath=subpath,
+            resolution_mode=resolution_mode,
+        )
+        if target_reason is not None:
+            return None, target_reason, True
+
+        package_dir = package_json.parent
+        for target in targets:
+            entrypoint = _resolve_entrypoint_target(root, package_dir, target)
+            if entrypoint is None:
+                continue
+            surface = inspect_js_file_api_surface(root, entrypoint, name=safe_source)
+            if surface is None:
+                continue
+            surface["origin"] = _relative_posix(root, package_json)
+            metadata = surface.get("metadata")
+            if isinstance(metadata, dict):
+                metadata.update(
+                    {
+                        "package_dir": _relative_posix(root, package_dir),
+                        "resolution_mode": resolution_mode,
+                    }
+                )
+            version = package_data.get("version")
+            if isinstance(version, str) and version.strip():
+                surface["version"] = version.strip()
+            return surface, None, True
+
+        return None, "unresolved_package_condition", True
+
+    return None, None, False
+
+
+def _add_commonjs_default_facade(
+    root: Path,
+    entrypoint: Path,
+    members: dict[str, dict[str, Any]],
+) -> None:
+    suffix = entrypoint.suffix.lower()
+    commonjs_by_extension = suffix in {".cjs", ".cts"}
+    commonjs_by_package = suffix == ".js" and _nearest_package_type(
+        root, entrypoint
+    ) == "commonjs"
+    if not commonjs_by_extension and not commonjs_by_package:
+        return
+    _add_export_member(
+        root,
+        members,
+        "default",
+        "commonjs",
+        entrypoint,
+        1,
+        source="commonjs_default_facade",
+    )
+
+
+def _nearest_package_type(root: Path, entrypoint: Path) -> str | None:
+    current = entrypoint.parent
+    while True:
+        package_json = current / "package.json"
+        if package_json.is_file() and not package_json.is_symlink():
+            package_type = _read_package_json(package_json).get("type")
+            return package_type if isinstance(package_type, str) else None
+        if current == root or current.parent == current:
+            return None
+        try:
+            current.relative_to(root)
+        except ValueError:
+            return None
+        current = current.parent
+
+
+def _package_source_subpath(package_name: str, module_source: str) -> str | None:
+    if module_source == package_name:
+        return ""
+    prefix = f"{package_name}/"
+    if module_source.startswith(prefix):
+        return module_source[len(prefix) :]
+    return None
+
+
+def _package_targets_for_mode(
+    package_data: dict[str, Any],
+    *,
+    subpath: str,
+    resolution_mode: str,
+) -> tuple[list[str], str | None]:
+    exports = package_data.get("exports")
+    if exports is not None:
+        export_value, export_reason = _package_export_value(exports, subpath)
+        if export_reason is not None:
+            return [], export_reason
+        targets, uncertain = _condition_targets(export_value, resolution_mode)
+        if uncertain:
+            return [], f"unsupported_{resolution_mode}_package_condition"
+        if not targets:
+            return [], f"unsupported_{resolution_mode}_package_condition"
+        return targets, None
+
+    if subpath:
+        return [f"src/{subpath}", subpath], None
+
+    field_priorities = {
+        "types": ("types", "typings", "source", "module", "main"),
+        "import": ("source", "module", "main"),
+        "require": ("main",),
+    }
+    for field in field_priorities[resolution_mode]:
+        target = package_data.get(field)
+        if isinstance(target, str) and target.strip():
+            return [target], None
+
+    return [
+        "src/index.ts",
+        "src/index.tsx",
+        "src/index.js",
+        "src/index.jsx",
+        "src/index.mts",
+        "src/index.cts",
+        "src/index.mjs",
+        "src/index.cjs",
+        "index.ts",
+        "index.tsx",
+        "index.js",
+        "index.jsx",
+        "index.mts",
+        "index.cts",
+        "index.mjs",
+        "index.cjs",
+    ], None
+
+
+def _package_export_value(exports: Any, subpath: str) -> tuple[Any, str | None]:
+    if isinstance(exports, (str, list)):
+        if subpath:
+            return None, "unresolved_package_subpath"
+        return exports, None
+    if not isinstance(exports, dict):
+        return None, "unsupported_package_exports"
+
+    if _has_subpath_export_keys(exports):
+        export_key = "." if not subpath else f"./{subpath}"
+        if export_key in exports:
+            return exports[export_key], None
+        if any(isinstance(key, str) and "*" in key for key in exports):
+            return None, "unsupported_wildcard_package_export"
+        return None, "unresolved_package_subpath"
+
+    if subpath:
+        return None, "unresolved_package_subpath"
+    return exports, None
+
+
+def _condition_targets(value: Any, resolution_mode: str) -> tuple[list[str], bool]:
+    if isinstance(value, str):
+        return ([value] if value.strip() else []), False
+    if isinstance(value, list):
+        targets: list[str] = []
+        for item in value:
+            item_targets, uncertain = _condition_targets(item, resolution_mode)
+            if uncertain:
+                return [], True
+            targets.extend(item_targets)
+        return _deduplicated_strings(targets), False
+    if not isinstance(value, dict):
+        return [], False
+
+    active_conditions = {
+        "types": {"types", "node-addons", "node", "import", "default"},
+        "import": {"node-addons", "node", "import", "default"},
+        "require": {"node-addons", "node", "require", "default"},
+    }
+    standard_conditions = {
+        "types",
+        "node-addons",
+        "node",
+        "import",
+        "require",
+        "default",
+    }
+    for condition, target_value in value.items():
+        if condition not in standard_conditions:
+            return [], True
+        if condition not in active_conditions[resolution_mode]:
+            continue
+        targets, uncertain = _condition_targets(target_value, resolution_mode)
+        if uncertain:
+            return [], True
+        if targets:
+            return targets, False
+    return [], False
+
+
+def _deduplicated_strings(values: list[str]) -> list[str]:
+    results: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        results.append(value)
+    return results
 def cache_js_api_surfaces(project_root: str | Path) -> list[dict[str, Any]]:
     surfaces = build_js_api_surfaces(project_root)
     for surface in surfaces:

--- a/skylos/core/js_api_surface_exports.py
+++ b/skylos/core/js_api_surface_exports.py
@@ -40,8 +40,10 @@ def collect_js_exports_from_file(
     visited: set[Path],
     *,
     depth: int,
+    diagnostics: set[str] | None = None,
 ) -> None:
     if depth > MAX_JS_API_REEXPORT_DEPTH:
+        _add_diagnostic(diagnostics, "reexport_depth_limit")
         return
     if file_path in visited:
         return
@@ -54,17 +56,22 @@ def collect_js_exports_from_file(
         errors="ignore",
     )
     if source_text is None:
+        _add_diagnostic(diagnostics, "source_unreadable")
         return
     source = source_text.encode("utf-8", "ignore")
     if is_minified_js_source(str(file_path), source):
+        _add_diagnostic(diagnostics, "minified_source")
         return
 
     core = TypeScriptCore(str(file_path), source)
     core.scan()
-    local_bindings = _module_scope_exportable_bindings(source, core.root_node)
-
-    if core.root_node is None:
+    if core.root_node is None or _has_blocking_parse_error(core):
+        _add_diagnostic(diagnostics, "parse_error")
         return
+    local_bindings = _module_scope_exportable_bindings(source, core.root_node)
+    if _has_conditional_commonjs_export(core, source):
+        _add_diagnostic(diagnostics, "conditional_commonjs_export")
+
     commonjs_exports_alias_valid = True
     ambiguous_star_exports: set[str] = set()
     for node in core.root_node.named_children:
@@ -79,9 +86,12 @@ def collect_js_exports_from_file(
                 depth,
                 local_bindings,
                 ambiguous_star_exports,
+                diagnostics,
             )
         assignment = _top_level_assignment_expression(node)
         if assignment is not None:
+            if not _commonjs_assignment_is_static(source, assignment):
+                _add_diagnostic(diagnostics, "dynamic_commonjs_export")
             commonjs_exports_alias_valid = _collect_commonjs_assignment(
                 root,
                 file_path,
@@ -90,6 +100,8 @@ def collect_js_exports_from_file(
                 members,
                 exports_alias_valid=commonjs_exports_alias_valid,
             )
+        elif _expression_may_mutate_commonjs_exports(source, node):
+            _add_diagnostic(diagnostics, "dynamic_commonjs_export")
 def _collect_export_statement(
     root: Path,
     file_path: Path,
@@ -100,6 +112,7 @@ def _collect_export_statement(
     depth: int,
     local_bindings: dict[str, str],
     ambiguous_star_exports: set[str],
+    diagnostics: set[str] | None,
 ) -> None:
     text = _node_text(source, node).strip()
     source_literal = _export_source_literal(source, node)
@@ -110,9 +123,19 @@ def _collect_export_statement(
 
     resolved = _resolved_reexport_source(root, file_path, source_literal)
     if source_literal is not None and resolved is None:
+        if source_literal.startswith("."):
+            _add_diagnostic(diagnostics, "unresolved_local_reexport")
+        else:
+            _add_diagnostic(diagnostics, "external_reexport")
         return
 
-    reexport_members = _reexport_members(root, resolved, visited, depth)
+    reexport_members = _reexport_members(
+        root,
+        resolved,
+        visited,
+        depth,
+        diagnostics,
+    )
     if _collect_namespace_reexport(
         root,
         file_path,
@@ -230,10 +253,17 @@ def _reexport_members(
     resolved: Path | None,
     visited: set[Path],
     depth: int,
+    diagnostics: set[str] | None,
 ) -> dict[str, dict[str, Any]]:
     if resolved is None:
         return {}
-    return _collect_resolved_reexport_members(root, resolved, visited, depth)
+    return _collect_resolved_reexport_members(
+        root,
+        resolved,
+        visited,
+        depth,
+        diagnostics,
+    )
 
 
 def _collect_namespace_reexport(
@@ -368,6 +398,7 @@ def _collect_resolved_reexport_members(
     resolved: Path,
     visited: set[Path],
     depth: int,
+    diagnostics: set[str] | None,
 ) -> dict[str, dict[str, Any]]:
     members: dict[str, dict[str, Any]] = {}
     collect_js_exports_from_file(
@@ -376,8 +407,60 @@ def _collect_resolved_reexport_members(
         members,
         set(visited),
         depth=depth + 1,
+        diagnostics=diagnostics,
     )
     return members
+
+
+def _commonjs_assignment_is_static(source: bytes, node: Any) -> bool:
+    left = node.child_by_field_name("left")
+    right = node.child_by_field_name("right")
+    if left is None:
+        return True
+
+    chain = _member_chain(source, left)
+    if len(chain) >= 3 and chain[:2] == ["module", "exports"]:
+        return True
+    if len(chain) == 2 and chain[0] == "exports":
+        return True
+    if chain == ["module", "exports"]:
+        return right is not None and right.type == "object"
+    if "exports" not in _node_text(source, left):
+        return True
+    return False
+
+
+def _expression_may_mutate_commonjs_exports(source: bytes, node: Any) -> bool:
+    if node.type != "expression_statement":
+        return False
+    text = _node_text(source, node)
+    if "exports" not in text:
+        return False
+    return "Object.assign" in text or "Object.defineProperty" in text
+
+
+def _has_blocking_parse_error(core: TypeScriptCore) -> bool:
+    if core.root_node is None or not core.root_node.has_error:
+        return False
+    for node in core._iter_nodes(core.root_node):
+        if not node.is_error and not node.is_missing:
+            continue
+        parent = node.parent
+        if (
+            node.type == "ERROR"
+            and core._get_text(node) == "type"
+            and parent is not None
+            and parent.type == "export_statement"
+            and core._get_text(parent).lstrip().startswith("export type *")
+        ):
+            continue
+        return True
+    return False
+
+
+def _add_diagnostic(diagnostics: set[str] | None, reason: str) -> None:
+    if diagnostics is not None:
+        diagnostics.add(reason)
 def _collect_commonjs_assignment(
     root: Path,
     file_path: Path,
@@ -394,6 +477,15 @@ def _collect_commonjs_assignment(
 
     chain = _member_chain(source, left)
     if len(chain) >= 2 and chain[:2] == ["module", "exports"]:
+        _add_export_member(
+            root,
+            members,
+            "default",
+            "commonjs",
+            file_path,
+            _node_line(node),
+            source="commonjs_default_facade",
+        )
         if len(chain) == 2:
             _remove_commonjs_members(members)
             for name, kind in _object_export_members(source, right):
@@ -422,6 +514,15 @@ def _collect_commonjs_assignment(
         _add_export_member(
             root,
             members,
+            "default",
+            "commonjs",
+            file_path,
+            _node_line(node),
+            source="commonjs_default_facade",
+        )
+        _add_export_member(
+            root,
+            members,
             chain[1],
             _value_kind(right),
             file_path,
@@ -441,6 +542,57 @@ def _top_level_assignment_expression(node: Any) -> Any | None:
         if child.type == "assignment_expression":
             return child
     return None
+
+
+def _has_conditional_commonjs_export(core: TypeScriptCore, source: bytes) -> bool:
+    if core.root_node is None:
+        return False
+    for node in core._iter_nodes(core.root_node):
+        if node.type == "assignment_expression":
+            left = node.child_by_field_name("left")
+            if (
+                left is not None
+                and _targets_commonjs_exports(source, left)
+                and not _is_top_level_expression(node)
+            ):
+                return True
+        if (
+            node.type == "call_expression"
+            and _call_mutates_commonjs_exports(source, node)
+            and not _is_top_level_expression(node)
+        ):
+            return True
+    return False
+
+
+def _targets_commonjs_exports(source: bytes, node: Any) -> bool:
+    chain = _member_chain(source, node)
+    if len(chain) >= 2 and chain[:2] == ["module", "exports"]:
+        return True
+    return bool(chain) and chain[0] == "exports"
+
+
+def _call_mutates_commonjs_exports(source: bytes, node: Any) -> bool:
+    function = node.child_by_field_name("function")
+    if function is None or _node_text(source, function) not in {
+        "Object.assign",
+        "Object.defineProperty",
+    }:
+        return False
+    arguments = node.child_by_field_name("arguments")
+    if arguments is None or not arguments.named_children:
+        return False
+    return _targets_commonjs_exports(source, arguments.named_children[0])
+
+
+def _is_top_level_expression(node: Any) -> bool:
+    parent = node.parent
+    if parent is None or parent.type != "expression_statement":
+        return False
+    grandparent = parent.parent
+    return grandparent is not None and grandparent.type == "program"
+
+
 def _resolve_relative_source(root: Path, base_dir: Path, source: str) -> Path | None:
     if not source.startswith("."):
         return None

--- a/skylos/core/verification_coverage.py
+++ b/skylos/core/verification_coverage.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+
+
+def build_ai_verification_coverage(
+    checks: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+) -> dict[str, Any]:
+    normalized = [dict(check) for check in checks if isinstance(check, dict)]
+    completed = [
+        str(check.get("id"))
+        for check in normalized
+        if check.get("status") == "completed" and check.get("id")
+    ]
+    skipped = [
+        {
+            "id": str(check.get("id")),
+            "reasons": _reason_codes(check),
+        }
+        for check in normalized
+        if check.get("status") == "skipped" and check.get("id")
+    ]
+    state = "complete"
+    if any(check.get("outcome") == "incomplete" for check in normalized):
+        state = "incomplete"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "state": state,
+        "completed_checks": completed,
+        "skipped_checks": skipped,
+        "checks": normalized,
+    }
+
+
+def reconcile_check_findings(
+    check: dict[str, Any],
+    finding_count: int,
+) -> dict[str, Any]:
+    reconciled = dict(check)
+    reconciled["finding_count"] = max(0, int(finding_count))
+    if reconciled["finding_count"]:
+        reconciled["outcome"] = "fail"
+    elif int(reconciled.get("skipped_references") or 0):
+        reconciled["outcome"] = "incomplete"
+    else:
+        reconciled["outcome"] = "pass"
+    return reconciled
+
+
+def _reason_codes(check: dict[str, Any]) -> list[str]:
+    reasons = check.get("reasons")
+    if not isinstance(reasons, list):
+        return []
+    codes = []
+    for reason in reasons:
+        if not isinstance(reason, dict):
+            continue
+        code = reason.get("code")
+        if isinstance(code, str) and code:
+            codes.append(code)
+    return codes

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -8,7 +8,7 @@ from skylos.contracts import contract_finding_metadata
 from skylos.core.evidence_contract import finding_evidence_contract
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 AI_VIBE_CATEGORIES = {
     "hallucinated_reference",
@@ -146,18 +146,24 @@ def build_verify_change_response(
         )
     )
 
-    return {
+    coverage = _verification_coverage(analysis_result)
+    status = _status_for_findings(findings, coverage)
+
+    response = {
         "schema_version": SCHEMA_VERSION,
         "tool": "verify_change",
-        "status": _status_for_findings(findings),
+        "status": status,
         "target": {
             "path": _target_path_for_payload(scan_target, target_file, project_root),
             "file": _target_file_for_payload(target_file, root),
             "range": _range_for_payload(parsed_range),
         },
         "findings": findings,
-        "summary": _summary(findings),
+        "summary": _summary(findings, status, coverage),
     }
+    if coverage is not None:
+        response["coverage"] = coverage
+    return response
 
 
 def _iter_ai_findings(
@@ -347,9 +353,18 @@ def _range_for_payload(line_range: tuple[int, int] | None) -> dict[str, int] | N
     return {"start_line": start, "end_line": end}
 
 
-def _summary(findings: list[dict[str, Any]]) -> str:
+def _summary(
+    findings: list[dict[str, Any]],
+    status: str,
+    coverage: dict[str, Any] | None,
+) -> str:
     count = len(findings)
     if count == 0:
+        if status == "incomplete":
+            skipped = _skipped_reference_count(coverage)
+            if skipped == 1:
+                return "Verification incomplete: 1 reference could not be proven"
+            return f"Verification incomplete: {skipped} references could not be proven"
         return "No AI-code issues found"
     if count == 1:
         issue_word = "issue"
@@ -434,10 +449,40 @@ def _validate_line_range(start: int, end: int) -> None:
         raise ValueError("line range end must be greater than or equal to start")
 
 
-def _status_for_findings(findings: list[dict[str, Any]]) -> str:
+def _status_for_findings(
+    findings: list[dict[str, Any]],
+    coverage: dict[str, Any] | None,
+) -> str:
     if findings:
         return "fail"
+    if isinstance(coverage, dict) and coverage.get("state") == "incomplete":
+        return "incomplete"
     return "pass"
+
+
+def _verification_coverage(
+    analysis_result: dict[str, Any],
+) -> dict[str, Any] | None:
+    summary = analysis_result.get("analysis_summary")
+    if not isinstance(summary, dict):
+        return None
+    coverage = summary.get("ai_verification")
+    if not isinstance(coverage, dict):
+        return None
+    return dict(coverage)
+
+
+def _skipped_reference_count(coverage: dict[str, Any] | None) -> int:
+    if not isinstance(coverage, dict):
+        return 0
+    checks = coverage.get("checks")
+    if not isinstance(checks, list):
+        return 0
+    total = 0
+    for check in checks:
+        if isinstance(check, dict):
+            total += max(0, _optional_int(check.get("skipped_references")) or 0)
+    return total
 
 
 def _target_path_for_payload(

--- a/skylos/engines/go_runner.py
+++ b/skylos/engines/go_runner.py
@@ -16,6 +16,32 @@ class GoEngineError(RuntimeError):
     pass
 
 
+def get_go_engine_status() -> dict[str, str]:
+    try:
+        engine_bin = resolve_go_engine_bin()
+    except GoEngineError as exc:
+        reason = str(exc).splitlines()[0] if str(exc) else "Go engine unavailable"
+        return {
+            "status": "unavailable",
+            "reason": reason,
+            "configured_by": "SKYLOS_GO_BIN" if os.getenv("SKYLOS_GO_BIN") else "discovery",
+        }
+
+    path = Path(engine_bin)
+    bundled_dir = Path(__file__).resolve().parent / "go"
+    if os.getenv("SKYLOS_GO_BIN"):
+        configured_by = "SKYLOS_GO_BIN"
+    elif path.parent == bundled_dir:
+        configured_by = "bundled"
+    else:
+        configured_by = "PATH"
+    return {
+        "status": "available",
+        "binary": str(path),
+        "configured_by": configured_by,
+    }
+
+
 def _is_runnable_go_engine(candidate: Path) -> bool:
     try:
         proc = subprocess.run(

--- a/skylos/reporting/result_builder.py
+++ b/skylos/reporting/result_builder.py
@@ -177,6 +177,29 @@ def _attach_analysis_reports(analyzer, result):
     if grep_verify_report is not None:
         result["analysis_summary"]["grep_verify"] = dict(grep_verify_report)
 
+    verification_checks = getattr(analyzer, "_ai_verification_checks", None)
+    if isinstance(verification_checks, list):
+        from skylos.core.verification_coverage import build_ai_verification_coverage
+
+        result["analysis_summary"]["ai_verification"] = (
+            build_ai_verification_coverage(verification_checks)
+        )
+
+    language_engines = getattr(analyzer, "_language_engine_reports", None)
+    if isinstance(language_engines, dict) and language_engines:
+        result["analysis_summary"]["language_engines"] = {
+            str(language): dict(report)
+            for language, report in language_engines.items()
+            if isinstance(report, dict)
+        }
+        incomplete_languages = sorted(
+            str(language)
+            for language, report in language_engines.items()
+            if isinstance(report, dict) and report.get("status") == "partial"
+        )
+        if incomplete_languages:
+            result["analysis_summary"]["incomplete_languages"] = incomplete_languages
+
 
 def _attach_workspace(analyzer, result, workspace_inventory, path):
     if workspace_inventory is None:

--- a/skylos/rules/ai_defect/__init__.py
+++ b/skylos/rules/ai_defect/__init__.py
@@ -16,6 +16,9 @@ from skylos.rules.ai_defect.ci_permission_expansion import (
     detect_ci_permission_expansion,
 )
 from skylos.rules.ai_defect.api_surface_drift import detect_cli_surface_drift
+from skylos.rules.ai_defect.js_api_hallucination import (
+    scan_js_local_api_hallucinations,
+)
 
 __all__ = [
     "PhantomCallRule",
@@ -28,4 +31,5 @@ __all__ = [
     "detect_test_impact_gaps",
     "detect_ci_permission_expansion",
     "detect_cli_surface_drift",
+    "scan_js_local_api_hallucinations",
 ]

--- a/skylos/rules/ai_defect/js_api_hallucination.py
+++ b/skylos/rules/ai_defect/js_api_hallucination.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Any
+
+from skylos.core.js_api_surface import (
+    inspect_js_file_api_surface,
+    inspect_js_package_api_surface,
+)
+from skylos.rules.ai_defect.js_api_references import (
+    JsApiReference,
+    extract_js_api_references,
+)
+from skylos.visitors.languages.typescript.analysis import resolve_ts_module
+
+
+JS_API_CHECK_ID = "typescript_local_api_surface"
+JS_SOURCE_SUFFIXES = (
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
+)
+
+
+@dataclass
+class _ScanState:
+    surface_cache: dict[str, dict[str, Any] | None] = field(default_factory=dict)
+    package_surface_cache: dict[
+        tuple[str, str], tuple[dict[str, Any] | None, str | None, bool]
+    ] = field(default_factory=dict)
+    reasons: Counter[str] = field(default_factory=Counter)
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    references: int = 0
+    verified: int = 0
+    skipped: int = 0
+
+    def skip(self, reason: str) -> None:
+        self.reasons[reason] += 1
+        self.skipped += 1
+
+
+def scan_js_local_api_hallucinations(
+    project_root: str | Path,
+    files: list[str | Path] | tuple[str | Path, ...],
+    raw_imports_by_file: dict[Any, list[dict[str, Any]]],
+    *,
+    monorepo_resolver: Any | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    root = _safe_root(project_root)
+    if root is None:
+        return [], failed_js_api_check("invalid_project_root")
+    js_files = _safe_js_files(root, files)
+    if not js_files:
+        return [], _not_applicable_check()
+
+    state = _ScanState()
+    for importer in js_files:
+        _scan_importer(root, importer, state, monorepo_resolver)
+
+    findings = _deduplicate_findings(state.findings)
+    coverage = _coverage_check(
+        applicable_files=len(js_files),
+        raw_imports=_raw_import_count(raw_imports_by_file, js_files),
+        references=state.references,
+        verified=state.verified,
+        skipped=state.skipped,
+        findings=len(findings),
+        reasons=state.reasons,
+        languages=_languages(js_files),
+    )
+    return findings, coverage
+
+
+def _scan_importer(
+    root: Path,
+    importer: Path,
+    state: _ScanState,
+    monorepo_resolver: Any | None,
+) -> None:
+    extracted, extraction_reasons = extract_js_api_references(importer)
+    if extraction_reasons:
+        state.reasons.update(extraction_reasons)
+        extraction_skips = sum(extraction_reasons.values())
+        state.references += extraction_skips
+        state.skipped += extraction_skips
+    for reference in extracted:
+        state.references += 1
+        _evaluate_reference(root, importer, reference, state, monorepo_resolver)
+
+
+def _evaluate_reference(
+    root: Path,
+    importer: Path,
+    reference: JsApiReference,
+    state: _ScanState,
+    monorepo_resolver: Any | None,
+) -> None:
+    reference_reason = _reference_skip_reason(reference)
+    if reference_reason is not None:
+        state.skip(reference_reason)
+        return
+    surface, resolution_reason = _surface_for_reference(
+        root,
+        importer,
+        reference,
+        state.surface_cache,
+        state.package_surface_cache,
+        monorepo_resolver,
+    )
+    if surface is None:
+        state.skip(resolution_reason or "unresolved_module")
+        return
+    members = surface.get("members")
+    if not isinstance(members, dict):
+        state.skip("invalid_api_surface")
+        return
+    incomplete_reason = _surface_incomplete_reason(surface)
+    if incomplete_reason is not None:
+        state.skip(incomplete_reason)
+        return
+    if reference.symbol in members:
+        state.verified += 1
+        return
+    state.findings.append(
+        _missing_symbol_finding(importer, reference, surface, members)
+    )
+
+
+def _reference_skip_reason(reference: JsApiReference) -> str | None:
+    if reference.skip_reason is not None:
+        return reference.skip_reason
+    if reference.source is None or reference.symbol is None:
+        return "incomplete_reference_metadata"
+    return None
+
+
+def failed_js_api_check(reason: str) -> dict[str, Any]:
+    return _coverage_check(
+        applicable_files=0,
+        raw_imports=0,
+        references=0,
+        verified=0,
+        skipped=1,
+        findings=0,
+        reasons=Counter({reason: 1}),
+        languages=[],
+    )
+
+
+def skipped_js_api_check(reason: str) -> dict[str, Any]:
+    check = _not_applicable_check()
+    check["reasons"] = [{"code": reason, "count": 1}]
+    return check
+
+
+def _surface_for_reference(
+    root: Path,
+    importer: Path,
+    reference: JsApiReference,
+    surface_cache: dict[str, dict[str, Any] | None],
+    package_surface_cache: dict[
+        tuple[str, str], tuple[dict[str, Any] | None, str | None, bool]
+    ],
+    monorepo_resolver: Any | None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    source = str(reference.source)
+    if not source.startswith("."):
+        resolution_mode = _reference_resolution_mode(reference)
+        package_key = (source, resolution_mode)
+        if package_key not in package_surface_cache:
+            package_surface_cache[package_key] = inspect_js_package_api_surface(
+                root,
+                source,
+                resolution_mode=resolution_mode,
+            )
+        package_surface, package_reason, matched_package = package_surface_cache[
+            package_key
+        ]
+        if matched_package:
+            return package_surface, package_reason
+
+    resolved = resolve_ts_module(source, str(importer), monorepo_resolver)
+    if resolved is None:
+        reason = (
+            "unresolved_local_module"
+            if source.startswith(".")
+            else "external_or_unresolved_module"
+        )
+        return None, reason
+
+    cache_key = str(Path(resolved).resolve(strict=False))
+    if cache_key not in surface_cache:
+        surface_cache[cache_key] = inspect_js_file_api_surface(
+            root,
+            resolved,
+            name=source,
+        )
+    surface = surface_cache[cache_key]
+    if surface is None:
+        return None, "unsafe_or_unsupported_module"
+    return surface, None
+
+
+def _reference_resolution_mode(reference: JsApiReference) -> str:
+    if reference.type_only:
+        return "types"
+    if reference.kind.startswith("commonjs_"):
+        return "require"
+    return "import"
+
+
+def _surface_incomplete_reason(surface: dict[str, Any]) -> str | None:
+    metadata = surface.get("metadata")
+    if not isinstance(metadata, dict) or metadata.get("complete", True):
+        return None
+    reasons = metadata.get("incomplete_reasons")
+    if not isinstance(reasons, list) or not reasons:
+        return "incomplete_api_surface"
+    return f"surface_{str(reasons[0])}"
+
+
+def _missing_symbol_finding(
+    importer: Path,
+    reference: JsApiReference,
+    surface: dict[str, Any],
+    members: dict[str, Any],
+) -> dict[str, Any]:
+    symbol = str(reference.symbol)
+    source = str(reference.source)
+    suggestions = get_close_matches(symbol, sorted(members), n=3, cutoff=0.6)
+    suggestion_text = ""
+    if suggestions:
+        suggestion_text = f" Available close matches: {', '.join(suggestions)}."
+    language = (
+        "typescript"
+        if importer.suffix.lower() in {".ts", ".tsx", ".mts", ".cts"}
+        else "javascript"
+    )
+    surface_origin = str(surface.get("origin") or source)
+    return {
+        "rule_id": "SKY-L012",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": reference.kind,
+        "name": symbol,
+        "simple_name": symbol,
+        "value": "phantom",
+        "threshold": 0,
+        "message": (
+            f"'{symbol}' is referenced from local module '{source}', but that "
+            f"symbol is not exported by its static API surface.{suggestion_text}"
+        ),
+        "suggested_fix": (
+            "Import an exported symbol, add the missing export, or update the stale reference."
+        ),
+        "file": str(importer),
+        "basename": importer.name,
+        "line": reference.line,
+        "col": reference.col,
+        "category": "ai_defect",
+        "defect_type": "hallucinated_reference",
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+        "confidence": 96,
+        "metadata": {
+            "language": language,
+            "reference_kind": reference.kind,
+            "module_source": source,
+            "member_name": symbol,
+            "type_only": reference.type_only,
+            "api_surface_source": "js_api_surface",
+            "surface_origin": surface_origin,
+            "proof_state": "verified",
+        },
+    }
+
+
+def _coverage_check(
+    *,
+    applicable_files: int,
+    raw_imports: int,
+    references: int,
+    verified: int,
+    skipped: int,
+    findings: int,
+    reasons: Counter[str],
+    languages: list[str],
+) -> dict[str, Any]:
+    if findings:
+        outcome = "fail"
+    elif skipped:
+        outcome = "incomplete"
+    else:
+        outcome = "pass"
+    return {
+        "id": JS_API_CHECK_ID,
+        "status": "completed",
+        "outcome": outcome,
+        "scope": "local_workspace_static_exports",
+        "languages": languages,
+        "applicable_files": applicable_files,
+        "raw_imports": raw_imports,
+        "references": references,
+        "checked_references": verified + findings,
+        "verified_references": verified,
+        "skipped_references": skipped,
+        "finding_count": findings,
+        "reasons": [
+            {"code": code, "count": count} for code, count in sorted(reasons.items())
+        ],
+    }
+
+
+def _not_applicable_check() -> dict[str, Any]:
+    return {
+        "id": JS_API_CHECK_ID,
+        "status": "skipped",
+        "outcome": "pass",
+        "scope": "local_workspace_static_exports",
+        "languages": [],
+        "applicable_files": 0,
+        "raw_imports": 0,
+        "references": 0,
+        "checked_references": 0,
+        "verified_references": 0,
+        "skipped_references": 0,
+        "finding_count": 0,
+        "reasons": [{"code": "no_supported_files", "count": 1}],
+    }
+
+
+def _safe_root(project_root: str | Path) -> Path | None:
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+    return root if root.is_dir() else None
+
+
+def _safe_js_files(root: Path, files: Any) -> list[Path]:
+    selected: list[Path] = []
+    seen: set[Path] = set()
+    for value in files or ():
+        candidate = Path(value)
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        try:
+            if candidate.is_symlink():
+                continue
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(root)
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_file() or not str(resolved).lower().endswith(
+            JS_SOURCE_SUFFIXES
+        ):
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        selected.append(resolved)
+    return sorted(selected, key=str)
+
+
+def _raw_import_count(
+    raw_imports_by_file: dict[Any, list[dict[str, Any]]],
+    js_files: list[Path],
+) -> int:
+    allowed = {str(path.resolve(strict=False)) for path in js_files}
+    count = 0
+    for file_path, imports in (raw_imports_by_file or {}).items():
+        if str(Path(file_path).resolve(strict=False)) not in allowed:
+            continue
+        if isinstance(imports, list):
+            count += len(imports)
+    return count
+
+
+def _languages(files: list[Path]) -> list[str]:
+    languages = set()
+    for path in files:
+        if path.suffix.lower() in {".ts", ".tsx", ".mts", ".cts"}:
+            languages.add("typescript")
+        else:
+            languages.add("javascript")
+    return sorted(languages)
+
+
+def _deduplicate_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    for finding in findings:
+        metadata = finding.get("metadata")
+        reference_kind = (
+            metadata.get("reference_kind") if isinstance(metadata, dict) else None
+        )
+        key = (
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("col"),
+            finding.get("simple_name"),
+            reference_kind,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(finding)
+    return unique

--- a/skylos/rules/ai_defect/js_api_namespace_references.py
+++ b/skylos/rules/ai_defect/js_api_namespace_references.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any
+
+from skylos.rules.ai_defect.js_api_reference_model import (
+    JsApiReference,
+    NamespaceBinding,
+    make_reference,
+    node_line,
+)
+from skylos.visitors.languages.typescript.core import TypeScriptCore
+
+
+def collect_namespace_member_references(
+    core: TypeScriptCore,
+    namespaces: dict[str, NamespaceBinding],
+    references: list[JsApiReference],
+) -> None:
+    if not namespaces or core.root_node is None:
+        return
+    for node in core._iter_nodes(core.root_node):
+        if node.type in {"member_expression", "subscript_expression"}:
+            _collect_namespace_member(core, node, namespaces, references)
+
+
+def _collect_namespace_member(
+    core: TypeScriptCore,
+    node: Any,
+    namespaces: dict[str, NamespaceBinding],
+    references: list[JsApiReference],
+) -> None:
+    object_node = node.child_by_field_name("object")
+    if object_node is None or object_node.type != "identifier":
+        return
+    alias = core._get_text(object_node)
+    binding = namespaces.get(alias)
+    if binding is None or _namespace_is_shadowed(core, node, alias, binding):
+        return
+    if node.type == "subscript_expression":
+        references.append(
+            make_reference(
+                binding.source,
+                None,
+                "computed_namespace_member",
+                node,
+                binding.source_line,
+                type_only=binding.type_only,
+                skip_reason="computed_namespace_member",
+            )
+        )
+        return
+    property_node = node.child_by_field_name("property")
+    if property_node is None or property_node.type != "property_identifier":
+        return
+    references.append(
+        make_reference(
+            binding.source,
+            core._get_text(property_node),
+            binding.kind,
+            property_node,
+            binding.source_line,
+            type_only=binding.type_only,
+        )
+    )
+
+
+def _namespace_is_shadowed(
+    core: TypeScriptCore,
+    node: Any,
+    alias: str,
+    binding: NamespaceBinding,
+) -> bool:
+    child = node
+    parent = node.parent
+    while parent is not None:
+        if _function_parameter_shadows(core, parent, alias):
+            return True
+        if _scope_statement_shadows(core, parent, child, alias, binding):
+            return True
+        child = parent
+        parent = parent.parent
+    return False
+
+
+def _function_parameter_shadows(core: TypeScriptCore, parent: Any, alias: str) -> bool:
+    function_types = {
+        "function_declaration",
+        "function_expression",
+        "arrow_function",
+        "method_definition",
+        "generator_function_declaration",
+        "generator_function",
+    }
+    if parent.type not in function_types:
+        return False
+    parameters = parent.child_by_field_name("parameters")
+    parameter = parent.child_by_field_name("parameter")
+    return alias in _binding_names(core, parameters or parameter)
+
+
+def _scope_statement_shadows(
+    core: TypeScriptCore,
+    parent: Any,
+    child: Any,
+    alias: str,
+    binding: NamespaceBinding,
+) -> bool:
+    if parent.type not in {"program", "statement_block"}:
+        return False
+    for sibling in parent.named_children:
+        if sibling == child or node_line(sibling) == binding.source_line:
+            continue
+        if _statement_declares_name(core, sibling, alias):
+            return True
+    return False
+
+
+def _statement_declares_name(core: TypeScriptCore, node: Any, alias: str) -> bool:
+    if node.type == "import_statement":
+        return False
+    if node.type in {"function_declaration", "class_declaration"}:
+        name_node = node.child_by_field_name("name")
+        return name_node is not None and core._get_text(name_node) == alias
+    if node.type in {"lexical_declaration", "variable_declaration"}:
+        return _declaration_contains_name(core, node, alias)
+    return False
+
+
+def _declaration_contains_name(core: TypeScriptCore, node: Any, alias: str) -> bool:
+    for declarator in node.named_children:
+        if declarator.type != "variable_declarator":
+            continue
+        if alias in _binding_names(core, declarator.child_by_field_name("name")):
+            return True
+    return False
+
+
+def _binding_names(core: TypeScriptCore, node: Any | None) -> set[str]:
+    if node is None:
+        return set()
+    direct_types = {
+        "identifier",
+        "shorthand_property_identifier_pattern",
+    }
+    if node.type in direct_types:
+        return {core._get_text(node)}
+    names: set[str] = set()
+    for child in node.named_children:
+        names.update(_binding_names(core, child))
+    return names

--- a/skylos/rules/ai_defect/js_api_reference_model.py
+++ b/skylos/rules/ai_defect/js_api_reference_model.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from skylos.visitors.languages.typescript.core import TypeScriptCore
+
+
+@dataclass(frozen=True)
+class JsApiReference:
+    source: str | None
+    symbol: str | None
+    kind: str
+    line: int
+    col: int
+    source_line: int
+    type_only: bool = False
+    skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class NamespaceBinding:
+    source: str
+    source_line: int
+    kind: str
+    type_only: bool = False
+
+
+@dataclass(frozen=True)
+class ImportContext:
+    source: str
+    source_line: int
+    clause: Any
+    type_only: bool
+
+
+def source_string_node(node: Any) -> Any | None:
+    return first_named_child(node, "string")
+
+
+def string_value(core: TypeScriptCore, node: Any | None) -> str | None:
+    if node is None or node.type != "string":
+        return None
+    text = core._get_text(node).strip()
+    if len(text) < 2 or text[0] not in {"'", '"'} or text[-1] != text[0]:
+        return None
+    return text[1:-1]
+
+
+def property_name(core: TypeScriptCore, node: Any) -> str | None:
+    if node.type in {"identifier", "property_identifier"}:
+        return core._get_text(node)
+    return string_value(core, node)
+
+
+def named_child(node: Any, node_type: str) -> Any | None:
+    return first_named_child(node, node_type)
+
+
+def first_named_child(node: Any, node_type: str) -> Any | None:
+    for child in node.named_children:
+        if child.type == node_type:
+            return child
+    return None
+
+
+def make_reference(
+    source: str,
+    symbol: str | None,
+    kind: str,
+    node: Any,
+    source_line: int,
+    *,
+    type_only: bool = False,
+    skip_reason: str | None = None,
+) -> JsApiReference:
+    return JsApiReference(
+        source=source,
+        symbol=symbol,
+        kind=kind,
+        line=node_line(node),
+        col=int(node.start_point[1]),
+        source_line=source_line,
+        type_only=type_only,
+        skip_reason=skip_reason,
+    )
+
+
+def node_line(node: Any) -> int:
+    return int(node.start_point[0]) + 1

--- a/skylos/rules/ai_defect/js_api_references.py
+++ b/skylos/rules/ai_defect/js_api_references.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from skylos.core.js_api_surface_utils import MAX_JS_API_SURFACE_SOURCE_BYTES
+from skylos.core.safe_cache_io import read_text_no_symlink
+from skylos.rules.ai_defect.js_api_namespace_references import (
+    collect_namespace_member_references as _collect_namespace_member_references,
+)
+from skylos.rules.ai_defect.js_api_reference_model import (
+    ImportContext as _ImportContext,
+    JsApiReference,
+    NamespaceBinding as _NamespaceBinding,
+    first_named_child as _first_named_child,
+    make_reference as _reference,
+    named_child as _named_child,
+    node_line as _line,
+    property_name as _property_name,
+    source_string_node as _source_string_node,
+    string_value as _string_value,
+)
+from skylos.visitors.languages.typescript import is_minified_js_source
+from skylos.visitors.languages.typescript.core import TypeScriptCore
+
+
+def extract_js_api_references(
+    path: Path,
+) -> tuple[list[JsApiReference], Counter[str]]:
+    source_text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_JS_API_SURFACE_SOURCE_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if source_text is None:
+        return [], Counter({"source_unreadable": 1})
+    source = source_text.encode("utf-8", "ignore")
+    if is_minified_js_source(str(path), source):
+        return [], Counter({"minified_source": 1})
+
+    core = TypeScriptCore(str(path), source)
+    core.scan()
+    if core.root_node is None or core.root_node.has_error:
+        return [], Counter({"parse_error": 1})
+    return _collect_references(core)
+
+
+def _collect_references(
+    core: TypeScriptCore,
+) -> tuple[list[JsApiReference], Counter[str]]:
+    references: list[JsApiReference] = []
+    namespaces: dict[str, _NamespaceBinding] = {}
+    reasons: Counter[str] = Counter()
+    for node in core.root_node.named_children:
+        if node.type == "import_statement":
+            _collect_import_references(core, node, references, namespaces)
+        elif node.type == "export_statement":
+            _collect_reexport_references(core, node, references)
+
+    for node in core._iter_nodes(core.root_node):
+        if node.type == "call_expression":
+            _collect_require_reference(core, node, references, namespaces, reasons)
+
+    _collect_namespace_member_references(core, namespaces, references)
+    return references, reasons
+
+
+def _collect_import_references(
+    core: TypeScriptCore,
+    node: Any,
+    references: list[JsApiReference],
+    namespaces: dict[str, _NamespaceBinding],
+) -> None:
+    if _collect_import_equals(core, node, references):
+        return
+    context = _import_context(core, node)
+    if context is None:
+        return
+    for child in context.clause.named_children:
+        _collect_import_clause_child(core, child, context, references, namespaces)
+
+
+def _collect_import_equals(
+    core: TypeScriptCore,
+    node: Any,
+    references: list[JsApiReference],
+) -> bool:
+    require_clause = _named_child(node, "import_require_clause")
+    if require_clause is None:
+        return False
+    source_node = _source_string_node(require_clause)
+    source = _string_value(core, source_node)
+    if source is not None and source_node is not None:
+        alias_node = _first_named_child(require_clause, "identifier")
+        references.append(
+            _reference(
+                source,
+                None,
+                "typescript_import_equals",
+                alias_node or require_clause,
+                _line(source_node),
+                skip_reason="unsupported_typescript_import_equals",
+            )
+        )
+    return True
+
+
+def _import_context(core: TypeScriptCore, node: Any) -> _ImportContext | None:
+    source_node = _source_string_node(node)
+    source = _string_value(core, source_node)
+    clause = _named_child(node, "import_clause")
+    if source is None or source_node is None or clause is None:
+        return None
+    return _ImportContext(
+        source=source,
+        source_line=_line(source_node),
+        clause=clause,
+        type_only=core._get_text(node).lstrip().startswith("import type "),
+    )
+
+
+def _collect_import_clause_child(
+    core: TypeScriptCore,
+    child: Any,
+    context: _ImportContext,
+    references: list[JsApiReference],
+    namespaces: dict[str, _NamespaceBinding],
+) -> None:
+    if child.type == "identifier":
+        references.append(
+            _reference(
+                context.source,
+                "default",
+                "default_import",
+                child,
+                context.source_line,
+                type_only=context.type_only,
+            )
+        )
+        return
+    if child.type == "namespace_import":
+        _collect_namespace_import(core, child, context, namespaces)
+        return
+    if child.type == "named_imports":
+        _collect_named_imports(core, child, context, references)
+
+
+def _collect_namespace_import(
+    core: TypeScriptCore,
+    child: Any,
+    context: _ImportContext,
+    namespaces: dict[str, _NamespaceBinding],
+) -> None:
+    alias_node = _first_named_child(child, "identifier")
+    if alias_node is None:
+        return
+    namespaces[core._get_text(alias_node)] = _NamespaceBinding(
+        source=context.source,
+        source_line=context.source_line,
+        kind="namespace_member",
+        type_only=context.type_only,
+    )
+
+
+def _collect_named_imports(
+    core: TypeScriptCore,
+    clause: Any,
+    context: _ImportContext,
+    references: list[JsApiReference],
+) -> None:
+    for specifier in clause.named_children:
+        if specifier.type != "import_specifier":
+            continue
+        name_node = specifier.child_by_field_name("name")
+        if name_node is None:
+            continue
+        specifier_type_only = core._get_text(specifier).lstrip().startswith("type ")
+        references.append(
+            _reference(
+                context.source,
+                core._get_text(name_node),
+                "named_import",
+                name_node,
+                context.source_line,
+                type_only=context.type_only or specifier_type_only,
+            )
+        )
+
+
+def _collect_reexport_references(
+    core: TypeScriptCore,
+    node: Any,
+    references: list[JsApiReference],
+) -> None:
+    source_node = _source_string_node(node)
+    source = _string_value(core, source_node)
+    if source is None or source_node is None:
+        return
+    context = _ImportContext(
+        source=source,
+        source_line=_line(source_node),
+        clause=_named_child(node, "export_clause"),
+        type_only=core._get_text(node).lstrip().startswith("export type "),
+    )
+    if context.clause is None:
+        return
+    for specifier in context.clause.named_children:
+        _collect_reexport_specifier(core, specifier, context, references)
+
+
+def _collect_reexport_specifier(
+    core: TypeScriptCore,
+    specifier: Any,
+    context: _ImportContext,
+    references: list[JsApiReference],
+) -> None:
+    if specifier.type != "export_specifier":
+        return
+    name_node = specifier.child_by_field_name("name")
+    if name_node is None:
+        return
+    specifier_type_only = core._get_text(specifier).lstrip().startswith("type ")
+    references.append(
+        _reference(
+            context.source,
+            core._get_text(name_node),
+            "named_reexport",
+            name_node,
+            context.source_line,
+            type_only=context.type_only or specifier_type_only,
+        )
+    )
+
+
+def _collect_require_reference(
+    core: TypeScriptCore,
+    node: Any,
+    references: list[JsApiReference],
+    namespaces: dict[str, _NamespaceBinding],
+    reasons: Counter[str],
+) -> None:
+    loader = _module_loader(core, node)
+    if loader is None:
+        return
+    argument = _first_call_argument(node)
+    source = _string_value(core, argument)
+    if source is None:
+        reasons["dynamic_module_specifier"] += 1
+        return
+    if loader == "import":
+        reasons["unsupported_dynamic_import"] += 1
+        return
+    parent = node.parent
+    if parent is None:
+        return
+    source_line = _line(argument)
+    if _collect_require_binding(
+        core, node, parent, source, source_line, references, namespaces
+    ):
+        return
+    _collect_require_access(core, node, parent, source, source_line, references)
+
+
+def _module_loader(core: TypeScriptCore, node: Any) -> str | None:
+    function = node.child_by_field_name("function")
+    if function is None or function.type not in {"identifier", "import"}:
+        return None
+    function_name = core._get_text(function)
+    if function.type == "identifier" and function_name != "require":
+        return None
+    return function.type
+
+
+def _first_call_argument(node: Any) -> Any | None:
+    arguments = node.child_by_field_name("arguments")
+    if arguments is None or not arguments.named_children:
+        return None
+    return arguments.named_children[0]
+
+
+def _collect_require_binding(
+    core: TypeScriptCore,
+    node: Any,
+    parent: Any,
+    source: str,
+    source_line: int,
+    references: list[JsApiReference],
+    namespaces: dict[str, _NamespaceBinding],
+) -> bool:
+    if parent.type != "variable_declarator":
+        return False
+    if parent.child_by_field_name("value") != node:
+        return False
+    name_node = parent.child_by_field_name("name")
+    if name_node is None:
+        return True
+    if name_node.type == "identifier":
+        namespaces[core._get_text(name_node)] = _NamespaceBinding(
+            source=source,
+            source_line=source_line,
+            kind="commonjs_namespace_member",
+        )
+    elif name_node.type == "object_pattern":
+        _collect_commonjs_destructure(core, source, source_line, name_node, references)
+    return True
+
+
+def _collect_require_access(
+    core: TypeScriptCore,
+    node: Any,
+    parent: Any,
+    source: str,
+    source_line: int,
+    references: list[JsApiReference],
+) -> None:
+    if parent.child_by_field_name("object") != node:
+        return
+    if parent.type == "member_expression":
+        property_node = parent.child_by_field_name("property")
+        if property_node is not None:
+            references.append(
+                _reference(
+                    source,
+                    core._get_text(property_node),
+                    "commonjs_member",
+                    property_node,
+                    source_line,
+                )
+            )
+        return
+    if parent.type == "subscript_expression":
+        references.append(
+            _reference(
+                source,
+                None,
+                "commonjs_computed_member",
+                parent,
+                source_line,
+                skip_reason="computed_namespace_member",
+            )
+        )
+
+
+def _collect_commonjs_destructure(
+    core: TypeScriptCore,
+    source: str,
+    source_line: int,
+    pattern: Any,
+    references: list[JsApiReference],
+) -> None:
+    for child in pattern.named_children:
+        if child.type == "shorthand_property_identifier_pattern":
+            references.append(
+                _reference(
+                    source,
+                    core._get_text(child),
+                    "commonjs_destructure",
+                    child,
+                    source_line,
+                )
+            )
+            continue
+        symbol_node = _destructure_symbol_node(child)
+        symbol = _property_name(core, symbol_node) if symbol_node is not None else None
+        if symbol is not None:
+            references.append(
+                _reference(
+                    source,
+                    symbol,
+                    "commonjs_destructure",
+                    symbol_node,
+                    source_line,
+                )
+            )
+            continue
+        references.append(
+            _reference(
+                source,
+                None,
+                "commonjs_destructure",
+                child,
+                source_line,
+                skip_reason="dynamic_commonjs_destructure",
+            )
+        )
+
+
+def _destructure_symbol_node(node: Any) -> Any | None:
+    if node.type != "pair_pattern":
+        return None
+    key_node = node.child_by_field_name("key")
+    if key_node is None:
+        named = list(node.named_children)
+        key_node = named[0] if named else None
+    if key_node is None:
+        return None
+    if key_node.type not in {"identifier", "property_identifier", "string"}:
+        return None
+    return key_node

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -65,7 +65,7 @@ _RULES = (
     RuleCatalogEntry("SKY-L009", "Debug leftover", "quality"),
     RuleCatalogEntry("SKY-L010", "Security TODO marker", "quality"),
     RuleCatalogEntry("SKY-L011", "Disabled security control", "quality"),
-    RuleCatalogEntry("SKY-L012", "Phantom function call", "ai_defect"),
+    RuleCatalogEntry("SKY-L012", "Phantom symbol reference", "ai_defect"),
     RuleCatalogEntry("SKY-L013", "Insecure randomness", "quality"),
     RuleCatalogEntry("SKY-L014", "Hardcoded credential", "quality"),
     RuleCatalogEntry("SKY-L016", "Undefined config", "quality"),

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -132,7 +132,12 @@ COMMANDS = [
         ],
         "group": "Utility",
     },
-    {"name": "skylos doctor", "desc": "Check installation health", "group": "Utility"},
+    {
+        "name": "skylos doctor [--format text|json]",
+        "desc": "Check installation health and language-engine availability",
+        "details": ["--format text|json  Print human-readable or machine-readable health"],
+        "group": "Utility",
+    },
     {
         "name": "skylos clean [--dry-run|--apply]",
         "desc": "Preview or apply safe dead-code cleanup",

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -75,6 +75,12 @@ OVERRIDE_DECORATORS = {
     "typing_extensions.override",
 }
 
+NUMBA_OVERLOAD_DECORATORS = {
+    "numba.extending.overload",
+    "numba.extending.overload_method",
+    "numba.extending.overload_attribute",
+}
+
 IMPLICIT_DUNDERS = {
     "__init__",
     "__new__",
@@ -718,6 +724,53 @@ class Visitor(ast.NodeVisitor):
             return self._get_decorator_name(deco.func)
         return None
 
+    def _local_binding_shadows_alias(
+        self, name: str, current_definition: str | None = None
+    ) -> bool:
+        if self.current_function_scope and self.local_var_maps:
+            for scope_map in reversed(self.local_var_maps):
+                if scope_map.get(name) != current_definition and name in scope_map:
+                    return True
+
+        candidates = []
+        if self.cls:
+            candidates.append(".".join(filter(None, [self.mod, self.cls, name])))
+        candidates.append(f"{self.mod}.{name}" if self.mod else name)
+
+        return any(
+            d.name in candidates
+            and d.name != current_definition
+            and d.type != "import"
+            for d in self.defs
+        )
+
+    def _resolve_alias_prefix(
+        self, name: str, current_definition: str | None = None
+    ) -> str:
+        head = name.split(".", 1)[0]
+        if self._local_binding_shadows_alias(head, current_definition):
+            return name
+        if name in self.alias:
+            return self.alias[name]
+        if "." not in name:
+            return name
+        _, rest = name.split(".", 1)
+        target = self.alias.get(head)
+        if target:
+            return f"{target}.{rest}"
+        return name
+
+    def _is_numba_overload_decorator(
+        self, name: str, current_definition: str | None = None
+    ) -> bool:
+        head = name.split(".", 1)[0]
+        if self._local_binding_shadows_alias(head, current_definition):
+            return False
+        return (
+            self._resolve_alias_prefix(name, current_definition)
+            in NUMBA_OVERLOAD_DECORATORS
+        )
+
     def _analyze_decorator_args(self, deco: ast.expr) -> None:
         if not isinstance(deco, ast.Call):
             return
@@ -871,6 +924,10 @@ class Visitor(ast.NodeVisitor):
                         )
                 elif any(
                     keyword in deco_name.lower() for keyword in FRAMEWORK_DECORATORS
+                ):
+                    self.add_ref(qualified_name)
+                elif isinstance(d, ast.Call) and self._is_numba_overload_decorator(
+                    deco_name, current_definition=qualified_name
                 ):
                     self.add_ref(qualified_name)
                 elif deco_name in self.local_registration_decorators:

--- a/test/test_ai_code_defect_benchmark.py
+++ b/test/test_ai_code_defect_benchmark.py
@@ -8,6 +8,7 @@ import pytest
 import skylos.benchmarks.ai_code_defects as benchmark
 from skylos.benchmarks.ai_code_defects import (
     AI_CODE_DEFECT_TAXONOMY,
+    BENCHMARK_LANGUAGES,
     format_summary,
     load_manifest,
     run_manifest,
@@ -60,6 +61,8 @@ EXPECTED_CASE_IDS = {
     "clean-api-signature",
     "clean-dynamic-api-surface",
     "clean-range-scope",
+    "typescript-local-api-hallucination",
+    "clean-typescript-local-api-surface",
     "clean-generated-code",
 }
 
@@ -101,6 +104,8 @@ EXPECTED_CASE_PATH_NAMES = [
     "clean_api_signature",
     "clean_dynamic_api_surface",
     "range_scoped_mixed_edit",
+    "typescript_local_api_hallucination",
+    "clean_typescript_local_api_surface",
     "clean_generated_code",
 ]
 
@@ -518,6 +523,45 @@ def _fake_findings_for_case(case_path, scan_kwargs=None):
         ]
     if case_name == "clean_api_signature":
         return []
+    if case_name == "typescript_local_api_hallucination":
+        return [
+            _finding(
+                "SKY-L012",
+                "hallucinated_reference",
+                file_path="src/app.ts",
+                metadata={
+                    "language": "typescript",
+                    "reference_kind": "named_import",
+                },
+            ),
+            _finding(
+                "SKY-L012",
+                "hallucinated_reference",
+                file_path="src/app.ts",
+                metadata={
+                    "language": "typescript",
+                    "reference_kind": "named_import",
+                },
+            ),
+            _finding(
+                "SKY-L012",
+                "hallucinated_reference",
+                file_path="src/app.ts",
+                metadata={
+                    "language": "typescript",
+                    "reference_kind": "namespace_member",
+                },
+            ),
+            _finding(
+                "SKY-L012",
+                "hallucinated_reference",
+                file_path="src/app.ts",
+                metadata={
+                    "language": "typescript",
+                    "reference_kind": "commonjs_destructure",
+                },
+            ),
+        ]
     return []
 
 
@@ -526,6 +570,7 @@ def test_checked_in_ai_code_defect_manifest_validates():
     cases = validate_manifest(manifest, MANIFEST_PATH)
 
     assert {case["id"] for case in cases} == EXPECTED_CASE_IDS
+    assert all(case.get("language") in BENCHMARK_LANGUAGES for case in cases)
     labels = set()
     for case in cases:
         for label in case["taxonomy"]:
@@ -589,10 +634,12 @@ def test_ai_code_defect_runner_scores_expectations(monkeypatch):
 
     summary = run_manifest(MANIFEST_PATH, verify_func=fake_verify)
 
-    assert summary["case_count"] == 37
-    assert summary["pass_count"] == 37
+    assert summary["case_count"] == 39
+    assert summary["pass_count"] == 39
     assert summary["failure_count"] == 0
     assert summary["scores"]["overall_score"] == pytest.approx(100.0)
+    assert summary["metadata"]["languages"]["labelled_cases"] == 39
+    assert summary["metadata"]["languages"]["coverage_rate"] == 1.0
 
     dependency_hallucination_case_names = {
         "api_signature_hallucination",
@@ -645,7 +692,7 @@ def test_ai_code_defect_runner_empty_selection_runs_all_cases(monkeypatch):
 
     summary = run_manifest(MANIFEST_PATH, selected_cases=None, verify_func=fake_verify)
 
-    assert summary["case_count"] == 37
+    assert summary["case_count"] == 39
     assert seen == EXPECTED_CASE_PATH_NAMES
 
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -16,6 +16,7 @@ from skylos.analyzer import (
     proc_file,
     analyze,
     _architecture_iad_strict,
+    _go_engine_analysis_report,
     _resolve_analysis_root,
 )
 from skylos.visitors.languages.shell import SHELL_SOURCE_EXTS
@@ -3437,6 +3438,60 @@ def test_changed_files_secret_scan_skips_symlink_targets_outside_root(tmp_path):
 
 
 class TestRepoPhantomReferences:
+    def test_resolve_analysis_root_stops_at_nested_javascript_package(
+        self, tmp_path
+    ):
+        (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+        package_root = tmp_path / "benchmarks" / "typescript-case"
+        source_root = package_root / "src"
+        source_root.mkdir(parents=True)
+        (package_root / "package.json").write_text(
+            '{"name": "typescript-case", "private": true}\n',
+            encoding="utf-8",
+        )
+
+        assert _resolve_analysis_root(source_root) == package_root
+
+    def test_go_engine_report_marks_engine_checks_partial(self):
+        with patch(
+            "skylos.engines.go_runner.get_go_engine_status",
+            return_value={
+                "status": "unavailable",
+                "reason": "Go engine binary not found",
+                "configured_by": "discovery",
+            },
+        ):
+            report = _go_engine_analysis_report([Path("main.go"), Path("helper.py")])
+
+        assert report["status"] == "partial"
+        assert report["completed_checks"] == ["quality"]
+        assert report["skipped_checks"] == ["dead_code", "security"]
+
+    def test_analyze_reports_unavailable_go_engine_in_summary(self, tmp_path):
+        source = tmp_path / "main.go"
+        source.write_text("package main\n\nfunc main() {}\n", encoding="utf-8")
+
+        with (
+            patch(
+                "skylos.engines.go_runner.get_go_engine_status",
+                return_value={
+                    "status": "unavailable",
+                    "reason": "Go engine binary not found",
+                    "configured_by": "discovery",
+                },
+            ),
+            patch(
+                "skylos.visitors.languages.go.go.run_go_engine_for_module",
+                side_effect=RuntimeError("Go engine binary not found"),
+            ),
+        ):
+            result = json.loads(analyze(str(tmp_path), grep_verify=False))
+
+        report = result["analysis_summary"]["language_engines"]["go"]
+        assert report["status"] == "partial"
+        assert report["skipped_checks"] == ["dead_code", "security"]
+        assert result["analysis_summary"]["incomplete_languages"] == ["go"]
+
     def test_resolve_analysis_root_ignores_home_git_root_without_project_marker(
         self, tmp_path, monkeypatch
     ):

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -204,7 +204,7 @@ def test_cli_guardrail_doctor_dispatch_exits_zero(monkeypatch):
         cli.main()
 
     assert exc.value.code == 0
-    mock_doctor.assert_called_once_with()
+    mock_doctor.assert_called_once_with([])
 
 
 def test_cli_guardrail_init_dispatch_exits_zero(monkeypatch):
@@ -638,6 +638,10 @@ def test_doctor_command_reports_core_statuses(tmp_path):
         patch("skylos.commands.doctor_cmd._llm_available", return_value=True),
         patch("skylos.commands.doctor_cmd._interactive_available", return_value=True),
         patch(
+            "skylos.commands.doctor_cmd._go_engine_status",
+            return_value={"status": "available", "binary": "/bin/skylos-go"},
+        ),
+        patch(
             "skylos.commands.doctor_cmd.load_config", return_value={"exclude": ["venv"]}
         ),
         patch("skylos.commands.doctor_cmd.Path.cwd", return_value=repo),
@@ -657,10 +661,40 @@ def test_doctor_command_reports_core_statuses(tmp_path):
     )
     assert "Python 3.12.1" in printed
     assert "Skylos 9.9.9" in printed
+    assert "Go engine available" in printed
     assert "Cloud connected" in printed
     assert "pyproject.toml [tool.skylos] config found" in printed
     assert "GitHub Actions workflow found" in printed
     assert "community rule pack(s) installed" in printed
+
+
+def test_doctor_command_json_reports_unavailable_go_engine(capsys):
+    with (
+        patch("skylos.commands.doctor_cmd.skylos.__version__", "9.9.9"),
+        patch(
+            "skylos.commands.doctor_cmd.platform.python_version", return_value="3.12.1"
+        ),
+        patch("skylos.commands.doctor_cmd._rust_available", return_value=True),
+        patch("skylos.commands.doctor_cmd._llm_available", return_value=False),
+        patch("skylos.commands.doctor_cmd._interactive_available", return_value=True),
+        patch(
+            "skylos.commands.doctor_cmd._go_engine_status",
+            return_value={
+                "status": "unavailable",
+                "reason": "Go engine binary not found",
+                "configured_by": "discovery",
+            },
+        ),
+    ):
+        from skylos.commands.doctor_cmd import run_doctor_command
+
+        exit_code = run_doctor_command(["--format", "json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["status"] == "degraded"
+    assert payload["checks"]["go_engine"]["status"] == "unavailable"
+    assert payload["checks"]["go_engine"]["reason"] == "Go engine binary not found"
 
 
 def test_discover_command_json_output_prints_report(tmp_path):

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -13,6 +13,95 @@ def _unused_function_names(result):
     return {item["full_name"] for item in result.get("unused_functions", [])}
 
 
+def test_numba_overload_implementation_is_live(tmp_path):
+    _write(
+        tmp_path / "skylos_false_positive.py",
+        """
+        import numba.extending
+        from numba import njit
+
+        def select_method(x):
+            return x
+
+        @numba.extending.overload(select_method)
+        def _select_method(x):
+            def temp(x):
+                return x
+            return temp
+
+        @njit()
+        def jitted_harness():
+            return select_method(0.0)
+
+        jitted_harness()
+        """,
+    )
+    _write(
+        tmp_path / "aliased_overload.py",
+        """
+        from numba.extending import overload as nb_overload
+        import numba.extending as ne
+
+        def select_alias(x):
+            return x
+
+        @nb_overload(select_alias)
+        def _select_alias(x):
+            def impl(x):
+                return x
+            return impl
+
+        @ne.overload(select_alias)
+        def _select_module_alias(x):
+            def impl(x):
+                return x
+            return impl
+
+        @ne.overload_method(object, "work")
+        def _select_method_alias(x):
+            def impl(x):
+                return x
+            return impl
+
+        @ne.overload_attribute(object, "value")
+        def _select_attribute_alias(x):
+            def impl(x):
+                return x
+            return impl
+        """,
+    )
+    _write(
+        tmp_path / "shadowed_alias.py",
+        """
+        from numba.extending import overload as nb_overload
+
+        def nb_overload(target):
+            def decorator(func):
+                return func
+            return decorator
+
+        @nb_overload(None)
+        def _shadowed_helper(x):
+            return x
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    unused = _unused_function_names(result)
+
+    assert "skylos_false_positive._select_method" not in unused
+    assert "skylos_false_positive._select_method.temp" not in unused
+    assert "aliased_overload._select_alias" not in unused
+    assert "aliased_overload._select_alias.impl" not in unused
+    assert "aliased_overload._select_module_alias" not in unused
+    assert "aliased_overload._select_module_alias.impl" not in unused
+    assert "aliased_overload._select_method_alias" not in unused
+    assert "aliased_overload._select_method_alias.impl" not in unused
+    assert "aliased_overload._select_attribute_alias" not in unused
+    assert "aliased_overload._select_attribute_alias.impl" not in unused
+    assert "shadowed_alias._shadowed_helper" in unused
+
+
 def test_optional_import_fallback_is_live(tmp_path):
     _write(
         tmp_path / "pkg" / "mod.py",

--- a/test/test_go_runner.py
+++ b/test/test_go_runner.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from skylos.engines import go_runner
@@ -33,3 +31,33 @@ def test_resolve_go_engine_bin_rejects_unrunnable_override(tmp_path, monkeypatch
 
     with pytest.raises(GoEngineError):
         resolve_go_engine_bin()
+
+
+def test_get_go_engine_status_reports_available_binary(monkeypatch):
+    monkeypatch.delenv("SKYLOS_GO_BIN", raising=False)
+    monkeypatch.setattr(
+        go_runner,
+        "resolve_go_engine_bin",
+        lambda: "/usr/local/bin/skylos-go",
+    )
+
+    assert go_runner.get_go_engine_status() == {
+        "status": "available",
+        "binary": "/usr/local/bin/skylos-go",
+        "configured_by": "PATH",
+    }
+
+
+def test_get_go_engine_status_reports_unavailable_reason(monkeypatch):
+    monkeypatch.delenv("SKYLOS_GO_BIN", raising=False)
+
+    def _missing():
+        raise GoEngineError("Go engine binary not found\nBuild it locally")
+
+    monkeypatch.setattr(go_runner, "resolve_go_engine_bin", _missing)
+
+    assert go_runner.get_go_engine_status() == {
+        "status": "unavailable",
+        "reason": "Go engine binary not found",
+        "configured_by": "discovery",
+    }

--- a/test/test_js_api_hallucination.py
+++ b/test/test_js_api_hallucination.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skylos.rules.ai_defect.js_api_hallucination import (
+    scan_js_local_api_hallucinations,
+)
+from skylos.visitors.languages.typescript.core import TypeScriptCore
+from skylos.visitors.languages.typescript.resolve import MonorepoResolver
+
+
+def _scan(repo: Path):
+    files = sorted(
+        path
+        for path in repo.rglob("*")
+        if path.is_file()
+        and path.name.endswith(
+            (".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs")
+        )
+    )
+    raw_imports = {}
+    for path in files:
+        core = TypeScriptCore(str(path), path.read_bytes())
+        core.scan()
+        if core.raw_imports:
+            raw_imports[path] = core.raw_imports
+    return scan_js_local_api_hallucinations(
+        repo,
+        files,
+        raw_imports,
+        monorepo_resolver=MonorepoResolver(str(repo)),
+    )
+
+
+def test_js_api_hallucination_finds_missing_named_default_type_and_namespace_exports(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "security.ts").write_text(
+        """
+export default function defaultGuard() { return true; }
+export function verifyToken() { return true; }
+export type User = { id: string };
+""",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        """
+import defaultGuard, {
+  verifyToken,
+  verifyAdmin,
+  type User,
+  type MissingType,
+} from "./security";
+import * as security from "./security";
+
+defaultGuard();
+verifyToken();
+security.verifyToken();
+security.verifyTenant();
+""",
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert {finding["simple_name"] for finding in findings} == {
+        "MissingType",
+        "verifyAdmin",
+        "verifyTenant",
+    }
+    assert {finding["metadata"]["reference_kind"] for finding in findings} == {
+        "named_import",
+        "namespace_member",
+    }
+    assert all(finding["metadata"]["proof_state"] == "verified" for finding in findings)
+    assert coverage["status"] == "completed"
+    assert coverage["outcome"] == "fail"
+    assert coverage["finding_count"] == 3
+    assert coverage["skipped_references"] == 0
+
+
+def test_js_api_hallucination_marks_external_and_computed_references_incomplete(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "local.ts").write_text(
+        "export function known() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        """
+import { useState } from "react";
+import * as local from "./local";
+
+local[window.location.hash]();
+useState();
+""",
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["references"] == 2
+    assert coverage["skipped_references"] == 2
+    assert {reason["code"] for reason in coverage["reasons"]} == {
+        "computed_namespace_member",
+        "external_or_unresolved_module",
+    }
+
+
+def test_js_api_hallucination_handles_workspace_reexports_and_commonjs(tmp_path):
+    repo = tmp_path / "repo"
+    app = repo / "apps" / "web"
+    api = repo / "packages" / "api"
+    legacy = repo / "packages" / "legacy"
+    app.mkdir(parents=True)
+    (api / "src").mkdir(parents=True)
+    legacy.mkdir(parents=True)
+    (repo / "package.json").write_text(
+        json.dumps({"name": "workspace-root", "workspaces": ["apps/*", "packages/*"]}),
+        encoding="utf-8",
+    )
+    (app / "package.json").write_text(
+        json.dumps({"name": "web", "private": True}),
+        encoding="utf-8",
+    )
+    (api / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@acme/api",
+                "exports": {".": "./src/index.ts"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (api / "src" / "index.ts").write_text(
+        """
+export { verifyToken } from "./security";
+export type { User } from "./types";
+export default function createClient() { return {}; }
+""",
+        encoding="utf-8",
+    )
+    (api / "src" / "security.ts").write_text(
+        "export function verifyToken() { return true; }\n",
+        encoding="utf-8",
+    )
+    (api / "src" / "types.ts").write_text(
+        "export interface User { id: string }\n",
+        encoding="utf-8",
+    )
+    (legacy / "package.json").write_text(
+        json.dumps({"name": "legacy-auth", "main": "./index.cjs"}),
+        encoding="utf-8",
+    )
+    (legacy / "index.cjs").write_text(
+        "module.exports = { validate: () => true };\n",
+        encoding="utf-8",
+    )
+    (app / "app.ts").write_text(
+        """
+import createClient, { verifyToken, type User } from "@acme/api";
+import * as api from "@acme/api";
+const { validate } = require("legacy-auth");
+const legacy = require("legacy-auth");
+
+createClient();
+verifyToken();
+api.verifyToken();
+validate();
+legacy.validate();
+const user: User = { id: "1" };
+""",
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 8
+    assert coverage["skipped_references"] == 0
+
+
+def test_js_api_hallucination_does_not_claim_absence_on_external_reexport(tmp_path):
+    repo = tmp_path / "repo"
+    src = repo / "src"
+    src.mkdir(parents=True)
+    (repo / "package.json").write_text(
+        json.dumps({"name": "@acme/api", "main": "./src/index.ts"}),
+        encoding="utf-8",
+    )
+    (src / "index.ts").write_text(
+        'export * from "third-party";\n',
+        encoding="utf-8",
+    )
+    (src / "app.ts").write_text(
+        'import { maybeExternal } from "@acme/api";\nmaybeExternal();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["reasons"] == [{"code": "surface_external_reexport", "count": 1}]
+
+
+def test_js_api_hallucination_ignores_shadowed_namespace_binding(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "security.ts").write_text(
+        "export function verifyToken() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        """
+import * as security from "./security";
+
+function run(security: { invented(): void }) {
+  security.invented();
+}
+
+security.verifyToken();
+""",
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 1
+
+
+def test_js_api_hallucination_marks_literal_dynamic_import_incomplete(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "api.ts").write_text(
+        "export function known() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        """
+async function run() {
+  const api = await import("./api");
+  api.invented();
+}
+""",
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["references"] == 1
+    assert coverage["skipped_references"] == 1
+    assert coverage["reasons"] == [{"code": "unsupported_dynamic_import", "count": 1}]
+
+
+def test_js_api_hallucination_marks_typescript_import_equals_incomplete(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "api.cjs").write_text(
+        "module.exports = { known: () => true };\n",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        """
+import api = require("./api.cjs");
+api.invented();
+""",
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["references"] == 1
+    assert coverage["skipped_references"] == 1
+    assert coverage["reasons"] == [
+        {"code": "unsupported_typescript_import_equals", "count": 1}
+    ]
+
+
+def test_js_api_hallucination_accepts_commonjs_default_facade(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "legacy.cjs").write_text(
+        "module.exports = { known: () => true };\n",
+        encoding="utf-8",
+    )
+    (repo / "app.mjs").write_text(
+        'import legacy from "./legacy.cjs";\nlegacy.known();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 1
+
+
+def test_js_api_hallucination_uses_require_package_condition(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "dual-package",
+                "exports": {
+                    ".": {
+                        "import": "./index.mjs",
+                        "require": "./index.cjs",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo / "index.mjs").write_text(
+        "export function esmOnly() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "index.cjs").write_text(
+        "module.exports = { cjsOnly: () => true };\n",
+        encoding="utf-8",
+    )
+    (repo / "app.cjs").write_text(
+        'const { cjsOnly } = require("dual-package");\ncjsOnly();\n',
+        encoding="utf-8",
+    )
+    (repo / "app.mjs").write_text(
+        'import { esmOnly } from "dual-package";\nesmOnly();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 2
+
+
+def test_js_api_hallucination_uses_types_package_condition(tmp_path):
+    repo = tmp_path / "repo"
+    types = repo / "types"
+    repo.mkdir()
+    types.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "typed-package",
+                "exports": {
+                    ".": {
+                        "types": "./types/index.d.ts",
+                        "import": "./index.js",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (types / "index.d.ts").write_text(
+        "export interface Options { enabled: boolean }\n",
+        encoding="utf-8",
+    )
+    (repo / "index.js").write_text(
+        "export function runtimeOnly() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        'import type { Options } from "typed-package";\n'
+        "const options: Options = { enabled: true };\n",
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 1
+
+
+def test_js_api_hallucination_marks_conditional_commonjs_exports_incomplete(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "api.cjs").write_text(
+        """
+if (process.env.ENABLE_API) {
+  module.exports.real = () => true;
+}
+""",
+        encoding="utf-8",
+    )
+    (repo / "app.cjs").write_text(
+        'const { real } = require("./api.cjs");\nreal();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["reasons"] == [
+        {"code": "surface_conditional_commonjs_export", "count": 1}
+    ]
+
+
+def test_js_api_hallucination_accepts_commonjs_package_default_for_plain_js(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"name": "legacy-package", "type": "commonjs"}),
+        encoding="utf-8",
+    )
+    (repo / "legacy.js").write_text(
+        'console.log("loaded");\n',
+        encoding="utf-8",
+    )
+    (repo / "app.mjs").write_text(
+        'import legacy from "./legacy.js";\nconsole.log(legacy);\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 1
+
+
+def test_js_api_hallucination_respects_package_condition_declaration_order(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "ordered-package",
+                "exports": {
+                    ".": {
+                        "node": "./node.js",
+                        "import": "./import.js",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo / "node.js").write_text(
+        "export function nodeOnly() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "import.js").write_text(
+        "export function importOnly() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.mjs").write_text(
+        'import { nodeOnly } from "ordered-package";\nnodeOnly();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 1
+
+
+def test_js_api_hallucination_marks_nested_commonjs_mutation_calls_incomplete(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "api.cjs").write_text(
+        """
+if (process.env.ENABLE_API) {
+  Object.defineProperty(module.exports, "real", { value: () => true });
+  Object.assign(exports, { other: () => true });
+}
+""",
+        encoding="utf-8",
+    )
+    (repo / "app.cjs").write_text(
+        'const { real, other } = require("./api.cjs");\nreal();\nother();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["reasons"] == [
+        {"code": "surface_conditional_commonjs_export", "count": 2}
+    ]
+
+
+def test_js_api_hallucination_does_not_fall_through_uncertain_nested_condition(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "nested-package",
+                "exports": {
+                    ".": {
+                        "import": {
+                            "custom": "./custom.js",
+                            "default": "./actual.js",
+                        },
+                        "default": "./fallback.js",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (repo / "custom.js").write_text(
+        "export function customOnly() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "actual.js").write_text(
+        "export function real() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "fallback.js").write_text(
+        "export function fallbackOnly() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.mjs").write_text(
+        'import { real } from "nested-package";\nreal();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["reasons"] == [
+        {"code": "unsupported_import_package_condition", "count": 1}
+    ]
+
+
+def test_js_api_hallucination_does_not_verify_incomplete_surface_member(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "api.cjs").write_text(
+        """
+module.exports = { real: () => true };
+if (process.env.DISABLE_API) {
+  module.exports = {};
+}
+""",
+        encoding="utf-8",
+    )
+    (repo / "app.cjs").write_text(
+        'const { real } = require("./api.cjs");\nreal();\n',
+        encoding="utf-8",
+    )
+
+    findings, coverage = _scan(repo)
+
+    assert findings == []
+    assert coverage["outcome"] == "incomplete"
+    assert coverage["verified_references"] == 0
+    assert coverage["reasons"] == [
+        {"code": "surface_conditional_commonjs_export", "count": 1}
+    ]

--- a/test/test_js_api_surface.py
+++ b/test/test_js_api_surface.py
@@ -106,7 +106,9 @@ module.exports.more = () => true;
     assert len(surfaces) == 1
     surface = surfaces[0]
     assert surface["name"] == "legacy-lib"
-    assert surface["exports"] == ["legacy", "more", "named"]
+    assert surface["exports"] == ["default", "legacy", "more", "named"]
+    assert surface["members"]["default"]["kind"] == "commonjs"
+    assert surface["members"]["default"]["source"] == "commonjs_default_facade"
     assert surface["members"]["legacy"]["kind"] == "value"
     assert surface["members"]["named"]["kind"] == "function"
     assert surface["members"]["more"]["kind"] == "function"
@@ -189,7 +191,11 @@ function install() {
     surfaces = build_js_api_surfaces(repo)
 
     assert len(surfaces) == 1
-    assert surfaces[0]["exports"] == ["visible"]
+    assert surfaces[0]["exports"] == ["default", "visible"]
+    assert surfaces[0]["metadata"]["complete"] is False
+    assert surfaces[0]["metadata"]["incomplete_reasons"] == [
+        "conditional_commonjs_export"
+    ]
 
 
 def test_js_api_surface_local_named_exports_require_existing_binding(tmp_path):

--- a/test/test_verify_change.py
+++ b/test/test_verify_change.py
@@ -42,7 +42,7 @@ def test_build_verify_change_response_filters_to_ai_findings(tmp_path):
 
     payload = build_verify_change_response(result, project_root=tmp_path)
 
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
     assert payload["tool"] == "verify_change"
     assert payload["status"] == "fail"
     assert payload["summary"] == "1 AI-code issue found"
@@ -55,6 +55,35 @@ def test_build_verify_change_response_filters_to_ai_findings(tmp_path):
     assert finding["range"]["file"] == "app.py"
     assert finding["range"]["start_line"] == 2
     assert finding["suggested_fix"]
+
+
+def test_build_verify_change_response_marks_unproven_references_incomplete(tmp_path):
+    result = {
+        "analysis_summary": {
+            "ai_verification": {
+                "schema_version": 1,
+                "state": "incomplete",
+                "completed_checks": ["typescript_local_api_surface"],
+                "skipped_checks": [],
+                "checks": [
+                    {
+                        "id": "typescript_local_api_surface",
+                        "status": "completed",
+                        "outcome": "incomplete",
+                        "skipped_references": 2,
+                    }
+                ],
+            }
+        }
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    assert payload["status"] == "incomplete"
+    assert payload["coverage"]["state"] == "incomplete"
+    assert payload["summary"] == (
+        "Verification incomplete: 2 references could not be proven"
+    )
 
 
 def test_build_verify_change_response_preserves_finding_metadata(tmp_path):
@@ -578,6 +607,117 @@ def test_verify_change_path_runs_existing_vibe_rules(tmp_path):
     assert payload["status"] == "fail"
     assert any(f["rule_id"] == "SKY-L012" for f in payload["findings"])
     assert all(f["range"]["start_line"] == 2 for f in payload["findings"])
+
+
+def test_verify_change_path_fails_on_missing_local_typescript_export(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "security.ts").write_text(
+        "export function verifyToken() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        'import { verifyTenant } from "./security";\nverifyTenant();\n',
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(repo)
+
+    assert payload["status"] == "fail"
+    finding = next(
+        finding
+        for finding in payload["findings"]
+        if finding["rule_id"] == "SKY-L012"
+    )
+    assert finding["range"]["file"] == "app.ts"
+    assert finding["metadata"]["language"] == "typescript"
+    assert finding["metadata"]["reference_kind"] == "named_import"
+    assert payload["coverage"]["state"] == "complete"
+
+
+def test_verify_change_path_passes_clean_local_typescript_surface(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "security.ts").write_text(
+        "export function verifyToken() { return true; }\n",
+        encoding="utf-8",
+    )
+    (repo / "app.ts").write_text(
+        'import { verifyToken } from "./security";\nverifyToken();\n',
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(repo)
+
+    assert payload["status"] == "pass"
+    check = payload["coverage"]["checks"][0]
+    assert check["id"] == "typescript_local_api_surface"
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_verify_change_path_is_incomplete_for_unresolved_typescript_dependency(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.ts").write_text(
+        'import { useState } from "react";\nuseState();\n',
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(repo)
+
+    assert payload["status"] == "incomplete"
+    assert payload["findings"] == []
+    check = payload["coverage"]["checks"][0]
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "external_or_unresolved_module", "count": 1}
+    ]
+
+
+def test_verify_change_file_uses_declared_monorepo_root(tmp_path):
+    repo = tmp_path / "repo"
+    app = repo / "apps" / "web"
+    api = repo / "packages" / "api"
+    (app / "src").mkdir(parents=True)
+    (api / "src").mkdir(parents=True)
+    (repo / "package.json").write_text(
+        json.dumps({"name": "root", "workspaces": ["apps/*", "packages/*"]}),
+        encoding="utf-8",
+    )
+    (app / "package.json").write_text(
+        json.dumps({"name": "web", "private": True}),
+        encoding="utf-8",
+    )
+    (api / "package.json").write_text(
+        json.dumps({"name": "@acme/api", "exports": "./src/index.ts"}),
+        encoding="utf-8",
+    )
+    (api / "src" / "index.ts").write_text(
+        "export function existing() { return true; }\n",
+        encoding="utf-8",
+    )
+    app_file = app / "src" / "app.ts"
+    app_file.write_text(
+        'import { missing } from "@acme/api";\nmissing();\n',
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(
+        app_file,
+        include_dependency_hallucinations=False,
+    )
+
+    assert payload["status"] == "fail"
+    finding = next(
+        finding
+        for finding in payload["findings"]
+        if finding["rule_id"] == "SKY-L012"
+    )
+    assert finding["metadata"]["module_source"] == "@acme/api"
+    assert finding["metadata"]["member_name"] == "missing"
 
 
 def test_verify_change_path_accepts_injected_analyzer_result(tmp_path):

--- a/test/test_verify_cmd.py
+++ b/test/test_verify_cmd.py
@@ -112,6 +112,26 @@ def test_run_verify_command_fails_on_findings_unless_disabled(capsys):
     assert no_fail_code == 0
 
 
+def test_run_verify_command_uses_distinct_incomplete_exit_code(capsys):
+    payload = {
+        "schema_version": 2,
+        "tool": "verify_change",
+        "status": "incomplete",
+        "target": {"path": ".", "file": None, "range": None},
+        "findings": [],
+        "summary": "Verification incomplete: 1 reference could not be proven",
+    }
+
+    exit_code = run_verify_command(
+        ["."],
+        verify_change_path_func=lambda *args, **kwargs: payload,
+        parse_exclude_folders_func=lambda **_kwargs: (),
+    )
+
+    assert exit_code == 2
+    assert json.loads(capsys.readouterr().out)["status"] == "incomplete"
+
+
 def test_run_verify_command_reads_stdin_manifest(monkeypatch, capsys):
     seen = {}
 


### PR DESCRIPTION
## Summary

  - Add eddeterministic TS/JS local and workspace API verification.
  - Introduced `pass`, `fail`, and `incomplete` verification outcomes.
  - Report Go engine availability and incomplete language coverage.
  - Add language-labelled AI defect benchmarks and fixtures.

## Tests

  - `pytest .`

## Notes

  The main behavioral change is that verification can now distinguish an established pass from an incomplete proof. This prevents unresolved or dynamic language behavior from being reported as successfully verified.