### PR TITLE
fix(analyzer): fail closed on compile-time syntax errors

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import traceback
+import warnings
 from pathlib import Path
 from collections import Counter, defaultdict
 
@@ -3738,8 +3739,9 @@ def _analysis_error_payload(file, error, *, kind=None):
     }
     if is_syntax_error:
         payload["suggestion"] = (
-            "Use a Python runtime that supports this syntax; official container "
-            "images provide matching -pythonX.Y tags."
+            "Fix the reported syntax, or use a Python runtime that supports the "
+            "project's syntax; official container images provide matching "
+            "-pythonX.Y tags."
         )
     return payload
 
@@ -3777,7 +3779,13 @@ def proc_file(
         ignore_lines = get_skylos_ignore_lines(source)
         noqa_codes_by_line = get_noqa_codes_by_line(source)
 
-        tree = ast.parse(source)
+        tree = ast.parse(source, filename=str(file))
+        # ast.parse() can accept ASTs that Python later rejects, such as
+        # functions with duplicate argument names. Compile without executing
+        # so every compile-time SyntaxError follows the incomplete-analysis path.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SyntaxWarning)
+            compile(tree, str(file), "exec", dont_inherit=True)
 
         raw_imports = collect_python_raw_imports(tree, file, mod)
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1910,11 +1910,38 @@ class TestClass:
                     f"{sys.version_info.micro}"
                 ),
                 "suggestion": (
-                    "Use a Python runtime that supports this syntax; official "
-                    "container images provide matching -pythonX.Y tags."
+                    "Fix the reported syntax, or use a Python runtime that "
+                    "supports the project's syntax; official container images "
+                    "provide matching -pythonX.Y tags."
                 ),
             }
         ]
+
+    def test_analyze_marks_ast_compile_error_incomplete_and_omits_grade(
+        self, tmp_path
+    ):
+        invalid_file = tmp_path / "duplicate_arguments.py"
+        invalid_file.write_text(
+            "def broken(_: object, /, _: object) -> None:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(analyze(str(tmp_path), grep_verify=False))
+
+        assert result["analysis_summary"]["analysis_error_count"] == 1
+        assert result["analysis_summary"]["grade_unavailable_reason"] == (
+            "analysis_incomplete"
+        )
+        assert "grade" not in result
+        assert len(result["analysis_errors"]) == 1
+        analysis_error = result["analysis_errors"][0]
+        assert analysis_error["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+        assert analysis_error["kind"] == "syntax_error"
+        assert analysis_error["error_type"] == "SyntaxError"
+        assert "duplicate argument '_'" in analysis_error["message"]
+        assert analysis_error["file"] == str(invalid_file)
+        assert analysis_error["line"] == 1
 
     def test_proc_file_keeps_findings_when_dynamic_fstring_pattern_has_regex_chars(
         self, tmp_path


### PR DESCRIPTION
Fixes #651

## Summary

  - Validated parsed Python ASTs with `compile()` without executing the target code
  - Catch syntax errors that `ast.parse()` accepts, included duplicate argument case described in #647.
  - Report `SKY-ANALYSIS-INCOMPLETE`, exits with code 2

## Tests

  - Reproduced #651 returning `100/A+` before the fix. Now returns exit code 2 with no grade.
  - Confirmed the #647 duplicate argument fixture now reports the syntax error.