### PR TITLE
fix(dependencies): parse pyproject metadata with TOML

### DIFF
--- a/skylos/rules/ai_defect/dependency_hallucination.py
+++ b/skylos/rules/ai_defect/dependency_hallucination.py
@@ -9,6 +9,11 @@ import urllib.request
 import urllib.error
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
 from skylos.core.safe_cache_io import (
     load_project_json_cache,
     read_text_no_symlink,
@@ -376,136 +381,86 @@ def _parse_requirements_txt(path):
     return deps
 
 
-def _extract_toml_array(txt, key):
-    pattern = re.compile(r"(?m)^\s*" + re.escape(key) + r"\s*=\s*\[")
-    match = pattern.search(txt)
-    if not match:
-        return None
+def _dependency_names(specs):
+    deps = set()
+    if not isinstance(specs, list):
+        return deps
 
-    start = match.end()
-    depth = 1
-    pos = start
-    while pos < len(txt) and depth > 0:
-        ch = txt[pos]
-        if ch == "[":
-            depth += 1
-        elif ch == "]":
-            depth -= 1
-        elif ch == '"':
-            pos += 1
-            while pos < len(txt) and txt[pos] != '"':
-                if txt[pos] == "\\":
-                    pos += 1
-                pos += 1
-        elif ch == "'":
-            pos += 1
-            while pos < len(txt) and txt[pos] != "'":
-                if txt[pos] == "\\":
-                    pos += 1
-                pos += 1
-        pos += 1
+    for spec in specs:
+        if not isinstance(spec, str):
+            continue
+        match = REQ_LINE_RE.match(spec.strip())
+        if match:
+            deps.add(_normalize_name(match.group(1)))
+    return deps
 
-    if depth != 0:
-        return None
 
-    return txt[start : pos - 1]
+def _project_dependency_metadata(data):
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return set(), None
+
+    deps = _dependency_names(project.get("dependencies"))
+    optional = project.get("optional-dependencies")
+    if isinstance(optional, dict):
+        for specs in optional.values():
+            deps.update(_dependency_names(specs))
+
+    raw_name = project.get("name")
+    project_name = raw_name if isinstance(raw_name, str) else None
+    return deps, project_name
+
+
+def _poetry_dependency_names(poetry):
+    deps = set()
+    poetry_dependencies = poetry.get("dependencies")
+    if isinstance(poetry_dependencies, dict):
+        for raw_name in poetry_dependencies:
+            name = _normalize_name(raw_name)
+            if name and name != "python":
+                deps.add(name)
+
+    poetry_extras = poetry.get("extras")
+    if isinstance(poetry_extras, dict):
+        for specs in poetry_extras.values():
+            deps.update(_dependency_names(specs))
+    return deps
+
+
+def _poetry_dependency_metadata(data):
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return set(), None
+
+    poetry = tool.get("poetry")
+    if not isinstance(poetry, dict):
+        return set(), None
+
+    raw_name = poetry.get("name")
+    project_name = raw_name if isinstance(raw_name, str) else None
+    return _poetry_dependency_names(poetry), project_name
 
 
 def _parse_pyproject_toml(path):
-    deps = set()
-    project_name = None
-
     txt = read_text_no_symlink(
         path,
         max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
         encoding="utf-8",
-        errors="ignore",
     )
     if txt is None:
-        return deps, project_name
+        return set(), None
 
-    name_match = re.search(r'(?m)^\s*name\s*=\s*["\']([^"\']+)["\']', txt)
-    if name_match:
-        project_name = name_match.group(1)
+    try:
+        data = tomllib.loads(txt)
+    except tomllib.TOMLDecodeError as exc:
+        logger.debug("Failed to parse dependency metadata from %s: %s", path, exc)
+        return set(), None
 
-    for key in ("dependencies",):
-        block = _extract_toml_array(txt, key)
-        if block is None:
-            continue
-        raw_items = re.findall(r'"([^"]+)"', block)
-        raw_items += re.findall(r"'([^']+)'", block)
-
-        for item in raw_items:
-            item = item.strip()
-            m = REQ_LINE_RE.match(item)
-            if not m:
-                continue
-
-            deps.add(_normalize_name(m.group(1)))
-
-    for section_re in (
-        r"\[project\.optional-dependencies\]",
-        r"\[tool\.poetry\.extras\]",
-    ):
-        section_match = re.search(section_re, txt)
-        if not section_match:
-            continue
-        rest = txt[section_match.end() :]
-        next_section = re.search(r"(?m)^\s*\[", rest)
-
-        if next_section:
-            section_body = rest[: next_section.start()]
-        else:
-            section_body = rest
-
-        for arr_match in re.finditer(r"(\w+)\s*=\s*\[", section_body):
-            arr_key = arr_match.group(1)
-            block = _extract_toml_array(section_body, arr_key)
-            if block is None:
-                continue
-
-            raw_items = re.findall(r'"([^"]+)"', block)
-            raw_items += re.findall(r"'([^']+)'", block)
-            for item in raw_items:
-                item = item.strip()
-                m = REQ_LINE_RE.match(item)
-                if m:
-                    deps.add(_normalize_name(m.group(1)))
-
-    in_poetry = False
-
-    for raw_line in txt.splitlines():
-        line = raw_line.strip()
-
-        if line.startswith("[") and line.endswith("]"):
-            if line == "[tool.poetry.dependencies]":
-                in_poetry = True
-            else:
-                in_poetry = False
-            continue
-
-        if not in_poetry:
-            continue
-
-        if not line:
-            continue
-
-        if line.startswith("#"):
-            continue
-
-        key = line.split("=", 1)[0].strip()
-        if not key:
-            continue
-
-        if key == "python":
-            continue
-
-        deps.add(_normalize_name(key))
-
-    if not project_name:
-        poetry_name = re.search(r'(?m)^\s*name\s*=\s*["\']([^"\']+)["\']', txt)
-        if poetry_name:
-            project_name = poetry_name.group(1)
+    deps, project_name = _project_dependency_metadata(data)
+    poetry_deps, poetry_name = _poetry_dependency_metadata(data)
+    deps.update(poetry_deps)
+    if project_name is None:
+        project_name = poetry_name
 
     return deps, project_name
 

--- a/skylos/rules/quality/unused_deps.py
+++ b/skylos/rules/quality/unused_deps.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 import re
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
+from skylos.core.safe_cache_io import read_text_no_symlink
+
 RULE_ID = "SKY-U005"
+MAX_DEPENDENCY_MANIFEST_BYTES = 5_000_000
 
 CLI_ONLY_PACKAGES = {
     "black",
@@ -59,6 +67,7 @@ FROM_RE = re.compile(r"^\s*from\s+([A-Za-z_][\w.]*)\s+import\b", re.MULTILINE)
 DYNAMIC_RE = re.compile(
     r"importlib\.import_module\s*\(\s*['\"]([A-Za-z_][\w.]*)['\"]", re.MULTILINE
 )
+REQ_LINE_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
 
 
 def _normalize_name(name):
@@ -115,11 +124,44 @@ def _build_import_to_dist():
     return mapping
 
 
+def _parse_pyproject_toml(path):
+    text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
+        encoding="utf-8",
+    )
+    if text is None:
+        return set(), None
+
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return set(), None
+
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return set(), None
+
+    project_name = project.get("name")
+    if not isinstance(project_name, str):
+        project_name = None
+
+    deps = set()
+    dependencies = project.get("dependencies")
+    if isinstance(dependencies, list):
+        for item in dependencies:
+            if not isinstance(item, str):
+                continue
+            match = REQ_LINE_RE.match(item.strip())
+            if match:
+                deps.add(_normalize_name(match.group(1)))
+
+    return deps, project_name
+
+
 def _collect_declared_deps(repo_root):
     deps = set()
     project_name = None
-
-    req_line_re = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
 
     current = repo_root
     for _ in range(5):
@@ -132,7 +174,7 @@ def _collect_declared_deps(repo_root):
                     line = line.strip()
                     if not line or line.startswith("#") or line.startswith("-"):
                         continue
-                    m = req_line_re.match(line)
+                    m = REQ_LINE_RE.match(line)
                     if m:
                         deps.add(_normalize_name(m.group(1)))
             except Exception:
@@ -140,30 +182,10 @@ def _collect_declared_deps(repo_root):
 
         pyproj_path = current / "pyproject.toml"
         if pyproj_path.exists():
-            try:
-                txt = pyproj_path.read_text(encoding="utf-8", errors="ignore")
-                name_match = re.search(r'(?m)^\s*name\s*=\s*["\']([^"\']+)["\']', txt)
-                if name_match and not project_name:
-                    project_name = name_match.group(1)
-
-                dep_block = re.search(r"(?m)^\s*dependencies\s*=\s*\[", txt)
-                if dep_block:
-                    start = dep_block.end()
-                    depth = 1
-                    pos = start
-                    while pos < len(txt) and depth > 0:
-                        if txt[pos] == "[":
-                            depth += 1
-                        elif txt[pos] == "]":
-                            depth -= 1
-                        pos += 1
-                    block = txt[start : pos - 1]
-                    for item in re.findall(r'["\']([^"\']+)["\']', block):
-                        m = req_line_re.match(item.strip())
-                        if m:
-                            deps.add(_normalize_name(m.group(1)))
-            except Exception:
-                pass
+            pyproject_deps, pyproject_name = _parse_pyproject_toml(pyproj_path)
+            deps.update(pyproject_deps)
+            if pyproject_name and not project_name:
+                project_name = pyproject_name
 
         setup_path = current / "setup.py"
         if setup_path.exists():
@@ -189,7 +211,7 @@ def _collect_declared_deps(repo_root):
                         pos += 1
                     block = txt[start : pos - 1]
                     for item in re.findall(r'["\']([^"\']+)["\']', block):
-                        rm = req_line_re.match(item.strip())
+                        rm = REQ_LINE_RE.match(item.strip())
                         if rm:
                             deps.add(_normalize_name(rm.group(1)))
             except Exception:
@@ -205,7 +227,7 @@ def _collect_declared_deps(repo_root):
                         line = line.strip()
                         if not line or line.startswith("#") or line.startswith("-"):
                             continue
-                        m = req_line_re.match(line)
+                        m = REQ_LINE_RE.match(line)
                         if m:
                             deps.add(_normalize_name(m.group(1)))
                 except Exception:

--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -265,8 +265,7 @@ def _poetry_non_pypi_source_names(tool: dict) -> set[str]:
     )
 
 
