### PR TITLE
fix(dead-code): wire evidence into reporting decisions

### DIFF
--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -48,9 +48,26 @@ Skylos static analysis  3 issues  1 file analyzed
 
     █  LOW  dead-code/function  Unused function: old_handler
       Dead Code  src/app.py:42
+      evidence: likely dead — no static references were found [analyzer] · symbol is not exported as public API [analyzer]
       def old_handler() -> None:
       Fix: Remove the unused function if it is not public API.
 ```
+
+Dead-code reporting is evidence-gated. The configured confidence threshold
+selects candidates, then the evidence decision determines the outcome:
+
+- `alive`: rescued and omitted from unused-code findings.
+- `uncertain`: recorded as an abstention and omitted from unused-code findings.
+- `likely_dead` or `validated_dead`: reported as unused code.
+
+The human formats show the classification plus the evidence reason and source.
+The TUI includes the full event list in its detail pane. JSON includes the full
+`dead_code_evidence` ledger, `dead_code_rescues`,
+`dead_code_abstentions`, and per-finding `dead_code_decision` data. Candidate
+outcome counts are available under
+`analysis_summary.dead_code_evidence.candidate_decisions`.
+Unverified same-name attribute matches are retained as contextual evidence;
+they do not rescue a symbol unless a stronger liveness signal confirms the use.
 
 Write the same pretty report to a file with `--output`:
 

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>971</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9127</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>975</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>9189</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1262,12 +1262,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/plugin_registry.py skylos/deadcode/browser_refs.py skylos/deadcode/liveness.py skylos/deadcode/config_entrypoints.py skylos/deadcode/python_ast.py skylos/deadcode/collect.py skylos/deadcode/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/plugin_registry.py skylos/deadcode/browser_refs.py skylos/deadcode/liveness.py skylos/deadcode/java_fxml_refs.py skylos/deadcode/config_entrypoints.py skylos/deadcode/finding_evidence.py skylos/deadcode/python_ast.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 8</span>
-          <span class="pill"><strong>symbols</strong> 137</span>
+          <span class="pill"><strong>files</strong> 10</span>
+          <span class="pill"><strong>symbols</strong> 163</span>
         </div>
       </div>
       <p>Dead-code specific analysis, framework liveness, and evidence support.</p>
@@ -1285,10 +1285,10 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">skylos/deadcode/plugin_registry.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/browser_refs.py" rel="noopener noreferrer">skylos/deadcode/browser_refs.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">skylos/deadcode/liveness.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/java_fxml_refs.py" rel="noopener noreferrer">skylos/deadcode/java_fxml_refs.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/config_entrypoints.py" rel="noopener noreferrer">skylos/deadcode/config_entrypoints.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/python_ast.py" rel="noopener noreferrer">skylos/deadcode/python_ast.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/collect.py" rel="noopener noreferrer">skylos/deadcode/collect.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/__init__.py" rel="noopener noreferrer">skylos/deadcode/__init__.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/finding_evidence.py" rel="noopener noreferrer">skylos/deadcode/finding_evidence.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/python_ast.py" rel="noopener noreferrer">skylos/deadcode/python_ast.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1545,7 +1545,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/llm" rel="noopener noreferrer">skylos/llm</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 67</span>
-          <span class="pill"><strong>symbols</strong> 671</span>
+          <span class="pill"><strong>symbols</strong> 672</span>
         </div>
       </div>
       <p>LLM security analysis, evidence grounding, provider runtime resolution, and prompt templates.</p>
@@ -1705,12 +1705,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/reporting output formatters and exports such as sarif, compact json, and human-readable reports. use this when scan results are right but the output is wrong or hard to consume. skylos/reporting/  skylos/reporting/result_builder.py skylos/reporting/dead_code_result.py skylos/reporting/grader.py skylos/reporting/provenance.py skylos/reporting/architecture_result.py skylos/reporting/github_annotations.py skylos/reporting/llm_report.py skylos/reporting/rollups.py">
+    <article class="folder-card searchable" data-search="skylos/reporting output formatters and exports such as sarif, compact json, and human-readable reports. use this when scan results are right but the output is wrong or hard to consume. skylos/reporting/  skylos/reporting/dead_code_result.py skylos/reporting/result_builder.py skylos/reporting/grader.py skylos/reporting/provenance.py skylos/reporting/architecture_result.py skylos/reporting/github_annotations.py skylos/reporting/llm_report.py skylos/reporting/rollups.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 10</span>
-          <span class="pill"><strong>symbols</strong> 98</span>
+          <span class="pill"><strong>symbols</strong> 103</span>
         </div>
       </div>
       <p>Output formatters and exports such as SARIF, compact JSON, and human-readable reports.</p>
@@ -1724,8 +1724,8 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">skylos/reporting/result_builder.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">skylos/reporting/dead_code_result.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">skylos/reporting/dead_code_result.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">skylos/reporting/result_builder.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">skylos/reporting/grader.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/provenance.py" rel="noopener noreferrer">skylos/reporting/provenance.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/architecture_result.py" rel="noopener noreferrer">skylos/reporting/architecture_result.py</a></li>
@@ -1735,16 +1735,16 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">build_analysis_result</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">dead_code_evidence</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">unused_definitions</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">dead_code_candidate_decisions</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">definition_context</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">whitelisted_definitions</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">build_analysis_result</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">_debug_traceback</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">_primary_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">_normal_set</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">_base_result</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/result_builder.py" rel="noopener noreferrer">_attach_analysis_reports</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">dead_code_evidence</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">unused_definitions</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">definition_context</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">whitelisted_definitions</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/dead_code_result.py" rel="noopener noreferrer">_primary_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">score_to_letter</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">count_lines_of_code</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting/grader.py" rel="noopener noreferrer">score_security</a> <span>def</span></li>
@@ -1889,12 +1889,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/ui terminal ui and presentation helpers. use this when the scan is correct but terminal interaction is confusing. skylos/ui/ test/test_suite.py test/test_tui.py skylos/ui/terminal_report.py skylos/ui/rich_report.py skylos/ui/tui.py skylos/ui/nudge.py skylos/ui/help.py skylos/ui/tour.py skylos/ui/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/ui terminal ui and presentation helpers. use this when the scan is correct but terminal interaction is confusing. skylos/ui/ test/test_suite.py test/test_tui.py skylos/ui/terminal_report.py skylos/ui/rich_report.py skylos/ui/tui.py skylos/ui/dead_code_evidence.py skylos/ui/nudge.py skylos/ui/help.py skylos/ui/tour.py skylos/ui/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 67</span>
+          <span class="pill"><strong>files</strong> 8</span>
+          <span class="pill"><strong>symbols</strong> 77</span>
         </div>
       </div>
       <p>Terminal UI and presentation helpers.</p>
@@ -1911,6 +1911,7 @@
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">skylos/ui/terminal_report.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">skylos/ui/rich_report.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">skylos/ui/tui.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/dead_code_evidence.py" rel="noopener noreferrer">skylos/ui/dead_code_evidence.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">skylos/ui/nudge.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/help.py" rel="noopener noreferrer">skylos/ui/help.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tour.py" rel="noopener noreferrer">skylos/ui/tour.py</a></li>
@@ -1927,7 +1928,7 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_shorten_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_results_pill</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_grep_verify_pill</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_display_cap</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_dead_code_evidence_pill</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">prepare_category_data</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">CategoryItem</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">FindingItem</a> <span>class</span></li>
@@ -1943,7 +1944,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 43</span>
-          <span class="pill"><strong>symbols</strong> 400</span>
+          <span class="pill"><strong>symbols</strong> 403</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1992,8 +1993,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 236</span>
-          <span class="pill"><strong>symbols</strong> 3369</span>
+          <span class="pill"><strong>files</strong> 237</span>
+          <span class="pill"><strong>symbols</strong> 3386</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/api/_payloads.py
+++ b/skylos/api/_payloads.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from typing import Any
 import json
 
+from skylos.deadcode.finding_evidence import dead_code_finding_evidence_payload
+
 
 __all__ = [
     "_build_legacy_payload",
@@ -213,6 +215,14 @@ def _compact_upload_finding(
         if snippet:
             compact["snippet"] = snippet
     metadata = _compact_finding_metadata(finding.get("metadata"))
+    dead_code_evidence = dead_code_finding_evidence_payload(
+        finding,
+        max_events=8,
+    )
+    if dead_code_evidence is not None:
+        if metadata is None:
+            metadata = {}
+        metadata["dead_code_evidence"] = dead_code_evidence
     if metadata:
         compact["metadata"] = metadata
     return compact

--- a/skylos/deadcode/evidence.py
+++ b/skylos/deadcode/evidence.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-CLASSIFICATION_POLICY = "dead-code-evidence-v2"
+CLASSIFICATION_POLICY = "dead-code-evidence-v3"
 
 
 class EvidenceKind(str, Enum):
@@ -20,6 +20,7 @@ class EvidenceKind(str, Enum):
     COVERAGE_HIT = "coverage_hit"
     TRACE_HIT = "trace_hit"
     GREP_RESCUE = "grep_rescue"
+    ATTRIBUTE_NAME_MATCH = "attribute_name_match"
     VALIDATION_PASS = "validation_pass"
     VALIDATION_FAIL = "validation_fail"
     UNCERTAINTY = "uncertainty"
@@ -251,7 +252,10 @@ class EvidenceLedger:
                 or event.kind == EvidenceKind.VALIDATION_FAIL
             ),
             dead_evidence_count=sum(
-                1 for event in events if event.kind in DEAD_EVIDENCE_KINDS
+                1
+                for event in events
+                if event.kind in DEAD_EVIDENCE_KINDS
+                or event.kind == EvidenceKind.VALIDATION_PASS
             ),
             uncertainty_count=sum(
                 1 for event in events if event.kind == EvidenceKind.UNCERTAINTY
@@ -620,10 +624,11 @@ def _event_from_heuristic_ref(key: str, confidence: Any) -> EvidenceEvent | None
 
     if key in {"same_file_attr", "same_pkg_attr", "global_attr"}:
         return EvidenceEvent(
-            kind=EvidenceKind.DYNAMIC_PATTERN,
-            reason=key,
+            kind=EvidenceKind.ATTRIBUTE_NAME_MATCH,
+            reason=f"unverified {key} match",
             source="attribute_reference",
             confidence=value,
+            details={"bucket": key},
         )
 
     if key.startswith("dead_code_liveness:"):

--- a/skylos/deadcode/finding_evidence.py
+++ b/skylos/deadcode/finding_evidence.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+_VALIDATED_DEAD_OUTCOMES = {
+    "true_positive",
+    "validated_dead",
+    "validation_pass",
+}
+_ALIVE_OUTCOMES = {
+    "alive",
+    "false_positive",
+    "validation_fail",
+}
+_UNCERTAIN_OUTCOMES = {
+    "inconclusive",
+    "uncertain",
+}
+
+
+def dead_code_finding_evidence_payload(
+    finding: dict[str, Any],
+    *,
+    max_events: int | None = None,
+) -> dict[str, Any] | None:
+    decision = finding.get("dead_code_decision")
+    events = finding.get("dead_code_evidence")
+    classification = finding.get("dead_code_classification")
+    reason = finding.get("dead_code_reason")
+    reason_tags = finding.get("dead_code_reason_tags")
+
+    has_decision = isinstance(decision, dict) and bool(decision)
+    has_events = isinstance(events, list) and bool(events)
+    if not any((classification, reason, reason_tags, has_decision, has_events)):
+        return None
+
+    payload: dict[str, Any] = {}
+    if classification:
+        payload["classification"] = str(classification)
+    disposition = finding.get("dead_code_disposition")
+    if disposition:
+        payload["disposition"] = str(disposition)
+    if reason:
+        payload["reason"] = str(reason)
+    if isinstance(reason_tags, (list, tuple)):
+        payload["reason_tags"] = [str(tag) for tag in reason_tags]
+    if has_decision:
+        payload["decision"] = dict(decision)
+    if isinstance(events, list):
+        visible = [dict(event) for event in events if isinstance(event, dict)]
+        if max_events is not None:
+            visible = visible[: max(0, max_events)]
+        payload["events"] = visible
+        if max_events is not None and len(events) > len(visible):
+            payload["events_truncated"] = len(events) - len(visible)
+    return payload
+
+
+def attach_dead_code_validation(
+    finding: dict[str, Any],
+    outcome: str,
+    *,
+    reason: str,
+    source: str,
+    confidence: float = 1.0,
+) -> dict[str, Any]:
+    normalized = str(outcome or "").strip().lower()
+    if normalized in _VALIDATED_DEAD_OUTCOMES:
+        classification = "validated_dead"
+        disposition = "reported"
+        kind = "validation_pass"
+        role = "supports_dead"
+        primary_reason = "Validator confirmed no live use"
+        reason_tags = ["validated_dead"]
+    elif normalized in _ALIVE_OUTCOMES:
+        classification = "alive"
+        disposition = "rescued"
+        kind = "validation_fail"
+        role = "supports_live"
+        primary_reason = "Validator found live use"
+        reason_tags = ["validation_failed"]
+    elif normalized in _UNCERTAIN_OUTCOMES:
+        classification = "uncertain"
+        disposition = "abstained"
+        kind = "uncertainty"
+        role = "uncertainty"
+        primary_reason = "Validator was inconclusive"
+        reason_tags = ["uncertainty"]
+    else:
+        raise ValueError(f"Unsupported dead-code validation outcome: {outcome}")
+
+    event = {
+        "kind": kind,
+        "role": role,
+        "reason": str(reason or primary_reason),
+        "source": str(source or "validator"),
+        "confidence": _confidence_float(confidence),
+        "details": {"validation_outcome": normalized},
+    }
+    events = [
+        dict(existing)
+        for existing in finding.get("dead_code_evidence", [])
+        if isinstance(existing, dict)
+    ]
+    if event not in events:
+        events.append(event)
+
+    current_decision = finding.get("dead_code_decision")
+    decision = dict(current_decision) if isinstance(current_decision, dict) else {}
+    decision.update(
+        {
+            "classification": classification,
+            "primary_reason": primary_reason,
+            "reason_tags": reason_tags,
+            "live_evidence_count": _role_count(events, "supports_live"),
+            "dead_evidence_count": _role_count(events, "supports_dead"),
+            "uncertainty_count": _role_count(events, "uncertainty"),
+        }
+    )
+
+    finding["dead_code_classification"] = classification
+    finding["dead_code_disposition"] = disposition
+    finding["dead_code_evidence"] = events
+    finding["dead_code_decision"] = decision
+    finding["dead_code_reason"] = primary_reason
+    finding["dead_code_reason_tags"] = reason_tags
+    return finding
+
+
+def _role_count(events: list[dict[str, Any]], role: str) -> int:
+    return sum(1 for event in events if event.get("role") == role)
+
+
+def _confidence_float(value: Any) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    if numeric > 1:
+        numeric /= 100.0
+    return max(0.0, min(numeric, 1.0))

--- a/skylos/llm/verify_orchestrator.py
+++ b/skylos/llm/verify_orchestrator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import json
 import logging
-import os
 import time
 from pathlib import Path
 from typing import Any
@@ -2414,6 +2413,35 @@ def _apply_dead_code_defaults(
             )
 
 
+def _attach_dead_code_validation_evidence(items: list[dict[str, Any]]) -> None:
+    from skylos.deadcode.finding_evidence import attach_dead_code_validation
+
+    outcome_by_verdict = {
+        "TRUE_POSITIVE": "validated_dead",
+        "FALSE_POSITIVE": "alive",
+        "UNCERTAIN": "uncertain",
+    }
+    for item in items:
+        verdict = str(item.get("_llm_verdict") or "").upper()
+        outcome = outcome_by_verdict.get(verdict)
+        if outcome is None:
+            continue
+        source = (
+            "llm_dead_code_verifier"
+            if item.get("_verified_by_llm")
+            else str(item.get("_source") or "dead_code_verifier")
+        )
+        attach_dead_code_validation(
+            item,
+            outcome,
+            reason=str(item.get("_llm_rationale") or "Dead-code verifier verdict"),
+            source=source,
+            confidence=item.get("_adjusted_confidence")
+            or item.get("confidence")
+            or 100,
+        )
+
+
 def _build_verification_output(
     findings: list[dict[str, Any]],
     new_dead: list[dict[str, Any]],
@@ -2431,6 +2459,8 @@ def _build_verification_output(
         rule_id="SKY-DEAD-CHALLENGE",
         default_source="llm_survivor_challenge",
     )
+    _attach_dead_code_validation_evidence(findings)
+    _attach_dead_code_validation_evidence(new_dead)
 
     return {
         "verified_findings": findings,

--- a/skylos/reporting/dead_code_result.py
+++ b/skylos/reporting/dead_code_result.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 
+REPORTABLE_DEAD_CODE_CLASSIFICATIONS = {
+    "dead",
+    "likely_dead",
+    "validated_dead",
+}
+
+
 def _primary_path(path):
     if not isinstance(path, (list, tuple)):
         return path
@@ -44,12 +51,69 @@ def dead_code_evidence(analyzer, path, pyproject_entrypoint_qnames, threshold=No
 def _evidence_by_name(dead_code_evidence_payload):
     by_name = {}
     for entry in dead_code_evidence_payload.get("symbols", []):
-        by_name[entry["qualified_name"]] = entry
+        by_name.setdefault(entry["qualified_name"], []).append(entry)
     return by_name
 
 
+def _evidence_for_definition(evidence_by_name, definition):
+    candidates = evidence_by_name.get(getattr(definition, "name", ""), [])
+    if not candidates:
+        return None
+
+    definition_file = _normalized_file(getattr(definition, "filename", ""))
+    file_matches = [
+        entry
+        for entry in candidates
+        if _files_identify_same_source(entry.get("file"), definition_file)
+    ]
+    definition_line = getattr(definition, "line", 0) or 0
+    definition_kind = str(getattr(definition, "type", ""))
+
+    if len(candidates) == 1:
+        entry = candidates[0]
+        if entry.get("file") and not file_matches:
+            return None
+        if entry.get("kind") and str(entry["kind"]) != definition_kind:
+            return None
+        if (
+            entry.get("line")
+            and definition_line
+            and entry["line"] != definition_line
+        ):
+            return None
+        return entry
+
+    narrowed = file_matches
+    if not narrowed:
+        return None
+    exact_matches = [
+        entry
+        for entry in narrowed
+        if (entry.get("line", 0) or 0) == definition_line
+        and str(entry.get("kind", "")) == definition_kind
+    ]
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+    return None
+
+
+def _normalized_file(value):
+    return Path(str(value or "")).as_posix().removeprefix("./")
+
+
+def _files_identify_same_source(entry_file, definition_file):
+    entry_path = _normalized_file(entry_file)
+    if not entry_path or not definition_file:
+        return False
+    if entry_path == definition_file:
+        return True
+    if not Path(entry_path).is_absolute():
+        return definition_file.endswith(f"/{entry_path}")
+    return False
+
+
 def _attach_evidence(target: dict, definition, evidence_by_name) -> None:
-    entry = evidence_by_name.get(getattr(definition, "name", ""))
+    entry = _evidence_for_definition(evidence_by_name, definition)
     if not entry:
         return
     target["dead_code_classification"] = entry["classification"]
@@ -61,6 +125,26 @@ def _attach_evidence(target: dict, definition, evidence_by_name) -> None:
         target["dead_code_reason_tags"] = list(decision.get("reason_tags") or [])
 
 
+def _candidate_disposition(definition, thr, evidence_by_name):
+    if not _is_dead_definition(definition, thr):
+        return None
+
+    entry = _evidence_for_definition(evidence_by_name, definition)
+    if not isinstance(entry, dict):
+        return "reported"
+
+    classification = str(entry.get("classification") or "")
+    if classification == "alive":
+        return "rescued"
+    if classification == "uncertain":
+        return "abstained"
+    if classification in REPORTABLE_DEAD_CODE_CLASSIFICATIONS:
+        return "reported"
+
+    # Unknown evidence states must not become destructive dead-code findings.
+    return "abstained"
+
+
 def _is_dead_definition(definition, thr):
     if definition.references != 0:
         return False
@@ -69,16 +153,6 @@ def _is_dead_definition(definition, thr):
     if definition.confidence <= 0:
         return False
     return definition.confidence >= thr
-
-
-def _dead_class_keys(analyzer, thr):
-    keys = set()
-    for key, definition in analyzer.defs.items():
-        if definition.type not in ("class", "type"):
-            continue
-        if _is_dead_definition(definition, thr):
-            keys.add(key)
-    return keys
 
 
 def _class_key_by_name_file(analyzer):
@@ -102,20 +176,51 @@ def _method_owner_key(definition, class_keys):
 
 
 def unused_definitions(analyzer, thr, dead_code_evidence_payload):
+    reported, _, _ = dead_code_candidate_decisions(
+        analyzer,
+        thr,
+        dead_code_evidence_payload,
+    )
+    return reported
+
+
+def dead_code_candidate_decisions(analyzer, thr, dead_code_evidence_payload):
     evidence_by_name = _evidence_by_name(dead_code_evidence_payload)
-    unused = []
-    dead_classes = _dead_class_keys(analyzer, thr)
+    dispositions = {}
+    for key, definition in analyzer.defs.items():
+        dispositions[key] = _candidate_disposition(
+            definition,
+            thr,
+            evidence_by_name,
+        )
+
+    reported = []
+    rescued = []
+    abstained = []
+    reported_classes = {
+        key
+        for key, definition in analyzer.defs.items()
+        if definition.type in ("class", "type")
+        and dispositions.get(key) == "reported"
+    }
     class_keys = _class_key_by_name_file(analyzer)
-    for definition in analyzer.defs.values():
-        if not _is_dead_definition(definition, thr):
+    for key, definition in analyzer.defs.items():
+        disposition = dispositions.get(key)
+        if disposition is None:
             continue
         owner_key = _method_owner_key(definition, class_keys)
-        if owner_key in dead_classes:
+        if disposition == "reported" and owner_key in reported_classes:
             continue
         item = definition.to_dict()
         _attach_evidence(item, definition, evidence_by_name)
-        unused.append(item)
-    return unused
+        item["dead_code_disposition"] = disposition
+        if disposition == "reported":
+            reported.append(item)
+        elif disposition == "rescued":
+            rescued.append(item)
+        else:
+            abstained.append(item)
+    return reported, rescued, abstained
 
 
 def _definition_loc(definition):

--- a/skylos/reporting/result_builder.py
+++ b/skylos/reporting/result_builder.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import os
+import traceback
 from pathlib import Path
 
 from skylos.config import load_config
 from skylos.core.evidence_contract import attach_evidence_contract
 from skylos.reporting.architecture_result import attach_circular_and_architecture
 from skylos.reporting.dead_code_result import (
+    dead_code_candidate_decisions,
     dead_code_evidence,
     definition_context,
-    unused_definitions,
     whitelisted_definitions,
 )
 from skylos.reporting.rollups import attach_directory_rollups
@@ -21,6 +23,11 @@ AI_DEFECT_RULE_IDS = {
     "SKY-D224",
     "SKY-D225",
 }
+
+
+def _debug_traceback():
+    if os.getenv("SKYLOS_DEBUG"):
+        traceback.print_exc()
 
 
 def _primary_path(path):
@@ -77,7 +84,11 @@ def build_analysis_result(
         pyproject_entrypoint_qnames,
         threshold=thr,
     )
-    unused = unused_definitions(analyzer, thr, evidence)
+    unused, rescued, abstained = dead_code_candidate_decisions(
+        analyzer,
+        thr,
+        evidence,
+    )
     context_map = definition_context(analyzer, thr, evidence)
     whitelisted = whitelisted_definitions(analyzer, all_suppressed)
 
@@ -90,6 +101,9 @@ def build_analysis_result(
         all_suppressed,
         evidence,
         ledger,
+        rescued,
+        abstained,
+        unused,
     )
     _attach_analysis_reports(analyzer, result)
     _attach_workspace(analyzer, result, workspace_inventory, path)
@@ -147,7 +161,16 @@ def _base_result(
     all_suppressed,
     dead_code_evidence,
     dead_code_ledger,
+    dead_code_rescues,
+    dead_code_abstentions,
+    reported_dead_code,
 ):
+    evidence_summary = dead_code_ledger.summary()
+    evidence_summary["candidate_decisions"] = {
+        "reported": len(reported_dead_code),
+        "rescued": len(dead_code_rescues),
+        "abstained": len(dead_code_abstentions),
+    }
     return {
         "definitions": context_map,
         "unused_functions": [],
@@ -159,11 +182,13 @@ def _base_result(
         "whitelisted": whitelisted,
         "suppressed": all_suppressed,
         "dead_code_evidence": dead_code_evidence,
+        "dead_code_rescues": dead_code_rescues,
+        "dead_code_abstentions": dead_code_abstentions,
         "analysis_summary": {
             "total_files": len(files),
             "excluded_folders": exclude_folders or [],
             "languages": analyzer._count_languages(files),
-            "dead_code_evidence": dead_code_ledger.summary(),
+            "dead_code_evidence": evidence_summary,
         },
     }
 

--- a/skylos/reporting/sarif.py
+++ b/skylos/reporting/sarif.py
@@ -2,6 +2,7 @@ import os
 import json
 
 from skylos.core.evidence_contract import finding_evidence_contract
+from skylos.deadcode.finding_evidence import dead_code_finding_evidence_payload
 
 
 def severity_to_sarif_level(severity):
@@ -175,6 +176,10 @@ class SarifExporter:
             evidence_contract = finding_evidence_contract(finding)
             if evidence_contract is not None:
                 properties["skylos_evidence_contract"] = evidence_contract
+
+            dead_code_evidence = dead_code_finding_evidence_payload(finding)
+            if dead_code_evidence is not None:
+                properties["skylos_dead_code_evidence"] = dead_code_evidence
 
             result_obj = {
                 "ruleId": rule_id,

--- a/skylos/ui/dead_code_evidence.py
+++ b/skylos/ui/dead_code_evidence.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+CLASSIFICATION_LABELS = {
+    "alive": "alive",
+    "dead": "dead",
+    "likely_dead": "likely dead",
+    "validated_dead": "validated dead",
+    "uncertain": "uncertain",
+}
+
+REASON_TAG_LABELS = {
+    "no_refs": "no refs",
+    "not_exported": "not exported",
+    "no_entrypoint": "no entrypoint",
+    "static_reference": "has refs",
+    "reachable_from_root": "root reachable",
+    "top_level_execution": "import-time call",
+    "framework_root": "framework entry",
+    "package_entrypoint": "package entry",
+    "test_entrypoint": "test entry",
+    "dynamic_pattern": "dynamic ref",
+    "coverage_hit": "coverage hit",
+    "trace_hit": "trace hit",
+    "grep_rescue": "grep usage",
+    "uncertainty": "uncertain",
+    "validated_dead": "validated dead",
+    "validation_failed": "live use found",
+    "no_liveness_evidence": "no live evidence",
+}
+
+_ROLE_ORDER = {
+    "alive": ("supports_live", "uncertainty", "supports_dead", "context"),
+    "uncertain": ("uncertainty", "supports_live", "supports_dead", "context"),
+    "dead": ("supports_dead", "uncertainty", "supports_live", "context"),
+    "likely_dead": ("supports_dead", "uncertainty", "supports_live", "context"),
+    "validated_dead": (
+        "supports_dead",
+        "uncertainty",
+        "supports_live",
+        "context",
+    ),
+}
+
+
+def dead_code_classification(item: dict[str, Any]) -> str:
+    classification = item.get("dead_code_classification")
+    if classification:
+        return str(classification)
+    decision = item.get("dead_code_decision")
+    if isinstance(decision, dict) and decision.get("classification"):
+        return str(decision["classification"])
+    return ""
+
+
+def compact_dead_code_evidence(
+    item: dict[str, Any],
+    *,
+    max_events: int = 3,
+) -> str:
+    classification = dead_code_classification(item)
+    label = CLASSIFICATION_LABELS.get(classification, classification.replace("_", " "))
+    events = _ordered_events(item, classification)
+    visible = [_compact_event(event) for event in events[: max(0, max_events)]]
+    visible = [text for text in visible if text]
+
+    if visible:
+        prefix = f"{label} — " if label else ""
+        suffix = ""
+        if len(events) > len(visible):
+            suffix = f" · +{len(events) - len(visible)}"
+        return prefix + " · ".join(visible) + suffix
+
+    fallback = _fallback_reason(item)
+    if label and fallback:
+        return f"{label} — {fallback}"
+    return label or fallback
+
+
+def dead_code_evidence_detail_lines(item: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    classification = dead_code_classification(item)
+    if classification:
+        label = CLASSIFICATION_LABELS.get(
+            classification,
+            classification.replace("_", " "),
+        )
+        lines.append(f"Decision: {label}")
+
+    decision = item.get("dead_code_decision")
+    if isinstance(decision, dict):
+        reason = decision.get("primary_reason")
+        if reason:
+            lines.append(f"Reason: {reason}")
+        lines.append(
+            "Support: "
+            f"live {int(decision.get('live_evidence_count') or 0)}, "
+            f"dead {int(decision.get('dead_evidence_count') or 0)}, "
+            f"uncertain {int(decision.get('uncertainty_count') or 0)}"
+        )
+
+    events = _ordered_events(item, classification)
+    if events:
+        lines.append("Evidence:")
+        for event in events:
+            role = str(event.get("role") or "context").replace("_", " ")
+            reason = str(event.get("reason") or event.get("kind") or "evidence")
+            source = str(event.get("source") or "unknown")
+            confidence = _confidence_label(event.get("confidence"))
+            lines.append(f"- {role}: {reason} [{source}, {confidence}]")
+    return lines
+
+
+def dead_code_candidate_counts(result: dict[str, Any]) -> dict[str, int]:
+    summary = result.get("analysis_summary")
+    if not isinstance(summary, dict):
+        return {}
+    evidence = summary.get("dead_code_evidence")
+    if not isinstance(evidence, dict):
+        return {}
+    decisions = evidence.get("candidate_decisions")
+    if not isinstance(decisions, dict):
+        return {}
+    return {
+        "reported": _safe_int(decisions.get("reported")),
+        "rescued": _safe_int(decisions.get("rescued")),
+        "abstained": _safe_int(decisions.get("abstained")),
+    }
+
+
+def _ordered_events(item: dict[str, Any], classification: str) -> list[dict[str, Any]]:
+    raw_events = item.get("dead_code_evidence")
+    if not isinstance(raw_events, list):
+        return []
+    events = [event for event in raw_events if isinstance(event, dict)]
+    order = _ROLE_ORDER.get(
+        classification,
+        ("supports_dead", "supports_live", "uncertainty", "context"),
+    )
+    rank = {role: index for index, role in enumerate(order)}
+    return sorted(
+        events,
+        key=lambda event: rank.get(str(event.get("role") or "context"), len(rank)),
+    )
+
+
+def _compact_event(event: dict[str, Any]) -> str:
+    reason = str(event.get("reason") or event.get("kind") or "").strip()
+    if not reason:
+        return ""
+    source = str(event.get("source") or "").strip()
+    if source:
+        return f"{reason} [{source}]"
+    return reason
+
+
+def _fallback_reason(item: dict[str, Any]) -> str:
+    tags = item.get("dead_code_reason_tags")
+    if not isinstance(tags, (list, tuple)):
+        decision = item.get("dead_code_decision")
+        if isinstance(decision, dict):
+            tags = decision.get("reason_tags")
+
+    if isinstance(tags, (list, tuple)):
+        visible = []
+        for raw_tag in tags:
+            tag = str(raw_tag)
+            if tag == "confidence_ge_threshold":
+                continue
+            label = REASON_TAG_LABELS.get(tag)
+            if label:
+                visible.append(label)
+        if visible:
+            return " · ".join(visible[:3])
+
+    reason = item.get("dead_code_reason")
+    if reason:
+        return str(reason)
+    decision = item.get("dead_code_decision")
+    if isinstance(decision, dict) and decision.get("primary_reason"):
+        return str(decision["primary_reason"])
+    return ""
+
+
+def _confidence_label(value: Any) -> str:
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return "confidence unknown"
+    if confidence <= 1:
+        confidence *= 100
+    return f"{round(confidence)}%"
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/skylos/ui/rich_report.py
+++ b/skylos/ui/rich_report.py
@@ -8,6 +8,11 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
 
+from skylos.ui.dead_code_evidence import (
+    compact_dead_code_evidence,
+    dead_code_candidate_counts,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +56,18 @@ def _grep_verify_pill(summary):
         return "[muted]Grep verify: off[/muted]"
     rescued_count = int(grep_verify.get("rescued_count") or 0)
     return f"[brand]Grep verify: on[/brand] [muted](rescued {rescued_count})[/muted]"
+
+
+def _dead_code_evidence_pill(result):
+    counts = dead_code_candidate_counts(result)
+    rescued = counts.get("rescued", 0)
+    abstained = counts.get("abstained", 0)
+    if not rescued and not abstained:
+        return None
+    return (
+        f"[good]Evidence rescued: {rescued}[/good] "
+        f"[warn]abstained: {abstained}[/warn]"
+    )
 
 
 def _display_cap(items, limit):
@@ -159,55 +176,8 @@ def _format_confidence(conf):
     return str(conf)
 
 
-_DEAD_CODE_REASON_LABELS = {
-    "no_refs": "no refs",
-    "not_exported": "not exported",
-    "no_entrypoint": "no entrypoint",
-    "static_reference": "has refs",
-    "reachable_from_root": "root reachable",
-    "top_level_execution": "import-time call",
-    "framework_root": "framework entry",
-    "package_entrypoint": "package entry",
-    "test_entrypoint": "test entry",
-    "dynamic_pattern": "dynamic ref",
-    "coverage_hit": "coverage hit",
-    "trace_hit": "trace hit",
-    "grep_rescue": "grep usage",
-    "uncertainty": "uncertain",
-    "validated_dead": "validated dead",
-    "validation_failed": "live use found",
-    "no_liveness_evidence": "no live evidence",
-}
-
-
 def _dead_code_why(item: dict) -> str:
-    decision = item.get("dead_code_decision") or {}
-    tags = item.get("dead_code_reason_tags")
-    if tags is None and isinstance(decision, dict):
-        tags = decision.get("reason_tags")
-
-    if isinstance(tags, (list, tuple)):
-        visible = []
-        for raw_tag in tags:
-            tag = str(raw_tag)
-            if tag == "confidence_ge_threshold":
-                continue
-            label = _DEAD_CODE_REASON_LABELS.get(tag)
-            if label:
-                visible.append(label)
-        if visible:
-            shown = visible[:3]
-            suffix = ""
-            if len(visible) > len(shown):
-                suffix = f" · +{len(visible) - len(shown)}"
-            return " · ".join(shown) + suffix
-
-    reason = item.get("dead_code_reason")
-    if reason is None and isinstance(decision, dict):
-        reason = decision.get("primary_reason")
-    if not reason:
-        return ""
-    return escape(str(reason))
+    return escape(compact_dead_code_evidence(item))
 
 
 def _render_unused(console: Console, root_path, limit, title, items, name_key="name"):
@@ -223,7 +193,7 @@ def _render_unused(console: Console, root_path, limit, title, items, name_key="n
     table.add_column("Location", style="muted", overflow="fold")
     table.add_column("Conf", style="yellow", width=6, justify="right")
     if has_why:
-        table.add_column("Why", style="muted", width=30, overflow="fold")
+        table.add_column("Evidence", style="muted", width=42, overflow="fold")
 
     show, overflow = _display_cap(items, limit)
     for i, item in enumerate(show, 1):
@@ -245,7 +215,7 @@ def _render_unused(console: Console, root_path, limit, title, items, name_key="n
         "[muted]Name — the unused function, import, class, or variable.[/muted]\n"
         "[muted]Conf — how confident Skylos is that this code is truly unused (higher = safer to remove).[/muted]\n"
         + (
-            "[muted]Why — compact evidence behind the dead-code decision.[/muted]\n"
+            "[muted]Evidence — classification and analyzer evidence behind the dead-code decision.[/muted]\n"
             if has_why
             else ""
         )
@@ -735,6 +705,7 @@ def render_results(
                     bad_style="muted",
                 ),
                 _grep_verify_pill(summ),
+                _dead_code_evidence_pill(result),
             ]
             if part
         )

--- a/skylos/ui/terminal_report.py
+++ b/skylos/ui/terminal_report.py
@@ -8,6 +8,10 @@ from rich.console import Console
 from rich.text import Text
 
 from skylos.api._snippets import _resolve_snippet_path
+from skylos.ui.dead_code_evidence import (
+    compact_dead_code_evidence,
+    dead_code_candidate_counts,
+)
 
 
 CATEGORY_SPECS = (
@@ -235,7 +239,7 @@ def _print_finding(console: Console, finding: PrettyFinding, short_path: str) ->
     if finding.why:
         console.print(
             Text.assemble(
-                ("      why: ", "dim"),
+                ("      evidence: ", "dim"),
                 (_truncate(finding.why, 140), "dim"),
             )
         )
@@ -289,6 +293,15 @@ def _summary_line(result: dict) -> Text:
         if parts:
             parts.append(Text("  "))
         parts.append(Text(f"{label}: {count}", style="dim"))
+
+    evidence_counts = dead_code_candidate_counts(result)
+    for key, label in (("rescued", "rescued"), ("abstained", "abstained")):
+        count = evidence_counts.get(key, 0)
+        if not count:
+            continue
+        if parts:
+            parts.append(Text("  "))
+        parts.append(Text(f"dead-code {label}: {count}", style="dim"))
 
     if not parts:
         return Text()
@@ -503,53 +516,8 @@ def _fix(item: dict, category: str) -> str:
     return ""
 
 
-_DEAD_CODE_REASON_LABELS = {
-    "no_refs": "no refs",
-    "not_exported": "not exported",
-    "no_entrypoint": "no entrypoint",
-    "static_reference": "has refs",
-    "reachable_from_root": "root reachable",
-    "top_level_execution": "import-time call",
-    "framework_root": "framework entry",
-    "package_entrypoint": "package entry",
-    "test_entrypoint": "test entry",
-    "dynamic_pattern": "dynamic ref",
-    "coverage_hit": "coverage hit",
-    "trace_hit": "trace hit",
-    "grep_rescue": "grep usage",
-    "uncertainty": "uncertain",
-    "validated_dead": "validated dead",
-    "validation_failed": "live use found",
-    "no_liveness_evidence": "no live evidence",
-}
-
-
 def _dead_code_why(item: dict) -> str:
-    decision = item.get("dead_code_decision") or {}
-    tags = item.get("dead_code_reason_tags")
-    if tags is None and isinstance(decision, dict):
-        tags = decision.get("reason_tags")
-
-    if isinstance(tags, (list, tuple)):
-        visible = []
-        for raw_tag in tags:
-            tag = str(raw_tag)
-            if tag == "confidence_ge_threshold":
-                continue
-            label = _DEAD_CODE_REASON_LABELS.get(tag)
-            if label:
-                visible.append(label)
-        if visible:
-            shown = visible[:3]
-            suffix = ""
-            if len(visible) > len(shown):
-                suffix = f" · +{len(visible) - len(shown)}"
-            return " · ".join(shown) + suffix
-
-    reason = item.get("dead_code_reason")
-    if reason is None and isinstance(decision, dict):
-        reason = decision.get("primary_reason")
-    return str(reason or "")
+    return compact_dead_code_evidence(item)
 
 
 def _read_source_line(

--- a/skylos/ui/tui.py
+++ b/skylos/ui/tui.py
@@ -15,7 +15,15 @@ from textual.widgets import (
     ListView,
     Static,
 )
+from rich.markup import escape
 from rich.text import Text
+
+from skylos.ui.dead_code_evidence import (
+    CLASSIFICATION_LABELS,
+    dead_code_candidate_counts,
+    dead_code_classification,
+    dead_code_evidence_detail_lines,
+)
 
 SEVERITY_COLORS = {
     "CRITICAL": "#ffffff on #8232b4 bold",
@@ -68,14 +76,21 @@ def _loc(item, root_path=None):
 def prepare_category_data(result: dict, root_path=None) -> dict:
     data = {}
 
-    dc_cols = ["Type", "Name", "File:Line", "Confidence"]
+    dc_cols = ["Type", "Name", "File:Line", "Confidence", "Decision"]
     dc_rows, dc_raw = [], []
     for key, type_label in DEAD_CODE_KEYS:
         for item in result.get(key) or []:
             name = item.get("name") or item.get("simple_name") or "?"
             conf = item.get("confidence", "?")
             conf_str = f"{conf}%" if isinstance(conf, (int, float)) else str(conf)
-            dc_rows.append((type_label, name, _loc(item, root_path), conf_str))
+            classification = dead_code_classification(item)
+            decision = CLASSIFICATION_LABELS.get(
+                classification,
+                classification.replace("_", " "),
+            )
+            dc_rows.append(
+                (type_label, name, _loc(item, root_path), conf_str, decision or "?")
+            )
             dc_raw.append({**item, "_type_label": type_label})
     data["dead_code"] = (dc_cols, dc_rows, dc_raw)
 
@@ -297,6 +312,15 @@ class OverviewPanel(VerticalScroll):
             lines.append(f"  [{style}]{label:15s} {n}[/{style}]")
         yield Static("\n".join(lines) + "\n")
 
+        evidence_counts = dead_code_candidate_counts(self.result)
+        if evidence_counts:
+            yield Static(
+                "  [bold]Dead-code evidence decisions[/bold]\n"
+                f"    Reported: {evidence_counts.get('reported', 0)}\n"
+                f"    [green]Rescued: {evidence_counts.get('rescued', 0)}[/green]\n"
+                f"    [yellow]Abstained: {evidence_counts.get('abstained', 0)}[/yellow]\n"
+            )
+
         sev_counts: dict[str, int] = {}
         for cat in ("security", "dependencies"):
             _, _, raw = self.category_data.get(cat, ([], [], []))
@@ -367,6 +391,8 @@ class DetailPanel(Static):
                 lines.append(
                     f"  [{color}]{'█' * bar_len}{'░' * (20 - bar_len)}[/{color}]"
                 )
+            for evidence_line in dead_code_evidence_detail_lines(item):
+                lines.append(f"  {escape(evidence_line)}")
 
         elif category == "security":
             lines.append(f"  [bold]Rule:[/bold]  {item.get('rule_id', '?')}")

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -23,6 +23,36 @@ from skylos.api import (
 
 
 class TestSkylosApi(unittest.TestCase):
+    def test_compact_upload_finding_preserves_dead_code_evidence(self):
+        compact = api._compact_upload_finding(
+            {
+                "rule_id": "SKY-U001",
+                "file_path": "app.py",
+                "line_number": 4,
+                "message": "Dead code: old_helper",
+                "severity": "LOW",
+                "category": "DEAD_CODE",
+                "dead_code_classification": "likely_dead",
+                "dead_code_disposition": "reported",
+                "dead_code_evidence": [
+                    {
+                        "kind": "no_static_references",
+                        "role": "supports_dead",
+                        "reason": "no static references were found",
+                        "source": "analyzer",
+                        "confidence": 1.0,
+                        "details": {"references": 0},
+                    }
+                ],
+            },
+            include_snippet=False,
+        )
+
+        evidence = compact["metadata"]["dead_code_evidence"]
+        self.assertEqual(evidence["classification"], "likely_dead")
+        self.assertEqual(evidence["disposition"], "reported")
+        self.assertEqual(evidence["events"][0]["source"], "analyzer")
+
     def test_cli_version_returns_package_version(self):
         self.assertEqual(api._cli_version(), str(skylos.__version__))
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -860,10 +860,12 @@ def test_render_results_unused_table_includes_compact_dead_code_reason():
 
     table = tables[0]
     headers = [column.header for column in table.columns]
-    assert "Why" in headers
+    assert "Evidence" in headers
 
-    why_col = next(column for column in table.columns if column.header == "Why")
-    assert list(why_col._cells) == ["uncertain · no refs · not exported · +1"]
+    evidence_col = next(
+        column for column in table.columns if column.header == "Evidence"
+    )
+    assert list(evidence_col._cells) == ["uncertain · no refs · not exported"]
 
 
 def test_render_results_shows_grep_verify_summary():

--- a/test/test_dead_code_evidence.py
+++ b/test/test_dead_code_evidence.py
@@ -1,15 +1,20 @@
 import json
 import sqlite3
+from types import SimpleNamespace
 
 from skylos.analyzer import analyze
 from skylos.deadcode.collect import collect_dead_code_findings
+from skylos.deadcode.finding_evidence import attach_dead_code_validation
 from skylos.deadcode.evidence import (
     CandidateClassification,
     EvidenceEvent,
     EvidenceKind,
     EvidenceLedger,
     SymbolKey,
+    build_dead_code_evidence,
 )
+from skylos.reporting.dead_code_result import dead_code_candidate_decisions
+from skylos.visitors.base import Definition
 
 
 def _entries_by_name(result):
@@ -86,7 +91,45 @@ def test_evidence_ledger_uses_paper_classification_precedence():
     assert ledger.classify(symbol) == CandidateClassification.VALIDATED_DEAD
 
 
-def test_analyzer_outputs_dead_code_evidence_without_changing_findings(tmp_path):
+def test_validation_outcomes_update_finding_classification_and_evidence():
+    base = {
+        "name": "old_helper",
+        "dead_code_classification": "likely_dead",
+        "dead_code_evidence": [],
+    }
+
+    validated = attach_dead_code_validation(
+        dict(base),
+        "validated_dead",
+        reason="verification found no live use",
+        source="test_validator",
+    )
+    assert validated["dead_code_classification"] == "validated_dead"
+    assert validated["dead_code_disposition"] == "reported"
+    assert validated["dead_code_evidence"][-1]["kind"] == "validation_pass"
+
+    alive = attach_dead_code_validation(
+        dict(base),
+        "alive",
+        reason="verification found a caller",
+        source="test_validator",
+    )
+    assert alive["dead_code_classification"] == "alive"
+    assert alive["dead_code_disposition"] == "rescued"
+    assert alive["dead_code_evidence"][-1]["kind"] == "validation_fail"
+
+    uncertain = attach_dead_code_validation(
+        dict(base),
+        "uncertain",
+        reason="verification was inconclusive",
+        source="test_validator",
+    )
+    assert uncertain["dead_code_classification"] == "uncertain"
+    assert uncertain["dead_code_disposition"] == "abstained"
+    assert uncertain["dead_code_evidence"][-1]["kind"] == "uncertainty"
+
+
+def test_analyzer_uses_dead_code_evidence_for_final_findings(tmp_path):
     module = tmp_path / "app.py"
     module.write_text(
         "\n".join(
@@ -111,6 +154,11 @@ def test_analyzer_outputs_dead_code_evidence_without_changing_findings(tmp_path)
     unused_names = {item["name"] for item in result["unused_functions"]}
     assert "unused" in unused_names
     assert "used" not in unused_names
+    assert result["analysis_summary"]["dead_code_evidence"]["candidate_decisions"] == {
+        "reported": 2,
+        "rescued": 0,
+        "abstained": 0,
+    }
 
     by_name = _entries_by_name(result)
 
@@ -156,7 +204,7 @@ def test_analyzer_outputs_dead_code_evidence_without_changing_findings(tmp_path)
     ]
 
 
-def test_uncertain_dead_code_decision_leads_with_uncertainty(tmp_path):
+def test_uncertain_dead_code_candidate_is_abstained_not_reported(tmp_path):
     module = tmp_path / "app.py"
     module.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
         "\n".join(
@@ -173,14 +221,21 @@ def test_uncertain_dead_code_decision_leads_with_uncertainty(tmp_path):
         analyze(str(tmp_path), conf=0, grep_verify=False, trace_file=False)
     )
 
+    assert "format_admin_status" not in {
+        item["name"] for item in result["unused_functions"]
+    }
     finding = next(
         item
-        for item in result["unused_functions"]
+        for item in result["dead_code_abstentions"]
         if item["name"] == "format_admin_status"
     )
     assert finding["dead_code_classification"] == "uncertain"
+    assert finding["dead_code_disposition"] == "abstained"
     assert finding["dead_code_reason_tags"][0] == "uncertainty"
     assert finding["dead_code_reason"].startswith("Uncertainty evidence present")
+    assert result["analysis_summary"]["dead_code_evidence"]["candidate_decisions"][
+        "abstained"
+    ] == 1
 
 
 def test_pyproject_entrypoint_is_reported_as_package_evidence(tmp_path):
@@ -248,6 +303,88 @@ def test_dynamic_pattern_evidence_is_reported_from_analyzer(tmp_path):
     assert by_name["app.handle_login"]["classification"] == "alive"
     assert _event_kinds(by_name["app.handle_login"]) >= {"dynamic_pattern"}
     assert "reachable_from_root" not in _event_kinds(by_name["app.handle_login"])
+    assert "app.handle_login" not in _unused_full_names(result, "unused_functions")
+
+
+def test_unverified_attribute_name_match_is_context_not_liveness(tmp_path):
+    definition = Definition(
+        "app.Factory.build",
+        "method",
+        tmp_path / "app.py",
+        3,
+    )
+    definition.confidence = 90
+    definition.references = 0
+    definition.heuristic_refs["same_pkg_attr"] = 0.2946
+    analyzer = SimpleNamespace(defs={"app.Factory.build": definition})
+    ledger = build_dead_code_evidence(
+        analyzer.defs,
+        project_root=tmp_path,
+        threshold=0,
+    )
+    payload = ledger.to_dict(
+        tmp_path,
+        definitions=analyzer.defs,
+        threshold=0,
+    )
+    reported, rescued, abstained = dead_code_candidate_decisions(
+        analyzer,
+        0,
+        payload,
+    )
+
+    assert len(reported) == 1
+    finding = reported[0]
+    assert finding["dead_code_classification"] == "likely_dead"
+    attribute_event = next(
+        event
+        for event in finding["dead_code_evidence"]
+        if event["kind"] == "attribute_name_match"
+    )
+    assert attribute_event["role"] == "context"
+    assert attribute_event["details"]["bucket"] == "same_pkg_attr"
+    assert rescued == []
+    assert abstained == []
+
+
+def test_evidence_identity_does_not_cross_files_or_symbol_kinds(tmp_path):
+    source = Definition(
+        "constants.PLAIN_UNUSED",
+        "variable",
+        tmp_path / "constants.py",
+        1,
+    )
+    source.references = 1
+    imported = Definition(
+        "constants.PLAIN_UNUSED",
+        "import",
+        tmp_path / "facade.py",
+        1,
+    )
+    imported.references = 0
+    analyzer = SimpleNamespace(defs={"source": source, "imported": imported})
+    ledger = build_dead_code_evidence(
+        analyzer.defs,
+        project_root=tmp_path,
+        threshold=0,
+    )
+    payload = ledger.to_dict(
+        tmp_path,
+        definitions=analyzer.defs,
+        threshold=0,
+    )
+
+    reported, rescued, abstained = dead_code_candidate_decisions(
+        analyzer,
+        0,
+        payload,
+    )
+
+    assert [(item["type"], item["file"]) for item in reported] == [
+        ("import", str(tmp_path / "facade.py"))
+    ]
+    assert rescued == []
+    assert abstained == []
 
 
 def test_gunicorn_config_settings_and_hooks_are_not_reported_dead(tmp_path):

--- a/test/test_sarif_exporter.py
+++ b/test/test_sarif_exporter.py
@@ -220,3 +220,47 @@ def test_results_include_skylos_evidence_contract_for_high_impact_findings():
     assert contract["sources"] == ["request.args['cmd']"]
     assert contract["sinks"] == ["subprocess.run"]
     assert contract["traces"] == ["app/routes.py:27", "handler", "subprocess.run"]
+
+
+def test_results_include_dead_code_classification_and_evidence():
+    findings = [
+        {
+            "rule_id": "SKY-U001",
+            "severity": "LOW",
+            "message": "Dead code: old_helper",
+            "file_path": "app.py",
+            "line_number": 5,
+            "category": "DEAD_CODE",
+            "dead_code_classification": "likely_dead",
+            "dead_code_disposition": "reported",
+            "dead_code_reason": "No static references",
+            "dead_code_reason_tags": ["no_refs"],
+            "dead_code_decision": {
+                "classification": "likely_dead",
+                "primary_reason": "No static references",
+                "reason_tags": ["no_refs"],
+                "live_evidence_count": 0,
+                "dead_evidence_count": 1,
+                "uncertainty_count": 0,
+            },
+            "dead_code_evidence": [
+                {
+                    "kind": "no_static_references",
+                    "role": "supports_dead",
+                    "reason": "no static references were found",
+                    "source": "analyzer",
+                    "confidence": 1.0,
+                    "details": {"references": 0},
+                }
+            ],
+        }
+    ]
+
+    sarif = SarifExporter(findings).generate()
+    evidence = sarif["runs"][0]["results"][0]["properties"][
+        "skylos_dead_code_evidence"
+    ]
+
+    assert evidence["classification"] == "likely_dead"
+    assert evidence["disposition"] == "reported"
+    assert evidence["events"][0]["source"] == "analyzer"

--- a/test/test_terminal_report.py
+++ b/test/test_terminal_report.py
@@ -64,7 +64,7 @@ def test_pretty_renderer_uses_secret_preview_instead_of_source_line(tmp_path):
     assert "sk_live_real_secret_value" not in output
 
 
-def test_pretty_renderer_prints_compact_dead_code_reason(tmp_path):
+def test_pretty_renderer_prints_classification_and_evidence_source(tmp_path):
     source = tmp_path / "src" / "app.py"
     result = {
         "analysis_summary": {"total_files": 1},
@@ -73,12 +73,16 @@ def test_pretty_renderer_prints_compact_dead_code_reason(tmp_path):
                 "name": "old_helper",
                 "file": str(source),
                 "line": 1,
-                "dead_code_reason_tags": [
-                    "uncertainty",
-                    "no_refs",
-                    "not_exported",
-                    "no_entrypoint",
-                    "confidence_ge_threshold",
+                "dead_code_classification": "likely_dead",
+                "dead_code_evidence": [
+                    {
+                        "kind": "no_static_references",
+                        "role": "supports_dead",
+                        "reason": "no static references were found",
+                        "source": "analyzer",
+                        "confidence": 1.0,
+                        "details": {"references": 0},
+                    }
                 ],
             }
         ],
@@ -89,7 +93,29 @@ def test_pretty_renderer_prints_compact_dead_code_reason(tmp_path):
     output = console.export_text()
 
     assert "Unused function: old_helper" in output
-    assert "why: uncertain · no refs · not exported" in output
+    assert "evidence: likely dead — no static references were found [analyzer]" in output
+
+
+def test_pretty_renderer_shows_rescued_and_abstained_counts():
+    result = {
+        "analysis_summary": {
+            "total_files": 1,
+            "dead_code_evidence": {
+                "candidate_decisions": {
+                    "reported": 0,
+                    "rescued": 2,
+                    "abstained": 1,
+                }
+            },
+        }
+    }
+
+    console = _recording_console()
+    render_pretty_results(console, result)
+    output = console.export_text()
+
+    assert "dead-code rescued: 2" in output
+    assert "dead-code abstained: 1" in output
 
 
 def test_pretty_renderer_sanitizes_control_chars_from_finding_fields(tmp_path):

--- a/test/test_tui.py
+++ b/test/test_tui.py
@@ -125,7 +125,7 @@ class TestPrepareCategoryData:
         data = prepare_category_data(sample_result)
         cols, rows, raw = data["dead_code"]
         assert len(rows) == 3
-        assert cols == ["Type", "Name", "File:Line", "Confidence"]
+        assert cols == ["Type", "Name", "File:Line", "Confidence", "Decision"]
 
     def test_dead_code_type_labels(self, sample_result):
         data = prepare_category_data(sample_result)
@@ -147,6 +147,22 @@ class TestPrepareCategoryData:
         data = prepare_category_data(result)
         _, rows, _ = data["dead_code"]
         assert rows[0][3] == "?"
+
+    def test_dead_code_decision_is_visible(self):
+        result = {
+            "unused_functions": [
+                {
+                    "name": "f",
+                    "file": "a.py",
+                    "line": 1,
+                    "confidence": 90,
+                    "dead_code_classification": "validated_dead",
+                }
+            ],
+        }
+        data = prepare_category_data(result)
+        _, rows, _ = data["dead_code"]
+        assert rows[0][4] == "validated dead"
 
     def test_security_rows(self, sample_result):
         data = prepare_category_data(sample_result)

--- a/test/test_verify_orchestrator.py
+++ b/test/test_verify_orchestrator.py
@@ -2001,6 +2001,12 @@ def test_build_verification_output_applies_defaults_without_overwriting_fields()
     assert survivor["_source"] == "registry_survivor_challenge"
     assert survivor["message"] == "keep survivor message"
     assert survivor["_category"] == "dead_code"
+    assert survivor["dead_code_classification"] == "validated_dead"
+    assert survivor["dead_code_disposition"] == "reported"
+    assert survivor["dead_code_evidence"][-1]["kind"] == "validation_pass"
+    assert survivor["dead_code_evidence"][-1]["source"] == (
+        "registry_survivor_challenge"
+    )
 
     assert result["entry_points"] == [
         {


### PR DESCRIPTION
## Summary

  - Make dead-code evidence control final reporting decisions.
  - Rescue alive symbols, abstain on uncertain symbols, and report only likely or validated dead code.
  - Treat fuzzy attribute-name matches as context instead of automatic liveness proof.
  
## Tests

- `pytest test/test_dead_code*.py test/test_framework_aware.py`
- `pytest test/test_cli*.py test/test_tui.py test/test_sarif_exporter.py test/test_api.py test/test_verify_orchestrator.py`