### PR TITLE
fix(quality): exempt underscore exception discard

### DIFF
--- a/skylos/rules/quality/logic_foundation.py
+++ b/skylos/rules/quality/logic_foundation.py
@@ -506,6 +506,8 @@ class UnusedExceptVarRule(SkylosRule):
             return None
         if not node.name:
             return None
+        if node.name == "_":
+            return None
 
         use_count = 0
         for child in ast.walk(node):

--- a/test/test_quality_new_rules.py
+++ b/test/test_quality_new_rules.py
@@ -32,10 +32,10 @@ class TestUnusedExceptVar:
         findings = check_code(UnusedExceptVarRule(), code)
         assert len(findings) == 0
 
-    def test_underscore_convention(self):
-        code = "try:\n    pass\nexcept ValueError as _:\n    print('ignored')\n"
+    def test_underscore_convention_is_not_flagged(self):
+        code = "try:\n    raise ValueError\nexcept ValueError as _:\n    pass\n"
         findings = check_code(UnusedExceptVarRule(), code)
-        assert len(findings) == 1
+        assert len(findings) == 0
 
     def test_multiple_except_one_unused(self):
         code = (


### PR DESCRIPTION
Fixes #648.

## Summary

  - Prevents `SKY-L005` from flagging the intentional exception discard name `_`.
  - Keeps reporting genuinely unused names such as `error` and `_error`.

  ## Testing

  - Checked `_` fixture no longer produces `SKY-L005`.
  - Checked named and underscore-prefixed unused exceptions are still reported.