### PR TITLE
fix(quality): exempt Protocol method stubs

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>977</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9210</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>9213</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1760,7 +1760,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 101</span>
-          <span class="pill"><strong>symbols</strong> 1087</span>
+          <span class="pill"><strong>symbols</strong> 1090</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, AI-defect, config, edge, CI/CD, and SCA findings.</p>

--- a/skylos/analysis/file_processing.py
+++ b/skylos/analysis/file_processing.py
@@ -114,7 +114,7 @@ LINTER_RULE_NODE_TYPES = {
     BroadFilePermissionsRule: (ast.Call,),
     UndefinedConfigRule: (ast.Module, ast.Call),
     StaleMockRule: (ast.Module, ast.Call),
-    UnfinishedGenerationRule: (ast.FunctionDef, ast.AsyncFunctionDef),
+    UnfinishedGenerationRule: (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef),
     DuplicateStringLiteralRule: (ast.Module,),
     TooManyReturnsRule: (ast.FunctionDef, ast.AsyncFunctionDef),
     BooleanTrapRule: (ast.FunctionDef, ast.AsyncFunctionDef),

--- a/skylos/rules/quality/logic_security.py
+++ b/skylos/rules/quality/logic_security.py
@@ -338,12 +338,81 @@ class DisabledSecurityRule(SkylosRule):
         return findings if findings else None
 
 
+_PROTOCOL_MODULES = {"typing", "typing_extensions"}
+
+
+def _protocol_import_bindings(module: ast.Module) -> tuple[set[str], set[str]]:
+    protocol_names: set[str] = set()
+    protocol_modules: set[str] = set()
+
+    for stmt in module.body:
+        if isinstance(stmt, ast.ImportFrom) and stmt.module in _PROTOCOL_MODULES:
+            for imported in stmt.names:
+                if imported.name == "Protocol":
+                    protocol_names.add(imported.asname or imported.name)
+        elif isinstance(stmt, ast.Import):
+            for imported in stmt.names:
+                if imported.name in _PROTOCOL_MODULES:
+                    protocol_modules.add(imported.asname or imported.name)
+
+    return protocol_names, protocol_modules
+
+
+def _is_protocol_base(
+    base: ast.expr,
+    protocol_names: set[str],
+    protocol_modules: set[str],
+) -> bool:
+    if isinstance(base, ast.Subscript):
+        base = base.value
+    if isinstance(base, ast.Name):
+        return base.id in protocol_names
+    return (
+        isinstance(base, ast.Attribute)
+        and base.attr == "Protocol"
+        and isinstance(base.value, ast.Name)
+        and base.value.id in protocol_modules
+    )
+
+
+def _protocol_method_ids(module: ast.Module) -> set[int]:
+    protocol_names, protocol_modules = _protocol_import_bindings(module)
+    if not protocol_names and not protocol_modules:
+        return set()
+
+    method_ids: set[int] = set()
+
+    for candidate in ast.walk(module):
+        if not isinstance(candidate, ast.ClassDef):
+            continue
+        if not any(
+            _is_protocol_base(base, protocol_names, protocol_modules)
+            for base in candidate.bases
+        ):
+            continue
+        method_ids.update(
+            id(stmt)
+            for stmt in candidate.body
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+        )
+
+    return method_ids
+
+
 class UnfinishedGenerationRule(SkylosRule):
     rule_id = "SKY-L026"
     name = "Unfinished Generation"
 
+    def __init__(self):
+        self._protocol_method_ids: set[int] = set()
+
     def visit_node(self, node, context):
+        if isinstance(node, ast.Module):
+            self._protocol_method_ids = _protocol_method_ids(node)
+            return None
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return None
+        if id(node) in self._protocol_method_ids:
             return None
 
         filename = context.get("filename", "")

--- a/test/test_vibe_rules.py
+++ b/test/test_vibe_rules.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import os
 import shutil
 import textwrap
@@ -8,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from skylos.analyzer import analyze
 from skylos.rules.ai_defect import PhantomCallRule, PhantomDecoratorRule
 from skylos.rules.quality.logic import (
     EmptyErrorHandlerRule,
@@ -2023,6 +2025,104 @@ class TestUnfinishedGeneration:
         findings = check_code(UnfinishedGenerationRule(), code)
         l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
         assert len(l026) == 0
+
+    def test_runtime_checkable_protocol_methods_not_flagged(self):
+        code = """
+        from typing import Protocol, runtime_checkable
+
+        @runtime_checkable
+        class ParentCall(Protocol):
+            def operation1(self) -> int: ...
+            def operation2(self) -> int: ...
+        """
+        findings = check_code(UnfinishedGenerationRule(), code)
+        l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
+        assert len(l026) == 0
+
+    @pytest.mark.parametrize(
+        ("import_statement", "protocol_base"),
+        [
+            ("import typing", "typing.Protocol"),
+            (
+                "from typing_extensions import Protocol as Interface",
+                "Interface",
+            ),
+            ("import typing_extensions as typing_ext", "typing_ext.Protocol"),
+        ],
+    )
+    def test_protocol_import_forms_not_flagged(self, import_statement, protocol_base):
+        code = f"""
+        {import_statement}
+
+        class ParentCall({protocol_base}):
+            def operation(self) -> int: ...
+        """
+        findings = check_code(UnfinishedGenerationRule(), code)
+        l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
+        assert len(l026) == 0
+
+    def test_protocol_subclass_placeholder_still_flagged(self):
+        code = """
+        from typing import Protocol
+
+        class ParentCall(Protocol):
+            def operation(self) -> int: ...
+
+        class BrokenImplementation(ParentCall):
+            def operation(self) -> int: ...
+        """
+        findings = check_code(UnfinishedGenerationRule(), code)
+        l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
+        assert [finding["name"] for finding in l026] == ["operation"]
+
+    def test_generic_protocol_method_not_flagged(self):
+        code = """
+        from typing import Protocol, TypeVar
+
+        T = TypeVar("T")
+
+        class ParentCall(Protocol[T]):
+            def operation(self) -> T: ...
+        """
+        findings = check_code(UnfinishedGenerationRule(), code)
+        l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
+        assert len(l026) == 0
+
+    def test_unrelated_protocol_named_base_still_flagged(self):
+        code = """
+        class Protocol:
+            pass
+
+        class ParentCall(Protocol):
+            def operation(self) -> int: ...
+        """
+        findings = check_code(UnfinishedGenerationRule(), code)
+        l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
+        assert [finding["name"] for finding in l026] == ["operation"]
+
+    def test_analyzer_ignores_protocol_method_stubs(self, tmp_path):
+        (tmp_path / "protocols.py").write_text(
+            "from typing import Protocol, runtime_checkable\n"
+            "\n"
+            "@runtime_checkable\n"
+            "class ParentCall(Protocol):\n"
+            "    def operation(self) -> int: ...\n"
+            "\n"
+            "class Worker:\n"
+            "    def unfinished(self) -> int: ...\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), enable_quality=True, grep_verify=False)
+        )
+        unfinished = [
+            finding
+            for finding in result.get("quality", [])
+            if finding.get("rule_id") == "SKY-L026"
+        ]
+
+        assert [finding["name"] for finding in unfinished] == ["unfinished"]
 
     def test_test_file_not_flagged(self):
         code = """


### PR DESCRIPTION
Fixes #660.

## Summary

  - Prevents `SKY-L026` from flagging valid method stubs declared directly on PEP 544 Protocol classes.
  - Supports `typing.Protocol`, `typing_extensions.Protocol`, qualified imports, aliases, generic Protocols, and `@runtime_checkable`.
  - Continues reporting unfinished methods in ordinary classes and concrete Protocol subclasses.

## Tests
    - `pytest -q test/test_vibe_rules.py`