### PR TITLE
feat(verify): add cross-language API verification coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,17 @@ skylos verify . --file src/app.py --range 40:75 --project-context
 
 `skylos verify` schema version 2 returns `pass`, `fail`, or `incomplete`.
 `incomplete` means a requested proof could not be established, such as a
-third-party TS/JS import or computed namespace member that Skylos did not
-resolve; it exits `2` unless `--no-fail` is set. The `coverage` object lists
-completed checks, skipped checks, checked references, and skip reasons.
+third-party TS/JS import, computed namespace member, unsupported language-local
+API check, or parser surface that Skylos could not prove; it exits `2` unless
+`--no-fail` is set. The `coverage` object lists detected languages, expected
+checks, language support, missing checks, completed/skipped checks, checked
+references, and deterministic skip reasons.
 
-For TypeScript and JavaScript, verification checks named imports, default and
-type-only imports, static namespace members, re-exports, and CommonJS exports
-against local and workspace package surfaces without executing Node.js.
+Deterministic local/workspace API verification currently covers Python,
+TypeScript/JavaScript, Go, and Java without executing target code. PHP, Rust,
+Dart, C#, Kotlin, and Shell retain their existing static-analysis coverage,
+but their local API proof is reported as unsupported and therefore incomplete.
+See [AI Code Verification Coverage](./docs/ai-code-verification.md).
 
 Create a local AI hallucination contract for repo-specific generated-code
 truth. `skylos verify` auto-discovers `.skylos/ai-contract.yml`:
@@ -345,17 +349,18 @@ or `--include-folder` to override an excluded folder.
 
 ## Language Support
 