-def _pyproject_non_pypi_source_names(text: str) -> set[str]:
-    data = _load_toml(text)
+def _pyproject_non_pypi_source_names(data: dict) -> set[str]:
     tool = data.get("tool")
     if not isinstance(tool, dict):
         return set()
@@ -338,11 +337,14 @@ def parse_requirements_txt_candidates(path: Path) -> list[dict]:
     return _parse_requirements_txt(path, version_extractor=_extract_version_candidate)
 
 
-def _pyproject_dependency_items(text: str) -> list[str]:
-    dep_block = _extract_toml_array(text, "dependencies")
-    if not dep_block:
+def _pyproject_dependency_items(data: dict) -> list[str]:
+    project = data.get("project")
+    if not isinstance(project, dict):
         return []
-    return re.findall(r"""['"]([^'"]+)['"]""", dep_block)
+    dependencies = project.get("dependencies")
+    if not isinstance(dependencies, list):
+        return []
+    return [item for item in dependencies if isinstance(item, str)]
 
 
 def _parse_pyproject_dependency_item(
@@ -377,11 +379,12 @@ def _parse_pyproject_dependency_item(
 def _parse_pyproject_dependency_array(
     path: Path,
     text: str,
+    data: dict,
     non_pypi_source_names: set[str],
     version_extractor,
 ) -> list[dict]:
     dependencies = []
-    for item in _pyproject_dependency_items(text):
+    for item in _pyproject_dependency_items(data):
         dependency = _parse_pyproject_dependency_item(
             path,
             text,
@@ -394,73 +397,86 @@ def _parse_pyproject_dependency_array(
     return dependencies
 
 
-def _poetry_dependency_lines(text: str):
-    in_poetry_dependencies = False
+def _extract_exact_poetry_version(value) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = re.fullmatch(r"\s*([0-9][A-Za-z0-9._+-]*)\s*", value)
+    return match.group(1) if match is not None else None
+
+
+def _extract_poetry_version_candidate(value) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = re.search(r"([0-9][A-Za-z0-9._*+-]*)", value)
+    return match.group(1) if match is not None else None
+
+
+def _poetry_dependency_items(data: dict):
+    tool = data.get("tool")
+    poetry = tool.get("poetry") if isinstance(tool, dict) else None
+    dependencies = poetry.get("dependencies") if isinstance(poetry, dict) else None
+    if not isinstance(dependencies, dict):
+        return ()
+    return dependencies.items()
+
+
+def _poetry_dependency_source(text: str, name: str) -> tuple[int, str]:
+    in_dependencies = False
     for lineno, raw_line in enumerate(text.splitlines(), 1):
         line = raw_line.strip()
         if line.startswith("[") and line.endswith("]"):
-            in_poetry_dependencies = line == "[tool.poetry.dependencies]"
+            in_dependencies = line == "[tool.poetry.dependencies]"
             continue
-        if in_poetry_dependencies and line and not line.startswith("#"):
-            yield lineno, line
+        if not in_dependencies or not line or line.startswith("#"):
+            continue
+        key, separator, _value = line.partition("=")
+        if separator and key.strip().strip("'\"") == name:
+            return lineno, line
+    return _find_line(text, name), name
 
 
-def _extract_exact_poetry_version(value: str) -> str | None:
-    match = re.fullmatch(r"\s*['\"]([0-9][A-Za-z0-9._+-]*)['\"]\s*,?\s*", value)
-    return match.group(1) if match is not None else None
-
-
-def _extract_poetry_version_candidate(value: str) -> str | None:
-    match = re.search(r"""['"]?\^?~?([0-9][A-Za-z0-9._*+-]*)""", value)
-    return match.group(1) if match is not None else None
-
-
-def _parse_poetry_dependency_line(
-    path: Path,
-    lineno: int,
-    line: str,
-    non_pypi_source_names: set[str],
-    version_extractor,
-) -> dict | None:
-    parts = line.split("=", 1)
-    if len(parts) != 2:
-        return None
-
-    name = parts[0].strip()
-    if name == "python" or _normalize_dependency_name(name) in non_pypi_source_names:
-        return None
-
-    version = version_extractor(parts[1].strip())
-    if not version:
-        return None
-
-    return {
-        "name": name,
-        "version": version,
-        "ecosystem": ECOSYSTEM_PYPI,
-        "file": str(path),
-        "line": lineno,
-        "snippet": line,
-    }
+def _poetry_version_values(value):
+    if isinstance(value, list):
+        versions = []
+        for candidate in value:
+            versions.extend(_poetry_version_values(candidate))
+        return versions
+    if isinstance(value, dict):
+        return _poetry_version_values(value.get("version"))
+    return [value]
 
 
 def _parse_poetry_dependencies(
     path: Path,
     text: str,
+    data: dict,
     non_pypi_source_names: set[str],
     version_extractor,
 ) -> list[dict]:
     dependencies = []
-    for lineno, line in _poetry_dependency_lines(text):
-        dependency = _parse_poetry_dependency_line(
-            path,
-            lineno,
-            line,
-            non_pypi_source_names,
-            version_extractor,
-        )
-        if dependency is not None:
-            dependencies.append(dependency)
+    for raw_name, raw_value in _poetry_dependency_items(data):
+        name = str(raw_name)
+        normalized_name = _normalize_dependency_name(name)
+        if normalized_name == "python" or normalized_name in non_pypi_source_names:
+            continue
+
+        lineno, snippet = _poetry_dependency_source(text, name)
+        seen_versions = set()
+        for raw_version in _poetry_version_values(raw_value):
+            version = version_extractor(raw_version)
+            if not version or version in seen_versions:
+                continue
+            seen_versions.add(version)
+            dependencies.append(
+                {
+                    "name": name,
+                    "version": version,
+                    "ecosystem": ECOSYSTEM_PYPI,
+                    "file": str(path),
+                    "line": lineno,
+                    "snippet": snippet,
+                }
+            )
     return dependencies
 
 
@@ -474,15 +490,19 @@ def _parse_pyproject_toml(
         path,
         max_bytes=MAX_MANIFEST_BYTES,
         encoding="utf-8",
-        errors="ignore",
     )
     if text is None:
         return []
 
-    non_pypi_source_names = _pyproject_non_pypi_source_names(text)
+    data = _load_toml(text)
+    if not data:
+        return []
+
+    non_pypi_source_names = _pyproject_non_pypi_source_names(data)
     dependencies = _parse_pyproject_dependency_array(
         path,
         text,
+        data,
         non_pypi_source_names,
         version_extractor,
     )
@@ -490,6 +510,7 @@ def _parse_pyproject_toml(
         _parse_poetry_dependencies(
             path,
             text,
+            data,
             non_pypi_source_names,
             poetry_version_extractor,
         )
@@ -614,33 +635,6 @@ def parse_go_mod(path: Path) -> list[dict]:
                 )
 
     return deps
-
-
-def _extract_toml_array(txt: str, key: str) -> str | None:
-    pattern = re.compile(r"(?m)^\s*" + re.escape(key) + r"\s*=\s*\[")
-    match = pattern.search(txt)
-    if not match:
-        return None
-    start = match.end()
-    depth = 1
-    pos = start
-    while pos < len(txt) and depth > 0:
-        ch = txt[pos]
-        if ch == "[":
-            depth += 1
-        elif ch == "]":
-            depth -= 1
-        elif ch in ('"', "'"):
-            quote = ch
-            pos += 1
-            while pos < len(txt) and txt[pos] != quote:
-                if txt[pos] == "\\":
-                    pos += 1
-                pos += 1
-        pos += 1
-    if depth != 0:
-        return None
-    return txt[start : pos - 1]
 
 
 def _find_line(text: str, needle: str) -> int:
@@ -787,11 +781,14 @@ def scan_dependencies(root: Path) -> list[dict]:
                     break
                 manifest_count += 1
                 fpath = Path(dirpath) / fname
+                text_errors = (
+                    None if fname in {"pyproject.toml", "package.json"} else "ignore"
+                )
                 manifest_text = read_text_no_symlink(
                     fpath,
                     max_bytes=MAX_MANIFEST_BYTES,
                     encoding="utf-8",
-                    errors="ignore",
+                    errors=text_errors,
                 )
                 if manifest_text is None:
                     parse_error_count += 1

--- a/test/test_hallucination_dependency.py
+++ b/test/test_hallucination_dependency.py
@@ -89,6 +89,40 @@ dependencies = [
     assert "google-genai" in deps
 
 
+def test_pyproject_comment_apostrophe_does_not_hide_declared_dependency(
+    monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        """
+[project]
+name = "issue-682-repro"
+version = "0.0.0"
+dependencies = [
+    # The project's dependency is declared on the next line.
+    "rich>=13",
+]
+requires-python = ">=3.10"
+""".strip(),
+        encoding="utf-8",
+    )
+    source = _write_py(repo / "reproduce.py", "from rich.console import Console\n")
+
+    monkeypatch.setattr(dep, "_get_stdlib_modules", lambda: set())
+    monkeypatch.setattr(dep, "_collect_local_modules", lambda root: set())
+    monkeypatch.setattr(dep, "_load_private_allowlist", lambda: set())
+    monkeypatch.setattr(
+        dep,
+        "_build_installed_module_mapping",
+        lambda: {"rich": {"rich"}},
+    )
+
+    findings = dep.scan_python_dependency_hallucinations(repo, [source])
+
+    assert _extract_single(findings, dep.RULE_ID_UNDECLARED) == []
+
+
 def test_uv_source_dependency_counts_as_declared_for_d223(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/test/test_sca_cache.py
+++ b/test/test_sca_cache.py
@@ -75,6 +75,21 @@ def test_scan_dependencies_reports_invalid_manifest(monkeypatch, tmp_path):
     assert result.receipt["parse_error_count"] == 1
 
 
+def test_scan_dependencies_reports_invalid_utf8_pyproject(monkeypatch, tmp_path):
+    monkeypatch.setattr(sca, "_requests", object())
+    (tmp_path / "pyproject.toml").write_bytes(
+        b'[project]\ndependencies = ["rich==13.0.0"]\n# \xff\n'
+    )
+
+    result = sca.scan_dependencies(tmp_path)
+
+    assert result == []
+    assert result.receipt["status"] == "incomplete"
+    assert result.receipt["complete"] is False
+    assert result.receipt["parse_error_count"] == 1
+    assert result.receipt["queried_dependency_count"] == 0
+
+
 def test_scan_dependencies_reports_osv_failure(monkeypatch, tmp_path):
     class FailingRequests:
         @staticmethod
@@ -152,6 +167,65 @@ def test_manifest_parsers_query_only_exact_versions(tmp_path):
     assert [
         (item["name"], item["version"]) for item in sca.parse_pyproject_toml(pyproject)
     ] == [("exact", "1.2.3")]
+
+
+def test_poetry_multiple_constraint_versions_are_preserved(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.poetry.dependencies]
+python = ">=3.7"
+foo = [
+    { version = "1.9.0", python = "<3.8" },
+    { version = "2.0.0", python = ">=3.8" },
+]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    expected = [("foo", "1.9.0"), ("foo", "2.0.0")]
+    assert [
+        (item["name"], item["version"])
+        for item in sca.parse_pyproject_toml(pyproject)
+    ] == expected
+    assert [
+        (item["name"], item["version"])
+        for item in sca.parse_pyproject_toml_candidates(pyproject)
+    ] == expected
+
+
+def test_pyproject_comment_apostrophe_preserves_dependency_candidates(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "issue-682-repro"
+version = "0.0.0"
+dependencies = [
+    # The project's dependency is declared on the next line.
+    "rich>=13",
+]
+requires-python = ">=3.10"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    candidates = sca.parse_pyproject_toml_candidates(pyproject)
+
+    assert [(item["name"], item["version"]) for item in candidates] == [
+        ("rich", "13")
+    ]
+
+
+def test_malformed_pyproject_does_not_produce_poetry_dependencies(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.poetry.dependencies]\nghost = "9.9.9"\nnot valid toml\n',
+        encoding="utf-8",
+    )
+
+    assert sca.parse_pyproject_toml(pyproject) == []
+    assert sca.parse_pyproject_toml_candidates(pyproject) == []
 
 
 def test_scan_receipt_counts_unresolved_ranges(monkeypatch, tmp_path):

--- a/test/test_vibe_rules.py
+++ b/test/test_vibe_rules.py
@@ -27,7 +27,10 @@ from skylos.rules.quality.logic import (
     MissingNetworkTimeoutRule,
 )
 from skylos.rules.ai_defect.phantom_refs import scan_repo_phantom_security_references
-from skylos.rules.quality.unused_deps import scan_unused_dependencies
+from skylos.rules.quality.unused_deps import (
+    _collect_declared_deps,
+    scan_unused_dependencies,
+)
 from skylos.rules.vibe_dictionary import build_vibe_dictionary
 
 
@@ -751,6 +754,30 @@ class TestUnusedDependencies:
             names = {f["name"] for f in u005}
             assert "rich" in names
             assert "click" not in names
+
+    def test_pyproject_comment_apostrophe_is_not_a_dependency(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            """
+[project]
+name = "issue-682-repro"
+version = "0.0.0"
+dependencies = [
+    # The project's dependency is declared on the next line.
+    "rich>=13",
+]
+requires-python = ">=3.10"
+""".strip(),
+            encoding="utf-8",
+        )
+        source = tmp_path / "app.py"
+        source.write_text("import rich\n", encoding="utf-8")
+
+        declared, project_name = _collect_declared_deps(tmp_path)
+        findings = scan_unused_dependencies(tmp_path, [source])
+
+        assert declared == {"rich"}
+        assert project_name == "issue-682-repro"
+        assert [item for item in findings if item["rule_id"] == "SKY-U005"] == []
 
 
 def check_code_with_source(rule, code, filename="test.py"):


### PR DESCRIPTION
Fixes #682

## Summary

Replaces hand-rolled `pyproject.toml` parsing with `tomllib` (`tomli` on Python 3.10) across:

  - `SKY-D223` dependency hallucination detection
  - `SKY-U005` unused dependency detection
  - SCA dependency inventory and version extraction

  ## Why?

  A valid toml comment containing an apostrophe. This could confuse the custom parser. Declared dependencies were then missed, causing FPs such as SKY-D223. Using a toml parser ensures comments, quoted values etc. are interpreted correctly.

  ## Tests

- `pytest test/test_hallucination_dependency.py test/test_sca_cache.py \
test/test_manifest_dependency_hallucination.py test/test_vibe_rules.py`
