### PR TITLE
fix(dead-code): honor underscore discard bindings

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>976</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9199</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>977</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>9204</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1212,7 +1212,7 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.   skylos/core/verify_change_schema.py skylos/core/gatekeeper.py skylos/core/js_api_surface_members.py skylos/core/python_api_surface.py skylos/core/go_api_surface.py skylos/core/java_api_surface.py skylos/core/js_api_surface_exports.py skylos/core/reference_index_store.py">
+    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.  test/test_underscore_discard_bindings.py skylos/core/verify_change_schema.py skylos/core/gatekeeper.py skylos/core/js_api_surface_members.py skylos/core/python_api_surface.py skylos/core/go_api_surface.py skylos/core/java_api_surface.py skylos/core/js_api_surface_exports.py skylos/core/reference_index_store.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
@@ -1227,7 +1227,7 @@
         <div class="mini-label">Entrypoints</div>
         <div class="link-row"><span class="muted">Generated only</span></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><span class="muted">No obvious matching test file</span></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_underscore_discard_bindings.py" rel="noopener noreferrer">test/test_underscore_discard_bindings.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
@@ -1944,7 +1944,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 43</span>
-          <span class="pill"><strong>symbols</strong> 403</span>
+          <span class="pill"><strong>symbols</strong> 404</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1993,8 +1993,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 238</span>
-          <span class="pill"><strong>symbols</strong> 3393</span>
+          <span class="pill"><strong>files</strong> 239</span>
+          <span class="pill"><strong>symbols</strong> 3397</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -189,6 +189,16 @@ IMPLICIT_DUNDERS = {
 METACLASS_BASES = {"ABCMeta", "EnumMeta", "type"}
 
 
+def _is_intentional_discard_name(name: str) -> bool:
+    if name == "_":
+        return True
+    if name.startswith("__"):
+        return False
+    if name.startswith("_"):
+        return True
+    return False
+
+
 def _exception_type_leaf_names(exc_type: ast.expr | None) -> set[str]:
     if exc_type is None:
         return set()
@@ -624,7 +634,7 @@ class Visitor(ast.NodeVisitor):
         self._complexity_stack[-1] += 1
 
         self.visit(node.iter)
-        self._bind_target(node.target, node.lineno)
+        self._bind_target(node.target, node.lineno, suppress_discards=True)
 
         for stmt in node.body:
             self.visit(stmt)
@@ -635,7 +645,7 @@ class Visitor(ast.NodeVisitor):
         self._complexity_stack[-1] += 1
 
         self.visit(node.iter)
-        self._bind_target(node.target, node.lineno)
+        self._bind_target(node.target, node.lineno, suppress_discards=True)
 
         for stmt in node.body:
             self.visit(stmt)
@@ -984,7 +994,7 @@ class Visitor(ast.NodeVisitor):
 
         for arg in all_args:
             param_name = f"{qualified_name}.{arg.arg}"
-            if not skip_params and arg.arg != "_":
+            if not skip_params and not _is_intentional_discard_name(arg.arg):
                 self.add_def(
                     param_name, "parameter", getattr(arg, "lineno", node.lineno)
                 )
@@ -998,7 +1008,7 @@ class Visitor(ast.NodeVisitor):
         if node.args.vararg:
             va = node.args.vararg
             param_name = f"{qualified_name}.{va.arg}"
-            if not skip_params and not va.arg.startswith("_"):
+            if not skip_params and not _is_intentional_discard_name(va.arg):
                 self.add_def(
                     param_name, "parameter", getattr(va, "lineno", node.lineno)
                 )
@@ -1007,7 +1017,7 @@ class Visitor(ast.NodeVisitor):
         if node.args.kwarg:
             ka = node.args.kwarg
             param_name = f"{qualified_name}.{ka.arg}"
-            if not skip_params and not ka.arg.startswith("_"):
+            if not skip_params and not _is_intentional_discard_name(ka.arg):
                 self.add_def(
                     param_name, "parameter", getattr(ka, "lineno", node.lineno)
                 )
@@ -1418,12 +1428,21 @@ class Visitor(ast.NodeVisitor):
             if self.current_function_scope and self.local_var_maps:
                 self.local_var_maps[-1][name] = outer_qname
 
-    def _bind_target(self, target: ast.expr, lineno: int) -> None:
+    def _bind_target(
+        self,
+        target: ast.expr,
+        lineno: int,
+        *,
+        suppress_discards: bool = False,
+    ) -> None:
         if isinstance(target, ast.Name):
             name_simple = target.id
             var_name = self._compute_variable_name(name_simple)
+            skip_definition = self._should_skip_variable_def(name_simple) or (
+                suppress_discards and _is_intentional_discard_name(name_simple)
+            )
 
-            if not self._should_skip_variable_def(name_simple):
+            if not skip_definition:
                 self.add_def(var_name, "variable", lineno)
 
             if self.current_function_scope and self.local_var_maps:
@@ -1431,9 +1450,17 @@ class Visitor(ast.NodeVisitor):
 
         elif isinstance(target, (ast.Tuple, ast.List)):
             for elt in target.elts:
-                self._bind_target(elt, lineno)
+                self._bind_target(
+                    elt,
+                    lineno,
+                    suppress_discards=suppress_discards,
+                )
         elif isinstance(target, ast.Starred):
-            self._bind_target(target.value, lineno)
+            self._bind_target(
+                target.value,
+                lineno,
+                suppress_discards=suppress_discards,
+            )
 
     def _compute_variable_name(self, name_simple: str) -> str:
         scope_parts = [self.mod]
@@ -1604,11 +1631,7 @@ class Visitor(ast.NodeVisitor):
             if self._should_skip_variable_def(name_simple):
                 return
 
-            if (
-                _in_tuple_unpack
-                and name_simple.startswith("_")
-                and not name_simple.startswith("__")
-            ):
+            if _in_tuple_unpack and _is_intentional_discard_name(name_simple):
                 return
 
             var_name = self._compute_variable_name(name_simple)

--- a/test/test_changes_analyzer.py
+++ b/test/test_changes_analyzer.py
@@ -23,8 +23,8 @@ def func(x: int) -> int:
         )
         assert "ast" in import_names, "Regular unused import should also be flagged"
 
