### PR TITLE
fix(dead-code): prevent unrelated parameter rescues

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>977</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9204</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>9205</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1217,7 +1217,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 35</span>
-          <span class="pill"><strong>symbols</strong> 495</span>
+          <span class="pill"><strong>symbols</strong> 496</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>

--- a/skylos/core/grep_verify.py
+++ b/skylos/core/grep_verify.py
@@ -87,7 +87,7 @@ class GrepStrategy:
         return self.result_key or self.name
 
 
-_GREP_VERIFY_CACHE_VERSION = "v3"
+_GREP_VERIFY_CACHE_VERSION = "v4"
 
 _DETERMINISTIC_RULES: list[tuple[str, str, str]] = [
     ("method_calls", "real_method_call", "Direct method-call usage found via grep"),

--- a/skylos/core/grep_verify_python_strategy.py
+++ b/skylos/core/grep_verify_python_strategy.py
@@ -19,6 +19,60 @@ from skylos.core.grep_verify_strategies import (
 )
 
 
+def _parameter_contract_search(
+    finding: dict,
+    project_root: str,
+    *,
+    simple_name: str,
+    owner_simple_name: str,
+    file_path: str,
+    max_per_strategy: int,
+) -> dict[str, list[str]]:
+    """Collect owner-aware evidence for a lexical parameter binding."""
+    results: dict[str, list[str]] = {}
+    if not owner_simple_name:
+        return results
+
+    callback_pattern = rf"callback\s*=\s*(?:[\w\.]+\.)*{re.escape(owner_simple_name)}\b"
+    callback_refs = _run_grep(
+        callback_pattern,
+        project_root,
+        use_regex=True,
+        include_globs=["*.py"],
+        max_results=max_per_strategy,
+    )
+    if callback_refs:
+        results["callback_registrations"] = callback_refs[:max_per_strategy]
+
+    signature_pattern = (
+        rf"def\s+{re.escape(owner_simple_name)}\s*\([^)]*\b{re.escape(simple_name)}\b"
+    )
+    signature_refs = _run_grep(
+        signature_pattern,
+        project_root,
+        use_regex=True,
+        include_globs=["*.py"],
+        max_results=max_per_strategy * 2,
+    )
+    if signature_refs:
+        override_refs = []
+        line_value = finding.get("line", 0)
+        line_num = int(line_value) if isinstance(line_value, (int, float)) else 0
+        for ref in signature_refs:
+            parts = ref.split(":", 2)
+            if len(parts) < 2 or not parts[1].isdigit():
+                continue
+            match_file = parts[0]
+            match_line = int(parts[1])
+            if match_file == file_path and abs(match_line - line_num) <= 3:
+                continue
+            override_refs.append(ref)
+        if override_refs:
+            results["signature_overrides"] = override_refs[:max_per_strategy]
+
+    return _deduplicate_grep_results(results)
+
+
 def multi_strategy_search(
     finding: dict,
     project_root: str,
@@ -55,6 +109,16 @@ def multi_strategy_search(
 
     if not simple_name or len(simple_name) <= 1:
         return results
+
+    if kind == "parameter":
+        return _parameter_contract_search(
+            finding,
+            project_root,
+            simple_name=simple_name,
+            owner_simple_name=owner_simple_name,
+            file_path=file_path,
+            max_per_strategy=max_per_strategy,
+        )
 
     def _should_early_exit() -> bool:
         for strategy in _STRONG_ALIVE_STRATEGIES:
@@ -265,46 +329,6 @@ def multi_strategy_search(
             if usages:
                 results["module_references"] = usages[:max_per_strategy]
                 break
-
-    if kind == "parameter" and owner_simple_name:
-        callback_pattern = (
-            rf"callback\s*=\s*(?:[\w\.]+\.)*{re.escape(owner_simple_name)}\b"
-        )
-        callback_refs = _run_grep(
-            callback_pattern,
-            project_root,
-            use_regex=True,
-            include_globs=["*.py"],
-            max_results=max_per_strategy,
-        )
-        if callback_refs:
-            results["callback_registrations"] = callback_refs[:max_per_strategy]
-
-        def _parse_int(value):
-            return int(value) if isinstance(value, (int, float)) else 0
-
-        signature_pattern = rf"def\s+{re.escape(owner_simple_name)}\s*\([^)]*\b{re.escape(simple_name)}\b"
-        signature_refs = _run_grep(
-            signature_pattern,
-            project_root,
-            use_regex=True,
-            include_globs=["*.py"],
-            max_results=max_per_strategy * 2,
-        )
-        if signature_refs:
-            override_refs = []
-            line_num = _parse_int(finding.get("line", 0))
-            for ref in signature_refs:
-                parts = ref.split(":", 2)
-                if len(parts) < 2 or not parts[1].isdigit():
-                    continue
-                match_file = parts[0]
-                match_line = int(parts[1])
-                if match_file == file_path and abs(match_line - line_num) <= 3:
-                    continue
-                override_refs.append(ref)
-            if override_refs:
-                results["signature_overrides"] = override_refs[:max_per_strategy]
 
     doc_refs = _run_grep(
         rf"\b{simple_name}\b",

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -186,6 +186,60 @@ class TestGrepVerifyFindings:
         verdicts = grep_verify_findings(findings, str(tmp_path))
         assert "lib.orphan" not in verdicts
 
+    def test_unrelated_parameter_declarations_do_not_rescue(self, tmp_path):
+        first = tmp_path / "first.py"
+        second = tmp_path / "second.py"
+        first.write_text("def target(unused_value: str) -> None:\n    pass\n")
+        second.write_text("def unrelated(unused_value: str) -> None:\n    pass\n")
+
+        findings = [
+            {
+                "name": "unused_value",
+                "full_name": "first.target.unused_value",
+                "simple_name": "unused_value",
+                "type": "parameter",
+                "file": str(first),
+                "line": 1,
+                "confidence": 80,
+            },
+            {
+                "name": "unused_value",
+                "full_name": "second.unrelated.unused_value",
+                "simple_name": "unused_value",
+                "type": "parameter",
+                "file": str(second),
+                "line": 1,
+                "confidence": 80,
+            },
+        ]
+
+        assert multi_strategy_search(findings[0], str(tmp_path)) == {}
+        assert multi_strategy_search(findings[1], str(tmp_path)) == {}
+        assert grep_verify_findings(findings, str(tmp_path)) == {}
+
+    def test_parameter_search_retains_owner_contract_evidence(self, tmp_path):
+        source = tmp_path / "callbacks.py"
+        source.write_text(
+            "def target(unused_value: str) -> None:\n"
+            "    pass\n"
+            "\n"
+            "register(callback=target)\n"
+        )
+        finding = {
+            "name": "unused_value",
+            "full_name": "callbacks.target.unused_value",
+            "simple_name": "unused_value",
+            "type": "parameter",
+            "file": str(source),
+            "line": 1,
+            "confidence": 80,
+        }
+
+        results = multi_strategy_search(finding, str(tmp_path))
+
+        assert set(results) == {"callback_registrations"}
+        assert "register(callback=target)" in results["callback_registrations"][0]
+
     def test_getattr_dispatch_rescues(self, tmp_path):
         (tmp_path / "plugin.py").write_text(
             "class Handler:\n    def process(self):\n        pass\n"
@@ -448,6 +502,34 @@ class TestQualifiedReferenceSubstring:
 
 
 class TestAnalyzerIntegration:
+    def test_grep_verify_matches_static_analysis_for_unrelated_parameters(
+        self, tmp_path
+    ):
+        (tmp_path / "first.py").write_text(
+            'def target(unused_value: str) -> None:\n    pass\n\ntarget("x")\n'
+        )
+        (tmp_path / "second.py").write_text(
+            'def unrelated(unused_value: str) -> None:\n    pass\n\nunrelated("x")\n'
+        )
+
+        from skylos.analyzer import analyze
+        import json
+
+        result_on = json.loads(analyze(str(tmp_path), conf=0, grep_verify=True))
+        result_off = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+
+        def unused_parameter_locations(result):
+            return {
+                (finding["file"], finding["full_name"])
+                for finding in result["unused_parameters"]
+            }
+
+        assert unused_parameter_locations(result_on) == unused_parameter_locations(
+            result_off
+        )
+        assert len(result_on["unused_parameters"]) == 2
+        assert result_on["analysis_summary"]["grep_verify"]["rescued_count"] == 0
+
     def test_grep_verify_rescues_dynamic_dispatch(self, tmp_path):
         (tmp_path / "plugin.py").write_text(
             'def handle_event():\n    return "handled"\n'


### PR DESCRIPTION
Fixes #649

## Summary

  - Prevents unrelated same named declarations from rescuing unused Python parameters.
  - Restricts parameter grep verification to owner-aware callback and override evidence.
  - Invalidates stale grep verification cache entries

  ## Tests

  - pytest test/test_grep_verify.py