### PR TITLE
fix(secrets): scan lockfiles for high-entropy secrets

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>994</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>9887</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>995</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>9963</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 296</span>
+          <span class="pill"><strong>symbols</strong> 304</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -1218,7 +1218,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 35</span>
-          <span class="pill"><strong>symbols</strong> 505</span>
+          <span class="pill"><strong>symbols</strong> 507</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1716,7 +1716,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/reporting" rel="noopener noreferrer">skylos/reporting</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 11</span>
-          <span class="pill"><strong>symbols</strong> 105</span>
+          <span class="pill"><strong>symbols</strong> 107</span>
         </div>
       </div>
       <p>Output formatters and exports such as SARIF, compact JSON, and human-readable reports.</p>
@@ -1766,7 +1766,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 106</span>
-          <span class="pill"><strong>symbols</strong> 1277</span>
+          <span class="pill"><strong>symbols</strong> 1288</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, AI-defect, config, edge, CI/CD, and SCA findings.</p>
@@ -1900,7 +1900,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/ui" rel="noopener noreferrer">skylos/ui</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 8</span>
-          <span class="pill"><strong>symbols</strong> 80</span>
+          <span class="pill"><strong>symbols</strong> 82</span>
         </div>
       </div>
       <p>Terminal UI and presentation helpers.</p>
@@ -1950,7 +1950,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 43</span>
-          <span class="pill"><strong>symbols</strong> 404</span>
+          <span class="pill"><strong>symbols</strong> 405</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1999,8 +1999,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 246</span>
-          <span class="pill"><strong>symbols</strong> 3712</span>
+          <span class="pill"><strong>files</strong> 247</span>
+          <span class="pill"><strong>symbols</strong> 3762</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2062,7 +2062,7 @@
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3 / 45</td>
+              <td>3 / 53</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -2139,7 +2139,7 @@
 
             <tr class="searchable" data-search="test/test_cli.py unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></td>
-              <td>72 / 73</td>
+              <td>75 / 76</td>
               <td><span class="warn">many symbols</span></td>
               <td>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</td>
             </tr>
@@ -6745,6 +6745,27 @@
               <td>skylos/analyzer.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_absolute_secret_scan_targets def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_absolute_secret_scan_targets</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_is_within_secret_scan_targets def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_is_within_secret_scan_targets</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_normalize_secret_changed_files def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_normalize_secret_changed_files</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_scan_secret_config_candidate def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_scan_secret_config_candidate</a></td>
               <td>def</td>
@@ -6754,6 +6775,13 @@
 
             <tr class="searchable" data-search="_scan_secret_config_candidates def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_scan_secret_config_candidates</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_secret_config_read_error_payload def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_secret_config_read_error_payload</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -6796,6 +6824,34 @@
 
             <tr class="searchable" data-search="_go_engine_analysis_report def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_go_engine_analysis_report</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_sanitize_go_engine_reason def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_sanitize_go_engine_reason</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_go_engine_analysis_error def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_go_engine_analysis_error</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_go_runtime_analysis_error def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_go_runtime_analysis_error</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_go_runtime_analysis_errors def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_go_runtime_analysis_errors</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -8399,62 +8455,6 @@
 
             <tr class="searchable" data-search="_create_precommit_snapshot def skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_create_precommit_snapshot</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_remap_precommit_result_files def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_remap_precommit_result_files</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_remap_precommit_file_value def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_remap_precommit_file_value</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_is_precommit_contract_evidence def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_is_precommit_contract_evidence</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_precommit_finding_targets_report_file def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_precommit_finding_targets_report_file</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_parse_unified_diff_ranges def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_parse_unified_diff_ranges</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_normalize_precommit_path def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_normalize_precommit_path</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_path_suffixes def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_path_suffixes</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_build_changed_range_index def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_build_changed_range_index</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/cli.py</td>

--- a/skylos/analysis/file_processing.py
+++ b/skylos/analysis/file_processing.py
@@ -53,6 +53,7 @@ from skylos.rules.quality.practices import (
 )
 from skylos.rules.quality.structure import ArgCountRule, FunctionLengthRule
 from skylos.rules.quality.unreachable import UnreachableCodeRule
+from skylos.rules.secrets import SECRET_CONFIG_SUFFIXES
 from skylos.rules.vibe_dictionary import build_vibe_dictionary
 from skylos.visitors.languages.csharp import scan_csharp_file
 from skylos.visitors.languages.dart import scan_dart_file
@@ -455,7 +456,7 @@ NON_PYTHON_SCANNERS = (
     ((".cs",), _scan_csharp_file),
     (KOTLIN_SOURCE_EXTS, _scan_kotlin_file),
     (SHELL_SOURCE_EXTS, _scan_shell_file),
-    ((".yaml", ".yml"), _scan_config_only_file),
+    (SECRET_CONFIG_SUFFIXES, _scan_config_only_file),
 )
 
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -37,6 +37,9 @@ from skylos.visitors.languages.typescript.analysis import (
 )
 from skylos.visitors.languages.go import clear_go_cache
 
+from skylos.rules.secrets import (
+    SECRET_CONFIG_SUFFIXES as _SECRET_CONFIG_SUFFIXES,
+)
 from skylos.rules.secrets import scan_ctx as _secrets_scan_ctx
 
 from skylos.rules.danger.calls import DangerousCallsRule
@@ -349,15 +352,6 @@ def _scan_ai_defect_diff_signals(
             )
 
 
