### PR TITLE
fix(ai-defect): recognize module dunder attributes in phantom refs

### DIFF
--- a/skylos/rules/ai_defect/phantom_refs.py
+++ b/skylos/rules/ai_defect/phantom_refs.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from skylos.analysis.control_flow import _parse_requires_python
 from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
 
@@ -29,6 +30,25 @@ _STANDARD_MODULE_ATTRIBUTES = frozenset(
     }
 )
 
+# ``__annotate__`` exists only on Python 3.14+ (PEP 749). It is exempted only
+# when the scanned project declares a version floor of >= 3.14.
+ANNOTATE_MIN_VERSION = (3, 14)
+ANNOTATE_ATTRIBUTE = "__annotate__"
+
+
+def _module_dunder_attributes(project_root) -> frozenset[str]:
+    """Module dunders exempt from phantom checks for this project.
+
+    ``__annotate__`` is exempt only when pyproject.toml declares
+    ``requires-python >= 3.14`` (PEP 749). Without that declaration the
+    attribute is treated as a phantom reference.
+    """
+    attributes = set(_STANDARD_MODULE_ATTRIBUTES)
+    min_version, _ = _parse_requires_python(str(project_root))
+    if min_version is not None and min_version >= ANNOTATE_MIN_VERSION:
+        attributes.add(ANNOTATE_ATTRIBUTE)
+    return frozenset(attributes)
+
 
 @dataclass
 class _ScopeInfo:
@@ -43,6 +63,7 @@ def scan_repo_phantom_security_references(
 ):
     vibe_dictionary = vibe_dictionary or DEFAULT_VIBE_DICTIONARY
     root = Path(project_root).resolve()
+    module_dunder_attributes = _module_dunder_attributes(root)
     files = [
         Path(f).resolve() for f in py_files if Path(f).suffix in PYTHON_SOURCE_SUFFIXES
     ]
@@ -142,6 +163,7 @@ def scan_repo_phantom_security_references(
                 dynamic_modules,
                 package_modules,
                 _ensure_module_loaded,
+                module_dunder_attributes,
             )
         )
 
