### PR TITLE
fix: fail closed when analysis subsystems raise instead

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -4656,7 +4656,10 @@ def proc_file(
                         if line.strip() and not line.strip().startswith("#")
                     ),
                 }
-            except Exception:
+            except Exception as exc:
+                scanner_errors.append(
+                    _subsystem_error_payload(file, "Architecture metrics", exc)
+                )
                 logger.debug(
                     "Architecture metric extraction failed for %s",
                     file,
@@ -4674,7 +4677,10 @@ def proc_file(
                 clone_fragments = extract_fragments(
                     Path(file), source, clone_cfg, tree=clone_tree
                 )
-            except Exception:
+            except Exception as exc:
+                scanner_errors.append(
+                    _subsystem_error_payload(file, "Clone extraction", exc)
+                )
                 logger.debug(
                     "Clone fragment extraction failed for %s", file, exc_info=True
                 )

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2701,7 +2701,12 @@ class Skylos:
                             if finding.get("rule_id") in project_ignore:
                                 continue
                             ai_defect_findings.append(finding)
-                    except Exception:
+                    except Exception as exc:
+                        result["analysis_errors"].append(
+                            _subsystem_error_payload(
+                                path, "Manifest dependency hallucination scan", exc
+                            )
+                        )
                         if os.getenv("SKYLOS_DEBUG"):
                             logger.error(
                                 "Manifest dependency scan failed", exc_info=True
@@ -2791,6 +2796,9 @@ class Skylos:
                         result["dependency_vulnerabilities"] = list(sca_findings)
                         result["analysis_summary"]["sca_count"] = len(sca_findings)
                     except Exception as exc:
+                        result["analysis_errors"].append(
+                            _subsystem_error_payload(path, "Dependency scan", exc)
+                        )
                         self._sca_coverage = {
                             "status": "incomplete",
                             "complete": False,
@@ -3164,7 +3172,10 @@ class Skylos:
                                         )
                                     ]
                                 all_secrets.extend(findings)
-                        except Exception:
+                        except Exception as exc:
+                            analysis_errors.append(
+                                _subsystem_error_payload(path, "Secret scan", exc)
+                            )
                             logger.debug("Secret scan failed for file", exc_info=True)
 
             if enable_secrets and _secrets_scan_ctx is not None:
@@ -3319,7 +3330,10 @@ class Skylos:
                             cf,
                         )
                         all_quality.extend(reg_findings)
-            except Exception:
+            except Exception as exc:
+                analysis_errors.append(
+                    _subsystem_error_payload(path, "Security regression detection", exc)
+                )
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error("Security regression scan failed", exc_info=True)
 
@@ -3334,7 +3348,12 @@ class Skylos:
                         changed_files=changed_files,
                     )
                 )
-            except Exception:
+            except Exception as exc:
+                analysis_errors.append(
+                    _subsystem_error_payload(
+                        path, "Security contract regression detection", exc
+                    )
+                )
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error("Security contract scan failed", exc_info=True)
 
@@ -3637,7 +3656,10 @@ class Skylos:
                             ][:remaining]
                             all_dangers.extend(bounded_hits)
                             injection_findings += len(bounded_hits)
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(path, "Prompt injection scan", exc)
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error(traceback.format_exc())
 
@@ -3666,7 +3688,12 @@ class Skylos:
                             all_ai_defects=all_ai_defects,
                             all_suppressed=all_suppressed,
                         )
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(
+                            path, "Python dependency hallucination scan", exc
+                        )
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error(traceback.format_exc())
 
@@ -3691,7 +3718,12 @@ class Skylos:
                             all_ai_defects=all_ai_defects,
                             all_suppressed=all_suppressed,
                         )
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(
+                            path, "Python API signature hallucination scan", exc
+                        )
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error(traceback.format_exc())
 
@@ -3711,7 +3743,12 @@ class Skylos:
                         all_ai_defects=all_ai_defects,
                         all_suppressed=all_suppressed,
                     )
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(
+                            path, "Manifest dependency hallucination scan", exc
+                        )
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error(traceback.format_exc())
 
@@ -3961,7 +3998,12 @@ class Skylos:
                                 all_ai_defects=all_ai_defects,
                                 all_suppressed=all_suppressed,
                             )
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(
+                            path, "Assertion weakening detection", exc
+                        )
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error("Assertion weakening scan failed", exc_info=True)
 
@@ -3993,7 +4035,10 @@ class Skylos:
                         all_ai_defects=all_ai_defects,
                         all_suppressed=all_suppressed,
                     )
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(path, "Test impact gap detection", exc)
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error("Test impact scan failed", exc_info=True)
 
@@ -4010,7 +4055,12 @@ class Skylos:
                         all_ai_defects=all_ai_defects,
                         all_suppressed=all_suppressed,
                     )
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(
+                            path, "AI defect diff signal scan", exc
+                        )
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error("AI defect diff scan failed", exc_info=True)
 
@@ -4044,7 +4094,10 @@ class Skylos:
                         if ud_findings:
                             all_quality.extend(ud_findings)
 
-            except Exception:
+            except Exception as exc:
+                analysis_errors.append(
+                    _subsystem_error_payload(path, "Unused dependency scan", exc)
+                )
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error(traceback.format_exc())
 
@@ -4056,7 +4109,10 @@ class Skylos:
                 )
                 if policy_findings:
                     all_quality.extend(policy_findings)
-            except Exception:
+            except Exception as exc:
+                analysis_errors.append(
+                    _subsystem_error_payload(path, "Repo policy analysis", exc)
+                )
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error(traceback.format_exc())
 
