### PR TITLE
fix(go): fail closed when native analysis is incomplete

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -290,6 +290,11 @@ jobs:
       - name: Smoke test CLI entrypoint
         run: docker run --rm skylos:smoke --version # skylos: ignore[SKY-D296] local smoke-test image
 
+      - name: Smoke test Go engine
+        run: |
+          docker run --rm skylos:smoke doctor --format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["checks"]["go_engine"]["status"] == "available"'
+
       - name: Verify image Python runtime
         shell: bash
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,6 +77,11 @@ jobs:
       - name: Check CLI version
         run: docker run --rm skylos:test --version
 
+      - name: Check Go engine
+        run: |
+          docker run --rm skylos:test doctor --format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["checks"]["go_engine"]["status"] == "available"'
+
       - name: Check Python runtime
         shell: bash
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.opencontainers.image.python.version=${PYTHON_VERSION}
 WORKDIR /work
 
 COPY --from=build /wheelhouse /tmp/wheelhouse
+COPY --from=go-build /out/skylos-go /usr/local/bin/skylos-go
 
 RUN python -m pip install --no-index --find-links=/tmp/wheelhouse skylos && \
     rm -rf /tmp/wheelhouse

--- a/README.md
+++ b/README.md
@@ -442,6 +442,13 @@ or `--include-folder` to override an excluded folder.
 | Kotlin | Yes | Partial | Partial | Unsupported | Kotlin symbol extraction with conservative static-analysis coverage |
 | Shell | No | Yes | Partial | Unsupported | shell-script security checks for command injection, SSRF, and path traversal |
 
