### PR TITLE
fix(container): prevent false-clean Python scans

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -246,15 +246,22 @@ jobs:
           python -m twine upload --skip-existing dist/*
 
   container:
+    name: container (Python ${{ matrix.python-version }})
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     permissions:
       contents: read
       packages: write
     env:
       IMAGE_NAME: ghcr.io/duriantaco/skylos
       RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      DEFAULT_PYTHON_VERSION: "3.14"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -278,10 +285,16 @@ jobs:
           fi
 
       - name: Build smoke image
-        run: docker build -t skylos:smoke . # skylos: ignore[SKY-D296] local smoke-test image
+        run: docker build --build-arg "PYTHON_VERSION=${PYTHON_VERSION}" -t skylos:smoke . # skylos: ignore[SKY-D296] local smoke-test image
 
       - name: Smoke test CLI entrypoint
         run: docker run --rm skylos:smoke --version # skylos: ignore[SKY-D296] local smoke-test image
+
+      - name: Verify image Python runtime
+        shell: bash
+        run: |
+          actual="$(docker run --rm --entrypoint python skylos:smoke -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" # skylos: ignore[SKY-D296] local smoke-test image
+          test "$actual" = "$PYTHON_VERSION"
 
       - name: Smoke test real scan
         run: |
@@ -307,20 +320,32 @@ jobs:
           MINOR: ${{ steps.meta.outputs.minor }}
         run: |
           revision="$(git rev-parse HEAD)"
+          runtime_tag="python${PYTHON_VERSION}"
           tags=(
-            "--tag" "${IMAGE_NAME}:${VERSION}"
+            "--tag" "${IMAGE_NAME}:${VERSION}-${runtime_tag}"
           )
           if [[ "$STABLE" == "true" ]]; then
             tags+=(
-              "--tag" "${IMAGE_NAME}:${MAJOR}.${MINOR}"
-              "--tag" "${IMAGE_NAME}:${MAJOR}"
-              "--tag" "${IMAGE_NAME}:latest"
+              "--tag" "${IMAGE_NAME}:${MAJOR}.${MINOR}-${runtime_tag}"
+              "--tag" "${IMAGE_NAME}:${MAJOR}-${runtime_tag}"
+              "--tag" "${IMAGE_NAME}:latest-${runtime_tag}"
             )
+          fi
+          if [[ "$PYTHON_VERSION" == "$DEFAULT_PYTHON_VERSION" ]]; then
+            tags+=("--tag" "${IMAGE_NAME}:${VERSION}")
+            if [[ "$STABLE" == "true" ]]; then
+              tags+=(
+                "--tag" "${IMAGE_NAME}:${MAJOR}.${MINOR}"
+                "--tag" "${IMAGE_NAME}:${MAJOR}"
+                "--tag" "${IMAGE_NAME}:latest"
+              )
+            fi
           fi
 
           build_and_push() {
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
+              --build-arg "PYTHON_VERSION=${PYTHON_VERSION}" \
               "${tags[@]}" \
               --label "org.opencontainers.image.title=skylos" \
               --label "org.opencontainers.image.description=Open-source AI code security and static analysis for Python, TypeScript, and Go." \
@@ -328,6 +353,7 @@ jobs:
               --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
               --label "org.opencontainers.image.version=${VERSION}" \
               --label "org.opencontainers.image.revision=${revision}" \
+              --label "org.opencontainers.image.python.version=${PYTHON_VERSION}" \
               --push \
               .
           }

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,8 +56,12 @@ jobs:
           flags: ${{ matrix.install_target == '.[llm]' && 'llm-extra' || 'default-install' }}
 
   docker_smoke:
-    name: docker-smoke
+    name: docker-smoke (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.14"]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -65,10 +69,16 @@ jobs:
           persist-credentials: false
 
       - name: Build image
-        run: docker build -t skylos:test .
+        run: docker build --build-arg "PYTHON_VERSION=${{ matrix.python-version }}" -t skylos:test .
 
       - name: Check CLI version
         run: docker run --rm skylos:test --version
+
+      - name: Check Python runtime
+        shell: bash
+        run: |
+          actual="$(docker run --rm --entrypoint python skylos:test -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+          test "$actual" = "${{ matrix.python-version }}"
 
       - name: Run fixture scan
         run: |
@@ -78,6 +88,18 @@ jobs:
             skylos:test \
             . --json --no-provenance > /tmp/skylos-docker-smoke.json
           grep -q '"unused_functions"' /tmp/skylos-docker-smoke.json
+
+      - name: Scan current Python syntax
+        if: matrix.python-version == '3.14'
+        run: |
+          mkdir -p /tmp/skylos-python-syntax
+          printf 'type CacheEntry[T = str] = dict[str, T]\n\ndef stale_helper():\n    return CacheEntry()\n' > /tmp/skylos-python-syntax/example.py
+          docker run --rm \
+            -v "/tmp/skylos-python-syntax:/work" \
+            -w /work \
+            skylos:test \
+            . --json --no-provenance > /tmp/skylos-python-syntax.json
+          grep -q '"stale_helper"' /tmp/skylos-python-syntax.json
 
   test:
     name: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG PYTHON_VERSION=3.14
+
 FROM golang:1.22 AS go-build
 
 WORKDIR /src/skylos/engines/go
@@ -8,7 +10,7 @@ COPY skylos/engines/go/internal ./internal
 
 RUN go build -o /out/skylos-go ./cmd/skylos-go
 
-FROM python:3.12-slim AS build
+FROM python:${PYTHON_VERSION}-slim AS build
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -28,12 +30,17 @@ RUN python -m pip install --upgrade pip build && \
     python -m build --wheel --outdir /dist && \
     python -m pip wheel --wheel-dir /wheelhouse /dist/*.whl
 
-FROM python:3.12-slim
+FROM python:${PYTHON_VERSION}-slim
+
+ARG PYTHON_VERSION
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    SKYLOS_CONTAINER_PYTHON_VERSION=${PYTHON_VERSION}
+
+LABEL org.opencontainers.image.python.version=${PYTHON_VERSION}
 
 WORKDIR /work
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,17 @@ docker pull ghcr.io/duriantaco/skylos:latest
 docker run --rm -v "$PWD":/work -w /work ghcr.io/duriantaco/skylos:latest . --json --no-provenance
 ```
 
+The unqualified image uses Python 3.14. Runtime-specific tags are also
+published for Python 3.11 through 3.14, so container scans can match a local or
+CI parser exactly:
+
+```bash
+docker run --rm -v "$PWD":/work -w /work ghcr.io/duriantaco/skylos:latest-python3.13 . --json --no-provenance
+```
+
+If a Python file cannot be parsed, Skylos reports `analysis_errors`, omits the
+grade, and exits with code 2 instead of treating the skipped file as clean.
+
 See [Installation](https://docs.skylos.dev/installation) for source installs,
 container usage, and optional dependencies.
 

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>975</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9189</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>976</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>9199</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 277</span>
+          <span class="pill"><strong>symbols</strong> 279</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -1894,7 +1894,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 8</span>
-          <span class="pill"><strong>symbols</strong> 77</span>
+          <span class="pill"><strong>symbols</strong> 78</span>
         </div>
       </div>
       <p>Terminal UI and presentation helpers.</p>
@@ -1989,12 +1989,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_behavior_benchmark.py test/test_agent_behavior_cli.py test/test_agent_behavior_contract.py test/test_agent_behavior_evaluator.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_audit_processor.py test/test_dangerous.py test/test_sync.py test/test_cli.py">
+    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_behavior_benchmark.py test/test_agent_behavior_cli.py test/test_agent_behavior_contract.py test/test_agent_behavior_evaluator.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_audit_processor.py test/test_dangerous.py test/test_cli.py test/test_sync.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 237</span>
-          <span class="pill"><strong>symbols</strong> 3386</span>
+          <span class="pill"><strong>files</strong> 238</span>
+          <span class="pill"><strong>symbols</strong> 3393</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2014,8 +2014,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_processor.py" rel="noopener noreferrer">test/test_audit_processor.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_dangerous.py" rel="noopener noreferrer">test/test_dangerous.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_sync.py" rel="noopener noreferrer">test/test_sync.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_sync.py" rel="noopener noreferrer">test/test_sync.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -2049,14 +2049,14 @@
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>34 / 153</td>
+              <td>34 / 154</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3 / 38</td>
+              <td>3 / 39</td>
               <td><span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -6830,6 +6830,13 @@
               <td>skylos/analyzer.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_analysis_error_payload def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_analysis_error_payload</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
             <tr class="searchable" data-search="proc_file def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">proc_file</a></td>
               <td>def</td>
@@ -8442,13 +8449,6 @@
 
             <tr class="searchable" data-search="_ensure_llm_support def skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_ensure_llm_support</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_build_analyzer_config def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_build_analyzer_config</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2094,6 +2094,7 @@ class Skylos:
         pyproject_entrypoint_qnames=None,
         pyproject_entrypoint_modules=None,
         config_file=None,
+        analysis_errors=None,
     ):
         from skylos.reporting.result_builder import build_analysis_result
 
@@ -2125,6 +2126,7 @@ class Skylos:
             pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
             pyproject_entrypoint_modules=pyproject_entrypoint_modules,
             config_file=config_file,
+            analysis_errors=analysis_errors,
         )
 
     def analyze(
@@ -2213,9 +2215,11 @@ class Skylos:
                 "unused_variables": [],
                 "unused_parameters": [],
                 "unused_files": [],
+                "analysis_errors": [],
                 "analysis_summary": {
                     "total_files": 0,
                     "excluded_folders": exclude_folders if exclude_folders else [],
+                    "analysis_error_count": 0,
                     "monorepo_detected": workspace_inventory.is_monorepo,
                     "workspace_count": len(workspace_inventory.packages),
                     "workspace_total_packages": workspace_inventory.total_packages,
@@ -2352,6 +2356,7 @@ class Skylos:
         all_quality = []
         all_ai_defects = []
         all_suppressed = []
+        analysis_errors = []
         empty_files = []
         file_contexts = []
         all_clone_fragments = []
@@ -2419,6 +2424,13 @@ class Skylos:
 
             for file, out in zip(files, outs):
                 if out is None:
+                    analysis_errors.append(
+                        _analysis_error_payload(
+                            file,
+                            RuntimeError("Static analysis worker returned no result"),
+                            kind="worker_error",
+                        )
+                    )
                     continue
 
                 mod = modmap[file]
@@ -2447,6 +2459,9 @@ class Skylos:
                 file_clone_fragments = out[22] if len(out) > 22 else []
                 file_architecture_metrics = out[23] if len(out) > 23 else None
                 file_top_level_refs = out[24] if len(out) > 24 else set()
+                file_analysis_error = out[25] if len(out) > 25 else None
+                if isinstance(file_analysis_error, dict):
+                    analysis_errors.append(file_analysis_error)
                 (
                     defs,
                     refs,
@@ -3666,6 +3681,7 @@ class Skylos:
             pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
             pyproject_entrypoint_modules=pyproject_entrypoint_modules,
             config_file=config_file,
+            analysis_errors=analysis_errors,
         )
 
         return json.dumps(result, indent=2)
@@ -3687,6 +3703,45 @@ def _is_truly_empty_or_docstring_only(tree):
         and isinstance(only.value, ast.Constant)
         and isinstance(only.value.value, str)
     )
+
+
+def _analysis_error_payload(file, error, *, kind=None):
+    is_syntax_error = isinstance(error, SyntaxError)
+    message = getattr(error, "msg", None) if is_syntax_error else None
+    message = str(message or error or type(error).__name__)
+    message = " ".join(message.splitlines())[:500]
+
+    line = getattr(error, "lineno", None) or 1
+    column = getattr(error, "offset", None) or 1
+    try:
+        line = max(1, int(line))
+    except (TypeError, ValueError):
+        line = 1
+    try:
+        column = max(1, int(column))
+    except (TypeError, ValueError):
+        column = 1
+
+    payload = {
+        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+        "severity": "HIGH",
+        "kind": kind or ("syntax_error" if is_syntax_error else "processing_error"),
+        "error_type": type(error).__name__,
+        "message": message,
+        "file": str(file),
+        "line": line,
+        "column": column,
+        "python_version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}."
+            f"{sys.version_info.micro}"
+        ),
+    }
+    if is_syntax_error:
+        payload["suggestion"] = (
+            "Use a Python runtime that supports this syntax; official container "
+            "images provide matching -pythonX.Y tags."
+        )
+    return payload
 
 
 def proc_file(
@@ -3909,6 +3964,7 @@ def proc_file(
             clone_fragments,
             architecture_metrics,
             getattr(v, "top_level_refs", set()),
+            None,
         )
 
     except Exception as e:
@@ -3944,6 +4000,7 @@ def proc_file(
             [],
             None,
             set(),
+            _analysis_error_payload(file, e),
         )
 
 

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1857,6 +1857,10 @@ def _formatted_output_gate_exit_code(
     provenance=None,
 ) -> int:
     """Evaluate --gate for output modes that must not print gate UI."""
+    incomplete_exit_code = _analysis_incomplete_exit_code(result)
+    if incomplete_exit_code:
+        return incomplete_exit_code
+
     from skylos.core.gatekeeper import (
         build_summary_markdown,
         check_gate,
@@ -1879,6 +1883,10 @@ def _formatted_output_gate_exit_code(
 def _concise_scan_exit_code(
     result: dict, config: dict, args, *, provenance=None
 ) -> int:
+    incomplete_exit_code = _analysis_incomplete_exit_code(result)
+    if incomplete_exit_code:
+        return incomplete_exit_code
+
     if bool(getattr(args, "gate", False)):
         return _formatted_output_gate_exit_code(
             result,
@@ -1894,6 +1902,7 @@ def _concise_scan_exit_code(
 
 
 CONCISE_FINDING_CATEGORIES = (
+    ("analysis_errors", "analysis error"),
     ("unused_functions", "unused function"),
     ("unused_imports", "unused import"),
     ("unused_classes", "unused class"),
@@ -1952,6 +1961,10 @@ def _format_concise_results(result: dict, *, root_path=None, limit=None) -> str:
 
 def _strict_scan_exit_code(result: dict, args) -> int:
     """Evaluate --strict when it is used without --gate."""
+    incomplete_exit_code = _analysis_incomplete_exit_code(result)
+    if incomplete_exit_code:
+        return incomplete_exit_code
+
     if not bool(getattr(args, "strict", False)):
         return 0
     if bool(getattr(args, "gate", False)) or bool(getattr(args, "force", False)):
@@ -1961,6 +1974,11 @@ def _strict_scan_exit_code(result: dict, args) -> int:
 
     passed, _reasons = check_gate(result, {}, strict=True)
     return 0 if passed else 1
+
+
+def _analysis_incomplete_exit_code(result: dict) -> int:
+    """Return the operational-error exit code when any file was not analyzed."""
+    return 2 if result.get("analysis_errors") else 0
 
 
 def _apply_config_driven_analysis_flags(args, project_cfg, console):

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -430,6 +430,11 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             _add(result.get("quality", []), "QUALITY", None)
             _add(result.get("secrets", []), "SECRET", None)
             _add(result.get("custom_rules", []), "CUSTOM", None)
+            _add(
+                result.get("analysis_errors", []),
+                "ANALYSIS",
+                "SKY-ANALYSIS-INCOMPLETE",
+            )
 
             _add(
                 result.get("unused_functions", []),
@@ -476,6 +481,10 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 )
             else:
                 print(result_json)
+
+            incomplete_exit_code = _strict_scan_exit_code(result, args)
+            if incomplete_exit_code == 2:
+                raise SystemExit(incomplete_exit_code)
 
             if args.upload:
                 _attach_upload_project_context(result, project_root)
@@ -593,6 +602,17 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
         sys.exit(1)
 
     if args.gate:
+        incomplete_exit_code = _strict_scan_exit_code(result, args)
+        if incomplete_exit_code:
+            render_results(
+                console,
+                result,
+                tree=args.tree,
+                root_path=project_root,
+                limit=getattr(args, "limit", None),
+            )
+            raise SystemExit(incomplete_exit_code)
+
         should_upload_gate = bool(getattr(args, "upload", False)) and not bool(
             getattr(args, "no_upload", False)
         )
@@ -621,6 +641,16 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             summary=bool(getattr(args, "summary", False)),
         )
         sys.exit(exit_code)
+
+    if args.interactive and result.get("analysis_errors"):
+        render_results(
+            console,
+            result,
+            tree=args.tree,
+            root_path=project_root,
+            limit=getattr(args, "limit", None),
+        )
+        raise SystemExit(2)
 
     if args.interactive:
         unused_functions = result.get("unused_functions", [])
@@ -760,7 +790,9 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
     )
     danger_count = len(result.get("danger", []) or [])
     quality_count = len(result.get("quality", []) or [])
-    if getattr(args, "format", "rich") != "pretty":
+    if getattr(args, "format", "rich") != "pretty" and not result.get(
+        "analysis_errors"
+    ):
         print_badge(
             unused_total,
             logging.getLogger("skylos"),

--- a/skylos/reporting/github_annotations.py
+++ b/skylos/reporting/github_annotations.py
@@ -72,6 +72,19 @@ def _github_dead_code_annotation(item, label):
 
 def _github_annotation_items(result):
     annotations = []
+    for error in result.get("analysis_errors", []) or []:
+        if not isinstance(error, dict):
+            continue
+        annotations.append(
+            {
+                "file": error.get("file") or "",
+                "line": error.get("line") or 1,
+                "msg": error.get("message") or "File analysis failed",
+                "title": "Skylos Analysis Incomplete",
+                "severity": "CRITICAL",
+            }
+        )
+
     for category in _GITHUB_FINDING_CATEGORIES:
         for finding in result.get(category, []) or []:
             annotations.append(_github_finding_annotation(finding))

--- a/skylos/reporting/llm_report.py
+++ b/skylos/reporting/llm_report.py
@@ -38,6 +38,15 @@ def _default_dead_code_llm_fields(finding, rule_id, severity, human_label):
 
 def _collect_llm_report_findings(result: dict):
     all_findings = []
+    for error in result.get("analysis_errors", []) or []:
+        if not isinstance(error, dict):
+            continue
+        finding = dict(error)
+        finding.setdefault("rule_id", "SKY-ANALYSIS-INCOMPLETE")
+        finding.setdefault("severity", "CRITICAL")
+        finding.setdefault("message", "File analysis failed")
+        all_findings.append((finding, "Analysis Incomplete"))
+
     for category, label in _LLM_REPORT_CATEGORIES:
         for finding in result.get(category, []):
             all_findings.append((finding, label))

--- a/skylos/reporting/result_builder.py
+++ b/skylos/reporting/result_builder.py
@@ -72,6 +72,7 @@ def build_analysis_result(
     pyproject_entrypoint_qnames=None,
     pyproject_entrypoint_modules=None,
     config_file=None,
+    analysis_errors=None,
 ):
     """Assemble the final result dict from analysis outputs."""
     architecture_main_guard_modules = _normal_set(architecture_main_guard_modules)
@@ -104,6 +105,7 @@ def build_analysis_result(
         rescued,
         abstained,
         unused,
+        analysis_errors,
     )
     _attach_analysis_reports(analyzer, result)
     _attach_workspace(analyzer, result, workspace_inventory, path)
@@ -164,7 +166,11 @@ def _base_result(
     dead_code_rescues,
     dead_code_abstentions,
     reported_dead_code,
+    analysis_errors,
 ):
+    normalized_analysis_errors = [
+        dict(error) for error in (analysis_errors or []) if isinstance(error, dict)
+    ]
     evidence_summary = dead_code_ledger.summary()
     evidence_summary["candidate_decisions"] = {
         "reported": len(reported_dead_code),
@@ -179,6 +185,7 @@ def _base_result(
         "unused_variables": [],
         "unused_parameters": [],
         "unused_files": [],
+        "analysis_errors": normalized_analysis_errors,
         "whitelisted": whitelisted,
         "suppressed": all_suppressed,
         "dead_code_evidence": dead_code_evidence,
@@ -188,6 +195,7 @@ def _base_result(
             "total_files": len(files),
             "excluded_folders": exclude_folders or [],
             "languages": analyzer._count_languages(files),
+            "analysis_error_count": len(normalized_analysis_errors),
             "dead_code_evidence": evidence_summary,
         },
     }
@@ -389,6 +397,11 @@ def _attach_grade(
         )
         result["analysis_summary"]["total_loc"] = total_loc
         result["analysis_summary"]["grade_categories"] = categories
+        if result.get("analysis_errors"):
+            result["analysis_summary"]["grade_unavailable_reason"] = (
+                "analysis_incomplete"
+            )
+            return
         result["grade"] = compute_grade(
             result,
             total_loc,

--- a/skylos/ui/rich_report.py
+++ b/skylos/ui/rich_report.py
@@ -75,6 +75,58 @@ def _display_cap(items, limit):
     return items[:cap], max(0, len(items) - cap)
 
 
+def _render_analysis_errors(
+    console: Console,
+    result,
+    *,
+    root_path=None,
+    limit=None,
+):
+    errors = [
+        error
+        for error in (result.get("analysis_errors") or [])
+        if isinstance(error, dict)
+    ]
+    if not errors:
+        return
+
+    count = len(errors)
+    console.print(
+        Panel.fit(
+            f"[bad]Analysis incomplete: {count} file(s) could not be analyzed.[/bad]\n"
+            "[muted]No grade or clean result was produced; Skylos exits with code 2.[/muted]",
+            border_style="bad",
+        )
+    )
+
+    table = Table(title="Analysis Errors", expand=True)
+    table.add_column("File", style="bold", overflow="fold")
+    table.add_column("Line", justify="right", width=6)
+    table.add_column("Error", overflow="fold")
+    table.add_column("Runtime", style="muted", width=14)
+
+    visible, overflow = _display_cap(errors, limit)
+    for error in visible:
+        path = escape(_shorten_path(error.get("file"), root_path))
+        line = str(error.get("line") or 1)
+        kind = str(error.get("kind") or error.get("error_type") or "analysis error")
+        message = str(error.get("message") or "File analysis failed")
+        runtime = str(error.get("python_version") or "?")
+        table.add_row(
+            path,
+            line,
+            escape(f"{kind.replace('_', ' ')}: {message}"),
+            escape(f"Python {runtime}"),
+        )
+
+    console.print(table)
+    if overflow:
+        console.print(
+            f"  [muted]... and {overflow} more (use --limit to adjust)[/muted]"
+        )
+    console.print()
+
+
 def _score_style(score):
     if score >= 90:
         return "good"
@@ -711,6 +763,13 @@ def render_results(
         )
     )
     console.print()
+
+    _render_analysis_errors(
+        console,
+        result,
+        root_path=root_path,
+        limit=limit,
+    )
 
     grade_data = result.get("grade")
     if grade_data:

--- a/skylos/ui/terminal_report.py
+++ b/skylos/ui/terminal_report.py
@@ -15,6 +15,7 @@ from skylos.ui.dead_code_evidence import (
 
 
 CATEGORY_SPECS = (
+    ("analysis_errors", "Analysis", "File analysis failed"),
     ("ai_defects", "AI Defect", "AI defect"),
     ("danger", "Security", "security issue"),
     ("secrets", "Secret", "secret detected"),
@@ -57,6 +58,7 @@ SEVERITY_RANK = {
 }
 
 SUMMARY_CATEGORIES = (
+    "analysis_errors",
     "unused_functions",
     "unused_imports",
     "unused_parameters",

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3,6 +3,7 @@ import json
 import tempfile
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 from collections import defaultdict
@@ -1833,6 +1834,7 @@ class TestClass:
             f.flush()
 
             try:
+                result = proc_file(f.name, "test_module")
                 (
                     defs,
                     refs,
@@ -1855,7 +1857,7 @@ class TestClass:
                     used_attr_context,
                     source_lines,
                     *_extra,
-                ) = proc_file(f.name, "test_module")
+                ) = result
 
                 assert defs == []
                 assert refs == []
@@ -1870,8 +1872,49 @@ class TestClass:
                 assert empty_file_finding is None
                 assert isinstance(test_flags, TestAwareVisitor)
                 assert isinstance(framework_flags, FrameworkAwareVisitor)
+                analysis_error = result[25]
+                assert analysis_error["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+                assert analysis_error["kind"] == "syntax_error"
+                assert analysis_error["error_type"] == "SyntaxError"
+                assert analysis_error["line"] == 1
+                assert analysis_error["python_version"]
             finally:
                 Path(f.name).unlink()
+
+    def test_analyze_marks_syntax_error_incomplete_and_omits_grade(self, tmp_path):
+        invalid_file = tmp_path / "future_syntax.py"
+        invalid_file.write_text(
+            "def invalid_syntax(:\n    pass\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), grep_verify=False))
+
+        assert result["analysis_summary"]["analysis_error_count"] == 1
+        assert result["analysis_summary"]["grade_unavailable_reason"] == (
+            "analysis_incomplete"
+        )
+        assert "grade" not in result
+        assert result["analysis_errors"] == [
+            {
+                "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                "severity": "HIGH",
+                "kind": "syntax_error",
+                "error_type": "SyntaxError",
+                "message": "invalid syntax",
+                "file": str(invalid_file),
+                "line": 1,
+                "column": 20,
+                "python_version": (
+                    f"{sys.version_info.major}.{sys.version_info.minor}."
+                    f"{sys.version_info.micro}"
+                ),
+                "suggestion": (
+                    "Use a Python runtime that supports this syntax; official "
+                    "container images provide matching -pythonX.Y tags."
+                ),
+            }
+        ]
 
     def test_proc_file_keeps_findings_when_dynamic_fstring_pattern_has_regex_chars(
         self, tmp_path

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -894,6 +894,46 @@ def test_render_results_shows_grep_verify_summary():
     assert "rescued 3" in printed
 
 
+def test_render_results_shows_analysis_errors_without_grade():
+    console = Mock()
+    result = {
+        "analysis_summary": {"total_files": 1, "analysis_error_count": 1},
+        "analysis_errors": [
+            {
+                "kind": "syntax_error",
+                "message": "invalid syntax",
+                "file": "/root/future.py",
+                "line": 1,
+                "python_version": "3.12.13",
+            }
+        ],
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_parameters": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "quality": [],
+        "danger": [],
+        "secrets": [],
+    }
+
+    cli.render_results(console, result, tree=False, root_path="/root")
+
+    tables = [
+        call.args[0]
+        for call in console.print.call_args_list
+        if call.args and isinstance(call.args[0], Table)
+    ]
+    assert any(table.title == "Analysis Errors" for table in tables)
+    panels = [
+        call.args[0]
+        for call in console.print.call_args_list
+        if call.args and isinstance(call.args[0], cli.Panel)
+    ]
+    assert any("Analysis incomplete" in str(panel.renderable) for panel in panels)
+    assert all("Codebase Grade" not in str(panel.renderable) for panel in panels)
+
+
 def test_render_results_tree_mode_groups_by_file_and_sorts_by_line():
     console = Mock()
 
@@ -1535,6 +1575,94 @@ def test_main_json_strict_failure_exits_nonzero(monkeypatch):
 
     assert e.value.code == 1
     mock_print.assert_called_once_with(json.dumps(result))
+
+
+def test_main_json_incomplete_analysis_exits_two_after_output(monkeypatch):
+    result = {
+        "analysis_summary": {
+            "total_files": 1,
+            "analysis_error_count": 1,
+            "grade_unavailable_reason": "analysis_incomplete",
+        },
+        "analysis_errors": [
+            {
+                "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                "severity": "HIGH",
+                "kind": "syntax_error",
+                "message": "invalid syntax",
+                "file": "app.py",
+                "line": 1,
+                "python_version": "3.12.13",
+            }
+        ],
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+    }
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", ".", "--json", "--upload", "--no-provenance"],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.upload_report") as upload_report,
+        patch("builtins.print") as mock_print,
+    ):
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+    assert exc.value.code == 2
+    mock_print.assert_called_once_with(json.dumps(result))
+    upload_report.assert_not_called()
+
+
+def test_main_incomplete_analysis_renders_without_badge_then_exits_two(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1, "analysis_error_count": 1},
+        "analysis_errors": [
+            {
+                "message": "invalid syntax",
+                "file": "app.py",
+                "line": 1,
+            }
+        ],
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+    }
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", ".", "--no-provenance", "--no-upload"],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.render_results") as render_results,
+        patch("skylos.cli.print_badge") as badge,
+    ):
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+    assert exc.value.code == 2
+    render_results.assert_called_once()
+    badge.assert_not_called()
 
 
 def test_main_strict_failure_renders_results_then_exits_nonzero(monkeypatch):

--- a/test/test_container_python_runtime.py
+++ b/test/test_container_python_runtime.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dockerfile_supports_selectable_python_runtime():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "ARG PYTHON_VERSION=3.14" in dockerfile
+    assert dockerfile.count("FROM python:${PYTHON_VERSION}-slim") == 2
+    assert "SKYLOS_CONTAINER_PYTHON_VERSION=${PYTHON_VERSION}" in dockerfile
+
+
+def test_publish_workflow_pushes_versioned_python_runtime_tags():
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'python-version: ["3.11", "3.12", "3.13", "3.14"]' in workflow
+    assert 'DEFAULT_PYTHON_VERSION: "3.14"' in workflow
+    assert '--build-arg "PYTHON_VERSION=${PYTHON_VERSION}"' in workflow
+    assert '"${IMAGE_NAME}:${VERSION}-${runtime_tag}"' in workflow
+    assert '"${IMAGE_NAME}:latest-${runtime_tag}"' in workflow
+    assert 'if [[ "$PYTHON_VERSION" == "$DEFAULT_PYTHON_VERSION" ]]' in workflow
+
+
+def test_ci_builds_oldest_and_default_python_runtime_images():
+    workflow = (ROOT / ".github" / "workflows" / "tests.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'python-version: ["3.11", "3.14"]' in workflow
+    assert '--build-arg "PYTHON_VERSION=${{ matrix.python-version }}"' in workflow
+    assert "type CacheEntry[T = str] = dict[str, T]" in workflow

--- a/test/test_terminal_report.py
+++ b/test/test_terminal_report.py
@@ -118,6 +118,30 @@ def test_pretty_renderer_shows_rescued_and_abstained_counts():
     assert "dead-code abstained: 1" in output
 
 
+def test_pretty_renderer_shows_incomplete_analysis_as_an_error(tmp_path):
+    result = {
+        "analysis_summary": {"total_files": 1, "analysis_error_count": 1},
+        "analysis_errors": [
+            {
+                "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                "severity": "HIGH",
+                "message": "invalid syntax",
+                "file": str(tmp_path / "future.py"),
+                "line": 1,
+            }
+        ],
+    }
+
+    console = _recording_console()
+    render_pretty_results(console, result, root_path=tmp_path)
+    output = console.export_text()
+
+    assert "analysis errors: 1" in output
+    assert "SKY-ANALYSIS-INCOMPLETE" in output
+    assert "invalid syntax" in output
+    assert "No findings to display" not in output
+
+
 def test_pretty_renderer_sanitizes_control_chars_from_finding_fields(tmp_path):
     source = tmp_path / "src" / "app.py"
     source.parent.mkdir()


### PR DESCRIPTION
Fixes #646

## Summary

  - Add official Docker runtime variants for Python 3.11, 3.12, 3.13, and 3.14.
  - Use Python 3.14 for unqualified image tags while publishing explicit `-pythonX.Y` tags.
  - Report parser failures as `SKY-ANALYSIS-INCOMPLETE`
  - Omit the grade, block uploads and interactive changes, and exit with code 2
  - Surface analysis errors in JSON, rich, concise, pretty, SARIF, GitHub annotation, and LLM outputs.

  ## Tests

  - Confirmed Python 3.14 parses issue fixture and detects `stale_helper`.
  - Confirmed Python 3.12 reports incompatible syntax, produces no grade, and exits with code 2.
  - Confirmed Python 3.11 completes a normal mounted repository scan.