### PR TITLE
fix(cli): render AI defects in rich output

### DIFF
--- a/skylos/ui/rich_report.py
+++ b/skylos/ui/rich_report.py
@@ -523,6 +523,7 @@ def _render_result_tree(console: Console, result, root_path=None):
     _add_unused(result.get("unused_parameters"), "parameter")
 
     _add_findings(result.get("danger"), "security", default_sev="high")
+    _add_findings(result.get("ai_defects"), "AI defect", default_sev="medium")
     _add_findings(result.get("secrets"), "secret", default_sev="high")
     _add_findings(result.get("quality"), "quality", default_sev="medium")
     _add_findings(
@@ -599,6 +600,58 @@ def _verification_label(verdict):
     if verdict == "UNKNOWN":
         return "[warn]UNKNOWN[/warn]"
     return "-"
+
+
+def _render_ai_defects(console: Console, root_path, limit, items):
+    if not items:
+        return
+
+    console.rule("[bold magenta]AI Defects")
+
+    table = Table(expand=True)
+    table.add_column("#", style="muted", width=3)
+    table.add_column("Defect", style="yellow", width=18)
+    table.add_column("Severity", width=8)
+    table.add_column("Message", overflow="fold")
+    table.add_column("Location", style="muted", width=18, overflow="fold")
+
+    show, overflow = _display_cap(items, limit)
+    for i, defect in enumerate(show, 1):
+        rule_id = str(defect.get("rule_id") or "UNKNOWN")
+        defect_name = str(_display_rule_name(rule_id))
+        defect_cell = f"{escape(defect_name)}\n[dim]{escape(rule_id)}[/dim]"
+        severity = str(defect.get("severity") or "UNKNOWN").title()
+        message = str(defect.get("message") or "AI defect detected")
+        short = _shorten_path(defect.get("file"), root_path)
+        location = f"{short}:{defect.get('line', '?')}"
+        symbol = (
+            defect.get("symbol")
+            or defect.get("name")
+            or defect.get("simple_name")
+            or "<module>"
+        )
+        message_cell = escape(message)
+        if symbol != "<module>":
+            message_cell += f"\n[muted]Symbol: {escape(str(symbol))}[/muted]"
+        table.add_row(
+            str(i),
+            defect_cell,
+            escape(severity),
+            message_cell,
+            escape(location),
+        )
+
+    console.print(table)
+    if overflow:
+        console.print(
+            f"  [muted]... and {overflow} more (use --limit to adjust)[/muted]"
+        )
+    console.print(
+        "[muted]Defect — the evidence-backed AI-code failure mode and rule ID.[/muted]\n"
+        "[muted]Severity — impact level: Critical > High > Medium > Low.[/muted]\n"
+        "[muted]Message — the defect evidence and affected symbol, when available.[/muted]\n"
+        + _RESULTS_DOCS_LINK
+    )
 
 
 def _render_danger(console: Console, root_path, limit, items):
@@ -742,6 +795,7 @@ def render_results(
                 ),
                 _results_pill("Unused vars", len(result.get("unused_variables", []))),
                 _results_pill("Unused classes", len(result.get("unused_classes", []))),
+                _results_pill("AI defects", len(result.get("ai_defects", []) or [])),
                 _results_pill(
                     "Quality", len(result.get("quality", []) or []), bad_style="warn"
                 ),
@@ -828,6 +882,9 @@ def render_results(
         )
         _render_secrets(console, root_path, limit, result.get("secrets", []) or [])
         _render_danger(console, root_path, limit, result.get("danger", []) or [])
+        _render_ai_defects(
+            console, root_path, limit, result.get("ai_defects", []) or []
+        )
         _render_quality(console, limit, result.get("quality", []) or [])
         _render_circular_deps(
             console, limit, result.get("circular_dependencies", []) or []

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
+from io import StringIO
+
 import pytest
 import json
 import logging
 from unittest.mock import Mock, patch
 import sys
 import types
+from rich.console import Console
 from rich.table import Table
 from rich.tree import Tree as RichTree
 import skylos.cli as cli
@@ -759,6 +762,137 @@ def test_llm_report_code_block_handles_unreadable_file(tmp_path, monkeypatch):
     monkeypatch.setattr(cli.pathlib.Path, "read_text", fail_read_text)
 
     assert cli._llm_report_code_block(str(src), 1, tmp_path, {}) == ""
+
+
+def test_render_results_includes_ai_defect_summary_and_table():
+    console = Mock()
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_parameters": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "quality": [],
+        "danger": [],
+        "secrets": [],
+        "ai_defects": [
+            {
+                "rule_id": "SKY-L012",
+                "severity": "CRITICAL",
+                "message": "Call to a missing local helper",
+                "file": "/root/app/views.py",
+                "line": 5,
+                "name": "security.require_auth",
+            }
+        ],
+    }
+
+    cli.render_results(console, result, tree=False, root_path="/root")
+
+    printed = "\n".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "AI defects: 1" in printed
+    console.rule.assert_any_call("[bold magenta]AI Defects")
+
+    tables = [
+        call.args[0]
+        for call in console.print.call_args_list
+        if call.args and isinstance(call.args[0], Table)
+    ]
+    ai_table = next(
+        table
+        for table in tables
+        if any(col.header == "Defect" for col in table.columns)
+    )
+    columns = {column.header: list(column._cells) for column in ai_table.columns}
+
+    assert "SKY-L012" in columns["Defect"][0]
+    assert columns["Severity"] == ["Critical"]
+    assert "Call to a missing local helper" in columns["Message"][0]
+    assert "security.require_auth" in columns["Message"][0]
+    assert columns["Location"] == ["/root/app/views.py:5"]
+
+
+def test_render_results_ai_defect_message_is_visible_at_narrow_terminal_width():
+    output = StringIO()
+    console = Console(
+        file=output,
+        force_terminal=False,
+        color_system=None,
+        width=80,
+        theme=cli._skylos_console_theme(),
+    )
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "ai_defects": [
+            {
+                "rule_id": "SKY-L012",
+                "severity": "CRITICAL",
+                "message": "Call to a missing local helper",
+                "file": "/root/app/views.py",
+                "line": 5,
+                "name": "security.require_auth",
+            }
+        ],
+    }
+
+    cli.render_results(
+        console,
+        result,
+        tree=False,
+        root_path="/root",
+        copy_badge=False,
+    )
+
+    rendered = output.getvalue()
+    assert "AI Defects" in rendered
+    assert "Call to a missing" in rendered
+    assert "local helper" in rendered
+    assert "security.require_" in rendered
+
+
+def test_render_results_tree_mode_includes_ai_defects():
+    console = Mock()
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_parameters": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "quality": [],
+        "danger": [],
+        "secrets": [],
+        "ai_defects": [
+            {
+                "rule_id": "SKY-A103",
+                "severity": "HIGH",
+                "message": "Workflow permissions expanded",
+                "file": "/root/.github/workflows/ci.yml",
+                "line": 9,
+            }
+        ],
+    }
+
+    cli.render_results(console, result, tree=True, root_path="/root")
+
+    tree = next(
+        call.args[0]
+        for call in console.print.call_args_list
+        if call.args and isinstance(call.args[0], RichTree)
+    )
+    finding_labels = [
+        str(finding.label)
+        for file_node in tree.children
+        for finding in file_node.children
+    ]
+
+    assert any(
+        "SKY-A103" in label and "Workflow permissions expanded" in label
+        for label in finding_labels
+    )
 
 
 def test_render_results_unused_table_includes_confidence_column_and_formats():


### PR DESCRIPTION
Fixes #668

 ## Summary

  - Added `AI defects` count to rich output summaries
  - Render findings in dedicated table with rule, severity, message, symbol, and location
  - Include AI defects in rich `--tree` output

  ## Testing

  - `pytest -q test/test_cli*.py`