### PR TITLE
feat(cli): add optional Ruff lint command

### DIFF
--- a/.agents/skills/skylos/references/cli.md
+++ b/.agents/skills/skylos/references/cli.md
@@ -7,6 +7,7 @@ Use this reference when running Skylos or interpreting CLI output.
 ```bash
 pip install -e .
 pip install -e ".[llm]"
+pip install -e ".[lint]"
 pip install -e ".[all]"
 skylos --version
 skylos doctor
@@ -113,5 +114,8 @@ only new findings.
 - `skylos cicd init`: generate CI workflow.
 - `skylos baseline .`: save current findings baseline.
 - `skylos clean`: interactively remove or comment dead code.
+- `skylos lint [path ...] [Ruff options]`: run optional Ruff Python linting;
+  install with `skylos[lint]`. Arguments are forwarded to `ruff check`, with
+  `.` used when no arguments are supplied.
 - `skylos cache stats|clear`: manage cache data.
 - `skylos doctor`: installation health check.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Need more commands? Read the [CLI Reference](https://docs.skylos.dev/cli-referen
 | First dead-code scan | `skylos .` | Finds unused functions, classes, imports, files, and framework entrypoint mistakes | [Dead code docs](https://docs.skylos.dev/dead-code-detection) |
 | Deterministic cleanup preview | `skylos clean . --dry-run --types import,function --confidence 80` | Shows safe import/function removals before writing; add `--apply` to edit files | [Dead code docs](https://docs.skylos.dev/dead-code-detection) |
 | Security and quality audit | `skylos . -a` | Adds dangerous flow, secrets, dependency, config, quality, and AI-defect checks | [Security docs](https://docs.skylos.dev/security-analysis) |
+| Optional Python linting | `pip install "skylos[lint]" && skylos lint .` | Runs Ruff with its native configuration, output, fixes, and exit codes through the Skylos CLI | [Python linting](./docs/python-linting.md) |
 | PR gate | `skylos cicd init` | Generates a GitHub Actions workflow with annotations and failure thresholds | [CI/CD guide](https://docs.skylos.dev/ci-cd) |
 | Readable terminal report | `skylos . --format pretty` | Groups findings by file with severity badges, snippets, and copyable `file:line` locations | [CLI output modes](./docs/cli-output.md) |
 | Selectable terminal triage | `skylos . --tui` | Opens a keyboard-driven category list, finding list, and detail pane | [CLI output modes](./docs/cli-output.md) |
@@ -333,6 +334,9 @@ pip install skylos
 # LLM-powered agent workflows
 pip install "skylos[llm]"
 
+# Ruff Python linting through `skylos lint`
+pip install "skylos[lint]"
+
 # All published optional extras
 pip install "skylos[all]"
 ```
