### PR TITLE
fix(analyzer): recognize VS Code and JavaFX FXML callbacks

### DIFF
--- a/benchmarks/dead_code/fixtures/java_fxml_controller/PrintController.java
+++ b/benchmarks/dead_code/fixtures/java_fxml_controller/PrintController.java
@@ -1,0 +1,17 @@
+import javafx.fxml.FXML;
+
+class PrintController {
+  @FXML
+  private void printButtonAction() {
+    System.out.println("print");
+  }
+
+  @FXML
+  private void staleAnnotated() {
+    System.out.println("stale annotation");
+  }
+
+  private void staleHelper() {
+    System.out.println("stale");
+  }
+}

--- a/benchmarks/dead_code/fixtures/java_fxml_controller/view.fxml
+++ b/benchmarks/dead_code/fixtures/java_fxml_controller/view.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+
+<Button xmlns:fx="http://javafx.com/fxml/1"
+        fx:controller="PrintController"
+        onAction="#printButtonAction"
+        text="Print" />

--- a/benchmarks/dead_code/fixtures/typescript_vscode_pseudoterminal/package.json
+++ b/benchmarks/dead_code/fixtures/typescript_vscode_pseudoterminal/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "vscode-pseudoterminal-fixture",
+  "private": true,
+  "main": "./out/extension.js",
+  "engines": {
+    "vscode": "^1.100.0"
+  }
+}

--- a/benchmarks/dead_code/fixtures/typescript_vscode_pseudoterminal/src/extension.ts
+++ b/benchmarks/dead_code/fixtures/typescript_vscode_pseudoterminal/src/extension.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode";
+
+export function activate() {
+  const execution = new vscode.CustomExecution(
+    async (): Promise<vscode.Pseudoterminal> => new BuildTerminal(),
+  );
+  const registration = vscode.tasks.registerTaskProvider(
+    "build",
+    new InternalTaskProvider(),
+  );
+  return { execution, registration };
+}
+
+class BuildTerminal implements vscode.Pseudoterminal {
+  open(_dimensions: vscode.TerminalDimensions | undefined): void {}
+
+  close(): void {}
+
+  staleHelper(): string {
+    return "stale";
+  }
+}
+
+class InternalTaskProvider implements vscode.TaskProvider<vscode.Task> {
+  provideTasks(): vscode.Task[] {
+    return [];
+  }
+
+  resolveTask(task: vscode.Task): vscode.Task {
+    return task;
+  }
+
+  staleProviderHelper(): string {
+    return "stale";
+  }
+}