-    def test_underscore_items_flagged_with_small_penalty(self):
-        """_ items get a small penalty (10) but are still flagged when truly unused"""
+    def test_private_symbols_reported_but_dummy_parameters_suppressed(self):
+        """Private symbols remain reportable while _parameters express non-use."""
         code = """
 _private_var = "private"
 
@@ -32,6 +32,7 @@ def _private_func():
     return "private"
 
 def regular_func(_private_param):
+    _local_var = "private"
     return "test"
 
 class Example:
@@ -49,10 +50,13 @@ class Example:
         assert "_private_var" in variable_names, (
             "Unused private variable should be flagged"
         )
+        assert "_local_var" in variable_names, (
+            "A direct local assignment should remain reportable"
+        )
 
         param_names = [p["name"] for p in result["unused_parameters"]]
-        assert "_private_param" in param_names, (
-            "Unused underscore parameter should be flagged"
+        assert "_private_param" not in param_names, (
+            "An underscore-prefixed parameter should be treated as intentional"
         )
 
     def test_unittest_magic_methods_not_flagged(self):

--- a/test/test_underscore_discard_bindings.py
+++ b/test/test_underscore_discard_bindings.py
@@ -1,0 +1,126 @@
+import json
+
+from skylos.analyzer import analyze
+
+
+def test_issue_647_uses_scope_aware_underscore_discard_policy(tmp_path):
+    source = tmp_path / "issue_647.py"
+    source.write_text(
+        """
+from collections.abc import AsyncIterator, Callable
+
+_module_assignment: object = object()
+
+
+def make_recursive(values: list[str]) -> Callable[[str], list[str]]:
+    if not values:
+        def dispatch_leaf(_unused_argument: str) -> list[str]:
+            return []
+
+        return dispatch_leaf
+
+    rest = make_recursive(values[1:])
+
+    def dispatch_branch(used_argument: str) -> list[str]:
+        return rest(used_argument)
+
+    return dispatch_branch
+
+
+def parameters(
+    _positional_only: object,
+    /,
+    _ordinary: object,
+    *,
+    _keyword_only: object,
+    regular_unused: object,
+    __private: object,
+) -> None:
+    pass
+
+
+def changing_type(_input2: str) -> None:
+    for _itr in range(5):
+        pass
+
+
+async def consume_async(stream: AsyncIterator[object]) -> None:
+    async for _async_item in stream:
+        pass
+
+
+def direct_assignment() -> None:
+    _local_assignment = object()
+
+
+def other_bindings(context: object, value: object) -> None:
+    with context as _with_binding:
+        pass
+    try:
+        raise ValueError
+    except ValueError as _error_binding:
+        pass
+    match value:
+        case {"key": _match_binding}:
+            pass
+
+
+for _loop_target in range(5):
+    pass
+
+for used_loop_target, _tuple_loop_target, *_starred_loop_target in (
+    (object(), object(), object()),
+):
+    print(used_loop_target)
+
+for __private_loop in range(1):
+    pass
+
+
+make_recursive([])
+parameters(
+    object(),
+    object(),
+    _keyword_only=object(),
+    regular_unused=object(),
+    __private=object(),
+)
+changing_type("test")
+direct_assignment()
+other_bindings(object(), {"key": object()})
+""",
+        encoding="utf-8",
+    )
+
+    result = json.loads(analyze(str(tmp_path), grep_verify=False))
+    unused_parameters = {
+        item["simple_name"] for item in result.get("unused_parameters", [])
+    }
+    unused_variables = {
+        item["simple_name"] for item in result.get("unused_variables", [])
+    }
+
+    assert {
+        "_unused_argument",
+        "_positional_only",
+        "_ordinary",
+        "_keyword_only",
+        "_input2",
+    }.isdisjoint(unused_parameters)
+    assert {"regular_unused", "__private"} <= unused_parameters
+
+    assert {
+        "_loop_target",
+        "_tuple_loop_target",
+        "_starred_loop_target",
+        "_itr",
+        "_async_item",
+    }.isdisjoint(unused_variables)
+    assert {
+        "_module_assignment",
+        "_local_assignment",
+        "__private_loop",
+        "_with_binding",
+        "_error_binding",
+        "_match_binding",
+    } <= unused_variables

--- a/test/test_visitor.py
+++ b/test/test_visitor.py
@@ -1556,6 +1556,51 @@ def fail_render(*_args, **_kwargs):
     assert "_kwargs" not in param_names
 
 
+def test_all_parameter_kinds_honor_intentional_discard_prefix(tmp_path):
+    code = """
+def handler(
+    _positional_only,
+    regular_positional_only,
+    /,
+    _ordinary,
+    regular_ordinary,
+    *,
+    _keyword_only,
+    regular_keyword_only,
+):
+    return regular_positional_only
+
+def variadic(*_args, **_kwargs):
+    pass
+
+def double_underscore(__ordinary, *__args, **__kwargs):
+    pass
+
+def read_dummy(_read_param):
+    return _read_param
+"""
+    v = _visit(code, tmp_path)
+    param_names = {d.simple_name for d in v.defs if d.type == "parameter"}
+
+    assert {
+        "_positional_only",
+        "_ordinary",
+        "_keyword_only",
+        "_args",
+        "_kwargs",
+        "_read_param",
+    }.isdisjoint(param_names)
+    assert {
+        "regular_positional_only",
+        "regular_ordinary",
+        "regular_keyword_only",
+        "__ordinary",
+        "__args",
+        "__kwargs",
+    } <= param_names
+    assert "test_module.read_dummy._read_param" in _ref_names(v)
+
+
 def test_regular_vararg_not_suppressed(tmp_path):
     """Non-underscore *args and **kwargs should still produce defs."""
     code = """
