### PR TITLE
fix(dead-code): invalidate grep cache on evidence changes

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>977</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9205</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>9210</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1217,7 +1217,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 35</span>
-          <span class="pill"><strong>symbols</strong> 496</span>
+          <span class="pill"><strong>symbols</strong> 500</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1994,7 +1994,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 239</span>
-          <span class="pill"><strong>symbols</strong> 3397</span>
+          <span class="pill"><strong>symbols</strong> 3398</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/core/grep_cache.py
+++ b/skylos/core/grep_cache.py
@@ -6,8 +6,11 @@ import logging
 import os
 import threading
 import time
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
+
+from skylos.core.grep_verify_common import _ALL_SOURCE_GLOBS, _GREP_EXCLUDE_DIRS
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +37,84 @@ def file_content_hash(file_path: str | Path) -> str:
         return ""
 
 
+def _resolve_repository_root(project_root: str | Path) -> Path | None:
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+    if root.is_file():
+        root = root.parent
+    if not root.is_dir():
+        return None
+    return root
+
+
+def _collect_repository_evidence_files(
+    root: Path,
+) -> list[tuple[str, Path]] | None:
+    evidence_files: list[tuple[str, Path]] = []
+
+    try:
+        for directory, dirnames, filenames in os.walk(root, followlinks=False):
+            directory_path = Path(directory)
+            dirnames[:] = sorted(
+                name
+                for name in dirnames
+                if not any(fnmatch(name, pattern) for pattern in _GREP_EXCLUDE_DIRS)
+                and not (directory_path / name).is_symlink()
+            )
+            for filename in filenames:
+                if not any(fnmatch(filename, pattern) for pattern in _ALL_SOURCE_GLOBS):
+                    continue
+                path = directory_path / filename
+                if path.is_symlink():
+                    continue
+                relative_path = path.relative_to(root).as_posix()
+                evidence_files.append((relative_path, path))
+    except (OSError, ValueError):
+        return None
+    return evidence_files
+
+
+def _update_digest_from_evidence_file(
+    digest: Any,
+    path: Path,
+) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(  # skylos: ignore[SKY-D215] in-root grep evidence
+            path, flags
+        )
+        with os.fdopen(fd, "rb") as evidence_file:
+            while chunk := evidence_file.read(64 * 1024):
+                digest.update(chunk)
+    except OSError:
+        digest.update(b"\0<unreadable>")
+
+
+def repository_evidence_fingerprint(project_root: str | Path) -> str | None:
+    """Hash every file that can contribute repository-wide grep evidence."""
+    root = _resolve_repository_root(project_root)
+    if root is None:
+        return None
+    evidence_files = _collect_repository_evidence_files(root)
+    if evidence_files is None:
+        return None
+
+    digest = hashlib.sha256(b"skylos-grep-evidence-v1\0")
+    for relative_path, path in sorted(evidence_files):
+        encoded_path = relative_path.encode("utf-8", errors="surrogateescape")
+        digest.update(len(encoded_path).to_bytes(8, "big"))
+        digest.update(encoded_path)
+        _update_digest_from_evidence_file(digest, path)
+        digest.update(b"\0")
+
+    digest.update(len(evidence_files).to_bytes(8, "big"))
+    return digest.hexdigest()[:20]
+
+
 def _make_key(
     strategy: str,
     simple_name: str,
@@ -49,6 +130,31 @@ class GrepCache:
         self._lock = threading.Lock()
         self._entries: dict[str, dict[str, Any]] = {}
         self._dirty = False
+        self._repository_fingerprint: str | None = None
+        self._fingerprint_root: Path | None = None
+
+    @property
+    def repository_fingerprint(self) -> str | None:
+        with self._lock:
+            return self._repository_fingerprint
+
+    def bind_repository(self, project_root: str | Path) -> str | None:
+        try:
+            root = Path(project_root).resolve(strict=True)
+        except OSError:
+            return None
+        if root.is_file():
+            root = root.parent
+
+        with self._lock:
+            if self._fingerprint_root == root:
+                return self._repository_fingerprint
+
+        fingerprint = repository_evidence_fingerprint(root)
+        with self._lock:
+            self._fingerprint_root = root
+            self._repository_fingerprint = fingerprint
+        return fingerprint
 
     def get(self, key: str) -> list[str] | None:
         with self._lock:
@@ -99,7 +205,9 @@ class GrepCache:
         with self._lock:
             return len(self._entries)
 
-    def _cache_path(self, project_root: str | Path, *, create: bool = False) -> Path | None:
+    def _cache_path(
+        self, project_root: str | Path, *, create: bool = False
+    ) -> Path | None:
         try:
             root = Path(project_root).resolve(strict=True)
         except OSError:
@@ -141,7 +249,9 @@ class GrepCache:
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         try:
-            fd = os.open(path, flags)  # skylos: ignore[SKY-D215] guarded project-local grep cache path
+            fd = os.open(  # skylos: ignore[SKY-D215] guarded local cache path
+                path, flags
+            )
         except OSError:
             return None
         try:
@@ -173,6 +283,7 @@ class GrepCache:
         return normalized
 
     def load(self, project_root: str | Path) -> None:
+        self.bind_repository(project_root)
         path = self._cache_path(project_root)
         if path is None:
             return
@@ -212,7 +323,9 @@ class GrepCache:
             flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
             if hasattr(os, "O_NOFOLLOW"):
                 flags |= os.O_NOFOLLOW
-            fd = os.open(temp_path, flags, 0o600)  # skylos: ignore[SKY-D215] guarded project-local grep cache temp path
+            fd = os.open(  # skylos: ignore[SKY-D215] guarded local cache temp
+                temp_path, flags, 0o600
+            )
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(payload)

--- a/skylos/core/grep_verify.py
+++ b/skylos/core/grep_verify.py
@@ -87,7 +87,7 @@ class GrepStrategy:
         return self.result_key or self.name
 
 
-_GREP_VERIFY_CACHE_VERSION = "v4"
+_GREP_VERIFY_CACHE_VERSION = "v5"
 
 _DETERMINISTIC_RULES: list[tuple[str, str, str]] = [
     ("method_calls", "real_method_call", "Direct method-call usage found via grep"),
@@ -111,13 +111,18 @@ def _cached_group_results(
 
     from skylos.core.grep_cache import file_content_hash as _fch
 
+    repository_fingerprint = getattr(cache, "repository_fingerprint", None)
+    if not isinstance(repository_fingerprint, str) or not repository_fingerprint:
+        return search_fn()
+
     simple_name = finding.get("simple_name", finding.get("name", ""))
     finding_file = finding.get("file", "")
     content_hash = _fch(finding_file) if finding_file else ""
     cache_key = (
         f"{_GREP_VERIFY_CACHE_VERSION}:group:{group_name}:"
         f"{simple_name}:{finding.get('full_name', '')}:"
-        f"{finding.get('type', '')}:{content_hash}"
+        f"{finding.get('type', '')}:{content_hash}:"
+        f"repo:{repository_fingerprint}"
     )
     cached = cache.get(cache_key)
     if cached is not None:
@@ -235,6 +240,9 @@ def grep_verify_findings(
     cache: Any = None,
 ) -> dict[str, GrepVerdict]:
     verdicts: dict[str, GrepVerdict] = {}
+    cache_binder = getattr(type(cache), "bind_repository", None)
+    if callable(cache_binder):
+        cache_binder(cache, project_root)
     start_time = time.monotonic()
     search_fn = _build_grep_search_fn(
         project_root,

--- a/test/test_grep_cache.py
+++ b/test/test_grep_cache.py
@@ -13,6 +13,7 @@ from skylos.core.grep_cache import (
     GrepCache,
     _make_key,
     file_content_hash,
+    repository_evidence_fingerprint,
 )
 
 
@@ -60,6 +61,40 @@ class TestFileContentHash:
         f = tmp_path / "s.py"
         f.write_text("x = 1")
         assert file_content_hash(str(f)) == file_content_hash(f)
+
+
+class TestRepositoryEvidenceFingerprint:
+    def test_changes_when_evidence_content_changes(self, tmp_path: Path) -> None:
+        evidence = tmp_path / "evidence.py"
+        evidence.write_bytes(b"A" * 9000)
+        first = repository_evidence_fingerprint(tmp_path)
+
+        evidence.write_bytes(b"A" * 8999 + b"B")
+        second = repository_evidence_fingerprint(tmp_path)
+
+        assert first is not None
+        assert second is not None
+        assert first != second
+
+    def test_changes_when_evidence_file_is_added(self, tmp_path: Path) -> None:
+        (tmp_path / "target.py").write_text("def target():\n    pass\n")
+        first = repository_evidence_fingerprint(tmp_path)
+
+        (tmp_path / "evidence.py").write_text("target()\n")
+        second = repository_evidence_fingerprint(tmp_path)
+
+        assert first != second
+
+    def test_ignores_skylos_cache_files(self, tmp_path: Path) -> None:
+        (tmp_path / "target.py").write_text("def target():\n    pass\n")
+        first = repository_evidence_fingerprint(tmp_path)
+
+        cache_file = tmp_path / CACHE_DIR / CACHE_FILE
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text('{"entries": {}}')
+        second = repository_evidence_fingerprint(tmp_path)
+
+        assert first == second
 
 
 class TestMakeKey:

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -502,6 +502,27 @@ class TestQualifiedReferenceSubstring:
 
 
 class TestAnalyzerIntegration:
+    def test_grep_cache_invalidates_when_repository_evidence_changes(self, tmp_path):
+        target = tmp_path / "target.py"
+        evidence = tmp_path / "evidence.py"
+        target.write_text("def _cached_helper() -> None:\n    pass\n")
+        evidence.write_text("from target import _cached_helper\n\n_cached_helper()\n")
+
+        from skylos.analyzer import analyze
+        import json
+
+        def unused_functions():
+            result = json.loads(analyze(str(target), conf=0, grep_verify=True))
+            return {finding["full_name"] for finding in result["unused_functions"]}
+
+        assert "target._cached_helper" not in unused_functions()
+
+        evidence.write_text("value = 1\n")
+        assert "target._cached_helper" in unused_functions()
+
+        evidence.write_text("from target import _cached_helper\n\n_cached_helper()\n")
+        assert "target._cached_helper" not in unused_functions()
+
     def test_grep_verify_matches_static_analysis_for_unrelated_parameters(
         self, tmp_path
     ):


### PR DESCRIPTION
Fixes #650.

## Summary

  - Added a repository-evidence fingerprint to grep-verification cache keys.
  - Invalidates cached results when grepped files are edited, added, removed, or renamed
  - Bypasses cache when a reliable fingerprint cannot be generated.
  - Excluded ignored dirs and Skylos’s own cache files from fingerprinting.

  ## Tests

  - `pytest test/test_grep_cache.py test/test_grep_verify.py`