--- a/benchmarks/dead_code/manifest.json
+++ b/benchmarks/dead_code/manifest.json
@@ -558,6 +558,71 @@
       }
     },
     {
+      "id": "java-fxml-controller-callbacks",
+      "path": "fixtures/java_fxml_controller",
+      "description": "JavaFX methods wired through FXML action metadata are framework callbacks, while unwired @FXML methods and ordinary helpers remain dead code.",
+      "languages": ["java"],
+      "taxonomy": ["java", "framework_precision", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/jakemarotta/FXMLExercise",
+        "license": "NOASSERTION",
+        "notes": "Distilled from @FXML controller callbacks reproduced at pinned revision a75a2c16042d06674fd2361238c9c4933cbdd4be."
+      },
+      "scan": {
+        "confidence": 0,
+        "grep_verify": true
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "unused": [
+          {"kind": "function", "file": "PrintController.java", "symbol": "staleAnnotated"},
+          {"kind": "function", "file": "PrintController.java", "symbol": "staleHelper"}
+        ],
+        "used": [
+          {"kind": "class", "file": "PrintController.java", "symbol": "PrintController"},
+          {"kind": "function", "file": "PrintController.java", "symbol": "printButtonAction"}
+        ]
+      }
+    },
+    {
+      "id": "typescript-vscode-pseudoterminal-callbacks",
+      "path": "fixtures/typescript_vscode_pseudoterminal",
+      "description": "VS Code Pseudoterminal and provider contract methods are host-invoked callbacks, while unrelated methods on the same classes remain dead code.",
+      "languages": ["typescript"],
+      "taxonomy": ["typescript", "framework_precision", "precision_guard"],
+      "importance": "critical",
+      "source": {
+        "repo": "https://github.com/microsoft/vscode-extension-samples",
+        "license": "MIT",
+        "notes": "Distilled from the task-provider sample at pinned revision 3d8442b16c7f353779e266f16295703b2b4a6dcc."
+      },
+      "scan": {
+        "confidence": 0,
+        "grep_verify": true
+      },
+      "budget": {
+        "max_seconds": 5.0
+      },
+      "expect": {
+        "unused": [
+          {"kind": "function", "file": "src/extension.ts", "symbol": "staleHelper"},
+          {"kind": "function", "file": "src/extension.ts", "symbol": "staleProviderHelper"}
+        ],
+        "used": [
+          {"kind": "function", "file": "src/extension.ts", "symbol": "activate"},
+          {"kind": "class", "file": "src/extension.ts", "symbol": "BuildTerminal"},
+          {"kind": "class", "file": "src/extension.ts", "symbol": "InternalTaskProvider"},
+          {"kind": "function", "file": "src/extension.ts", "symbol": "open"},
+          {"kind": "function", "file": "src/extension.ts", "symbol": "close"},
+          {"kind": "function", "file": "src/extension.ts", "symbol": "provideTasks"},
+          {"kind": "function", "file": "src/extension.ts", "symbol": "resolveTask"}
+        ]
+      }
+    },
+    {
       "id": "ts-js-package-reachability",
       "path": "fixtures/ts_js_package",
       "description": "TypeScript package entrypoints and imports should keep live exports reachable while stale TS and JS exports are reported.",

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -3541,6 +3541,19 @@ class Skylos:
         self._call_arg_types = all_call_arg_types
 
         try:
+            from skylos.deadcode.java_fxml_refs import collect_java_fxml_refs
+
+            java_fxml_refs = collect_java_fxml_refs(
+                Path(root),
+                files,
+                exclude_folders=exclude_folders,
+            )
+            self.refs.extend(java_fxml_refs)
+        except Exception:
+            if os.getenv("SKYLOS_DEBUG"):
+                logger.error("Java FXML liveness scan failed", exc_info=True)
+
+        try:
             from skylos.deadcode.browser_refs import (
                 collect_browser_event_handler_refs,
             )

--- a/skylos/deadcode/java_fxml_refs.py
+++ b/skylos/deadcode/java_fxml_refs.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+from skylos.core.file_discovery import discover_source_files
+from skylos.core.safe_cache_io import read_project_text_no_symlink
+from skylos.visitors.languages.java.core import JavaCore
+
+_FXML_SUFFIXES = {".fxml"}
+_MAX_REFERENCE_FILE_BYTES = 512_000
+_CONTROLLER_SCOPE_TYPES = {
+    "compact_constructor_declaration",
+    "constructor_declaration",
+    "method_declaration",
+}
+_XML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_CONTROLLER_RE = re.compile(
+    r"""\bfx:controller\s*=\s*(?P<quote>["'])"""
+    r"""(?P<name>[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)"""
+    r"""(?P=quote)"""
+)
+_HANDLER_RE = re.compile(
+    r"""\bon[A-Za-z_$][\w$]*\s*=\s*(?P<quote>["'])"""
+    r"""\s*#(?P<name>[A-Za-z_$][\w$]*)\s*(?P=quote)"""
+)
+_FxmlDocument = tuple[Path, str, set[str]]
+
+
+def collect_java_fxml_refs(
+    project_root: Path,
+    source_files,
+    *,
+    exclude_folders=None,
+) -> list[tuple[str, str]]:
+    root = Path(project_root).resolve()
+    java_files = _java_source_files(source_files)
+    if not java_files or not root.is_dir():
+        return []
+
+    fxml_files = discover_source_files(
+        root,
+        _FXML_SUFFIXES,
+        exclude_folders=exclude_folders,
+    )
+    if not fxml_files:
+        return []
+
+    documents = _read_fxml_documents(root, fxml_files)
+    if not documents:
+        return []
+
+    programmatic_controllers: list[tuple[str, str]] = []
+    if _needs_programmatic_controllers(documents):
+        programmatic_controllers = _collect_programmatic_controllers(root, java_files)
+    return _collect_fxml_document_refs(root, documents, programmatic_controllers)
+
+
+def _java_source_files(source_files) -> list[Path]:
+    java_files: list[Path] = []
+    for file_path in source_files:
+        path = Path(file_path)
+        if path.suffix.lower() == ".java":
+            java_files.append(path.resolve())
+    return java_files
+
+
+def _read_fxml_documents(
+    project_root: Path,
+    fxml_files,
+) -> list[_FxmlDocument]:
+    documents: list[_FxmlDocument] = []
+    for fxml_file in fxml_files:
+        path = Path(fxml_file)
+        source = _read_fxml_source(project_root, path)
+        if source is None:
+            continue
+        controllers = {
+            match.group("name").rsplit(".", 1)[-1]
+            for match in _CONTROLLER_RE.finditer(source)
+        }
+        documents.append((path, source, controllers))
+    return documents
+
+
+def _read_fxml_source(project_root: Path, fxml_file: Path) -> str | None:
+    source = read_project_text_no_symlink(
+        project_root,
+        fxml_file,
+        max_bytes=_MAX_REFERENCE_FILE_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if source is None:
+        return None
+    return _XML_COMMENT_RE.sub("", source)
+
+
+def _needs_programmatic_controllers(documents: list[_FxmlDocument]) -> bool:
+    return any(not controllers for _, _, controllers in documents)
+
+
+def _collect_fxml_document_refs(
+    project_root: Path,
+    documents: list[_FxmlDocument],
+    programmatic_controllers: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    refs: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for fxml_file, source, declared_controllers in documents:
+        controllers = _controllers_for_fxml_file(
+            project_root,
+            fxml_file,
+            declared_controllers,
+            programmatic_controllers,
+        )
+        _append_fxml_refs(refs, seen, fxml_file, source, controllers)
+    return refs
+
+
+def _controllers_for_fxml_file(
+    project_root: Path,
+    fxml_file: Path,
+    declared_controllers: set[str],
+    programmatic_controllers: list[tuple[str, str]],
+) -> set[str]:
+    if declared_controllers:
+        return declared_controllers
+    return _programmatic_controllers_for_file(
+        project_root,
+        fxml_file,
+        programmatic_controllers,
+    )
+
+
+def _append_fxml_refs(
+    refs: list[tuple[str, str]],
+    seen: set[tuple[str, str]],
+    fxml_file: Path,
+    source: str,
+    controllers: set[str],
+) -> None:
+    handlers = {match.group("name") for match in _HANDLER_RE.finditer(source)}
+    ref_file = str(fxml_file)
+    for controller in sorted(controllers):
+        _append_ref(refs, seen, controller, ref_file)
+        _append_ref(refs, seen, f"{controller}.initialize", ref_file)
+        for handler in sorted(handlers):
+            _append_ref(refs, seen, f"{controller}.{handler}", ref_file)
+
+
+def _collect_programmatic_controllers(
+    project_root: Path,
+    java_files: list[Path],
+) -> list[tuple[str, str]]:
+    bindings: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for java_file in java_files:
+        candidates = _programmatic_bindings_for_java_file(project_root, java_file)
+        _append_unique_bindings(bindings, seen, candidates)
+
+    return bindings
+
+
+def _programmatic_bindings_for_java_file(
+    project_root: Path,
+    java_file: Path,
+) -> list[tuple[str, str]]:
+    source = read_project_text_no_symlink(
+        project_root,
+        java_file,
+        max_bytes=_MAX_REFERENCE_FILE_BYTES,
+        encoding="utf-8",
+        errors="ignore",
+    )
+    if source is None or not _has_programmatic_fxml_markers(source):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    root_node = JavaCore(str(java_file), source_bytes).root_node
+    if root_node is None:
+        return []
+
+    bindings: list[tuple[str, str]] = []
+    for class_node in _nodes_of_type(root_node, "class_declaration"):
+        bindings.extend(_programmatic_bindings_for_class(class_node, source_bytes))
+    return bindings
+
+
+def _has_programmatic_fxml_markers(source: str) -> bool:
+    return ".fxml" in source.lower() and "setController" in source
+
+
+def _programmatic_bindings_for_class(
+    class_node,
+    source: bytes,
+) -> list[tuple[str, str]]:
+    class_name_node = class_node.child_by_field_name("name")
+    if class_name_node is None:
+        return []
+
+    controller = _node_text(class_name_node, source)
+    bindings: list[tuple[str, str]] = []
+    for scope_node in _controller_scope_nodes(class_node):
+        if _node_sets_itself_as_fxml_controller(scope_node, source):
+            bindings.extend(
+                (resource_path, controller)
+                for resource_path in _fxml_resource_paths(scope_node, source)
+            )
+    return bindings
+
+
+def _controller_scope_nodes(class_node):
+    return (
+        node
+        for node in _walk_class_nodes(class_node)
+        if node.type in _CONTROLLER_SCOPE_TYPES
+    )
+
+
+def _fxml_resource_paths(scope_node, source: bytes):
+    for node in _walk_class_nodes(scope_node):
+        if node.type != "string_literal":
+            continue
+        literal = _node_text(node, source).strip('"')
+        if literal.lower().endswith(".fxml"):
+            yield literal.replace("\\", "/").lstrip("/")
+
+
+def _nodes_of_type(root_node, node_type: str):
+    return (node for node in _walk_nodes(root_node) if node.type == node_type)
+
+
+def _append_unique_bindings(
+    bindings: list[tuple[str, str]],
+    seen: set[tuple[str, str]],
+    candidates: list[tuple[str, str]],
+) -> None:
+    for binding in candidates:
+        if binding in seen:
+            continue
+        seen.add(binding)
+        bindings.append(binding)
+
+
+def _node_sets_itself_as_fxml_controller(scope_node, source: bytes) -> bool:
+    for node in _walk_class_nodes(scope_node):
+        if node.type != "method_invocation":
+            continue
+        name_node = node.child_by_field_name("name")
+        arguments = node.child_by_field_name("arguments")
+        if name_node is None or arguments is None:
+            continue
+        if _node_text(name_node, source) != "setController":
+            continue
+        normalized_arguments = "".join(_node_text(arguments, source).split())
+        if normalized_arguments == "(this)":
+            return True
+    return False
+
+
+def _walk_class_nodes(class_node):
+    stack = list(reversed(class_node.children))
+    while stack:
+        current = stack.pop()
+        if current.type == "class_declaration":
+            continue
+        yield current
+        stack.extend(reversed(current.children))
+
+
+def _programmatic_controllers_for_file(
+    project_root: Path,
+    fxml_file: Path,
+    bindings: list[tuple[str, str]],
+) -> set[str]:
+    try:
+        relative_path = fxml_file.resolve().relative_to(project_root).as_posix()
+    except (OSError, ValueError):
+        relative_path = fxml_file.name
+
+    filename = fxml_file.name
+    controllers: set[str] = set()
+    for resource_path, controller in bindings:
+        resource_name = PurePosixPath(resource_path).name
+        if relative_path.endswith(resource_path) or filename == resource_name:
+            controllers.add(controller)
+    return controllers
+
+
+def _walk_nodes(node):
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        stack.extend(reversed(current.children))
+
+
+def _node_text(node, source: bytes) -> str:
+    return source[node.start_byte : node.end_byte].decode("utf-8")
+
+
+def _append_ref(
+    refs: list[tuple[str, str]],
+    seen: set[tuple[str, str]],
+    name: str,
+    ref_file: str,
+) -> None:
+    ref = (name, ref_file)
+    if ref in seen:
+        return
+    seen.add(ref)
+    refs.append(ref)

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -389,6 +389,7 @@ class Visitor(ast.NodeVisitor):
         self._free_vars = defaultdict(set)
         self._lambda_counter = 0
         self._comprehension_scope_stack = []
+        self._type_parameter_scope_stack = []
         self.inferred_types = {}
         self.metaclass_classes = set()
         self.descriptor_classes = set()
@@ -784,6 +785,23 @@ class Visitor(ast.NodeVisitor):
                 if isinstance(kw.value, ast.Name):
                     self.add_ref(self.qual(kw.value.id))
 
+    def _type_parameter_names(self, node: ast.AST) -> set[str]:
+        return {
+            name
+            for type_param in getattr(node, "type_params", ())
+            if isinstance((name := getattr(type_param, "name", None)), str)
+        }
+
+    def _is_active_type_parameter(self, name: str) -> bool:
+        return any(
+            name in scope for scope in reversed(self._type_parameter_scope_stack)
+        )
+
+    def _visit_type_parameter_annotations(self, node: ast.AST) -> None:
+        for type_param in getattr(node, "type_params", ()):
+            self.visit_annotation(getattr(type_param, "bound", None))
+            self.visit_annotation(getattr(type_param, "default_value", None))
+
     def visit_FunctionDef(
         self, node: Union[ast.FunctionDef, ast.AsyncFunctionDef]
     ) -> None:
@@ -995,7 +1013,21 @@ class Visitor(ast.NodeVisitor):
                 )
             self.current_function_params.append((ka.arg, param_name))
 
-        self.visit_arguments(node.args)
+        type_parameter_names = self._type_parameter_names(node)
+        if type_parameter_names:
+            self.visit_argument_defaults(node.args)
+            self._type_parameter_scope_stack.append(type_parameter_names)
+
+            current_params = self.current_function_params
+            self.current_function_params = []
+            try:
+                self._visit_type_parameter_annotations(node)
+            finally:
+                self.current_function_params = current_params
+
+            self.visit_argument_annotations(node.args)
+        else:
+            self.visit_arguments(node.args)
         self.visit_annotation(node.returns)
 
         if node.returns:
@@ -1029,6 +1061,8 @@ class Visitor(ast.NodeVisitor):
         self.local_var_maps.pop()
         self.local_type_maps.pop()
         self.local_constants.pop()
+        if type_parameter_names:
+            self._type_parameter_scope_stack.pop()
 
         self._current_function_qname = prev_function_qname
         self._nonlocal_names = prev_nonlocals
@@ -1250,9 +1284,6 @@ class Visitor(ast.NodeVisitor):
         for keyword in node.keywords:
             if keyword.arg == "metaclass":
                 self.metaclass_classes.add(node.name)
-                self.visit(keyword.value)
-            else:
-                self.visit(keyword.value)
 
         for deco in node.decorator_list:
             deco_name = self._get_decorator_name(deco)
@@ -1269,6 +1300,14 @@ class Visitor(ast.NodeVisitor):
             ):
                 self.attrs_classes.add(node.name)
             self.visit(deco)
+
+        type_parameter_names = self._type_parameter_names(node)
+        if type_parameter_names:
+            self._type_parameter_scope_stack.append(type_parameter_names)
+            self._visit_type_parameter_annotations(node)
+
+        for keyword in node.keywords:
+            self.visit(keyword.value)
 
         prev_in_protocol = self._in_protocol_class
         self._in_protocol_class = is_protocol
@@ -1341,6 +1380,9 @@ class Visitor(ast.NodeVisitor):
 
         if is_cst:
             self.in_cst_class -= 1
+
+        if type_parameter_names:
+            self._type_parameter_scope_stack.pop()
 
         self._in_protocol_class = prev_in_protocol
 
@@ -1454,6 +1496,21 @@ class Visitor(ast.NodeVisitor):
         self._extract_string_refs(node.value)
         self.generic_visit(node)
         self._track_instance_attr_types(node)
+
+    def visit_TypeAlias(self, node: ast.AST) -> None:
+        name_node = getattr(node, "name", None)
+        if isinstance(name_node, ast.Name):
+            self.type_alias_names.add(name_node.id)
+
+        type_parameter_names = self._type_parameter_names(node)
+        if type_parameter_names:
+            self._type_parameter_scope_stack.append(type_parameter_names)
+            self._visit_type_parameter_annotations(node)
+
+        self.visit_annotation(getattr(node, "value", None))
+
+        if type_parameter_names:
+            self._type_parameter_scope_stack.pop()
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         self.visit_annotation(node.annotation)
@@ -2070,6 +2127,9 @@ class Visitor(ast.NodeVisitor):
                     self.add_ref(fq)
                     return
 
+        if self._is_active_type_parameter(node.id):
+            return
+
         shadowed = self._shadowed_module_aliases.get(node.id)
         if shadowed:
             self.first_read_lineno.setdefault(shadowed, node.lineno)
@@ -2146,6 +2206,9 @@ class Visitor(ast.NodeVisitor):
                                     self._current_function_qname
                                 ].append((_param_name, type_name, node.attr))
                                 break
