### PR TITLE
fix(typescript): ignore null guards in timing comparison rule

### DIFF
--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -644,6 +644,16 @@ def _unwrap_ts_expression(node):
     return node
 
 
+def _is_null_literal_expression(node) -> bool:
+    current = node
+    while current is not None:
+        unwrapped = _unwrap_ts_expression(current)
+        if unwrapped is current:
+            return current.type == "null"
+        current = unwrapped
+    return False
+
+
 def _has_dynamic_url_part(node) -> bool:
     unwrapped = _unwrap_ts_expression(node)
     if unwrapped is not node:
@@ -1853,22 +1863,26 @@ def _check_timing_comparison(
             if has_eq:
                 left = node.child_by_field_name("left")
                 right = node.child_by_field_name("right")
-                for operand in (left, right):
-                    if operand is None:
-                        continue
-                    name = _extract_var_name(operand, source_bytes)
-                    if name and _is_timing_sensitive(name):
-                        findings.append(
-                            {
-                                "rule_id": "SKY-D253",
-                                "severity": "MEDIUM",
-                                "message": f"Timing-unsafe comparison of '{name}'. Use crypto.timingSafeEqual() for constant-time comparison.",
-                                "file": str(file_path),
-                                "line": node.start_point[0] + 1,
-                                "col": 0,
-                            }
-                        )
-                        break
+                if not (
+                    _is_null_literal_expression(left)
+                    or _is_null_literal_expression(right)
+                ):
+                    for operand in (left, right):
+                        if operand is None:
+                            continue
+                        name = _extract_var_name(operand, source_bytes)
+                        if name and _is_timing_sensitive(name):
+                            findings.append(
+                                {
+                                    "rule_id": "SKY-D253",
+                                    "severity": "MEDIUM",
+                                    "message": f"Timing-unsafe comparison of '{name}'. Use crypto.timingSafeEqual() for constant-time comparison.",
+                                    "file": str(file_path),
+                                    "line": node.start_point[0] + 1,
+                                    "col": 0,
+                                }
+                            )
+                            break
         for child in node.children:
             stack.append(child)
 

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -2071,6 +2071,61 @@ class TestInsecureCookies:
 class TestTimingUnsafeComparison:
     """SKY-D253: Direct comparison of security-sensitive variables."""
 
+    def test_null_guard_is_not_timing_comparison(self, tmp_path):
+        code = (
+            "export function reportIsLoaded(digest) {\n"
+            "    return digest !== null;\n"
+            "}\n"
+        )
+        _, _, _, danger = _scan_ts_file(tmp_path, "reproduce.js", code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D253" not in ids
+
+    @pytest.mark.parametrize(
+        "expression",
+        (
+            "null === token",
+            "hash == null",
+            "null != signature",
+            "digest !== (null as null)",
+        ),
+    )
+    def test_null_guard_variants_are_not_timing_comparisons(
+        self, tmp_path, expression
+    ):
+        _, _, _, danger = _scan_ts(tmp_path, f"if ({expression}) {{ proceed(); }}\n")
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D253" not in ids
+
+    def test_null_guard_does_not_hide_sensitive_comparison(self, tmp_path):
+        code = "if ((digest === expectedDigest) !== null) { proceed(); }\n"
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        d253 = [finding for finding in danger if finding["rule_id"] == "SKY-D253"]
+        assert len(d253) == 1
+
+    @pytest.mark.parametrize(
+        "expression",
+        (
+            "nullDigest === expectedDigest",
+            "digest === object.null",
+            'digest === "null"',
+        ),
+    )
+    def test_null_lookalikes_remain_timing_comparisons(self, tmp_path, expression):
+        _, _, _, danger = _scan_ts(tmp_path, f"if ({expression}) {{ proceed(); }}\n")
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D253" in ids
+
+    def test_shadowed_undefined_remains_timing_comparison(self, tmp_path):
+        code = (
+            "function compare(token, undefined) {\n"
+            "    return token === undefined;\n"
+            "}\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D253" in ids
+
     def test_password_triple_eq(self, tmp_path):
         code = (
             "function verify(password: string, stored: string) {\n"


### PR DESCRIPTION
Fixes #700.

## Summary

  - Stop SKY-D253 from flagging null guards such as digest !== null
  - Preserve findings for timing sensitive comparisons

  ## Tests

  - pytest test/test_typescript_expanded.py
  - TypeScript tests