@@ -4091,6 +4147,9 @@ class Skylos:
                         if os.getenv("SKYLOS_DEBUG"):
                             logger.error(traceback.format_exc())
             except Exception as exc:
+                analysis_errors.append(
+                    _subsystem_error_payload(path, "Dependency scan", exc)
+                )
                 self._sca_coverage = {
                     "status": "incomplete",
                     "complete": False,
@@ -4357,6 +4416,18 @@ def _analysis_error_payload(file, error, *, kind=None):
             "project's syntax; official container images provide matching "
             "-pythonX.Y tags."
         )
+    return payload
+
+
+def _subsystem_error_payload(path, subsystem, error):
+    """Record that one analysis subsystem did not finish.
+
+    Without this the subsystem's findings are simply absent, which is
+    indistinguishable from the subsystem having found nothing.
+    """
+    payload = _analysis_error_payload(path, error, kind="processing_error")
+    payload["subsystem"] = subsystem
+    payload["message"] = f"{subsystem} did not complete: {payload['message']}"
     return payload
 
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -3007,6 +3007,8 @@ class Skylos:
                 file_analysis_error = out[25] if len(out) > 25 else None
                 if isinstance(file_analysis_error, dict):
                     analysis_errors.append(file_analysis_error)
+                elif isinstance(file_analysis_error, list):
+                    analysis_errors.extend(file_analysis_error)
                 (
                     defs,
                     refs,
@@ -4434,6 +4436,7 @@ def proc_file(
 
         quality_findings = []
         danger_findings = []
+        scanner_errors = []
 
         if full_scan and enable_quality_rules:
             quality_findings = scan_python_quality(tree, source, file, cfg)
@@ -4451,15 +4454,21 @@ def proc_file(
             linter_d.visit(tree)
             danger_findings = linter_d.findings
 
+            from skylos.rules.danger._incomplete import RULE_ID as INCOMPLETE_RULE_ID
+            from skylos.rules.danger._incomplete import scanner_failure_finding
             from skylos.rules.danger.danger import scan_file_with_tree
 
             taint_findings = []
             try:
                 scan_file_with_tree(tree, Path(file), taint_findings, source=source)
-            except Exception:
+            except Exception as exc:
                 logger.debug("Taint analysis failed for %s", file, exc_info=True)
-            if taint_findings:
-                danger_findings.extend(taint_findings)
+                taint_findings.append(scanner_failure_finding(file, "Taint", exc))
+            for taint_finding in taint_findings:
+                if taint_finding.get("rule_id") == INCOMPLETE_RULE_ID:
+                    scanner_errors.append(taint_finding)
+                else:
+                    danger_findings.append(taint_finding)
 
         pro_findings = []
         if extra_visitors:
@@ -4613,7 +4622,7 @@ def proc_file(
             clone_fragments,
             architecture_metrics,
             getattr(v, "top_level_refs", set()),
-            None,
+            scanner_errors or None,
             ignore_rules_by_line,
         )
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -649,7 +649,11 @@ def _scan_secret_config_candidate(
             "tree": None,
         }
         return list(_secrets_scan_ctx(ctx))
-    except Exception:
+    except Exception as exc:
+        if analysis_errors is not None:
+            analysis_errors.append(
+                _subsystem_error_payload(resolved, "Secret scan", exc)
+            )
         logger.debug("Secret scan failed for config file: %s", candidate, exc_info=True)
         return []
 
@@ -2820,6 +2824,11 @@ class Skylos:
                         expected_checks=self._ai_verification_expectations,
                     )
                 )
+            # Recomputed last: the optional no-source subsystems above append
+            # after the earlier count was taken.
+            result["analysis_summary"]["analysis_error_count"] = len(
+                result["analysis_errors"]
+            )
             return json.dumps(result)
 
         logger.info(f"Analyzing {len(files)} files...")
@@ -3174,7 +3183,7 @@ class Skylos:
                                 all_secrets.extend(findings)
                         except Exception as exc:
                             analysis_errors.append(
-                                _subsystem_error_payload(path, "Secret scan", exc)
+                                _subsystem_error_payload(Path(file), "Secret scan", exc)
                             )
                             logger.debug("Secret scan failed for file", exc_info=True)
 
@@ -3858,7 +3867,10 @@ class Skylos:
                             all_ai_defects=all_ai_defects,
                             all_suppressed=all_suppressed,
                         )
-                except Exception:
+                except Exception as exc:
+                    analysis_errors.append(
+                        _subsystem_error_payload(path, "Phantom reference scan", exc)
+                    )
                     if os.getenv("SKYLOS_DEBUG"):
                         logger.error(traceback.format_exc())
 

--- a/skylos/rules/danger/_incomplete.py
+++ b/skylos/rules/danger/_incomplete.py
@@ -1,0 +1,23 @@
+"""Shared payload for a taint scanner that could not finish a file.
+
+A scanner that raises must not leave the file looking clean. Each ``scan()``
+records this finding instead of only printing to stderr, so the failure reaches
+``analysis_errors`` and the run fails closed.
+"""
+
+RULE_ID = "SKY-ANALYSIS-INCOMPLETE"
+
+
+def scanner_failure_finding(file_path, scanner: str, error: BaseException) -> dict:
+    message = " ".join(str(error).splitlines())[:500] or type(error).__name__
+    return {
+        "rule_id": RULE_ID,
+        "severity": "HIGH",
+        "kind": "processing_error",
+        "error_type": type(error).__name__,
+        "scanner": scanner,
+        "message": f"{scanner} analysis did not complete: {message}",
+        "file": str(file_path),
+        "line": 1,
+        "column": 1,
+    }