+
+            if self._is_active_type_parameter(base):
+                return
 
             if self.cls and base in {"self", "cls"}:
                 owner = f"{self.mod}.{self.cls}" if self.mod else self.cls
@@ -2246,7 +2309,7 @@ class Visitor(ast.NodeVisitor):
                     continue
                 self.add_ref(self.qual(tok))
 
-    def visit_arguments(self, args: ast.arguments) -> None:
+    def visit_argument_annotations(self, args: ast.arguments) -> None:
         current_params = self.current_function_params
         self.current_function_params = []
         try:
@@ -2260,6 +2323,13 @@ class Visitor(ast.NodeVisitor):
                 self.visit_annotation(args.vararg.annotation)
             if args.kwarg:
                 self.visit_annotation(args.kwarg.annotation)
+        finally:
+            self.current_function_params = current_params
+
+    def visit_argument_defaults(self, args: ast.arguments) -> None:
+        current_params = self.current_function_params
+        self.current_function_params = []
+        try:
             for default in args.defaults:
                 self.visit(default)
             for default in args.kw_defaults:
@@ -2267,6 +2337,10 @@ class Visitor(ast.NodeVisitor):
                     self.visit(default)
         finally:
             self.current_function_params = current_params
+
+    def visit_arguments(self, args: ast.arguments) -> None:
+        self.visit_argument_annotations(args)
+        self.visit_argument_defaults(args)
 
     def _annotation_to_string(self, node: ast.expr) -> Optional[str]:
         if isinstance(node, ast.Name):