-_SECRET_CONFIG_SUFFIXES = {
-    ".yaml",
-    ".yml",
-    ".json",
-    ".toml",
-    ".ini",
-    ".cfg",
-    ".conf",
-}
 MAX_SECRET_CONFIG_BYTES = 8_000_000
 
 _TS_JS_SOURCE_EXTS = (
@@ -515,13 +509,26 @@ def _is_secret_config_candidate(path: Path) -> bool:
 
 
 def _resolve_secret_config_candidate(path: Path, root: Path) -> Path | None:
-    candidate = Path(path)
-    if candidate.is_symlink():
-        return None
-    if not _is_secret_config_candidate(candidate):
-        return None
     try:
         resolved_root = Path(root).resolve(strict=True)
+        raw_candidate = Path(os.path.abspath(Path(path)))
+        if raw_candidate.is_symlink():
+            return None
+        candidate = raw_candidate.parent.resolve(strict=True) / raw_candidate.name
+        if candidate.is_symlink():
+            return None
+        relative_candidate = candidate.relative_to(resolved_root)
+        if not relative_candidate.parts or any(
+            part in {"", ".", ".."} for part in relative_candidate.parts
+        ):
+            return None
+        current = resolved_root
+        for part in relative_candidate.parts:
+            current /= part
+            if current.is_symlink():
+                return None
+        if not _is_secret_config_candidate(candidate):
+            return None
         resolved = candidate.resolve(strict=True)
         resolved.relative_to(resolved_root)
     except (OSError, ValueError):
@@ -533,18 +540,80 @@ def _resolve_secret_config_candidate(path: Path, root: Path) -> Path | None:
 
 def _iter_secret_config_candidates(
     root: Path,
-    scan_target: Path,
+    scan_target,
     changed_files: set[str] | None,
 ):
     if changed_files is not None:
-        for raw_path in changed_files:
-            candidate = Path(raw_path)
-            yield candidate if candidate.is_absolute() else root / candidate
+        for candidate in _normalize_secret_changed_files(
+            root, scan_target, changed_files
+        ):
+            yield Path(candidate)
         return
-    if scan_target.is_file() or scan_target.is_symlink():
-        yield scan_target
-        return
-    yield from root.rglob("*")
+
+    for target in _absolute_secret_scan_targets(scan_target):
+        if target.is_file() or target.is_symlink():
+            yield target
+        elif target.is_dir():
+            yield from target.rglob("*")
+
+
+def _absolute_secret_scan_targets(scan_target) -> tuple[Path, ...]:
+    raw_targets = (
+        scan_target if isinstance(scan_target, (list, tuple)) else (scan_target,)
+    )
+    targets = []
+    for raw_target in raw_targets:
+        target = Path(raw_target).expanduser()
+        if not target.is_absolute():
+            target = Path(os.path.abspath(target))
+        if not target.is_symlink():
+            try:
+                target = target.resolve(strict=False)
+            except OSError:
+                pass
+        targets.append(target)
+    return tuple(targets)
+
+
+def _is_within_secret_scan_targets(
+    candidate: Path, scan_targets: tuple[Path, ...]
+) -> bool:
+    for target in scan_targets:
+        if candidate == target:
+            return True
+        if target.is_symlink() or not target.is_dir():
+            continue
+        try:
+            candidate.relative_to(target)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _normalize_secret_changed_files(
+    root: Path,
+    scan_target,
+    changed_files: set[str] | None,
+) -> set[str] | None:
+    if changed_files is None:
+        return None
+
+    scan_targets = _absolute_secret_scan_targets(scan_target)
+    normalized = set()
+    for raw_path in changed_files:
+        candidate = Path(raw_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        candidate = Path(os.path.abspath(candidate))
+        try:
+            candidate = candidate.parent.resolve(strict=False) / candidate.name
+            scope_candidate = candidate.resolve(strict=False)
+        except OSError:
+            continue
+        if _is_within_secret_scan_targets(scope_candidate, scan_targets):
+            normalized.add(str(candidate))
+    return normalized
 
 
 def _scan_secret_config_candidate(
@@ -553,6 +622,7 @@ def _scan_secret_config_candidate(
     root: Path,
     excluded: set[str],
     scanned: set[str],
+    analysis_errors: list[dict] | None = None,
 ) -> list[dict]:
     resolved = _resolve_secret_config_candidate(candidate, root)
     if resolved is None or str(resolved) in scanned:
@@ -561,6 +631,7 @@ def _scan_secret_config_candidate(
         rel = str(resolved.relative_to(root))
         if excluded.intersection(Path(rel).parts):
             return []
+        scanned.add(str(resolved))
         source = read_project_text_no_symlink(
             root,
             resolved,
@@ -569,6 +640,8 @@ def _scan_secret_config_candidate(
             errors="ignore",
         )
         if source is None:
+            if analysis_errors is not None:
+                analysis_errors.append(_secret_config_read_error_payload(resolved))
             return []
         ctx = {
             "relpath": rel,
@@ -588,6 +661,7 @@ def _scan_secret_config_candidates(
     changed_files: set[str] | None,
     exclude_folders: list[str] | None,
     already_scanned: set[str] | None = None,
+    analysis_errors: list[dict] | None = None,
 ) -> list[dict]:
     if _secrets_scan_ctx is None:
         return []
@@ -595,7 +669,7 @@ def _scan_secret_config_candidates(
         root = Path(root).resolve(strict=True)
     except OSError:
         return []
-    scanned = already_scanned or set()
+    scanned = already_scanned if already_scanned is not None else set()
     excluded = set(exclude_folders or [])
     findings: list[dict] = []
     for candidate in _iter_secret_config_candidates(root, scan_target, changed_files):
@@ -605,9 +679,29 @@ def _scan_secret_config_candidates(
                 root=root,
                 excluded=excluded,
                 scanned=scanned,
+                analysis_errors=analysis_errors,
             )
         )
     return findings
+
+
+def _secret_config_read_error_payload(path: Path) -> dict:
+    try:
+        too_large = path.stat().st_size > MAX_SECRET_CONFIG_BYTES
+    except OSError:
+        too_large = False
+
+    if too_large:
+        kind = "secret_config_too_large"
+        message = (
+            f"Secret scan skipped {path.name}: file exceeds the "
+            f"{MAX_SECRET_CONFIG_BYTES}-byte safety limit"
+        )
+    else:
+        kind = "secret_config_read_error"
+        message = f"Secret scan could not safely read {path.name}"
+
+    return _analysis_error_payload(path, RuntimeError(message), kind=kind)
 
 
 _GREP_VERIFY_TYPE_PRIORITY = {
@@ -2648,16 +2742,26 @@ class Skylos:
                     result["analysis_summary"]["ai_defects_count"] = len(
                         ai_defect_findings
                     )
-            if enable_secrets and not first_is_symlink:
+            if enable_secrets and (
+                not first_is_symlink or isinstance(path, (list, tuple))
+            ):
                 secret_findings = _scan_secret_config_candidates(
                     root=Path(root),
-                    scan_target=no_source_scan_target,
+                    scan_target=(
+                        path
+                        if isinstance(path, (list, tuple))
+                        else no_source_scan_target
+                    ),
                     changed_files=changed_files,
                     exclude_folders=exclude_folders,
+                    analysis_errors=result["analysis_errors"],
                 )
                 if secret_findings:
                     result["secrets"] = secret_findings
                     result["analysis_summary"]["secrets_count"] = len(secret_findings)
+                result["analysis_summary"]["analysis_error_count"] = len(
+                    result["analysis_errors"]
+                )
             if enable_sca:
                 if first_is_symlink:
                     self._sca_coverage = {
@@ -2777,6 +2881,7 @@ class Skylos:
         all_quality = []
         all_ai_defects = []
         all_suppressed = []
+        secret_scanned_files = set()
         analysis_errors = list(language_engine_errors)
         empty_files = []
         file_contexts = []
@@ -2823,6 +2928,13 @@ class Skylos:
                 ignore_literals=True,
                 skip_docstrings=True,
             )
+
+        secret_scan_target = path if isinstance(path, (list, tuple)) else _first
+        secret_changed_files = _normalize_secret_changed_files(
+            root,
+            secret_scan_target,
+            changed_files,
+        )
 
         try:
             outs = run_proc_file_parallel(
@@ -2986,7 +3098,11 @@ class Skylos:
                     all_dangers.extend(pro_finds)
 
                 if enable_secrets and _secrets_scan_ctx is not None:
-                    if changed_files is None or str(file) in changed_files:
+                    if (
+                        secret_changed_files is None
+                        or str(file) in secret_changed_files
+                    ):
+                        secret_scanned_files.add(str(Path(file).resolve()))
                         try:
                             file_source_lines = (
                                 out[19]
@@ -2995,6 +3111,20 @@ class Skylos:
                             )
                             if file_source_lines:
                                 src_lines = file_source_lines
+                            elif _is_secret_config_candidate(Path(file)):
+                                src = read_project_text_no_symlink(
+                                    root,
+                                    Path(file),
+                                    max_bytes=MAX_SECRET_CONFIG_BYTES,
+                                    encoding="utf-8",
+                                    errors="ignore",
+                                )
+                                if src is None:
+                                    analysis_errors.append(
+                                        _secret_config_read_error_payload(Path(file))
+                                    )
+                                    continue
+                                src_lines = src.splitlines(True)
                             else:
                                 src = Path(file).read_text(
                                     encoding="utf-8", errors="ignore"
@@ -3036,38 +3166,24 @@ class Skylos:
                             logger.debug("Secret scan failed for file", exc_info=True)
 
             if enable_secrets and _secrets_scan_ctx is not None:
-                scanned = {str(Path(f).resolve()) for f in files}
-                if changed_files is not None:
-                    cfg_candidates = []
-                    for raw_path in changed_files:
-                        cfg_file = Path(raw_path)
-                        if not cfg_file.is_absolute():
-                            cfg_file = root / cfg_file
-                        cfg_candidates.append(cfg_file)
-                else:
-                    cfg_candidates = root.rglob("*")
+                scanned = set(secret_scanned_files)
+                cfg_candidates = _iter_secret_config_candidates(
+                    root,
+                    secret_scan_target,
+                    secret_changed_files,
+                )
 
+                excluded = set(exclude_folders or [])
                 for cfg_file in cfg_candidates:
-                    cfg_file = Path(cfg_file)
-                    resolved_cfg = _resolve_secret_config_candidate(cfg_file, root)
-                    if resolved_cfg is None:
-                        continue
-                    if str(resolved_cfg) in scanned:
-                        continue
-                    try:
-                        rel = str(resolved_cfg.relative_to(root))
-                        if any(ex in Path(rel).parts for ex in (exclude_folders or [])):
-                            continue
-                        src = resolved_cfg.read_text(encoding="utf-8", errors="ignore")
-                        src_lines = src.splitlines(True)
-                        ctx = {"relpath": rel, "lines": src_lines, "tree": None}
-                        findings = list(_secrets_scan_ctx(ctx))
-                        if findings:
-                            all_secrets.extend(findings)
-                    except Exception:
-                        logger.debug(
-                            "Secret scan failed for config file", exc_info=True
+                    all_secrets.extend(
+                        _scan_secret_config_candidate(
+                            Path(cfg_file),
+                            root=root,
+                            excluded=excluded,
+                            scanned=scanned,
+                            analysis_errors=analysis_errors,
                         )
+                    )
 
         finally:
             if injected:

--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
-import re, ast
+
+import ast
+import base64
+import binascii
+import re
+from bisect import bisect_right
 from math import log2
 
 __all__ = ["scan_ctx"]
@@ -24,11 +29,7 @@ CLIENT_ENV_RE = re.compile(
 
 JS_TS_SUFFIXES = (".js", ".jsx", ".ts", ".tsx")
 
-ALLOWED_FILE_SUFFIXES = (
-    ".py",
-    ".pyi",
-    ".pyw",
-    ".env",
+SECRET_CONFIG_SUFFIXES = (
     ".yaml",
     ".yml",
     ".json",
@@ -37,6 +38,14 @@ ALLOWED_FILE_SUFFIXES = (
     ".ini",
     ".cfg",
     ".conf",
+)
+
+ALLOWED_FILE_SUFFIXES = (
+    ".py",
+    ".pyi",
+    ".pyw",
+    ".env",
+    *SECRET_CONFIG_SUFFIXES,
     ".ts",
     ".tsx",
     ".js",
@@ -109,19 +118,42 @@ SAFE_TEST_HINTS = {
 
 _IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-KNOWN_HASH_VALUE_RE = re.compile(
-    r"(?i)"
-    r"(?:sha(?:1|224|256|384|512)[-:].+)"
-    r"|(?:[0-9a-f]{40})"
-    r"|(?:[0-9a-f]{64})"
-)
-KNOWN_HASH_FIELD_PREFIX_RE = re.compile(
+KNOWN_INTEGRITY_FIELD_VALUE_RE = re.compile(
     r"""(?ix)
     (?:^|[\s,{])
-    ['"]?(?:integrity|hash|checksum|resolved)['"]?
-    \s*[:=]\s*['"]?$
+    ['"]?(?P<field>integrity|hash|checksum)['"]?
+    (?:
+        \s*[:=]\s*(?P<q>['"])(?P<quoted>[^'"]+)(?P=q)
+        |
+        \s+(?P<bare>[^\s,}\]]+)
+    )
 """
 )
+SRI_VALUE_RE = re.compile(
+    r"(?i)^(?P<algorithm>sha(?:1|224|256|384|512))-(?P<digest>[A-Za-z0-9+/_-]+={0,2})$"
+)
+SRI_TOKEN_RE = re.compile(
+    r"(?i)(?<![A-Za-z0-9+/_=-])"
+    r"(?P<token>sha(?:1|224|256|384|512)-[A-Za-z0-9+/_-]+={0,2})"
+    r"(?![A-Za-z0-9+/_=-])"
+)
+PREFIXED_HEX_DIGEST_RE = re.compile(
+    r"(?i)^(?P<algorithm>sha(?:1|224|256|384|512))[-:](?P<digest>[0-9a-f]+)$"
+)
+HEX_DIGEST_LENGTHS = {
+    "sha1": 40,
+    "sha224": 56,
+    "sha256": 64,
+    "sha384": 96,
+    "sha512": 128,
+}
+SRI_DIGEST_LENGTHS = {
+    "sha1": 20,
+    "sha224": 28,
+    "sha256": 32,
+    "sha384": 48,
+    "sha512": 64,
+}
 
 IGNORE_DIRECTIVE = "skylos: ignore[SKY-S101]"
 DEFAULT_MIN_ENTROPY = 3.9
@@ -183,32 +215,121 @@ def _has_bare_token_charset_mix(s):
 
 
 def _find_generic_value(line_content):
+    known_integrity_spans = _known_integrity_spans(line_content)
+
     keyed_match = GENERIC_KEYED_VALUE.search(line_content)
     if keyed_match:
         keyed_token = keyed_match.group("val")
         keyed_start = keyed_match.start("val")
-        if not _is_known_hash_candidate(keyed_token, line_content, keyed_start):
-            return keyed_token, False, keyed_start
+        return keyed_token, False, keyed_start
 
     for bare_match in BARE_GENERIC_VALUE.finditer(line_content):
         bare_token = bare_match.group("bare")
         bare_start = bare_match.start("bare")
         if not _has_bare_token_charset_mix(bare_token):
             continue
-        if _is_known_hash_candidate(bare_token, line_content, bare_start):
+        if _is_known_integrity_candidate(bare_token, bare_start, known_integrity_spans):
             continue
         return bare_token, True, bare_start
 
     return None
 
 
-def _is_known_hash_candidate(token: str, line_content: str, start: int) -> bool:
-    clean_token = token.strip()
-    if KNOWN_HASH_VALUE_RE.fullmatch(clean_token):
+def _known_integrity_spans(line_content: str) -> list[tuple[int, int]]:
+    spans = []
+    for match in KNOWN_INTEGRITY_FIELD_VALUE_RE.finditer(line_content):
+        field = match.group("field").lower()
+        value_group = "quoted" if match.group("quoted") is not None else "bare"
+        raw_value = match.group(value_group)
+        value = raw_value.strip()
+        if not _is_known_integrity_value(field, value):
+            continue
+
+        value_start = (
+            match.start(value_group) + len(raw_value) - len(raw_value.lstrip())
+        )
+        spans.append((value_start, value_start + len(value)))
+
+    for match in SRI_TOKEN_RE.finditer(line_content):
+        token = match.group("token")
+        if _is_valid_sri_token(token):
+            spans.append((match.start("token"), match.end("token")))
+
+    if not spans:
+        return []
+
+    spans.sort()
+    merged = [spans[0]]
+    for start, end in spans[1:]:
+        previous_start, previous_end = merged[-1]
+        if start <= previous_end:
+            merged[-1] = (previous_start, max(previous_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _is_known_integrity_candidate(
+    token: str, start: int, known_integrity_spans: list[tuple[int, int]]
+) -> bool:
+    end = start + len(token)
+    span_index = bisect_right(known_integrity_spans, (start, float("inf"))) - 1
+    if span_index < 0:
+        return False
+    span_start, span_end = known_integrity_spans[span_index]
+    return span_start <= start and end <= span_end
+
+
+def _is_known_integrity_value(field: str, value: str) -> bool:
+    if field == "integrity":
+        sri_tokens = value.split()
+        return bool(sri_tokens) and all(
+            _is_valid_sri_token(token) for token in sri_tokens
+        )
+
+    if _is_valid_prefixed_hex_digest(value) or _is_valid_sri_token(value):
         return True
 
-    prefix = line_content[:start]
-    return bool(KNOWN_HASH_FIELD_PREFIX_RE.search(prefix))
+    return field == "checksum" and bool(re.fullmatch(r"(?i)[0-9a-f]{64}", value))
+
+
+def _is_valid_prefixed_hex_digest(value: str) -> bool:
+    match = PREFIXED_HEX_DIGEST_RE.fullmatch(value)
+    if match is None:
+        return False
+
+    algorithm = match.group("algorithm").lower()
+    return len(match.group("digest")) == HEX_DIGEST_LENGTHS[algorithm]
+
+
+def _is_valid_sri_token(value: str) -> bool:
+    match = SRI_VALUE_RE.fullmatch(value)
+    if match is None:
+        return False
+
+    algorithm = match.group("algorithm").lower()
+    expected_digest_length = SRI_DIGEST_LENGTHS[algorithm]
+    expected_encoded_length = 4 * ((expected_digest_length + 2) // 3)
+    expected_padding = (-expected_digest_length) % 3
+    encoded_digest = match.group("digest")
+    unpadded_digest = encoded_digest.rstrip("=")
+    supplied_padding = len(encoded_digest) - len(unpadded_digest)
+    if len(
+        unpadded_digest
+    ) != expected_encoded_length - expected_padding or supplied_padding not in {
+        0,
+        expected_padding,
+    }:
+        return False
+
+    normalized_digest = unpadded_digest.translate(str.maketrans("-_", "+/"))
+    normalized_digest += "=" * expected_padding
+    try:
+        digest = base64.b64decode(normalized_digest, validate=True)
+    except (binascii.Error, ValueError):
+        return False
+
+    return len(digest) == expected_digest_length
 
 
 def _docstring_lines(tree):

--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -33,6 +33,7 @@ ALLOWED_FILE_SUFFIXES = (
     ".yml",
     ".json",
     ".toml",
+    ".lock",
     ".ini",
     ".cfg",
     ".conf",

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3595,6 +3595,264 @@ def test_changed_files_scans_dotenv_for_secrets(tmp_path):
     assert ".env" in scanned
 
 
+_ISSUE_693_UV_LOCK = """\
+version = 1
+revision = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "internal-telemetry"
+version = "1.4.2"
+source = { registry = "https://artifacts.corp.internal/api/pypi/pypi-private/simple" }
+wheels = [
+    { url = "https://artifacts.corp.internal/api/pypi/pypi-private/download/internal_telemetry-1.4.2-py3-none-any.whl?access_token=V7pQ-2mKzR9xLd4TbN6wYc0JsE3hU8fA1gXvM5nP", hash = "sha256:3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f3f" },
+]
+"""
+
+
+def _issue_693_findings(result):
+    return [
+        finding
+        for finding in result.get("secrets", [])
+        if finding.get("rule_id") == "SKY-S101"
+        and finding.get("file") == "uv.lock"
+        and finding.get("provider") == "generic"
+        and finding.get("line") == 10
+        and finding.get("col") == 131
+        and finding.get("end_col") == 171
+        and finding.get("preview") == "V7pQ…M5nP"
+    ]
+
+
+def test_lockfile_only_directory_secret_survives_final_result(tmp_path):
+    (tmp_path / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
+
+    assert len(_issue_693_findings(result)) == 1
+    assert result["analysis_summary"]["secrets_count"] == len(result["secrets"])
+
+
+def test_direct_lockfile_secret_does_not_report_python_parse_error(tmp_path):
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    (tmp_path / "sibling.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+
+    result = json.loads(analyze(str(lockfile), enable_secrets=True, grep_verify=False))
+
+    assert len(_issue_693_findings(result)) == 1
+    assert {finding["file"] for finding in result["secrets"]} == {"uv.lock"}
+    assert result["analysis_errors"] == []
+    assert result["analysis_summary"]["analysis_error_count"] == 0
+
+
+def test_lockfile_secret_survives_final_result_with_source_files(tmp_path):
+    (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
+
+    assert len(_issue_693_findings(result)) == 1
+
+
+def test_changed_lockfile_secret_survives_final_result(tmp_path):
+    (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    changed_lock = tmp_path / "uv.lock"
+    changed_lock.write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    (tmp_path / "unchanged.lock").write_text(
+        _ISSUE_693_UV_LOCK.replace("uv.lock", "unchanged.lock"),
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(
+            str(tmp_path),
+            enable_secrets=True,
+            changed_files={str(changed_lock.resolve())},
+            grep_verify=False,
+        )
+    )
+
+    assert len(_issue_693_findings(result)) == 1
+    assert all(finding.get("file") != "unchanged.lock" for finding in result["secrets"])
+
+
+def _issue_693_preview_files(result):
+    return [
+        finding["file"]
+        for finding in result.get("secrets", [])
+        if finding.get("preview") == "V7pQ…M5nP"
+    ]
+
+
+def test_multiple_source_directories_keep_secret_scan_in_scope(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "app.py").write_text("print('first')\n", encoding="utf-8")
+    (second / "app.py").write_text("print('second')\n", encoding="utf-8")
+    (first / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    (tmp_path / "outside.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+
+    result = json.loads(
+        analyze([str(first), str(second)], enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_693_preview_files(result) == ["first/uv.lock"]
+
+
+def test_multiple_config_only_directories_keep_secret_scan_in_scope(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    (second / "safe.lock").write_text("version = 1\n", encoding="utf-8")
+    (tmp_path / "outside.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+
+    result = json.loads(
+        analyze([str(first), str(second)], enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_693_preview_files(result) == ["first/uv.lock"]
+
+
+def test_overlapping_scan_targets_deduplicate_lockfile_findings(tmp_path):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (nested / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+
+    result = json.loads(
+        analyze([str(tmp_path), str(nested)], enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_693_preview_files(result) == ["nested/uv.lock"]
+
+
+def test_changed_files_cannot_widen_multiple_scan_targets(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "app.py").write_text("print('first')\n", encoding="utf-8")
+    (second / "app.py").write_text("print('second')\n", encoding="utf-8")
+    selected_lock = first / "uv.lock"
+    selected_lock.write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    outside_lock = tmp_path / "outside.lock"
+    outside_lock.write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+
+    result = json.loads(
+        analyze(
+            [str(first), str(second)],
+            enable_secrets=True,
+            changed_files={str(selected_lock), str(outside_lock)},
+            grep_verify=False,
+        )
+    )
+
+    assert _issue_693_preview_files(result) == ["first/uv.lock"]
+
+
+def test_changed_file_cannot_escape_scan_target_through_symlink_parent(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    outside = tmp_path / "outside"
+    first.mkdir()
+    second.mkdir()
+    outside.mkdir()
+    (first / "app.py").write_text("print('first')\n", encoding="utf-8")
+    (second / "app.py").write_text("print('second')\n", encoding="utf-8")
+    outside_lock = outside / "uv.lock"
+    outside_lock.write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    escape = first / "escape"
+    escape.symlink_to(outside, target_is_directory=True)
+
+    result = json.loads(
+        analyze(
+            [str(first), str(second)],
+            enable_secrets=True,
+            changed_files={str(escape / "uv.lock")},
+            grep_verify=False,
+        )
+    )
+
+    assert _issue_693_preview_files(result) == []
+
+
+def test_direct_lockfile_accepts_relative_changed_file(tmp_path, monkeypatch):
+    (tmp_path / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = json.loads(
+        analyze(
+            "uv.lock",
+            enable_secrets=True,
+            changed_files={"uv.lock"},
+            grep_verify=False,
+        )
+    )
+
+    assert len(_issue_693_findings(result)) == 1
+
+
+def test_symlink_first_target_does_not_hide_safe_later_target(tmp_path):
+    skipped = tmp_path / "skipped"
+    safe = tmp_path / "safe"
+    skipped.mkdir()
+    safe.mkdir()
+    (safe / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    link = tmp_path / "linked"
+    link.symlink_to(skipped, target_is_directory=True)
+
+    result = json.loads(
+        analyze([str(link), str(safe)], enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_693_preview_files(result) == ["safe/uv.lock"]
+
+
+def test_scan_targets_through_symlinked_ancestor_are_canonicalized(tmp_path):
+    real_root = tmp_path / "real"
+    first = real_root / "first"
+    second = real_root / "second"
+    first.mkdir(parents=True)
+    second.mkdir()
+    (second / "uv.lock").write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    alias = tmp_path / "alias"
+    alias.symlink_to(real_root, target_is_directory=True)
+
+    result = json.loads(
+        analyze(
+            [str(alias / "first"), str(alias / "second")],
+            enable_secrets=True,
+            grep_verify=False,
+        )
+    )
+
+    assert _issue_693_preview_files(result) == ["second/uv.lock"]
+
+
+@pytest.mark.parametrize("with_source", [False, True])
+def test_oversized_lockfile_reports_incomplete_secret_scan(
+    tmp_path, monkeypatch, with_source
+):
+    if with_source:
+        (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    lockfile = tmp_path / "uv.lock"
+    lockfile.write_text(_ISSUE_693_UV_LOCK, encoding="utf-8")
+    monkeypatch.setattr("skylos.analyzer.MAX_SECRET_CONFIG_BYTES", 64)
+
+    target = tmp_path if with_source else lockfile
+    result = json.loads(analyze(str(target), enable_secrets=True, grep_verify=False))
+
+    assert _issue_693_findings(result) == []
+    assert result["analysis_summary"]["analysis_error_count"] == 1
+    assert result["analysis_errors"][0]["kind"] == "secret_config_too_large"
+    assert "64-byte safety limit" in result["analysis_errors"][0]["message"]
+
+
 def test_config_secret_scan_skips_symlink_targets_outside_root(tmp_path):
     (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
     outside_secret = tmp_path.parent / "outside_secret"

--- a/test/test_secrets.py
+++ b/test/test_secrets.py
@@ -221,19 +221,37 @@ def test_generic_scan_handles_long_non_secret_token_without_quadratic_retry():
 
 
 @pytest.mark.parametrize(
-    "line",
+    "line,relpath",
     [
-        '"integrity": "sha512-AbCdEfGh1234567890AbCdEfGh1234567890AABB"',
-        '"hash": "sha256-xYz1234567890AbCdEfGh1234567890AABB0011"',
-        '"checksum": "sha384-xYzAbCdEfGh1234567890AbCdEfGh1234567890"',
-        '"resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz"',
-        'commit = "da39a3ee5e6b4b0d3255bfef95601890afd80709"',
-        'digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"',
+        (
+            "  integrity sha512-nJhYv8z5ti1j2f7/Bt+4YN+j4/H0uDltKcAx0fBvGG0Fa9JEOv3UJ3e6qb1d5IqhvIiqoBs1XqAkONKvgjfG4Q==",
+            "yarn.lock",
+        ),
+        (
+            '    "integrity": "sha512-gQPbrbqehsdBgYdB78XpzcVywutyHjCW7lwwJRybfNc9LRmN1hu2Vv1cndQ/o5y5RaL3D/2fbxSyj16vrzQ+sA=="',
+            "package-lock.json",
+        ),
+        (
+            'sdist = { url = "https://files.pythonhosted.org/pkg.tar.gz", hash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", size = 123 }',
+            "uv.lock",
+        ),
+        (
+            'checksum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"',
+            "Cargo.lock",
+        ),
+        (
+            '["pkg@1.0.0", "", {}, "sha512-nJhYv8z5ti1j2f7/Bt+4YN+j4/H0uDltKcAx0fBvGG0Fa9JEOv3UJ3e6qb1d5IqhvIiqoBs1XqAkONKvgjfG4Q=="],',
+            "bun.lock",
+        ),
+        (
+            '["pkg@1.0.0", "", {}, "sha512-nJhYv8z5ti1j2f7_Bt-4YN-j4_H0uDltKcAx0fBvGG0Fa9JEOv3UJ3e6qb1d5IqhvIiqoBs1XqAkONKvgjfG4Q"],',
+            "bun.lock",
+        ),
     ],
 )
-def test_known_hashes_not_flagged_as_generic(line):
+def test_known_lockfile_integrity_values_not_flagged_as_generic(line, relpath):
     src = line + "\n"
-    ctx = _ctx_from_source(src, rel="package-lock.json")
+    ctx = _ctx_from_source(src, rel=relpath)
     generic = [f for f in scan_ctx(ctx) if f["provider"] == "generic"]
     assert generic == []
 
@@ -251,10 +269,7 @@ def test_hash_marker_does_not_suppress_generic_secret_on_same_line():
 
 def test_json_hash_field_does_not_suppress_later_generic_secret():
     token = "aB3dE5fG7hI9jK2lM4nO6pQ8rS0-tU1vW2xY3zZ"
-    src = (
-        '{"hash": "sha256-deadbeef", '
-        f'"api_key": "{token}"}}\n'
-    )
+    src = f'{{"hash": "sha256-deadbeef", "api_key": "{token}"}}\n'
     ctx = _ctx_from_source(src, rel="config.json")
 
     generic = [f for f in scan_ctx(ctx) if f["provider"] == "generic"]
@@ -263,11 +278,98 @@ def test_json_hash_field_does_not_suppress_later_generic_secret():
     assert generic[0]["preview"] == "aB3d…Y3zZ"
 
 
-def test_real_secret_on_hash_line_still_caught_by_provider():
-    src = '"integrity": "ghp_1234567890abcdef1234567890abcdef1234"\n'
-    ctx = _ctx_from_source(src, rel="config.json")
+@pytest.mark.parametrize("secret_key", ["access_token", "api_key"])
+def test_real_secret_beside_valid_integrity_value_is_still_detected(secret_key):
+    integrity = (
+        "sha512-nJhYv8z5ti1j2f7/Bt+4YN+j4/H0uDltKcAx0fBvGG0Fa9JEOv3UJ3e6qb1d5Iq"
+        "hvIiqoBs1XqAkONKvgjfG4Q=="
+    )
+    token = "aB3dE5fG7hI9jK2lM4nO6pQ8rS0-tU1vW2xY3zZ"
+    src = f'{{"integrity": "{integrity}", "{secret_key}": "{token}"}}\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="package-lock.json"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["col"] == src.index(token)
+    assert generic[0]["preview"] == "aB3d…Y3zZ"
+
+
+@pytest.mark.parametrize(
+    "token,provider",
+    [
+        ("ghp_" + "1234567890abcdef" * 2 + "1234", "github"),
+        ("sk_live_" + "a1B2c3D4e5F6g7H8", "stripe"),
+    ],
+)
+def test_provider_secret_in_integrity_field_is_still_detected(token, provider):
+    src = f'"integrity": "{token}"\n'
+    ctx = _ctx_from_source(src, rel="package-lock.json")
     providers = [f["provider"] for f in scan_ctx(ctx)]
-    assert "github" in providers
+    assert provider in providers
+
+
+def test_unrecognized_integrity_value_is_still_detected_as_generic():
+    token = "aB3dE5fG7hI9jK2lM4nO6pQ8rS0-tU1vW2xY3zZ"
+    src = f'"integrity": "{token}"\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="package-lock.json"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["col"] == src.index(token)
+
+
+def test_malformed_sri_value_is_still_detected_as_generic():
+    token = "sha512-AbCdEfGh1234567890AbCdEfGh1234567890AABB"
+    src = f'  integrity "{token}"\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="yarn.lock"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["col"] == src.index(token)
+
+
+def test_secret_key_context_is_not_suppressed_by_valid_sri_shape():
+    token = (
+        "sha512-nJhYv8z5ti1j2f7/Bt+4YN+j4/H0uDltKcAx0fBvGG0Fa9JEOv3UJ3e6qb1d5Iq"
+        "hvIiqoBs1XqAkONKvgjfG4Q=="
+    )
+    src = f'api_key = "{token}"\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="uv.lock"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["col"] == src.index(token)
+
+
+def test_many_integrity_values_are_scanned_in_linear_time():
+    sri = (
+        "sha512-nJhYv8z5ti1j2f7/Bt+4YN+j4/H0uDltKcAx0fBvGG0Fa9JEOv3UJ3e6qb1d5Iq"
+        "hvIiqoBs1XqAkONKvgjfG4Q=="
+    )
+    src = (f'"integrity": "{sri}", ' * 10_000) + "\n"
+
+    started_at = time.perf_counter()
+    findings = list(scan_ctx(_ctx_from_source(src, rel="bun.lock")))
+    elapsed = time.perf_counter() - started_at
+
+    assert findings == []
+    assert elapsed < 1.0
 
 
 def test_lockfile_suffix_scanned_for_secrets():
@@ -280,7 +382,10 @@ def test_lockfile_suffix_scanned_for_secrets():
 
 def test_lockfile_hash_field_still_not_flagged():
     # Checksums inside lockfiles are public integrity data, not secrets.
-    src = 'hash = "sha256-xYz1234567890AbCdEfGh1234567890AABB0011"\n'
+    src = (
+        'hash = "sha256:e3b0c44298fc1c149afbf4c8996fb924'
+        '27ae41e4649b934ca495991b7852b855"\n'
+    )
     ctx = _ctx_from_source(src, rel="uv.lock")
     generic = [f for f in scan_ctx(ctx) if f["provider"] == "generic"]
     assert generic == []

--- a/test/test_secrets.py
+++ b/test/test_secrets.py
@@ -268,3 +268,19 @@ def test_real_secret_on_hash_line_still_caught_by_provider():
     ctx = _ctx_from_source(src, rel="config.json")
     providers = [f["provider"] for f in scan_ctx(ctx)]
     assert "github" in providers
+
+
+def test_lockfile_suffix_scanned_for_secrets():
+    # Issue #693: .lock files (uv.lock, Cargo.lock, package-lock.json style)
+    # were skipped entirely because ".lock" was not in the allowed suffixes.
+    src = 'access_token = "aB3dE5fG7hI9jK2lM4nO6pQ8rS0-tU1vW2xY3zZ"\n'
+    findings = list(scan_ctx(_ctx_from_source(src, rel="uv.lock")))
+    assert any(f["provider"] == "generic" for f in findings)
+
+
+def test_lockfile_hash_field_still_not_flagged():
+    # Checksums inside lockfiles are public integrity data, not secrets.
+    src = 'hash = "sha256-xYz1234567890AbCdEfGh1234567890AABB0011"\n'
+    ctx = _ctx_from_source(src, rel="uv.lock")
+    generic = [f for f in scan_ctx(ctx) if f["provider"] == "generic"]
+    assert generic == []

--- a/test/test_secrets_nonpy.py
+++ b/test/test_secrets_nonpy.py
@@ -15,6 +15,9 @@ class TestAllowedSuffixes:
     def test_toml_suffix_allowed(self):
         assert ".toml" in ALLOWED_FILE_SUFFIXES
 
+    def test_lockfile_suffix_allowed(self):
+        assert ".lock" in ALLOWED_FILE_SUFFIXES
+
     def test_ts_suffixes_allowed(self):
         assert ".ts" in ALLOWED_FILE_SUFFIXES
         assert ".tsx" in ALLOWED_FILE_SUFFIXES


### PR DESCRIPTION
Skylos skipped `.lock` files during secret scans, so secrets inside files such as `uv.lock` and `Cargo.lock` could be missed.

This adds lockfile scanning while avoiding checksum noise. Valid package hashes are ignored, but actual API keys and high-entropy secrets are still reported.

The follow-up also:

- covers folder, direct-file, multi-path, and changed-file scans
- prevents symlink and path escapes
- reports lockfiles that cannot be safely scanned

Tests:

- `pytest .`

Closes #693
