### PR TITLE
fix(quality): exempt Protocol classes from cohesion checks

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>979</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9249</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>980</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>9252</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1759,8 +1759,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 101</span>
-          <span class="pill"><strong>symbols</strong> 1092</span>
+          <span class="pill"><strong>files</strong> 102</span>
+          <span class="pill"><strong>symbols</strong> 1094</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, AI-defect, config, edge, CI/CD, and SCA findings.</p>
@@ -1994,7 +1994,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 240</span>
-          <span class="pill"><strong>symbols</strong> 3422</span>
+          <span class="pill"><strong>symbols</strong> 3423</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/analysis/file_processing.py
+++ b/skylos/analysis/file_processing.py
@@ -124,7 +124,7 @@ LINTER_RULE_NODE_TYPES = {
     GodFileRule: (ast.Module,),
     GodClassRule: (ast.ClassDef,),
     CBORule: (ast.ClassDef,),
-    LCOMRule: (ast.ClassDef,),
+    LCOMRule: (ast.Module, ast.ClassDef),
     UnreachableCodeRule: (
         ast.Module,
         ast.FunctionDef,

--- a/skylos/rules/quality/_protocols.py
+++ b/skylos/rules/quality/_protocols.py
@@ -1,0 +1,67 @@
+import ast
+
+
+_PROTOCOL_MODULES = frozenset({"typing", "typing_extensions"})
+
+
+def _protocol_import_bindings(module: ast.Module) -> tuple[set[str], set[str]]:
+    protocol_names: set[str] = set()
+    protocol_modules: set[str] = set()
+
+    for stmt in module.body:
+        if isinstance(stmt, ast.ImportFrom) and stmt.module in _PROTOCOL_MODULES:
+            for imported in stmt.names:
+                if imported.name == "Protocol":
+                    protocol_names.add(imported.asname or imported.name)
+        elif isinstance(stmt, ast.Import):
+            for imported in stmt.names:
+                if imported.name in _PROTOCOL_MODULES:
+                    protocol_modules.add(imported.asname or imported.name)
+
+    return protocol_names, protocol_modules
+
+
+def _is_protocol_base(
+    base: ast.expr,
+    protocol_names: set[str],
+    protocol_modules: set[str],
+) -> bool:
+    if isinstance(base, ast.Subscript):
+        base = base.value
+    if isinstance(base, ast.Name):
+        return base.id in protocol_names
+    return (
+        isinstance(base, ast.Attribute)
+        and base.attr == "Protocol"
+        and isinstance(base.value, ast.Name)
+        and base.value.id in protocol_modules
+    )
+
+
+def _protocol_classes(module: ast.Module) -> list[ast.ClassDef]:
+    protocol_names, protocol_modules = _protocol_import_bindings(module)
+    if not protocol_names and not protocol_modules:
+        return []
+
+    return [
+        candidate
+        for candidate in ast.walk(module)
+        if isinstance(candidate, ast.ClassDef)
+        and any(
+            _is_protocol_base(base, protocol_names, protocol_modules)
+            for base in candidate.bases
+        )
+    ]
+
+
+def protocol_class_ids(module: ast.Module) -> set[int]:
+    return {id(candidate) for candidate in _protocol_classes(module)}
+
+
+def protocol_method_ids(module: ast.Module) -> set[int]:
+    return {
+        id(stmt)
+        for candidate in _protocol_classes(module)
+        for stmt in candidate.body
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }

--- a/skylos/rules/quality/cohesion.py
+++ b/skylos/rules/quality/cohesion.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from skylos.rules.base import SkylosRule
+from skylos.rules.quality._protocols import protocol_class_ids
 
 DATACLASS_DECORATORS = frozenset(
     {
@@ -354,11 +355,17 @@ class LCOMRule(SkylosRule):
     def __init__(self, low_threshold=2, high_threshold=4):
         self.low_threshold = low_threshold
         self.high_threshold = high_threshold
+        self._protocol_class_ids: set[int] = set()
 
     def visit_node(
         self, node: ast.AST, context: dict[str, Any]
     ) -> Optional[list[dict[str, Any]]]:
+        if isinstance(node, ast.Module):
+            self._protocol_class_ids = protocol_class_ids(node)
+            return None
         if not isinstance(node, ast.ClassDef):
+            return None
+        if id(node) in self._protocol_class_ids:
             return None
 
         result = analyze_cohesion(node)

--- a/skylos/rules/quality/logic_security.py
+++ b/skylos/rules/quality/logic_security.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from skylos.rules.base import SkylosRule
+from skylos.rules.quality._protocols import protocol_method_ids
 from skylos.rules.quality.logic_foundation import _string_literal_value
 from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
@@ -338,67 +339,6 @@ class DisabledSecurityRule(SkylosRule):
         return findings if findings else None
 
 
-_PROTOCOL_MODULES = {"typing", "typing_extensions"}
-
-
-def _protocol_import_bindings(module: ast.Module) -> tuple[set[str], set[str]]:
-    protocol_names: set[str] = set()
-    protocol_modules: set[str] = set()
-
-    for stmt in module.body:
-        if isinstance(stmt, ast.ImportFrom) and stmt.module in _PROTOCOL_MODULES:
-            for imported in stmt.names:
-                if imported.name == "Protocol":
-                    protocol_names.add(imported.asname or imported.name)
-        elif isinstance(stmt, ast.Import):
-            for imported in stmt.names:
-                if imported.name in _PROTOCOL_MODULES:
-                    protocol_modules.add(imported.asname or imported.name)
-
-    return protocol_names, protocol_modules
-
-
-def _is_protocol_base(
-    base: ast.expr,
-    protocol_names: set[str],
-    protocol_modules: set[str],
-) -> bool:
-    if isinstance(base, ast.Subscript):
-        base = base.value
-    if isinstance(base, ast.Name):
-        return base.id in protocol_names
-    return (
-        isinstance(base, ast.Attribute)
-        and base.attr == "Protocol"
-        and isinstance(base.value, ast.Name)
-        and base.value.id in protocol_modules
-    )
-
-
-def _protocol_method_ids(module: ast.Module) -> set[int]:
-    protocol_names, protocol_modules = _protocol_import_bindings(module)
-    if not protocol_names and not protocol_modules:
-        return set()
-
-    method_ids: set[int] = set()
-
-    for candidate in ast.walk(module):
-        if not isinstance(candidate, ast.ClassDef):
-            continue
-        if not any(
-            _is_protocol_base(base, protocol_names, protocol_modules)
-            for base in candidate.bases
-        ):
-            continue
-        method_ids.update(
-            id(stmt)
-            for stmt in candidate.body
-            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
-        )
-
-    return method_ids
-
-
 class UnfinishedGenerationRule(SkylosRule):
     rule_id = "SKY-L026"
     name = "Unfinished Generation"
@@ -408,7 +348,7 @@ class UnfinishedGenerationRule(SkylosRule):
 
     def visit_node(self, node, context):
         if isinstance(node, ast.Module):
-            self._protocol_method_ids = _protocol_method_ids(node)
+            self._protocol_method_ids = protocol_method_ids(node)
             return None
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             return None

--- a/test/test_cohesion.py
+++ b/test/test_cohesion.py
@@ -1,4 +1,9 @@
 import ast
+import json
+
+import pytest
+
+from skylos.analyzer import analyze
 from skylos.rules.quality.cohesion import LCOMRule, analyze_cohesion, _UnionFind
 
 
@@ -8,6 +13,19 @@ def _parse(code: str) -> ast.ClassDef:
         if isinstance(node, ast.ClassDef):
             return node
     raise ValueError("No class found")
+
+
+def _run_lcom_rule(code: str, **rule_kwargs) -> list[dict]:
+    tree = ast.parse(code)
+    rule = LCOMRule(**rule_kwargs)
+    context = {"filename": "test.py"}
+    rule.visit_node(tree, context)
+
+    findings = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            findings.extend(rule.visit_node(node, context) or [])
+    return findings
 
 
 class TestUnionFind:
@@ -279,3 +297,115 @@ class Config:
         node = _parse(code)
         result = rule.visit_node(node, {"filename": "test.py"})
         assert result is None
+
+    @pytest.mark.parametrize(
+        ("import_statement", "protocol_base"),
+        [
+            ("from typing import Protocol", "Protocol"),
+            ("import typing", "typing.Protocol"),
+            (
+                "from typing_extensions import Protocol as Interface",
+                "Interface",
+            ),
+            (
+                "import typing_extensions as typing_ext",
+                "typing_ext.Protocol",
+            ),
+            (
+                "from typing import Protocol",
+                "Protocol[int]",
+            ),
+        ],
+    )
+    def test_protocol_classes_exempted(self, import_statement, protocol_base):
+        code = f"""
+{import_statement}
+
+class ParentCall({protocol_base}):
+    def operation1(self) -> int: ...
+    def operation2(self) -> int: ...
+    def operation3(self) -> int: ...
+"""
+        assert _run_lcom_rule(code) == []
+
+    def test_runtime_checkable_protocol_exempted(self):
+        code = """
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class ParentCall(Protocol):
+    def operation1(self) -> int: ...
+    def operation2(self) -> int: ...
+    def operation3(self) -> int: ...
+    def operation4(self) -> int: ...
+    def operation5(self) -> int: ...
+    def operation6(self) -> int: ...
+"""
+        assert _run_lcom_rule(code) == []
+
+    def test_analyzer_exempts_runtime_checkable_protocol(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SKYLOS_JOBS", "1")
+        (tmp_path / "skylos_cohesion.py").write_text(
+            "from typing import Protocol, runtime_checkable\n"
+            "\n"
+            "@runtime_checkable\n"
+            "class ParentCall(Protocol):\n"
+            "    def operation1(self) -> int: ...\n"
+            "    def operation2(self) -> int: ...\n"
+            "    def operation3(self) -> int: ...\n"
+            "    def operation4(self) -> int: ...\n"
+            "    def operation5(self) -> int: ...\n"
+            "    def operation6(self) -> int: ...\n",
+            encoding="utf-8",
+        )
+
+        payload = json.loads(
+            analyze(str(tmp_path), enable_quality=True, grep_verify=False)
+        )
+        findings = [
+            finding
+            for finding in payload.get("quality", [])
+            if finding.get("rule_id") == "SKY-Q702"
+        ]
+
+        assert findings == []
+
+    def test_unrelated_protocol_named_base_not_exempted(self):
+        code = """
+class Protocol:
+    pass
+
+class ParentCall(Protocol):
+    def operation1(self):
+        self.a = 1
+
+    def operation2(self):
+        self.b = 2
+
+    def operation3(self):
+        self.c = 3
+"""
+        findings = _run_lcom_rule(code)
+        assert [finding["name"] for finding in findings] == ["ParentCall"]
+
+    def test_protocol_subclass_not_exempted(self):
+        code = """
+from typing import Protocol
+
+class ParentCall(Protocol):
+    def operation1(self) -> int: ...
+    def operation2(self) -> int: ...
+    def operation3(self) -> int: ...
+
+class ConcreteParentCall(ParentCall):
+    def operation1(self):
+        self.a = 1
+
+    def operation2(self):
+        self.b = 2
+
+    def operation3(self):
+        self.c = 3
+"""
+        findings = _run_lcom_rule(code)
+        assert [finding["name"] for finding in findings] == ["ConcreteParentCall"]


### PR DESCRIPTION
Fixes #670

## Summary

  - Exempt genuine PEP 544 protocol declarations from `SKY-Q702`
  - Support protocols imported from `typing` and `typing_extensions`
  - Share protocol detection with the existing unfinished-generation rule

  ## Tests

  - pytest test/test_cohesion.py test/test_vibe_rules.py test/test_quality_rules.py \
test/test_quality_new_rules.py test/test_good_practices_rules.py test/test_quality_standards.py \
test/test_concurrency_quality.py test/test_community_rules.py test/test_ai_pr_diff_rules.py \
test/test_rules_cmd.py
