### PR TITLE
fix(quality): handle positional-only defaults

### DIFF
--- a/skylos/rules/quality/logic_security.py
+++ b/skylos/rules/quality/logic_security.py
@@ -1338,12 +1338,13 @@ class MockPlaceholderDataRule(SkylosRule):
 def _iter_arg_defaults(func_node):
     args = func_node.args
     num_defaults = len(args.defaults)
-    num_args = len(args.args)
+    positional_args = [*args.posonlyargs, *args.args]
+    num_args = len(positional_args)
     offset = num_args - num_defaults
 
     for i, default in enumerate(args.defaults):
         if default:
-            yield args.args[offset + i], default
+            yield positional_args[offset + i], default
     for arg, default in zip(args.kwonlyargs, args.kw_defaults):
         if default:
             yield arg, default

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3388,6 +3388,50 @@ def fake_call():
             "low_entropy_uuid",
         }
 
+    def test_analyze_flags_protocol_and_implementation_defaults(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("SKYLOS_JOBS", "1")
+        src = tmp_path / "protocols.py"
+        src.write_text(
+            """
+from typing import Protocol
+
+class Notifier(Protocol):
+    def notify(
+        self,
+        protocol_email: str = "test@example.com",
+        /,
+    ) -> None:
+        ...
+
+class ConcreteNotifier(Notifier):
+    def notify(
+        self,
+        implementation_email: str = "test@example.com",
+        /,
+    ) -> None:
+        return None
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
+        )
+        assert result.get("analysis_errors", []) == []
+        findings = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L032"
+        ]
+
+        assert {finding["name"] for finding in findings} == {
+            "protocol_email",
+            "implementation_email",
+        }
+
     def test_analyze_flags_no_effect_statement(self, tmp_path):
         src = tmp_path / "app.py"
         src.write_text(

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3388,7 +3388,7 @@ def fake_call():
             "low_entropy_uuid",
         }
 
-    def test_analyze_flags_protocol_and_implementation_defaults(
+    def test_analyze_handles_protocol_positional_only_ellipsis_default(
         self,
         tmp_path,
         monkeypatch,
@@ -3399,21 +3399,9 @@ def fake_call():
             """
 from typing import Protocol
 
-class Notifier(Protocol):
-    def notify(
-        self,
-        protocol_email: str = "test@example.com",
-        /,
-    ) -> None:
+class SupportsRead(Protocol):
+    def read(self, length: int = ..., /) -> bytes:
         ...
-
-class ConcreteNotifier(Notifier):
-    def notify(
-        self,
-        implementation_email: str = "test@example.com",
-        /,
-    ) -> None:
-        return None
 """.strip()
             + "\n",
             encoding="utf-8",
@@ -3426,11 +3414,7 @@ class ConcreteNotifier(Notifier):
         findings = [
             f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L032"
         ]
-
-        assert {finding["name"] for finding in findings} == {
-            "protocol_email",
-            "implementation_email",
-        }
+        assert findings == []
 
     def test_analyze_flags_no_effect_statement(self, tmp_path):
         src = tmp_path / "app.py"

--- a/test/test_quality_rules.py
+++ b/test/test_quality_rules.py
@@ -387,6 +387,15 @@ password = os.environ["PASSWORD"]
         findings = check_code(rule, code)
         assert not any(f["rule_id"] == "SKY-L014" for f in findings)
 
+    def test_positional_only_default(self):
+        code = """
+def connect(api_password: str = "mysecretpassword123", /) -> None:
+    return None
+"""
+        rule = HardcodedCredentialRule()
+        findings = check_code(rule, code, filename="app.py")
+        assert [finding["name"] for finding in findings] == ["api_password"]
+
 
 # --- SKY-L032: Mock Or Placeholder Data ---
 
@@ -427,6 +436,60 @@ SAMPLE_URL = "https://example.com/users"
         findings = check_code(rule, code, filename="app.py")
         assert [f["name"] for f in findings] == ["SAMPLE_URL"]
         assert findings[0]["mock_data_type"] == "placeholder_domain"
+
+    def test_positional_only_placeholder_default(self):
+        code = """
+def notify(support_email: str = "test@example.com", /) -> None:
+    return None
+"""
+        rule = MockPlaceholderDataRule()
+        findings = check_code(rule, code, filename="app.py")
+        assert [finding["name"] for finding in findings] == ["support_email"]
+        assert findings[0]["mock_data_type"] == "placeholder_email"
+
+    def test_mixed_positional_defaults_preserve_names(self):
+        code = """
+def notify(
+    required: str,
+    protocol_email: str = "test@example.com",
+    /,
+    implementation_email: str = "test@example.com",
+) -> None:
+    return None
+"""
+        rule = MockPlaceholderDataRule()
+        findings = check_code(rule, code, filename="app.py")
+        assert [finding["name"] for finding in findings] == [
+            "protocol_email",
+            "implementation_email",
+        ]
+
+    def test_protocol_and_implementation_defaults_flagged(self):
+        code = """
+from typing import Protocol
+
+class Notifier(Protocol):
+    def notify(
+        self,
+        protocol_email: str = "test@example.com",
+        /,
+    ) -> None:
+        ...
+
+class ConcreteNotifier(Notifier):
+    def notify(
+        self,
+        implementation_email: str = "test@example.com",
+        /,
+    ) -> None:
+        return None
+"""
+        rule = MockPlaceholderDataRule()
+        findings = check_code(rule, code, filename="app.py")
+        assert {finding["name"] for finding in findings} == {
+            "protocol_email",
+            "implementation_email",
+        }
 
 
 # --- SKY-UC001: Unreachable Code ---


### PR DESCRIPTION
Closes #707.

Note: Although not mentioned in the original issue, SKY-L014 is also affected by the fix, because it reuses the same helper.

## Summary

- map positional defaults across both `posonlyargs` and ordinary `args`
- prevent crashes for all-positional-only defaults and preserve names for mixed positional defaults
- verify SKY-L032 fires for placeholder string defaults on both Protocol declarations and concrete implementations
- retain SKY-L014 coverage for the shared default-argument helper

## Testing

- `pytest -q test/test_quality_rules.py test/test_analyzer.py` — 214 passed
- exact Protocol `length: int = ...` reproducer — no analysis errors and no SKY-L032 finding
- Protocol `"test@example.com"` positional-only default — SKY-L032 reported with the correct parameter name
- full suite — 6030 passed, 7 skipped, with 2 unrelated failures that reproduce on pristine `main` in the local Python 3.14 environment

## AI Use Disclosure
Codex GPT-5.6 Sol drafted the PR, and it, including the testing coverage, was reviewed per repository llm review guidelines by both Sol and Claude Opus-5.0. The analyzer changes are just 3 lines and human verified as well.