+Go dead-code and security checks require the native `skylos-go` engine. If
+Skylos discovers Go files but cannot run that engine, the report is marked
+incomplete, no grade or clean result is produced, and the CLI exits with status
+`2`. Run `skylos doctor` to verify engine availability and configure
+`SKYLOS_GO_BIN` when using a separately built engine. The official GitHub
+Action builds the matching native engine automatically.
+
 See [Rules Reference](https://docs.skylos.dev/rules-reference) for rule families
 and scanner scope.
 

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,44 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    - name: Detect Go sources
+      id: go_sources
+      shell: bash
+      env:
+        SKYLOS_PATH: ${{ inputs.path }}
+      run: |
+        if find "$SKYLOS_PATH" -type f -name '*.go' -print -quit 2>/dev/null | grep -q .; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Set up Go
+      if: steps.go_sources.outputs.present == 'true'
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+      with:
+        go-version: "1.22.x"
+        cache: false
+
+    - name: Build Skylos Go engine
+      if: steps.go_sources.outputs.present == 'true'
+      shell: bash
+      env:
+        SKYLOS_ACTION_PATH: ${{ github.action_path }}
+      run: |
+        ENGINE_DIR="$RUNNER_TEMP/skylos-go-engine"
+        ENGINE_NAME="skylos-go"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          ENGINE_NAME="skylos-go.exe"
+        fi
+        mkdir -p "$ENGINE_DIR"
+        (
+          cd "$SKYLOS_ACTION_PATH/skylos/engines/go"
+          GOCACHE="$RUNNER_TEMP/skylos-go-build-cache" \
+          GOPATH="$RUNNER_TEMP/skylos-go-gopath" \
+            go build -trimpath -o "$ENGINE_DIR/$ENGINE_NAME" ./cmd/skylos-go
+        )
+
     - name: Install Skylos
       shell: bash
       run: python -m pip install "${{ github.action_path }}"
@@ -66,6 +104,7 @@ runs:
         SKYLOS_ANALYSIS: ${{ inputs.analysis }}
         SKYLOS_CONFIDENCE: ${{ inputs.confidence }}
         SKYLOS_TOKEN: ${{ inputs.token }}
+        SKYLOS_GO_BIN: ${{ format('{0}/skylos-go-engine/skylos-go{1}', runner.temp, runner.os == 'Windows' && '.exe' || '') }}
       run: |
         REPORT="skylos-report.json"
         echo "report=$REPORT" >> "$GITHUB_OUTPUT"
@@ -86,10 +125,18 @@ runs:
         fi
 
         # Run scan
+        set +e
         python -m skylos.cli "$SKYLOS_PATH" \
           --confidence "$SKYLOS_CONFIDENCE" \
           $FLAGS \
-          --json > "$REPORT" || true
+          --json > "$REPORT"
+        SCAN_STATUS=$?
+        set -e
+
+        if [ "$SCAN_STATUS" -ne 0 ] && [ "$SCAN_STATUS" -ne 2 ]; then
+          echo "::error::Skylos scan failed with exit code $SCAN_STATUS"
+          exit "$SCAN_STATUS"
+        fi
 
         # Count findings
         COUNT=$(python -c "
@@ -102,6 +149,11 @@ runs:
         echo "### Skylos Scan Results" >> "$GITHUB_STEP_SUMMARY"
         echo "Found **$COUNT** issue(s) in \`$SKYLOS_PATH\`" >> "$GITHUB_STEP_SUMMARY"
 
+        if [ "$SCAN_STATUS" -eq 2 ]; then
+          echo "::error::Skylos analysis was incomplete; refusing a clean result"
+          exit 2
+        fi
+
     - name: Upload to Skylos Dashboard
       shell: bash
       env:
@@ -109,6 +161,7 @@ runs:
         SKYLOS_PATH: ${{ inputs.path }}
         SKYLOS_ANALYSIS: ${{ inputs.analysis }}
         SKYLOS_CONFIDENCE: ${{ inputs.confidence }}
+        SKYLOS_GO_BIN: ${{ format('{0}/skylos-go-engine/skylos-go{1}', runner.temp, runner.os == 'Windows' && '.exe' || '') }}
       run: |
         # Upload works with SKYLOS_TOKEN or tokenless via GitHub OIDC
         FLAGS=""
@@ -159,15 +212,17 @@ runs:
       if: inputs.mode == 'gate' || inputs.mode == 'review'
       shell: bash
       run: |
+        set +e
         python -m skylos.cli cicd gate \
           --input skylos-report.json \
           --summary
         RESULT=$?
+        set -e
         if [ $RESULT -eq 0 ]; then
           echo "passed=true" >> "$GITHUB_OUTPUT"
         else
           echo "passed=false" >> "$GITHUB_OUTPUT"
-          exit 1
+          exit "$RESULT"
         fi
 
     - name: Upload Report Artifact

--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -103,6 +103,16 @@ skylos . --format llm
 skylos . --format github
 ```
 
+## Exit Codes And Incomplete Analysis
+
+Skylos reserves exit status `0` for successful command completion, `1` for
+finding or policy failures in modes that enforce them, and `2` when required
+analysis could not complete. An unavailable native language engine is an
+incomplete analysis: Skylos emits a `SKY-ANALYSIS-INCOMPLETE` diagnostic, omits
+the grade and clean-code claim, and exits with status `2` in every output mode.
+`--force` and advisory gate settings do not convert incomplete analysis into a
+passing result.
+
 The legacy flags still work:
 
 ```bash

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -730,10 +730,16 @@ def _go_engine_analysis_report(files) -> dict | None:
 
     engine_status = get_go_engine_status()
     available = engine_status.get("status") == "available"
+    engine_report = dict(engine_status)
+    if "reason" in engine_report:
+        engine_report["reason"] = (
+            _sanitize_go_engine_reason(engine_report.get("reason"))
+            or "Go engine unavailable"
+        )
     report = {
         "status": "available" if available else "partial",
         "file_count": go_file_count,
-        "engine": dict(engine_status),
+        "engine": engine_report,
         "completed_checks": ["quality"],
         "skipped_checks": [],
     }
@@ -742,6 +748,141 @@ def _go_engine_analysis_report(files) -> dict | None:
     else:
         report["skipped_checks"] = ["dead_code", "security"]
     return report
+
+
+_ANSI_ESCAPE_RE = re.compile(
+    r"(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|"
+    r"\x1b[PX^_][^\x1b]*(?:\x1b\\)|\x1b[@-_]|\x9b[0-?]*[ -/]*[@-~])"
+)
+
+
+def _sanitize_go_engine_reason(value) -> str:
+    text = _ANSI_ESCAPE_RE.sub("", str(value or ""))
+    text = "".join(
+        " " if ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F else char for char in text
+    )
+    return " ".join(text.split())[:500]
+
+
+def _go_engine_analysis_error(files, report: dict | None) -> dict | None:
+    if not isinstance(report, dict) or report.get("status") != "partial":
+        return None
+
+    go_files = sorted(
+        (Path(file_path) for file_path in files if str(file_path).endswith(".go")),
+        key=lambda path: str(path),
+    )
+    if not go_files:
+        return None
+
+    engine = report.get("engine")
+    engine = engine if isinstance(engine, dict) else {}
+    reason = (
+        _sanitize_go_engine_reason(engine.get("reason") or "Go engine unavailable")
+        or "Go engine unavailable"
+    )
+    skipped_checks = [
+        str(check)
+        for check in (report.get("skipped_checks") or [])
+        if str(check).strip()
+    ]
+    skipped_label = ", ".join(check.replace("_", " ") for check in skipped_checks)
+    message = f"Go analysis incomplete: {reason}."
+    if skipped_label:
+        message += f" Skipped checks: {skipped_label}."
+
+    return {
+        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+        "severity": "HIGH",
+        "kind": "language_engine_unavailable",
+        "error_type": "GoEngineUnavailable",
+        "message": message,
+        "file": str(go_files[0]),
+        "line": 1,
+        "column": 1,
+        "language": "go",
+        "affected_file_count": len(go_files),
+        "skipped_checks": skipped_checks,
+        "suggestion": (
+            "Run `skylos doctor` and configure a runnable skylos-go engine "
+            "for this platform."
+        ),
+    }
+
+
+def _go_runtime_analysis_error(failure: dict, skipped_checks: list[str]):
+    module_files = sorted(
+        (
+            Path(file_path)
+            for file_path in (failure.get("files") or [])
+            if str(file_path).endswith(".go")
+        ),
+        key=lambda path: str(path),
+    )
+    if not module_files:
+        return None
+
+    reason = (
+        _sanitize_go_engine_reason(
+            failure.get("reason") or "Go engine failed during analysis"
+        )
+        or "Go engine failed during analysis"
+    )
+    error_type = (
+        _sanitize_go_engine_reason(failure.get("error_type") or "GoEngineError")
+        or "GoEngineError"
+    )
+    skipped_label = ", ".join(check.replace("_", " ") for check in skipped_checks)
+    return {
+        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+        "severity": "HIGH",
+        "kind": "language_engine_unavailable",
+        "error_type": error_type,
+        "message": (
+            f"Go analysis incomplete: {reason}. Skipped checks: {skipped_label}."
+        ),
+        "file": str(module_files[0]),
+        "line": 1,
+        "column": 1,
+        "language": "go",
+        "module_root": str(failure.get("module_root") or ""),
+        "affected_file_count": len(module_files),
+        "skipped_checks": list(skipped_checks),
+        "suggestion": (
+            "Run `skylos doctor`, then retry the Go scan after fixing "
+            "the reported engine error."
+        ),
+    }
+
+
+def _go_runtime_analysis_errors(
+    report: dict | None,
+    failures,
+) -> list[dict]:
+    if not isinstance(report, dict) or report.get("status") != "available":
+        return []
+
+    normalized_failures = [failure for failure in failures if isinstance(failure, dict)]
+    if not normalized_failures:
+        return []
+
+    skipped_checks = ["dead_code", "security"]
+    report.update(
+        {
+            "status": "partial",
+            "completed_checks": ["quality"],
+            "skipped_checks": list(skipped_checks),
+            "failed_module_count": len(normalized_failures),
+        }
+    )
+    errors = (
+        _go_runtime_analysis_error(failure, skipped_checks)
+        for failure in sorted(
+            normalized_failures,
+            key=lambda item: str(item.get("module_root") or ""),
+        )
+    )
+    return [error for error in errors if error is not None]
 
 
 def _no_source_danger_targets(
@@ -2356,8 +2497,12 @@ class Skylos:
         self._ai_verification_checks = [] if enable_ai_defects else None
         self._language_engine_reports = {}
         go_engine_report = _go_engine_analysis_report(files)
+        language_engine_errors = []
         if go_engine_report is not None:
             self._language_engine_reports["go"] = go_engine_report
+            go_engine_error = _go_engine_analysis_error(files, go_engine_report)
+            if go_engine_error is not None:
+                language_engine_errors.append(go_engine_error)
 
         from skylos.visitors.languages.typescript.workspace import (
             discover_workspace_inventory,
@@ -2632,7 +2777,7 @@ class Skylos:
         all_quality = []
         all_ai_defects = []
         all_suppressed = []
-        analysis_errors = []
+        analysis_errors = list(language_engine_errors)
         empty_files = []
         file_contexts = []
         all_clone_fragments = []
@@ -2698,6 +2843,16 @@ class Skylos:
 
             if os.getenv("SKYLOS_DEBUG"):
                 logger.info(f"[DBG] run_proc_file_parallel returned outs={len(outs)}")
+
+            if go_engine_report is not None:
+                from skylos.visitors.languages.go.go import get_go_engine_failures
+
+                analysis_errors.extend(
+                    _go_runtime_analysis_errors(
+                        go_engine_report,
+                        get_go_engine_failures(),
+                    )
+                )
 
             for file, out in zip(files, outs):
                 if out is None:

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -2358,7 +2358,11 @@ def _strict_scan_exit_code(result: dict, args) -> int:
 
 def _analysis_incomplete_exit_code(result: dict) -> int:
     """Return the operational-error exit code when any file was not analyzed."""
-    return 2 if result.get("analysis_errors") else 0
+    summary = result.get("analysis_summary")
+    incomplete_languages = (
+        summary.get("incomplete_languages") if isinstance(summary, dict) else None
+    )
+    return 2 if result.get("analysis_errors") or incomplete_languages else 0
 
 
 def _apply_config_driven_analysis_flags(args, project_cfg, console):

--- a/skylos/core/gatekeeper.py
+++ b/skylos/core/gatekeeper.py
@@ -556,6 +556,42 @@ def _build_findings_lists(results, danger, reliability, quality, secrets):
     }
 
 
+def _analysis_incomplete_reasons(results):
+    results = results if isinstance(results, dict) else {}
+    reasons = []
+
+    analysis_errors = results.get("analysis_errors")
+    if analysis_errors:
+        try:
+            error_count = len(analysis_errors)
+        except TypeError:
+            error_count = 1
+        reasons.append(
+            f"Analysis incomplete: {error_count} analysis error(s) prevented a "
+            "complete scan"
+        )
+
+    summary = results.get("analysis_summary")
+    summary = summary if isinstance(summary, dict) else {}
+    raw_languages = summary.get("incomplete_languages")
+    if isinstance(raw_languages, (list, tuple, set)):
+        languages = sorted(
+            {
+                str(language).strip()
+                for language in raw_languages
+                if str(language).strip()
+            }
+        )
+    elif raw_languages:
+        languages = [str(raw_languages).strip()]
+    else:
+        languages = []
+    if languages:
+        reasons.append("Incomplete language engine coverage: " + ", ".join(languages))
+
+    return reasons
+
+
 def check_gate(results, config, strict=False, provenance=None):
     """
     Evaluate scan results against gate thresholds.
@@ -572,7 +608,10 @@ def check_gate(results, config, strict=False, provenance=None):
     results = results or {}
     config = config or {}
 
-    reasons = []
+    reasons = _analysis_incomplete_reasons(results)
+    if reasons:
+        return False, reasons
+
     total_findings = _count_dead_code_findings(results)
     danger = results.get("danger", []) or []
     reliability = results.get("reliability", []) or []
@@ -791,6 +830,17 @@ def _handle_advisory_gate(console, reasons):
     return 0
 
 
+def _handle_incomplete_gate(console, reasons):
+    console.print("\n[bold red]Analysis incomplete[/bold red]")
+    for reason in reasons or []:
+        console.print(f"   • {reason}")
+    console.print(
+        "[red]The quality gate cannot pass because required analysis did not "
+        "complete.[/red]"
+    )
+    return 2
+
+
 def run_gate_interaction(
     *,
     results=None,
@@ -822,11 +872,20 @@ def run_gate_interaction(
     gate_cfg = config.get("gate") or {}
 
     strict = bool(strict or gate_cfg.get("strict", False))
+    incomplete_reasons = _analysis_incomplete_reasons(results)
     passed, reasons = _resolve_gate_check(results, config, strict, provenance)
 
     if summary:
-        md = build_summary_markdown(results, passed, reasons, advisory=advisory)
+        md = build_summary_markdown(
+            results,
+            passed,
+            reasons,
+            advisory=advisory and not incomplete_reasons,
+        )
         write_github_summary(md)
+
+    if incomplete_reasons:
+        return _handle_incomplete_gate(console, reasons or incomplete_reasons)
 
     if passed:
         return _handle_passed_gate(console, command_to_run)

--- a/skylos/reporting/github_annotations.py
+++ b/skylos/reporting/github_annotations.py
@@ -28,13 +28,22 @@ _GITHUB_DEAD_CODE_CATEGORIES = (
 )
 
 
+def _escape_github_command_data(value):
+    """Escape a GitHub workflow-command data value."""
+    return str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _escape_github_command_property(value):
+    """Escape a GitHub workflow-command property value."""
+    return _escape_github_command_data(value).replace(":", "%3A").replace(",", "%2C")
+
+
 def _emit_github_grade_annotation(result):
     grade_data = result.get("grade")
     if grade_data:
         overall = grade_data["overall"]
-        print(
-            f"::notice title=Skylos Grade::{overall['letter']} ({overall['score']}/100)"
-        )
+        grade = f"{overall['letter']} ({overall['score']}/100)"
+        print(f"::notice title=Skylos Grade::{_escape_github_command_data(grade)}")
 
 
 def _github_finding_annotation(finding):
@@ -109,10 +118,11 @@ def _github_annotation_sort_key(annotation):
 
 def _emit_github_annotation(annotation):
     level = _GITHUB_ANNOTATION_LEVELS.get(annotation["severity"], "warning")
-    print(
-        f"::{level} file={annotation['file']},line={annotation['line']},"
-        f"title={annotation['title']}::{annotation['msg']}"
-    )
+    file = _escape_github_command_property(annotation["file"])
+    line = _escape_github_command_property(annotation["line"])
+    title = _escape_github_command_property(annotation["title"])
+    msg = _escape_github_command_data(annotation["msg"])
+    print(f"::{level} file={file},line={line},title={title}::{msg}")
 
 
 def _emit_github_annotations(result, *, max_annotations=50, severity_filter=None):

--- a/skylos/reporting/result_builder.py
+++ b/skylos/reporting/result_builder.py
@@ -416,7 +416,9 @@ def _attach_grade(
         )
         result["analysis_summary"]["total_loc"] = total_loc
         result["analysis_summary"]["grade_categories"] = categories
-        if result.get("analysis_errors"):
+        if result.get("analysis_errors") or result["analysis_summary"].get(
+            "incomplete_languages"
+        ):
             result["analysis_summary"]["grade_unavailable_reason"] = (
                 "analysis_incomplete"
             )

--- a/skylos/rules/quality/regression.py
+++ b/skylos/rules/quality/regression.py
@@ -55,7 +55,7 @@ _VALIDATION_DECORATORS = {
 }
 
 _VALIDATION_CALLS_RE = re.compile(
-    r"(?:validate|sanitize|html\.escape|bleach\.clean|markupsafe\.escape|"
+    r"(?P<control>validate|sanitize|html\.escape|bleach\.clean|markupsafe\.escape|"
     r"(?<![.\w])escape)\("
 )
 
@@ -87,8 +87,8 @@ _AUDIT_DECORATORS = {
 }
 
 _SANITIZATION_CALLS_RE = re.compile(
-    r"(?:html\.escape\(|bleach\.clean\(|markupsafe\.escape\(|DOMPurify\.sanitize\(|"
-    r"escape_string\(|parameterized\(|(?<![.\w])text\()"
+    r"(?P<control>html\.escape|bleach\.clean|markupsafe\.escape|DOMPurify\.sanitize|"
+    r"escape_string|parameterized|(?<![.\w])text)\("
 )
 
 _PERMISSION_CALLS_RE = re.compile(
@@ -124,6 +124,12 @@ def _has_verify_setting(line: str, pattern: re.Pattern[str]) -> bool:
     if _looks_like_metadata_string(line):
         return False
     return bool(pattern.search(line))
+
+
+def _control_calls(line: str, pattern: re.Pattern[str]) -> set[str]:
+    if _looks_like_metadata_string(line):
+        return set()
+    return {match.group("control") for match in pattern.finditer(line)}
 
 
 def _removed_csrf_protection(line: str) -> str | None:
@@ -312,8 +318,12 @@ def detect_security_regressions(
                     )
                 )
 
+    added_validation_calls = set().union(
+        *(_control_calls(line, _VALIDATION_CALLS_RE) for _, line in added_lines)
+    )
     for line_no, line in removed_lines:
-        if _VALIDATION_CALLS_RE.search(line):
+        removed_validation_calls = _control_calls(line, _VALIDATION_CALLS_RE)
+        if removed_validation_calls - added_validation_calls:
             findings.append(
                 _make_finding(
                     file_path,
@@ -394,8 +404,12 @@ def detect_security_regressions(
                 )
             )
 
+    added_sanitization_calls = set().union(
+        *(_control_calls(line, _SANITIZATION_CALLS_RE) for _, line in added_lines)
+    )
     for line_no, line in removed_lines:
-        if _SANITIZATION_CALLS_RE.search(line):
+        removed_sanitization_calls = _control_calls(line, _SANITIZATION_CALLS_RE)
+        if removed_sanitization_calls - added_sanitization_calls:
             findings.append(
                 _make_finding(
                     file_path,

--- a/skylos/ui/rich_report.py
+++ b/skylos/ui/rich_report.py
@@ -74,6 +74,23 @@ def _display_cap(items, limit):
     return items[:cap], max(0, len(items) - cap)
 
 
+def _analysis_error_affected_file_count(error):
+    count = error.get("affected_file_count")
+    if isinstance(count, int) and not isinstance(count, bool) and count > 0:
+        return count
+    return 1
+
+
+def _analysis_error_runtime(error):
+    kind = str(error.get("kind") or error.get("error_type") or "")
+    if kind == "language_engine_unavailable":
+        language = str(error.get("language") or "").strip()
+        return f"{language.title()} engine" if language else "Language engine"
+
+    runtime = str(error.get("python_version") or "?")
+    return f"Python {runtime}"
+
+
 def _render_analysis_errors(
     console: Console,
     result,
@@ -89,10 +106,16 @@ def _render_analysis_errors(
     if not errors:
         return
 
-    count = len(errors)
+    error_count = len(errors)
+    affected_file_count = sum(
+        _analysis_error_affected_file_count(error) for error in errors
+    )
+    affected_label = "file" if affected_file_count == 1 else "files"
+    error_label = "error" if error_count == 1 else "errors"
     console.print(
         Panel.fit(
-            f"[bad]Analysis incomplete: {count} file(s) could not be analyzed.[/bad]\n"
+            f"[bad]Analysis incomplete: {affected_file_count} affected "
+            f"{affected_label} across {error_count} analysis {error_label}.[/bad]\n"
             "[muted]No grade or clean result was produced; Skylos exits with code 2.[/muted]",
             border_style="bad",
         )
@@ -102,6 +125,7 @@ def _render_analysis_errors(
     table.add_column("File", style="bold", overflow="fold")
     table.add_column("Line", justify="right", width=6)
     table.add_column("Error", overflow="fold")
+    table.add_column("Affected", justify="right", width=10)
     table.add_column("Runtime", style="muted", width=14)
 
     visible, overflow = _display_cap(errors, limit)
@@ -110,12 +134,14 @@ def _render_analysis_errors(
         line = str(error.get("line") or 1)
         kind = str(error.get("kind") or error.get("error_type") or "analysis error")
         message = str(error.get("message") or "File analysis failed")
-        runtime = str(error.get("python_version") or "?")
+        affected_count = _analysis_error_affected_file_count(error)
+        affected = "1 file" if affected_count == 1 else f"{affected_count} files"
         table.add_row(
             path,
             line,
             escape(f"{kind.replace('_', ' ')}: {message}"),
-            escape(f"Python {runtime}"),
+            affected,
+            escape(_analysis_error_runtime(error)),
         )
 
     console.print(table)

--- a/skylos/ui/tui.py
+++ b/skylos/ui/tui.py
@@ -41,6 +41,7 @@ SEVERITY_FG = {
 
 CATEGORIES = [
     ("overview", "Overview"),
+    ("analysis_errors", "Analysis Errors"),
     ("dead_code", "Dead Code"),
     ("security", "Security"),
     ("reliability", "Reliability"),
@@ -76,6 +77,21 @@ def _loc(item, root_path=None):
 
 def prepare_category_data(result: dict, root_path=None) -> dict:
     data = {}
+
+    analysis_cols = ["Rule", "Severity", "Message", "File:Line", "Language"]
+    analysis_rows, analysis_raw = [], []
+    for item in result.get("analysis_errors") or []:
+        analysis_rows.append(
+            (
+                item.get("rule_id") or "SKY-ANALYSIS-INCOMPLETE",
+                (item.get("severity") or "HIGH").upper(),
+                item.get("message") or "Analysis incomplete",
+                _loc(item, root_path),
+                item.get("language") or "?",
+            )
+        )
+        analysis_raw.append(item)
+    data["analysis_errors"] = (analysis_cols, analysis_rows, analysis_raw)
 
     dc_cols = ["Type", "Name", "File:Line", "Confidence", "Decision"]
     dc_rows, dc_raw = [], []
@@ -271,7 +287,7 @@ def _finding_severity(category: str, item: dict, row: tuple) -> str:
     raw = item.get("severity")
     if raw:
         return str(raw).upper()
-    if category in {"security", "secrets", "dependencies"}:
+    if category in {"analysis_errors", "security", "secrets", "dependencies"}:
         return "HIGH"
     if category in {"quality", "reliability"}:
         return "MEDIUM"
@@ -281,7 +297,7 @@ def _finding_severity(category: str, item: dict, row: tuple) -> str:
 def _finding_rule(category: str, item: dict, row: tuple) -> str:
     if category == "dead_code":
         return f"dead-code/{str(row[0]).lower().replace(' ', '-')}"
-    if category in {"security", "reliability"}:
+    if category in {"analysis_errors", "security", "reliability"}:
         return str(row[0])
     if category == "secrets":
         return str(row[0])
@@ -295,7 +311,7 @@ def _finding_rule(category: str, item: dict, row: tuple) -> str:
 def _finding_title(category: str, item: dict, row: tuple) -> str:
     if category == "dead_code":
         return f"Unused {str(row[0]).lower()}: {row[1]}"
-    if category in {"security", "reliability"}:
+    if category in {"analysis_errors", "security", "reliability"}:
         return str(row[2])
     if category == "secrets":
         return str(row[1])
@@ -342,7 +358,7 @@ class OverviewPanel(VerticalScroll):
             )
 
         sev_counts: dict[str, int] = {}
-        for cat in ("security", "reliability", "dependencies"):
+        for cat in ("analysis_errors", "security", "reliability", "dependencies"):
             _, _, raw = self.category_data.get(cat, ([], [], []))
             for item in raw:
                 sev = (item.get("severity") or "").upper()
@@ -381,6 +397,7 @@ class OverviewPanel(VerticalScroll):
 
         file_counts: dict[str, int] = {}
         for cat_key in (
+            "analysis_errors",
             "dead_code",
             "security",
             "reliability",
@@ -421,7 +438,7 @@ class DetailPanel(Static):
             for evidence_line in dead_code_evidence_detail_lines(item):
                 lines.append(f"  {escape(evidence_line)}")
 
-        elif category in {"security", "reliability"}:
+        elif category in {"analysis_errors", "security", "reliability"}:
             lines.append(f"  [bold]Rule:[/bold]  {item.get('rule_id', '?')}")
             sev = item.get("severity", "?")
             color = (
@@ -431,6 +448,13 @@ class DetailPanel(Static):
             )
             lines.append(f"  [bold]Severity:[/bold]  [{color}]{sev}[/{color}]")
             lines.append(f"  [bold]Message:[/bold]  {item.get('message', '')}")
+            if category == "analysis_errors":
+                language = item.get("language")
+                if language:
+                    lines.append(f"  [bold]Language:[/bold]  {language}")
+                suggestion = item.get("suggestion")
+                if suggestion:
+                    lines.append(f"  [bold]Next step:[/bold]  {suggestion}")
             ver = item.get("verification") or {}
             if category == "security" and ver.get("verdict"):
                 lines.append(f"  [bold]Verification:[/bold]  {ver['verdict']}")

--- a/skylos/visitors/languages/go/go.py
+++ b/skylos/visitors/languages/go/go.py
@@ -41,18 +41,53 @@ def clear_go_cache():
     _go_module_cache.clear()
 
 
-def _get_module_result(module_root):
-    key = str(module_root)
+def get_go_engine_failures():
+    failures = []
+    for module_root in sorted(_go_module_cache):
+        entry = _go_module_cache[module_root]
+        failure = entry.get("failure") if isinstance(entry, dict) else None
+        if not isinstance(failure, dict):
+            continue
+        failures.append(
+            {
+                **failure,
+                "files": sorted(str(path) for path in entry.get("files", set())),
+            }
+        )
+    return failures
+
+
+def _get_module_result(module_root, file_path=None):
+    resolved_root = Path(module_root).resolve()
+    key = str(resolved_root)
     if key not in _go_module_cache:
         try:
-            _go_module_cache[key] = run_go_engine_for_module(module_root)
+            result = run_go_engine_for_module(resolved_root)
+            if not isinstance(result, dict):
+                raise TypeError("Go engine returned a non-object result")
+            _go_module_cache[key] = {
+                "result": result,
+                "failure": None,
+                "files": set(),
+            }
         except Exception as e:
             import os
 
             if os.getenv("SKYLOS_DEBUG"):
                 print(f"Go analysis failed: {e}")
-            _go_module_cache[key] = {"findings": [], "symbols": None}
-    return _go_module_cache[key]
+            _go_module_cache[key] = {
+                "result": {"findings": [], "symbols": None},
+                "failure": {
+                    "module_root": key,
+                    "error_type": type(e).__name__,
+                    "reason": str(e) or type(e).__name__,
+                },
+                "files": set(),
+            }
+    entry = _go_module_cache[key]
+    if file_path is not None:
+        entry["files"].add(str(Path(file_path)))
+    return entry["result"]
 
 
 def _convert_symbols(symbols_data, file_path):
@@ -95,7 +130,7 @@ def scan_go_file(file_path, cfg):
     if not _is_safe_go_file(file_path, module_root):
         return _empty_go_scan_result(cfg)
 
-    result = _get_module_result(module_root)
+    result = _get_module_result(module_root, file_path)
     is_generated = _is_generated_go_file(file_path)
 
     findings = result.get("findings", [])

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -11,6 +11,7 @@ from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.analysis.penalties import apply_penalties
 from skylos.deadcode.config_entrypoints import configured_entrypoint_reason
+from skylos.engines.go_runner import GoEngineError
 
 from skylos.analyzer import (
     Skylos,
@@ -3685,7 +3686,10 @@ class TestRepoPhantomReferences:
                 "skylos.engines.go_runner.get_go_engine_status",
                 return_value={
                     "status": "unavailable",
-                    "reason": "Go engine binary not found",
+                    "reason": (
+                        "\x1b[31mGo engine binary not found\x1b[0m\n"
+                        "unsafe\x00\x85detail"
+                    ),
                     "configured_by": "discovery",
                 },
             ),
@@ -3699,7 +3703,116 @@ class TestRepoPhantomReferences:
         report = result["analysis_summary"]["language_engines"]["go"]
         assert report["status"] == "partial"
         assert report["skipped_checks"] == ["dead_code", "security"]
+        assert report["engine"]["reason"] == (
+            "Go engine binary not found unsafe detail"
+        )
         assert result["analysis_summary"]["incomplete_languages"] == ["go"]
+        assert result["analysis_summary"]["analysis_error_count"] == 1
+        assert result["analysis_summary"]["grade_unavailable_reason"] == (
+            "analysis_incomplete"
+        )
+        assert "grade" not in result
+
+        assert len(result["analysis_errors"]) == 1
+        error = result["analysis_errors"][0]
+        assert error["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+        assert error["kind"] == "language_engine_unavailable"
+        assert error["error_type"] == "GoEngineUnavailable"
+        assert error["file"] == str(source)
+        assert error["language"] == "go"
+        assert error["affected_file_count"] == 1
+        assert error["skipped_checks"] == ["dead_code", "security"]
+        assert "Go engine binary not found" in error["message"]
+        assert "python_version" not in error
+
+    def test_analyze_fails_closed_once_when_available_go_engine_crashes(self, tmp_path):
+        (tmp_path / "go.mod").write_text(
+            "module example.com/demo\n\ngo 1.22\n",
+            encoding="utf-8",
+        )
+        first_source = tmp_path / "a.go"
+        second_source = tmp_path / "z.go"
+        first_source.write_text("package demo\n", encoding="utf-8")
+        second_source.write_text("package demo\n", encoding="utf-8")
+
+        def quality_finding(_root_node, _source, file_path):
+            return [
+                {
+                    "rule_id": "SKY-Q301",
+                    "severity": "MEDIUM",
+                    "message": "Quality analysis still ran",
+                    "file": file_path,
+                    "line": 1,
+                    "col": 0,
+                    "name": "demo",
+                    "simple_name": "demo",
+                }
+            ]
+
+        with (
+            patch(
+                "skylos.engines.go_runner.get_go_engine_status",
+                return_value={
+                    "status": "available",
+                    "binary": "/tmp/skylos-go",
+                    "configured_by": "PATH",
+                },
+            ),
+            patch(
+                "skylos.visitors.languages.go.go.run_go_engine_for_module",
+                side_effect=GoEngineError(
+                    "\x1b[31mengine crashed\x1b[0m\nunsafe\x00\x85detail"
+                ),
+            ) as run_engine,
+            patch("skylos.visitors.languages.go.go.GO_LANG", object()),
+            patch("skylos.visitors.languages.go.go.Parser") as parser_type,
+            patch(
+                "skylos.visitors.languages.go.go.scan_go_quality",
+                side_effect=quality_finding,
+            ),
+        ):
+            parser_type.return_value.parse.return_value.root_node = object()
+            result = json.loads(
+                analyze(
+                    str(tmp_path),
+                    enable_quality=True,
+                    grep_verify=False,
+                )
+            )
+
+        run_engine.assert_called_once_with(tmp_path.resolve())
+        report = result["analysis_summary"]["language_engines"]["go"]
+        assert report["status"] == "partial"
+        assert report["completed_checks"] == ["quality"]
+        assert report["skipped_checks"] == ["dead_code", "security"]
+        assert report["failed_module_count"] == 1
+        assert result["analysis_summary"]["incomplete_languages"] == ["go"]
+        assert result["analysis_summary"]["analysis_error_count"] == 1
+        assert result["analysis_summary"]["grade_unavailable_reason"] == (
+            "analysis_incomplete"
+        )
+        assert "grade" not in result
+
+        assert len(result["analysis_errors"]) == 1
+        error = result["analysis_errors"][0]
+        assert error["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+        assert error["kind"] == "language_engine_unavailable"
+        assert error["error_type"] == "GoEngineError"
+        assert error["file"] == str(first_source)
+        assert error["module_root"] == str(tmp_path.resolve())
+        assert error["affected_file_count"] == 2
+        assert "engine crashed unsafe detail" in error["message"]
+        assert all(
+            not (ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F)
+            for char in error["message"]
+        )
+
+        quality = [
+            finding
+            for finding in result.get("quality", [])
+            if finding.get("message") == "Quality analysis still ran"
+        ]
+        assert len(quality) == 2
 
     def test_resolve_analysis_root_ignores_home_git_root_without_project_marker(
         self, tmp_path, monkeypatch

--- a/test/test_cicd_gate.py
+++ b/test/test_cicd_gate.py
@@ -71,6 +71,41 @@ def test_gate_fails_on_dependency_vulnerability(clean_results):
     assert "1 dependency vulnerabilities (max: 0)" in reasons
 
 
+def test_gate_fails_closed_on_incomplete_language_engine(clean_results):
+    clean_results["analysis_errors"] = [
+        {
+            "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+            "kind": "language_engine_unavailable",
+            "message": "Go analysis incomplete",
+        }
+    ]
+    clean_results["analysis_summary"] = {"incomplete_languages": ["go"]}
+
+    passed, reasons = check_gate(clean_results, {})
+
+    assert passed is False
+    assert any("Analysis incomplete" in reason for reason in reasons)
+    assert "Incomplete language engine coverage: go" in reasons
+
+
+def test_gate_incomplete_analysis_is_not_advisory_or_force_bypass(clean_results):
+    clean_results["analysis_errors"] = [
+        {
+            "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+            "message": "Go analysis incomplete",
+        }
+    ]
+
+    exit_code = run_gate_interaction(
+        result=clean_results,
+        config={},
+        advisory=True,
+        force=True,
+    )
+
+    assert exit_code == 2
+
+
 def test_gate_strict_mode(clean_results):
     clean_results["quality"] = [
         {

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2471,6 +2471,15 @@ def test_main_json_incomplete_analysis_exits_two_after_output(monkeypatch):
     upload_report.assert_not_called()
 
 
+def test_incomplete_language_summary_uses_operational_exit_code():
+    result = {
+        "analysis_errors": [],
+        "analysis_summary": {"incomplete_languages": ["go"]},
+    }
+
+    assert cli._analysis_incomplete_exit_code(result) == 2
+
+
 def test_main_incomplete_analysis_renders_without_badge_then_exits_two(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1, "analysis_error_count": 1},

--- a/test/test_container_python_runtime.py
+++ b/test/test_container_python_runtime.py
@@ -12,6 +12,13 @@ def test_dockerfile_supports_selectable_python_runtime():
     assert "SKYLOS_CONTAINER_PYTHON_VERSION=${PYTHON_VERSION}" in dockerfile
 
 
+def test_docker_runtime_includes_native_go_engine():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "RUN go build -o /out/skylos-go ./cmd/skylos-go" in dockerfile
+    assert "COPY --from=go-build /out/skylos-go /usr/local/bin/skylos-go" in dockerfile
+
+
 def test_publish_workflow_pushes_versioned_python_runtime_tags():
     workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(
         encoding="utf-8"
@@ -23,6 +30,8 @@ def test_publish_workflow_pushes_versioned_python_runtime_tags():
     assert '"${IMAGE_NAME}:${VERSION}-${runtime_tag}"' in workflow
     assert '"${IMAGE_NAME}:latest-${runtime_tag}"' in workflow
     assert 'if [[ "$PYTHON_VERSION" == "$DEFAULT_PYTHON_VERSION" ]]' in workflow
+    assert "skylos:smoke doctor --format json" in workflow
+    assert "json.load(sys.stdin)" in workflow
 
 
 def test_ci_builds_oldest_and_default_python_runtime_images():
@@ -33,3 +42,5 @@ def test_ci_builds_oldest_and_default_python_runtime_images():
     assert 'python-version: ["3.11", "3.14"]' in workflow
     assert '--build-arg "PYTHON_VERSION=${{ matrix.python-version }}"' in workflow
     assert "type CacheEntry[T = str] = dict[str, T]" in workflow
+    assert "skylos:test doctor --format json" in workflow
+    assert "json.load(sys.stdin)" in workflow

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -591,6 +591,62 @@ def test_composite_action_validates_and_quotes_max_comments_input():
     assert "=~ ^[0-9]+$" in run
 
 
+def test_composite_action_preserves_incomplete_scan_exit_code():
+    action = _composite_action()
+    steps = action["runs"]["steps"]
+    scan_step = next(s for s in steps if s.get("name") == "Run Skylos Scan")
+    gate_step = next(s for s in steps if s.get("name") == "Quality Gate")
+
+    assert "|| true" not in scan_step["run"]
+    assert "SCAN_STATUS=$?" in scan_step["run"]
+    assert 'if [ "$SCAN_STATUS" -eq 2 ]' in scan_step["run"]
+    assert "exit 2" in scan_step["run"]
+    assert "set +e" in gate_step["run"]
+    assert "RESULT=$?" in gate_step["run"]
+    assert 'exit "$RESULT"' in gate_step["run"]
+
+
+def test_composite_action_builds_platform_native_go_engine():
+    action = _composite_action()
+    steps = action["runs"]["steps"]
+    detect_step = next(s for s in steps if s.get("name") == "Detect Go sources")
+    setup_step = next(s for s in steps if s.get("name") == "Set up Go")
+    build_step = next(s for s in steps if s.get("name") == "Build Skylos Go engine")
+
+    assert detect_step["env"]["SKYLOS_PATH"] == "${{ inputs.path }}"
+    assert 'find "$SKYLOS_PATH"' in detect_step["run"]
+    assert "present=true" in detect_step["run"]
+    assert "present=false" in detect_step["run"]
+    go_sources_condition = "steps.go_sources.outputs.present == 'true'"
+    assert setup_step["if"] == go_sources_condition
+    assert build_step["if"] == go_sources_condition
+
+    setup_ref = setup_step["uses"].split("@", 1)[1]
+    assert len(setup_ref) == 40
+    assert all(char in "0123456789abcdef" for char in setup_ref)
+    assert setup_step["with"]["go-version"] == "1.22.x"
+    assert setup_step["with"]["cache"] is False
+
+    assert build_step["env"]["SKYLOS_ACTION_PATH"] == "${{ github.action_path }}"
+    assert 'cd "$SKYLOS_ACTION_PATH/skylos/engines/go"' in build_step["run"]
+    assert "go build -trimpath" in build_step["run"]
+    assert 'ENGINE_NAME="skylos-go.exe"' in build_step["run"]
+    assert '"$ENGINE_DIR/$ENGINE_NAME"' in build_step["run"]
+    assert "$GITHUB_ENV" not in build_step["run"]
+
+    expected_engine = (
+        "${{ format('{0}/skylos-go-engine/skylos-go{1}', runner.temp, "
+        "runner.os == 'Windows' && '.exe' || '') }}"
+    )
+    scan_steps = [
+        s
+        for s in steps
+        if s.get("name") in {"Run Skylos Scan", "Upload to Skylos Dashboard"}
+    ]
+    assert len(scan_steps) == 2
+    assert all(s["env"]["SKYLOS_GO_BIN"] == expected_engine for s in scan_steps)
+
+
 def test_composite_action_passes_skylos_actions_audit():
     assert scan_github_actions_file("action.yml", root=".") == []
 

--- a/test/test_github_annotations.py
+++ b/test/test_github_annotations.py
@@ -106,3 +106,43 @@ class TestGitHubAnnotations:
         assert lines[0].startswith("::error")
         assert lines[1].startswith("::error")  # HIGH -> error
         assert "Unused class: OldClass" in lines[2]
+
+    def test_annotation_escapes_workflow_command_values(self):
+        result = {
+            "danger": [
+                {
+                    "rule_id": "SKY-D999,forged:title%\r\n::notice injected",
+                    "severity": "HIGH",
+                    "file": "src,bad:name%\r\n::warning injected.py",
+                    "line": "7,forged:title%\r\n::notice injected",
+                    "message": "Real issue: 100%, retry\r\n::error injected",
+                }
+            ],
+        }
+
+        lines = _capture_annotations(result)
+
+        assert lines == [
+            "::error "
+            "file=src%2Cbad%3Aname%25%0D%0A%3A%3Awarning injected.py,"
+            "line=7%2Cforged%3Atitle%25%0D%0A%3A%3Anotice injected,"
+            "title=Skylos SKY-D999%2Cforged%3Atitle%25%0D%0A%3A%3Anotice injected::"
+            "Real issue: 100%25, retry%0D%0A::error injected"
+        ]
+
+    def test_grade_escapes_workflow_command_data(self):
+        result = {
+            "grade": {
+                "overall": {
+                    "letter": "A%\r\n::error injected",
+                    "score": "100\n::warning injected",
+                }
+            }
+        }
+
+        lines = _capture_annotations(result)
+
+        assert lines == [
+            "::notice title=Skylos Grade::"
+            "A%25%0D%0A::error injected (100%0A::warning injected/100)"
+        ]

--- a/test/test_language_verification_integration.py
+++ b/test/test_language_verification_integration.py
@@ -232,6 +232,9 @@ func main() { security.VerifyToken("ok") }
         )
 
     assert result["analysis_summary"]["language_engines"]["go"]["status"] == "partial"
+    assert result["analysis_summary"]["analysis_error_count"] == 1
+    assert result["analysis_errors"][0]["kind"] == "language_engine_unavailable"
+    assert "grade" not in result
     coverage = result["analysis_summary"]["ai_verification"]
     assert coverage["state"] == "complete"
     check = next(

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -225,6 +225,27 @@ class TestInputValidationRemoval:
         validation_findings = [f for f in findings if f["control_type"] == "validation"]
         assert len(validation_findings) >= 1
 
+    def test_escape_refactor_preserves_validation_control(self):
+        diff = _make_diff(
+            ["    safe = escape(f'Python {runtime}')"],
+            ["    safe = escape(runtime_label(error))"],
+        )
+
+        findings = detect_security_regressions(diff, "report.py")
+
+        assert not any(f["control_type"] == "validation" for f in findings)
+        assert not any(f["control_type"] == "sanitization" for f in findings)
+
+    def test_different_added_validator_does_not_hide_escape_removal(self):
+        diff = _make_diff(
+            ["    safe = escape(user_input)"],
+            ["    validate(metadata)", "    safe = user_input"],
+        )
+
+        findings = detect_security_regressions(diff, "views.py")
+
+        assert any(f["control_type"] == "validation" for f in findings)
+
     def test_read_text_removed_is_not_sanitization_regression(self):
         diff = _make_diff(
             ["    source = path.read_text(encoding='utf-8')"],

--- a/test/test_rich_report.py
+++ b/test/test_rich_report.py
@@ -1,0 +1,62 @@
+from io import StringIO
+
+from rich.console import Console
+from rich.theme import Theme
+
+from skylos.ui.rich_report import _render_analysis_errors
+
+
+def _render_errors(result):
+    output = StringIO()
+    console = Console(
+        file=output,
+        force_terminal=False,
+        color_system=None,
+        theme=Theme({"bad": "bold red", "muted": "dim"}),
+        width=180,
+    )
+    _render_analysis_errors(console, result)
+    return output.getvalue()
+
+
+def test_aggregate_go_engine_error_shows_affected_files_and_engine_runtime():
+    rendered = _render_errors(
+        {
+            "analysis_errors": [
+                {
+                    "kind": "language_engine_unavailable",
+                    "message": "Go analysis incomplete: engine unavailable.",
+                    "file": "/repo/first.go",
+                    "line": 1,
+                    "language": "go",
+                    "affected_file_count": 4,
+                }
+            ]
+        }
+    )
+
+    assert "Analysis incomplete: 4 affected files across 1 analysis error." in rendered
+    assert "4 files" in rendered
+    assert "Go engine" in rendered
+    assert "Python ?" not in rendered
+
+
+def test_syntax_error_keeps_python_runtime_and_single_file_rendering():
+    rendered = _render_errors(
+        {
+            "analysis_errors": [
+                {
+                    "kind": "syntax_error",
+                    "message": "invalid syntax",
+                    "file": "/repo/broken.py",
+                    "line": 7,
+                    "python_version": "3.12.13",
+                }
+            ]
+        }
+    )
+
+    assert "Analysis incomplete: 1 affected file across 1 analysis error." in rendered
+    assert "syntax error: invalid syntax" in rendered
+    assert "1 file" in rendered
+    assert "Python 3.12.13" in rendered

--- a/test/test_tui.py
+++ b/test/test_tui.py
@@ -114,12 +114,42 @@ class TestPrepareCategoryData:
 
     def test_returns_all_category_keys(self, sample_result):
         data = prepare_category_data(sample_result)
+        assert "analysis_errors" in data
         assert "dead_code" in data
         assert "security" in data
         assert "secrets" in data
         assert "quality" in data
         assert "dependencies" in data
         assert "suppressed" in data
+
+    def test_analysis_errors_are_visible(self):
+        result = {
+            "analysis_errors": [
+                {
+                    "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                    "severity": "HIGH",
+                    "message": "Go analysis incomplete: engine unavailable.",
+                    "file": "main.go",
+                    "line": 1,
+                    "language": "go",
+                    "suggestion": "Configure a runnable Go engine.",
+                }
+            ]
+        }
+
+        cols, rows, raw = prepare_category_data(result)["analysis_errors"]
+
+        assert cols == ["Rule", "Severity", "Message", "File:Line", "Language"]
+        assert rows == [
+            (
+                "SKY-ANALYSIS-INCOMPLETE",
+                "HIGH",
+                "Go analysis incomplete: engine unavailable.",
+                "main.go:1",
+                "go",
+            )
+        ]
+        assert raw[0]["suggestion"] == "Configure a runnable Go engine."
 
     def test_dead_code_aggregates_all_types(self, sample_result):
         data = prepare_category_data(sample_result)
@@ -267,6 +297,7 @@ class TestPrepareCategoryData:
     def test_empty_result(self):
         data = prepare_category_data({})
         for key in (
+            "analysis_errors",
             "dead_code",
             "security",
             "secrets",
@@ -370,6 +401,23 @@ class TestSkylosAppInit:
         assert app.category_counts["secrets"] == 0
         assert app.category_counts["quality"] == 0
         assert app.category_counts["overview"] == 3
+
+    def test_analysis_errors_count_toward_overview(self, sample_result):
+        sample_result["analysis_errors"] = [
+            {
+                "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                "severity": "HIGH",
+                "message": "Go engine unavailable",
+                "file": "main.go",
+                "line": 1,
+                "language": "go",
+            }
+        ]
+
+        app = SkylosApp(sample_result)
+
+        assert app.category_counts["analysis_errors"] == 1
+        assert app.category_counts["overview"] == 4
 
     def test_root_path_stored(self, sample_result, tmp_path):
         app = SkylosApp(sample_result, root_path=tmp_path)


### PR DESCRIPTION
Fixes #692 

## Summary

  - fail closed when the native Go engine is missing, crashes, times out, or returns invalid output
  - emit SKY-ANALYSIS-INCOMPLETE, omit misleading grades, and preserve exit code 2 across CLI formats and CI gates
  - keep Python-only scans unchanged and continue analyzing available languages in mixed repositories
  - build the platform native go engine in gh action, including windows support
  - retain the Go engine in Docker runtime images and verify it during release smoke

  ## Tests

  - go test ./...
  - Ruff, YAML parsing