@@ -175,6 +197,7 @@ def scan_repo_phantom_security_references(
                     member_name,
                     module_members,
                     package_modules,
+                    module_dunder_attributes,
                 ):
                     continue
                 findings.append(
@@ -227,6 +250,7 @@ def scan_repo_phantom_security_references(
                     member_name,
                     module_members,
                     package_modules,
+                    module_dunder_attributes,
                 ):
                     continue
 
@@ -271,6 +295,7 @@ def scan_repo_phantom_security_references(
                     member_name,
                     module_members,
                     package_modules,
+                    module_dunder_attributes,
                 ):
                     continue
 
@@ -296,6 +321,7 @@ def _direct_local_import_findings(
     dynamic_modules,
     package_modules,
     ensure_module_loaded,
+    module_dunder_attributes: frozenset[str] = _STANDARD_MODULE_ATTRIBUTES,
 ):
     findings = []
     for node in ast.walk(tree):
@@ -317,6 +343,7 @@ def _direct_local_import_findings(
                 alias.name,
                 module_members,
                 package_modules,
+                module_dunder_attributes,
             ):
                 continue
             if base in package_modules:
@@ -341,10 +368,11 @@ def _module_has_member(
     member_name,
     module_members,
     package_modules,
+    module_dunder_attributes: frozenset[str] = _STANDARD_MODULE_ATTRIBUTES,
 ):
     if member_name in module_members.get(module_name, set()):
         return True
-    if member_name in _STANDARD_MODULE_ATTRIBUTES:
+    if member_name in module_dunder_attributes:
         return True
     return member_name == "__path__" and module_name in package_modules
 

--- a/skylos/rules/ai_defect/phantom_refs.py
+++ b/skylos/rules/ai_defect/phantom_refs.py
@@ -12,21 +12,19 @@ from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
 PYTHON_SOURCE_SUFFIXES = (".py", ".pyi", ".pyw")
 
-# Module attributes that the import system creates on every module (or that
-# every module object carries by definition). References to these are not
-# phantom members even when the source does not define them explicitly.
-MODULE_DUNDER_ATTRIBUTES = frozenset(
+# Stable attributes supplied by the import system or inherited by module
+# objects. Version-specific attributes belong in target-aware analysis.
+_STANDARD_MODULE_ATTRIBUTES = frozenset(
     {
-        "__annotate__",
         "__annotations__",
         "__cached__",
+        "__class__",
         "__dict__",
         "__doc__",
         "__file__",
         "__loader__",
         "__name__",
         "__package__",
-        "__path__",
         "__spec__",
     }
 )
@@ -172,7 +170,12 @@ def scan_repo_phantom_security_references(
                     continue
                 if target_module in dynamic_modules:
                     continue
-                if member_name in module_members.get(target_module, set()):
+                if _module_has_member(
+                    target_module,
+                    member_name,
+                    module_members,
+                    package_modules,
+                ):
                     continue
                 findings.append(
                     _build_reference_finding(
@@ -219,7 +222,12 @@ def scan_repo_phantom_security_references(
                     continue
                 if target_module in dynamic_modules:
                     continue
-                if member_name in module_members.get(target_module, set()):
+                if _module_has_member(
+                    target_module,
+                    member_name,
+                    module_members,
+                    package_modules,
+                ):
                     continue
 
                 findings.append(
@@ -258,7 +266,12 @@ def scan_repo_phantom_security_references(
                     continue
                 if target_module in dynamic_modules:
                     continue
-                if member_name in module_members.get(target_module, set()):
+                if _module_has_member(
+                    target_module,
+                    member_name,
+                    module_members,
+                    package_modules,
+                ):
                     continue
 
                 findings.append(
@@ -299,7 +312,12 @@ def _direct_local_import_findings(
             full_module = f"{base}.{alias.name}"
             if full_module in local_modules:
                 continue
-            if alias.name in module_members.get(base, set()):
+            if _module_has_member(
+                base,
+                alias.name,
+                module_members,
+                package_modules,
+            ):
                 continue
             if base in package_modules:
                 continue
@@ -316,6 +334,19 @@ def _direct_local_import_findings(
 
 def _is_package_module_file(file_path):
     return file_path.name in {"__init__.py", "__init__.pyi", "__init__.pyw"}
+
+
+def _module_has_member(
+    module_name,
+    member_name,
+    module_members,
+    package_modules,
+):
+    if member_name in module_members.get(module_name, set()):
+        return True
+    if member_name in _STANDARD_MODULE_ATTRIBUTES:
+        return True
+    return member_name == "__path__" and module_name in package_modules
 
 
 def _repo_member_names(module_members):
@@ -649,10 +680,6 @@ def _resolve_local_module_member(
         parent_map=parent_map,
         scope_infos=scope_infos,
     ):
-        return None
-
-    final_member = chain[-1]
-    if final_member in MODULE_DUNDER_ATTRIBUTES:
         return None
 
     current_module = base_module

--- a/skylos/rules/ai_defect/phantom_refs.py
+++ b/skylos/rules/ai_defect/phantom_refs.py
@@ -12,6 +12,25 @@ from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
 PYTHON_SOURCE_SUFFIXES = (".py", ".pyi", ".pyw")
 
+# Module attributes that the import system creates on every module (or that
+# every module object carries by definition). References to these are not
+# phantom members even when the source does not define them explicitly.
+MODULE_DUNDER_ATTRIBUTES = frozenset(
+    {
+        "__annotate__",
+        "__annotations__",
+        "__cached__",
+        "__dict__",
+        "__doc__",
+        "__file__",
+        "__loader__",
+        "__name__",
+        "__package__",
+        "__path__",
+        "__spec__",
+    }
+)
+
 
 @dataclass
 class _ScopeInfo:
@@ -630,6 +649,10 @@ def _resolve_local_module_member(
         parent_map=parent_map,
         scope_infos=scope_infos,
     ):
+        return None
+
+    final_member = chain[-1]
+    if final_member in MODULE_DUNDER_ATTRIBUTES:
         return None
 
     current_module = base_module

--- a/skylos/rules/ai_defect/python_api_hallucination.py
+++ b/skylos/rules/ai_defect/python_api_hallucination.py
@@ -11,6 +11,7 @@ from skylos.rules.ai_defect.phantom_refs import (
     _build_parent_map,
     _build_scope_infos,
     _collect_module_facts,
+    _module_has_member,
     _module_name,
     _resolve_local_module_member,
     _resolve_import_from_base,
@@ -187,7 +188,12 @@ def _inspect_target_references(
             state.skip("dynamic_module_surface")
         elif target_module not in trees:
             state.skip("target_surface_unavailable")
-        elif member_name in members.get(target_module, set()):
+        elif _module_has_member(
+            target_module,
+            member_name,
+            members,
+            package_modules,
+        ):
             state.verified += 1
 
 
@@ -265,7 +271,12 @@ def _inspect_from_import(
             state.skip("target_surface_unavailable")
             continue
         full_module = f"{base}.{alias.name}"
-        if full_module in local_modules or alias.name in members.get(base, set()):
+        if full_module in local_modules or _module_has_member(
+            base,
+            alias.name,
+            members,
+            package_modules,
+        ):
             state.verified += 1
         elif base in package_modules:
             state.skip("package_import_ownership_uncertain")

--- a/skylos/rules/ai_defect/python_api_hallucination.py
+++ b/skylos/rules/ai_defect/python_api_hallucination.py
@@ -11,6 +11,7 @@ from skylos.rules.ai_defect.phantom_refs import (
     _build_parent_map,
     _build_scope_infos,
     _collect_module_facts,
+    _module_dunder_attributes,
     _module_has_member,
     _module_name,
     _resolve_local_module_member,
@@ -105,6 +106,7 @@ def _inspect_python_coverage(
     )
     state = _PythonCoverageState(reasons=Counter())
     target_modules = {_module_name(root, path): path for path in targets}
+    module_dunder_attributes = _module_dunder_attributes(root)
 
     for module_name, target_path in target_modules.items():
         tree = trees.get(module_name)
@@ -124,6 +126,7 @@ def _inspect_python_coverage(
             dynamic,
             package_modules,
             state,
+            module_dunder_attributes,
         )
 
     checked = state.verified + len(findings)
@@ -150,6 +153,7 @@ def _inspect_target_references(
     dynamic: set[str],
     package_modules: set[str],
     state: _PythonCoverageState,
+    module_dunder_attributes: frozenset[str],
 ) -> None:
     parent_map = _build_parent_map(tree)
     scope_infos = _build_scope_infos(tree, current_module, local_modules)
@@ -167,6 +171,7 @@ def _inspect_target_references(
         dynamic,
         package_modules,
         state,
+        module_dunder_attributes,
     )
 
     for expression, owner in _reference_expressions(tree, parent_map):
@@ -193,6 +198,7 @@ def _inspect_target_references(
             member_name,
             members,
             package_modules,
+            module_dunder_attributes,
         ):
             state.verified += 1
 
@@ -221,6 +227,7 @@ def _inspect_import_references(
     dynamic: set[str],
     package_modules: set[str],
     state: _PythonCoverageState,
+    module_dunder_attributes: frozenset[str],
 ) -> None:
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -234,6 +241,7 @@ def _inspect_import_references(
                 dynamic,
                 package_modules,
                 state,
+                module_dunder_attributes,
             )
         elif isinstance(node, ast.Import):
             _inspect_module_import(root, node, local_modules, state)
@@ -249,6 +257,7 @@ def _inspect_from_import(
     dynamic: set[str],
     package_modules: set[str],
     state: _PythonCoverageState,
+    module_dunder_attributes: frozenset[str],
 ) -> None:
     base = _resolve_import_from_base(current_module, node)
     if base not in local_modules:
@@ -276,6 +285,7 @@ def _inspect_from_import(
             alias.name,
             members,
             package_modules,
+            module_dunder_attributes,
         ):
             state.verified += 1
         elif base in package_modules:

--- a/test/test_python_api_hallucination.py
+++ b/test/test_python_api_hallucination.py
@@ -145,6 +145,52 @@ def test_python_local_api_check_flags_unimported_submodule_attribute(tmp_path):
     assert check["outcome"] == "fail"
 
 
+def test_python_local_api_check_passes_module_dunder_attributes(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_package/__init__.py": "",
+            "reproduce.py": (
+                "import sample_package\n\n"
+                "for attr in (\n"
+                "    sample_package.__name__,\n"
+                "    sample_package.__spec__,\n"
+                "    sample_package.__package__,\n"
+                "    sample_package.__loader__,\n"
+                "    sample_package.__file__,\n"
+                "    sample_package.__cached__,\n"
+                "    sample_package.__path__,\n"
+                "    sample_package.__doc__,\n"
+                "    sample_package.__dict__,\n"
+                "    sample_package.__annotations__,\n"
+                "):\n"
+                "    pass\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+
+
+def test_python_local_api_check_passes_module_dunder_attributes_via_alias(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_package/__init__.py": "",
+            "reproduce.py": (
+                "import sample_package as pkg\n\n"
+                "print(pkg.__file__)\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+
+
 def test_python_local_api_check_passes_pep695_type_alias_import(tmp_path):
     if not hasattr(ast, "TypeAlias"):
         return

--- a/test/test_python_api_hallucination.py
+++ b/test/test_python_api_hallucination.py
@@ -273,6 +273,61 @@ def test_python_local_api_check_does_not_assume_versioned_module_attribute(
     assert check["outcome"] == "fail"
 
 
+def test_python_local_api_check_passes_annotate_on_314_floor(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "pyproject.toml": '[project]\nrequires-python = ">=3.14"\n',
+            "sample_module.py": "",
+            "reproduce.py": (
+                "import sample_module\n\n"
+                "annotate = sample_module.__annotate__\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+
+
+def test_python_local_api_check_flags_annotate_without_pyproject(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_module.py": "",
+            "reproduce.py": (
+                "import sample_module\n\n"
+                "annotate = sample_module.__annotate__\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["__annotate__"]
+    assert check["outcome"] == "fail"
+
+
+def test_python_local_api_check_flags_annotate_with_future_annotations(tmp_path):
+    # from __future__ import annotations does NOT create __annotate__
+    # (maintainer-verified on 3.12). It must stay a phantom below 3.14.
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_module.py": "",
+            "reproduce.py": (
+                "from __future__ import annotations\n"
+                "import sample_module\n\n"
+                "annotate = sample_module.__annotate__\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["__annotate__"]
+    assert check["outcome"] == "fail"
+
+
 def test_python_local_api_check_passes_module_dunder_direct_import(tmp_path):
     findings, check = _scan(
         tmp_path,

--- a/test/test_python_api_hallucination.py
+++ b/test/test_python_api_hallucination.py
@@ -1,5 +1,7 @@
 import ast
 
+import pytest
+
 from skylos.rules.ai_defect.python_api_hallucination import (
     scan_python_local_api_hallucinations,
 )
@@ -163,6 +165,7 @@ def test_python_local_api_check_passes_module_dunder_attributes(tmp_path):
                 "    sample_package.__doc__,\n"
                 "    sample_package.__dict__,\n"
                 "    sample_package.__annotations__,\n"
+                "    sample_package.__class__,\n"
                 "):\n"
                 "    pass\n"
             ),
@@ -172,6 +175,8 @@ def test_python_local_api_check_passes_module_dunder_attributes(tmp_path):
 
     assert findings == []
     assert check["outcome"] == "pass"
+    assert check["references"] == 12
+    assert check["verified_references"] == 12
 
 
 def test_python_local_api_check_passes_module_dunder_attributes_via_alias(tmp_path):
@@ -189,6 +194,152 @@ def test_python_local_api_check_passes_module_dunder_attributes_via_alias(tmp_pa
 
     assert findings == []
     assert check["outcome"] == "pass"
+    assert check["references"] == 2
+    assert check["verified_references"] == 2
+
+
+@pytest.mark.parametrize(
+    ("usage", "rule_id", "finding_type"),
+    [
+        ("module_path = sample_module.__path__\n", "SKY-L012", "module_member"),
+        ("sample_module.__path__()\n", "SKY-L012", "call"),
+        (
+            "@sample_module.__path__\ndef protected():\n    pass\n",
+            "SKY-L023",
+            "decorator",
+        ),
+    ],
+)
+def test_python_local_api_check_flags_package_only_path_on_module(
+    tmp_path,
+    usage,
+    rule_id,
+    finding_type,
+):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_module.py": "",
+            "reproduce.py": "import sample_module\n\n" + usage,
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert [
+        (finding["rule_id"], finding["type"], finding["simple_name"])
+        for finding in findings
+    ] == [(rule_id, finding_type, "__path__")]
+    assert check["outcome"] == "fail"
+    assert check["references"] == 2
+    assert check["verified_references"] == 1
+
+
+def test_python_local_api_check_flags_unknown_dunder_attribute(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_module.py": "",
+            "reproduce.py": (
+                "import sample_module\n\n"
+                "missing = sample_module.__not_a_module_attribute__\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == [
+        "__not_a_module_attribute__"
+    ]
+    assert check["outcome"] == "fail"
+
+
+def test_python_local_api_check_does_not_assume_versioned_module_attribute(
+    tmp_path,
+):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "pyproject.toml": '[project]\nrequires-python = ">=3.10,<3.14"\n',
+            "sample_module.py": "",
+            "reproduce.py": (
+                "import sample_module\n\n"
+                "annotate = sample_module.__annotate__\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["__annotate__"]
+    assert check["outcome"] == "fail"
+
+
+def test_python_local_api_check_passes_module_dunder_direct_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_module.py": "",
+            "reproduce.py": "from sample_module import __file__\n",
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["references"] == 1
+    assert check["verified_references"] == 1
+
+
+def test_python_local_api_check_passes_package_path_direct_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_package/__init__.py": "",
+            "reproduce.py": "from sample_package import __path__\n",
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["references"] == 1
+    assert check["verified_references"] == 1
+
+
+def test_python_local_api_check_flags_module_path_direct_import(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_module.py": "",
+            "reproduce.py": "from sample_module import __path__\n",
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert [
+        (finding["rule_id"], finding["type"], finding["simple_name"])
+        for finding in findings
+    ] == [("SKY-L012", "from_import", "__path__")]
+    assert check["outcome"] == "fail"
+
+
+def test_python_local_api_check_passes_imported_submodule_dunder(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "sample_package/__init__.py": "",
+            "sample_package/child.py": "",
+            "reproduce.py": (
+                "import sample_package.child\n\n"
+                "module_file = sample_package.child.__file__\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["references"] == 2
+    assert check["verified_references"] == 2
 
 
 def test_python_local_api_check_passes_pep695_type_alias_import(tmp_path):


### PR DESCRIPTION
Fixes #684

## Summary

- Recognize import-provided module attributes such as `__file__`.
- Keep `__path__` package-only and `__annotate__` Python 3.14+ only.
- Preserve detection for genuinely missing attributes.

## Tests

- 332 focused tests passed.
- 47/47 corpus cases passed.
- All GitHub checks passed.