### PR TITLE
fix(cli): enable SKY-D223 when explicitly selected

### DIFF
--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1486,6 +1486,9 @@ _RULE_SELECTION_ANALYSIS_CATEGORY_OVERRIDES = {
     "SKY-U005": "quality",
     "SKY-UC001": "quality",
     "SKY-UC002": "quality",
+    # D223 is presented as a security finding, but dependency declaration
+    # analysis runs in the AI-defect phase.
+    "SKY-D223": "ai_defect",
     # Generic normalized IDs are not first-class catalog entries.
     "SKY-AI000": "ai_defect",
     "SKY-D000": "security",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -798,6 +798,23 @@ def test_selected_rule_analysis_flags_use_catalog_categories_not_prefixes():
     assert args.danger is False
 
 
+def test_selected_d223_enables_its_ai_defect_analyzer():
+    args = types.SimpleNamespace(
+        select=["SKY-D223"],
+        danger=False,
+        ai_defects=False,
+        quality=False,
+        secrets=False,
+        sca=False,
+    )
+
+    cli._apply_selected_rule_analysis_flags(args)
+
+    assert args.select == ["SKY-D223"]
+    assert args.ai_defects is True
+    assert args.danger is False
+
+
 def test_selected_reliability_rule_enables_danger_analysis():
     args = types.SimpleNamespace(
         select=["SKY-GPU001"],
@@ -2078,6 +2095,57 @@ def test_main_concise_clean_output_prints_nothing(monkeypatch):
 
     mock_print.assert_not_called()
     progress.assert_not_called()
+
+
+def test_main_select_d223_enables_ai_defect_execution_family(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "ai_defects": [
+            {
+                "rule_id": "SKY-D223",
+                "file": "app.py",
+                "line": 1,
+                "message": "undeclared dependency",
+            }
+        ],
+        "quality": [],
+        "secrets": [],
+    }
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "skylos",
+            ".",
+            "--select=SKY-D223",
+            "--format",
+            "json",
+            "--no-provenance",
+        ],
+    )
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)) as analyze,
+        patch("skylos.cli.load_config", return_value={}),
+        patch("builtins.print") as mock_print,
+    ):
+        cli.main()
+
+    assert analyze.call_args.kwargs["enable_ai_defects"] is True
+    assert analyze.call_args.kwargs["enable_danger"] is False
+    selected_result = json.loads(mock_print.call_args.args[0])
+    assert [finding["rule_id"] for finding in selected_result["ai_defects"]] == [
+        "SKY-D223"
+    ]
 
 
 def test_main_select_ai_rule_enables_family_and_filters_concise_output(monkeypatch):


### PR DESCRIPTION
Fixes #681

## Summary

  - Enable the correct analyzer family when `SKY-D223` is explicitly selected.
  - Preserve D223's existing public security classification.

  ## Problem

  `skylos --select=SKY-D223 .` previously enabled danger analysis because D223 is categorized as a security rule.

However, the D223 undeclared-dependency detector executes in the AI defect analysis phase. Therefore, detector never ran unless users also supplied `-a` or `--ai-defects`, allowing an explicitly selected rule to return a false-clean report.

  ## Fix

  Route `SKY-D223` to the ai defect execution family when resolving `--select`.

  ## Tests

  - `pytest test/test_cli.py test/test_hallucination_dependency.py`