@@ -496,6 +500,7 @@ A local Astronomer scan on April 26, 2026 computed 420 stargazers and returned
 | GitHub Action | [GitHub Action](./action.yml) | PR gates, annotations, and CI enforcement |
 | VS Code extension | [VS Code extension](./editors/vscode/README.md) | in-editor findings and AI-assisted fixes |
 | MCP server | [MCP setup](https://docs.skylos.dev/mcp-server) | expose Skylos scans to AI agents and coding assistants |
+| Ruff | [Python linting](./docs/python-linting.md) | optional Python linting through `skylos lint` |
 | Docker image | [Installation](https://docs.skylos.dev/installation) | run Skylos without a local Python install |
 | Skylos Cloud | [Cloud workflow](https://docs.skylos.dev/cloud-workflow) | optional upload and dashboard workflows |
 
@@ -517,6 +522,7 @@ metadata, and supports monorepo subprojects through `--scan-path`.
 | First scan and core workflows | [Quick Start](https://docs.skylos.dev/quick-start) |
 | CLI commands, flags, and examples | [CLI Reference](https://docs.skylos.dev/cli-reference) |
 | CLI output modes, pretty reports, and TUI controls | [CLI Output Modes](./docs/cli-output.md) |
+| Optional Ruff linting through the Skylos CLI | [Python Linting](./docs/python-linting.md) |
 | CI setup, PR gates, annotations, and branch protection | [CI/CD](https://docs.skylos.dev/ci-cd) |
 | Dead-code behavior and framework awareness | [Dead Code Detection](https://docs.skylos.dev/dead-code-detection) |
 | Security scanning and taint analysis | [Security Analysis](https://docs.skylos.dev/security-analysis) |
@@ -548,6 +554,12 @@ dead code, security, secrets, quality, and AI-defect checks.
 
 No. Core static analysis runs locally without API keys. LLM features are
 optional through `skylos[llm]` and agent commands.
+
+**Does Skylos replace Ruff?**
+
+No. `skylos lint` is an optional convenience entry point that delegates to
+Ruff. Install it with `pip install "skylos[lint]"`; normal Skylos scans do not
+run Ruff or merge Ruff violations into `SKY-*` findings.
 
 **Can I use it only on changed code?**
 

--- a/dictionary.md
+++ b/dictionary.md
@@ -33,6 +33,7 @@ Rule IDs use a stable public prefix:
 | Local-first | Core static analysis runs on the developer machine or CI runner without requiring cloud upload or LLM calls. |
 | Core scan | `skylos .`; dead-code focused scan. |
 | Full audit | `skylos . -a`; enables security, secrets, dependency, quality, and AI-defect checks in addition to dead code. |
+| Ruff lint integration | `skylos lint`; optional Python-only delegation to `ruff check` with native Ruff configuration, output, fixes, and exit codes. Install with `skylos[lint]`; it is not part of normal Skylos scans. |
 | Dead code | Unused functions, classes, imports, variables, parameters, files, unnecessary exports, and unreachable code. |
 | Security / danger | Potentially exploitable code paths such as injection, SSRF, path traversal, weak crypto, unsafe deserialization, and CI/CD supply-chain risk. |
 | Secrets | Hardcoded credentials, tokens, API keys, and client-side exposure of server-only values. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This repository keeps lightweight local docs for features that need examples clo
 |:---|:---|
 | Generated codebase navigator for contributors | [Skylos Repo Map](./repo-map/index.html) |
 | CLI output modes, pretty reports, and TUI controls | [CLI Output Modes](./cli-output.md) |
+| Optional Ruff Python linting through the Skylos CLI | [Python Linting](./python-linting.md) |
 | Deterministic AI-code verification coverage and language support | [AI Code Verification](./ai-code-verification.md) |
 | Local contracts for verifying AI-written code | [AI Hallucination Contracts](./ai-hallucination-contracts.md) |
 | Pre-deployment agent verification, evidence reports, and attestation | [Agent Verification](./agent-verification.md) |

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -94,6 +94,7 @@ Mehr Befehle stehen in der [CLI Reference](https://docs.skylos.dev/cli-reference
 |:---|:---|:---|:---|
 | Erster Dead-Code-Scan | `skylos .` | Findet ungenutzte Funktionen, Klassen, Imports, Dateien und Fehler bei Framework-Entrypoints | [Dead-code docs](https://docs.skylos.dev/dead-code-detection) |
 | Security- und Quality-Audit | `skylos . -a` | Aktiviert gefährliche Datenflüsse, Secrets, Dependencies und Quality-Prüfungen | [Security docs](https://docs.skylos.dev/security-analysis) |
+| Optionales Python-Linting | `pip install "skylos[lint]" && skylos lint .` | Führt Ruff mit nativer Konfiguration, Ausgabe, Fixes und Exit-Codes über die Skylos-CLI aus | [Python linting](../python-linting.md) |
 | PR-Gate | `skylos cicd init` | Erzeugt einen GitHub-Actions-Workflow mit Annotationen und Failure-Thresholds | [CI/CD guide](https://docs.skylos.dev/ci-cd) |
 | Lesbarer Terminalreport | `skylos . --format pretty` | Gruppiert Findings nach Datei, mit Severity, Snippets und kopierbaren `file:line`-Positionen | [CLI output modes](../cli-output.md) |
 | Interaktive Terminaltriage | `skylos . --tui` | Öffnet eine tastaturgesteuerte Ansicht für Kategorien, Findings und Details | [CLI output modes](../cli-output.md) |
@@ -146,6 +147,9 @@ pip install skylos
 
 # LLM-gestützte Agent-Workflows
 pip install "skylos[llm]"
+
+# Ruff-Python-Linting über `skylos lint`
+pip install "skylos[lint]"
 
 # Alle veröffentlichten optionalen Extras
 pip install "skylos[all]"
@@ -273,6 +277,7 @@ Branch-Metadaten und unterstützt Monorepo-Subprojekte über `--scan-path`.
 | Erster Scan und Kernworkflows | [Quick Start](https://docs.skylos.dev/quick-start) |
 | CLI-Befehle, Flags und Beispiele | [CLI Reference](https://docs.skylos.dev/cli-reference) |
 | CLI-Ausgabemodi, Pretty Reports und TUI-Steuerung | [CLI Output Modes](../cli-output.md) |
+| Optionales Ruff-Linting über die Skylos-CLI | [Python Linting](../python-linting.md) |
 | CI-Setup, PR-Gates, Annotationen und Branch Protection | [CI/CD](https://docs.skylos.dev/ci-cd) |
 | Dead-Code-Verhalten und Framework-Awareness | [Dead Code Detection](https://docs.skylos.dev/dead-code-detection) |
 | Security-Scanning und Taint-Analyse | [Security Analysis](https://docs.skylos.dev/security-analysis) |
@@ -304,6 +309,12 @@ kombinierten Workflow für Dead Code, Security, Secrets und Quality.
 
 Nein. Die Kernanalyse läuft lokal ohne API Keys. LLM-Funktionen sind optional
 über `skylos[llm]` und Agent-Befehle.
+
+**Ersetzt Skylos Ruff?**
+
+Nein. `skylos lint` ist ein optionaler Einstiegspunkt, der an Ruff delegiert.
+Die Installation erfolgt mit `pip install "skylos[lint]"`; normale
+Skylos-Scans führen Ruff nicht aus.
 
 **Kann ich nur geänderten Code prüfen?**
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -58,6 +58,7 @@ git push
 |:---|:---|:---|:---|
 | 第一次死代码扫描 | `skylos .` | 发现未使用的函数、类、导入、文件和框架入口点问题 | [死代码文档](https://docs.skylos.dev/dead-code-detection) |
 | 安全与质量审计 | `skylos . -a` | 增加危险数据流、密钥、依赖和质量检查 | [安全文档](https://docs.skylos.dev/security-analysis) |
+| 可选 Python lint | `pip install "skylos[lint]" && skylos lint .` | 通过 Skylos CLI 运行 Ruff，并保留其原生配置、输出、修复和退出码 | [Python linting](../python-linting.md) |
 | PR 门控 | `skylos cicd init` | 生成带注释和失败阈值的 GitHub Actions 工作流 | [CI/CD 指南](https://docs.skylos.dev/ci-cd) |
 | 更易读的终端报告 | `skylos . --format pretty` | 按文件分组展示发现，包含严重级别标记、代码片段和可复制的 `file:line` 位置 | [CLI Output Modes](../cli-output.md) |
 | 可选择的终端界面 | `skylos . --tui` | 打开键盘驱动的分类列表、发现列表和详情面板 | [CLI Output Modes](../cli-output.md) |
@@ -96,6 +97,9 @@ pip install skylos
 
 # LLM Agent 工作流
 pip install "skylos[llm]"
+
+# 通过 `skylos lint` 使用 Ruff Python lint
+pip install "skylos[lint]"
 
 # 所有已发布的可选 extras
 pip install "skylos[all]"
@@ -183,6 +187,7 @@ Skylos 辅助的死代码清理 PR 已被
 | 第一次扫描和核心工作流 | [Quick Start](https://docs.skylos.dev/quick-start) |
 | CLI 命令、flags 和示例 | [CLI Reference](https://docs.skylos.dev/cli-reference) |
 | CLI 输出模式、pretty 报告和 TUI 快捷键 | [CLI Output Modes](../cli-output.md) |
+| 通过 Skylos CLI 使用可选 Ruff lint | [Python Linting](../python-linting.md) |
 | CI 设置、PR 门控、注释和分支保护 | [CI/CD](https://docs.skylos.dev/ci-cd) |
 | 死代码行为和框架感知 | [Dead Code Detection](https://docs.skylos.dev/dead-code-detection) |
 | 安全扫描和污点分析 | [Security Analysis](https://docs.skylos.dev/security-analysis) |
@@ -209,6 +214,11 @@ Skylos 辅助的死代码清理 PR 已被
 **Skylos 需要 LLM 吗？**
 
 不需要。核心静态分析在本地运行，不需要 API key。LLM 功能是可选的，通过 `skylos[llm]` 和 agent 命令使用。
+
+**Skylos 会替代 Ruff 吗？**
+
+不会。`skylos lint` 是一个委托给 Ruff 的可选命令入口。使用
+`pip install "skylos[lint]"` 安装；普通 Skylos 扫描不会运行 Ruff。
 
 **可以只扫描变更代码吗？**
 

--- a/docs/python-linting.md
+++ b/docs/python-linting.md
@@ -1,0 +1,68 @@
+# Python Linting With Ruff
+
+Skylos can run [Ruff](https://docs.astral.sh/ruff/) through the same `skylos`
+CLI used for repository analysis. Ruff remains an optional dependency, so the
+core Skylos install stays focused on its multi-language analyzers.
+
+## Install
+
+```bash
+pip install "skylos[lint]"
+```
+
+The `all` extra also includes lint support:
+
+```bash
+pip install "skylos[all]"
+```
+
+## Run
+
+Lint the current directory:
+
+```bash
+skylos lint
+```
+
+Pass paths and Ruff `check` options after `lint`:
+
+```bash
+skylos lint src test
+skylos lint src --select E,F,I
+skylos lint . --fix
+skylos lint . --diff
+```
+
+With no arguments, Skylos invokes `ruff check .`. Other than the top-level
+`-h` / `--help` flags, which display Skylos wrapper help, it forwards the
+arguments unchanged to `ruff check` using the Python environment that runs
+Skylos. It does not use a shell.
+
+## Configuration And Exit Codes
+
+Ruff continues to discover configuration from `pyproject.toml`, `ruff.toml`,
+or `.ruff.toml`. Skylos does not translate Ruff rules into `SKY-*` findings or
+merge them into Skylos reports.
+
+The command preserves Ruff's output and exit code:
+
+| Exit code | Meaning |
+|:---|:---|
+| `0` | No lint violations remain |
+| `1` | Lint violations were found |
+| `2` | Ruff could not run because of invalid options, configuration, or another error |
+
+This means existing CI checks can replace `ruff check ...` with
+`skylos lint ...` without changing their pass/fail behavior.
+
+## Relationship To Skylos Analysis
+
+`skylos lint` is a convenience entry point for Ruff's fast Python lint rules.
+It is separate from `skylos .` and `skylos . -a`, which cover Skylos dead
+code, security, secrets, dependency, quality, and AI-defect analysis across
+multiple languages. Installing the `lint` extra does not make Ruff run during
+a normal Skylos scan.
+
+For all Ruff options and configuration behavior, see the
+[Ruff linter documentation](https://docs.astral.sh/ruff/linter/) and
+[Ruff configuration documentation](https://docs.astral.sh/ruff/configuration/).

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>977</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9214</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>979</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>9238</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 279</span>
+          <span class="pill"><strong>symbols</strong> 282</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -1119,8 +1119,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/commands" rel="noopener noreferrer">skylos/commands</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 29</span>
-          <span class="pill"><strong>symbols</strong> 214</span>
+          <span class="pill"><strong>files</strong> 30</span>
+          <span class="pill"><strong>symbols</strong> 216</span>
         </div>
       </div>
       <p>Command modules used by the CLI for focused command behavior.</p>
@@ -1760,7 +1760,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 101</span>
-          <span class="pill"><strong>symbols</strong> 1090</span>
+          <span class="pill"><strong>symbols</strong> 1092</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, AI-defect, config, edge, CI/CD, and SCA findings.</p>
@@ -1889,12 +1889,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/ui terminal ui and presentation helpers. use this when the scan is correct but terminal interaction is confusing. skylos/ui/ test/test_suite.py test/test_tui.py skylos/ui/terminal_report.py skylos/ui/rich_report.py skylos/ui/tui.py skylos/ui/dead_code_evidence.py skylos/ui/nudge.py skylos/ui/help.py skylos/ui/tour.py skylos/ui/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/ui terminal ui and presentation helpers. use this when the scan is correct but terminal interaction is confusing. skylos/ui/ test/test_suite.py test/test_tui.py skylos/ui/rich_report.py skylos/ui/terminal_report.py skylos/ui/tui.py skylos/ui/dead_code_evidence.py skylos/ui/nudge.py skylos/ui/help.py skylos/ui/tour.py skylos/ui/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 8</span>
-          <span class="pill"><strong>symbols</strong> 78</span>
+          <span class="pill"><strong>symbols</strong> 79</span>
         </div>
       </div>
       <p>Terminal UI and presentation helpers.</p>
@@ -1908,8 +1908,8 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">skylos/ui/terminal_report.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">skylos/ui/rich_report.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">skylos/ui/rich_report.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">skylos/ui/terminal_report.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">skylos/ui/tui.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/dead_code_evidence.py" rel="noopener noreferrer">skylos/ui/dead_code_evidence.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/nudge.py" rel="noopener noreferrer">skylos/ui/nudge.py</a></li>
@@ -1919,16 +1919,16 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">PrettyFinding</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">render_pretty_results</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">collect_pretty_findings</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">_make_pretty_finding</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">_print_finding</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">render_results</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">render_results</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_shorten_path</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_results_pill</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_grep_verify_pill</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/rich_report.py" rel="noopener noreferrer">_dead_code_evidence_pill</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">PrettyFinding</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">render_pretty_results</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">collect_pretty_findings</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">_make_pretty_finding</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/terminal_report.py" rel="noopener noreferrer">_print_finding</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">prepare_category_data</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">CategoryItem</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui/tui.py" rel="noopener noreferrer">FindingItem</a> <span>class</span></li>
@@ -1989,12 +1989,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_behavior_benchmark.py test/test_agent_behavior_cli.py test/test_agent_behavior_contract.py test/test_agent_behavior_evaluator.py test/test_java_security.py test/test_verify_orchestrator.py test/test_debt.py test/test_cli_refactor_guardrails.py test/test_audit_processor.py test/test_dangerous.py test/test_cli.py test/test_sync.py">
+    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_behavior_benchmark.py test/test_agent_behavior_cli.py test/test_agent_behavior_contract.py test/test_agent_behavior_evaluator.py test/test_java_security.py test/test_verify_orchestrator.py test/test_cli_refactor_guardrails.py test/test_debt.py test/test_audit_processor.py test/test_dangerous.py test/test_cli.py test/test_sync.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 239</span>
-          <span class="pill"><strong>symbols</strong> 3399</span>
+          <span class="pill"><strong>files</strong> 240</span>
+          <span class="pill"><strong>symbols</strong> 3415</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2010,8 +2010,8 @@
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_audit_processor.py" rel="noopener noreferrer">test/test_audit_processor.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_dangerous.py" rel="noopener noreferrer">test/test_dangerous.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></li>
@@ -2029,10 +2029,10 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">sample_defs_map</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">sample_source_cache</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">survivor_with_heuristic</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_collect_debt_signals_maps_dimensions_and_dead_code</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_collect_debt_signals_skips_paths_outside_project_root</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_god_file_signal_becomes_modularity_debt_hotspot</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test_collect_debt_signals_filters_to_changed_files</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test_cli_public_entrypoint_stays_compatibility_facade</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test_cli_grade_render_only_shows_scanned_categories</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test_cli_guardrail_overview_dispatch_exits_zero</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test_cli_guardrail_commands_dispatch_exits_zero</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -2049,21 +2049,21 @@
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>34 / 154</td>
+              <td>34 / 155</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3 / 39</td>
-              <td><span class="warn">shared path</span></td>
+              <td>3 / 40</td>
+              <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/config.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/config.py" rel="noopener noreferrer">skylos/config.py</a></td>
-              <td>10 / 38</td>
+              <td>11 / 39</td>
               <td><span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -2103,6 +2103,13 @@
               <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
             </tr>
 
+            <tr class="searchable" data-search="test/test_cli_refactor_guardrails.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></td>
+              <td>68 / 73</td>
+              <td><span class="warn">many symbols</span></td>
+              <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
+            </tr>
+
             <tr class="searchable" data-search="test/test_debt.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_debt.py" rel="noopener noreferrer">test/test_debt.py</a></td>
               <td>70 / 73</td>
@@ -2115,13 +2122,6 @@
               <td>3 / 72</td>
               <td><span class="warn">many symbols</span></td>
               <td>Deep-audit candidate selection, processing, redaction, export, and revalidation.</td>
-            </tr>
-
-            <tr class="searchable" data-search="test/test_cli_refactor_guardrails.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli_refactor_guardrails.py" rel="noopener noreferrer">test/test_cli_refactor_guardrails.py</a></td>
-              <td>66 / 71</td>
-              <td><span class="warn">many symbols</span></td>
-              <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/rules/config/cicd/github_actions.py rule catalog and concrete rule implementations for quality, security, ai-defect, config, edge, ci/cd, and sca findings.">
@@ -6620,6 +6620,13 @@
               <td>skylos/analyzer.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_finding_is_inline_ignored def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_finding_is_inline_ignored</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_extend_unsuppressed_danger_findings def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_extend_unsuppressed_danger_findings</a></td>
               <td>def</td>
@@ -8442,13 +8449,6 @@
 
             <tr class="searchable" data-search="_get_sarif_exporter_class def skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_get_sarif_exporter_class</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_ensure_llm_support def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_ensure_llm_support</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,14 @@ Discord = "https://discord.gg/Ftn9t9tErf"
 
 [project.optional-dependencies]
 llm = ["litellm>=1.84.0,<1.85.0", "aiohttp>=3.14.0"]
+lint = ["ruff>=0.15.0"]
 test = ["pytest>=9.0.2"]
-all = ["pytest>=9.0.2", "litellm>=1.84.0,<1.85.0", "aiohttp>=3.14.0"]
+all = [
+    "pytest>=9.0.2",
+    "litellm>=1.84.0,<1.85.0",
+    "aiohttp>=3.14.0",
+    "ruff>=0.15.0",
+]
 
 [project.scripts]
 skylos = "skylos.cli:main"

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1467,6 +1467,12 @@ def _run_clean_command(argv):
     return run_clean_command(argv)
 
 
+def _run_lint_command(argv):
+    from skylos.commands.lint_cmd import run_lint_command
+
+    return run_lint_command(argv)
+
+
 def _run_cache_command(argv):
     from skylos.commands.cache_cmd import run_cache_command
 

--- a/skylos/cli_core/dispatch.py
+++ b/skylos/cli_core/dispatch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 
 from rich.console import Console
+from rich.markup import escape
 
 
 EARLY_COMMAND_HANDLERS = {
@@ -15,6 +16,7 @@ EARLY_COMMAND_HANDLERS = {
     "badge": "_run_badge_command",
     "whitelist": "_run_whitelist_command",
     "clean": "_run_clean_command",
+    "lint": "_run_lint_command",
     "cache": "_run_cache_command",
     "contract": "_handle_contract_command",
     "doctor": "_run_doctor_command",
@@ -60,11 +62,11 @@ def run_early_command_help(
 
     console.print("[bold]Usage:[/bold]")
     for item in matches:
-        console.print(f"  {item['name']}")
+        console.print(f"  {escape(item['name'])}")
 
     console.print("\n[bold]Description:[/bold]")
     for item in matches:
-        console.print(f"  {item['desc']}")
+        console.print(f"  {escape(item['desc'])}")
 
     detail_lines = []
     for item in matches:
@@ -73,7 +75,7 @@ def run_early_command_help(
     if detail_lines:
         console.print("\n[bold]Options:[/bold]")
         for detail in detail_lines:
-            console.print(f"  {detail}")
+            console.print(f"  {escape(detail)}")
 
     console.print("\nRun [bold]skylos commands[/bold] for all commands.")
     return 0

--- a/skylos/commands/lint_cmd.py
+++ b/skylos/commands/lint_cmd.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+
+from rich.console import Console
+from rich.markup import escape
+
+
+def _ruff_is_available(find_spec_func: Callable[[str], object | None]) -> bool:
+    try:
+        return find_spec_func("ruff") is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
+def run_lint_command(
+    argv: Sequence[str],
+    *,
+    console_factory: Callable[[], Console] = Console,
+    find_spec_func: Callable[[str], object | None] = importlib.util.find_spec,
+    run_func: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+    executable: str | None = None,
+) -> int:
+    """Run Ruff with arguments passed as a list, never through a shell."""
+    console = console_factory()
+    if not _ruff_is_available(find_spec_func):
+        console.print("[bold red]Ruff is not installed.[/bold red]")
+        install_command = escape('pip install "skylos[lint]"')
+        console.print(f"Install lint support with: [bold]{install_command}[/bold]")
+        return 2
+
+    command = [
+        executable or sys.executable,
+        "-m",
+        "ruff",
+        "check",
+        *(list(argv) if argv else ["."]),
+    ]
+    try:
+        completed = run_func(command, check=False)
+    except OSError as exc:
+        console.print(f"[bold red]Could not start Ruff:[/bold red] {exc}")
+        return 2
+
+    return int(completed.returncode)

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -12,6 +12,17 @@ COMMANDS = [
         "group": "Core Analysis",
     },
     {
+        "name": "skylos lint [path ...] [Ruff options]",
+        "desc": "Run Ruff Python linting through Skylos",
+        "details": [
+            "Arguments are forwarded to `ruff check`; the default path is `.`",
+            'Install support with: pip install "skylos[lint]"',
+            "Ruff configuration is read from pyproject.toml, ruff.toml, or .ruff.toml",
+            "Exit codes are preserved: 0 clean, 1 findings, 2 error",
+        ],
+        "group": "Core Analysis",
+    },
+    {
         "name": "skylos verify <path>",
         "desc": "Verify changed code for AI-code defects",
         "group": "AI Agent",

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -298,6 +298,40 @@ def test_cli_guardrail_clean_dispatch_preserves_argv(monkeypatch):
     mock_clean.assert_called_once_with(["pkg"])
 
 
+def test_cli_guardrail_lint_dispatch_preserves_ruff_argv(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", "lint", "src", "--select", "E,F", "--no-cache"],
+    )
+
+    with (
+        patch("skylos.commands.lint_cmd.run_lint_command", return_value=1) as mock_lint,
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 1
+    mock_lint.assert_called_once_with(["src", "--select", "E,F", "--no-cache"])
+
+
+def test_cli_guardrail_lint_help_documents_optional_extra(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["skylos", "lint", "--help"])
+
+    with (
+        patch("skylos.commands.lint_cmd.run_lint_command") as mock_lint,
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    mock_lint.assert_not_called()
+    output = capsys.readouterr().out
+    assert "skylos lint [path ...] [Ruff options]" in output
+    assert 'pip install "skylos[lint]"' in output
+    assert "ruff check" in output
+
+
 def test_cli_guardrail_clean_help_lists_noninteractive_flags(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["skylos", "clean", "--help"])
 

--- a/test/test_lint_cmd.py
+++ b/test/test_lint_cmd.py
@@ -1,0 +1,100 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+from rich.console import Console
+
+from skylos.commands.lint_cmd import run_lint_command
+
+
+def test_lint_command_defaults_to_current_directory():
+    find_spec = Mock(return_value=object())
+    run = Mock(
+        return_value=subprocess.CompletedProcess(
+            args=["python", "-m", "ruff", "check", "."],
+            returncode=0,
+        )
+    )
+
+    exit_code = run_lint_command(
+        [],
+        find_spec_func=find_spec,
+        run_func=run,
+        executable="/venv/bin/python",
+    )
+
+    assert exit_code == 0
+    find_spec.assert_called_once_with("ruff")
+    run.assert_called_once_with(
+        ["/venv/bin/python", "-m", "ruff", "check", "."],
+        check=False,
+    )
+
+
+def test_lint_command_forwards_ruff_arguments_and_exit_code():
+    find_spec = Mock(return_value=object())
+    run = Mock(
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+        )
+    )
+    argv = ["src", "test", "--select", "E,F", "--no-cache"]
+
+    exit_code = run_lint_command(
+        argv,
+        find_spec_func=find_spec,
+        run_func=run,
+        executable="/venv/bin/python",
+    )
+
+    assert exit_code == 1
+    run.assert_called_once_with(
+        ["/venv/bin/python", "-m", "ruff", "check", *argv],
+        check=False,
+    )
+
+
+def test_lint_command_reports_missing_optional_extra():
+    console = Console(record=True, width=120)
+    run = Mock()
+
+    exit_code = run_lint_command(
+        ["src"],
+        find_spec_func=Mock(return_value=None),
+        run_func=run,
+        console_factory=lambda: console,
+    )
+
+    assert exit_code == 2
+    run.assert_not_called()
+    output = console.export_text()
+    assert "Ruff is not installed" in output
+    assert 'pip install "skylos[lint]"' in output
+
+
+def test_lint_command_reports_launch_failure():
+    console = Console(record=True, width=120)
+    run = Mock(side_effect=OSError("executable unavailable"))
+
+    exit_code = run_lint_command(
+        ["src"],
+        find_spec_func=Mock(return_value=object()),
+        run_func=run,
+        console_factory=lambda: console,
+        executable="/missing/python",
+    )
+
+    assert exit_code == 2
+    assert "Could not start Ruff" in console.export_text()
+
+
+def test_lint_extra_is_optional_and_included_in_all():
+    import tomllib
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    metadata = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    extras = metadata["project"]["optional-dependencies"]
+
+    assert extras["lint"] == ["ruff>=0.15.0"]
+    assert "ruff>=0.15.0" in extras["all"]

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -959,7 +959,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981, upload-time = "2024-07-31T22:39:18.854Z" }
 wheels = [
@@ -2333,6 +2333,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+]
+
+[[package]]
 name = "runs"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2368,7 +2393,7 @@ wheels = [
 
 [[package]]
 name = "skylos"
-version = "4.29.0"
+version = "4.31.1"
 source = { editable = "." }
 dependencies = [
     { name = "ca9" },
@@ -2398,6 +2423,10 @@ all = [
     { name = "aiohttp" },
     { name = "litellm" },
     { name = "pytest" },
+    { name = "ruff" },
+]
+lint = [
+    { name = "ruff" },
 ]
 llm = [
     { name = "aiohttp" },
@@ -2425,6 +2454,8 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich", specifier = ">=14.0.0" },
+    { name = "ruff", marker = "extra == 'all'", specifier = ">=0.15.0" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.15.0" },
     { name = "textual", specifier = ">=1.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
@@ -2435,7 +2466,7 @@ requires-dist = [
     { name = "tree-sitter-rust", specifier = ">=0.24.2" },
     { name = "tree-sitter-typescript", specifier = ">=0.23.2" },
 ]
-provides-extras = ["llm", "test", "all"]
+provides-extras = ["llm", "lint", "test", "all"]
 
 [[package]]
 name = "sniffio"


### PR DESCRIPTION
## Summary

  - add optional `skylos lint` command that delegates to `ruff check`
  - add `skylos[lint]` extra and include Ruff in `skylos[all]`
  - preserve Ruff arguments, configuration, output, fixes, and exit codes
  - show installation message when Ruff is unavailable

  Ruff is optional. Installing the extra does not run Ruff during normal `skylos .` or `skylos . -a` scans.

  ## Tests

 pytest test/test_cli.py test/test_cli_addopts_safety.py test/test_cli_agent_parser.py \
    test/test_cli_coverage.py test/test_cli_decorators.py test/test_cli_llm_provider.py \
    test/test_cli_precommit.py test/test_cli_refactor_guardrails.py test/test_cli_terminal_probe.py \
    test/test_cli_uncovered_paths.py test/test_lint_cmd.py test/test_terminal_report.py