--- a/skylos/visitors/languages/typescript/framework.py
+++ b/skylos/visitors/languages/typescript/framework.py
@@ -10,10 +10,39 @@ from .nextjs import (
 
 _REACT_WRAPPERS: set[str] = {"memo", "forwardRef"}
 
+# Host-invoked methods for the VS Code contracts exercised by the pinned
+# extension samples. Import binding checks below avoid treating local same-name
+# interfaces as framework contracts.
+_VSCODE_CONTRACT_METHODS: dict[str, frozenset[str]] = {
+    "CodeLensProvider": frozenset({"provideCodeLenses", "resolveCodeLens"}),
+    "DocumentLinkProvider": frozenset({"provideDocumentLinks", "resolveDocumentLink"}),
+    "FileSystemProvider": frozenset(
+        {
+            "copy",
+            "createDirectory",
+            "delete",
+            "readDirectory",
+            "readFile",
+            "rename",
+            "stat",
+            "watch",
+            "writeFile",
+        }
+    ),
+    "Pseudoterminal": frozenset({"open", "close", "handleInput", "setDimensions"}),
+    "TaskProvider": frozenset({"provideTasks", "resolveTask"}),
+    "TextDocumentContentProvider": frozenset({"provideTextDocumentContent"}),
+    "TreeDataProvider": frozenset(
+        {"getChildren", "getParent", "getTreeItem", "resolveTreeItem"}
+    ),
+    "TreeDragAndDropController": frozenset({"handleDrag", "handleDrop"}),
+}
+
 _QUERY_CACHE: dict[tuple[int, str], Query] = {}
 
 _FW_PATTERN = """
 (import_statement source: (string) @import_src)
+(import_require_clause source: (string) @import_src)
 (export_statement (function_declaration name: (identifier) @export_func_name))
 (export_statement (class_declaration name: (type_identifier) @export_class_name))
 (export_statement (identifier) @export_default_ident)
@@ -104,6 +133,7 @@ class TSFrameworkVisitor:
         self._scan_nextjs_named_exports()
         self._scan_react_patterns()
         self._scan_custom_hooks()
+        self._scan_vscode_contract_methods()
 
     def _get_text(self, node) -> str:
         return self._source[node.start_byte : node.end_byte].decode("utf-8")
@@ -118,6 +148,8 @@ class TSFrameworkVisitor:
                 self.detected_frameworks.add("next")
             if raw == "react" or raw.startswith("react/") or raw == "react-dom":
                 self.detected_frameworks.add("react")
+            if raw == "vscode":
+                self.detected_frameworks.add("vscode")
 
     def _scan_file_conventions(self) -> None:
         if is_nextjs_default_export_file(self._file_path):
@@ -245,3 +277,195 @@ class TSFrameworkVisitor:
         for node in self._captures.get("export_var_name", []):
             if self._get_text(node).startswith("use") and len(self._get_text(node)) > 3:
                 self.framework_decorated_lines.add(self._line_of(node))
+
+    def _scan_vscode_contract_methods(self) -> None:
+        if "vscode" not in self.detected_frameworks:
+            return
+
+        namespace_bindings, named_contract_bindings = (
+            self._vscode_contract_import_bindings()
+        )
+        if not namespace_bindings and not named_contract_bindings:
+            return
+
+        for name_node in self._captures.get("class_name", []):
+            class_node = name_node.parent
+            if class_node is None or class_node.type != "class_declaration":
+                continue
+            callback_names = self._vscode_class_callback_names(
+                class_node,
+                namespace_bindings,
+                named_contract_bindings,
+            )
+            class_body = _first_named_child_of_type(class_node, "class_body")
+            if class_body is None or not callback_names:
+                continue
+            self._mark_vscode_callback_methods(class_body, callback_names)
+
+    def _vscode_class_callback_names(
+        self,
+        class_node,
+        namespace_bindings: set[str],
+        named_contract_bindings: dict[str, str],
+    ) -> set[str]:
+        callback_names: set[str] = set()
+        heritage = _first_named_child_of_type(class_node, "class_heritage")
+        if heritage is None:
+            return callback_names
+
+        for clause in _named_children_of_type(heritage, "implements_clause"):
+            callback_names.update(
+                self._vscode_implemented_callback_names(
+                    clause,
+                    namespace_bindings,
+                    named_contract_bindings,
+                )
+            )
+        return callback_names
+
+    def _vscode_implemented_callback_names(
+        self,
+        implements_clause,
+        namespace_bindings: set[str],
+        named_contract_bindings: dict[str, str],
+    ) -> set[str]:
+        callback_names: set[str] = set()
+        for contract_node in implements_clause.named_children:
+            contract_name = self._vscode_contract_name(
+                contract_node,
+                namespace_bindings,
+                named_contract_bindings,
+            )
+            if contract_name is not None:
+                callback_names.update(_VSCODE_CONTRACT_METHODS.get(contract_name, ()))
+        return callback_names
+
+    def _vscode_contract_name(
+        self,
+        contract_node,
+        namespace_bindings: set[str],
+        named_contract_bindings: dict[str, str],
+    ) -> str | None:
+        contract_text = self._get_text(contract_node).split("<", 1)[0].strip()
+        if "." not in contract_text:
+            return named_contract_bindings.get(contract_text)
+
+        namespace_name, contract_name = contract_text.rsplit(".", 1)
+        if namespace_name in namespace_bindings:
+            return contract_name
+        return None
+
+    def _mark_vscode_callback_methods(
+        self,
+        class_body,
+        callback_names: set[str],
+    ) -> None:
+        for member in _named_children_of_type(class_body, "method_definition"):
+            method_name_node = member.child_by_field_name("name")
+            if method_name_node is None:
+                continue
+            if self._get_text(method_name_node) in callback_names:
+                self.framework_decorated_lines.add(self._line_of(method_name_node))
+
+    def _vscode_contract_import_bindings(self) -> tuple[set[str], dict[str, str]]:
+        namespace_bindings: set[str] = set()
+        named_contract_bindings: dict[str, str] = {}
+
+        for src_node in self._captures.get("import_src", []):
+            if self._get_text(src_node).strip("'\"") != "vscode":
+                continue
+
+            import_statement = _ancestor_of_type(src_node, "import_statement")
+            if import_statement is None:
+                continue
+            self._record_vscode_import_bindings(
+                import_statement,
+                namespace_bindings,
+                named_contract_bindings,
+            )
+
+        return namespace_bindings, named_contract_bindings
+
+    def _record_vscode_import_bindings(
+        self,
+        import_statement,
+        namespace_bindings: set[str],
+        named_contract_bindings: dict[str, str],
+    ) -> None:
+        for clause in import_statement.named_children:
+            if clause.type == "import_require_clause":
+                self._record_vscode_namespace_binding(clause, namespace_bindings)
+            elif clause.type == "import_clause":
+                self._record_vscode_import_clause_bindings(
+                    clause,
+                    namespace_bindings,
+                    named_contract_bindings,
+                )
+
+    def _record_vscode_import_clause_bindings(
+        self,
+        import_clause,
+        namespace_bindings: set[str],
+        named_contract_bindings: dict[str, str],
+    ) -> None:
+        for binding in import_clause.named_children:
+            if binding.type == "identifier":
+                namespace_bindings.add(self._get_text(binding))
+            elif binding.type == "namespace_import":
+                self._record_vscode_namespace_binding(
+                    binding,
+                    namespace_bindings,
+                )
+            elif binding.type == "named_imports":
+                self._record_vscode_named_imports(
+                    binding,
+                    named_contract_bindings,
+                )
+
+    def _record_vscode_namespace_binding(
+        self,
+        node,
+        namespace_bindings: set[str],
+    ) -> None:
+        identifier = _first_named_child_of_type(node, "identifier")
+        if identifier is not None:
+            namespace_bindings.add(self._get_text(identifier))
+
+    def _record_vscode_named_imports(
+        self,
+        named_imports,
+        named_contract_bindings: dict[str, str],
+    ) -> None:
+        for specifier in _named_children_of_type(named_imports, "import_specifier"):
+            binding = self._vscode_named_import_binding(specifier)
+            if binding is not None:
+                local_name, contract_name = binding
+                named_contract_bindings[local_name] = contract_name
+
+    def _vscode_named_import_binding(self, specifier) -> tuple[str, str] | None:
+        name_node = specifier.child_by_field_name("name")
+        if name_node is None:
+            return None
+
+        contract_name = self._get_text(name_node)
+        if contract_name not in _VSCODE_CONTRACT_METHODS:
+            return None
+
+        alias_node = specifier.child_by_field_name("alias")
+        local_name_node = alias_node if alias_node is not None else name_node
+        return self._get_text(local_name_node), contract_name
+
+
+def _named_children_of_type(node, node_type: str):
+    return (child for child in node.named_children if child.type == node_type)
+
+
+def _first_named_child_of_type(node, node_type: str):
+    return next(_named_children_of_type(node, node_type), None)
+
+
+def _ancestor_of_type(node, node_type: str):
+    current = node
+    while current is not None and current.type != node_type:
+        current = current.parent
+    return current

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3040,15 +3040,120 @@ class TrulyUnused {
         result = json.loads(result_json)
 
         unreachable_classes = {item["name"] for item in result["unused_classes"]}
-        unreachable_functions = {
-            item["name"] for item in result["unused_functions"]
-        }
+        unreachable_functions = {item["name"] for item in result["unused_functions"]}
 
         assert "PackagePrivateService" not in unreachable_classes
         assert "AuditRecord" not in unreachable_classes
         assert "OrderResource" not in unreachable_classes
         assert "TrulyUnused" in unreachable_classes
         assert "PackagePrivateService.staleHelper" in unreachable_functions
+
+    def test_analyze_java_fxml_callbacks_stay_live(self, tmp_path):
+        (tmp_path / "PrintController.java").write_text(
+            """
+import javafx.fxml.FXML;
+
+class PrintController {
+    @FXML
+    private void printButtonAction() {
+    }
+
+    @FXML
+    private void initialize() {
+    }
+
+    @FXML
+    private void staleAnnotated() {
+    }
+
+    private void staleHelper() {
+    }
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "view.fxml").write_text(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<Button xmlns:fx="http://javafx.com/fxml/1"
+        fx:controller="PrintController"
+        id="#staleAnnotated"
+        onAction="#printButtonAction">
+    <!-- <Button onAction="#staleAnnotated" /> -->
+</Button>
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+        unreachable_functions = {item["name"] for item in result["unused_functions"]}
+
+        assert "PrintController" not in unreachable_classes
+        assert "PrintController.printButtonAction" not in unreachable_functions
+        assert "PrintController.initialize" not in unreachable_functions
+        assert "PrintController.staleAnnotated" in unreachable_functions
+        assert "PrintController.staleHelper" in unreachable_functions
+
+    def test_analyze_java_programmatic_fxml_controller_callbacks_stay_live(
+        self, tmp_path
+    ):
+        (tmp_path / "SelfLoadingController.java").write_text(
+            """
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+
+class SelfLoadingController {
+    SelfLoadingController() {
+        FXMLLoader loader = new FXMLLoader(
+            getClass().getResource("self-loading.fxml")
+        );
+        loader.setController(this);
+    }
+
+    private void inspectUnrelatedResource() {
+        getClass().getResource("unrelated.fxml");
+    }
+
+    @FXML
+    private void submitAction() {
+    }
+
+    @FXML
+    private void staleAnnotated() {
+    }
+}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "self-loading.fxml").write_text(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<Button xmlns:fx="http://javafx.com/fxml/1"
+        onAction="#submitAction" />
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "unrelated.fxml").write_text(
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<Button xmlns:fx="http://javafx.com/fxml/1"
+        onAction="#staleAnnotated" />
+""",
+            encoding="utf-8",
+        )
+
+        result_json = analyze(str(tmp_path), conf=0, grep_verify=False)
+        result = json.loads(result_json)
+
+        unreachable_classes = {item["name"] for item in result["unused_classes"]}
+        unreachable_functions = {item["name"] for item in result["unused_functions"]}
+
+        assert "SelfLoadingController" not in unreachable_classes
+        assert "SelfLoadingController.submitAction" not in unreachable_functions
+        assert "SelfLoadingController.staleAnnotated" in unreachable_functions
 
     def test_analyze_java_junit5_annotations_mark_tests_live(self, tmp_path):
         (tmp_path / "BillingTest.java").write_text(

--- a/test/test_pep695_type_params.py
+++ b/test/test_pep695_type_params.py
@@ -1,0 +1,208 @@
+import ast
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.visitors.base import Visitor
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 syntax requires Python 3.12+",
+)
+
+
+def _reference_names(code: str) -> set[str]:
+    visitor = Visitor("sample", "sample.py")
+    visitor.visit(ast.parse(code))
+    return {name for name, _filename in visitor.refs}
+
+
+def test_issue_641_class_bounds_keep_imports_live(tmp_path):
+    (tmp_path / "contract.py").write_text(
+        """
+from typing import Protocol
+
+
+class ParentClass[Inputs](Protocol):
+    pass
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "manager.py").write_text(
+        """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import NamedTuple
+    from contract import ParentClass
+
+
+class Manager[ParentType: ParentClass[NamedTuple]]:
+    pass
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "manager_runtime.py").write_text(
+        """
+import os
+
+from typing import NamedTuple
+from contract import ParentClass
+
+
+class Manager[ParentType: ParentClass[NamedTuple]]:
+    pass
+
+
+print(Manager.__type_params__[0].__bound__)
+""",
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
+    )
+    unused_imports = {
+        (Path(item["file"]).name, item["simple_name"])
+        for item in result.get("unused_imports", [])
+    }
+
+    issue_imports = {
+        ("manager.py", "NamedTuple"),
+        ("manager.py", "ParentClass"),
+        ("manager_runtime.py", "NamedTuple"),
+        ("manager_runtime.py", "ParentClass"),
+    }
+    assert unused_imports.isdisjoint(issue_imports)
+    assert ("manager_runtime.py", "os") in unused_imports
+
+
+def test_generic_function_bounds_and_annotations_use_their_own_type_params():
+    refs = _reference_names(
+        """
+from bounds import AsyncBound, SyncBound
+from external import T, U
+
+
+def convert[T: SyncBound](value: T) -> T:
+    return value
+
+
+async def convert_async[U: AsyncBound](value: U) -> U:
+    return value
+"""
+    )
+
+    assert "bounds.SyncBound" in refs
+    assert "bounds.AsyncBound" in refs
+    assert "external.T" not in refs
+    assert "external.U" not in refs
+
+
+def test_generic_class_scope_shadows_imports_but_not_bound_names():
+    refs = _reference_names(
+        """
+from bounds import GenericBase, ItemBound
+from external import T
+
+
+class Container[T: ItemBound](GenericBase[T]):
+    item: T
+"""
+    )
+
+    assert "bounds.ItemBound" in refs
+    assert "bounds.GenericBase" in refs
+    assert "external.T" not in refs
+
+
+def test_generic_type_alias_scope_shadows_imports():
+    refs = _reference_names(
+        """
+from bounds import AliasBound, Wrapper
+from external import T
+
+
+type Alias[T: AliasBound] = Wrapper[T]
+"""
+    )
+
+    assert "bounds.AliasBound" in refs
+    assert "bounds.Wrapper" in refs
+    assert "external.T" not in refs
+
+
+def test_generic_definition_defaults_and_decorators_use_outer_scope():
+    refs = _reference_names(
+        """
+from external import ClassT, FunctionT
+
+
+def decorate(value):
+    return lambda target: target
+
+
+@decorate(ClassT)
+class Container[ClassT]:
+    pass
+
+
+def transform[FunctionT](value=FunctionT):
+    return value
+"""
+    )
+
+    assert "external.ClassT" in refs
+    assert "external.FunctionT" in refs
+
+
+def test_quoted_type_parameter_bound_is_an_annotation_reference():
+    refs = _reference_names(
+        """
+from bounds import ForwardBound
+
+
+class Container[T: "ForwardBound"]:
+    pass
+"""
+    )
+
+    assert "bounds.ForwardBound" in refs
+
+
+def test_type_parameter_default_is_an_annotation_reference():
+    if sys.version_info >= (3, 13):
+        refs = _reference_names(
+            """
+from defaults import DefaultType
+
+
+class Container[T = DefaultType]:
+    pass
+"""
+        )
+    else:
+        tree = ast.parse(
+            """
+from defaults import DefaultType
+
+
+class Container[T]:
+    pass
+"""
+        )
+        type_param = tree.body[1].type_params[0]
+        type_param.default_value = ast.copy_location(
+            ast.Name(id="DefaultType", ctx=ast.Load()),
+            type_param,
+        )
+
+        visitor = Visitor("sample", "sample.py")
+        visitor.visit(tree)
+        refs = {name for name, _filename in visitor.refs}
+
+    assert "defaults.DefaultType" in refs

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -1120,6 +1120,101 @@ class TestTSMonorepoReachability:
         assert "activate" not in unused_exports
         assert "deactivate" not in unused_exports
 
+    def test_vscode_pseudoterminal_callbacks_are_framework_entrypoints(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (tmp_path / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "task-provider",
+                    "private": True,
+                    "main": "./out/extension.js",
+                    "engines": {"vscode": "^1.100.0"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (src_dir / "extension.ts").write_text(
+            """
+import * as vscode from "vscode";
+import type {
+    Pseudoterminal as TerminalContract,
+    TerminalDimensions,
+} from "vscode";
+
+export function activate() {
+    return new vscode.CustomExecution(
+        async (): Promise<TerminalContract> => new BuildTerminal()
+    );
+}
+
+class BuildTerminal implements TerminalContract {
+    open(_dimensions: TerminalDimensions | undefined): void {}
+    close(): void {}
+    staleHelper(): void {}
+}
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(src_dir), conf=0, grep_verify=False))
+        unused_functions = {item["name"] for item in result.get("unused_functions", [])}
+
+        assert "BuildTerminal.open" not in unused_functions
+        assert "BuildTerminal.close" not in unused_functions
+        assert "BuildTerminal.staleHelper" in unused_functions
+
+    def test_vscode_task_provider_callbacks_are_framework_entrypoints(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (tmp_path / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "task-provider",
+                    "private": True,
+                    "main": "./out/extension.js",
+                    "engines": {"vscode": "^1.100.0"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (src_dir / "extension.ts").write_text(
+            """
+import * as vscode from "vscode";
+
+export function activate(): vscode.Disposable {
+    return vscode.tasks.registerTaskProvider(
+        "build",
+        new InternalTaskProvider()
+    );
+}
+
+class InternalTaskProvider implements vscode.TaskProvider<vscode.Task> {
+    provideTasks(): vscode.Task[] {
+        return [];
+    }
+
+    resolveTask(task: vscode.Task): vscode.Task {
+        return task;
+    }
+
+    staleHelper(): void {}
+}
+""",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(src_dir), conf=0, grep_verify=False))
+        unused_functions = {item["name"] for item in result.get("unused_functions", [])}
+
+        assert "InternalTaskProvider.provideTasks" not in unused_functions
+        assert "InternalTaskProvider.resolveTask" not in unused_functions
+        assert "InternalTaskProvider.staleHelper" in unused_functions
+
     def test_direct_project_reference_keeps_referenced_package_entrypoint_live(
         self, tmp_path
     ):

--- a/test/test_typescript_framework.py
+++ b/test/test_typescript_framework.py
@@ -345,6 +345,127 @@ export const config = { key: "value" };
     assert len(fw.detected_frameworks) == 0
 
 
+def test_vscode_pseudoterminal_contract_callbacks(tmp_path):
+    code = """\
+import * as vscode from "vscode";
+
+class BuildTerminal implements vscode.Pseudoterminal {
+    open(dimensions: vscode.TerminalDimensions | undefined): void {}
+    close(): void {}
+    staleHelper(): void {}
+}
+"""
+    defs, fw = _scan(tmp_path, "terminal.ts", code)
+    names = _decorated_names(defs, fw)
+
+    assert "BuildTerminal.open" in names
+    assert "BuildTerminal.close" in names
+    assert "BuildTerminal.staleHelper" not in names
+
+
+def test_vscode_pseudoterminal_contract_import_bindings(tmp_path):
+    cases = [
+        (
+            'import type { Pseudoterminal } from "vscode";',
+            "Pseudoterminal",
+        ),
+        (
+            'import type { Pseudoterminal as TerminalContract } from "vscode";',
+            "TerminalContract",
+        ),
+        (
+            'import type * as editorApi from "vscode";',
+            "editorApi.Pseudoterminal",
+        ),
+        (
+            'import editorApi from "vscode";',
+            "editorApi.Pseudoterminal",
+        ),
+        (
+            'import editorApi = require("vscode");',
+            "editorApi.Pseudoterminal",
+        ),
+    ]
+
+    for index, (import_statement, contract_name) in enumerate(cases):
+        code = f"""\
+{import_statement}
+
+class BuildTerminal implements {contract_name} {{
+    open(): void {{}}
+    close(): void {{}}
+    staleHelper(): void {{}}
+}}
+"""
+        defs, fw = _scan(tmp_path, f"terminal-{index}.ts", code)
+        names = _decorated_names(defs, fw)
+
+        assert "BuildTerminal.open" in names
+        assert "BuildTerminal.close" in names
+        assert "BuildTerminal.staleHelper" not in names
+
+
+def test_vscode_provider_contract_callbacks(tmp_path):
+    contracts = {
+        "CodeLensProvider": {"provideCodeLenses", "resolveCodeLens"},
+        "DocumentLinkProvider": {"provideDocumentLinks", "resolveDocumentLink"},
+        "FileSystemProvider": {
+            "copy",
+            "createDirectory",
+            "delete",
+            "readDirectory",
+            "readFile",
+            "rename",
+            "stat",
+            "watch",
+            "writeFile",
+        },
+        "TaskProvider": {"provideTasks", "resolveTask"},
+        "TextDocumentContentProvider": {"provideTextDocumentContent"},
+        "TreeDataProvider": {
+            "getChildren",
+            "getParent",
+            "getTreeItem",
+            "resolveTreeItem",
+        },
+        "TreeDragAndDropController": {"handleDrag", "handleDrop"},
+    }
+
+    for index, (contract_name, callback_names) in enumerate(contracts.items()):
+        methods = "\n".join(
+            f"    {callback_name}(): void {{}}" for callback_name in callback_names
+        )
+        code = f"""\
+import type {{ {contract_name} }} from "vscode";
+
+class Provider implements {contract_name} {{
+{methods}
+    staleHelper(): void {{}}
+}}
+"""
+        defs, fw = _scan(tmp_path, f"provider-{index}.ts", code)
+        names = _decorated_names(defs, fw)
+
+        assert {f"Provider.{name}" for name in callback_names} <= names
+        assert "Provider.staleHelper" not in names
+
+
+def test_plain_open_and_close_methods_are_not_framework_callbacks(tmp_path):
+    code = """\
+import * as vscode from "vscode";
+
+interface Pseudoterminal {}
+
+class FileHandle implements Pseudoterminal {
+    open(): void {}
+    close(): void {}
+}
+"""
+    defs, fw = _scan(tmp_path, "file-handle.ts", code)
+
+    assert _decorated_names(defs, fw) == set()
+
+
 def test_non_convention_file_with_next_import(tmp_path):
     code = """\
 import { useRouter } from "next/navigation";


### PR DESCRIPTION
## Summary

  - Recognize methods for imported VS Code contracts, such as `Pseudoterminal`, `TaskProvider`, and provider interfaces
  - Detect JavaFX FXML controllers, event handlers, `initialize` callbacks, and programmatic `FXMLLoader#setController(this)` bindings
  - Preserve TP reporting for local lookalike interfaces, stale `@FXML` methods, and unrelated helpers.
