### PR TITLE
test(audit): add deep-audit logic fixtures

### DIFF
--- a/benchmarks/deep_audit_logic/fixtures/cross_tenant_refund/safe/refunds/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/cross_tenant_refund/safe/refunds/service.py
@@ -10,4 +10,5 @@ def refund_order(actor, order, amount):
         raise ValueError("refund must equal the captured amount")
     order.status = "refunded"
     order.refunded_amount = amount
+    order.save(update_fields=["status", "refunded_amount"])
     return order

--- a/benchmarks/deep_audit_logic/fixtures/cross_tenant_refund/vulnerable/refunds/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/cross_tenant_refund/vulnerable/refunds/service.py
@@ -10,4 +10,5 @@ def refund_order(actor, order, amount):
         raise ValueError("refund must equal the captured amount")
     order.status = "refunded"
     order.refunded_amount = amount
+    order.save(update_fields=["status", "refunded_amount"])
     return order

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/archive/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/archive/service.py
@@ -1,0 +1,9 @@
+# ruff: noqa: F821 - provider is an application-supplied fixture dependency
+
+
+def process_payment_event(event):
+    return provider.capture(
+        event.payment_id,
+        event.amount,
+        idempotency_key=event.id,
+    )

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payment_webhook.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payment_webhook.py
@@ -1,0 +1,8 @@
+from payments.service import process_payment_event
+from payments.signatures import verify_event
+
+
+def payment_webhook(event):
+    if not verify_event(event):
+        raise PermissionError("invalid payment webhook signature")
+    return process_payment_event(event)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/gateway.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/gateway.py
@@ -1,0 +1,5 @@
+from .models import ProviderCapture
+
+
+def capture(payment_id, amount):
+    return ProviderCapture.objects.create(payment_id=payment_id, amount=amount)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class EventReceipt(models.Model):
+    event_id = models.CharField(max_length=255, unique=True)
+
+
+class ProviderCapture(models.Model):
+    payment_id = models.CharField(max_length=255)
+    amount = models.DecimalField(max_digits=12, decimal_places=2)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/service.py
@@ -1,0 +1,8 @@
+from . import gateway, store
+
+
+def process_payment_event(event):
+    if not store.claim_once(event.id):
+        return "duplicate"
+    gateway.capture(event.payment_id, event.amount)
+    return "captured"

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/signatures.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/signatures.py
@@ -1,0 +1,18 @@
+import hmac
+import json
+import os
+
+
+def verify_event(event):
+    secret = os.environ["PAYMENT_WEBHOOK_SECRET"].encode("utf-8")
+    payload = json.dumps(
+        {
+            "amount": str(event.amount),
+            "event_id": str(event.id),
+            "payment_id": str(event.payment_id),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    expected = hmac.digest(secret, payload, "sha256").hex()
+    return hmac.compare_digest(event.signature or "", expected)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/store.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/claim_first/payments/store.py
@@ -1,0 +1,6 @@
+from .models import EventReceipt
+
+
+def claim_once(event_id):
+    _receipt, created = EventReceipt.objects.get_or_create(event_id=event_id)
+    return created

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/archive/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/archive/service.py
@@ -1,0 +1,9 @@
+# ruff: noqa: F821 - model and provider are application-supplied fixture dependencies
+
+
+def process_payment_event(event):
+    if EventReceipt.objects.filter(event_id=event.id).exists():
+        return "duplicate"
+    provider.capture(event.payment_id, event.amount)
+    EventReceipt.objects.create(event_id=event.id)
+    return "captured"

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payment_webhook.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payment_webhook.py
@@ -1,0 +1,8 @@
+from payments.service import process_payment_event
+from payments.signatures import verify_event
+
+
+def payment_webhook(event):
+    if not verify_event(event):
+        raise PermissionError("invalid payment webhook signature")
+    return process_payment_event(event)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/gateway.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/gateway.py
@@ -1,0 +1,11 @@
+from .models import ProviderCapture
+
+
+def capture_once(event_id, payment_id, amount):
+    capture, created = ProviderCapture.objects.get_or_create(
+        payment_id=payment_id,
+        defaults={"idempotency_key": event_id, "amount": amount},
+    )
+    if not created and capture.amount != amount:
+        raise ValueError("idempotency key reused with different payment data")
+    return capture

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/models.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+
+class EventReceipt(models.Model):
+    event_id = models.CharField(max_length=255, unique=True)
+    status = models.CharField(max_length=16)
+    provider_capture_id = models.CharField(max_length=255, null=True)
+
+
+class ProviderCapture(models.Model):
+    idempotency_key = models.CharField(max_length=255, unique=True)
+    payment_id = models.CharField(max_length=255, unique=True)
+    amount = models.DecimalField(max_digits=12, decimal_places=2)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/service.py
@@ -1,0 +1,9 @@
+from . import gateway, store
+
+
+def process_payment_event(event):
+    capture = gateway.capture_once(event.id, event.payment_id, event.amount)
+    store.ensure_pending(event.id)
+    if store.mark_completed(event.id, capture.id):
+        return "captured"
+    return "duplicate"

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/signatures.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/signatures.py
@@ -1,0 +1,18 @@
+import hmac
+import json
+import os
+
+
+def verify_event(event):
+    secret = os.environ["PAYMENT_WEBHOOK_SECRET"].encode("utf-8")
+    payload = json.dumps(
+        {
+            "amount": str(event.amount),
+            "event_id": str(event.id),
+            "payment_id": str(event.payment_id),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    expected = hmac.digest(secret, payload, "sha256").hex()
+    return hmac.compare_digest(event.signature or "", expected)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/store.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/lookalike/payments/store.py
@@ -1,0 +1,18 @@
+from .models import EventReceipt
+
+
+def ensure_pending(event_id):
+    EventReceipt.objects.get_or_create(
+        event_id=event_id,
+        defaults={"status": "pending"},
+    )
+
+
+def mark_completed(event_id, capture_id):
+    return (
+        EventReceipt.objects.filter(event_id=event_id, status="pending").update(
+            status="completed",
+            provider_capture_id=capture_id,
+        )
+        == 1
+    )

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/archive/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/archive/service.py
@@ -1,0 +1,8 @@
+from payments import gateway, store
+
+
+def process_payment_event(event):
+    if not store.claim_once(event.id):
+        return "duplicate"
+    gateway.capture(event.payment_id, event.amount)
+    return "captured"

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payment_webhook.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payment_webhook.py
@@ -1,0 +1,8 @@
+from payments.service import process_payment_event
+from payments.signatures import verify_event
+
+
+def payment_webhook(event):
+    if not verify_event(event):
+        raise PermissionError("invalid payment webhook signature")
+    return process_payment_event(event)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/gateway.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/gateway.py
@@ -1,0 +1,5 @@
+from .models import ProviderCapture
+
+
+def capture(payment_id, amount):
+    return ProviderCapture.objects.create(payment_id=payment_id, amount=amount)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class EventReceipt(models.Model):
+    event_id = models.CharField(max_length=255, db_index=True)
+
+
+class ProviderCapture(models.Model):
+    payment_id = models.CharField(max_length=255)
+    amount = models.DecimalField(max_digits=12, decimal_places=2)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/service.py
@@ -1,0 +1,9 @@
+from . import gateway, store
+
+
+def process_payment_event(event):
+    if store.event_seen(event.id):
+        return "duplicate"
+    gateway.capture(event.payment_id, event.amount)
+    store.mark_event_seen(event.id)
+    return "captured"

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/signatures.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/signatures.py
@@ -1,0 +1,18 @@
+import hmac
+import json
+import os
+
+
+def verify_event(event):
+    secret = os.environ["PAYMENT_WEBHOOK_SECRET"].encode("utf-8")
+    payload = json.dumps(
+        {
+            "amount": str(event.amount),
+            "event_id": str(event.id),
+            "payment_id": str(event.payment_id),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    expected = hmac.digest(secret, payload, "sha256").hex()
+    return hmac.compare_digest(event.signature or "", expected)

--- a/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/store.py
+++ b/benchmarks/deep_audit_logic/fixtures/idempotency/vulnerable/payments/store.py
@@ -1,0 +1,9 @@
+from .models import EventReceipt
+
+
+def event_seen(event_id):
+    return EventReceipt.objects.filter(event_id=event_id).exists()
+
+
+def mark_event_seen(event_id):
+    EventReceipt.objects.create(event_id=event_id)

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/app.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/app.py
@@ -1,0 +1,16 @@
+from django.core.validators import validate_email
+
+from models import Request
+from middleware.pipeline import dispatch
+
+
+def update_account(request: Request):
+    return dispatch(request, _save_account)
+
+
+def _save_account(request: Request):
+    email = request.json["email"]
+    validate_email(email)
+    request.user.account.email = email
+    request.user.account.save(update_fields=["email"])
+    return request.user.account

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/legacy/pipeline.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/legacy/pipeline.py
@@ -1,0 +1,7 @@
+from middleware.auth import require_user
+
+
+def dispatch(request, handler):
+    response = handler(request)
+    require_user(request)
+    return response

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/middleware/auth.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/middleware/auth.py
@@ -1,0 +1,3 @@
+def require_user(request):
+    if request.user is None or not request.user.is_authenticated:
+        raise PermissionError("authentication required")

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/middleware/pipeline.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/middleware/pipeline.py
@@ -1,0 +1,6 @@
+from .auth import require_user
+
+
+def dispatch(request, handler):
+    require_user(request)
+    return handler(request)

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/safe/models.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from django.db import models
+
+
+class Account(models.Model):
+    email = models.EmailField()
+
+
+@dataclass(frozen=True)
+class RequestUser:
+    is_authenticated: bool
+    account: Account
+
+
+@dataclass(frozen=True)
+class Request:
+    user: RequestUser
+    json: dict[str, str]

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/app.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/app.py
@@ -1,0 +1,16 @@
+from django.core.validators import validate_email
+
+from models import Request
+from middleware.pipeline import dispatch
+
+
+def update_account(request: Request):
+    return dispatch(request, _save_account)
+
+
+def _save_account(request: Request):
+    email = request.json["email"]
+    validate_email(email)
+    request.user.account.email = email
+    request.user.account.save(update_fields=["email"])
+    return request.user.account

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/legacy/pipeline.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/legacy/pipeline.py
@@ -1,0 +1,6 @@
+from middleware.auth import require_user
+
+
+def dispatch(request, handler):
+    require_user(request)
+    return handler(request)

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/middleware/auth.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/middleware/auth.py
@@ -1,0 +1,3 @@
+def require_user(request):
+    if request.user is None or not request.user.is_authenticated:
+        raise PermissionError("authentication required")

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/middleware/pipeline.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/middleware/pipeline.py
@@ -1,0 +1,7 @@
+from .auth import require_user
+
+
+def dispatch(request, handler):
+    response = handler(request)
+    require_user(request)
+    return response

--- a/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/middleware_order/vulnerable/models.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from django.db import models
+
+
+class Account(models.Model):
+    email = models.EmailField()
+
+
+@dataclass(frozen=True)
+class RequestUser:
+    is_authenticated: bool
+    account: Account
+
+
+@dataclass(frozen=True)
+class Request:
+    user: RequestUser
+    json: dict[str, str]

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/api.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/api.py
@@ -1,0 +1,7 @@
+from invoices.service import load_invoice
+
+
+def invoice_endpoint(actor, invoice_id):
+    if not actor.is_authenticated:
+        raise PermissionError("authentication required")
+    return load_invoice(actor.tenant_id, invoice_id)

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/archive/cache.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/archive/cache.py
@@ -1,0 +1,7 @@
+from invoices.backend import get_or_set
+from invoices.database import fetch_invoice
+
+
+def get_invoice(tenant_id, invoice_id):
+    key = invoice_id
+    return get_or_set(key, lambda: fetch_invoice(tenant_id, invoice_id))

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/backend.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/backend.py
@@ -1,0 +1,16 @@
+from collections import OrderedDict
+
+
+_MAX_ENTRIES = 1024
+_ENTRIES = OrderedDict()
+
+
+def get_or_set(key, factory):
+    if key in _ENTRIES:
+        _ENTRIES.move_to_end(key)
+        return _ENTRIES[key]
+    value = factory()
+    if len(_ENTRIES) >= _MAX_ENTRIES:
+        _ENTRIES.popitem(last=False)
+    _ENTRIES[key] = value
+    return value

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/cache.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/cache.py
@@ -1,0 +1,7 @@
+from .backend import get_or_set
+from .database import fetch_invoice
+
+
+def get_invoice(tenant_id, invoice_id):
+    key = (tenant_id, invoice_id)
+    return get_or_set(key, lambda: fetch_invoice(tenant_id, invoice_id))

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/database.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/database.py
@@ -1,0 +1,5 @@
+from .models import Invoice
+
+
+def fetch_invoice(tenant_id, invoice_id):
+    return Invoice.objects.get(tenant_id=tenant_id, invoice_number=invoice_id)

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+
+class Invoice(models.Model):
+    tenant_id = models.CharField(max_length=255)
+    invoice_number = models.CharField(max_length=255)
+    total = models.DecimalField(max_digits=12, decimal_places=2)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["tenant_id", "invoice_number"],
+                name="unique_invoice_number_per_tenant",
+            )
+        ]

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/safe/invoices/service.py
@@ -1,0 +1,5 @@
+from .cache import get_invoice
+
+
+def load_invoice(tenant_id, invoice_id):
+    return get_invoice(tenant_id, invoice_id)

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/api.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/api.py
@@ -1,0 +1,7 @@
+from invoices.service import load_invoice
+
+
+def invoice_endpoint(actor, invoice_id):
+    if not actor.is_authenticated:
+        raise PermissionError("authentication required")
+    return load_invoice(actor.tenant_id, invoice_id)

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/archive/cache.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/archive/cache.py
@@ -1,0 +1,7 @@
+from invoices.backend import get_or_set
+from invoices.database import fetch_invoice
+
+
+def get_invoice(tenant_id, invoice_id):
+    key = (tenant_id, invoice_id)
+    return get_or_set(key, lambda: fetch_invoice(tenant_id, invoice_id))

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/backend.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/backend.py
@@ -1,0 +1,16 @@
+from collections import OrderedDict
+
+
+_MAX_ENTRIES = 1024
+_ENTRIES = OrderedDict()
+
+
+def get_or_set(key, factory):
+    if key in _ENTRIES:
+        _ENTRIES.move_to_end(key)
+        return _ENTRIES[key]
+    value = factory()
+    if len(_ENTRIES) >= _MAX_ENTRIES:
+        _ENTRIES.popitem(last=False)
+    _ENTRIES[key] = value
+    return value

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/cache.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/cache.py
@@ -1,0 +1,7 @@
+from .backend import get_or_set
+from .database import fetch_invoice
+
+
+def get_invoice(tenant_id, invoice_id):
+    key = invoice_id
+    return get_or_set(key, lambda: fetch_invoice(tenant_id, invoice_id))

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/database.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/database.py
@@ -1,0 +1,5 @@
+from .models import Invoice
+
+
+def fetch_invoice(tenant_id, invoice_id):
+    return Invoice.objects.get(tenant_id=tenant_id, invoice_number=invoice_id)

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+
+class Invoice(models.Model):
+    tenant_id = models.CharField(max_length=255)
+    invoice_number = models.CharField(max_length=255)
+    total = models.DecimalField(max_digits=12, decimal_places=2)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["tenant_id", "invoice_number"],
+                name="unique_invoice_number_per_tenant",
+            )
+        ]

--- a/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/tenant_cache/vulnerable/invoices/service.py
@@ -1,0 +1,5 @@
+from .cache import get_invoice
+
+
+def load_invoice(tenant_id, invoice_id):
+    return get_invoice(tenant_id, invoice_id)

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/archive/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/archive/service.py
@@ -1,0 +1,13 @@
+import json
+
+from processing.signatures import verify_signature
+from processing.store import apply_event
+
+
+def accept_event(headers, body):
+    event = json.loads(body)
+    event_id = event["id"]
+    apply_event(event)
+    if not verify_signature(headers.get("X-Signature"), body):
+        raise PermissionError("invalid webhook signature")
+    return event_id

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/models.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+
+class Account(models.Model):
+    provider_subscription_id = models.CharField(max_length=255, unique=True)
+    plan = models.CharField(max_length=64)
+    plan_version = models.PositiveBigIntegerField(null=True)

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/service.py
@@ -1,0 +1,13 @@
+import json
+
+from .signatures import verify_signature
+from .store import apply_event
+
+
+def accept_event(headers, body):
+    if not verify_signature(headers.get("X-Signature"), body):
+        raise PermissionError("invalid webhook signature")
+    event = json.loads(body)
+    event_id = event["id"]
+    apply_event(event)
+    return event_id

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/signatures.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/signatures.py
@@ -1,0 +1,8 @@
+import hmac
+import os
+
+
+def verify_signature(provided, body):
+    secret = os.environ["WEBHOOK_SECRET"].encode("utf-8")
+    expected = hmac.digest(secret, body, "sha256").hex()
+    return hmac.compare_digest(provided or "", expected)

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/store.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/processing/store.py
@@ -1,0 +1,26 @@
+from django.db import transaction
+
+from .models import Account
+
+
+PLAN_BY_PRICE_ID = {"price_basic": "basic", "price_pro": "pro"}
+
+
+@transaction.atomic
+def apply_event(event):
+    version = event["version"]
+    if type(version) is not int or version < 0:
+        raise ValueError("invalid provider version")
+    try:
+        plan = PLAN_BY_PRICE_ID[event["price_id"]]
+    except KeyError as exc:
+        raise ValueError("unknown provider price") from exc
+    account = Account.objects.select_for_update().get(
+        provider_subscription_id=event["subscription_id"]
+    )
+    if account.plan_version is not None and version <= account.plan_version:
+        return "already_applied"
+    account.plan = plan
+    account.plan_version = version
+    account.save(update_fields=["plan", "plan_version"])
+    return "applied"

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/webhook.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/lookalike/webhook.py
@@ -1,0 +1,5 @@
+from processing.service import accept_event
+
+
+def webhook(request):
+    return accept_event(request.headers, request.body)

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/archive/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/archive/service.py
@@ -1,0 +1,13 @@
+import json
+
+from processing.signatures import verify_signature
+from processing.store import apply_event
+
+
+def accept_event(headers, body):
+    if not verify_signature(headers.get("X-Signature"), body):
+        raise PermissionError("invalid webhook signature")
+    event = json.loads(body)
+    event_id = event["id"]
+    apply_event(event)
+    return event_id

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/models.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/models.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+
+class Account(models.Model):
+    provider_subscription_id = models.CharField(max_length=255, unique=True)
+    plan = models.CharField(max_length=64)
+    plan_version = models.PositiveBigIntegerField(null=True)

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/service.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/service.py
@@ -1,0 +1,13 @@
+import json
+
+from .signatures import verify_signature
+from .store import apply_event
+
+
+def accept_event(headers, body):
+    event = json.loads(body)
+    event_id = event["id"]
+    apply_event(event)
+    if not verify_signature(headers.get("X-Signature"), body):
+        raise PermissionError("invalid webhook signature")
+    return event_id

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/signatures.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/signatures.py
@@ -1,0 +1,8 @@
+import hmac
+import os
+
+
+def verify_signature(provided, body):
+    secret = os.environ["WEBHOOK_SECRET"].encode("utf-8")
+    expected = hmac.digest(secret, body, "sha256").hex()
+    return hmac.compare_digest(provided or "", expected)

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/store.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/processing/store.py
@@ -1,0 +1,26 @@
+from django.db import transaction
+
+from .models import Account
+
+
+PLAN_BY_PRICE_ID = {"price_basic": "basic", "price_pro": "pro"}
+
+
+@transaction.atomic
+def apply_event(event):
+    version = event["version"]
+    if type(version) is not int or version < 0:
+        raise ValueError("invalid provider version")
+    try:
+        plan = PLAN_BY_PRICE_ID[event["price_id"]]
+    except KeyError as exc:
+        raise ValueError("unknown provider price") from exc
+    account = Account.objects.select_for_update().get(
+        provider_subscription_id=event["subscription_id"]
+    )
+    if account.plan_version is not None and version <= account.plan_version:
+        return "already_applied"
+    account.plan = plan
+    account.plan_version = version
+    account.save(update_fields=["plan", "plan_version"])
+    return "applied"

--- a/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/webhook.py
+++ b/benchmarks/deep_audit_logic/fixtures/webhook_verification/vulnerable/webhook.py
@@ -1,0 +1,5 @@
+from processing.service import accept_event
+
+
+def webhook(request):
+    return accept_event(request.headers, request.body)


### PR DESCRIPTION
## Summary

  - Add fixtures covering middleware ordering, webhook verification, tenant-scoped caching, and payment idempotency.
  - Include vulnerable, safe, and lookalike variants with unreachable decoy implementations.
  - Update the refund fixtures to persist the mutated order state.


## Tests
  - pytest -q test/test_deep_audit_logic_benchmark.py