-| Language | Dead Code | Security | Quality | Notes |
-|:---|:---:|:---:|:---:|:---|
-| Python | Yes | Yes | Yes | strongest coverage; framework-aware static analysis and optional tracing |
-| TypeScript / JavaScript | Yes | Yes | Yes | Tree-sitter parsing, package graph reachability, framework conventions, local/workspace API hallucination checks |
-| Java | Yes | Yes | Yes | Tree-sitter parsing and structured security-flow analysis |
-| Go | Yes | Partial | Partial | native engine availability is reported in scan JSON and `skylos doctor --format json` |
-| PHP | Yes | Yes | Partial | PHP parser coverage plus taint-style security sinks and sources |
-| Rust | Yes | Yes | Partial | Rust parser coverage plus security sink/source checks |
-| Dart | Yes | Yes | Partial | Dart parser coverage plus selected security sinks and sources |
-| C# | Yes | Yes | Partial | C# symbol coverage plus selected ASP.NET, process, SQL, HTTP, and file sinks |
-| Shell | No | Yes | Partial | shell-script security checks for command injection, SSRF, and path traversal |
+| Language | Dead Code | Security | Quality | Local API Proof (`verify`) | Notes |
+|:---|:---:|:---:|:---:|:---:|:---|
+| Python | Yes | Yes | Yes | Supported | strongest coverage; framework-aware static analysis and optional tracing |
+| TypeScript / JavaScript | Yes | Yes | Yes | Supported | Tree-sitter parsing, package graph reachability, framework conventions |
+| Java | Yes | Yes | Yes | Supported | Tree-sitter parsing, structured security-flow analysis, conservative static-member proof |
+| Go | Yes | Partial | Partial | Supported | native engine status remains separate from deterministic workspace API proof |
+| PHP | Yes | Yes | Partial | Unsupported | PHP parser coverage plus taint-style security sinks and sources |
+| Rust | Yes | Yes | Partial | Unsupported | Rust parser coverage plus security sink/source checks |
+| Dart | Yes | Yes | Partial | Unsupported | Dart parser coverage plus selected security sinks and sources |
+| C# | Yes | Yes | Partial | Unsupported | C# symbol coverage plus selected ASP.NET, process, SQL, HTTP, and file sinks |
+| Kotlin | Yes | Partial | Partial | Unsupported | Kotlin symbol extraction with conservative static-analysis coverage |
+| Shell | No | Yes | Partial | Unsupported | shell-script security checks for command injection, SSRF, and path traversal |
 
 See [Rules Reference](https://docs.skylos.dev/rules-reference) for rule families
 and scanner scope.

--- a/benchmarks/ai_code_defects/fixtures/clean_go_local_api_surface/cmd/app/main.go
+++ b/benchmarks/ai_code_defects/fixtures/clean_go_local_api_surface/cmd/app/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "example.com/skylos-clean-go-surface/security"
+
+func main() {
+	security.VerifyToken("token")
+}

--- a/benchmarks/ai_code_defects/fixtures/clean_go_local_api_surface/go.mod
+++ b/benchmarks/ai_code_defects/fixtures/clean_go_local_api_surface/go.mod
@@ -1,0 +1,3 @@
+module example.com/skylos-clean-go-surface
+
+go 1.22

--- a/benchmarks/ai_code_defects/fixtures/clean_go_local_api_surface/security/security.go
+++ b/benchmarks/ai_code_defects/fixtures/clean_go_local_api_surface/security/security.go
@@ -1,0 +1,5 @@
+package security
+
+func VerifyToken(value string) bool {
+	return value != ""
+}

--- a/benchmarks/ai_code_defects/fixtures/clean_java_local_api_surface/src/demo/app/App.java
+++ b/benchmarks/ai_code_defects/fixtures/clean_java_local_api_surface/src/demo/app/App.java
@@ -1,0 +1,9 @@
+package demo.app;
+
+import demo.security.TokenVerifier;
+
+class App {
+    boolean run() {
+        return TokenVerifier.verify("token");
+    }
+}

--- a/benchmarks/ai_code_defects/fixtures/clean_java_local_api_surface/src/demo/security/TokenVerifier.java
+++ b/benchmarks/ai_code_defects/fixtures/clean_java_local_api_surface/src/demo/security/TokenVerifier.java
@@ -1,0 +1,7 @@
+package demo.security;
+
+public final class TokenVerifier {
+    public static boolean verify(String value) {
+        return value != null;
+    }
+}

--- a/benchmarks/ai_code_defects/fixtures/go_local_api_hallucination/cmd/app/main.go
+++ b/benchmarks/ai_code_defects/fixtures/go_local_api_hallucination/cmd/app/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "example.com/skylos-go-hallucination/security"
+
+func main() {
+	security.VerifySession("token")
+}

--- a/benchmarks/ai_code_defects/fixtures/go_local_api_hallucination/go.mod
+++ b/benchmarks/ai_code_defects/fixtures/go_local_api_hallucination/go.mod
@@ -1,0 +1,3 @@
+module example.com/skylos-go-hallucination
+
+go 1.22

--- a/benchmarks/ai_code_defects/fixtures/go_local_api_hallucination/security/security.go
+++ b/benchmarks/ai_code_defects/fixtures/go_local_api_hallucination/security/security.go
@@ -1,0 +1,5 @@
+package security
+
+func VerifyToken(value string) bool {
+	return value != ""
+}

--- a/benchmarks/ai_code_defects/fixtures/java_local_api_hallucination/src/demo/app/App.java
+++ b/benchmarks/ai_code_defects/fixtures/java_local_api_hallucination/src/demo/app/App.java
@@ -1,0 +1,9 @@
+package demo.app;
+
+import demo.security.TokenVerifier;
+
+class App {
+    boolean run() {
+        return TokenVerifier.verifySession("token");
+    }
+}

--- a/benchmarks/ai_code_defects/fixtures/java_local_api_hallucination/src/demo/security/TokenVerifier.java
+++ b/benchmarks/ai_code_defects/fixtures/java_local_api_hallucination/src/demo/security/TokenVerifier.java
@@ -1,0 +1,7 @@
+package demo.security;
+
+public final class TokenVerifier {
+    public static boolean verify(String value) {
+        return value != null;
+    }
+}

--- a/benchmarks/ai_code_defects/manifest.json
+++ b/benchmarks/ai_code_defects/manifest.json
@@ -1437,6 +1437,152 @@
       }
     },
     {
+      "id": "go-local-api-hallucination",
+      "language": "go",
+      "path": "fixtures/go_local_api_hallucination",
+      "description": "Generated Go code calls an exported symbol that does not exist in a local module package.",
+      "taxonomy": ["hallucinated_reference"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic recall fixture for deterministic Go workspace API-surface verification."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true
+      },
+      "expect": {
+        "finding_count": 1,
+        "verification": {
+          "status": "fail",
+          "coverage_state": "complete",
+          "checks": {
+            "go_workspace_api_surface": "fail"
+          }
+        },
+        "present": [
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference",
+            "file_contains": "cmd/app/main.go",
+            "metadata": {
+              "language": "go",
+              "reference_kind": "package_selector"
+            }
+          }
+        ],
+        "absent": []
+      }
+    },
+    {
+      "id": "clean-go-local-api-surface",
+      "language": "go",
+      "path": "fixtures/clean_go_local_api_surface",
+      "description": "Generated Go code calls an existing exported symbol in a local module package.",
+      "taxonomy": ["hallucinated_reference", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic precision fixture for deterministic Go workspace API-surface verification."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true
+      },
+      "expect": {
+        "finding_count": 0,
+        "verification": {
+          "status": "pass",
+          "coverage_state": "complete",
+          "checks": {
+            "go_workspace_api_surface": "pass"
+          }
+        },
+        "present": [],
+        "absent": [
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference"
+          }
+        ]
+      }
+    },
+    {
+      "id": "java-local-api-hallucination",
+      "language": "java",
+      "path": "fixtures/java_local_api_hallucination",
+      "description": "Generated Java code calls a static member that does not exist on an explicitly imported local type.",
+      "taxonomy": ["hallucinated_reference"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic recall fixture for deterministic Java workspace API-surface verification."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true
+      },
+      "expect": {
+        "finding_count": 1,
+        "verification": {
+          "status": "fail",
+          "coverage_state": "complete",
+          "checks": {
+            "java_workspace_api_surface": "fail"
+          }
+        },
+        "present": [
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference",
+            "file_contains": "src/demo/app/App.java",
+            "metadata": {
+              "language": "java",
+              "reference_kind": "static_member"
+            }
+          }
+        ],
+        "absent": []
+      }
+    },
+    {
+      "id": "clean-java-local-api-surface",
+      "language": "java",
+      "path": "fixtures/clean_java_local_api_surface",
+      "description": "Generated Java code calls an existing static member on an explicitly imported local type.",
+      "taxonomy": ["hallucinated_reference", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/duriantaco/skylos",
+        "license": "MIT",
+        "notes": "Synthetic precision fixture for deterministic Java workspace API-surface verification."
+      },
+      "scan": {
+        "confidence": 60,
+        "project_context": true
+      },
+      "expect": {
+        "finding_count": 0,
+        "verification": {
+          "status": "pass",
+          "coverage_state": "complete",
+          "checks": {
+            "java_workspace_api_surface": "pass"
+          }
+        },
+        "present": [],
+        "absent": [
+          {
+            "rule_id": "SKY-L012",
+            "vibe_category": "hallucinated_reference"
+          }
+        ]
+      }
+    },
+    {
       "id": "clean-generated-code",
       "language": "python",
       "path": "fixtures/clean_generated_code",

--- a/dictionary.md
+++ b/dictionary.md
@@ -302,7 +302,7 @@ use the `SKY-A` prefix.
 | A103 | HIGH | CI permission expansion | GitHub Actions |
 | A104 | MEDIUM | Public CLI surface drift | Diff-aware CLI |
 | A105 | HIGH | Contract route guard missing | Python contract verify |
-| L012 | CRITICAL | Phantom function, import, or module-member reference | Python, TS/JS |
+| L012 | CRITICAL | Phantom function, import, or module-member reference | Python, TS/JS, Go, Java |
 | L023 | CRITICAL | Phantom decorator | Python |
 | D222 | CRITICAL | Dependency hallucination | Python |
 | D224 | HIGH | API signature hallucination | Python |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This repository keeps lightweight local docs for features that need examples clo
 |:---|:---|
 | Generated codebase navigator for contributors | [Skylos Repo Map](./repo-map/index.html) |
 | CLI output modes, pretty reports, and TUI controls | [CLI Output Modes](./cli-output.md) |
+| Deterministic AI-code verification coverage and language support | [AI Code Verification](./ai-code-verification.md) |
 | Local contracts for verifying AI-written code | [AI Hallucination Contracts](./ai-hallucination-contracts.md) |
 | Pre-deployment agent verification, evidence reports, and attestation | [Agent Verification](./agent-verification.md) |
 | Rule ID prefixes and product terminology | [Rule Dictionary](../dictionary.md) |

--- a/docs/ai-code-verification.md
+++ b/docs/ai-code-verification.md
@@ -1,0 +1,168 @@
+# AI Code Verification Coverage
+
+`skylos verify` checks generated or edited source code before an agent hands it
+to review. It is deterministic static analysis: Skylos does not execute target
+code, invoke package managers or compilers, call an LLM judge, or query a
+network service for local/workspace API verification.
+
+This command has a narrower purpose than `skylos defend`:
+
+- `skylos verify`: did the edited code contain a proven AI-code defect, and did
+  every applicable deterministic verification check complete?
+- `skylos defend`: does an agent implementation contain expected static
+  guardrails before deployment?
+
+Neither command currently proves the runtime behavior of a running agent.
+
+## Status and exit codes
+
+Schema-version-2 responses use three statuses:
+
+| Status | Exit | Meaning |
+|:---|:---:|:---|
+| `pass` | `0` | No verified findings and every applicable expected check completed |
+| `fail` | `1` | At least one verified AI-code finding exists |
+| `incomplete` | `2` | No finding exists, but one or more required proofs were unsupported, skipped, uncertain, or missing |
+
+Findings take precedence over incomplete coverage. `--no-fail` changes the
+process exit code to `0`, but does not change the JSON status.
+
+## Local API verification support
+
+The local/workspace API suite currently has deterministic proof for:
+
+| Language | Check ID | Scope |
+|:---|:---|:---|
+| Python | `python_local_api_reference` | Repo-local imported references with statically resolvable module surfaces |
+| TypeScript / JavaScript | `typescript_local_api_surface` | Local and workspace imports, exports, namespaces, re-exports, and CommonJS surfaces |
+| Go | `go_workspace_api_surface` | Exported selectors from local modules, workspaces, and local replacements |
+| Java | `java_workspace_api_surface` | Explicitly attributable local types and statically knowable members |
+
+PHP, Rust, Dart, C#, Kotlin, and Shell remain supported by their existing
+Skylos static-analysis rules, but deterministic local/workspace API proof is
+not implemented for those languages. Their expected checks are emitted as
+unsupported and `skylos verify` reports `incomplete` rather than silently
+claiming a complete proof.
+
+## Coverage object
+
+When AI verification runs, the response includes an `coverage` object:
+
+```json
+{
+  "schema_version": 1,
+  "state": "incomplete",
+  "detected_languages": ["go", "php"],
+  "expected_checks": [
+    {
+      "id": "go_workspace_api_surface",
+      "languages": ["go"],
+      "applicable_files": 2,
+      "capability": "local_workspace_api_surface",
+      "support": "supported"
+    },
+    {
+      "id": "php_workspace_api_surface",
+      "languages": ["php"],
+      "applicable_files": 1,
+      "capability": "local_workspace_api_surface",
+      "support": "unsupported",
+      "reason": "local_api_verification_not_implemented"
+    }
+  ],
+  "missing_checks": [],
+  "language_support": [
+    {
+      "language": "go",
+      "capability": "local_workspace_api_surface",
+      "status": "supported",
+      "check_id": "go_workspace_api_surface"
+    },
+    {
+      "language": "php",
+      "capability": "local_workspace_api_surface",
+      "status": "unsupported",
+      "check_id": "php_workspace_api_surface",
+      "reason": "local_api_verification_not_implemented"
+    }
+  ],
+  "completed_checks": ["go_workspace_api_surface"],
+  "skipped_checks": [
+    {
+      "id": "php_workspace_api_surface",
+      "reasons": ["unsupported_capability"]
+    }
+  ],
+  "checks": [
+    {
+      "id": "go_workspace_api_surface",
+      "status": "completed",
+      "outcome": "pass",
+      "references": 1,
+      "verified_references": 1,
+      "skipped_references": 0,
+      "finding_count": 0
+    },
+    {
+      "id": "php_workspace_api_surface",
+      "status": "skipped",
+      "outcome": "incomplete",
+      "references": 0,
+      "verified_references": 0,
+      "skipped_references": 0,
+      "finding_count": 0,
+      "reasons": [{"code": "unsupported_capability", "count": 1}]
+    }
+  ]
+}
+```
+
+Fields have these meanings:
+
+- `state`: `complete` only when every applicable expected proof completed;
+  otherwise `incomplete`.
+- `detected_languages`: canonical source-language labels found in the selected
+  scan files.
+- `expected_checks`: the required proof universe derived from those files,
+  including explicit support state.
+- `missing_checks`: supported checks that were expected but produced no record.
+- `language_support`: one support record per detected language and capability.
+- `completed_checks`: check IDs whose detector completed, including detectors
+  that completed with verified findings.
+- `skipped_checks`: skipped check IDs and deterministic reason codes.
+- `checks`: reconciled check records with reference, finding, and skip counts.
+
+Malformed or duplicate detector records are reconciled conservatively. They
+add `malformed_check_record` or `duplicate_check_record` reasons and keep
+coverage incomplete instead of allowing the last record to silently win.
+
+Inline `skylos: ignore` comments are explicit waivers. A waived finding is
+removed from the failure count, but its check records `suppressed_findings` and
+a `finding_suppressed` reason so the resulting pass is not silent. Project-level
+rule disables remain incomplete because the required detector did not run.
+
+The TypeScript/JavaScript languages share one check record when both are
+present. A repository with no applicable source files has no expected checks
+and remains complete.
+
+## Conservative proof rules
+
+`SKY-L012` remains the common hallucinated-reference rule across languages.
+Findings add `metadata.language` and `metadata.reference_kind` rather than
+creating language-specific rule IDs.
+
+Skylos reports a finding only when the relevant local API surface is complete.
+Parser failures, wildcard ownership, build-conditional Go surfaces, ambiguous
+packages or Java types, generated/inherited Java members, shadowed qualifiers,
+and unsupported instance-type inference produce incomplete coverage instead of
+a critical finding or a false pass.
+
+Java proof is also bounded by source set, nearest build/source module, member
+kind, and visibility. Test fixtures or unrelated modules cannot prove a
+production reference; nested-type and protected cross-package cases remain
+incomplete when inheritance or ownership cannot be established statically.
+File-scoped Go and Java scans carry `exclude_folders` into workspace discovery;
+excluded workspace paths therefore cannot supply evidence. Python imports that
+resolve to local modules outside the selected subtree are reported as
+`local_import_outside_scan` incompleteness rather than being trusted or treated
+as external.

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -51,7 +51,6 @@ from skylos.core.file_discovery import (
 from skylos.core.linter import LinterVisitor
 
 from skylos.rules.quality.policy import analyze_repo_policy
-from skylos.rules.ai_defect.phantom_refs import scan_repo_phantom_security_references
 from skylos.rules.vibe_dictionary import build_vibe_dictionary
 from skylos.rules.quality.clones import (
     CloneConfig,
@@ -123,6 +122,31 @@ def _python_signature_files(files):
     return py_files
 
 
+def _verification_surface_root(path, discovered_root, project_root):
+    targets = path if isinstance(path, (list, tuple)) else [path]
+    resolved_targets = [Path(target).resolve() for target in targets]
+    if resolved_targets and all(target.is_file() for target in resolved_targets):
+        return project_root
+    return Path(discovered_root).resolve()
+
+
+def _verification_should_discover_workspace(path):
+    targets = path if isinstance(path, (list, tuple)) else [path]
+    resolved_targets = [Path(target).resolve() for target in targets]
+    return bool(resolved_targets) and all(
+        target.is_file() for target in resolved_targets
+    )
+
+
+def _python_verification_surface_root(surface_root):
+    root = Path(surface_root).resolve()
+    if any(
+        (root / f"__init__{suffix}").is_file() for suffix in PYTHON_SIGNATURE_SUFFIXES
+    ):
+        return root.parent
+    return root
+
+
 def _extend_unsuppressed_danger_findings(
     findings,
     *,
@@ -169,6 +193,38 @@ def _extend_unsuppressed_ai_defect_findings(
             continue
 
         all_ai_defects.append(finding)
+
+
+def _append_ai_verification_result(
+    findings,
+    check,
+    *,
+    project_ignore,
+    per_file_ignore_lines,
+    all_ai_defects,
+    all_suppressed,
+    verification_checks,
+):
+    from skylos.core.verification_coverage import reconcile_check_findings
+
+    before_count = len(all_ai_defects)
+    before_suppressed = len(all_suppressed)
+    _extend_unsuppressed_ai_defect_findings(
+        findings,
+        project_ignore=project_ignore,
+        per_file_ignore_lines=per_file_ignore_lines,
+        all_ai_defects=all_ai_defects,
+        all_suppressed=all_suppressed,
+    )
+    accepted_count = len(all_ai_defects) - before_count
+    suppressed_count = len(all_suppressed) - before_suppressed
+    verification_checks.append(
+        reconcile_check_findings(
+            check,
+            accepted_count,
+            suppressed_count=suppressed_count,
+        )
+    )
 
 
 def _relative_changed_file(root, changed_file):
@@ -681,8 +737,10 @@ class Skylos:
                 p = p[source_root_idx + 1 :]
                 break
 
-        if p[-1].endswith(".py"):
-            p[-1] = p[-1][:-3]
+        for suffix in PYTHON_SIGNATURE_SUFFIXES:
+            if p[-1].endswith(suffix):
+                p[-1] = p[-1][: -len(suffix)]
+                break
         if p[-1] == "__init__":
             p.pop()
         return ".".join(p)
@@ -773,13 +831,11 @@ class Skylos:
         p = Path(path).resolve()
 
         if p.is_file():
-            if p.suffix == ".pyi":
-                return [], p.parent
             return [p], p.parent
 
         root = p
         exts = {
-            ".py",
+            *PYTHON_SIGNATURE_SUFFIXES,
             ".go",
             *(_TS_JS_SOURCE_EXTS),
             ".java",
@@ -792,6 +848,8 @@ class Skylos:
         }
         ext_list = [
             "py",
+            "pyi",
+            "pyw",
             "go",
             "ts",
             "tsx",
@@ -2111,6 +2169,20 @@ class Skylos:
             project_root = _resolve_analysis_root(project_root)
 
         files, root = self._discover_files(path, exclude_folders)
+        verification_surface_root = _verification_surface_root(
+            path,
+            root,
+            project_root,
+        )
+        if enable_ai_defects:
+            from skylos.core.verification_registry import (
+                expected_ai_verification_checks,
+            )
+
+            self._ai_verification_expectations = expected_ai_verification_checks(files)
+        else:
+            self._ai_verification_expectations = None
+        self._ai_verification_checks = [] if enable_ai_defects else None
         self._language_engine_reports = {}
         go_engine_report = _go_engine_analysis_report(files)
         if go_engine_report is not None:
@@ -2200,6 +2272,17 @@ class Skylos:
                     result["analysis_summary"]["ai_defects_count"] = len(
                         ai_defect_findings
                     )
+            if enable_ai_defects:
+                from skylos.core.verification_coverage import (
+                    build_ai_verification_coverage,
+                )
+
+                result["analysis_summary"]["ai_verification"] = (
+                    build_ai_verification_coverage(
+                        self._ai_verification_checks,
+                        expected_checks=self._ai_verification_expectations,
+                    )
+                )
             return json.dumps(result)
 
         logger.info(f"Analyzing {len(files)} files...")
@@ -2268,7 +2351,6 @@ class Skylos:
         all_dangers = []
         all_quality = []
         all_ai_defects = []
-        self._ai_verification_checks = [] if enable_ai_defects else None
         all_suppressed = []
         empty_files = []
         file_contexts = []
@@ -3034,42 +3116,85 @@ class Skylos:
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error(traceback.format_exc())
 
-            try:
-                _ai_py_files = [
-                    f for f in files if str(f).endswith((".py", ".pyi", ".pyw"))
-                ]
-                if (
-                    _ai_py_files
-                    and (
-                        "SKY-L012" not in project_ignore
-                        or "SKY-L023" not in project_ignore
+            _ai_py_files = [
+                f for f in files if str(f).endswith((".py", ".pyi", ".pyw"))
+            ]
+            if _ai_py_files:
+                from skylos.rules.ai_defect.python_api_hallucination import (
+                    failed_python_api_check,
+                    scan_python_local_api_hallucinations,
+                    skipped_python_api_check,
+                )
+
+                ignored_python_rules = {"SKY-L012", "SKY-L023"} & project_ignore
+                vibe_dictionary = build_vibe_dictionary(project_cfg.get("vibe"))
+                if ignored_python_rules == {"SKY-L012", "SKY-L023"}:
+                    self._ai_verification_checks.append(
+                        skipped_python_api_check("rule_ignored")
                     )
-                    and project_root.exists()
-                ):
-                    repo_py_files = discover_source_files(
-                        project_root,
-                        {".py"},
-                        exclude_folders=exclude_folders,
+                elif not project_root.exists():
+                    self._ai_verification_checks.append(
+                        failed_python_api_check("invalid_project_root")
                     )
-                    phantom_findings = scan_repo_phantom_security_references(
-                        project_root,
-                        repo_py_files,
-                        target_files=_ai_py_files,
-                        vibe_dictionary=build_vibe_dictionary(project_cfg.get("vibe")),
-                    )
-                    _extend_unsuppressed_ai_defect_findings(
-                        phantom_findings,
-                        project_ignore=project_ignore,
-                        per_file_ignore_lines=per_file_ignore_lines,
-                        all_ai_defects=all_ai_defects,
-                        all_suppressed=all_suppressed,
-                    )
+                else:
+                    try:
+                        if _verification_should_discover_workspace(path):
+                            python_verification_root = project_root
+                            repo_py_files = discover_source_files(
+                                project_root,
+                                set(PYTHON_SIGNATURE_SUFFIXES),
+                                exclude_folders=exclude_folders,
+                            )
+                        else:
+                            python_verification_root = (
+                                _python_verification_surface_root(
+                                    verification_surface_root
+                                )
+                            )
+                            repo_py_files = list(_ai_py_files)
+                        phantom_findings, python_check = (
+                            scan_python_local_api_hallucinations(
+                                python_verification_root,
+                                repo_py_files,
+                                target_files=_ai_py_files,
+                                vibe_dictionary=vibe_dictionary,
+                            )
+                        )
+                        if ignored_python_rules:
+                            python_check["skipped_references"] = int(
+                                python_check.get("skipped_references") or 0
+                            ) + len(ignored_python_rules)
+                            python_check.setdefault("reasons", []).append(
+                                {
+                                    "code": "rule_ignored",
+                                    "count": len(ignored_python_rules),
+                                }
+                            )
+                        _append_ai_verification_result(
+                            phantom_findings,
+                            python_check,
+                            project_ignore=project_ignore,
+                            per_file_ignore_lines=per_file_ignore_lines,
+                            all_ai_defects=all_ai_defects,
+                            all_suppressed=all_suppressed,
+                            verification_checks=self._ai_verification_checks,
+                        )
+                    except Exception:
+                        self._ai_verification_checks.append(
+                            failed_python_api_check("detector_error")
+                        )
+                        if os.getenv("SKYLOS_DEBUG"):
+                            logger.error(
+                                "Python API hallucination scan failed",
+                                exc_info=True,
+                            )
+
+                try:
                     from skylos.rules.ai_defect import (
                         PhantomCallRule,
                         PhantomDecoratorRule,
                     )
 
-                    vibe_dictionary = build_vibe_dictionary(project_cfg.get("vibe"))
                     fallback_rules = []
                     if "SKY-L012" not in project_ignore:
                         fallback_rules.append(
@@ -3095,9 +3220,91 @@ class Skylos:
                             all_ai_defects=all_ai_defects,
                             all_suppressed=all_suppressed,
                         )
-            except Exception:
-                if os.getenv("SKYLOS_DEBUG"):
-                    logger.error(traceback.format_exc())
+                except Exception:
+                    if os.getenv("SKYLOS_DEBUG"):
+                        logger.error(traceback.format_exc())
+
+            _ai_go_files = [f for f in files if str(f).endswith(".go")]
+            if _ai_go_files:
+                from skylos.rules.ai_defect.go_api_hallucination import (
+                    failed_go_api_check,
+                    scan_go_local_api_hallucinations,
+                    skipped_go_api_check,
+                )
+
+                if "SKY-L012" in project_ignore:
+                    self._ai_verification_checks.append(
+                        skipped_go_api_check("rule_ignored")
+                    )
+                else:
+                    try:
+                        go_findings, go_check = scan_go_local_api_hallucinations(
+                            project_root,
+                            _ai_go_files,
+                            restrict_to_files=not _verification_should_discover_workspace(
+                                path
+                            ),
+                            exclude_folders=exclude_folders,
+                        )
+                        _append_ai_verification_result(
+                            go_findings,
+                            go_check,
+                            project_ignore=project_ignore,
+                            per_file_ignore_lines=per_file_ignore_lines,
+                            all_ai_defects=all_ai_defects,
+                            all_suppressed=all_suppressed,
+                            verification_checks=self._ai_verification_checks,
+                        )
+                    except Exception:
+                        self._ai_verification_checks.append(
+                            failed_go_api_check("detector_error")
+                        )
+                        if os.getenv("SKYLOS_DEBUG"):
+                            logger.error(
+                                "Go API hallucination scan failed",
+                                exc_info=True,
+                            )
+
+            _ai_java_files = [f for f in files if str(f).endswith(".java")]
+            if _ai_java_files:
+                from skylos.rules.ai_defect.java_api_hallucination import (
+                    failed_java_api_check,
+                    scan_java_local_api_hallucinations,
+                    skipped_java_api_check,
+                )
+
+                if "SKY-L012" in project_ignore:
+                    self._ai_verification_checks.append(
+                        skipped_java_api_check("rule_ignored")
+                    )
+                else:
+                    try:
+                        java_findings, java_check = scan_java_local_api_hallucinations(
+                            verification_surface_root,
+                            _ai_java_files,
+                            discover_workspace=_verification_should_discover_workspace(
+                                path
+                            ),
+                            exclude_folders=exclude_folders,
+                        )
+                        _append_ai_verification_result(
+                            java_findings,
+                            java_check,
+                            project_ignore=project_ignore,
+                            per_file_ignore_lines=per_file_ignore_lines,
+                            all_ai_defects=all_ai_defects,
+                            all_suppressed=all_suppressed,
+                            verification_checks=self._ai_verification_checks,
+                        )
+                    except Exception:
+                        self._ai_verification_checks.append(
+                            failed_java_api_check("detector_error")
+                        )
+                        if os.getenv("SKYLOS_DEBUG"):
+                            logger.error(
+                                "Java API hallucination scan failed",
+                                exc_info=True,
+                            )
 
             if changed_files and "SKY-A101" not in project_ignore:
                 try:
@@ -3289,7 +3496,6 @@ class Skylos:
                 logger.error("MDX component import graph scan failed", exc_info=True)
 
         if enable_ai_defects:
-            from skylos.core.verification_coverage import reconcile_check_findings
             from skylos.rules.ai_defect.js_api_hallucination import (
                 failed_js_api_check,
                 scan_js_local_api_hallucinations,
@@ -3308,17 +3514,14 @@ class Skylos:
                         ts_raw_imports,
                         monorepo_resolver=monorepo_resolver,
                     )
-                    before_count = len(all_ai_defects)
-                    _extend_unsuppressed_ai_defect_findings(
+                    _append_ai_verification_result(
                         js_findings,
+                        js_check,
                         project_ignore=project_ignore,
                         per_file_ignore_lines=per_file_ignore_lines,
                         all_ai_defects=all_ai_defects,
                         all_suppressed=all_suppressed,
-                    )
-                    accepted_count = len(all_ai_defects) - before_count
-                    self._ai_verification_checks.append(
-                        reconcile_check_findings(js_check, accepted_count)
+                        verification_checks=self._ai_verification_checks,
                     )
                 except Exception:
                     self._ai_verification_checks.append(
@@ -3545,6 +3748,12 @@ def proc_file(
 
         if full_scan and enable_quality_rules:
             quality_findings = scan_python_quality(tree, source, file, cfg)
+            if Path(file).suffix == ".pyi":
+                quality_findings = [
+                    finding
+                    for finding in quality_findings
+                    if finding.get("rule_id") not in {"SKY-L026", "SKY-L033"}
+                ]
 
         if full_scan and enable_danger_rules:
             d_rules = [DangerousCallsRule()]

--- a/skylos/benchmarks/ai_code_defects.py
+++ b/skylos/benchmarks/ai_code_defects.py
@@ -41,10 +41,17 @@ IMPORTANCE_WEIGHTS = {
     "critical": 3.0,
 }
 BENCHMARK_LANGUAGES = {
+    "csharp",
+    "dart",
     "go",
+    "java",
     "javascript",
+    "kotlin",
     "multi",
+    "php",
     "python",
+    "rust",
+    "shell",
     "typescript",
 }
 DEPENDENCY_STATUS_VALUES = {
@@ -343,6 +350,7 @@ def _validate_expectations(case: dict[str, Any], case_id: str) -> None:
         raise ValueError(f"AI-code-defect benchmark case {case_id} needs expectations")
 
     _validate_expectation_finding_count(expect, case_id)
+    _validate_verification_expectation(expect, case_id)
 
     total = 0
     for mode in ("present", "absent"):
@@ -378,6 +386,51 @@ def _validate_expectation_finding_count(
             f"AI-code-defect benchmark case {case_id} expect.finding_count "
             "must not be negative"
         )
+
+
+def _validate_verification_expectation(
+    expect: dict[str, Any],
+    case_id: str,
+) -> None:
+    verification = expect.get("verification")
+    if verification is None:
+        return
+    if not isinstance(verification, dict):
+        raise ValueError(
+            f"AI-code-defect benchmark case {case_id} expect.verification must be an object"
+        )
+    for key, allowed in (
+        ("status", {"pass", "fail", "incomplete"}),
+        ("coverage_state", {"complete", "incomplete"}),
+    ):
+        value = verification.get(key)
+        if value is None:
+            continue
+        if value not in allowed:
+            values = ", ".join(sorted(allowed))
+            raise ValueError(
+                f"AI-code-defect benchmark case {case_id} "
+                f"expect.verification.{key} must be one of: {values}"
+            )
+    checks = verification.get("checks")
+    if checks is None:
+        return
+    if not isinstance(checks, dict) or not checks:
+        raise ValueError(
+            f"AI-code-defect benchmark case {case_id} "
+            "expect.verification.checks must be a non-empty object"
+        )
+    for check_id, outcome in checks.items():
+        if not isinstance(check_id, str) or not check_id:
+            raise ValueError(
+                f"AI-code-defect benchmark case {case_id} verification check IDs "
+                "must be non-empty strings"
+            )
+        if outcome not in {"pass", "fail", "incomplete"}:
+            raise ValueError(
+                f"AI-code-defect benchmark case {case_id} verification check "
+                f"'{check_id}' must expect pass, fail, or incomplete"
+            )
 
 
 def _validate_expectation(expectation: Any, case_id: str, mode: str) -> None:
@@ -683,6 +736,8 @@ def _run_case(
         "importance": case.get("importance", "high"),
         "elapsed_seconds": elapsed,
         "finding_count": len(findings),
+        "status": result.get("status"),
+        "coverage_state": _coverage_state(result),
         "failures": [failure.to_dict() for failure in failures],
         "present_total": counts["present_total"],
         "present_matched": counts["present_matched"],
@@ -855,6 +910,7 @@ def _evaluate_case(
 
     expect = case["expect"]
     _evaluate_finding_count(case, findings, failures)
+    _evaluate_verification_contract(case, result, failures)
 
     for expectation in expect["present"]:
         counts["present_total"] += 1
@@ -884,6 +940,81 @@ def _evaluate_case(
         )
 
     return failures, counts
+
+
+def _evaluate_verification_contract(
+    case: dict[str, Any],
+    result: dict[str, Any],
+    failures: list[AICodeDefectBenchmarkFailure],
+) -> None:
+    verification = case["expect"].get("verification")
+    if not isinstance(verification, dict):
+        return
+    expected_status = verification.get("status")
+    if expected_status is not None and result.get("status") != expected_status:
+        failures.append(
+            AICodeDefectBenchmarkFailure(
+                case["id"],
+                "verification",
+                "status",
+                {"status": expected_status},
+                [{"status": result.get("status")}],
+            )
+        )
+    expected_coverage = verification.get("coverage_state")
+    actual_coverage = _coverage_state(result)
+    if expected_coverage is not None and actual_coverage != expected_coverage:
+        failures.append(
+            AICodeDefectBenchmarkFailure(
+                case["id"],
+                "verification",
+                "coverage_state",
+                {"coverage_state": expected_coverage},
+                [{"coverage_state": actual_coverage}],
+            )
+        )
+    expected_checks = verification.get("checks")
+    if not isinstance(expected_checks, dict):
+        return
+    actual_checks = _coverage_checks(result)
+    for check_id, expected_outcome in expected_checks.items():
+        actual = actual_checks.get(check_id)
+        actual_outcome = actual.get("outcome") if actual is not None else None
+        if actual_outcome == expected_outcome:
+            continue
+        failures.append(
+            AICodeDefectBenchmarkFailure(
+                case["id"],
+                "verification",
+                "check_outcome",
+                {"id": check_id, "outcome": expected_outcome},
+                [actual] if actual is not None else [],
+            )
+        )
+
+
+def _coverage_state(result: dict[str, Any]) -> str | None:
+    coverage = result.get("coverage")
+    if not isinstance(coverage, dict):
+        return None
+    state = coverage.get("state")
+    return state if isinstance(state, str) else None
+
+
+def _coverage_checks(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    coverage = result.get("coverage")
+    if not isinstance(coverage, dict):
+        return {}
+    checks = coverage.get("checks")
+    if not isinstance(checks, list):
+        return {}
+    return {
+        str(check["id"]): check
+        for check in checks
+        if isinstance(check, dict)
+        and isinstance(check.get("id"), str)
+        and check.get("id")
+    }
 
 
 def _challenge_metadata_for_case(

--- a/skylos/core/go_api_surface.py
+++ b/skylos/core/go_api_surface.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from tree_sitter import Parser, Query, QueryCursor
+
+from skylos.core.go_module_manifest import (
+    MAX_GO_MANIFEST_BYTES,
+    GoModule,
+    GoReplacement,
+    go_work_use_paths,
+    module_from_manifest,
+)
+from skylos.core.file_discovery import should_exclude_path
+from skylos.core.safe_cache_io import read_text_no_symlink
+from skylos.visitors.languages.go.quality import GO_LANG
+
+
+MAX_GO_SOURCE_BYTES = 2 * 1024 * 1024
+MAX_GO_PACKAGE_FILES = 500
+
+_GO_BUILD_SUFFIXES = {
+    "386",
+    "aix",
+    "amd64",
+    "amd64p32",
+    "android",
+    "arm",
+    "arm64",
+    "darwin",
+    "dragonfly",
+    "freebsd",
+    "hurd",
+    "illumos",
+    "ios",
+    "js",
+    "linux",
+    "loong64",
+    "mips",
+    "mips64",
+    "mips64le",
+    "mipsle",
+    "netbsd",
+    "openbsd",
+    "plan9",
+    "ppc64",
+    "ppc64le",
+    "riscv64",
+    "s390x",
+    "solaris",
+    "sparc64",
+    "wasip1",
+    "wasm",
+    "windows",
+}
+
+_SURFACE_PATTERN = """
+(function_declaration name: (identifier) @member)
+(type_spec name: (type_identifier) @member)
+(const_spec name: (identifier) @member)
+(var_spec name: (identifier) @member)
+"""
+
+
+@dataclass(frozen=True)
+class GoParsedFile:
+    path: Path
+    source: bytes
+    root_node: Any
+    package_name: str
+    build_conditional: bool
+
+
+@dataclass(frozen=True)
+class GoPackageSurface:
+    import_path: str
+    directory: Path
+    package_name: str | None
+    members: dict[str, dict[str, Any]]
+    complete: bool
+    incomplete_reasons: tuple[str, ...]
+
+
+def safe_go_files(root: Path, files: Iterable[str | Path]) -> list[Path]:
+    selected: set[Path] = set()
+    for value in files:
+        candidate = Path(value)
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        resolved = _safe_contained_file(root, candidate)
+        if resolved is not None and resolved.suffix == ".go":
+            selected.add(resolved)
+    return sorted(selected, key=str)
+
+
+def parse_go_file(path: Path) -> tuple[GoParsedFile | None, str | None]:
+    if GO_LANG is None:
+        return None, "parser_unavailable"
+    source_text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_GO_SOURCE_BYTES,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if source_text is None:
+        return None, "source_unreadable"
+    source = source_text.encode("utf-8", errors="replace")
+    root_node = Parser(GO_LANG).parse(source).root_node
+    if root_node.has_error:
+        return None, "parse_error"
+    package_name = _package_name(root_node, source)
+    if not package_name:
+        return None, "package_clause_missing"
+    return (
+        GoParsedFile(
+            path=path,
+            source=source,
+            root_node=root_node,
+            package_name=package_name,
+            build_conditional=(
+                _has_build_constraint(source_text)
+                or _has_build_constrained_filename(path.name)
+            ),
+        ),
+        None,
+    )
+
+
+def discover_go_modules(root: Path, files: Iterable[Path]) -> list[GoModule]:
+    modules, _ = discover_go_modules_with_reasons(root, files)
+    return modules
+
+
+def discover_go_modules_with_reasons(
+    root: Path,
+    files: Iterable[Path],
+    *,
+    exclude_folders: Sequence[str] | None = None,
+) -> tuple[list[GoModule], tuple[str, ...]]:
+    manifests: set[Path] = set()
+    reasons: set[str] = set()
+    for file_path in files:
+        manifest = _nearest_go_mod(root, file_path.parent)
+        if manifest is not None:
+            manifests.add(manifest)
+    workspace_manifests, workspace_reasons = _go_work_manifests(
+        root,
+        exclude_folders=exclude_folders,
+    )
+    manifests.update(workspace_manifests)
+    reasons.update(workspace_reasons)
+
+    modules = []
+    seen_paths: set[str] = set()
+    for manifest in sorted(manifests, key=str):
+        module = module_from_manifest(root, manifest)
+        if module is None:
+            reasons.add("module_manifest_invalid")
+            continue
+        module, excluded_replacement = _without_excluded_replacements(
+            module,
+            root,
+            exclude_folders,
+        )
+        if excluded_replacement:
+            reasons.add("excluded_workspace_paths")
+        if module.module_path in seen_paths:
+            continue
+        modules.append(module)
+        seen_paths.add(module.module_path)
+    return (
+        sorted(modules, key=lambda item: (-len(item.module_path), item.module_path)),
+        tuple(sorted(reasons)),
+    )
+
+
+def resolve_go_import(
+    import_path: str,
+    modules: Iterable[GoModule],
+) -> tuple[GoModule | None, Path | None, bool]:
+    for module in modules:
+        resolved = _resolve_module_import(import_path, module)
+        if resolved is not None:
+            return module, resolved, True
+        replacement = _resolve_replacement_import(import_path, module.replacements)
+        if replacement is not None:
+            return module, replacement, True
+        if _matches_import_prefix(import_path, module.unresolved_replacements):
+            return module, None, True
+    return None, None, False
+
+
+def inspect_go_package_surface(
+    module: GoModule,
+    import_path: str,
+    directory: Path,
+    *,
+    allowed_files: frozenset[Path] | None = None,
+    exclude_folders: Sequence[str] | None = None,
+) -> GoPackageSurface:
+    try:
+        if directory.is_symlink():
+            raise ValueError
+        resolved_directory = directory.resolve(strict=True)
+        resolved_directory.relative_to(module.scan_root)
+    except (OSError, ValueError):
+        return _incomplete_surface(import_path, directory, "unsafe_package_path")
+    if resolved_directory.is_symlink() or not resolved_directory.is_dir():
+        return _incomplete_surface(import_path, directory, "unsafe_package_path")
+
+    paths = _package_go_files(
+        resolved_directory,
+        allowed_files=allowed_files,
+        scan_root=module.scan_root,
+        exclude_folders=exclude_folders,
+    )
+    if paths is None:
+        return _incomplete_surface(
+            import_path, resolved_directory, "package_file_limit"
+        )
+    if not paths:
+        return _incomplete_surface(
+            import_path, resolved_directory, "package_surface_empty"
+        )
+
+    members: dict[str, dict[str, Any]] = {}
+    package_names: set[str] = set()
+    reasons: set[str] = set()
+    for path in paths:
+        parsed, reason = parse_go_file(path)
+        if parsed is None:
+            reasons.add(reason or "parse_error")
+            continue
+        package_names.add(parsed.package_name)
+        if parsed.build_conditional:
+            reasons.add("build_conditional_surface")
+        _collect_exported_members(parsed, members, reasons)
+
+    if len(package_names) > 1:
+        reasons.add("ambiguous_package_name")
+    package_name = next(iter(package_names)) if len(package_names) == 1 else None
+    return GoPackageSurface(
+        import_path=import_path,
+        directory=resolved_directory,
+        package_name=package_name,
+        members=members,
+        complete=not reasons,
+        incomplete_reasons=tuple(sorted(reasons)),
+    )
+
+
+def node_text(parsed: GoParsedFile, node: Any) -> str:
+    return parsed.source[node.start_byte : node.end_byte].decode(
+        "utf-8", errors="replace"
+    )
+
+
+def iter_nodes(node: Any) -> Iterable[Any]:
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        stack.extend(reversed(current.named_children))
+
+
+def _safe_contained_file(root: Path, candidate: Path) -> Path | None:
+    try:
+        if candidate.is_symlink():
+            return None
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return resolved if resolved.is_file() else None
+
+
+def _nearest_go_mod(root: Path, start: Path) -> Path | None:
+    current = start
+    while True:
+        candidate = current / "go.mod"
+        if _safe_contained_file(root, candidate) is not None:
+            return candidate.resolve()
+        if current == root or current.parent == current:
+            return None
+        try:
+            current.parent.relative_to(root)
+        except ValueError:
+            return None
+        current = current.parent
+
+
+def _go_work_manifests(
+    root: Path,
+    *,
+    exclude_folders: Sequence[str] | None = None,
+) -> tuple[set[Path], set[str]]:
+    work_file = _safe_contained_file(root, root / "go.work")
+    if work_file is None:
+        return set(), set()
+    text = read_text_no_symlink(
+        work_file,
+        max_bytes=MAX_GO_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if text is None:
+        return set(), {"go_work_unreadable"}
+    manifests: set[Path] = set()
+    reasons: set[str] = set()
+    for value in go_work_use_paths(text):
+        directory = (root / value).resolve(strict=False)
+        try:
+            directory.relative_to(root)
+        except ValueError:
+            reasons.add("unsafe_workspace_path")
+            continue
+        if should_exclude_path(directory, root, exclude_folders):
+            reasons.add("excluded_workspace_paths")
+            continue
+        manifest = _safe_contained_file(root, directory / "go.mod")
+        if manifest is not None:
+            manifests.add(manifest)
+        else:
+            reasons.add("workspace_module_manifest_missing")
+    return manifests, reasons
+
+
+def _resolve_module_import(import_path: str, module: GoModule) -> Path | None:
+    if import_path == module.module_path:
+        return module.root
+    prefix = f"{module.module_path}/"
+    if import_path.startswith(prefix):
+        return module.root / import_path[len(prefix) :]
+    return None
+
+
+def _resolve_replacement_import(
+    import_path: str,
+    replacements: Iterable[GoReplacement],
+) -> Path | None:
+    for replacement in replacements:
+        if import_path == replacement.import_path:
+            return replacement.directory
+        prefix = f"{replacement.import_path}/"
+        if import_path.startswith(prefix):
+            return replacement.directory / import_path[len(prefix) :]
+    return None
+
+
+def _matches_import_prefix(import_path: str, prefixes: Iterable[str]) -> bool:
+    return any(
+        import_path == prefix or import_path.startswith(f"{prefix}/")
+        for prefix in prefixes
+    )
+
+
+def _package_go_files(
+    directory: Path,
+    *,
+    allowed_files: frozenset[Path] | None,
+    scan_root: Path,
+    exclude_folders: Sequence[str] | None,
+) -> list[Path] | None:
+    if allowed_files is not None:
+        return _selected_package_go_files(
+            directory,
+            allowed_files,
+            scan_root,
+            exclude_folders,
+        )
+    return _discovered_package_go_files(
+        directory,
+        scan_root,
+        exclude_folders,
+    )
+
+
+def _selected_package_go_files(
+    directory: Path,
+    allowed_files: frozenset[Path],
+    scan_root: Path,
+    exclude_folders: Sequence[str] | None,
+) -> list[Path] | None:
+    paths = [
+        path
+        for path in allowed_files
+        if path.parent == directory
+        and _is_package_go_file(path)
+        and not should_exclude_path(path, scan_root, exclude_folders)
+    ]
+    return _bounded_package_files(paths)
+
+
+def _discovered_package_go_files(
+    directory: Path,
+    scan_root: Path,
+    exclude_folders: Sequence[str] | None,
+) -> list[Path] | None:
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return []
+    paths: list[Path] = []
+    for path in entries:
+        if not _is_package_go_file(path):
+            continue
+        resolved = _safe_contained_file(directory, path)
+        if resolved is None or should_exclude_path(
+            resolved,
+            scan_root,
+            exclude_folders,
+        ):
+            continue
+        paths.append(resolved)
+    return _bounded_package_files(paths)
+
+
+def _is_package_go_file(path: Path) -> bool:
+    return path.suffix == ".go" and not path.name.endswith("_test.go")
+
+
+def _bounded_package_files(paths: Iterable[Path]) -> list[Path] | None:
+    selected = sorted(paths, key=str)
+    if len(selected) > MAX_GO_PACKAGE_FILES:
+        return None
+    return selected
+
+
+def _without_excluded_replacements(
+    module: GoModule,
+    root: Path,
+    exclude_folders: Sequence[str] | None,
+) -> tuple[GoModule, bool]:
+    if not exclude_folders:
+        return module, False
+    replacements = []
+    unresolved = set(module.unresolved_replacements)
+    excluded = False
+    for replacement in module.replacements:
+        if should_exclude_path(replacement.directory, root, exclude_folders):
+            unresolved.add(replacement.import_path)
+            excluded = True
+            continue
+        replacements.append(replacement)
+    return (
+        GoModule(
+            module_path=module.module_path,
+            root=module.root,
+            scan_root=module.scan_root,
+            replacements=tuple(replacements),
+            unresolved_replacements=tuple(sorted(unresolved)),
+        ),
+        excluded,
+    )
+
+
+def _collect_exported_members(
+    parsed: GoParsedFile,
+    members: dict[str, dict[str, Any]],
+    reasons: set[str],
+) -> None:
+    try:
+        captures = QueryCursor(Query(GO_LANG, _SURFACE_PATTERN)).captures(
+            parsed.root_node
+        )
+    except Exception:
+        reasons.add("surface_query_error")
+        return
+    for node in captures.get("member", []):
+        name = node_text(parsed, node)
+        if not name[:1].isupper():
+            continue
+        members.setdefault(
+            name,
+            {
+                "file": str(parsed.path),
+                "line": int(node.start_point[0]) + 1,
+            },
+        )
+
+
+def _package_name(root_node: Any, source: bytes) -> str | None:
+    for child in root_node.named_children:
+        if child.type != "package_clause":
+            continue
+        for name_node in child.named_children:
+            if name_node.type == "package_identifier":
+                return source[name_node.start_byte : name_node.end_byte].decode(
+                    "utf-8", errors="replace"
+                )
+    return None
+
+
+def _has_build_constraint(source: str) -> bool:
+    for line in source.splitlines()[:20]:
+        stripped = line.strip()
+        if stripped.startswith("//go:build ") or stripped.startswith("// +build "):
+            return True
+        if stripped.startswith("package "):
+            return False
+    return False
+
+
+def _has_build_constrained_filename(filename: str) -> bool:
+    stem = Path(filename).stem
+    suffix = stem.rsplit("_", 1)[-1]
+    return suffix in _GO_BUILD_SUFFIXES
+
+
+def _incomplete_surface(
+    import_path: str,
+    directory: Path,
+    reason: str,
+) -> GoPackageSurface:
+    return GoPackageSurface(
+        import_path=import_path,
+        directory=directory,
+        package_name=None,
+        members={},
+        complete=False,
+        incomplete_reasons=(reason,),
+    )

--- a/skylos/core/go_module_manifest.py
+++ b/skylos/core/go_module_manifest.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from skylos.core.safe_cache_io import read_text_no_symlink
+
+
+MAX_GO_MANIFEST_BYTES = 512 * 1024
+
+
+@dataclass(frozen=True)
+class GoReplacement:
+    import_path: str
+    directory: Path
+
+
+@dataclass(frozen=True)
+class GoModule:
+    module_path: str
+    root: Path
+    scan_root: Path
+    replacements: tuple[GoReplacement, ...] = ()
+    unresolved_replacements: tuple[str, ...] = ()
+
+
+def go_work_use_paths(text: str) -> list[str]:
+    paths: list[str] = []
+    in_use_block = False
+    for raw_line in text.splitlines():
+        line = raw_line.split("//", 1)[0].strip()
+        if not line:
+            continue
+        if line == "use (":
+            in_use_block = True
+            continue
+        if in_use_block and line == ")":
+            in_use_block = False
+            continue
+        if line.startswith("use "):
+            paths.append(_unquote(line[4:].strip()))
+        elif in_use_block:
+            paths.append(_unquote(line.split()[0]))
+    return [path for path in paths if path]
+
+
+def module_from_manifest(scan_root: Path, manifest: Path) -> GoModule | None:
+    text = read_text_no_symlink(
+        manifest,
+        max_bytes=MAX_GO_MANIFEST_BYTES,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if text is None:
+        return None
+    module_path = _module_path(text)
+    if not module_path:
+        return None
+    module_root = manifest.parent.resolve()
+    replacements, unresolved_replacements = _local_replacements(
+        scan_root,
+        module_root,
+        text,
+    )
+    return GoModule(
+        module_path=module_path,
+        root=module_root,
+        scan_root=scan_root,
+        replacements=replacements,
+        unresolved_replacements=unresolved_replacements,
+    )
+
+
+def _module_path(text: str) -> str | None:
+    for raw_line in text.splitlines():
+        line = raw_line.split("//", 1)[0].strip()
+        if not line.startswith("module "):
+            continue
+        value = _unquote(line[7:].strip())
+        return value.split()[0] if value else None
+    return None
+
+
+def _local_replacements(
+    scan_root: Path,
+    module_root: Path,
+    text: str,
+) -> tuple[tuple[GoReplacement, ...], tuple[str, ...]]:
+    replacements: list[GoReplacement] = []
+    unresolved: set[str] = set()
+    for directive in _replace_directives(text):
+        left, separator, right = directive.partition("=>")
+        if not separator:
+            continue
+        old_path = left.strip().split()[0]
+        target = _unquote(right.strip().split()[0])
+        if not target.startswith((".", "/")):
+            continue
+        directory = Path(target)
+        if not directory.is_absolute():
+            directory = module_root / directory
+        try:
+            resolved = directory.resolve(strict=False)
+            resolved.relative_to(scan_root)
+        except (OSError, ValueError):
+            unresolved.add(old_path)
+            continue
+        replacements.append(GoReplacement(old_path, resolved))
+    return tuple(replacements), tuple(sorted(unresolved))
+
+
+def _replace_directives(text: str) -> list[str]:
+    directives: list[str] = []
+    in_block = False
+    for raw_line in text.splitlines():
+        line = raw_line.split("//", 1)[0].strip()
+        if line == "replace (":
+            in_block = True
+            continue
+        if in_block and line == ")":
+            in_block = False
+            continue
+        if line.startswith("replace "):
+            directives.append(line[8:].strip())
+        elif in_block and line:
+            directives.append(line)
+    return directives
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] in {'"', "'", "`"} and value[-1] == value[0]:
+        return value[1:-1]
+    return value

--- a/skylos/core/java_api_surface.py
+++ b/skylos/core/java_api_surface.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from skylos.core.file_discovery import should_exclude_path
+from skylos.core.safe_cache_io import read_text_no_symlink
+from skylos.visitors.languages.java.core import JAVA_LANG, _get_parser
+
+
+MAX_JAVA_SOURCE_BYTES = 2 * 1024 * 1024
+MAX_JAVA_SURFACE_FILES = 5_000
+
+_SKIP_DIRECTORIES = {
+    ".git",
+    ".gradle",
+    ".idea",
+    "build",
+    "node_modules",
+    "out",
+    "target",
+    "vendor",
+}
+
+_TYPE_NODE_TYPES = {
+    "annotation_type_declaration",
+    "class_declaration",
+    "enum_declaration",
+    "interface_declaration",
+    "record_declaration",
+}
+
+_INHERITANCE_NODE_TYPES = {
+    "extends_interfaces",
+    "super_interfaces",
+    "superclass",
+}
+
+_KNOWN_CODEGEN_ANNOTATIONS = {
+    "AutoValue",
+    "Builder",
+    "Data",
+    "GenerateImmutable",
+    "Immutable",
+    "UtilityClass",
+    "Value",
+}
+
+_JAVA_BUILD_MARKERS = {
+    "build.gradle",
+    "build.gradle.kts",
+    "pom.xml",
+    "settings.gradle",
+    "settings.gradle.kts",
+}
+
+_JAVA_TEST_SOURCE_SETS = {
+    "androidtest",
+    "functionaltest",
+    "integrationtest",
+    "test",
+    "testfixtures",
+}
+
+
+@dataclass(frozen=True)
+class JavaParsedFile:
+    path: Path
+    source: bytes
+    root_node: Any
+    package_name: str
+    source_set: str
+    module_root: Path
+
+
+@dataclass(frozen=True)
+class JavaMemberSurface:
+    name: str
+    kind: str
+    visibility: str
+    file: Path
+    line: int
+
+
+@dataclass(frozen=True)
+class JavaTypeSurface:
+    qualified_name: str
+    simple_name: str
+    package_name: str
+    source_set: str
+    module_root: Path
+    file: Path
+    members: dict[str, tuple[JavaMemberSurface, ...]]
+    complete: bool
+    incomplete_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class JavaSurfaceIndex:
+    types: dict[str, JavaTypeSurface]
+    packages: frozenset[str]
+    global_reasons: tuple[str, ...]
+    ambiguous_types: frozenset[str]
+
+    def type_surface(self, qualified_name: str) -> JavaTypeSurface | None:
+        return self.types.get(qualified_name)
+
+    def package_is_local(self, package_name: str) -> bool:
+        return package_name in self.packages
+
+    def proof_reason(self, surface: JavaTypeSurface | None = None) -> str | None:
+        if self.global_reasons:
+            return self.global_reasons[0]
+        if surface is not None and not surface.complete:
+            return surface.incomplete_reasons[0]
+        return None
+
+
+def java_source_sets_compatible(importer: str, surface: str) -> bool:
+    if importer == "test":
+        return surface in {"main", "test"}
+    return importer == "main" and surface == "main"
+
+
+def java_module_roots_compatible(importer: Path, surface: Path) -> bool:
+    return importer == surface
+
+
+def safe_java_files(root: Path, files: Iterable[str | Path]) -> list[Path]:
+    selected: set[Path] = set()
+    for value in files:
+        candidate = Path(value)
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        resolved = _safe_contained_file(root, candidate)
+        if resolved is not None and resolved.suffix == ".java":
+            selected.add(resolved)
+    return sorted(selected, key=str)
+
+
+def parse_java_file(
+    path: Path,
+    *,
+    root: Path | None = None,
+) -> tuple[JavaParsedFile | None, str | None]:
+    if JAVA_LANG is None:
+        return None, "parser_unavailable"
+    source_text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_JAVA_SOURCE_BYTES,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if source_text is None:
+        return None, "source_unreadable"
+    source = source_text.encode("utf-8", errors="replace")
+    root_node = _get_parser(JAVA_LANG).parse(source).root_node
+    if root_node.has_error:
+        return None, "parse_error"
+    return (
+        JavaParsedFile(
+            path=path,
+            source=source,
+            root_node=root_node,
+            package_name=_package_name(root_node, source),
+            source_set=_java_source_set(root or path.parent, path),
+            module_root=_java_module_root(root or path.parent, path),
+        ),
+        None,
+    )
+
+
+def build_java_surface_index(
+    root: Path,
+    selected_files: Iterable[Path],
+    *,
+    discover_workspace: bool = True,
+    exclude_folders: Sequence[str] | None = None,
+) -> JavaSurfaceIndex:
+    files, discovery_reason = _discover_java_files(
+        root,
+        selected_files,
+        discover_workspace=discover_workspace,
+        exclude_folders=exclude_folders,
+    )
+    surfaces: dict[str, JavaTypeSurface] = {}
+    packages: set[str] = set()
+    ambiguous: set[str] = set()
+    global_reasons: set[str] = set()
+    if discovery_reason:
+        global_reasons.add(discovery_reason)
+
+    for path in files:
+        parsed, reason = parse_java_file(path, root=root)
+        if parsed is None:
+            global_reasons.add(reason or "parse_error")
+            continue
+        packages.add(parsed.package_name)
+        for surface in _file_type_surfaces(parsed):
+            if surface.qualified_name in surfaces:
+                ambiguous.add(surface.qualified_name)
+                continue
+            surfaces[surface.qualified_name] = surface
+
+    for qualified_name in ambiguous:
+        surfaces.pop(qualified_name, None)
+    return JavaSurfaceIndex(
+        types=surfaces,
+        packages=frozenset(packages),
+        global_reasons=tuple(sorted(global_reasons)),
+        ambiguous_types=frozenset(ambiguous),
+    )
+
+
+def node_text(parsed: JavaParsedFile, node: Any) -> str:
+    return parsed.source[node.start_byte : node.end_byte].decode(
+        "utf-8", errors="replace"
+    )
+
+
+def iter_nodes(node: Any) -> Iterable[Any]:
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        stack.extend(reversed(current.named_children))
+
+
+def _discover_java_files(
+    root: Path,
+    selected_files: Iterable[Path],
+    *,
+    discover_workspace: bool,
+    exclude_folders: Sequence[str] | None,
+) -> tuple[list[Path], str | None]:
+    discovered = set(safe_java_files(root, selected_files))
+    if not discover_workspace:
+        return sorted(discovered, key=str), None
+    discovery_reason = "excluded_workspace_paths" if exclude_folders else None
+    for directory, names, files in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        names[:] = [
+            name
+            for name in names
+            if name not in _SKIP_DIRECTORIES
+            and not (directory_path / name).is_symlink()
+            and not should_exclude_path(
+                directory_path / name,
+                root,
+                exclude_folders,
+            )
+        ]
+        for name in files:
+            if not name.endswith(".java"):
+                continue
+            if should_exclude_path(directory_path / name, root, exclude_folders):
+                continue
+            resolved = _safe_contained_file(root, directory_path / name)
+            if resolved is not None:
+                discovered.add(resolved)
+            if len(discovered) > MAX_JAVA_SURFACE_FILES:
+                return sorted(discovered, key=str), "source_file_limit"
+    return sorted(discovered, key=str), discovery_reason
+
+
+def _file_type_surfaces(parsed: JavaParsedFile) -> list[JavaTypeSurface]:
+    surfaces = []
+    for node in parsed.root_node.named_children:
+        if node.type not in _TYPE_NODE_TYPES:
+            continue
+        name_node = node.child_by_field_name("name")
+        if name_node is None:
+            continue
+        simple_name = node_text(parsed, name_node)
+        qualified_name = (
+            f"{parsed.package_name}.{simple_name}"
+            if parsed.package_name
+            else simple_name
+        )
+        members, reasons = _type_members(parsed, node)
+        surfaces.append(
+            JavaTypeSurface(
+                qualified_name=qualified_name,
+                simple_name=simple_name,
+                package_name=parsed.package_name,
+                source_set=parsed.source_set,
+                module_root=parsed.module_root,
+                file=parsed.path,
+                members=members,
+                complete=not reasons,
+                incomplete_reasons=tuple(sorted(reasons)),
+            )
+        )
+    return surfaces
+
+
+def _type_members(
+    parsed: JavaParsedFile,
+    type_node: Any,
+) -> tuple[dict[str, tuple[JavaMemberSurface, ...]], set[str]]:
+    members: dict[str, list[JavaMemberSurface]] = {}
+    reasons: set[str] = set()
+    if any(child.type in _INHERITANCE_NODE_TYPES for child in type_node.named_children):
+        reasons.add("inherited_members")
+    if _type_uses_codegen_annotation(parsed, type_node):
+        reasons.add("generated_members")
+    body = type_node.child_by_field_name("body")
+    if body is None:
+        return members, reasons
+    for declaration in body.named_children:
+        _collect_static_declaration(parsed, type_node, declaration, members)
+    return {name: tuple(values) for name, values in members.items()}, reasons
+
+
+def _collect_static_declaration(
+    parsed: JavaParsedFile,
+    type_node: Any,
+    declaration: Any,
+    members: dict[str, list[JavaMemberSurface]],
+) -> None:
+    if declaration.type == "method_declaration":
+        if _member_is_static(parsed, type_node, declaration):
+            _add_named_member(parsed, type_node, declaration, members, kind="method")
+        return
+    if declaration.type == "field_declaration":
+        if not _member_is_static(parsed, type_node, declaration):
+            return
+        for child in declaration.named_children:
+            if child.type == "variable_declarator":
+                _add_named_member(
+                    parsed,
+                    type_node,
+                    child,
+                    members,
+                    kind="field",
+                    modifiers_node=declaration,
+                )
+        return
+    if declaration.type == "enum_constant":
+        _add_named_member(
+            parsed,
+            type_node,
+            declaration,
+            members,
+            kind="field",
+            implicit_public=True,
+        )
+        return
+    if declaration.type in _TYPE_NODE_TYPES and _member_is_static(
+        parsed, type_node, declaration
+    ):
+        _add_named_member(parsed, type_node, declaration, members, kind="type")
+
+
+def _member_is_static(parsed: JavaParsedFile, type_node: Any, declaration: Any) -> bool:
+    if declaration.type in {
+        "annotation_type_declaration",
+        "enum_declaration",
+        "interface_declaration",
+        "record_declaration",
+    }:
+        return True
+    if type_node.type in {"annotation_type_declaration", "interface_declaration"}:
+        return declaration.type != "method_declaration" or "static" in _modifier_text(
+            parsed, declaration
+        )
+    return "static" in _modifier_text(parsed, declaration)
+
+
+def _modifier_text(parsed: JavaParsedFile, node: Any) -> str:
+    for child in node.named_children:
+        if child.type == "modifiers":
+            return node_text(parsed, child)
+    return ""
+
+
+def _add_named_member(
+    parsed: JavaParsedFile,
+    type_node: Any,
+    declaration: Any,
+    members: dict[str, list[JavaMemberSurface]],
+    *,
+    kind: str,
+    modifiers_node: Any | None = None,
+    implicit_public: bool = False,
+) -> None:
+    name_node = declaration.child_by_field_name("name")
+    if name_node is None:
+        return
+    name = node_text(parsed, name_node)
+    members.setdefault(name, []).append(
+        JavaMemberSurface(
+            name=name,
+            kind=kind,
+            visibility=_member_visibility(
+                parsed,
+                type_node,
+                modifiers_node or declaration,
+                implicit_public=implicit_public,
+            ),
+            file=parsed.path,
+            line=int(name_node.start_point[0]) + 1,
+        )
+    )
+
+
+def _member_visibility(
+    parsed: JavaParsedFile,
+    type_node: Any,
+    declaration: Any,
+    *,
+    implicit_public: bool,
+) -> str:
+    modifiers = _modifier_text(parsed, declaration).split()
+    for visibility in ("public", "protected", "private"):
+        if visibility in modifiers:
+            return visibility
+    if implicit_public or type_node.type in {
+        "annotation_type_declaration",
+        "interface_declaration",
+    }:
+        return "public"
+    return "package"
+
+
+def _type_uses_codegen_annotation(parsed: JavaParsedFile, node: Any) -> bool:
+    modifiers = next(
+        (child for child in node.named_children if child.type == "modifiers"),
+        None,
+    )
+    if modifiers is None:
+        return False
+    text = node_text(parsed, modifiers)
+    return any(
+        re.search(
+            rf"@(?:[A-Za-z_$][\w$]*\.)*{re.escape(name)}\b",
+            text,
+        )
+        is not None
+        for name in _KNOWN_CODEGEN_ANNOTATIONS
+    )
+
+
+def _java_source_set(root: Path, path: Path) -> str:
+    try:
+        relative = path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except (OSError, ValueError):
+        relative = Path(path.name)
+    parts = [part.lower() for part in relative.parts]
+    if any(
+        part in {"generated", "generated-sources", "generated-test-sources"}
+        for part in parts
+    ):
+        return "generated"
+    for index, part in enumerate(parts[:-1]):
+        if part == "src" and parts[index + 1] in _JAVA_TEST_SOURCE_SETS:
+            return "test"
+    return "main"
+
+
+def _java_module_root(root: Path, path: Path) -> Path:
+    resolved_root = root.resolve(strict=False)
+    resolved_path = path.resolve(strict=False)
+    current = resolved_path.parent
+    while True:
+        if any((current / marker).is_file() for marker in _JAVA_BUILD_MARKERS):
+            return current
+        if current == resolved_root or current.parent == current:
+            break
+        try:
+            current.parent.relative_to(resolved_root)
+        except ValueError:
+            break
+        current = current.parent
+    try:
+        relative = resolved_path.relative_to(resolved_root)
+    except ValueError:
+        return resolved_root
+    parts = relative.parts
+    for index, part in enumerate(parts[:-1]):
+        if part.lower() == "src":
+            return resolved_root.joinpath(*parts[:index])
+    return resolved_root
+
+
+def _package_name(root_node: Any, source: bytes) -> str:
+    for child in root_node.named_children:
+        if child.type != "package_declaration" or not child.named_children:
+            continue
+        name_node = child.named_children[0]
+        return source[name_node.start_byte : name_node.end_byte].decode(
+            "utf-8", errors="replace"
+        )
+    return ""
+
+
+def _safe_contained_file(root: Path, candidate: Path) -> Path | None:
+    try:
+        if candidate.is_symlink():
+            return None
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return resolved if resolved.is_file() else None

--- a/skylos/core/verification_coverage.py
+++ b/skylos/core/verification_coverage.py
@@ -8,8 +8,16 @@ SCHEMA_VERSION = 1
 
 def build_ai_verification_coverage(
     checks: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    *,
+    expected_checks: list[Any] | tuple[Any, ...] | None = None,
 ) -> dict[str, Any]:
-    normalized = [dict(check) for check in checks if isinstance(check, dict)]
+    from skylos.core.verification_registry import (
+        expectation_payloads,
+        reconcile_expected_verification_checks,
+    )
+
+    expectations = list(expected_checks or ())
+    normalized = reconcile_expected_verification_checks(checks, expectations)
     completed = [
         str(check.get("id"))
         for check in normalized
@@ -24,23 +32,69 @@ def build_ai_verification_coverage(
         if check.get("status") == "skipped" and check.get("id")
     ]
     state = "complete"
-    if any(check.get("outcome") == "incomplete" for check in normalized):
+    if any(_check_proof_incomplete(check) for check in normalized):
         state = "incomplete"
+    expectation_data = expectation_payloads(expectations)
+    missing_checks = [
+        str(check.get("id"))
+        for check in normalized
+        if _reason_codes(check) == ["expected_check_missing"] and check.get("id")
+    ]
     return {
         "schema_version": SCHEMA_VERSION,
         "state": state,
+        "detected_languages": sorted(
+            {
+                language
+                for expectation in expectation_data
+                for language in expectation.get("languages", [])
+                if isinstance(language, str)
+            }
+        ),
+        "expected_checks": expectation_data,
+        "missing_checks": missing_checks,
+        "language_support": _language_support(expectation_data),
         "completed_checks": completed,
         "skipped_checks": skipped,
         "checks": normalized,
     }
 
 
+def _language_support(expectations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    support: list[dict[str, Any]] = []
+    for expectation in expectations:
+        for language in expectation.get("languages", []):
+            if not isinstance(language, str):
+                continue
+            item = {
+                "language": language,
+                "capability": expectation.get("capability"),
+                "status": expectation.get("support"),
+                "check_id": expectation.get("id"),
+            }
+            if expectation.get("reason"):
+                item["reason"] = expectation["reason"]
+            support.append(item)
+    return sorted(
+        support, key=lambda item: (str(item["language"]), str(item["check_id"]))
+    )
+
+
 def reconcile_check_findings(
     check: dict[str, Any],
     finding_count: int,
+    *,
+    suppressed_count: int = 0,
 ) -> dict[str, Any]:
     reconciled = dict(check)
     reconciled["finding_count"] = max(0, int(finding_count))
+    reconciled["suppressed_findings"] = max(0, int(suppressed_count))
+    if reconciled["suppressed_findings"]:
+        reconciled["reasons"] = _reconciled_reasons(
+            reconciled.get("reasons"),
+            "finding_suppressed",
+            reconciled["suppressed_findings"],
+        )
     if reconciled["finding_count"]:
         reconciled["outcome"] = "fail"
     elif int(reconciled.get("skipped_references") or 0):
@@ -48,6 +102,25 @@ def reconcile_check_findings(
     else:
         reconciled["outcome"] = "pass"
     return reconciled
+
+
+def _reconciled_reasons(
+    reasons: Any,
+    code: str,
+    count: int,
+) -> list[dict[str, Any]]:
+    normalized = (
+        [dict(reason) for reason in reasons if isinstance(reason, dict)]
+        if isinstance(reasons, list)
+        else []
+    )
+    for reason in normalized:
+        if reason.get("code") != code:
+            continue
+        reason["count"] = max(0, int(reason.get("count") or 0)) + count
+        return normalized
+    normalized.append({"code": code, "count": count})
+    return sorted(normalized, key=lambda reason: str(reason.get("code", "")))
 
 
 def _reason_codes(check: dict[str, Any]) -> list[str]:
@@ -62,3 +135,9 @@ def _reason_codes(check: dict[str, Any]) -> list[str]:
         if isinstance(code, str) and code:
             codes.append(code)
     return codes
+
+
+def _check_proof_incomplete(check: dict[str, Any]) -> bool:
+    if check.get("outcome") == "incomplete":
+        return True
+    return int(check.get("skipped_references") or 0) > 0

--- a/skylos/core/verification_registry.py
+++ b/skylos/core/verification_registry.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LOCAL_API_CAPABILITY = "local_workspace_api_surface"
+
+
+@dataclass(frozen=True)
+class VerificationExpectation:
+    check_id: str
+    languages: tuple[str, ...]
+    applicable_files: int
+    supported: bool
+    capability: str = LOCAL_API_CAPABILITY
+    unsupported_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "id": self.check_id,
+            "languages": list(self.languages),
+            "applicable_files": self.applicable_files,
+            "capability": self.capability,
+            "support": "supported" if self.supported else "unsupported",
+        }
+        if self.unsupported_reason:
+            payload["reason"] = self.unsupported_reason
+        return payload
+
+
+_LANGUAGE_SUFFIXES = {
+    ".py": "python",
+    ".pyi": "python",
+    ".pyw": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".mts": "typescript",
+    ".cts": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".go": "go",
+    ".java": "java",
+    ".php": "php",
+    ".rs": "rust",
+    ".dart": "dart",
+    ".cs": "csharp",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".zsh": "shell",
+    ".ksh": "shell",
+    ".bats": "shell",
+}
+
+_CHECK_ORDER = {
+    "python_local_api_reference": 0,
+    "typescript_local_api_surface": 1,
+    "go_workspace_api_surface": 2,
+    "java_workspace_api_surface": 3,
+    "php_workspace_api_surface": 4,
+    "rust_workspace_api_surface": 5,
+    "dart_workspace_api_surface": 6,
+    "csharp_workspace_api_surface": 7,
+    "kotlin_workspace_api_surface": 8,
+    "shell_workspace_api_surface": 9,
+}
+
+_UNSUPPORTED_REASON = "local_api_verification_not_implemented"
+
+
+def expected_ai_verification_checks(
+    files: Iterable[str | Path],
+) -> list[VerificationExpectation]:
+    counts = detected_verification_languages(files)
+    expectations: list[VerificationExpectation] = []
+    _append_single_language_expectation(
+        expectations,
+        counts,
+        language="python",
+        check_id="python_local_api_reference",
+        supported=True,
+    )
+    _append_js_expectation(expectations, counts)
+    _append_single_language_expectation(
+        expectations,
+        counts,
+        language="go",
+        check_id="go_workspace_api_surface",
+        supported=True,
+    )
+    _append_single_language_expectation(
+        expectations,
+        counts,
+        language="java",
+        check_id="java_workspace_api_surface",
+        supported=True,
+    )
+    for language in ("php", "rust", "dart", "csharp", "kotlin", "shell"):
+        _append_single_language_expectation(
+            expectations,
+            counts,
+            language=language,
+            check_id=f"{language}_workspace_api_surface",
+            supported=False,
+        )
+    return sorted(expectations, key=lambda item: _CHECK_ORDER[item.check_id])
+
+
+def detected_verification_languages(
+    files: Iterable[str | Path],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in files:
+        language = _LANGUAGE_SUFFIXES.get(Path(value).suffix.lower())
+        if language is None:
+            continue
+        counts[language] = counts.get(language, 0) + 1
+    return counts
+
+
+def reconcile_expected_verification_checks(
+    checks: Iterable[dict[str, Any]],
+    expectations: Iterable[VerificationExpectation | dict[str, Any]],
+) -> list[dict[str, Any]]:
+    normalized_checks = [dict(check) for check in checks if isinstance(check, dict)]
+    normalized_expectations = _normalize_expectations(expectations)
+    checks_by_id, malformed_checks = _checks_by_id(normalized_checks)
+    reconciled: list[dict[str, Any]] = []
+    expected_ids: set[str] = set()
+
+    for expectation in normalized_expectations:
+        expected_ids.add(expectation.check_id)
+        actual_records = checks_by_id.get(expectation.check_id, [])
+        if not expectation.supported:
+            reconciled.append(_incomplete_check(expectation, "unsupported_capability"))
+        elif not actual_records:
+            reconciled.append(_incomplete_check(expectation, "expected_check_missing"))
+        else:
+            reconciled.append(
+                _enrich_actual_check(
+                    _merge_actual_checks(actual_records),
+                    expectation,
+                )
+            )
+
+    for check_id, records in checks_by_id.items():
+        if check_id not in expected_ids:
+            reconciled.append(_merge_actual_checks(records))
+    reconciled.extend(malformed_checks)
+    return reconciled
+
+
+def expectation_payloads(
+    expectations: Iterable[VerificationExpectation | dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [item.to_dict() for item in _normalize_expectations(expectations)]
+
+
+def _append_single_language_expectation(
+    expectations: list[VerificationExpectation],
+    counts: dict[str, int],
+    *,
+    language: str,
+    check_id: str,
+    supported: bool,
+) -> None:
+    file_count = counts.get(language, 0)
+    if not file_count:
+        return
+    expectations.append(
+        VerificationExpectation(
+            check_id=check_id,
+            languages=(language,),
+            applicable_files=file_count,
+            supported=supported,
+            unsupported_reason=None if supported else _UNSUPPORTED_REASON,
+        )
+    )
+
+
+def _append_js_expectation(
+    expectations: list[VerificationExpectation],
+    counts: dict[str, int],
+) -> None:
+    languages = tuple(
+        language for language in ("typescript", "javascript") if counts.get(language, 0)
+    )
+    if not languages:
+        return
+    expectations.append(
+        VerificationExpectation(
+            check_id="typescript_local_api_surface",
+            languages=languages,
+            applicable_files=sum(counts[language] for language in languages),
+            supported=True,
+        )
+    )
+
+
+def _normalize_expectations(
+    expectations: Iterable[VerificationExpectation | dict[str, Any]],
+) -> list[VerificationExpectation]:
+    normalized: list[VerificationExpectation] = []
+    for expectation in expectations:
+        if isinstance(expectation, VerificationExpectation):
+            normalized.append(expectation)
+            continue
+        if not isinstance(expectation, dict):
+            continue
+        check_id = expectation.get("id")
+        languages = expectation.get("languages")
+        if not isinstance(check_id, str) or not check_id:
+            continue
+        if not isinstance(languages, list) or not all(
+            isinstance(language, str) and language for language in languages
+        ):
+            continue
+        normalized.append(
+            VerificationExpectation(
+                check_id=check_id,
+                languages=tuple(languages),
+                applicable_files=max(0, int(expectation.get("applicable_files") or 0)),
+                supported=expectation.get("support") != "unsupported",
+                capability=str(expectation.get("capability") or LOCAL_API_CAPABILITY),
+                unsupported_reason=(
+                    str(expectation.get("reason"))
+                    if expectation.get("reason")
+                    else None
+                ),
+            )
+        )
+    return sorted(normalized, key=lambda item: _CHECK_ORDER.get(item.check_id, 100))
+
+
+def _incomplete_check(
+    expectation: VerificationExpectation,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "id": expectation.check_id,
+        "status": "skipped",
+        "outcome": "incomplete",
+        "scope": expectation.capability,
+        "languages": list(expectation.languages),
+        "applicable_files": expectation.applicable_files,
+        "raw_imports": 0,
+        "references": 0,
+        "checked_references": 0,
+        "verified_references": 0,
+        "skipped_references": 0,
+        "finding_count": 0,
+        "reasons": [{"code": reason, "count": 1}],
+    }
+
+
+def _enrich_actual_check(
+    check: dict[str, Any],
+    expectation: VerificationExpectation,
+) -> dict[str, Any]:
+    enriched = dict(check)
+    actual_applicable_files = max(0, int(enriched.get("applicable_files") or 0))
+    enriched["expected_applicable_files"] = expectation.applicable_files
+    enriched["scope"] = str(enriched.get("scope") or expectation.capability)
+    enriched["languages"] = sorted(
+        {
+            *expectation.languages,
+            *(
+                language
+                for language in enriched.get("languages", [])
+                if isinstance(language, str) and language
+            ),
+        }
+    )
+    enriched["applicable_files"] = actual_applicable_files
+    if enriched.get("status") == "skipped":
+        enriched["outcome"] = "incomplete"
+    elif actual_applicable_files < expectation.applicable_files:
+        if enriched.get("outcome") != "fail":
+            enriched["outcome"] = "incomplete"
+        enriched["skipped_references"] = max(
+            1,
+            int(enriched.get("skipped_references") or 0),
+        )
+        _append_reason(enriched, "expected_file_coverage_mismatch")
+    return enriched
+
+
+def _checks_by_id(
+    checks: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    malformed = []
+    for check in checks:
+        check_id = check.get("id")
+        if not isinstance(check_id, str) or not check_id:
+            malformed.append(_malformed_check())
+            continue
+        grouped.setdefault(check_id, []).append(check)
+    return grouped, malformed
+
+
+def _merge_actual_checks(records: list[dict[str, Any]]) -> dict[str, Any]:
+    normalized = [_normalize_actual_check(record) for record in records]
+    if len(normalized) == 1:
+        return normalized[0]
+    merged = dict(normalized[0])
+    merged["languages"] = _merged_check_languages(normalized)
+    _merge_max_check_counts(merged, normalized)
+    merged["skipped_references"] = (
+        sum(int(check.get("skipped_references") or 0) for check in normalized) + 1
+    )
+    merged["reasons"] = _merged_reasons(normalized)
+    _append_reason(merged, "duplicate_check_record")
+    merged["status"] = _merged_check_status(normalized)
+    merged["outcome"] = _merged_check_outcome(normalized, merged)
+    return merged
+
+
+def _merged_check_languages(checks: list[dict[str, Any]]) -> list[str]:
+    return sorted(
+        {
+            language
+            for check in checks
+            for language in check.get("languages", [])
+            if isinstance(language, str) and language
+        }
+    )
+
+
+def _merge_max_check_counts(
+    merged: dict[str, Any],
+    checks: list[dict[str, Any]],
+) -> None:
+    for key in (
+        "applicable_files",
+        "raw_imports",
+        "references",
+        "checked_references",
+        "verified_references",
+        "finding_count",
+        "suppressed_findings",
+    ):
+        merged[key] = max(int(check.get(key) or 0) for check in checks)
+
+
+def _merged_check_status(checks: list[dict[str, Any]]) -> str:
+    if all(check.get("status") == "completed" for check in checks):
+        return "completed"
+    return "skipped"
+
+
+def _merged_check_outcome(
+    checks: list[dict[str, Any]],
+    merged: dict[str, Any],
+) -> str:
+    if int(merged.get("finding_count") or 0):
+        return "fail"
+    if any(check.get("outcome") == "fail" for check in checks):
+        return "fail"
+    return "incomplete"
+
+
+def _normalize_actual_check(check: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(check)
+    malformed = False
+    if normalized.get("status") not in {"completed", "skipped"}:
+        normalized["status"] = "skipped"
+        malformed = True
+    if normalized.get("outcome") not in {"pass", "fail", "incomplete"}:
+        normalized["outcome"] = "incomplete"
+        malformed = True
+    for key in (
+        "applicable_files",
+        "raw_imports",
+        "references",
+        "checked_references",
+        "verified_references",
+        "skipped_references",
+        "finding_count",
+        "suppressed_findings",
+    ):
+        normalized[key] = max(0, int(normalized.get(key) or 0))
+    if normalized["finding_count"]:
+        normalized["outcome"] = "fail"
+    elif normalized["skipped_references"] or (
+        normalized["status"] == "skipped" and not _is_not_applicable_check(normalized)
+    ):
+        normalized["outcome"] = "incomplete"
+    if malformed:
+        normalized["skipped_references"] = max(
+            1,
+            normalized["skipped_references"],
+        )
+        if normalized["outcome"] != "fail":
+            normalized["outcome"] = "incomplete"
+        _append_reason(normalized, "malformed_check_record")
+    return normalized
+
+
+def _is_not_applicable_check(check: dict[str, Any]) -> bool:
+    reasons = check.get("reasons")
+    return (
+        check.get("outcome") == "pass"
+        and int(check.get("applicable_files") or 0) == 0
+        and isinstance(reasons, list)
+        and any(
+            isinstance(reason, dict) and reason.get("code") == "no_supported_files"
+            for reason in reasons
+        )
+    )
+
+
+def _merged_reasons(checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    counts: Counter[str] = Counter()
+    for check in checks:
+        reasons = check.get("reasons")
+        if not isinstance(reasons, list):
+            continue
+        for reason in reasons:
+            if not isinstance(reason, dict):
+                continue
+            code = reason.get("code")
+            if isinstance(code, str) and code:
+                counts[code] += max(1, int(reason.get("count") or 0))
+    return [{"code": code, "count": count} for code, count in sorted(counts.items())]
+
+
+def _malformed_check() -> dict[str, Any]:
+    return {
+        "id": "malformed_verification_check",
+        "status": "skipped",
+        "outcome": "incomplete",
+        "scope": LOCAL_API_CAPABILITY,
+        "languages": [],
+        "applicable_files": 0,
+        "raw_imports": 0,
+        "references": 0,
+        "checked_references": 0,
+        "verified_references": 0,
+        "skipped_references": 1,
+        "finding_count": 0,
+        "reasons": [{"code": "malformed_check_record", "count": 1}],
+    }
+
+
+def _append_reason(check: dict[str, Any], code: str) -> None:
+    reasons = check.setdefault("reasons", [])
+    if not isinstance(reasons, list):
+        reasons = []
+        check["reasons"] = reasons
+    for reason in reasons:
+        if isinstance(reason, dict) and reason.get("code") == code:
+            reason["count"] = max(1, int(reason.get("count") or 0))
+            return
+    reasons.append({"code": code, "count": 1})

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -147,6 +147,7 @@ def build_verify_change_response(
     )
 
     coverage = _verification_coverage(analysis_result)
+    coverage = _reconcile_response_coverage(coverage, findings)
     status = _status_for_findings(findings, coverage)
 
     response = {
@@ -208,9 +209,7 @@ def _normalize_finding(
     rule_id = str(_finding_value(finding, ("rule_id", "rule"), "UNKNOWN"))
     default_vibe, default_likelihood = _rule_defaults(rule_id)
     vibe_category = str(_finding_value(finding, ("vibe_category",), default_vibe))
-    ai_likelihood = str(
-        _finding_value(finding, ("ai_likelihood",), default_likelihood)
-    )
+    ai_likelihood = str(_finding_value(finding, ("ai_likelihood",), default_likelihood))
     confidence = _confidence(finding.get("confidence"), ai_likelihood)
     severity = str(_finding_value(finding, ("severity",), "MEDIUM")).upper()
 
@@ -364,7 +363,19 @@ def _summary(
             skipped = _skipped_reference_count(coverage)
             if skipped == 1:
                 return "Verification incomplete: 1 reference could not be proven"
-            return f"Verification incomplete: {skipped} references could not be proven"
+            if skipped:
+                return (
+                    f"Verification incomplete: {skipped} references could not be proven"
+                )
+            incomplete_checks = _incomplete_check_count(coverage)
+            if incomplete_checks == 1:
+                return "Verification incomplete: 1 required check did not complete"
+            if incomplete_checks:
+                return (
+                    "Verification incomplete: "
+                    f"{incomplete_checks} required checks did not complete"
+                )
+            return "Verification incomplete: required checks did not complete"
         return "No AI-code issues found"
     if count == 1:
         issue_word = "issue"
@@ -472,6 +483,58 @@ def _verification_coverage(
     return dict(coverage)
 
 
+def _reconcile_response_coverage(
+    coverage: dict[str, Any] | None,
+    findings: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not isinstance(coverage, dict) or findings:
+        return coverage
+    checks = coverage.get("checks")
+    if not isinstance(checks, list):
+        return coverage
+    normalized_checks = []
+    missing_evidence = False
+    for check in checks:
+        if not isinstance(check, dict):
+            normalized_checks.append(check)
+            continue
+        normalized = dict(check)
+        reasons = normalized.get("reasons")
+        normalized["reasons"] = (
+            [dict(reason) for reason in reasons if isinstance(reason, dict)]
+            if isinstance(reasons, list)
+            else []
+        )
+        if normalized.get("outcome") == "fail":
+            missing_evidence = True
+            normalized["outcome"] = "incomplete"
+            normalized["finding_count"] = 0
+            normalized["skipped_references"] = max(
+                1,
+                _optional_int(normalized.get("skipped_references")) or 0,
+            )
+            _append_coverage_reason(
+                normalized, "finding_evidence_missing_from_response"
+            )
+        normalized_checks.append(normalized)
+    if not missing_evidence:
+        return coverage
+    reconciled = dict(coverage)
+    reconciled["state"] = "incomplete"
+    reconciled["checks"] = normalized_checks
+    return reconciled
+
+
+def _append_coverage_reason(check: dict[str, Any], code: str) -> None:
+    reasons = check.setdefault("reasons", [])
+    for reason in reasons:
+        if reason.get("code") == code:
+            reason["count"] = max(1, _optional_int(reason.get("count")) or 0)
+            return
+    reasons.append({"code": code, "count": 1})
+    reasons.sort(key=lambda reason: str(reason.get("code", "")))
+
+
 def _skipped_reference_count(coverage: dict[str, Any] | None) -> int:
     if not isinstance(coverage, dict):
         return 0
@@ -483,6 +546,19 @@ def _skipped_reference_count(coverage: dict[str, Any] | None) -> int:
         if isinstance(check, dict):
             total += max(0, _optional_int(check.get("skipped_references")) or 0)
     return total
+
+
+def _incomplete_check_count(coverage: dict[str, Any] | None) -> int:
+    if not isinstance(coverage, dict):
+        return 0
+    checks = coverage.get("checks")
+    if not isinstance(checks, list):
+        return 0
+    return sum(
+        1
+        for check in checks
+        if isinstance(check, dict) and check.get("outcome") == "incomplete"
+    )
 
 
 def _target_path_for_payload(

--- a/skylos/reporting/result_builder.py
+++ b/skylos/reporting/result_builder.py
@@ -181,8 +181,12 @@ def _attach_analysis_reports(analyzer, result):
     if isinstance(verification_checks, list):
         from skylos.core.verification_coverage import build_ai_verification_coverage
 
-        result["analysis_summary"]["ai_verification"] = (
-            build_ai_verification_coverage(verification_checks)
+        expected_checks = getattr(analyzer, "_ai_verification_expectations", None)
+        result["analysis_summary"]["ai_verification"] = build_ai_verification_coverage(
+            verification_checks,
+            expected_checks=expected_checks
+            if isinstance(expected_checks, list)
+            else None,
         )
 
     language_engines = getattr(analyzer, "_language_engine_reports", None)
@@ -336,6 +340,8 @@ def _attach_unused_ts_exports(result, unused_ts_exports):
         return
     result.setdefault("unused_exports", []).extend(unused_ts_exports)
     result["analysis_summary"]["unused_exports_count"] = len(unused_ts_exports)
+
+
 def _attach_grade(
     result,
     files,

--- a/skylos/rules/ai_defect/__init__.py
+++ b/skylos/rules/ai_defect/__init__.py
@@ -19,6 +19,15 @@ from skylos.rules.ai_defect.api_surface_drift import detect_cli_surface_drift
 from skylos.rules.ai_defect.js_api_hallucination import (
     scan_js_local_api_hallucinations,
 )
+from skylos.rules.ai_defect.python_api_hallucination import (
+    scan_python_local_api_hallucinations,
+)
+from skylos.rules.ai_defect.go_api_hallucination import (
+    scan_go_local_api_hallucinations,
+)
+from skylos.rules.ai_defect.java_api_hallucination import (
+    scan_java_local_api_hallucinations,
+)
 
 __all__ = [
     "PhantomCallRule",
@@ -32,4 +41,7 @@ __all__ = [
     "detect_ci_permission_expansion",
     "detect_cli_surface_drift",
     "scan_js_local_api_hallucinations",
+    "scan_python_local_api_hallucinations",
+    "scan_go_local_api_hallucinations",
+    "scan_java_local_api_hallucinations",
 ]

--- a/skylos/rules/ai_defect/go_api_hallucination.py
+++ b/skylos/rules/ai_defect/go_api_hallucination.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from skylos.core.go_api_surface import (
+    GoModule,
+    GoPackageSurface,
+    GoParsedFile,
+    discover_go_modules_with_reasons,
+    inspect_go_package_surface,
+    iter_nodes,
+    node_text,
+    parse_go_file,
+    resolve_go_import,
+    safe_go_files,
+)
+
+
+GO_API_CHECK_ID = "go_workspace_api_surface"
+
+
+@dataclass(frozen=True)
+class _GoImportBinding:
+    alias: str
+    import_path: str
+    surface: GoPackageSurface
+
+
+@dataclass
+class _GoScanState:
+    surface_cache: dict[tuple[str, str], GoPackageSurface] = field(default_factory=dict)
+    allowed_surface_files: frozenset[Path] | None = None
+    exclude_folders: tuple[str, ...] = ()
+    reasons: Counter[str] = field(default_factory=Counter)
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    references: int = 0
+    verified: int = 0
+    skipped: int = 0
+
+    def skip(self, reason: str) -> None:
+        self.reasons[reason] += 1
+        self.skipped += 1
+
+
+def scan_go_local_api_hallucinations(
+    project_root: str | Path,
+    files: Iterable[str | Path],
+    *,
+    restrict_to_files: bool = False,
+    exclude_folders: Sequence[str] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    root = _safe_root(project_root)
+    if root is None:
+        return [], failed_go_api_check("invalid_project_root")
+    go_files = safe_go_files(root, files)
+    if not go_files:
+        return [], _not_applicable_check()
+
+    modules, discovery_reasons = discover_go_modules_with_reasons(
+        root,
+        go_files,
+        exclude_folders=exclude_folders,
+    )
+    state = _GoScanState(
+        allowed_surface_files=frozenset(go_files) if restrict_to_files else None,
+        exclude_folders=tuple(exclude_folders or ()),
+    )
+    combined_reasons = set(discovery_reasons)
+    if not restrict_to_files and exclude_folders:
+        combined_reasons.add("excluded_workspace_paths")
+    for reason in sorted(combined_reasons):
+        state.references += 1
+        state.skip(reason)
+    for importer in go_files:
+        _scan_go_importer(importer, modules, state)
+
+    findings = _deduplicate_findings(state.findings)
+    return findings, _coverage_check(
+        applicable_files=len(go_files),
+        references=state.references,
+        verified=state.verified,
+        skipped=state.skipped,
+        findings=len(findings),
+        reasons=state.reasons,
+    )
+
+
+def failed_go_api_check(reason: str) -> dict[str, Any]:
+    return _coverage_check(
+        applicable_files=0,
+        references=0,
+        verified=0,
+        skipped=1,
+        findings=0,
+        reasons=Counter({reason: 1}),
+    )
+
+
+def skipped_go_api_check(reason: str) -> dict[str, Any]:
+    check = _not_applicable_check()
+    check["reasons"] = [{"code": reason, "count": 1}]
+    return check
+
+
+def _scan_go_importer(
+    importer: Path,
+    modules: list[GoModule],
+    state: _GoScanState,
+) -> None:
+    parsed, parse_reason = parse_go_file(importer)
+    if parsed is None:
+        state.references += 1
+        state.skip(parse_reason or "parse_error")
+        return
+    module = _module_for_file(importer, modules)
+    if module is None:
+        state.references += 1
+        state.skip("go_module_manifest_missing")
+        return
+    bindings = _local_import_bindings(parsed, modules, state)
+    if not bindings:
+        return
+    for node in iter_nodes(parsed.root_node):
+        if node.type == "selector_expression":
+            _inspect_selector(parsed, node, bindings, state)
+
+
+def _local_import_bindings(
+    parsed: GoParsedFile,
+    modules: list[GoModule],
+    state: _GoScanState,
+) -> dict[str, _GoImportBinding]:
+    bindings: dict[str, _GoImportBinding] = {}
+    for spec in _import_specs(parsed):
+        import_path = _import_path(parsed, spec)
+        if not import_path:
+            state.references += 1
+            state.skip("dynamic_import_path")
+            continue
+        module, directory, matched_local = resolve_go_import(import_path, modules)
+        if not matched_local:
+            continue
+        if module is None or directory is None:
+            state.references += 1
+            state.skip("unresolved_local_package")
+            continue
+        surface = _go_surface(module, import_path, directory, state)
+        alias = _import_alias(parsed, spec, surface)
+        if alias == "_":
+            continue
+        if alias == ".":
+            state.references += 1
+            state.skip("dot_import")
+            continue
+        if not alias:
+            state.references += 1
+            state.skip("import_alias_unresolved")
+            continue
+        binding = _GoImportBinding(alias, import_path, surface)
+        if alias in bindings:
+            state.references += 1
+            state.skip("ambiguous_import_alias")
+            bindings.pop(alias, None)
+            continue
+        bindings[alias] = binding
+    return bindings
+
+
+def _go_surface(
+    module: GoModule,
+    import_path: str,
+    directory: Path,
+    state: _GoScanState,
+) -> GoPackageSurface:
+    key = (import_path, str(directory.resolve(strict=False)))
+    if key not in state.surface_cache:
+        state.surface_cache[key] = inspect_go_package_surface(
+            module,
+            import_path,
+            directory,
+            allowed_files=state.allowed_surface_files,
+            exclude_folders=state.exclude_folders,
+        )
+    return state.surface_cache[key]
+
+
+def _inspect_selector(
+    parsed: GoParsedFile,
+    node: Any,
+    bindings: dict[str, _GoImportBinding],
+    state: _GoScanState,
+) -> None:
+    operand = node.child_by_field_name("operand")
+    field_node = node.child_by_field_name("field")
+    if operand is None or operand.type != "identifier" or field_node is None:
+        return
+    alias = node_text(parsed, operand)
+    binding = bindings.get(alias)
+    if binding is None:
+        return
+    state.references += 1
+    if _alias_is_shadowed(parsed, node, alias):
+        state.skip("import_alias_shadowed")
+        return
+    if not binding.surface.complete:
+        reason = binding.surface.incomplete_reasons[0]
+        state.skip(f"surface_{reason}")
+        return
+    symbol = node_text(parsed, field_node)
+    if symbol in binding.surface.members:
+        state.verified += 1
+        return
+    state.findings.append(_missing_go_symbol_finding(parsed, field_node, binding))
+
+
+def _import_specs(parsed: GoParsedFile) -> list[Any]:
+    specs = []
+    for node in iter_nodes(parsed.root_node):
+        if node.type == "import_spec":
+            specs.append(node)
+    return specs
+
+
+def _import_path(parsed: GoParsedFile, spec: Any) -> str | None:
+    path_node = spec.child_by_field_name("path")
+    if path_node is None:
+        return None
+    raw = node_text(parsed, path_node).strip()
+    if len(raw) < 2 or raw[0] not in {'"', "`"} or raw[-1] != raw[0]:
+        return None
+    return raw[1:-1]
+
+
+def _import_alias(
+    parsed: GoParsedFile,
+    spec: Any,
+    surface: GoPackageSurface,
+) -> str | None:
+    name_node = spec.child_by_field_name("name")
+    if name_node is not None:
+        return node_text(parsed, name_node)
+    if surface.package_name:
+        return surface.package_name
+    tail = surface.import_path.rstrip("/").rsplit("/", 1)[-1]
+    return tail or None
+
+
+def _module_for_file(path: Path, modules: Iterable[GoModule]) -> GoModule | None:
+    candidates = []
+    for module in modules:
+        try:
+            path.relative_to(module.root)
+        except ValueError:
+            continue
+        candidates.append(module)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda module: len(module.root.parts))
+
+
+def _alias_is_shadowed(parsed: GoParsedFile, selector: Any, alias: str) -> bool:
+    function = _enclosing_function(selector)
+    if function is None:
+        return False
+    for node in iter_nodes(function):
+        if node.start_byte >= selector.start_byte:
+            continue
+        if node.type not in {"identifier", "package_identifier"}:
+            continue
+        if node_text(parsed, node) != alias:
+            continue
+        if _declaration_identifier(node):
+            return True
+    return False
+
+
+def _enclosing_function(node: Any) -> Any | None:
+    current = node.parent
+    while current is not None:
+        if current.type in {
+            "function_declaration",
+            "method_declaration",
+            "func_literal",
+        }:
+            return current
+        current = current.parent
+    return None
+
+
+def _declaration_identifier(node: Any) -> bool:
+    current = node
+    for _ in range(4):
+        parent = current.parent
+        if parent is None:
+            return False
+        if parent.type in {
+            "parameter_declaration",
+            "variadic_parameter_declaration",
+            "var_spec",
+        }:
+            return _inside_named_field(parent, node, "name")
+        if parent.type in {"short_var_declaration", "range_clause"}:
+            return _inside_named_field(parent, node, "left")
+        if parent.type in {
+            "function_declaration",
+            "method_declaration",
+            "func_literal",
+        }:
+            return False
+        current = parent
+    return False
+
+
+def _inside_named_field(parent: Any, node: Any, field_name: str) -> bool:
+    field_nodes = parent.children_by_field_name(field_name)
+    return any(_node_contains(field_node, node) for field_node in field_nodes)
+
+
+def _node_contains(container: Any, node: Any) -> bool:
+    return (
+        container.start_byte <= node.start_byte and node.end_byte <= container.end_byte
+    )
+
+
+def _missing_go_symbol_finding(
+    parsed: GoParsedFile,
+    field_node: Any,
+    binding: _GoImportBinding,
+) -> dict[str, Any]:
+    symbol = node_text(parsed, field_node)
+    suggestions = get_close_matches(
+        symbol,
+        sorted(binding.surface.members),
+        n=3,
+        cutoff=0.6,
+    )
+    suggestion_text = (
+        f" Available close matches: {', '.join(suggestions)}." if suggestions else ""
+    )
+    return {
+        "rule_id": "SKY-L012",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": "package_selector",
+        "name": symbol,
+        "simple_name": symbol,
+        "value": "phantom",
+        "threshold": 0,
+        "message": (
+            f"'{symbol}' is referenced from local Go package "
+            f"'{binding.import_path}', but that symbol is not exported by its "
+            f"static API surface.{suggestion_text}"
+        ),
+        "suggested_fix": (
+            "Use an exported package symbol, add the missing declaration, or update the stale reference."
+        ),
+        "file": str(parsed.path),
+        "basename": parsed.path.name,
+        "line": int(field_node.start_point[0]) + 1,
+        "col": int(field_node.start_point[1]),
+        "category": "ai_defect",
+        "defect_type": "hallucinated_reference",
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+        "confidence": 96,
+        "metadata": {
+            "language": "go",
+            "reference_kind": "package_selector",
+            "module_source": binding.import_path,
+            "member_name": symbol,
+            "api_surface_source": "go_api_surface",
+            "surface_origin": str(binding.surface.directory),
+            "proof_state": "verified",
+        },
+    }
+
+
+def _coverage_check(
+    *,
+    applicable_files: int,
+    references: int,
+    verified: int,
+    skipped: int,
+    findings: int,
+    reasons: Counter[str],
+) -> dict[str, Any]:
+    outcome = "fail" if findings else ("incomplete" if skipped else "pass")
+    return {
+        "id": GO_API_CHECK_ID,
+        "status": "completed",
+        "outcome": outcome,
+        "scope": "local_workspace_api_surface",
+        "languages": ["go"],
+        "applicable_files": applicable_files,
+        "raw_imports": 0,
+        "references": references,
+        "checked_references": verified + findings,
+        "verified_references": verified,
+        "skipped_references": skipped,
+        "finding_count": findings,
+        "reasons": [
+            {"code": code, "count": count} for code, count in sorted(reasons.items())
+        ],
+    }
+
+
+def _not_applicable_check() -> dict[str, Any]:
+    return {
+        "id": GO_API_CHECK_ID,
+        "status": "skipped",
+        "outcome": "pass",
+        "scope": "local_workspace_api_surface",
+        "languages": [],
+        "applicable_files": 0,
+        "raw_imports": 0,
+        "references": 0,
+        "checked_references": 0,
+        "verified_references": 0,
+        "skipped_references": 0,
+        "finding_count": 0,
+        "reasons": [{"code": "no_supported_files", "count": 1}],
+    }
+
+
+def _safe_root(project_root: str | Path) -> Path | None:
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+    return root if root.is_dir() else None
+
+
+def _deduplicate_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    for finding in findings:
+        key = (
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("col"),
+            finding.get("simple_name"),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(finding)
+    return unique

--- a/skylos/rules/ai_defect/java_api_hallucination.py
+++ b/skylos/rules/ai_defect/java_api_hallucination.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from skylos.core.java_api_surface import (
+    JavaParsedFile,
+    JavaSurfaceIndex,
+    build_java_surface_index,
+    iter_nodes,
+    node_text,
+    parse_java_file,
+    safe_java_files,
+)
+from skylos.rules.ai_defect.java_api_hallucination_resolution import (
+    JavaScanState as _JavaScanState,
+    JavaTypeBinding as _JavaTypeBinding,
+    last_identifier as _last_identifier,
+    nested_type_owner as _nested_type_owner,
+    resolve_surface as _resolve_surface,
+    safe_root as _safe_root,
+    surface_ownership_reason as _surface_ownership_reason,
+    type_name_is_shadowed as _type_name_is_shadowed,
+    verify_surface_member as _verify_surface_member,
+)
+from skylos.rules.ai_defect.java_api_hallucination_reporting import (
+    JAVA_API_CHECK_ID as JAVA_API_CHECK_ID,
+    coverage_check as _coverage_check,
+    deduplicate_findings as _deduplicate_findings,
+    failed_java_api_check,
+    not_applicable_check as _not_applicable_check,
+    skipped_java_api_check as skipped_java_api_check,
+)
+
+
+def scan_java_local_api_hallucinations(
+    project_root: str | Path,
+    files: Iterable[str | Path],
+    *,
+    discover_workspace: bool = True,
+    exclude_folders: Sequence[str] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    root = _safe_root(project_root)
+    if root is None:
+        return [], failed_java_api_check("invalid_project_root")
+    java_files = safe_java_files(root, files)
+    if not java_files:
+        return [], _not_applicable_check()
+
+    index = build_java_surface_index(
+        root,
+        java_files,
+        discover_workspace=discover_workspace,
+        exclude_folders=exclude_folders,
+    )
+    state = _JavaScanState()
+    for reason in index.global_reasons:
+        if reason not in {"excluded_workspace_paths", "source_file_limit"}:
+            continue
+        state.references += 1
+        state.skip(reason)
+    for importer in java_files:
+        _scan_java_importer(root, importer, index, state)
+
+    findings = _deduplicate_findings(state.findings)
+    return findings, _coverage_check(
+        applicable_files=len(java_files),
+        references=state.references,
+        verified=state.verified,
+        skipped=state.skipped,
+        findings=len(findings),
+        reasons=state.reasons,
+    )
+
+
+def _scan_java_importer(
+    root: Path,
+    importer: Path,
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> None:
+    parsed, parse_reason = parse_java_file(importer, root=root)
+    if parsed is None:
+        state.references += 1
+        state.skip(parse_reason or "parse_error")
+        return
+    bindings = _type_bindings(parsed, index, state)
+    local_instances = _local_instance_names(parsed, bindings, index)
+    for node in iter_nodes(parsed.root_node):
+        if node.type == "method_invocation":
+            _inspect_method_invocation(
+                parsed, node, bindings, local_instances, index, state
+            )
+        elif node.type == "method_reference":
+            _inspect_method_reference(
+                parsed,
+                node,
+                bindings,
+                local_instances,
+                index,
+                state,
+            )
+        elif node.type == "field_access":
+            _inspect_field_access(parsed, node, bindings, index, state)
+
+
+def _type_bindings(
+    parsed: JavaParsedFile,
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> dict[str, _JavaTypeBinding]:
+    bindings = _same_package_bindings(parsed, index)
+    for node in parsed.root_node.named_children:
+        if node.type != "import_declaration":
+            continue
+        _apply_import(parsed, node, index, bindings, state)
+    return bindings
+
+
+def _same_package_bindings(
+    parsed: JavaParsedFile,
+    index: JavaSurfaceIndex,
+) -> dict[str, _JavaTypeBinding]:
+    bindings = {}
+    for qualified_name, surface in index.types.items():
+        if surface.package_name != parsed.package_name:
+            continue
+        ownership_reason = _surface_ownership_reason(parsed, surface)
+        if ownership_reason:
+            continue
+        bindings[surface.simple_name] = _JavaTypeBinding(
+            surface.simple_name,
+            qualified_name,
+            surface,
+        )
+    return bindings
+
+
+def _apply_import(
+    parsed: JavaParsedFile,
+    node: Any,
+    index: JavaSurfaceIndex,
+    bindings: dict[str, _JavaTypeBinding],
+    state: _JavaScanState,
+) -> None:
+    import_text = " ".join(node_text(parsed, node).replace(";", "").split())
+    if not import_text.startswith("import "):
+        return
+    value = import_text[7:]
+    is_static = value.startswith("static ")
+    if is_static:
+        value = value[7:]
+        _verify_static_import(parsed, node, value, index, state)
+        return
+    if value.endswith(".*"):
+        package_name = value[:-2]
+        if index.package_is_local(package_name):
+            state.references += 1
+            state.skip("wildcard_import")
+        return
+    _bind_explicit_type_import(parsed, value, index, bindings, state)
+
+
+def _verify_static_import(
+    parsed: JavaParsedFile,
+    node: Any,
+    value: str,
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> None:
+    wildcard = value.endswith(".*")
+    type_name = value[:-2] if wildcard else value.rsplit(".", 1)[0]
+    surface = index.type_surface(type_name)
+    if surface is None:
+        package_name = type_name.rsplit(".", 1)[0] if "." in type_name else ""
+        if index.package_is_local(package_name):
+            state.references += 1
+            _missing_or_incomplete_type(type_name, index, state)
+        return
+    state.references += 1
+    ownership_reason = _surface_ownership_reason(parsed, surface)
+    if ownership_reason:
+        state.skip(ownership_reason)
+        return
+    if wildcard:
+        state.skip("static_wildcard_import")
+        return
+    reason = index.proof_reason(surface)
+    if reason:
+        state.skip(f"surface_{reason}")
+        return
+    member_name = value.rsplit(".", 1)[-1]
+    name_node = _last_identifier(node)
+    _verify_surface_member(
+        parsed,
+        name_node or node,
+        surface,
+        member_name,
+        expected_kind="member",
+        state=state,
+    )
+
+
+def _bind_explicit_type_import(
+    parsed: JavaParsedFile,
+    qualified_name: str,
+    index: JavaSurfaceIndex,
+    bindings: dict[str, _JavaTypeBinding],
+    state: _JavaScanState,
+) -> None:
+    surface = index.type_surface(qualified_name)
+    package_name, _, simple_name = qualified_name.rpartition(".")
+    if surface is None:
+        owner_surface = _nested_type_owner(qualified_name, index)
+        if owner_surface is not None:
+            state.references += 1
+            ownership_reason = _surface_ownership_reason(parsed, owner_surface)
+            state.skip(ownership_reason or "nested_type_import_unsupported")
+            return
+        if index.package_is_local(package_name):
+            state.references += 1
+            _missing_or_incomplete_type(qualified_name, index, state)
+        return
+    ownership_reason = _surface_ownership_reason(parsed, surface)
+    if ownership_reason:
+        state.references += 1
+        state.skip(ownership_reason)
+        return
+    binding = _JavaTypeBinding(simple_name, qualified_name, surface)
+    existing = bindings.get(simple_name)
+    if existing is not None and existing.qualified_name != qualified_name:
+        state.references += 1
+        state.skip("ambiguous_type_import")
+        bindings.pop(simple_name, None)
+        return
+    bindings[simple_name] = binding
+
+
+def _missing_or_incomplete_type(
+    qualified_name: str,
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> None:
+    reason = index.proof_reason()
+    if qualified_name in index.ambiguous_types:
+        reason = "ambiguous_type"
+    if reason:
+        state.skip(f"surface_{reason}")
+        return
+    state.skip("local_type_ownership_uncertain")
+
+
+def _inspect_method_invocation(
+    parsed: JavaParsedFile,
+    node: Any,
+    bindings: dict[str, _JavaTypeBinding],
+    local_instances: set[str],
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> None:
+    object_node = node.child_by_field_name("object")
+    name_node = node.child_by_field_name("name")
+    if object_node is None or name_node is None:
+        return
+    if _nested_local_type_qualifier(parsed, object_node, bindings, index):
+        state.references += 1
+        state.skip("nested_type_member_unsupported")
+        return
+    if object_node.type == "identifier":
+        object_name = node_text(parsed, object_node)
+        if object_name in local_instances:
+            state.references += 1
+            state.skip("instance_type_inference_unsupported")
+            return
+    _inspect_qualified_member(
+        parsed, node, object_node, name_node, bindings, index, state
+    )
+
+
+def _inspect_method_reference(
+    parsed: JavaParsedFile,
+    node: Any,
+    bindings: dict[str, _JavaTypeBinding],
+    local_instances: set[str],
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> None:
+    if len(node.named_children) < 2:
+        return
+    qualifier_node = node.named_children[0]
+    member_node = node.named_children[-1]
+    qualifier = node_text(parsed, qualifier_node)
+    if qualifier_node.type == "identifier" and qualifier in local_instances:
+        state.references += 1
+        state.skip("instance_method_reference_unsupported")
+        return
+    surface, binding = _resolve_surface(parsed, qualifier, bindings, index)
+    if surface is None:
+        return
+    state.references += 1
+    ownership_reason = _surface_ownership_reason(parsed, surface)
+    if ownership_reason:
+        state.skip(ownership_reason)
+        return
+    if binding is not None and _type_name_is_shadowed(parsed, node, qualifier):
+        state.skip("type_name_shadowed")
+        return
+    reason = index.proof_reason(surface)
+    if reason:
+        state.skip(f"surface_{reason}")
+        return
+    member_name = node_text(parsed, member_node)
+    if member_name not in surface.members:
+        state.skip("method_reference_unsupported")
+        return
+    _verify_surface_member(
+        parsed,
+        member_node,
+        surface,
+        member_name,
+        expected_kind="method",
+        state=state,
+    )
+
+
+def _inspect_field_access(
+    parsed: JavaParsedFile,
+    node: Any,
+    bindings: dict[str, _JavaTypeBinding],
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> None:
+    object_node = node.child_by_field_name("object")
+    field_node = node.child_by_field_name("field")
+    if object_node is None or field_node is None:
+        return
+    if _nested_local_type_qualifier(parsed, object_node, bindings, index):
+        state.references += 1
+        state.skip("nested_type_member_unsupported")
+        return
+    qualifier = node_text(parsed, object_node)
+    surface, _binding = _resolve_surface(parsed, qualifier, bindings, index)
+    if surface is not None:
+        member_name = node_text(parsed, field_node)
+        if any(
+            member.kind == "type" for member in surface.members.get(member_name, ())
+        ):
+            state.references += 1
+            state.skip("nested_type_member_unsupported")
+            return
+    _inspect_qualified_member(
+        parsed,
+        node,
+        object_node,
+        field_node,
+        bindings,
+        index,
+        state,
+        expected_kind="field",
+    )
+
+
+def _inspect_qualified_member(
+    parsed: JavaParsedFile,
+    owner: Any,
+    qualifier_node: Any,
+    member_node: Any,
+    bindings: dict[str, _JavaTypeBinding],
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+    *,
+    expected_kind: str = "method",
+) -> None:
+    qualifier = node_text(parsed, qualifier_node)
+    surface, binding = _resolve_surface(parsed, qualifier, bindings, index)
+    if surface is None:
+        _inspect_missing_qualified_local_type(
+            qualifier,
+            index,
+            state,
+        )
+        return
+    state.references += 1
+    ownership_reason = _surface_ownership_reason(parsed, surface)
+    if ownership_reason:
+        state.skip(ownership_reason)
+        return
+    if binding is not None and _type_name_is_shadowed(parsed, owner, qualifier):
+        state.skip("type_name_shadowed")
+        return
+    reason = index.proof_reason(surface)
+    if reason:
+        state.skip(f"surface_{reason}")
+        return
+    member_name = node_text(parsed, member_node)
+    _verify_surface_member(
+        parsed,
+        member_node,
+        surface,
+        member_name,
+        expected_kind=expected_kind,
+        state=state,
+    )
+
+
+def _inspect_missing_qualified_local_type(
+    qualifier: str,
+    index: JavaSurfaceIndex,
+    state: _JavaScanState,
+) -> None:
+    package_name, separator, simple_name = qualifier.rpartition(".")
+    if not separator or not simple_name[:1].isupper():
+        return
+    if not index.package_is_local(package_name):
+        return
+    state.references += 1
+    _missing_or_incomplete_type(qualifier, index, state)
+
+
+def _local_instance_names(
+    parsed: JavaParsedFile,
+    bindings: dict[str, _JavaTypeBinding],
+    index: JavaSurfaceIndex,
+) -> set[str]:
+    names: set[str] = set()
+    for node in iter_nodes(parsed.root_node):
+        if node.type not in {
+            "formal_parameter",
+            "local_variable_declaration",
+            "field_declaration",
+        }:
+            continue
+        type_node = node.child_by_field_name("type")
+        if type_node is None:
+            continue
+        type_name = node_text(parsed, type_node).split("<", 1)[0].rstrip("[]")
+        if type_name == "var":
+            names.update(_inferred_local_instance_names(parsed, node, bindings, index))
+            continue
+        surface, _binding = _resolve_surface(parsed, type_name, bindings, index)
+        if surface is None or _surface_ownership_reason(parsed, surface):
+            continue
+        for name_node in node.children_by_field_name("name"):
+            names.add(node_text(parsed, name_node))
+        for child in node.named_children:
+            if child.type == "variable_declarator":
+                name_node = child.child_by_field_name("name")
+                if name_node is not None:
+                    names.add(node_text(parsed, name_node))
+    return names
+
+
+def _inferred_local_instance_names(
+    parsed: JavaParsedFile,
+    declaration: Any,
+    bindings: dict[str, _JavaTypeBinding],
+    index: JavaSurfaceIndex,
+) -> set[str]:
+    names: set[str] = set()
+    for child in declaration.named_children:
+        if child.type != "variable_declarator":
+            continue
+        value_node = child.child_by_field_name("value")
+        name_node = child.child_by_field_name("name")
+        if value_node is None or name_node is None:
+            continue
+        if value_node.type != "object_creation_expression":
+            continue
+        type_node = value_node.child_by_field_name("type")
+        if type_node is None:
+            continue
+        type_name = node_text(parsed, type_node)
+        surface, _binding = _resolve_surface(parsed, type_name, bindings, index)
+        if surface is None or _surface_ownership_reason(parsed, surface):
+            continue
+        names.add(node_text(parsed, name_node))
+    return names
+
+
+def _nested_local_type_qualifier(
+    parsed: JavaParsedFile,
+    node: Any,
+    bindings: dict[str, _JavaTypeBinding],
+    index: JavaSurfaceIndex,
+) -> bool:
+    qualifier = node_text(parsed, node)
+    if "." not in qualifier:
+        return False
+    segments = qualifier.split(".")
+    if segments[0] in bindings:
+        return True
+    for end in range(len(segments) - 1, 0, -1):
+        surface, _binding = _resolve_surface(
+            parsed,
+            ".".join(segments[:end]),
+            bindings,
+            index,
+        )
+        if surface is not None and not _surface_ownership_reason(parsed, surface):
+            return True
+    return False

--- a/skylos/rules/ai_defect/java_api_hallucination_reporting.py
+++ b/skylos/rules/ai_defect/java_api_hallucination_reporting.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from collections import Counter
+from difflib import get_close_matches
+from typing import Any
+
+from skylos.core.java_api_surface import JavaParsedFile, JavaTypeSurface
+
+
+JAVA_API_CHECK_ID = "java_workspace_api_surface"
+
+
+def failed_java_api_check(reason: str) -> dict[str, Any]:
+    return coverage_check(
+        applicable_files=0,
+        references=0,
+        verified=0,
+        skipped=1,
+        findings=0,
+        reasons=Counter({reason: 1}),
+    )
+
+
+def skipped_java_api_check(reason: str) -> dict[str, Any]:
+    check = not_applicable_check()
+    check["reasons"] = [{"code": reason, "count": 1}]
+    return check
+
+
+def missing_java_member_finding(
+    parsed: JavaParsedFile,
+    member_node: Any,
+    surface: JavaTypeSurface,
+    member_name: str,
+    *,
+    expected_kind: str = "member",
+) -> dict[str, Any]:
+    suggestions = get_close_matches(
+        member_name,
+        sorted(surface.members),
+        n=3,
+        cutoff=0.6,
+    )
+    suggestion_text = (
+        f" Available close matches: {', '.join(suggestions)}." if suggestions else ""
+    )
+    return _java_finding(
+        parsed,
+        member_node,
+        member_name,
+        "static_member",
+        (
+            f"'{member_name}' is referenced from local Java type "
+            f"'{surface.qualified_name}', but that static {expected_kind} is not present "
+            f"in its source API surface.{suggestion_text}"
+        ),
+        module_source=surface.qualified_name,
+        surface_origin=str(surface.file),
+        extra_metadata={"expected_member_kind": expected_kind},
+    )
+
+
+def invalid_java_member_kind_finding(
+    parsed: JavaParsedFile,
+    member_node: Any,
+    surface: JavaTypeSurface,
+    member_name: str,
+    *,
+    expected_kind: str,
+    actual_kinds: list[str],
+) -> dict[str, Any]:
+    actual = ", ".join(sorted(set(actual_kinds)))
+    return _java_finding(
+        parsed,
+        member_node,
+        member_name,
+        "static_member",
+        (
+            f"'{member_name}' is used as a static {expected_kind} on local Java "
+            f"type '{surface.qualified_name}', but the source surface declares it "
+            f"as {actual}."
+        ),
+        module_source=surface.qualified_name,
+        surface_origin=str(surface.file),
+        extra_metadata={
+            "expected_member_kind": expected_kind,
+            "actual_member_kinds": actual,
+        },
+    )
+
+
+def inaccessible_java_member_finding(
+    parsed: JavaParsedFile,
+    member_node: Any,
+    surface: JavaTypeSurface,
+    member_name: str,
+    *,
+    visibility: str,
+) -> dict[str, Any]:
+    return _java_finding(
+        parsed,
+        member_node,
+        member_name,
+        "static_member",
+        (
+            f"'{member_name}' exists on local Java type '{surface.qualified_name}', "
+            f"but its {visibility} visibility does not allow this reference."
+        ),
+        module_source=surface.qualified_name,
+        surface_origin=str(surface.file),
+        extra_metadata={"member_visibility": visibility},
+    )
+
+
+def coverage_check(
+    *,
+    applicable_files: int,
+    references: int,
+    verified: int,
+    skipped: int,
+    findings: int,
+    reasons: Counter[str],
+) -> dict[str, Any]:
+    outcome = "fail" if findings else ("incomplete" if skipped else "pass")
+    return {
+        "id": JAVA_API_CHECK_ID,
+        "status": "completed",
+        "outcome": outcome,
+        "scope": "local_workspace_api_surface",
+        "languages": ["java"],
+        "applicable_files": applicable_files,
+        "raw_imports": 0,
+        "references": references,
+        "checked_references": verified + findings,
+        "verified_references": verified,
+        "skipped_references": skipped,
+        "finding_count": findings,
+        "reasons": [
+            {"code": code, "count": count} for code, count in sorted(reasons.items())
+        ],
+    }
+
+
+def not_applicable_check() -> dict[str, Any]:
+    return {
+        "id": JAVA_API_CHECK_ID,
+        "status": "skipped",
+        "outcome": "pass",
+        "scope": "local_workspace_api_surface",
+        "languages": [],
+        "applicable_files": 0,
+        "raw_imports": 0,
+        "references": 0,
+        "checked_references": 0,
+        "verified_references": 0,
+        "skipped_references": 0,
+        "finding_count": 0,
+        "reasons": [{"code": "no_supported_files", "count": 1}],
+    }
+
+
+def deduplicate_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    for finding in findings:
+        key = (
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("col"),
+            finding.get("simple_name"),
+            finding.get("type"),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(finding)
+    return unique
+
+
+def _java_finding(
+    parsed: JavaParsedFile,
+    node: Any,
+    symbol: str,
+    reference_kind: str,
+    message: str,
+    *,
+    module_source: str,
+    surface_origin: str,
+    extra_metadata: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    metadata = {
+        "language": "java",
+        "reference_kind": reference_kind,
+        "module_source": module_source,
+        "member_name": symbol,
+        "api_surface_source": "java_api_surface",
+        "surface_origin": surface_origin,
+        "proof_state": "verified",
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    return {
+        "rule_id": "SKY-L012",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": reference_kind,
+        "name": symbol,
+        "simple_name": symbol,
+        "value": "phantom",
+        "threshold": 0,
+        "message": message,
+        "suggested_fix": (
+            "Use an existing local type or static member, add the missing declaration, "
+            "or update the stale reference."
+        ),
+        "file": str(parsed.path),
+        "basename": parsed.path.name,
+        "line": int(node.start_point[0]) + 1,
+        "col": int(node.start_point[1]),
+        "category": "ai_defect",
+        "defect_type": "hallucinated_reference",
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+        "confidence": 96,
+        "metadata": metadata,
+    }

--- a/skylos/rules/ai_defect/java_api_hallucination_resolution.py
+++ b/skylos/rules/ai_defect/java_api_hallucination_resolution.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from skylos.core.java_api_surface import (
+    JavaMemberSurface,
+    JavaParsedFile,
+    JavaSurfaceIndex,
+    JavaTypeSurface,
+    iter_nodes,
+    java_module_roots_compatible,
+    java_source_sets_compatible,
+    node_text,
+)
+from skylos.rules.ai_defect.java_api_hallucination_reporting import (
+    inaccessible_java_member_finding,
+    invalid_java_member_kind_finding,
+    missing_java_member_finding,
+)
+
+
+@dataclass(frozen=True)
+class JavaTypeBinding:
+    simple_name: str
+    qualified_name: str
+    surface: JavaTypeSurface
+
+
+@dataclass
+class JavaScanState:
+    reasons: Counter[str] = field(default_factory=Counter)
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    references: int = 0
+    verified: int = 0
+    skipped: int = 0
+
+    def skip(self, reason: str) -> None:
+        self.reasons[reason] += 1
+        self.skipped += 1
+
+
+def resolve_surface(
+    parsed: JavaParsedFile,
+    qualifier: str,
+    bindings: dict[str, JavaTypeBinding],
+    index: JavaSurfaceIndex,
+) -> tuple[JavaTypeSurface | None, JavaTypeBinding | None]:
+    binding = bindings.get(qualifier)
+    if binding is not None:
+        return binding.surface, binding
+    surface = index.type_surface(qualifier)
+    if surface is None and "." not in qualifier and parsed.package_name:
+        surface = index.type_surface(f"{parsed.package_name}.{qualifier}")
+    return surface, None
+
+
+def surface_ownership_reason(
+    parsed: JavaParsedFile,
+    surface: JavaTypeSurface,
+) -> str | None:
+    if not java_source_sets_compatible(parsed.source_set, surface.source_set):
+        return "source_set_ownership_uncertain"
+    if not java_module_roots_compatible(parsed.module_root, surface.module_root):
+        return "module_ownership_uncertain"
+    return None
+
+
+def nested_type_owner(
+    qualified_name: str,
+    index: JavaSurfaceIndex,
+) -> JavaTypeSurface | None:
+    segments = qualified_name.split(".")
+    for end in range(len(segments) - 1, 0, -1):
+        surface = index.type_surface(".".join(segments[:end]))
+        if surface is not None:
+            return surface
+    return None
+
+
+def verify_surface_member(
+    parsed: JavaParsedFile,
+    member_node: Any,
+    surface: JavaTypeSurface,
+    member_name: str,
+    *,
+    expected_kind: str,
+    state: JavaScanState,
+) -> None:
+    members = list(surface.members.get(member_name, ()))
+    if not members:
+        state.findings.append(
+            missing_java_member_finding(
+                parsed,
+                member_node,
+                surface,
+                member_name,
+                expected_kind=expected_kind,
+            )
+        )
+        return
+    kind_matches = (
+        members
+        if expected_kind == "member"
+        else [member for member in members if member.kind == expected_kind]
+    )
+    if not kind_matches:
+        state.findings.append(
+            invalid_java_member_kind_finding(
+                parsed,
+                member_node,
+                surface,
+                member_name,
+                expected_kind=expected_kind,
+                actual_kinds=[member.kind for member in members],
+            )
+        )
+        return
+    access_states = [
+        _member_access_state(parsed, surface, member) for member in kind_matches
+    ]
+    if "accessible" in access_states:
+        state.verified += 1
+        return
+    if "uncertain" in access_states:
+        state.skip("member_visibility_uncertain")
+        return
+    state.findings.append(
+        inaccessible_java_member_finding(
+            parsed,
+            member_node,
+            surface,
+            member_name,
+            visibility=kind_matches[0].visibility,
+        )
+    )
+
+
+def type_name_is_shadowed(parsed: JavaParsedFile, owner: Any, name: str) -> bool:
+    function = _enclosing_method(owner)
+    if function is None:
+        return False
+    for node in iter_nodes(function):
+        if node.start_byte >= owner.start_byte or node.type != "identifier":
+            continue
+        if node_text(parsed, node) != name:
+            continue
+        parent = node.parent
+        if parent is not None and parent.type in {
+            "formal_parameter",
+            "variable_declarator",
+        }:
+            if node in parent.children_by_field_name("name"):
+                return True
+    return False
+
+
+def last_identifier(node: Any) -> Any | None:
+    identifiers = [
+        child
+        for child in iter_nodes(node)
+        if child.type in {"identifier", "type_identifier"}
+    ]
+    return identifiers[-1] if identifiers else None
+
+
+def safe_root(project_root: str | Path) -> Path | None:
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+    return root if root.is_dir() else None
+
+
+def _member_access_state(
+    parsed: JavaParsedFile,
+    surface: JavaTypeSurface,
+    member: JavaMemberSurface,
+) -> str:
+    if member.visibility == "public":
+        return "accessible"
+    if member.visibility == "private":
+        return "accessible" if parsed.path == surface.file else "inaccessible"
+    if member.visibility == "package":
+        return (
+            "accessible"
+            if parsed.package_name == surface.package_name
+            else "inaccessible"
+        )
+    if member.visibility == "protected":
+        return (
+            "accessible" if parsed.package_name == surface.package_name else "uncertain"
+        )
+    return "uncertain"
+
+
+def _enclosing_method(node: Any) -> Any | None:
+    current = node.parent
+    while current is not None:
+        if current.type in {
+            "constructor_declaration",
+            "lambda_expression",
+            "method_declaration",
+        }:
+            return current
+        current = current.parent
+    return None

--- a/skylos/rules/ai_defect/phantom_refs.py
+++ b/skylos/rules/ai_defect/phantom_refs.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
 
+PYTHON_SOURCE_SUFFIXES = (".py", ".pyi", ".pyw")
+
+
 @dataclass
 class _ScopeInfo:
     shadowed_names: set[str]
@@ -22,9 +25,13 @@ def scan_repo_phantom_security_references(
 ):
     vibe_dictionary = vibe_dictionary or DEFAULT_VIBE_DICTIONARY
     root = Path(project_root).resolve()
-    files = [Path(f).resolve() for f in py_files if Path(f).suffix == ".py"]
+    files = [
+        Path(f).resolve() for f in py_files if Path(f).suffix in PYTHON_SOURCE_SUFFIXES
+    ]
     target_paths = {
-        Path(f).resolve() for f in (target_files or files) if Path(f).suffix == ".py"
+        Path(f).resolve()
+        for f in (target_files or files)
+        if Path(f).suffix in PYTHON_SOURCE_SUFFIXES
     }
 
     module_to_file = {}
@@ -46,6 +53,11 @@ def scan_repo_phantom_security_references(
         file_to_module[file_path] = module_name
 
     local_modules = set(module_to_file)
+    package_modules = {
+        module_name
+        for module_name, file_path in module_to_file.items()
+        if _is_package_module_file(file_path)
+    }
     if not local_modules:
         return []
 
@@ -102,8 +114,57 @@ def scan_repo_phantom_security_references(
         _store_module_facts(current_module, tree)
         parent_map = _build_parent_map(tree)
         scope_infos = _build_scope_infos(tree, current_module, local_modules)
+        findings.extend(
+            _direct_local_import_findings(
+                file_path,
+                current_module,
+                tree,
+                local_modules,
+                module_members,
+                dynamic_modules,
+                package_modules,
+                _ensure_module_loaded,
+            )
+        )
 
         for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+                if _attribute_is_call_target(node, parent_map):
+                    continue
+                if _attribute_is_decorator_target(node, parent_map):
+                    continue
+                if _attribute_is_nested_prefix(node, parent_map):
+                    continue
+                resolved = _resolve_local_module_member(
+                    expr=node,
+                    node=node,
+                    tree=tree,
+                    parent_map=parent_map,
+                    scope_infos=scope_infos,
+                    module_alias_exports=module_alias_exports,
+                    local_modules=local_modules,
+                    ensure_module_loaded=_ensure_module_loaded,
+                )
+                if not resolved:
+                    continue
+                target_module, member_name, expr_text = resolved
+                if not _ensure_module_loaded(target_module):
+                    continue
+                if target_module in dynamic_modules:
+                    continue
+                if member_name in module_members.get(target_module, set()):
+                    continue
+                findings.append(
+                    _build_reference_finding(
+                        file_path,
+                        node,
+                        expr_text,
+                        target_module,
+                        member_name,
+                    )
+                )
+                continue
+
             if isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Name):
                     bare_finding = _bare_call_finding(
@@ -173,8 +234,6 @@ def scan_repo_phantom_security_references(
                     continue
 
                 target_module, member_name, expr_text = resolved
-                if member_name not in vibe_dictionary.phantom_security_decorators:
-                    continue
                 if not _ensure_module_loaded(target_module):
                     continue
                 if target_module in dynamic_modules:
@@ -193,6 +252,50 @@ def scan_repo_phantom_security_references(
                 )
 
     return findings
+
+
+def _direct_local_import_findings(
+    file_path,
+    current_module,
+    tree,
+    local_modules,
+    module_members,
+    dynamic_modules,
+    package_modules,
+    ensure_module_loaded,
+):
+    findings = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        base = _resolve_import_from_base(current_module, node)
+        if base not in local_modules:
+            continue
+        if not ensure_module_loaded(base) or base in dynamic_modules:
+            continue
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            full_module = f"{base}.{alias.name}"
+            if full_module in local_modules:
+                continue
+            if alias.name in module_members.get(base, set()):
+                continue
+            if base in package_modules:
+                continue
+            findings.append(
+                _build_import_finding(
+                    file_path,
+                    node,
+                    base,
+                    alias.name,
+                )
+            )
+    return findings
+
+
+def _is_package_module_file(file_path):
+    return file_path.name in {"__init__.py", "__init__.pyi", "__init__.pyw"}
 
 
 def _repo_member_names(module_members):
@@ -274,8 +377,10 @@ def _module_name(root: Path, file_path: Path) -> str:
     if not parts:
         return ""
 
-    if parts[-1].endswith(".py"):
-        parts[-1] = parts[-1][:-3]
+    for suffix in PYTHON_SOURCE_SUFFIXES:
+        if parts[-1].endswith(suffix):
+            parts[-1] = parts[-1][: -len(suffix)]
+            break
     if parts[-1] == "__init__":
         parts.pop()
     return ".".join(parts)
@@ -573,6 +678,34 @@ def _is_decorator_expression(child, parent):
     return bool(decorator_list) and child in decorator_list
 
 
+def _attribute_is_call_target(node, parent_map):
+    parent = parent_map.get(node)
+    return isinstance(parent, ast.Call) and parent.func is node
+
+
+def _attribute_is_decorator_target(node, parent_map):
+    child = node
+    current = parent_map.get(node)
+    while current is not None:
+        if isinstance(current, ast.Call) and current.func is child:
+            child = current
+            current = parent_map.get(current)
+            continue
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return child in current.decorator_list
+        if isinstance(current, ast.Attribute) and current.value is child:
+            child = current
+            current = parent_map.get(current)
+            continue
+        break
+    return False
+
+
+def _attribute_is_nested_prefix(node, parent_map):
+    parent = parent_map.get(node)
+    return isinstance(parent, ast.Attribute) and parent.value is node
+
+
 def _resolve_import_from_base(current_module, node):
     module = node.module or ""
     if "." in current_module:
@@ -709,6 +842,62 @@ def _build_decorator_finding(file_path, node, expr_text, target_module, member_n
             f"Decorator '@{expr_text}' resolves to local module '{target_module}', "
             f"but '{member_name}' is not defined or re-exported there. "
             f"AI-generated code often hallucinates security decorators on local modules."
+        ),
+        "file": str(file_path),
+        "basename": file_path.name,
+        "line": node.lineno,
+        "col": node.col_offset,
+        "category": "ai_defect",
+        "defect_type": "hallucinated_reference",
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+    }
+
+
+def _build_reference_finding(
+    file_path,
+    node,
+    expr_text,
+    target_module,
+    member_name,
+):
+    return {
+        "rule_id": "SKY-L012",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": "module_member",
+        "name": expr_text,
+        "simple_name": member_name,
+        "value": "phantom",
+        "threshold": 0,
+        "message": (
+            f"Reference '{expr_text}' resolves to local module '{target_module}', "
+            f"but '{member_name}' is not defined or re-exported there."
+        ),
+        "file": str(file_path),
+        "basename": file_path.name,
+        "line": node.lineno,
+        "col": node.col_offset,
+        "category": "ai_defect",
+        "defect_type": "hallucinated_reference",
+        "vibe_category": "hallucinated_reference",
+        "ai_likelihood": "high",
+    }
+
+
+def _build_import_finding(file_path, node, target_module, member_name):
+    return {
+        "rule_id": "SKY-L012",
+        "kind": "logic",
+        "severity": "CRITICAL",
+        "type": "from_import",
+        "name": member_name,
+        "simple_name": member_name,
+        "value": "phantom",
+        "threshold": 0,
+        "message": (
+            f"Import from local module '{target_module}' requests '{member_name}', "
+            "but that name is not defined or re-exported there."
         ),
         "file": str(file_path),
         "basename": file_path.name,

--- a/skylos/rules/ai_defect/python_api_hallucination.py
+++ b/skylos/rules/ai_defect/python_api_hallucination.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from skylos.core.safe_cache_io import read_text_no_symlink
+from skylos.rules.ai_defect.phantom_refs import (
+    _build_parent_map,
+    _build_scope_infos,
+    _collect_module_facts,
+    _module_name,
+    _resolve_local_module_member,
+    _resolve_import_from_base,
+    scan_repo_phantom_security_references,
+)
+from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
+
+
+PYTHON_API_CHECK_ID = "python_local_api_reference"
+_MAX_PYTHON_SOURCE_BYTES = 2 * 1024 * 1024
+PYTHON_API_SUFFIXES = (".py", ".pyi", ".pyw")
+
+
+@dataclass
+class _PythonCoverageState:
+    references: int = 0
+    verified: int = 0
+    skipped: int = 0
+    reasons: Counter[str] = None
+
+    def __post_init__(self) -> None:
+        if self.reasons is None:
+            self.reasons = Counter()
+
+    def skip(self, reason: str) -> None:
+        self.skipped += 1
+        self.reasons[reason] += 1
+
+
+def scan_python_local_api_hallucinations(
+    project_root: str | Path,
+    py_files: Iterable[str | Path],
+    *,
+    target_files: Iterable[str | Path] | None = None,
+    vibe_dictionary: Any | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    root = _safe_root(project_root)
+    if root is None:
+        return [], failed_python_api_check("invalid_project_root")
+    files = _safe_python_files(root, py_files)
+    if not files:
+        return [], _not_applicable_check()
+    targets = _safe_python_files(root, target_files or files)
+    if not targets:
+        return [], failed_python_api_check("no_safe_target_files")
+
+    dictionary = vibe_dictionary or DEFAULT_VIBE_DICTIONARY
+    findings = scan_repo_phantom_security_references(
+        root,
+        files,
+        target_files=targets,
+        vibe_dictionary=dictionary,
+    )
+    _enrich_python_findings(findings)
+    coverage = _inspect_python_coverage(root, files, targets, findings)
+    return findings, coverage
+
+
+def failed_python_api_check(reason: str) -> dict[str, Any]:
+    return _coverage_check(
+        applicable_files=0,
+        references=0,
+        verified=0,
+        skipped=1,
+        findings=0,
+        reasons=Counter({reason: 1}),
+    )
+
+
+def skipped_python_api_check(reason: str) -> dict[str, Any]:
+    check = _not_applicable_check()
+    check["reasons"] = [{"code": reason, "count": 1}]
+    return check
+
+
+def _inspect_python_coverage(
+    root: Path,
+    files: list[Path],
+    targets: list[Path],
+    findings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    modules = _module_files(root, files)
+    local_modules = set(modules)
+    package_modules = {
+        module_name
+        for module_name, file_path in modules.items()
+        if file_path.name in {"__init__.py", "__init__.pyi", "__init__.pyw"}
+    }
+    trees, members, aliases, dynamic, load_reasons = _load_module_facts(
+        modules, local_modules
+    )
+    state = _PythonCoverageState(reasons=Counter())
+    target_modules = {_module_name(root, path): path for path in targets}
+
+    for module_name, target_path in target_modules.items():
+        tree = trees.get(module_name)
+        if tree is None:
+            state.references += 1
+            state.skip(load_reasons.get(module_name, "target_surface_unavailable"))
+            continue
+        _inspect_target_references(
+            root,
+            target_path,
+            module_name,
+            tree,
+            local_modules,
+            trees,
+            members,
+            aliases,
+            dynamic,
+            package_modules,
+            state,
+        )
+
+    checked = state.verified + len(findings)
+    state.references = max(state.references, checked + state.skipped)
+    return _coverage_check(
+        applicable_files=len(targets),
+        references=state.references,
+        verified=state.verified,
+        skipped=state.skipped,
+        findings=len(findings),
+        reasons=state.reasons,
+    )
+
+
+def _inspect_target_references(
+    root: Path,
+    target_path: Path,
+    current_module: str,
+    tree: ast.AST,
+    local_modules: set[str],
+    trees: dict[str, ast.AST],
+    members: dict[str, set[str]],
+    aliases: dict[str, dict[str, str]],
+    dynamic: set[str],
+    package_modules: set[str],
+    state: _PythonCoverageState,
+) -> None:
+    parent_map = _build_parent_map(tree)
+    scope_infos = _build_scope_infos(tree, current_module, local_modules)
+
+    def ensure_module_loaded(module_name: str) -> bool:
+        return module_name in trees
+
+    _inspect_import_references(
+        root,
+        current_module,
+        tree,
+        local_modules,
+        trees,
+        members,
+        dynamic,
+        package_modules,
+        state,
+    )
+
+    for expression, owner in _reference_expressions(tree, parent_map):
+        resolved = _resolve_local_module_member(
+            expr=expression,
+            node=owner,
+            tree=tree,
+            parent_map=parent_map,
+            scope_infos=scope_infos,
+            module_alias_exports=aliases,
+            local_modules=local_modules,
+            ensure_module_loaded=ensure_module_loaded,
+        )
+        if resolved is None:
+            continue
+        target_module, member_name, _ = resolved
+        state.references += 1
+        if target_module in dynamic:
+            state.skip("dynamic_module_surface")
+        elif target_module not in trees:
+            state.skip("target_surface_unavailable")
+        elif member_name in members.get(target_module, set()):
+            state.verified += 1
+
+
+def _reference_expressions(
+    tree: ast.AST,
+    parent_map: dict[ast.AST, ast.AST],
+) -> Iterable[tuple[ast.AST, ast.AST]]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or not isinstance(node.ctx, ast.Load):
+            continue
+        parent = parent_map.get(node)
+        if isinstance(parent, ast.Attribute) and parent.value is node:
+            continue
+        owner = parent if isinstance(parent, ast.Call) and parent.func is node else node
+        yield node, owner
+
+
+def _inspect_import_references(
+    root: Path,
+    current_module: str,
+    tree: ast.AST,
+    local_modules: set[str],
+    trees: dict[str, ast.AST],
+    members: dict[str, set[str]],
+    dynamic: set[str],
+    package_modules: set[str],
+    state: _PythonCoverageState,
+) -> None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            _inspect_from_import(
+                root,
+                current_module,
+                node,
+                local_modules,
+                trees,
+                members,
+                dynamic,
+                package_modules,
+                state,
+            )
+        elif isinstance(node, ast.Import):
+            _inspect_module_import(root, node, local_modules, state)
+
+
+def _inspect_from_import(
+    root: Path,
+    current_module: str,
+    node: ast.ImportFrom,
+    local_modules: set[str],
+    trees: dict[str, ast.AST],
+    members: dict[str, set[str]],
+    dynamic: set[str],
+    package_modules: set[str],
+    state: _PythonCoverageState,
+) -> None:
+    base = _resolve_import_from_base(current_module, node)
+    if base not in local_modules:
+        if _local_module_exists(root, base):
+            state.references += 1
+            state.skip("local_import_outside_scan")
+        elif node.level and _has_local_module_prefix(base, local_modules):
+            state.references += 1
+            state.skip("unresolved_relative_import")
+        return
+    for alias in node.names:
+        state.references += 1
+        if alias.name == "*":
+            state.skip("wildcard_import")
+            continue
+        if base in dynamic:
+            state.skip("dynamic_module_surface")
+            continue
+        if base not in trees:
+            state.skip("target_surface_unavailable")
+            continue
+        full_module = f"{base}.{alias.name}"
+        if full_module in local_modules or alias.name in members.get(base, set()):
+            state.verified += 1
+        elif base in package_modules:
+            state.skip("package_import_ownership_uncertain")
+
+
+def _inspect_module_import(
+    root: Path,
+    node: ast.Import,
+    local_modules: set[str],
+    state: _PythonCoverageState,
+) -> None:
+    for alias in node.names:
+        if alias.name in local_modules:
+            state.references += 1
+            state.verified += 1
+        elif _has_local_module_prefix(alias.name, local_modules):
+            state.references += 1
+            state.skip("local_import_ownership_uncertain")
+        elif _local_module_exists(root, alias.name):
+            state.references += 1
+            state.skip("local_import_outside_scan")
+
+
+def _has_local_module_prefix(module_name: str, local_modules: set[str]) -> bool:
+    return any(
+        module_name.startswith(f"{candidate}.")
+        or candidate.startswith(f"{module_name}.")
+        for candidate in local_modules
+    )
+
+
+def _local_module_exists(root: Path, module_name: str) -> bool:
+    if not module_name:
+        return False
+    module_path = root.joinpath(*module_name.split("."))
+    candidates = [module_path.with_suffix(suffix) for suffix in PYTHON_API_SUFFIXES]
+    candidates.extend(
+        module_path / f"__init__{suffix}" for suffix in PYTHON_API_SUFFIXES
+    )
+    for candidate in candidates:
+        if candidate.is_symlink():
+            continue
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            continue
+        if candidate.is_file():
+            return True
+    return module_path.is_dir() and not module_path.is_symlink()
+
+
+def _module_files(root: Path, files: list[Path]) -> dict[str, Path]:
+    modules: dict[str, Path] = {}
+    for file_path in files:
+        module_name = _module_name(root, file_path)
+        if module_name:
+            modules[module_name] = file_path
+    return modules
+
+
+def _enrich_python_findings(findings: list[dict[str, Any]]) -> None:
+    for finding in findings:
+        metadata = finding.setdefault("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+            finding["metadata"] = metadata
+        metadata.setdefault("language", "python")
+        metadata.setdefault("reference_kind", str(finding.get("type") or "reference"))
+        metadata.setdefault("member_name", str(finding.get("simple_name") or ""))
+        metadata.setdefault("proof_state", "verified")
+
+
+def _load_module_facts(
+    modules: dict[str, Path],
+    local_modules: set[str],
+) -> tuple[
+    dict[str, ast.AST],
+    dict[str, set[str]],
+    dict[str, dict[str, str]],
+    set[str],
+    dict[str, str],
+]:
+    trees: dict[str, ast.AST] = {}
+    members: dict[str, set[str]] = {}
+    aliases: dict[str, dict[str, str]] = {}
+    dynamic: set[str] = set()
+    reasons: dict[str, str] = {}
+    for module_name, file_path in modules.items():
+        tree, reason = _parse_python_file(file_path)
+        if tree is None:
+            reasons[module_name] = reason or "target_surface_unavailable"
+            continue
+        trees[module_name] = tree
+        module_members, has_dynamic_getattr, exported_modules = _collect_module_facts(
+            tree, module_name, local_modules
+        )
+        members[module_name] = module_members
+        aliases[module_name] = {
+            alias: target
+            for alias, target in exported_modules.items()
+            if target in local_modules
+        }
+        if has_dynamic_getattr:
+            dynamic.add(module_name)
+    return trees, members, aliases, dynamic, reasons
+
+
+def _parse_python_file(path: Path) -> tuple[ast.AST | None, str | None]:
+    source = read_text_no_symlink(
+        path,
+        max_bytes=_MAX_PYTHON_SOURCE_BYTES,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if source is None:
+        return None, "source_unreadable"
+    try:
+        return ast.parse(source), None
+    except SyntaxError:
+        return None, "parse_error"
+
+
+def _safe_root(project_root: str | Path) -> Path | None:
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+    return root if root.is_dir() else None
+
+
+def _safe_python_files(
+    root: Path,
+    files: Iterable[str | Path],
+) -> list[Path]:
+    selected: set[Path] = set()
+    for value in files:
+        candidate = Path(value)
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        try:
+            if candidate.is_symlink():
+                continue
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(root)
+        except (OSError, ValueError):
+            continue
+        if resolved.is_file() and resolved.suffix in PYTHON_API_SUFFIXES:
+            selected.add(resolved)
+    return sorted(selected, key=str)
+
+
+def _coverage_check(
+    *,
+    applicable_files: int,
+    references: int,
+    verified: int,
+    skipped: int,
+    findings: int,
+    reasons: Counter[str],
+) -> dict[str, Any]:
+    outcome = "fail" if findings else ("incomplete" if skipped else "pass")
+    return {
+        "id": PYTHON_API_CHECK_ID,
+        "status": "completed",
+        "outcome": outcome,
+        "scope": "local_workspace_api_surface",
+        "languages": ["python"],
+        "applicable_files": applicable_files,
+        "raw_imports": 0,
+        "references": references,
+        "checked_references": verified + findings,
+        "verified_references": verified,
+        "skipped_references": skipped,
+        "finding_count": findings,
+        "reasons": [
+            {"code": code, "count": count} for code, count in sorted(reasons.items())
+        ],
+    }
+
+
+def _not_applicable_check() -> dict[str, Any]:
+    return {
+        "id": PYTHON_API_CHECK_ID,
+        "status": "skipped",
+        "outcome": "pass",
+        "scope": "local_workspace_api_surface",
+        "languages": [],
+        "applicable_files": 0,
+        "raw_imports": 0,
+        "references": 0,
+        "checked_references": 0,
+        "verified_references": 0,
+        "skipped_references": 0,
+        "finding_count": 0,
+        "reasons": [{"code": "no_supported_files", "count": 1}],
+    }

--- a/test/test_ai_code_defect_benchmark.py
+++ b/test/test_ai_code_defect_benchmark.py
@@ -14,6 +14,7 @@ from skylos.benchmarks.ai_code_defects import (
     run_manifest,
     validate_manifest,
 )
+from skylos.verify_change import verify_change_path
 
 
 MANIFEST_PATH = (
@@ -63,6 +64,10 @@ EXPECTED_CASE_IDS = {
     "clean-range-scope",
     "typescript-local-api-hallucination",
     "clean-typescript-local-api-surface",
+    "go-local-api-hallucination",
+    "clean-go-local-api-surface",
+    "java-local-api-hallucination",
+    "clean-java-local-api-surface",
     "clean-generated-code",
 }
 
@@ -106,8 +111,64 @@ EXPECTED_CASE_PATH_NAMES = [
     "range_scoped_mixed_edit",
     "typescript_local_api_hallucination",
     "clean_typescript_local_api_surface",
+    "go_local_api_hallucination",
+    "clean_go_local_api_surface",
+    "java_local_api_hallucination",
+    "clean_java_local_api_surface",
     "clean_generated_code",
 ]
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expected_status", "check_id", "expected_outcome"),
+    [
+        (
+            "go_local_api_hallucination",
+            "fail",
+            "go_workspace_api_surface",
+            "fail",
+        ),
+        (
+            "clean_go_local_api_surface",
+            "pass",
+            "go_workspace_api_surface",
+            "pass",
+        ),
+        (
+            "java_local_api_hallucination",
+            "fail",
+            "java_workspace_api_surface",
+            "fail",
+        ),
+        (
+            "clean_java_local_api_surface",
+            "pass",
+            "java_workspace_api_surface",
+            "pass",
+        ),
+    ],
+)
+def test_checked_in_local_api_benchmarks_assert_verification_contract(
+    monkeypatch,
+    fixture,
+    expected_status,
+    check_id,
+    expected_outcome,
+):
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    payload = verify_change_path(
+        MANIFEST_PATH.parent / "fixtures" / fixture,
+        project_context=True,
+        include_dependency_hallucinations=False,
+    )
+
+    assert payload["status"] == expected_status
+    assert payload["coverage"]["state"] == "complete"
+    check = next(
+        item for item in payload["coverage"]["checks"] if item["id"] == check_id
+    )
+    assert check["outcome"] == expected_outcome
+    assert check["finding_count"] == (1 if expected_outcome == "fail" else 0)
 
 
 def _finding(
@@ -562,7 +623,69 @@ def _fake_findings_for_case(case_path, scan_kwargs=None):
                 },
             ),
         ]
+    if case_name == "go_local_api_hallucination":
+        return [
+            _finding(
+                "SKY-L012",
+                "hallucinated_reference",
+                file_path="cmd/app/main.go",
+                metadata={
+                    "language": "go",
+                    "reference_kind": "package_selector",
+                },
+            )
+        ]
+    if case_name == "java_local_api_hallucination":
+        return [
+            _finding(
+                "SKY-L012",
+                "hallucinated_reference",
+                file_path="src/demo/app/App.java",
+                metadata={
+                    "language": "java",
+                    "reference_kind": "static_member",
+                },
+            )
+        ]
     return []
+
+
+def _fake_result_for_case(case_path, scan_kwargs=None):
+    findings = _fake_findings_for_case(case_path, scan_kwargs)
+    contracts = {
+        "go_local_api_hallucination": (
+            "fail",
+            "go_workspace_api_surface",
+            "fail",
+        ),
+        "clean_go_local_api_surface": (
+            "pass",
+            "go_workspace_api_surface",
+            "pass",
+        ),
+        "java_local_api_hallucination": (
+            "fail",
+            "java_workspace_api_surface",
+            "fail",
+        ),
+        "clean_java_local_api_surface": (
+            "pass",
+            "java_workspace_api_surface",
+            "pass",
+        ),
+    }
+    contract = contracts.get(Path(case_path).name)
+    if contract is None:
+        return {"findings": findings}
+    status, check_id, outcome = contract
+    return {
+        "status": status,
+        "findings": findings,
+        "coverage": {
+            "state": "complete",
+            "checks": [{"id": check_id, "outcome": outcome}],
+        },
+    }
 
 
 def test_checked_in_ai_code_defect_manifest_validates():
@@ -627,18 +750,18 @@ def test_ai_code_defect_runner_scores_expectations(monkeypatch):
 
     def fake_verify(case_path, **kwargs):
         seen.append((Path(case_path).name, kwargs))
-        return {"findings": _fake_findings_for_case(case_path, kwargs)}
+        return _fake_result_for_case(case_path, kwargs)
 
     ticks = iter(range(100))
     monkeypatch.setattr(benchmark.time, "perf_counter", lambda: next(ticks))
 
     summary = run_manifest(MANIFEST_PATH, verify_func=fake_verify)
 
-    assert summary["case_count"] == 39
-    assert summary["pass_count"] == 39
+    assert summary["case_count"] == 43
+    assert summary["pass_count"] == 43
     assert summary["failure_count"] == 0
     assert summary["scores"]["overall_score"] == pytest.approx(100.0)
-    assert summary["metadata"]["languages"]["labelled_cases"] == 39
+    assert summary["metadata"]["languages"]["labelled_cases"] == 43
     assert summary["metadata"]["languages"]["coverage_rate"] == 1.0
 
     dependency_hallucination_case_names = {
@@ -688,11 +811,11 @@ def test_ai_code_defect_runner_empty_selection_runs_all_cases(monkeypatch):
 
     def fake_verify(case_path, **_kwargs):
         seen.append(Path(case_path).name)
-        return {"findings": _fake_findings_for_case(case_path, _kwargs)}
+        return _fake_result_for_case(case_path, _kwargs)
 
     summary = run_manifest(MANIFEST_PATH, selected_cases=None, verify_func=fake_verify)
 
-    assert summary["case_count"] == 39
+    assert summary["case_count"] == 43
     assert seen == EXPECTED_CASE_PATH_NAMES
 
 
@@ -821,6 +944,33 @@ def test_ai_code_defect_runner_reports_missing_expectation(monkeypatch):
     for failure in summary["cases"][0]["failures"]:
         failure_modes.add(failure["mode"])
     assert "present" in failure_modes
+
+
+def test_ai_code_defect_runner_enforces_verification_contract():
+    def fake_verify(_case_path, **_kwargs):
+        return {
+            "status": "incomplete",
+            "findings": [],
+            "coverage": {
+                "state": "incomplete",
+                "checks": [
+                    {
+                        "id": "java_workspace_api_surface",
+                        "outcome": "incomplete",
+                    }
+                ],
+            },
+        }
+
+    summary = run_manifest(
+        MANIFEST_PATH,
+        selected_cases={"clean-java-local-api-surface"},
+        verify_func=fake_verify,
+    )
+
+    assert summary["failure_count"] == 1
+    modes = {failure["mode"] for failure in summary["cases"][0]["failures"]}
+    assert modes == {"check_outcome", "coverage_state", "status"}
 
 
 def test_ai_code_defect_runner_matches_metadata_expectations(monkeypatch, tmp_path):

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -268,6 +268,8 @@ class TestSkylos:
             mock_dir,
             {
                 ".py",
+                ".pyi",
+                ".pyw",
                 ".go",
                 ".ts",
                 ".tsx",
@@ -3730,8 +3732,16 @@ def handler(request):
         assert ai_defects == []
         assert len(suppressed) == 1
         assert suppressed[0]["reason"] == "inline ignore comment"
+        check = next(
+            item
+            for item in result["analysis_summary"]["ai_verification"]["checks"]
+            if item["id"] == "python_local_api_reference"
+        )
+        assert check["outcome"] == "pass"
+        assert check["suppressed_findings"] == 1
+        assert {reason["code"] for reason in check["reasons"]} >= {"finding_suppressed"}
 
-    def test_analyze_subtree_resolves_repo_local_modules_outside_selection(
+    def test_analyze_subtree_marks_repo_local_modules_outside_selection_incomplete(
         self, tmp_path
     ):
         (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
@@ -3765,8 +3775,14 @@ def handler(request):
             f for f in result.get("ai_defects", []) if f.get("rule_id") == "SKY-L012"
         ]
 
-        assert len(ai_defects) == 1
-        assert ai_defects[0]["name"] == "security.require_auth"
+        assert ai_defects == []
+        check = next(
+            item
+            for item in result["analysis_summary"]["ai_verification"]["checks"]
+            if item["id"] == "python_local_api_reference"
+        )
+        assert check["outcome"] == "incomplete"
+        assert check["reasons"] == [{"code": "local_import_outside_scan", "count": 1}]
 
     def test_analyze_flags_stale_bare_call_resembling_local_symbol(self, tmp_path):
         pkg = tmp_path / "billing"

--- a/test/test_go_api_hallucination.py
+++ b/test/test_go_api_hallucination.py
@@ -9,7 +9,10 @@ from skylos.verify_change import verify_change_path
 def _write(root: Path, relative: str, source: str) -> Path:
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(source, encoding="utf-8")
+    path.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        source,
+        encoding="utf-8",
+    )
     return path
 
 

--- a/test/test_go_api_hallucination.py
+++ b/test/test_go_api_hallucination.py
@@ -1,0 +1,459 @@
+from pathlib import Path
+
+from skylos.rules.ai_defect.go_api_hallucination import (
+    scan_go_local_api_hallucinations,
+)
+from skylos.verify_change import verify_change_path
+
+
+def _write(root: Path, relative: str, source: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _module(tmp_path, app_source, package_source=None):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    app = _write(tmp_path, "cmd/app/main.go", app_source)
+    files = [app]
+    if package_source is not None:
+        files.append(_write(tmp_path, "security/security.go", package_source))
+    return scan_go_local_api_hallucinations(tmp_path, files)
+
+
+def test_go_local_api_check_passes_existing_export(tmp_path):
+    findings, check = _module(
+        tmp_path,
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+        """package security
+func VerifyToken(value string) bool { return value != "" }
+""",
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_go_local_api_check_fails_missing_export(tmp_path):
+    findings, check = _module(
+        tmp_path,
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifySession("ok") }
+""",
+        """package security
+func VerifyToken(value string) bool { return value != "" }
+""",
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["VerifySession"]
+    assert findings[0]["metadata"]["language"] == "go"
+    assert check["outcome"] == "fail"
+
+
+def test_go_local_api_check_resolves_explicit_alias(tmp_path):
+    findings, check = _module(
+        tmp_path,
+        """package main
+import sec "example.com/demo/security"
+func main() { sec.VerifyToken("ok") }
+""",
+        """package security
+func VerifyToken(value string) bool { return value != "" }
+""",
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_go_local_api_check_ignores_external_package(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "github.com/external/security"
+func main() { security.Unknown() }
+""",
+    )
+
+    findings, check = scan_go_local_api_hallucinations(tmp_path, [app])
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["references"] == 0
+
+
+def test_go_local_api_check_marks_dot_import_incomplete(tmp_path):
+    findings, check = _module(
+        tmp_path,
+        """package main
+import . "example.com/demo/security"
+func main() { VerifyToken("ok") }
+""",
+        """package security
+func VerifyToken(value string) bool { return value != "" }
+""",
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "dot_import", "count": 1}]
+
+
+def test_go_local_api_check_marks_build_conditional_surface_incomplete(tmp_path):
+    findings, check = _module(
+        tmp_path,
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+        """//go:build linux
+
+package security
+func VerifyToken(value string) bool { return value != "" }
+""",
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "surface_build_conditional_surface", "count": 1}
+    ]
+
+
+def test_go_local_api_check_marks_filename_constrained_surface_incomplete(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+    conditional = _write(
+        tmp_path,
+        "security/security_linux.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+
+    findings, check = scan_go_local_api_hallucinations(
+        tmp_path,
+        [app, conditional],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "surface_build_conditional_surface", "count": 1}
+    ]
+
+
+def test_go_local_api_check_marks_shadowed_import_alias_incomplete(tmp_path):
+    findings, check = _module(
+        tmp_path,
+        """package main
+import "example.com/demo/security"
+func main() {
+    security := struct{ Missing int }{Missing: 1}
+    _ = security.Missing
+}
+""",
+        """package security
+func VerifyToken(value string) bool { return value != "" }
+""",
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "import_alias_shadowed", "count": 1}]
+
+
+def test_go_local_api_check_without_module_manifest_is_incomplete(tmp_path):
+    app = _write(tmp_path, "main.go", "package main\nfunc main() {}\n")
+
+    findings, check = scan_go_local_api_hallucinations(tmp_path, [app])
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "go_module_manifest_missing", "count": 1}]
+
+
+def test_go_local_api_check_resolves_local_replace(tmp_path):
+    _write(
+        tmp_path,
+        "go.mod",
+        """module example.com/demo
+
+go 1.22
+replace example.com/shared => ./shared
+""",
+    )
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/shared/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+    package = _write(
+        tmp_path,
+        "shared/security/security.go",
+        """package security
+func VerifyToken(value string) bool { return value != "" }
+""",
+    )
+
+    findings, check = scan_go_local_api_hallucinations(tmp_path, [app, package])
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_go_local_api_check_marks_out_of_root_local_replace_incomplete(tmp_path):
+    _write(
+        tmp_path,
+        "go.mod",
+        """module example.com/demo
+
+go 1.22
+replace example.com/shared => ../shared
+""",
+    )
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/shared/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+
+    findings, check = scan_go_local_api_hallucinations(tmp_path, [app])
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "unresolved_local_package", "count": 1}]
+
+
+def test_go_local_api_check_marks_out_of_root_workspace_incomplete(tmp_path):
+    _write(
+        tmp_path,
+        "go.work",
+        """go 1.22
+
+use (
+    .
+    ../shared
+)
+""",
+    )
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+    security = _write(
+        tmp_path,
+        "security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+
+    findings, check = scan_go_local_api_hallucinations(
+        tmp_path,
+        [app, security],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["verified_references"] == 1
+    assert check["reasons"] == [{"code": "unsafe_workspace_path", "count": 1}]
+
+
+def test_go_local_api_check_marks_mixed_package_surface_incomplete(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+    security = _write(
+        tmp_path,
+        "security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+    alternate = _write(
+        tmp_path,
+        "security/alternate.go",
+        "package alternate\nfunc Other() {}\n",
+    )
+
+    findings, check = scan_go_local_api_hallucinations(
+        tmp_path,
+        [app, security, alternate],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "surface_ambiguous_package_name", "count": 1}]
+
+
+def test_verify_change_passes_clean_go_workspace_surface(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    _write(
+        tmp_path,
+        "security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+    _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "pass"
+    check = next(
+        item
+        for item in payload["coverage"]["checks"]
+        if item["id"] == "go_workspace_api_surface"
+    )
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_verify_change_fails_missing_go_workspace_export(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    _write(
+        tmp_path,
+        "security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+    _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifySession("ok") }
+""",
+    )
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "fail"
+    finding = next(
+        item for item in payload["findings"] if item["rule_id"] == "SKY-L012"
+    )
+    assert finding["metadata"]["language"] == "go"
+    assert finding["metadata"]["member_name"] == "VerifySession"
+
+
+def test_verify_change_go_surface_respects_excluded_folders(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    _write(
+        tmp_path,
+        "security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+    _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifySession("ok") }
+""",
+    )
+
+    payload = verify_change_path(tmp_path, exclude_folders=["security"])
+
+    assert payload["status"] == "incomplete"
+    assert not any(
+        finding.get("metadata", {}).get("language") == "go"
+        for finding in payload["findings"]
+    )
+    check = next(
+        item
+        for item in payload["coverage"]["checks"]
+        if item["id"] == "go_workspace_api_surface"
+    )
+    assert check["reasons"] == [{"code": "surface_package_surface_empty", "count": 1}]
+
+
+def test_go_file_scoped_workspace_discovery_respects_excluded_folders(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/generated/security"
+func main() { security.VerifySession("ok") }
+""",
+    )
+    _write(
+        tmp_path,
+        "generated/security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+
+    findings, check = scan_go_local_api_hallucinations(
+        tmp_path,
+        [app],
+        restrict_to_files=False,
+        exclude_folders=["generated"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert "excluded_workspace_paths" in {reason["code"] for reason in check["reasons"]}
+
+
+def test_verify_change_go_file_scope_carries_excluded_folders(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    app = _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/generated/security"
+func main() { security.VerifySession("ok") }
+""",
+    )
+    _write(
+        tmp_path,
+        "generated/security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+
+    payload = verify_change_path(app, exclude_folders=["generated"])
+
+    assert payload["status"] == "incomplete"
+    assert not any(
+        finding.get("metadata", {}).get("language") == "go"
+        for finding in payload["findings"]
+    )
+    check = next(
+        item
+        for item in payload["coverage"]["checks"]
+        if item["id"] == "go_workspace_api_surface"
+    )
+    assert "excluded_workspace_paths" in {reason["code"] for reason in check["reasons"]}

--- a/test/test_java_api_hallucination.py
+++ b/test/test_java_api_hallucination.py
@@ -1,0 +1,907 @@
+from pathlib import Path
+
+from skylos.core.java_api_surface import build_java_surface_index
+from skylos.rules.ai_defect.java_api_hallucination import (
+    scan_java_local_api_hallucinations,
+)
+from skylos.verify_change import verify_change_path
+
+
+def _write(root: Path, relative: str, source: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _scan(tmp_path: Path, app_source: str, **sources: str):
+    files = [_write(tmp_path, "src/demo/app/App.java", app_source)]
+    files.extend(
+        _write(tmp_path, relative, source) for relative, source in sources.items()
+    )
+    return scan_java_local_api_hallucinations(tmp_path, files)
+
+
+TOKEN_VERIFIER = """package demo.security;
+public final class TokenVerifier {
+    public static boolean verify(String value) { return value != null; }
+    public static final String VERSION = "1";
+}
+"""
+
+
+def test_java_local_api_check_passes_explicit_local_static_references(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() {
+        return TokenVerifier.verify(TokenVerifier.VERSION);
+    }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 2
+
+
+def test_java_local_api_check_fails_missing_static_member(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verifySession("ok"); }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["verifySession"]
+    assert findings[0]["metadata"]["language"] == "java"
+    assert findings[0]["metadata"]["reference_kind"] == "static_member"
+    assert check["outcome"] == "fail"
+
+
+def test_java_local_api_check_resolves_same_package_type(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+class App {
+    boolean run() { return LocalVerifier.verify("ok"); }
+}
+""",
+        **{
+            "src/demo/app/LocalVerifier.java": """package demo.app;
+class LocalVerifier {
+    static boolean verify(String value) { return value != null; }
+}
+"""
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_java_local_api_check_passes_explicit_static_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import static demo.security.TokenVerifier.verify;
+class App {
+    boolean run() { return verify("ok"); }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_java_local_api_check_fails_missing_explicit_static_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import static demo.security.TokenVerifier.verifySession;
+class App {
+    boolean run() { return verifySession("ok"); }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["verifySession"]
+    assert check["outcome"] == "fail"
+
+
+def test_java_local_api_check_marks_local_wildcard_import_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.*;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "wildcard_import", "count": 1}]
+
+
+def test_java_local_api_check_ignores_external_type_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import external.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.unknown("ok"); }
+}
+""",
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["references"] == 0
+
+
+def test_java_local_api_check_treats_overloads_as_one_member(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok", true); }
+}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+public final class TokenVerifier {
+    public static boolean verify(String value) { return value != null; }
+    public static boolean verify(String value, boolean strict) { return strict; }
+}
+"""
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_java_surface_indexes_implicitly_static_nested_interface(tmp_path):
+    token_verifier = _write(
+        tmp_path,
+        "src/demo/security/TokenVerifier.java",
+        """package demo.security;
+public final class TokenVerifier {
+    public interface Policy {}
+}
+""",
+    )
+
+    index = build_java_surface_index(tmp_path, [token_verifier])
+
+    surface = index.type_surface("demo.security.TokenVerifier")
+    assert surface is not None
+    assert surface.complete is True
+    assert "Policy" in surface.members
+
+
+def test_java_local_api_check_marks_inherited_surface_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+        **{
+            "src/demo/security/BaseVerifier.java": """package demo.security;
+class BaseVerifier {}
+""",
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+public final class TokenVerifier extends BaseVerifier {
+    public static boolean verify(String value) { return value != null; }
+}
+""",
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "surface_inherited_members", "count": 1}]
+
+
+def test_java_local_api_check_marks_ambiguous_duplicate_type_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+        **{
+            "src/one/TokenVerifier.java": TOKEN_VERIFIER,
+            "src/two/TokenVerifier.java": TOKEN_VERIFIER,
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "surface_ambiguous_type", "count": 1}]
+
+
+def test_java_local_api_check_marks_parse_failed_surface_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": TOKEN_VERIFIER,
+            "src/demo/broken/Broken.java": "package demo.broken; class Broken {",
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "parse_error", "count": 1},
+        {"code": "surface_parse_error", "count": 1},
+    ]
+
+
+def test_java_local_api_check_marks_local_instance_reference_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run(TokenVerifier verifier) { return verifier.verify("ok"); }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "instance_type_inference_unsupported", "count": 1}
+    ]
+
+
+def test_java_local_api_check_marks_shadowed_type_name_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run(Object TokenVerifier) {
+        return TokenVerifier.verify("ok");
+    }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "type_name_shadowed", "count": 1}]
+
+
+def test_java_local_api_check_verifies_static_method_reference(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+import java.util.function.Predicate;
+class App {
+    Predicate<String> verifier() { return TokenVerifier::verify; }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_java_local_api_check_marks_missing_method_reference_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+import java.util.function.Predicate;
+class App {
+    Predicate<String> verifier() { return TokenVerifier::missing; }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "method_reference_unsupported", "count": 1}]
+
+
+def test_java_local_api_check_marks_nested_type_member_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.Policy.missing(); }
+}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+public final class TokenVerifier {
+    public static final class Policy {}
+}
+"""
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert {reason["code"] for reason in check["reasons"]} == {
+        "nested_type_member_unsupported"
+    }
+
+
+def test_java_local_api_check_marks_var_instance_call_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() {
+        var verifier = new TokenVerifier();
+        return verifier.missing("ok");
+    }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "instance_type_inference_unsupported", "count": 1}
+    ]
+
+
+def test_java_local_api_check_marks_instance_method_reference_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    Object run(TokenVerifier verifier) { return verifier::missing; }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "instance_method_reference_unsupported", "count": 1}
+    ]
+
+
+def test_java_local_api_check_rejects_field_used_as_method(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    String run() { return TokenVerifier.VERSION(); }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["VERSION"]
+    assert findings[0]["metadata"]["expected_member_kind"] == "method"
+    assert findings[0]["metadata"]["actual_member_kinds"] == "field"
+    assert check["outcome"] == "fail"
+
+
+def test_java_local_api_check_rejects_inaccessible_private_static_method(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    void run() { TokenVerifier.hidden(); }
+}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+public final class TokenVerifier {
+    private static void hidden() {}
+}
+"""
+        },
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["hidden"]
+    assert findings[0]["metadata"]["member_visibility"] == "private"
+    assert check["outcome"] == "fail"
+
+
+def test_java_local_api_check_marks_cross_package_protected_member_incomplete(
+    tmp_path,
+):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    void run() { TokenVerifier.protectedMethod(); }
+}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+public class TokenVerifier {
+    protected static void protectedMethod() {}
+}
+"""
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "member_visibility_uncertain", "count": 1}]
+
+
+def test_java_local_api_check_marks_nested_type_field_access_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    Object run() { return TokenVerifier.Policy.MISSING; }
+}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+public final class TokenVerifier {
+    public static final class Policy {}
+}
+"""
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert "nested_type_member_unsupported" in {
+        reason["code"] for reason in check["reasons"]
+    }
+
+
+def test_java_local_api_check_marks_nested_type_import_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier.Policy;
+class App {}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+public final class TokenVerifier {
+    public static final class Policy {}
+}
+"""
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "nested_type_import_unsupported", "count": 1}]
+
+
+def test_java_local_api_check_does_not_use_unrelated_module_surface(tmp_path):
+    _write(tmp_path, "module-a/build.gradle", "")
+    _write(tmp_path, "module-b/build.gradle", "")
+    token_verifier = _write(
+        tmp_path,
+        "module-a/src/main/java/demo/security/TokenVerifier.java",
+        TOKEN_VERIFIER,
+    )
+    app = _write(
+        tmp_path,
+        "module-b/src/main/java/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+    )
+
+    findings, check = scan_java_local_api_hallucinations(
+        tmp_path,
+        [app, token_verifier],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "module_ownership_uncertain", "count": 1}]
+
+
+def test_java_local_api_check_marks_explicit_missing_local_type_incomplete(tmp_path):
+    _write(
+        tmp_path,
+        "src/demo/security/ExistingVerifier.java",
+        "package demo.security;\nclass ExistingVerifier {}\n",
+    )
+    app = _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.MissingVerifier;
+class App {
+    boolean run() { return MissingVerifier.verify("ok"); }
+}
+""",
+    )
+
+    findings, check = scan_java_local_api_hallucinations(tmp_path, [app])
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "local_type_ownership_uncertain", "count": 1}]
+
+
+def test_java_local_api_check_marks_fully_qualified_missing_type_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+class App {
+    boolean run() { return demo.security.MissingVerifier.verify("ok"); }
+}
+""",
+        **{
+            "src/demo/security/ExistingVerifier.java": (
+                "package demo.security;\nclass ExistingVerifier {}\n"
+            )
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "local_type_ownership_uncertain", "count": 1}]
+
+
+def test_java_local_api_check_does_not_use_test_surface_for_main_code(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.missing("ok"); }
+}
+""",
+        **{
+            "src/test/java/demo/security/TokenVerifier.java": TOKEN_VERIFIER,
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "source_set_ownership_uncertain", "count": 1}]
+
+
+def test_java_local_api_check_classifies_test_fixtures_as_test_surface(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+        **{
+            "src/testFixtures/java/demo/security/TokenVerifier.java": TOKEN_VERIFIER,
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "source_set_ownership_uncertain", "count": 1}]
+
+
+def test_java_source_set_ignores_absolute_ancestor_named_test(tmp_path):
+    root = tmp_path / "test" / "repo"
+    token_verifier = _write(
+        root,
+        "src/main/java/demo/security/TokenVerifier.java",
+        TOKEN_VERIFIER,
+    )
+    app = _write(
+        root,
+        "src/main/java/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+    )
+
+    findings, check = scan_java_local_api_hallucinations(
+        root,
+        [app, token_verifier],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+
+
+def test_java_local_api_check_allows_test_code_to_use_main_surface(tmp_path):
+    token_verifier = _write(
+        tmp_path,
+        "src/main/java/demo/security/TokenVerifier.java",
+        TOKEN_VERIFIER,
+    )
+    test_app = _write(
+        tmp_path,
+        "src/test/java/demo/app/AppTest.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class AppTest {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+    )
+
+    findings, check = scan_java_local_api_hallucinations(
+        tmp_path,
+        [token_verifier, test_app],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_java_local_api_check_marks_generated_surface_incomplete(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.missing("ok"); }
+}
+""",
+        **{
+            "generated/demo/security/TokenVerifier.java": TOKEN_VERIFIER,
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "source_set_ownership_uncertain", "count": 1}]
+
+
+def test_java_local_api_check_recognizes_qualified_codegen_annotation(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+        **{
+            "src/demo/security/TokenVerifier.java": """package demo.security;
+@lombok.Data
+public final class TokenVerifier {}
+"""
+        },
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "surface_generated_members", "count": 1}]
+
+
+def test_java_local_api_check_passes_fully_qualified_local_type(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        """package demo.app;
+class App {
+    boolean run() { return demo.security.TokenVerifier.verify("ok"); }
+}
+""",
+        **{"src/demo/security/TokenVerifier.java": TOKEN_VERIFIER},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_verify_change_passes_clean_java_workspace_surface(tmp_path):
+    _write(tmp_path, "src/demo/security/TokenVerifier.java", TOKEN_VERIFIER)
+    _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+    )
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "pass"
+    check = next(
+        item
+        for item in payload["coverage"]["checks"]
+        if item["id"] == "java_workspace_api_surface"
+    )
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_verify_change_fails_missing_java_workspace_member(tmp_path):
+    _write(tmp_path, "src/demo/security/TokenVerifier.java", TOKEN_VERIFIER)
+    _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verifySession("ok"); }
+}
+""",
+    )
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "fail"
+    finding = next(
+        item for item in payload["findings"] if item["rule_id"] == "SKY-L012"
+    )
+    assert finding["metadata"]["language"] == "java"
+    assert finding["metadata"]["member_name"] == "verifySession"
+
+
+def test_verify_change_keeps_nested_java_surface_inside_requested_scan(tmp_path):
+    _write(tmp_path, "pyproject.toml", "[tool.skylos]\n")
+    case_root = tmp_path / "benchmarks" / "current"
+    _write(case_root, "src/demo/security/TokenVerifier.java", TOKEN_VERIFIER)
+    _write(
+        case_root,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verifySession("ok"); }
+}
+""",
+    )
+    _write(
+        tmp_path,
+        "benchmarks/sibling/src/demo/security/TokenVerifier.java",
+        TOKEN_VERIFIER,
+    )
+
+    payload = verify_change_path(case_root)
+
+    assert payload["status"] == "fail"
+    finding = next(
+        item for item in payload["findings"] if item["rule_id"] == "SKY-L012"
+    )
+    assert finding["metadata"]["member_name"] == "verifySession"
+
+
+def test_verify_change_java_surface_respects_excluded_folders(tmp_path):
+    _write(tmp_path, "src/demo/security/TokenVerifier.java", TOKEN_VERIFIER)
+    _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verifySession("ok"); }
+}
+""",
+    )
+    _write(
+        tmp_path,
+        "generated/demo/security/TokenVerifier.java",
+        TOKEN_VERIFIER,
+    )
+
+    payload = verify_change_path(tmp_path, exclude_folders=["generated"])
+
+    assert payload["status"] == "fail"
+    finding = next(
+        item for item in payload["findings"] if item["rule_id"] == "SKY-L012"
+    )
+    assert finding["metadata"]["member_name"] == "verifySession"
+
+
+def test_java_file_scoped_workspace_discovery_respects_excluded_folders(tmp_path):
+    app = _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.missing("ok"); }
+}
+""",
+    )
+    _write(
+        tmp_path,
+        "generated/demo/security/TokenVerifier.java",
+        TOKEN_VERIFIER,
+    )
+
+    findings, check = scan_java_local_api_hallucinations(
+        tmp_path,
+        [app],
+        discover_workspace=True,
+        exclude_folders=["generated"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert "excluded_workspace_paths" in {reason["code"] for reason in check["reasons"]}
+
+
+def test_verify_change_java_file_scope_carries_excluded_folders(tmp_path):
+    _write(tmp_path, "pyproject.toml", "[tool.skylos]\n")
+    app = _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.missing("ok"); }
+}
+""",
+    )
+    _write(
+        tmp_path,
+        "generated/demo/security/TokenVerifier.java",
+        TOKEN_VERIFIER,
+    )
+
+    payload = verify_change_path(app, exclude_folders=["generated"])
+
+    assert payload["status"] == "incomplete"
+    assert not any(
+        finding.get("metadata", {}).get("language") == "java"
+        for finding in payload["findings"]
+    )
+    check = next(
+        item
+        for item in payload["coverage"]["checks"]
+        if item["id"] == "java_workspace_api_surface"
+    )
+    assert "excluded_workspace_paths" in {reason["code"] for reason in check["reasons"]}

--- a/test/test_java_api_hallucination.py
+++ b/test/test_java_api_hallucination.py
@@ -10,7 +10,10 @@ from skylos.verify_change import verify_change_path
 def _write(root: Path, relative: str, source: str) -> Path:
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(source, encoding="utf-8")
+    path.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        source,
+        encoding="utf-8",
+    )
     return path
 
 

--- a/test/test_language_verification_integration.py
+++ b/test/test_language_verification_integration.py
@@ -11,7 +11,10 @@ from skylos.verify_change import verify_change_path
 def _write(root: Path, relative: str, source: str) -> Path:
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(source, encoding="utf-8")
+    path.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        source,
+        encoding="utf-8",
+    )
     return path
 
 

--- a/test/test_language_verification_integration.py
+++ b/test/test_language_verification_integration.py
@@ -1,0 +1,283 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.verify_change import verify_change_path
+
+
+def _write(root: Path, relative: str, source: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    ("filename", "source", "language", "check_id"),
+    [
+        (
+            "main.php",
+            "<?php function value() { return 1; }\n",
+            "php",
+            "php_workspace_api_surface",
+        ),
+        ("main.rs", "fn main() {}\n", "rust", "rust_workspace_api_surface"),
+        ("main.dart", "void main() {}\n", "dart", "dart_workspace_api_surface"),
+        ("Program.cs", "class Program {}\n", "csharp", "csharp_workspace_api_surface"),
+        ("Main.kt", "fun main() {}\n", "kotlin", "kotlin_workspace_api_surface"),
+        ("main.sh", "echo ok\n", "shell", "shell_workspace_api_surface"),
+    ],
+)
+def test_verify_change_marks_unsupported_local_api_language_incomplete(
+    tmp_path,
+    filename,
+    source,
+    language,
+    check_id,
+):
+    _write(tmp_path, filename, source)
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "incomplete"
+    assert payload["summary"] == (
+        "Verification incomplete: 1 required check did not complete"
+    )
+    assert payload["coverage"]["detected_languages"] == [language]
+    check = next(
+        item for item in payload["coverage"]["checks"] if item["id"] == check_id
+    )
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "unsupported_capability", "count": 1}]
+
+
+def test_verify_change_no_source_files_has_complete_empty_coverage(tmp_path):
+    _write(tmp_path, "README.txt", "documentation only\n")
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "pass"
+    assert payload["coverage"]["state"] == "complete"
+    assert payload["coverage"]["detected_languages"] == []
+    assert payload["coverage"]["expected_checks"] == []
+    assert payload["coverage"]["checks"] == []
+
+
+def test_verify_change_reports_every_expected_check_in_mixed_language_repo(tmp_path):
+    _write(tmp_path, "app.py", "VALUE = 1\n")
+    _write(tmp_path, "web/app.ts", "export const value = 1;\n")
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    _write(
+        tmp_path,
+        "security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+    _write(
+        tmp_path,
+        "cmd/app/main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+    _write(
+        tmp_path,
+        "src/demo/security/TokenVerifier.java",
+        """package demo.security;
+public final class TokenVerifier {
+    public static boolean verify(String value) { return value != null; }
+}
+""",
+    )
+    _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verify("ok"); }
+}
+""",
+    )
+    _write(tmp_path, "legacy/main.php", "<?php function value() { return 1; }\n")
+    _write(tmp_path, "native/main.rs", "fn main() {}\n")
+    _write(tmp_path, "mobile/main.dart", "void main() {}\n")
+    _write(tmp_path, "dotnet/Program.cs", "class Program {}\n")
+    _write(tmp_path, "jvm/Main.kt", "fun main() {}\n")
+    _write(tmp_path, "scripts/entrypoint.sh", "echo ok\n")
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "incomplete"
+    coverage = payload["coverage"]
+    assert coverage["detected_languages"] == [
+        "csharp",
+        "dart",
+        "go",
+        "java",
+        "kotlin",
+        "php",
+        "python",
+        "rust",
+        "shell",
+        "typescript",
+    ]
+    expected_ids = {item["id"] for item in coverage["expected_checks"]}
+    assert expected_ids == {
+        "python_local_api_reference",
+        "typescript_local_api_surface",
+        "go_workspace_api_surface",
+        "java_workspace_api_surface",
+        "php_workspace_api_surface",
+        "rust_workspace_api_surface",
+        "dart_workspace_api_surface",
+        "csharp_workspace_api_surface",
+        "kotlin_workspace_api_surface",
+        "shell_workspace_api_surface",
+    }
+    checks = {item["id"]: item for item in coverage["checks"]}
+    for check_id in (
+        "python_local_api_reference",
+        "typescript_local_api_surface",
+        "go_workspace_api_surface",
+        "java_workspace_api_surface",
+    ):
+        assert checks[check_id]["outcome"] == "pass"
+    for check_id in (
+        "php_workspace_api_surface",
+        "rust_workspace_api_surface",
+        "dart_workspace_api_surface",
+        "csharp_workspace_api_surface",
+        "kotlin_workspace_api_surface",
+        "shell_workspace_api_surface",
+    ):
+        assert checks[check_id]["outcome"] == "incomplete"
+
+
+def test_verify_change_finding_wins_over_unsupported_language_incomplete(tmp_path):
+    _write(tmp_path, "legacy/main.php", "<?php function value() { return 1; }\n")
+    _write(
+        tmp_path,
+        "src/demo/security/TokenVerifier.java",
+        """package demo.security;
+public final class TokenVerifier {
+    public static boolean verify(String value) { return value != null; }
+}
+""",
+    )
+    _write(
+        tmp_path,
+        "src/demo/app/App.java",
+        """package demo.app;
+import demo.security.TokenVerifier;
+class App {
+    boolean run() { return TokenVerifier.verifySession("ok"); }
+}
+""",
+    )
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "fail"
+    assert payload["coverage"]["state"] == "incomplete"
+    assert any(
+        finding.get("metadata", {}).get("member_name") == "verifySession"
+        for finding in payload["findings"]
+    )
+
+
+def test_go_api_verification_stays_separate_from_native_engine_status(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    _write(
+        tmp_path,
+        "security/security.go",
+        'package security\nfunc VerifyToken(value string) bool { return value != "" }\n',
+    )
+    _write(
+        tmp_path,
+        "main.go",
+        """package main
+import "example.com/demo/security"
+func main() { security.VerifyToken("ok") }
+""",
+    )
+
+    with (
+        patch(
+            "skylos.engines.go_runner.get_go_engine_status",
+            return_value={
+                "status": "unavailable",
+                "reason": "Go engine binary not found",
+                "configured_by": "discovery",
+            },
+        ),
+        patch(
+            "skylos.visitors.languages.go.go.run_go_engine_for_module",
+            side_effect=RuntimeError("Go engine binary not found"),
+        ),
+    ):
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                enable_ai_defects=True,
+                enable_dependency_hallucinations=False,
+                grep_verify=False,
+            )
+        )
+
+    assert result["analysis_summary"]["language_engines"]["go"]["status"] == "partial"
+    coverage = result["analysis_summary"]["ai_verification"]
+    assert coverage["state"] == "complete"
+    check = next(
+        item for item in coverage["checks"] if item["id"] == "go_workspace_api_surface"
+    )
+    assert check["outcome"] == "pass"
+
+
+def test_verify_change_converts_java_detector_error_to_incomplete(tmp_path):
+    _write(tmp_path, "App.java", "class App {}\n")
+
+    with patch(
+        "skylos.rules.ai_defect.java_api_hallucination.scan_java_local_api_hallucinations",
+        side_effect=RuntimeError("synthetic detector failure"),
+    ):
+        payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "incomplete"
+    check = next(
+        item
+        for item in payload["coverage"]["checks"]
+        if item["id"] == "java_workspace_api_surface"
+    )
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "detector_error", "count": 1},
+        {"code": "expected_file_coverage_mismatch", "count": 1},
+    ]
+
+
+def test_analyzer_records_ignored_local_api_checks_as_incomplete(tmp_path):
+    _write(tmp_path, "go.mod", "module example.com/demo\n\ngo 1.22\n")
+    _write(tmp_path, "main.go", "package main\nfunc main() {}\n")
+    _write(tmp_path, "App.java", "class App {}\n")
+
+    result = json.loads(
+        analyze(
+            str(tmp_path),
+            enable_ai_defects=True,
+            enable_dependency_hallucinations=False,
+            grep_verify=False,
+            project_config_overrides={"ignore": ["SKY-L012"]},
+        )
+    )
+
+    coverage = result["analysis_summary"]["ai_verification"]
+    assert coverage["state"] == "incomplete"
+    checks = {item["id"]: item for item in coverage["checks"]}
+    for check_id in ("go_workspace_api_surface", "java_workspace_api_surface"):
+        assert checks[check_id]["status"] == "skipped"
+        assert checks[check_id]["outcome"] == "incomplete"
+        assert checks[check_id]["reasons"] == [{"code": "rule_ignored", "count": 1}]

--- a/test/test_python_api_hallucination.py
+++ b/test/test_python_api_hallucination.py
@@ -1,0 +1,239 @@
+from skylos.rules.ai_defect.python_api_hallucination import (
+    scan_python_local_api_hallucinations,
+)
+from skylos.verify_change import verify_change_path
+
+
+def _scan(tmp_path, files, targets=None):
+    paths = []
+    for name, source in files.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+        paths.append(path)
+    target_paths = [tmp_path / name for name in (targets or files)]
+    return scan_python_local_api_hallucinations(
+        tmp_path,
+        paths,
+        target_files=target_paths,
+    )
+
+
+def test_python_local_api_check_passes_existing_member(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "security.py": "def verify_token(value):\n    return bool(value)\n",
+            "app.py": "import security\nsecurity.verify_token('ok')\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 2
+
+
+def test_python_local_api_check_fails_missing_member(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "security.py": "def verify_token(value):\n    return bool(value)\n",
+            "app.py": "import security\nsecurity.verify_session('ok')\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["verify_session"]
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 1
+
+
+def test_python_local_api_check_is_incomplete_for_dynamic_surface(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "plugins.py": "def __getattr__(name):\n    return lambda: name\n",
+            "app.py": "import plugins\nplugins.generated_helper()\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "dynamic_module_surface", "count": 1}]
+
+
+def test_python_local_api_check_is_incomplete_for_target_parse_error(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {"app.py": "def broken(:\n    pass\n"},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [{"code": "parse_error", "count": 1}]
+
+
+def test_python_local_api_check_ignores_external_package_surface(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {"app.py": "import requests\nrequests.get('https://example.test')\n"},
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["references"] == 0
+
+
+def test_python_local_api_check_passes_existing_direct_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "security.py": "VERIFY_TOKEN = 'ok'\n",
+            "app.py": "from security import VERIFY_TOKEN as token\nprint(token)\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_python_local_api_check_fails_missing_direct_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "security.py": "VERIFY_TOKEN = 'ok'\n",
+            "app.py": "from security import VERIFY_SESSION\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["VERIFY_SESSION"]
+    assert findings[0]["metadata"]["reference_kind"] == "from_import"
+    assert check["outcome"] == "fail"
+
+
+def test_python_local_api_check_fails_missing_attribute_value(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "security.py": "VERIFY_TOKEN = 'ok'\n",
+            "app.py": "import security\nvalue = security.VERIFY_SESSION\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["VERIFY_SESSION"]
+    assert findings[0]["metadata"]["reference_kind"] == "module_member"
+    assert check["outcome"] == "fail"
+
+
+def test_python_local_api_check_uses_stub_only_api_surface(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "security.pyi": "def verify_token(value: str) -> bool: ...\n",
+            "app.py": "import security\nsecurity.verify_token('ok')\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 2
+
+
+def test_python_local_submodule_import_is_incomplete_when_ownership_is_uncertain(
+    tmp_path,
+):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "security.py": "VERIFY_TOKEN = 'ok'\n",
+            "app.py": "import security.missing\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "incomplete"
+    assert check["reasons"] == [
+        {"code": "local_import_ownership_uncertain", "count": 1}
+    ]
+
+
+def test_verify_change_discovers_python_stub_files(tmp_path):
+    (tmp_path / "security.pyi").write_text(
+        "def verify_token(value: str) -> bool: ...\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app.py").write_text(
+        "import security\nsecurity.verify_token('ok')\n",
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(tmp_path)
+
+    assert payload["status"] == "pass"
+    check = next(
+        item
+        for item in payload["coverage"]["checks"]
+        if item["id"] == "python_local_api_reference"
+    )
+    assert check["applicable_files"] == 2
+
+
+def test_verify_change_python_surface_respects_excluded_folders(tmp_path):
+    (tmp_path / "security.py").write_text(
+        "def verify_token(value):\n    return bool(value)\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app.py").write_text(
+        "import security\nsecurity.verify_session('ok')\n",
+        encoding="utf-8",
+    )
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    (generated / "security.py").write_text(
+        "def verify_session(value):\n    return bool(value)\n",
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(tmp_path, exclude_folders=["generated"])
+
+    assert payload["status"] == "fail"
+    finding = next(
+        item for item in payload["findings"] if item["rule_id"] == "SKY-L012"
+    )
+    assert finding["metadata"]["member_name"] == "verify_session"
+
+
+def test_verify_change_keeps_nested_python_surface_inside_requested_scan(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
+    case_root = tmp_path / "benchmarks" / "current"
+    case_root.mkdir(parents=True)
+    (case_root / "security.py").write_text(
+        "def verify_token(value):\n    return bool(value)\n",
+        encoding="utf-8",
+    )
+    (case_root / "app.py").write_text(
+        "import security\nsecurity.verify_session('ok')\n",
+        encoding="utf-8",
+    )
+    sibling = tmp_path / "benchmarks" / "sibling"
+    sibling.mkdir(parents=True)
+    (sibling / "security.py").write_text(
+        "def verify_session(value):\n    return bool(value)\n",
+        encoding="utf-8",
+    )
+
+    payload = verify_change_path(case_root)
+
+    assert payload["status"] == "fail"
+    finding = next(
+        item for item in payload["findings"] if item["rule_id"] == "SKY-L012"
+    )
+    assert finding["metadata"]["member_name"] == "verify_session"

--- a/test/test_python_api_hallucination.py
+++ b/test/test_python_api_hallucination.py
@@ -9,7 +9,10 @@ def _scan(tmp_path, files, targets=None):
     for name, source in files.items():
         path = tmp_path / name
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(source, encoding="utf-8")
+        path.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+            source,
+            encoding="utf-8",
+        )
         paths.append(path)
     target_paths = [tmp_path / name for name in (targets or files)]
     return scan_python_local_api_hallucinations(

--- a/test/test_verification_coverage.py
+++ b/test/test_verification_coverage.py
@@ -1,0 +1,292 @@
+from pathlib import Path
+
+from skylos.core.verification_coverage import (
+    build_ai_verification_coverage,
+    reconcile_check_findings,
+)
+from skylos.core.verification_registry import expected_ai_verification_checks
+
+
+def test_expected_checks_deduplicate_typescript_and_javascript():
+    expectations = expected_ai_verification_checks(
+        [Path("app.ts"), Path("legacy.cjs"), Path("other.txt")]
+    )
+
+    assert [item.check_id for item in expectations] == ["typescript_local_api_surface"]
+    assert expectations[0].languages == ("typescript", "javascript")
+    assert expectations[0].applicable_files == 2
+
+
+def test_coverage_marks_supported_missing_check_incomplete():
+    expectations = expected_ai_verification_checks([Path("main.go")])
+
+    coverage = build_ai_verification_coverage([], expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert coverage["missing_checks"] == ["go_workspace_api_surface"]
+    assert coverage["checks"][0]["reasons"] == [
+        {"code": "expected_check_missing", "count": 1}
+    ]
+
+
+def test_coverage_marks_unsupported_language_explicitly():
+    expectations = expected_ai_verification_checks([Path("main.php")])
+
+    coverage = build_ai_verification_coverage([], expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert coverage["missing_checks"] == []
+    assert coverage["language_support"] == [
+        {
+            "language": "php",
+            "capability": "local_workspace_api_surface",
+            "status": "unsupported",
+            "check_id": "php_workspace_api_surface",
+            "reason": "local_api_verification_not_implemented",
+        }
+    ]
+    assert coverage["checks"][0]["reasons"] == [
+        {"code": "unsupported_capability", "count": 1}
+    ]
+
+
+def test_expected_checks_cover_every_discovered_source_language():
+    expectations = expected_ai_verification_checks(
+        [
+            Path("app.py"),
+            Path("app.ts"),
+            Path("legacy.js"),
+            Path("main.go"),
+            Path("App.java"),
+            Path("main.php"),
+            Path("main.rs"),
+            Path("main.dart"),
+            Path("Program.cs"),
+            Path("Main.kt"),
+            Path("build.kts"),
+            Path("entrypoint.sh"),
+        ]
+    )
+
+    assert {language for item in expectations for language in item.languages} == {
+        "python",
+        "typescript",
+        "javascript",
+        "go",
+        "java",
+        "php",
+        "rust",
+        "dart",
+        "csharp",
+        "kotlin",
+        "shell",
+    }
+    assert {item.check_id for item in expectations if not item.supported} == {
+        "php_workspace_api_surface",
+        "rust_workspace_api_surface",
+        "dart_workspace_api_surface",
+        "csharp_workspace_api_surface",
+        "kotlin_workspace_api_surface",
+        "shell_workspace_api_surface",
+    }
+
+
+def test_coverage_marks_expected_file_count_mismatch_incomplete():
+    expectations = expected_ai_verification_checks([Path("app.ts"), Path("app.js")])
+    check = {
+        "id": "typescript_local_api_surface",
+        "status": "completed",
+        "outcome": "pass",
+        "languages": ["typescript"],
+        "applicable_files": 1,
+        "skipped_references": 0,
+        "finding_count": 0,
+    }
+
+    coverage = build_ai_verification_coverage([check], expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert coverage["checks"][0]["languages"] == ["javascript", "typescript"]
+    assert coverage["checks"][0]["applicable_files"] == 1
+    assert coverage["checks"][0]["expected_applicable_files"] == 2
+    assert coverage["checks"][0]["reasons"] == [
+        {"code": "expected_file_coverage_mismatch", "count": 1}
+    ]
+
+
+def test_coverage_preserves_incomplete_proof_when_check_also_has_findings():
+    expectations = expected_ai_verification_checks([Path("app.java")])
+    check = {
+        "id": "java_workspace_api_surface",
+        "status": "completed",
+        "outcome": "fail",
+        "languages": ["java"],
+        "applicable_files": 1,
+        "skipped_references": 1,
+        "finding_count": 1,
+    }
+
+    coverage = build_ai_verification_coverage([check], expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert coverage["checks"][0]["outcome"] == "fail"
+
+
+def test_coverage_treats_skipped_expected_check_as_incomplete():
+    expectations = expected_ai_verification_checks([Path("app.ts")])
+    check = {
+        "id": "typescript_local_api_surface",
+        "status": "skipped",
+        "outcome": "pass",
+        "languages": [],
+        "applicable_files": 0,
+        "skipped_references": 0,
+        "finding_count": 0,
+        "reasons": [{"code": "rule_ignored", "count": 1}],
+    }
+
+    coverage = build_ai_verification_coverage([check], expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert coverage["checks"][0]["outcome"] == "incomplete"
+
+
+def test_coverage_without_source_expectations_remains_complete():
+    coverage = build_ai_verification_coverage([], expected_checks=[])
+
+    assert coverage["state"] == "complete"
+    assert coverage["detected_languages"] == []
+    assert coverage["expected_checks"] == []
+    assert coverage["checks"] == []
+
+
+def test_coverage_marks_malformed_expected_check_incomplete():
+    expectations = expected_ai_verification_checks([Path("app.java")])
+    check = {
+        "id": "java_workspace_api_surface",
+        "languages": ["java"],
+        "applicable_files": 1,
+        "finding_count": 0,
+    }
+
+    coverage = build_ai_verification_coverage([check], expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert coverage["checks"][0]["outcome"] == "incomplete"
+    assert coverage["checks"][0]["reasons"] == [
+        {"code": "malformed_check_record", "count": 1}
+    ]
+
+
+def test_coverage_merges_duplicate_checks_conservatively():
+    expectations = expected_ai_verification_checks([Path("app.go")])
+    checks = [
+        {
+            "id": "go_workspace_api_surface",
+            "status": "completed",
+            "outcome": "incomplete",
+            "languages": ["go"],
+            "applicable_files": 1,
+            "skipped_references": 1,
+            "finding_count": 0,
+            "reasons": [{"code": "surface_parse_error", "count": 1}],
+        },
+        {
+            "id": "go_workspace_api_surface",
+            "status": "completed",
+            "outcome": "pass",
+            "languages": ["go"],
+            "applicable_files": 1,
+            "skipped_references": 0,
+            "finding_count": 0,
+            "reasons": [],
+        },
+    ]
+
+    coverage = build_ai_verification_coverage(checks, expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert len(coverage["checks"]) == 1
+    assert coverage["checks"][0]["outcome"] == "incomplete"
+    assert {reason["code"] for reason in coverage["checks"][0]["reasons"]} == {
+        "duplicate_check_record",
+        "surface_parse_error",
+    }
+
+
+def test_coverage_preserves_duplicate_failure_and_marks_proof_incomplete():
+    expectations = expected_ai_verification_checks([Path("app.java")])
+    checks = [
+        {
+            "id": "java_workspace_api_surface",
+            "status": "completed",
+            "outcome": "fail",
+            "languages": ["java"],
+            "applicable_files": 1,
+            "skipped_references": 0,
+            "finding_count": 1,
+        },
+        {
+            "id": "java_workspace_api_surface",
+            "status": "completed",
+            "outcome": "pass",
+            "languages": ["java"],
+            "applicable_files": 1,
+            "skipped_references": 0,
+            "finding_count": 0,
+        },
+    ]
+
+    coverage = build_ai_verification_coverage(checks, expected_checks=expectations)
+
+    assert coverage["state"] == "incomplete"
+    assert coverage["checks"][0]["outcome"] == "fail"
+    assert coverage["checks"][0]["finding_count"] == 1
+
+
+def test_reconcile_check_findings_clears_suppressed_detector_failure():
+    check = {
+        "id": "go_workspace_api_surface",
+        "status": "completed",
+        "outcome": "fail",
+        "finding_count": 2,
+        "skipped_references": 0,
+    }
+
+    reconciled = reconcile_check_findings(check, 0)
+
+    assert reconciled["finding_count"] == 0
+    assert reconciled["outcome"] == "pass"
+
+
+def test_reconcile_check_findings_preserves_uncertainty_after_suppression():
+    check = {
+        "id": "java_workspace_api_surface",
+        "status": "completed",
+        "outcome": "fail",
+        "finding_count": 1,
+        "skipped_references": 1,
+    }
+
+    reconciled = reconcile_check_findings(check, 0)
+
+    assert reconciled["finding_count"] == 0
+    assert reconciled["outcome"] == "incomplete"
+
+
+def test_reconcile_check_findings_records_suppressed_waiver():
+    check = {
+        "id": "python_local_api_reference",
+        "status": "completed",
+        "outcome": "fail",
+        "finding_count": 1,
+        "skipped_references": 0,
+        "reasons": [],
+    }
+
+    reconciled = reconcile_check_findings(check, 0, suppressed_count=1)
+
+    assert reconciled["finding_count"] == 0
+    assert reconciled["suppressed_findings"] == 1
+    assert reconciled["outcome"] == "pass"
+    assert reconciled["reasons"] == [{"code": "finding_suppressed", "count": 1}]

--- a/test/test_verify_change.py
+++ b/test/test_verify_change.py
@@ -86,6 +86,140 @@ def test_build_verify_change_response_marks_unproven_references_incomplete(tmp_p
     )
 
 
+def test_build_verify_change_response_summarizes_unfinished_required_check(tmp_path):
+    result = {
+        "analysis_summary": {
+            "ai_verification": {
+                "schema_version": 1,
+                "state": "incomplete",
+                "checks": [
+                    {
+                        "id": "php_workspace_api_surface",
+                        "status": "skipped",
+                        "outcome": "incomplete",
+                        "skipped_references": 0,
+                        "reasons": [{"code": "unsupported_capability", "count": 1}],
+                    }
+                ],
+            }
+        }
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    assert payload["status"] == "incomplete"
+    assert payload["summary"] == (
+        "Verification incomplete: 1 required check did not complete"
+    )
+
+
+def test_build_verify_change_response_findings_override_incomplete_coverage(tmp_path):
+    app = tmp_path / "app.java"
+    app.write_text("class App {}\n", encoding="utf-8")
+    result = {
+        "ai_defects": [
+            {
+                "rule_id": "SKY-L012",
+                "file": str(app),
+                "line": 1,
+                "message": "Missing local member.",
+            }
+        ],
+        "analysis_summary": {
+            "ai_verification": {
+                "schema_version": 1,
+                "state": "incomplete",
+                "checks": [
+                    {
+                        "id": "java_workspace_api_surface",
+                        "outcome": "incomplete",
+                        "skipped_references": 1,
+                    }
+                ],
+            }
+        },
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    assert payload["status"] == "fail"
+    assert payload["summary"] == "1 AI-code issue found"
+
+
+def test_build_verify_change_response_filtered_finding_keeps_proof_incomplete(tmp_path):
+    app = tmp_path / "app.java"
+    other = tmp_path / "other.java"
+    app.write_text("class App {}\n", encoding="utf-8")
+    other.write_text("class Other {}\n", encoding="utf-8")
+    result = {
+        "ai_defects": [
+            {
+                "rule_id": "SKY-L012",
+                "file": str(other),
+                "line": 1,
+                "message": "Missing local member.",
+            }
+        ],
+        "analysis_summary": {
+            "ai_verification": {
+                "schema_version": 1,
+                "state": "incomplete",
+                "checks": [
+                    {
+                        "id": "java_workspace_api_surface",
+                        "outcome": "fail",
+                        "skipped_references": 1,
+                        "finding_count": 1,
+                    }
+                ],
+            }
+        },
+    }
+
+    payload = build_verify_change_response(
+        result,
+        project_root=tmp_path,
+        target_file=app,
+    )
+
+    assert payload["findings"] == []
+    assert payload["status"] == "incomplete"
+
+
+def test_build_verify_change_response_never_passes_with_unrepresented_failed_check(
+    tmp_path,
+):
+    result = {
+        "analysis_summary": {
+            "ai_verification": {
+                "schema_version": 1,
+                "state": "complete",
+                "checks": [
+                    {
+                        "id": "java_workspace_api_surface",
+                        "status": "completed",
+                        "outcome": "fail",
+                        "skipped_references": 0,
+                        "finding_count": 1,
+                    }
+                ],
+            }
+        }
+    }
+
+    payload = build_verify_change_response(result, project_root=tmp_path)
+
+    assert payload["findings"] == []
+    assert payload["status"] == "incomplete"
+    assert payload["coverage"]["state"] == "incomplete"
+    check = payload["coverage"]["checks"][0]
+    assert check["outcome"] == "incomplete"
+    assert check["finding_count"] == 0
+    assert check["reasons"] == [
+        {"code": "finding_evidence_missing_from_response", "count": 1}
+    ]
+
+
 def test_build_verify_change_response_preserves_finding_metadata(tmp_path):
     manifest = tmp_path / "package.json"
     manifest.write_text('{"dependencies": {"ghost": "1.0.0"}}\n')


### PR DESCRIPTION
## Summary

  - Derive expected language verification checks from scanned files so missing or unsupported checks report `incomplete` instead of silently passing.
  - Added deterministic API hallucination verification for Python, Go, and Java.
  - Preserve TS/JS verification
  - Explicitly report unsupported verification for PHP, Rust, Dart, C#, Kotlin, and Shell.
  - Harden Go and Java proof boundaries
  - Add benchmark contracts with clean and hallucinated Go/Java fixtures.

  ## Tests

  - 159 analyzer and benchmark tests passed.
  - 8 adversarial manual smoke cases passed.
  - 4/4 Go/Java benchmark cases passed.