--- a/skylos/rules/danger/_incomplete.py
+++ b/skylos/rules/danger/_incomplete.py
@@ -5,6 +5,9 @@ records this finding instead of only printing to stderr, so the failure reaches
 ``analysis_errors`` and the run fails closed.
 """
 
+import sys
+
+
 RULE_ID = "SKY-ANALYSIS-INCOMPLETE"
 
 
@@ -20,4 +23,10 @@ def scanner_failure_finding(file_path, scanner: str, error: BaseException) -> di
         "file": str(file_path),
         "line": 1,
         "column": 1,
+        # Kept in step with _analysis_error_payload; reports render "Python ?"
+        # without it. Sharing that builder would mean importing the analyzer.
+        "python_version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}."
+            f"{sys.version_info.micro}"
+        ),
     }

--- a/skylos/rules/danger/danger_access/access_flow.py
+++ b/skylos/rules/danger/danger_access/access_flow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import ast
-import sys
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 class _MassAssignmentChecker(ast.NodeVisitor):
@@ -64,4 +64,4 @@ def scan(tree, file_path, findings):
         checker = _MassAssignmentChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(f"Access control analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "Access control", e))

--- a/skylos/rules/danger/danger_agent/tool_privilege.py
+++ b/skylos/rules/danger/danger_agent/tool_privilege.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import ast
-import sys
 
 from skylos.rules.danger.calls import _qualified_name_from_call, _resolve_expr_name
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 DANGEROUS_TOOL_CONSTRUCTORS = {
@@ -359,7 +359,4 @@ def scan(tree, file_path, findings):
         checker = _AgentToolPrivilegeChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(
-            f"Agent tool privilege analysis failed for {file_path}: {e}",
-            file=sys.stderr,
-        )
+        findings.append(scanner_failure_finding(file_path, "Agent tool privilege", e))

--- a/skylos/rules/danger/danger_cmd/cmd_flow.py
+++ b/skylos/rules/danger/danger_cmd/cmd_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import ast
-import sys
 from skylos.rules.danger.taint import TaintVisitor, CMD_SANITIZERS
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 def _qualified_name(node):
@@ -87,4 +87,4 @@ def scan(tree, file_path, findings):
         checker = _CmdFlowChecker(file_path, findings, sanitizers=CMD_SANITIZERS)
         checker.visit(tree)
     except Exception as e:
-        print(f"CMD flow failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "CMD flow", e))

--- a/skylos/rules/danger/danger_cors/cors_flow.py
+++ b/skylos/rules/danger/danger_cors/cors_flow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import ast
-import sys
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 def _qualified_name(node):
@@ -108,4 +108,4 @@ def scan(tree, file_path, findings):
         checker = _CORSChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(f"CORS analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "CORS", e))

--- a/skylos/rules/danger/danger_fs/path_flow.py
+++ b/skylos/rules/danger/danger_fs/path_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import ast
-import sys
 from skylos.rules.danger.taint import TaintVisitor, PATH_SANITIZERS
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 SYMLINK_WRITE_RULE = "SKY-D324"
@@ -626,4 +626,4 @@ def scan(tree, file_path, findings):
         checker = _PathFlowChecker(file_path, findings, sanitizers=PATH_SANITIZERS)
         checker.visit(tree)
     except Exception as e:
-        print(f"Path traversal analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "Path traversal", e))

--- a/skylos/rules/danger/danger_jwt/jwt_flow.py
+++ b/skylos/rules/danger/danger_jwt/jwt_flow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import ast
-import sys
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 def _qualified_name(node):
@@ -93,4 +93,4 @@ def scan(tree, file_path, findings):
         checker = _JWTChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(f"JWT analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "JWT", e))

--- a/skylos/rules/danger/danger_llm/consumption.py
+++ b/skylos/rules/danger/danger_llm/consumption.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import sys
 from dataclasses import dataclass
 
 from .utils import (
@@ -11,6 +10,7 @@ from .utils import (
     qualified_name_from_call,
     root_name,
 )
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 TOKEN_LIMIT_KEYWORDS = {
@@ -350,8 +350,5 @@ def scan(tree, file_path, findings):
         checker = _LLMConsumptionChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(
-            f"LLM consumption analysis failed for {file_path}: {e}",
-            file=sys.stderr,
-        )
+        findings.append(scanner_failure_finding(file_path, "LLM consumption", e))
 

--- a/skylos/rules/danger/danger_llm/llm_flow.py
+++ b/skylos/rules/danger/danger_llm/llm_flow.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import sys
 
 from skylos.rules.danger.taint import TaintVisitor
 
@@ -23,6 +22,7 @@ from .utils import (
     qualified_name_from_expr,
     root_name,
 )
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 class _LLMFlowChecker(SensitiveExpressionMixin, TaintVisitor):
     def __init__(self, file_path, findings):
@@ -378,7 +378,4 @@ def scan(tree, file_path, findings):
         checker = _LLMFlowChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(
-            f"LLM application flow analysis failed for {file_path}: {e}",
-            file=sys.stderr,
-        )
+        findings.append(scanner_failure_finding(file_path, "LLM application flow", e))

--- a/skylos/rules/danger/danger_mcp/mcp_flow.py
+++ b/skylos/rules/danger/danger_mcp/mcp_flow.py
@@ -356,9 +356,9 @@ class _MCPChecker(ast.NodeVisitor):
 
 
 def scan(tree, file_path, findings):
-    if not _is_mcp_file(tree):
-        return
     try:
+        if not _is_mcp_file(tree):
+            return
         checker = _MCPChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:

--- a/skylos/rules/danger/danger_mcp/mcp_flow.py
+++ b/skylos/rules/danger/danger_mcp/mcp_flow.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import ast
 import re
-import sys
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 _INJECTION_TAG_RE = re.compile(
@@ -362,4 +362,4 @@ def scan(tree, file_path, findings):
         checker = _MCPChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(f"MCP analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "MCP", e))

--- a/skylos/rules/danger/danger_ml/model_deserialization.py
+++ b/skylos/rules/danger/danger_ml/model_deserialization.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import ast
-import sys
 
 from skylos.rules.danger.calls import _qualified_name_from_call
 from skylos.rules.danger.taint import TaintVisitor
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 MODEL_ARTIFACT_SUFFIXES = (
@@ -321,7 +321,4 @@ def scan(tree, file_path, findings):
         checker = _ModelDeserializationChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(
-            f"ML model deserialization analysis failed for {file_path}: {e}",
-            file=sys.stderr,
-        )
+        findings.append(scanner_failure_finding(file_path, "ML model deserialization", e))

--- a/skylos/rules/danger/danger_net/ssrf_flow.py
+++ b/skylos/rules/danger/danger_net/ssrf_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import ast
-import sys
 from skylos.rules.danger.taint import TaintVisitor, URL_SANITIZERS
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 HTTP_MODULES = frozenset(
@@ -444,4 +444,4 @@ def scan(tree, file_path, findings):
         checker = _SSRFFlowChecker(file_path, findings, sanitizers=URL_SANITIZERS)
         checker.visit(tree)
     except Exception as e:
-        print(f"SSRF flow analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "SSRF flow", e))

--- a/skylos/rules/danger/danger_redirect/redirect_flow.py
+++ b/skylos/rules/danger/danger_redirect/redirect_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import ast
-import sys
 from skylos.rules.danger.taint import TaintVisitor
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 REDIRECT_FUNCS = {"redirect", "HttpResponseRedirect", "HttpResponsePermanentRedirect"}
@@ -119,4 +119,4 @@ def scan(tree, file_path, findings):
         checker = _RedirectFlowChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(f"Redirect flow analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "Redirect flow", e))

--- a/skylos/rules/danger/danger_sql/sql_flow.py
+++ b/skylos/rules/danger/danger_sql/sql_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import ast
-import sys
 from skylos.rules.danger.taint import TaintVisitor
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 DB_MODULES = frozenset(
@@ -473,4 +473,4 @@ def scan(tree, file_path, findings):
         checker = _SQLFlowChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(f"SQL flow analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "SQL flow", e))

--- a/skylos/rules/danger/danger_sql/sql_raw_flow.py
+++ b/skylos/rules/danger/danger_sql/sql_raw_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import ast
-import sys
 from skylos.rules.danger.taint import TaintVisitor
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 def _qualified_name(node: ast.Call):
@@ -128,4 +128,4 @@ def scan(tree: ast.AST, file_path, findings):
         checker = _SQLRawFlowChecker(file_path, findings)
         checker.visit(tree)
     except Exception as e:
-        print(f"Raw SQL flow analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "Raw SQL flow", e))

--- a/skylos/rules/danger/danger_web/xss_flow.py
+++ b/skylos/rules/danger/danger_web/xss_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import ast
-import sys
 from skylos.rules.danger.taint import TaintVisitor, XSS_SANITIZERS
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 
 def _qualified_name_from_call(node: ast.Call):
@@ -170,4 +170,4 @@ def scan(tree, file_path, findings):
         checker = _XSSFlowChecker(file_path, findings, sanitizers=XSS_SANITIZERS)
         checker.visit(tree)
     except Exception as e:
-        print(f"XSS analysis failed for {file_path}: {e}", file=sys.stderr)
+        findings.append(scanner_failure_finding(file_path, "XSS", e))

--- a/skylos/rules/danger/danger_webhook/webhook_flow.py
+++ b/skylos/rules/danger/danger_webhook/webhook_flow.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import ast
 import re
-import sys
 from pathlib import Path
+from skylos.rules.danger._incomplete import scanner_failure_finding
 
 RULE_ID = "SKY-D282"
 
@@ -234,6 +234,4 @@ def scan(tree: ast.AST, file_path, findings, *, source: str | None = None) -> No
         checker = _WebhookSignatureChecker(file_path, findings, source)
         checker.visit(tree)
     except Exception as e:
-        print(
-            f"Webhook signature analysis failed for {file_path}: {e}", file=sys.stderr
-        )
+        findings.append(scanner_failure_finding(file_path, "Webhook signature", e))

--- a/test/test_scanner_failure_reporting.py
+++ b/test/test_scanner_failure_reporting.py
@@ -1,0 +1,146 @@
+"""A taint scanner that fails must not leave the file looking clean.
+
+These tests are structural on purpose. They enumerate the scanners rather than
+listing them, so a scanner added later that swallows its own exceptions fails
+here instead of silently dropping findings in the field.
+"""
+
+import ast
+import importlib
+import json
+import pkgutil
+
+import pytest
+
+import skylos.rules.danger as danger_package
+from skylos.analyzer import analyze
+from skylos.cli import _analysis_incomplete_exit_code
+from skylos.rules.danger._incomplete import RULE_ID as INCOMPLETE_RULE_ID
+
+
+def _scanner_modules():
+    modules = []
+    for info in pkgutil.walk_packages(
+        danger_package.__path__, danger_package.__name__ + "."
+    ):
+        try:
+            module = importlib.import_module(info.name)
+        except Exception:  # pragma: no cover - optional dependency
+            continue
+        if callable(getattr(module, "scan", None)):
+            modules.append(module)
+    return sorted(modules, key=lambda module: module.__name__)
+
+
+SCANNER_MODULES = _scanner_modules()
+
+
+def test_scanner_modules_are_discovered():
+    assert len(SCANNER_MODULES) >= 16
+
+
+@pytest.mark.parametrize(
+    "module",
+    SCANNER_MODULES,
+    ids=[m.__name__.rsplit(".", 1)[-1] for m in SCANNER_MODULES],
+)
+def test_scanner_records_incomplete_analysis_instead_of_swallowing(module):
+    """An unusable tree forces the scanner into its own failure path."""
+    findings = []
+
+    module.scan(object(), "app.py", findings)
+
+    assert [finding["rule_id"] for finding in findings] == [INCOMPLETE_RULE_ID], (
+        f"{module.__name__}.scan() dropped its failure instead of recording it"
+    )
+    payload = findings[0]
+    assert payload["kind"] == "processing_error"
+    assert payload["severity"] == "HIGH"
+    assert payload["file"] == "app.py"
+    assert payload["scanner"]
+    assert payload["error_type"]
+
+
+def test_taint_dispatcher_failure_reaches_analysis_errors(tmp_path, monkeypatch):
+    """The net around scan_file_with_tree must fail closed, not logger.debug."""
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    (tmp_path / "app.py").write_text(
+        "import sqlite3\n\n\n"
+        "def get_user(user_id):\n"
+        '    cur = sqlite3.connect("d").cursor()\n'
+        '    cur.execute("SELECT * FROM t WHERE id = \'" + user_id + "\'")\n'
+        "    return cur.fetchall()\n",
+        encoding="utf-8",
+    )
+
+    import skylos.rules.danger.danger as danger_module
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated dispatcher failure")
+
+    monkeypatch.setattr(danger_module, "scan_file_with_tree", boom)
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, enable_danger=True, grep_verify=False)
+    )
+
+    recorded = [
+        entry
+        for entry in result.get("analysis_errors", [])
+        if entry.get("rule_id") == INCOMPLETE_RULE_ID
+    ]
+    assert recorded, "a failed taint dispatch was reported as a clean scan"
+    assert recorded[0]["error_type"] == "RuntimeError"
+    assert _analysis_incomplete_exit_code(result) == 2
+
+
+def test_scanner_failures_are_not_reported_as_security_findings(tmp_path, monkeypatch):
+    """The incomplete marker belongs in analysis_errors, not in the findings list."""
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    (tmp_path / "app.py").write_text("value = 1\n", encoding="utf-8")
+
+    import skylos.rules.danger.danger_sql.sql_flow as sql_flow
+
+    class Boom(sql_flow._SQLFlowChecker):
+        def visit(self, node):
+            raise RuntimeError("simulated scanner failure")
+
+    monkeypatch.setattr(sql_flow, "_SQLFlowChecker", Boom)
+
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, enable_danger=True, grep_verify=False)
+    )
+
+    for key, value in result.items():
+        if key == "analysis_errors" or not isinstance(value, list):
+            continue
+        assert not [
+            item
+            for item in value
+            if isinstance(item, dict) and item.get("rule_id") == INCOMPLETE_RULE_ID
+        ], f"incomplete-analysis marker leaked into {key}"
+
+
+def test_every_scanner_guards_its_whole_body():
+    """The failure handler must cover the scanner's early gates too.
+
+    mcp_flow once evaluated its "is this an MCP file" gate outside the try, so
+    a failure there escaped the handler entirely.
+    """
+    offenders = []
+    for module in SCANNER_MODULES:
+        source = ast.parse(open(module.__file__, encoding="utf-8").read())
+        for node in ast.walk(source):
+            if not isinstance(node, ast.FunctionDef) or node.name != "scan":
+                continue
+            body = [
+                statement
+                for statement in node.body
+                if not (
+                    isinstance(statement, ast.Expr)
+                    and isinstance(statement.value, ast.Constant)
+                )
+            ]
+            if len(body) != 1 or not isinstance(body[0], ast.Try):
+                offenders.append(module.__name__)
+    assert not offenders, f"scan() body not fully guarded in: {offenders}"

--- a/test/test_scanner_failure_reporting.py
+++ b/test/test_scanner_failure_reporting.py
@@ -59,6 +59,9 @@ def test_scanner_records_incomplete_analysis_instead_of_swallowing(module):
     assert payload["file"] == "app.py"
     assert payload["scanner"]
     assert payload["error_type"]
+    # Reports render "Python ?" without this; it is set independently of
+    # _analysis_error_payload, so it needs its own assertion.
+    assert payload["python_version"].count(".") == 2
 
 
 def test_taint_dispatcher_failure_reaches_analysis_errors(tmp_path, monkeypatch):

--- a/test/test_subsystem_failure_reporting.py
+++ b/test/test_subsystem_failure_reporting.py
@@ -9,6 +9,7 @@ import ast
 import inspect
 import json
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -17,6 +18,7 @@ from skylos.analyzer import analyze
 from skylos.cli import _analysis_incomplete_exit_code
 
 
+GITHUB_TOKEN = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
 SECRET_SOURCE = 'GITHUB_PAT = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"\n'
 
 
@@ -57,6 +59,81 @@ def test_secret_scan_failure_is_not_reported_as_no_secrets(tmp_path, monkeypatch
     assert _analysis_incomplete_exit_code(result) == 2
 
 
+def test_config_only_secret_scan_failure_is_recorded(tmp_path, monkeypatch):
+    """The config-file path is a separate helper from the per-file loop."""
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    (tmp_path / ".env").write_text(f"GITHUB_TOKEN={GITHUB_TOKEN}\n", encoding="utf-8")
+
+    baseline = json.loads(
+        analyze(str(tmp_path), conf=0, enable_secrets=True, grep_verify=False)
+    )
+    baseline_ids = {
+        finding["rule_id"]
+        for value in baseline.values()
+        if isinstance(value, list)
+        for finding in value
+        if isinstance(finding, dict) and finding.get("rule_id")
+    }
+    assert "SKY-S101" in baseline_ids, "fixture no longer produces a secret finding"
+
+    monkeypatch.setattr(analyzer_module, "_secrets_scan_ctx", _boom)
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, enable_secrets=True, grep_verify=False)
+    )
+
+    recorded = [
+        entry
+        for entry in result.get("analysis_errors", [])
+        if entry.get("subsystem") == "Secret scan"
+    ]
+    assert recorded, "a crashed config secret scan was reported as a clean repository"
+    assert recorded[0]["file"].endswith(".env")
+    assert _analysis_incomplete_exit_code(result) == 2
+
+
+def test_secret_failure_names_the_file_not_the_repository(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    for name in ("a.py", "b.py"):
+        (tmp_path / name).write_text(
+            f'TOKEN_{name[0]} = "{GITHUB_TOKEN}"\n', encoding="utf-8"
+        )
+
+    monkeypatch.setattr(analyzer_module, "_secrets_scan_ctx", _boom)
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, enable_secrets=True, grep_verify=False)
+    )
+
+    recorded = [
+        entry
+        for entry in result.get("analysis_errors", [])
+        if entry.get("subsystem") == "Secret scan"
+    ]
+    assert recorded
+    assert {Path(entry["file"]).name for entry in recorded} == {"a.py", "b.py"}, (
+        "a per-file failure must name the file, not the scan root"
+    )
+
+
+def test_no_source_result_reports_its_own_error_count(tmp_path, monkeypatch):
+    """Optional no-source subsystems append after the earlier count was taken."""
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    (tmp_path / "package.json").write_text(
+        '{"dependencies": {"left-pad": "1.0.0"}}', encoding="utf-8"
+    )
+
+    import skylos.rules.sca.vulnerability_scanner as vulnerability_scanner
+
+    monkeypatch.setattr(vulnerability_scanner, "scan_dependencies", _boom)
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, enable_sca=True, grep_verify=False)
+    )
+
+    assert result["analysis_summary"]["analysis_error_count"] == len(
+        result["analysis_errors"]
+    )
+    assert result["analysis_errors"]
+
+
 def test_subsystem_payload_names_the_subsystem():
     payload = analyzer_module._subsystem_error_payload(
         "/repo", "Secret scan", RuntimeError("boom")
@@ -71,7 +148,16 @@ def _analyze_handlers():
     """Broad handlers in analyze() that wrap subsystem work."""
     source = textwrap.dedent(inspect.getsource(analyzer_module.Skylos.analyze))
     tree = ast.parse(source)
-    subsystem_markers = ("scan", "detect", "analyze", "hallucination", "policy")
+    subsystem_markers = (
+        "scan",
+        "detect",
+        "analyze",
+        "hallucination",
+        "policy",
+        "rule",
+        "visitor",
+        "linter",
+    )
     handlers = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Try):

--- a/test/test_subsystem_failure_reporting.py
+++ b/test/test_subsystem_failure_reporting.py
@@ -1,0 +1,126 @@
+"""A failed analysis subsystem must not be reported as a clean result.
+
+The structural test is the important one: it enumerates the exception handlers
+in analyze() rather than listing them, so a feature block added later that only
+logs its failure fails here instead of silently reporting nothing in the field.
+"""
+
+import ast
+import inspect
+import json
+import textwrap
+
+import pytest
+
+import skylos.analyzer as analyzer_module
+from skylos.analyzer import analyze
+from skylos.cli import _analysis_incomplete_exit_code
+
+
+SECRET_SOURCE = 'GITHUB_PAT = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"\n'
+
+
+def _boom(*_args, **_kwargs):
+    raise RuntimeError("simulated subsystem failure")
+
+
+def test_secret_scan_failure_is_not_reported_as_no_secrets(tmp_path, monkeypatch):
+    """The worst case: a crashed secret scanner asserting the repo is clean."""
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    (tmp_path / "config.py").write_text(SECRET_SOURCE, encoding="utf-8")
+
+    baseline = json.loads(
+        analyze(str(tmp_path), conf=0, enable_secrets=True, grep_verify=False)
+    )
+    baseline_ids = {
+        finding["rule_id"]
+        for value in baseline.values()
+        if isinstance(value, list)
+        for finding in value
+        if isinstance(finding, dict) and finding.get("rule_id")
+    }
+    assert "SKY-S101" in baseline_ids, "fixture no longer produces a secret finding"
+
+    monkeypatch.setattr(analyzer_module, "_secrets_scan_ctx", _boom)
+    result = json.loads(
+        analyze(str(tmp_path), conf=0, enable_secrets=True, grep_verify=False)
+    )
+
+    recorded = [
+        entry
+        for entry in result.get("analysis_errors", [])
+        if entry.get("subsystem") == "Secret scan"
+    ]
+    assert recorded, "a crashed secret scan was reported as a clean repository"
+    assert recorded[0]["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+    assert recorded[0]["error_type"] == "RuntimeError"
+    assert _analysis_incomplete_exit_code(result) == 2
+
+
+def test_subsystem_payload_names_the_subsystem():
+    payload = analyzer_module._subsystem_error_payload(
+        "/repo", "Secret scan", RuntimeError("boom")
+    )
+    assert payload["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+    assert payload["severity"] == "HIGH"
+    assert payload["subsystem"] == "Secret scan"
+    assert payload["message"].startswith("Secret scan did not complete:")
+
+
+def _analyze_handlers():
+    """Broad handlers in analyze() that wrap subsystem work."""
+    source = textwrap.dedent(inspect.getsource(analyzer_module.Skylos.analyze))
+    tree = ast.parse(source)
+    subsystem_markers = ("scan", "detect", "analyze", "hallucination", "policy")
+    handlers = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        called = {
+            call.func.attr
+            if isinstance(call.func, ast.Attribute)
+            else getattr(call.func, "id", "")
+            for call in ast.walk(ast.Module(body=node.body, type_ignores=[]))
+            if isinstance(call, ast.Call)
+        }
+        if not any(
+            marker in name.lower()
+            for name in called
+            if name
+            for marker in subsystem_markers
+        ):
+            continue
+        for handler in node.handlers:
+            exc_type = handler.type
+            broad = exc_type is None or any(
+                isinstance(name, ast.Name) and name.id in ("Exception", "BaseException")
+                for name in ast.walk(exc_type)
+            )
+            if broad:
+                handlers.append((handler, sorted(name for name in called if name)))
+    return handlers
+
+
+def test_analyze_has_subsystem_handlers_to_check():
+    assert len(_analyze_handlers()) >= 15
+
+
+@pytest.mark.parametrize("index", range(len(_analyze_handlers())))
+def test_no_analyze_subsystem_handler_swallows_its_failure(index):
+    """Every broad handler around subsystem work must leave a trace in the output.
+
+    Recording an analysis error, an existing _analysis_error_payload, or a
+    failed_*_api_check all count. Only logging does not: the subsystem's
+    findings are then simply absent, which reads as "found nothing".
+    """
+    handler, called = _analyze_handlers()[index]
+    body = ast.dump(ast.Module(body=handler.body, type_ignores=[]))
+    records = (
+        "analysis_errors" in body
+        or "_analysis_error_payload" in body
+        or ("failed_" in body and "_api_check" in body)
+    )
+    assert records, (
+        f"handler at line {handler.lineno} of analyze() wrapping {called} "
+        "only logs its failure; the run would report a clean result"
+    )

--- a/test/test_subsystem_failure_reporting.py
+++ b/test/test_subsystem_failure_reporting.py
@@ -188,7 +188,52 @@ def _analyze_handlers():
 
 
 def test_analyze_has_subsystem_handlers_to_check():
-    assert len(_analyze_handlers()) >= 15
+    """Pinned near the real count so coverage cannot quietly shrink.
+
+    Raise this when a subsystem is added; a drop means handlers stopped
+    matching the markers and are no longer being checked.
+    """
+    assert len(_analyze_handlers()) >= 22
+
+
+def _worker_handlers():
+    """Broad handlers in proc_file(), which runs per file in the workers."""
+    source = textwrap.dedent(inspect.getsource(analyzer_module.proc_file))
+    tree = ast.parse(source)
+    handlers = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        for handler in node.handlers:
+            exc_type = handler.type
+            broad = exc_type is None or any(
+                isinstance(name, ast.Name) and name.id in ("Exception", "BaseException")
+                for name in ast.walk(exc_type)
+            )
+            if broad:
+                handlers.append(handler)
+    return handlers
+
+
+@pytest.mark.parametrize("index", range(len(_worker_handlers())))
+def test_no_worker_handler_swallows_its_failure(index):
+    """proc_file's per-file handlers must record too.
+
+    Clone extraction and architecture metrics once logged and continued, so
+    a crash there dropped SKY-C401 with an empty analysis_errors list.
+    """
+    handler = _worker_handlers()[index]
+    body = ast.dump(ast.Module(body=handler.body, type_ignores=[]))
+    records = (
+        "scanner_errors" in body
+        or "scanner_failure_finding" in body
+        or "_analysis_error_payload" in body
+        or "_subsystem_error_payload" in body
+    )
+    assert records, (
+        f"handler at line {handler.lineno} of proc_file() only logs its failure; "
+        "the file would be reported as fully analyzed"
+    )
 
 
 @pytest.mark.parametrize("index", range(len(_analyze_handlers())))

--- a/test/test_xss_flow.py
+++ b/test/test_xss_flow.py
@@ -120,7 +120,7 @@ def test_rule_sky_d228_html_plus_local_clean_is_not_flagged():
     assert _find_rule(findings, "SKY-D228") is False
 
 
-def test_scan_does_not_raise_on_exception(monkeypatch, capsys):
+def test_scan_records_incomplete_analysis_on_exception(monkeypatch):
     class Boom(xss._XSSFlowChecker):
         def visit(self, node):
             raise RuntimeError("boom")
@@ -131,8 +131,10 @@ def test_scan_does_not_raise_on_exception(monkeypatch, capsys):
     tree = ast.parse("x = 1\n")
     xss.scan(tree, "x.py", findings)
 
-    err = capsys.readouterr().err
-    assert "XSS analysis failed for x.py" in err
+    assert [finding["rule_id"] for finding in findings] == ["SKY-ANALYSIS-INCOMPLETE"]
+    assert findings[0]["scanner"] == "XSS"
+    assert findings[0]["error_type"] == "RuntimeError"
+    assert findings[0]["file"] == "x.py"
 
 
 def _scan_src(src: str):


### PR DESCRIPTION
## Relevant Issues
Closes #713, plus applies essentially the same fix to 15+ additional sites, to harden skylos against potentially similar failure classes in the future. Subject to several known limitations documented below, which would either be scoped to a separate PR or require a design/API decision (such as whether to clean up the possibly dead `danger.py:590 scan_ctx`). 

## What does this PR do?


Makes analysis failures visible instead of silent. Skylos caught exceptions in three places and continued with only a log line, so a scanner that crashed produced the same output as one that found nothing: exit 0, empty `analysis_errors`, no indication that part of the scan never ran.

Three families are addressed:

1. **Taint scanners** — all 16 `scan()` functions in `skylos/rules/danger/danger_*/` caught `Exception` and printed one line to stderr.
2. **The taint dispatcher** — `analyzer.py` wrapped `scan_file_with_tree` in `logger.debug`, which is invisible at default verbosity and also covers `_PythonCommandExfilChecker`.
3. **`analyze()` feature blocks and worker extraction** — 15 subsystem blocks (secrets, prompt injection, dependency/SCA, AI-defect, repo policy, security regressions) plus clone extraction and architecture metrics in `proc_file`.

Each now records a `SKY-ANALYSIS-INCOMPLETE` entry naming what failed, routed into `analysis_errors`. No new exit-code machinery: `_analysis_incomplete_exit_code` already returns 2 for a non-empty `analysis_errors`.

This follows the pattern already established for incomplete analysis by the container false-clean fix and the Go engine-unavailable fix, which introduced `SKY-ANALYSIS-INCOMPLETE` for exactly this situation.

## Behavior changes

- **Exit code.** A run where a scanner or subsystem raises now exits **2** instead of 0. CI that treats non-zero as failure will start failing on repositories where analysis is partially broken. This is the point of the change, but it is the item most likely to surprise.
- **`analysis_errors` gains entries** with `rule_id: SKY-ANALYSIS-INCOMPLETE`, `severity: HIGH`, `kind: processing_error`, plus a `scanner` (taint) or `subsystem` (analyze/worker) field naming the component.
- **stderr messages removed.** The 16 `print(f"... analysis failed for {path}: {e}", file=sys.stderr)` lines are replaced by structured findings. Anything grepping stderr for those strings needs updating. One existing test did exactly that (`test_xss_flow.py`) and has been rewritten to assert the recorded payload.
- **`mcp_flow.scan()` gate moved inside its `try`.** It evaluated `_is_mcp_file(tree)` outside the handler, so a failure there escaped `scan()` entirely rather than being recorded.
- **`analysis_error_count`** is recomputed immediately before no-source results are returned; optional subsystems append after the earlier count was taken, so it could disagree with `len(analysis_errors)`.
- **Per-file secret failures name the file**, not the scan root, so GitHub annotations point at a real path.

## Testing


New coverage is deliberately structural rather than case-by-case, so a component added later that swallows its failures fails these tests:

- `test/test_scanner_failure_reporting.py` — enumerates the taint scanners via `pkgutil` (16 discovered) and forces each into its failure path; also asserts each `scan()` body is fully guarded, and that the incomplete marker lands in `analysis_errors` rather than the findings list.
- `test/test_subsystem_failure_reporting.py` — extracts `analyze()`'s broad handlers by AST (22) and `proc_file`'s (4), asserting each records rather than only logging; plus end-to-end cases for secret scanning (`.py` and `.env` paths), per-file attribution, and the summary count.

Suite result: **6077 passed**. Two failures are pre-existing and reproduce on clean `main` (`test_observations_reject_excessive_json_nesting_without_crashing` and its OpenAI twin).

## Precision Impact

No rule logic changes; no finding is added, removed, or reclassified for code that analyzes successfully. The only new output is `SKY-ANALYSIS-INCOMPLETE`, emitted only when a component raises.

## Known limitations and leftovers

Deliberately out of scope, each worth its own issue:

- **`danger.py:590 scan_ctx`** is a second entrypoint with its own swallow. It appears unused (only `scan_file_with_tree` is imported anywhere), so it was left alone rather than guessing at a plugin contract.
- **Local API hallucination detectors** (Python/Go/Java/JS) record `failed_*_api_check` and set `ai_verification.state: incomplete`, but the exit-code rule ignores that field, so those failures still exit 0. Gating it is a policy decision: a missing Go or Java toolchain reaches the same path, so ordinary machines would start exiting 2.
- **Git change auto-detection** still swallows. On failure `changed_files` stays `None`, which is also the legitimate "no changes" state, so recording an error there changes the meaning of a normal outcome.
- **The phantom fallback re-reads and re-parses inside its loop**, so one unreadable file drops phantom detection for every remaining file. Fixing that is a behavioral change beyond error reporting.
- **Custom and community rule loading** (`analysis/file_processing.py`) still fails open — a malformed rule file means those rules silently never run.
- `_incomplete.py` duplicates the payload shape instead of sharing `_analysis_error_payload`, which lives in `analyzer.py` and cannot be imported from a rules module without a cycle. `python_version` is kept in step by hand and asserted in tests.
- The structural tests match handlers by call-name markers, so a subsystem whose call names avoid `scan`/`detect`/`analyze`/`rule`/`visitor`/`linter` could escape the guard. The `analyze()` count is pinned at its real value so coverage cannot shrink unnoticed.

Scope of the underlying risk: apart from `mcp_flow`, these handlers are **latent** rather than actively firing. A search of 432 variants across all 16 scanners — each engaged with a fixture that produces a real finding, crossed with modern-syntax and signature mutations — found no other live trigger, with a positive control confirming the search detects the known `mcp_flow` bug.

## Checklist

- [x] Tests pass (`python3 -m pytest test/`)
- [x] No new false positives introduced (if modifying analysis logic)

## AI Use Disclosure

The sites to change were identified by a sweep with Claude Opus 5.0, as were the respective patches. Code review was done per skylos llm agent instructions using both GPT-5.6 Sol and a separate Claude Opus 5.0 agent. I reviewed all the changes by hand; they are largely essentially the same change repeated near-identically at every relevant site, plus unit tests.  