@@ -1566,3 +1611,72 @@ def handler(*args, **kwargs):
     param_names = {d.simple_name for d in v.defs if d.type == "parameter"}
     assert "args" in param_names
     assert "kwargs" in param_names
+
+
+def test_loop_targets_honor_intentional_discard_prefix(tmp_path):
+    code = """
+async def consume(rows, stream):
+    for _single in rows:
+        pass
+    for used, _tuple, *_starred in rows:
+        print(used)
+    async for _async_item in stream:
+        pass
+    for __private_loop in rows:
+        pass
+    for regular_loop in rows:
+        pass
+    for _read_later in rows:
+        print(_read_later)
+"""
+    v = _visit(code, tmp_path)
+    variable_names = {d.simple_name for d in v.defs if d.type == "variable"}
+
+    assert {
+        "_single",
+        "_tuple",
+        "_starred",
+        "_async_item",
+        "_read_later",
+    }.isdisjoint(variable_names)
+    assert {"used", "__private_loop", "regular_loop"} <= variable_names
+    assert "test_module.consume._read_later" in _ref_names(v)
+
+
+def test_other_underscore_binding_contexts_remain_defined(tmp_path):
+    code = """
+_module_assignment = object()
+
+class Example:
+    _class_assignment = object()
+
+def _private_function(context, value):
+    _local_assignment = value
+    with context as _with_binding:
+        pass
+    try:
+        raise ValueError
+    except ValueError as _error_binding:
+        pass
+    match value:
+        case {"key": _match_binding}:
+            pass
+
+class _PrivateClass:
+    pass
+"""
+    v = _visit(code, tmp_path)
+    variable_names = {d.simple_name for d in v.defs if d.type == "variable"}
+    function_names = {d.simple_name for d in v.defs if d.type == "function"}
+    class_names = {d.simple_name for d in v.defs if d.type == "class"}
+
+    assert {
+        "_module_assignment",
+        "_class_assignment",
+        "_local_assignment",
+        "_with_binding",
+        "_error_binding",
+        "_match_binding",
+    } <= variable_names
+    assert "_private_function" in function_names
+    assert "_PrivateClass" in class_names


### PR DESCRIPTION
Fixes #647.

## Summary

  - Treats single underscore prefixed Python params and loop targets as intentional discard bindings.
  - Supports all parameter forms and recursively destructured `for` and `async for` targets.

  ## Tests

  - Issue #647 reproductions were manually retested.