### PR TITLE
fix(ai-defect): recognize PEP 695 type aliases

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>977</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9213</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>9214</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1994,7 +1994,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 239</span>
-          <span class="pill"><strong>symbols</strong> 3398</span>
+          <span class="pill"><strong>symbols</strong> 3399</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/rules/ai_defect/phantom_refs.py
+++ b/skylos/rules/ai_defect/phantom_refs.py
@@ -394,6 +394,7 @@ def _collect_module_facts(tree, current_module, local_modules):
     if not isinstance(tree, ast.Module):
         return members, has_dynamic_getattr, exported_modules
 
+    type_alias_node = getattr(ast, "TypeAlias", None)
     for stmt in tree.body:
         if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
             members.add(stmt.name)
@@ -406,6 +407,8 @@ def _collect_module_facts(tree, current_module, local_modules):
                 members.update(_extract_target_names(target))
         elif isinstance(stmt, ast.AnnAssign):
             members.update(_extract_target_names(stmt.target))
+        elif type_alias_node is not None and isinstance(stmt, type_alias_node):
+            members.update(_extract_target_names(stmt.name))
         elif isinstance(stmt, ast.Import):
             for alias in stmt.names:
                 bound_name = alias.asname or alias.name.split(".", 1)[0]

--- a/test/test_python_api_hallucination.py
+++ b/test/test_python_api_hallucination.py
@@ -1,3 +1,5 @@
+import ast
+
 from skylos.rules.ai_defect.python_api_hallucination import (
     scan_python_local_api_hallucinations,
 )
@@ -97,6 +99,27 @@ def test_python_local_api_check_passes_existing_direct_import(tmp_path):
             "app.py": "from security import VERIFY_TOKEN as token\nprint(token)\n",
         },
         targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 1
+
+
+def test_python_local_api_check_passes_pep695_type_alias_import(tmp_path):
+    if not hasattr(ast, "TypeAlias"):
+        return
+
+    findings, check = _scan(
+        tmp_path,
+        {
+            "alias_package/consumer.py": (
+                "from .provider import NativePostStepCall\n"
+                "assert NativePostStepCall.__value__ is int\n"
+            ),
+            "alias_package/provider.py": "type NativePostStepCall = int\n",
+        },
+        targets=["alias_package/consumer.py"],
     )
 
     assert findings == []

--- a/test/test_vibe_rules.py
+++ b/test/test_vibe_rules.py
@@ -1080,6 +1080,42 @@ class TestPhantomCall:
         assert l012[0]["name"] == "totals.compute_total"
         assert l012[0]["simple_name"] == "compute_total"
 
+    def test_repo_pep695_type_alias_import_not_flagged(self):
+        if not hasattr(ast, "TypeAlias"):
+            return
+
+        findings = scan_repo_code(
+            {
+                "alias_package/consumer.py": """
+                    from .provider import NativePostStepCall
+                """,
+                "alias_package/provider.py": """
+                    type NativePostStepCall = int
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert len(l012) == 0
+
+    def test_repo_pep695_type_alias_does_not_hide_missing_import(self):
+        if not hasattr(ast, "TypeAlias"):
+            return
+
+        findings = scan_repo_code(
+            {
+                "alias_package/consumer.py": """
+                    from .provider import MissingPostStepCall
+                """,
+                "alias_package/provider.py": """
+                    type NativePostStepCall = int
+                """,
+            }
+        )
+
+        l012 = [f for f in findings if f["rule_id"] == "SKY-L012"]
+        assert [finding["name"] for finding in l012] == ["MissingPostStepCall"]
+
     def test_repo_dynamic_module_not_flagged(self):
         findings = scan_repo_code(
             {


### PR DESCRIPTION
Fixes #659

## Summary

  - Recognize PEP 695 type Name = ... declarations as valid module members.
  - Prevent FPs SKY-L012 findings when importing these aliases.

  ## Tests

  - `pytest -q test/test_vibe_rules.py test/test_python_api_hallucination.py`

