### PR TITLE
refactor(analyzer): extract file worker and reset run state

### DIFF
--- a/skylos/analysis/architecture_support.py
+++ b/skylos/analysis/architecture_support.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from skylos.analysis.circular_deps import _resolve_from_import_targets
+
+
+def architecture_iad_strict(architecture_cfg) -> bool:
+    if not isinstance(architecture_cfg, dict):
+        return False
+    for key in ("enforce_iad", "strict_iad"):
+        if key in architecture_cfg:
+            return bool(architecture_cfg.get(key))
+    return False
+
+
+def expand_reexported_entrypoint_modules(
+    entrypoint_qnames: set[str],
+    entrypoint_modules: set[str],
+    raw_imports_by_file: dict[Path, list],
+    modmap: dict[Path, str],
+    module_files: dict[str, str],
+) -> set[str]:
+    modules = set(entrypoint_modules)
+    known_modules = set(module_files)
+
+    for qname in entrypoint_qnames:
+        if "." not in qname:
+            continue
+
+        entry_module, entry_symbol = qname.rsplit(".", 1)
+        for file_path, raw_imports in raw_imports_by_file.items():
+            if modmap.get(file_path) != entry_module:
+                continue
+
+            for import_module, _line, import_type, imported_names in raw_imports:
+                if import_type != "from_import":
+                    continue
+                if entry_symbol not in imported_names:
+                    continue
+                if import_module in known_modules:
+                    modules.add(import_module)
+
+    return modules
+
+
+def find_package_boundary_modules(
+    raw_imports_by_file: dict[Path, list],
+    modmap: dict[Path, str],
+    module_files: dict[str, str],
+) -> set[str]:
+    modules: set[str] = set()
+    known_modules = set(module_files)
+
+    for file_path, raw_imports in raw_imports_by_file.items():
+        package_module = modmap.get(file_path)
+        if not package_module or Path(file_path).name != "__init__.py":
+            continue
+
+        for import_module, _line, import_type, imported_names in raw_imports:
+            if import_type != "from_import":
+                continue
+
+            targets = _resolve_from_import_targets(
+                import_module,
+                imported_names,
+                known_modules,
+            )
+            for target in targets:
+                if target != package_module and target.startswith(package_module + "."):
+                    modules.add(target)
+
+    return modules

--- a/skylos/analysis/errors.py
+++ b/skylos/analysis/errors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+
+def analysis_error_payload(
+    file: object,
+    error: BaseException,
+    *,
+    kind: str | None = None,
+) -> dict[str, Any]:
+    """Build the stable payload used when static analysis cannot complete."""
+    is_syntax_error = isinstance(error, SyntaxError)
+    message = getattr(error, "msg", None) if is_syntax_error else None
+    message = str(message or error or type(error).__name__)
+    message = " ".join(message.splitlines())[:500]
+
+    line = getattr(error, "lineno", None) or 1
+    column = getattr(error, "offset", None) or 1
+    try:
+        line = max(1, int(line))
+    except (TypeError, ValueError):
+        line = 1
+    try:
+        column = max(1, int(column))
+    except (TypeError, ValueError):
+        column = 1
+
+    payload = {
+        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+        "severity": "HIGH",
+        "kind": kind or ("syntax_error" if is_syntax_error else "processing_error"),
+        "error_type": type(error).__name__,
+        "message": message,
+        "file": str(file),
+        "line": line,
+        "column": column,
+        "python_version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}."
+            f"{sys.version_info.micro}"
+        ),
+    }
+    if is_syntax_error:
+        payload["suggestion"] = (
+            "Fix the reported syntax, or use a Python runtime that supports the "
+            "project's syntax; official container images provide matching "
+            "-pythonX.Y tags."
+        )
+    return payload

--- a/skylos/analysis/file_worker.py
+++ b/skylos/analysis/file_worker.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+import ast
+import logging
+import os
+import traceback
+import warnings
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from skylos.analysis.errors import analysis_error_payload
+from skylos.analysis.file_processing import (
+    collect_python_raw_imports,
+    scan_non_python_file,
+    scan_python_quality,
+    set_linter_node_types,
+)
+from skylos.analysis.finding_filter import finding_is_inline_ignored
+from skylos.config import (
+    get_noqa_codes_by_line,
+    get_skylos_ignore_lines,
+    get_skylos_ignore_rules_by_line,
+    load_config,
+)
+from skylos.core.linter import LinterVisitor
+from skylos.core.safe_cache_io import (
+    read_project_text_no_symlink,
+    read_text_no_symlink,
+)
+from skylos.rules.danger.calls import DangerousCallsRule
+from skylos.rules.quality.clones import extract_fragments
+from skylos.visitors.base import Visitor
+from skylos.visitors.framework_aware import FrameworkAwareVisitor
+from skylos.visitors.test_aware import TestAwareVisitor
+
+
+logger = logging.getLogger("Skylos")
+MAX_PYTHON_SOURCE_BYTES = 2_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkerOptions:
+    extra_visitors: Iterable[type] | None
+    full_scan: bool
+    collect_clone_fragments: bool
+    clone_cfg: object | None
+    collect_architecture_metrics: bool
+    enable_quality_rules: bool
+    enable_danger_rules: bool
+    project_root: str | Path | None
+    visitor_class: type
+    test_aware_visitor_class: type
+    framework_aware_visitor_class: type
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedPython:
+    source: str
+    tree: ast.AST
+    masked: int
+    raw_imports: list
+    empty_file_finding: dict | None
+    ignore_lines: set
+    ignore_rules_by_line: dict
+    noqa_codes_by_line: dict
+    framework_imports: tuple[ast.AST, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _FindingResults:
+    quality: list
+    danger: list
+    custom: list
+    suppressed: list
+
+
+@dataclass(frozen=True, slots=True)
+class _VisitorResults:
+    visitor: object
+    test_visitor: object
+    framework_visitor: object
+
+
+@dataclass(frozen=True, slots=True)
+class _Artifacts:
+    clone_fragments: list
+    architecture_metrics: dict | None
+
+
+def _is_truly_empty_or_docstring_only(tree: ast.AST) -> bool:
+    if not isinstance(tree, ast.Module):
+        return False
+    if not tree.body:
+        return True
+    if len(tree.body) != 1:
+        return False
+
+    only = tree.body[0]
+    return (
+        isinstance(only, ast.Expr)
+        and isinstance(only.value, ast.Constant)
+        and isinstance(only.value.value, str)
+    )
+
+
+def _file_and_module(file_or_args, mod):
+    if mod is None and isinstance(file_or_args, tuple):
+        return file_or_args
+    return file_or_args, mod
+
+
+def _read_python_source(file, project_root=None) -> str:
+    read_kwargs = {
+        "max_bytes": MAX_PYTHON_SOURCE_BYTES,
+        "encoding": "utf-8",
+    }
+    if project_root is None:
+        source = read_text_no_symlink(file, **read_kwargs)
+    else:
+        source = read_project_text_no_symlink(project_root, file, **read_kwargs)
+    if source is None:
+        raise SourceReadError(
+            "source must be a regular, non-symlink UTF-8 file no larger than "
+            f"{MAX_PYTHON_SOURCE_BYTES} bytes"
+        )
+    return source
+
+
+class SourceReadError(OSError):
+    """Raised when an analyzer worker cannot safely read a source file."""
+
+
+def _parse_python_source(source: str, file) -> ast.AST:
+    tree = ast.parse(source, filename=str(file))
+    # ast.parse() can accept ASTs that Python later rejects, such as functions
+    # with duplicate argument names. Compile without executing so those errors
+    # follow the incomplete-analysis path.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SyntaxWarning)
+        compile(tree, str(file), "exec", dont_inherit=True)
+    return tree
+
+
+def _empty_file_finding(tree: ast.AST, file, cfg) -> dict | None:
+    skip_names = {"__init__.py", "__main__.py", "main.py"}
+    if (
+        Path(file).name in skip_names
+        or "SKY-E002" in cfg["ignore"]
+        or not _is_truly_empty_or_docstring_only(tree)
+    ):
+        return None
+    return {
+        "rule_id": "SKY-E002",
+        "message": "Empty Python file (no code, or docstring-only)",
+        "file": str(file),
+        "line": 1,
+        "severity": "LOW",
+        "category": "DEAD_CODE",
+    }
+
+
+def _masked_tree(tree: ast.AST, file, cfg) -> tuple[ast.AST, int]:
+    from skylos.analysis.ast_mask import (
+        apply_body_mask,
+        default_mask_spec_from_config,
+    )
+
+    tree, masked = apply_body_mask(tree, default_mask_spec_from_config(cfg))
+    if masked and os.getenv("SKYLOS_DEBUG"):
+        logger.info(f"{file}: masked {masked} bodies (skipped inner analysis)")
+    return tree, masked
+
+
+def _quality_findings(
+    file, prepared: _PreparedPython, cfg, options: _WorkerOptions
+) -> list:
+    if not options.full_scan or not options.enable_quality_rules:
+        return []
+    findings = scan_python_quality(prepared.tree, prepared.source, file, cfg)
+    if Path(file).suffix == ".pyi":
+        findings = [
+            finding
+            for finding in findings
+            if finding.get("rule_id") not in {"SKY-L026", "SKY-L033"}
+        ]
+    return findings
+
+
+def _danger_findings(file, prepared: _PreparedPython, options: _WorkerOptions) -> list:
+    if not options.full_scan or not options.enable_danger_rules:
+        return []
+
+    danger_rules = [DangerousCallsRule()]
+    set_linter_node_types(danger_rules)
+    danger_linter = LinterVisitor(danger_rules, str(file))
+    danger_linter.visit(prepared.tree)
+    findings = danger_linter.findings
+
+    from skylos.rules.danger.danger import scan_file_with_tree
+
+    taint_findings = []
+    try:
+        scan_file_with_tree(
+            prepared.tree,
+            Path(file),
+            taint_findings,
+            source=prepared.source,
+        )
+    except Exception:
+        logger.debug("Taint analysis failed for %s", file, exc_info=True)
+    findings.extend(taint_findings)
+    return findings
+
+
+def _custom_findings(tree, file, extra_visitors: Iterable[type] | None) -> list:
+    findings = []
+    for visitor_class in extra_visitors or ():
+        checker = visitor_class(file, findings)
+        checker.visit(tree)
+    return findings
+
+
+def _filter_inline_ignored(
+    findings,
+    category,
+    ignore_lines,
+    ignore_rules_by_line,
+) -> tuple[list, list]:
+    active = []
+    suppressed = []
+    for finding in findings:
+        if not finding_is_inline_ignored(
+            finding,
+            ignore_lines,
+            ignore_rules_by_line,
+        ):
+            active.append(finding)
+            continue
+        suppressed.append(
+            {
+                **finding,
+                "category": category,
+                "reason": "inline ignore comment",
+            }
+        )
+    return active, suppressed
+
+
+def _apply_inline_ignores(
+    quality_findings,
+    danger_findings,
+    ignore_lines,
+    ignore_rules_by_line,
+) -> tuple[list, list, list]:
+    quality_findings, suppressed_quality = _filter_inline_ignored(
+        quality_findings,
+        "quality",
+        ignore_lines,
+        ignore_rules_by_line,
+    )
+    danger_findings, suppressed_danger = _filter_inline_ignored(
+        danger_findings,
+        "security",
+        ignore_lines,
+        ignore_rules_by_line,
+    )
+    return (
+        quality_findings,
+        danger_findings,
+        suppressed_quality + suppressed_danger,
+    )
+
+
+def _copy_framework_metadata(framework_visitor, visitor) -> None:
+    attributes = (
+        ("dataclass_fields", set()),
+        ("first_read_lineno", {}),
+        ("protocol_classes", set()),
+        ("namedtuple_classes", set()),
+        ("enum_classes", set()),
+        ("attrs_classes", set()),
+        ("orm_model_classes", set()),
+        ("type_alias_names", set()),
+        ("abc_classes", set()),
+        ("abstract_methods", {}),
+        ("abc_implementers", {}),
+        ("protocol_implementers", {}),
+        ("protocol_method_names", {}),
+        ("version_conditional_lines", set()),
+    )
+    for attribute, default in attributes:
+        setattr(framework_visitor, attribute, getattr(visitor, attribute, default))
+
+
+def _run_visitors(
+    file,
+    mod,
+    prepared: _PreparedPython,
+    options: _WorkerOptions,
+) -> _VisitorResults:
+    test_visitor = options.test_aware_visitor_class(filename=file)
+    test_visitor.visit(prepared.tree)
+    test_visitor.ignore_lines = prepared.ignore_lines
+    test_visitor.noqa_codes_by_line = prepared.noqa_codes_by_line
+
+    # The already parsed tree supplies all framework import evidence. Avoid a
+    # second path-based read after the worker's bounded no-follow read.
+    framework_visitor = options.framework_aware_visitor_class()
+    for import_node in prepared.framework_imports:
+        framework_visitor.visit(import_node)
+    framework_visitor.visit(prepared.tree)
+    framework_visitor.finalize()
+    visitor = options.visitor_class(mod, file)
+    visitor.visit(prepared.tree)
+    visitor.finalize()
+    _copy_framework_metadata(framework_visitor, visitor)
+    return _VisitorResults(visitor, test_visitor, framework_visitor)
+
+
+def _architecture_metrics(
+    file,
+    prepared: _PreparedPython,
+    enabled,
+) -> dict | None:
+    if not enabled:
+        return None
+    try:
+        from skylos.analysis.architecture import (
+            _compute_abstractness,
+            _has_main_guard,
+        )
+
+        architecture_tree = (
+            ast.parse(prepared.source) if prepared.masked else prepared.tree
+        )
+        return {
+            "abstractness": _compute_abstractness(architecture_tree),
+            "has_main_guard": _has_main_guard(architecture_tree),
+            "loc": sum(
+                1
+                for line in prepared.source.splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ),
+        }
+    except Exception:
+        logger.debug(
+            "Architecture metric extraction failed for %s",
+            file,
+            exc_info=True,
+        )
+        return None
+
+
+def _clone_fragments(
+    file, prepared: _PreparedPython, cfg, options: _WorkerOptions
+) -> list:
+    if (
+        not options.collect_clone_fragments
+        or options.clone_cfg is None
+        or "SKY-C401" in cfg.get("ignore", [])
+    ):
+        return []
+    try:
+        clone_tree = None if prepared.masked else prepared.tree
+        return extract_fragments(
+            Path(file),
+            prepared.source,
+            options.clone_cfg,
+            tree=clone_tree,
+        )
+    except Exception:
+        logger.debug("Clone fragment extraction failed for %s", file, exc_info=True)
+        return []
+
+
+def _success_result(
+    cfg,
+    prepared: _PreparedPython,
+    findings: _FindingResults,
+    visitors: _VisitorResults,
+    artifacts: _Artifacts,
+) -> tuple:
+    visitor = visitors.visitor
+    return (
+        visitor.defs,
+        visitor.refs,
+        visitor.dyn,
+        visitor.exports,
+        visitors.test_visitor,
+        visitors.framework_visitor,
+        findings.quality,
+        findings.danger,
+        findings.custom,
+        visitor.pattern_tracker,
+        prepared.empty_file_finding,
+        cfg,
+        prepared.raw_imports,
+        prepared.ignore_lines,
+        findings.suppressed,
+        visitor.inferred_types,
+        visitor.instance_attr_types,
+        getattr(visitor, "_used_attr_names", set()),
+        getattr(visitor, "_used_attr_names_with_context", set()),
+        prepared.source.splitlines(True),
+        getattr(visitor, "param_method_refs", {}),
+        getattr(visitor, "call_arg_types", {}),
+        artifacts.clone_fragments,
+        artifacts.architecture_metrics,
+        getattr(visitor, "top_level_refs", set()),
+        None,
+        prepared.ignore_rules_by_line,
+    )
+
+
+def _error_result(file, cfg, error, options: _WorkerOptions) -> tuple:
+    logger.error(f"{file}: {error}")
+    if os.getenv("SKYLOS_DEBUG"):
+        logger.error(traceback.format_exc())
+    test_visitor = options.test_aware_visitor_class(filename=file)
+    test_visitor.ignore_lines = set()
+    framework_visitor = options.framework_aware_visitor_class()
+    return (
+        [],
+        [],
+        set(),
+        set(),
+        test_visitor,
+        framework_visitor,
+        [],
+        [],
+        [],
+        None,
+        None,
+        cfg,
+        [],
+        set(),
+        [],
+        {},
+        {},
+        set(),
+        set(),
+        [],
+        {},
+        {},
+        [],
+        None,
+        set(),
+        analysis_error_payload(
+            file,
+            error,
+            kind="source_read_error" if isinstance(error, SourceReadError) else None,
+        ),
+        {},
+    )
+
+
+def _prepare_python(file, mod, cfg, source: str) -> _PreparedPython:
+    ignore_lines = get_skylos_ignore_lines(source)
+    ignore_rules_by_line = get_skylos_ignore_rules_by_line(source)
+    noqa_codes_by_line = get_noqa_codes_by_line(source)
+    tree = _parse_python_source(source, file)
+    raw_imports = collect_python_raw_imports(tree, file, mod)
+    empty_file_finding = _empty_file_finding(tree, file, cfg)
+    framework_imports = tuple(
+        node
+        for node in ast.iter_child_nodes(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    )
+    tree, masked = _masked_tree(tree, file, cfg)
+    return _PreparedPython(
+        source,
+        tree,
+        masked,
+        raw_imports,
+        empty_file_finding,
+        ignore_lines,
+        ignore_rules_by_line,
+        noqa_codes_by_line,
+        framework_imports if masked else (),
+    )
+
+
+def _process_python_file(file, mod, cfg, source, options: _WorkerOptions) -> tuple:
+    prepared = _prepare_python(file, mod, cfg, source)
+    quality = _quality_findings(file, prepared, cfg, options)
+    danger = _danger_findings(file, prepared, options)
+    custom = _custom_findings(prepared.tree, file, options.extra_visitors)
+    quality, danger, suppressed = _apply_inline_ignores(
+        quality,
+        danger,
+        prepared.ignore_lines,
+        prepared.ignore_rules_by_line,
+    )
+    findings = _FindingResults(quality, danger, custom, suppressed)
+    visitors = _run_visitors(file, mod, prepared, options)
+    artifacts = _Artifacts(
+        _clone_fragments(file, prepared, cfg, options),
+        _architecture_metrics(
+            file,
+            prepared,
+            options.collect_architecture_metrics,
+        ),
+    )
+    return _success_result(cfg, prepared, findings, visitors, artifacts)
+
+
+def _process_python_entry(file, mod, config_file, options: _WorkerOptions) -> tuple:
+    try:
+        source = _read_python_source(file, options.project_root)
+    except Exception as error:
+        config_start = options.project_root or Path(file).parent
+        cfg = load_config(config_start, config_file=config_file)
+        return _error_result(file, cfg, error, options)
+
+    cfg = load_config(file, config_file=config_file)
+    try:
+        return _process_python_file(file, mod, cfg, source, options)
+    except Exception as error:
+        return _error_result(file, cfg, error, options)
+
+
+def process_file(
+    file_or_args: Any,
+    mod: Any = None,
+    extra_visitors: Iterable[type] | None = None,
+    full_scan: bool = True,
+    collect_clone_fragments: bool = False,
+    clone_cfg: object | None = None,
+    collect_architecture_metrics: bool = False,
+    enable_quality_rules: bool = True,
+    enable_danger_rules: bool = True,
+    config_file: str | Path | None = None,
+    *,
+    project_root: str | Path | None = None,
+    visitor_class: type = Visitor,
+    test_aware_visitor_class: type = TestAwareVisitor,
+    framework_aware_visitor_class: type = FrameworkAwareVisitor,
+) -> tuple | None:
+    """Process one source file and return the analyzer worker result tuple."""
+    file, mod = _file_and_module(file_or_args, mod)
+    options = _WorkerOptions(
+        extra_visitors=extra_visitors,
+        full_scan=full_scan,
+        collect_clone_fragments=collect_clone_fragments,
+        clone_cfg=clone_cfg,
+        collect_architecture_metrics=collect_architecture_metrics,
+        enable_quality_rules=enable_quality_rules,
+        enable_danger_rules=enable_danger_rules,
+        project_root=project_root,
+        visitor_class=visitor_class,
+        test_aware_visitor_class=test_aware_visitor_class,
+        framework_aware_visitor_class=framework_aware_visitor_class,
+    )
+    if str(file).endswith((".py", ".pyi", ".pyw")):
+        return _process_python_entry(file, mod, config_file, options)
+
+    cfg = load_config(file, config_file=config_file)
+    return scan_non_python_file(
+        file,
+        cfg,
+        enable_quality_rules=enable_quality_rules,
+        enable_danger_rules=enable_danger_rules,
+    )

--- a/skylos/analysis/finding_filter.py
+++ b/skylos/analysis/finding_filter.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def finding_is_inline_ignored(
+    finding: dict[str, Any],
+    ignore_lines: set[int] | None,
+    ignore_rules_by_line: dict[int, set[str]] | None,
+) -> bool:
+    """Return whether a finding is suppressed by a line-scoped comment."""
+    line = finding.get("line")
+    if ignore_lines and line in ignore_lines:
+        return True
+
+    rule_id = str(finding.get("rule_id") or "").upper()
+    return bool(
+        rule_id
+        and ignore_rules_by_line
+        and rule_id in ignore_rules_by_line.get(line, set())
+    )

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import traceback
-import warnings
 from pathlib import Path
 from collections import Counter, defaultdict
 
@@ -17,7 +16,11 @@ except ImportError:
 
 from skylos.visitors.base import Visitor
 
-from skylos.analysis.circular_deps import _resolve_from_import_targets
+from skylos.analysis.architecture_support import (
+    architecture_iad_strict,
+    expand_reexported_entrypoint_modules,
+    find_package_boundary_modules,
+)
 
 from skylos.constants import (
     AUTO_CALLED,
@@ -42,14 +45,10 @@ from skylos.rules.secrets import (
 )
 from skylos.rules.secrets import scan_ctx as _secrets_scan_ctx
 
-from skylos.rules.danger.calls import DangerousCallsRule
-
-
-from skylos.config import (
-    get_noqa_codes_by_line,
-    get_skylos_ignore_lines,
-    get_skylos_ignore_rules_by_line,
-    load_config,
+from skylos.config import load_config
+from skylos.analysis.errors import analysis_error_payload as _analysis_error_payload
+from skylos.analysis.finding_filter import (
+    finding_is_inline_ignored as _finding_is_inline_ignored,
 )
 from skylos.core.file_discovery import (
     discover_source_files,
@@ -57,7 +56,6 @@ from skylos.core.file_discovery import (
     should_exclude_path,
 )
 from skylos.core.safe_cache_io import read_project_text_no_symlink
-
 from skylos.core.linter import LinterVisitor
 
 from skylos.rules.quality.policy import analyze_repo_policy
@@ -66,17 +64,11 @@ from skylos.rules.quality.clones import (
     CloneConfig,
     GroupingMode,
     CloneType,
-    extract_fragments,
     detect_pairs,
     group_pairs,
 )
 from skylos.analysis.penalties import apply_penalties
-from skylos.analysis.file_processing import (
-    collect_python_raw_imports,
-    scan_python_quality,
-    scan_non_python_file,
-    set_linter_node_types,
-)
+from skylos.analysis.file_worker import process_file
 
 from skylos.scale.parallel_static import run_proc_file_parallel
 
@@ -85,6 +77,43 @@ logging.basicConfig(
 )
 logger = logging.getLogger("Skylos")
 PYTHON_SIGNATURE_SUFFIXES = (".py", ".pyi", ".pyw")
+
+# Compatibility aliases for integrations that imported these private helpers from
+# skylos.analyzer before architecture reporting moved to its own dependency layer.
+_architecture_iad_strict = architecture_iad_strict
+_expand_reexported_entrypoint_modules = expand_reexported_entrypoint_modules
+_find_package_boundary_modules = find_package_boundary_modules
+
+_OPTIONAL_RUN_STATE_ATTRIBUTES = (
+    "_sca_coverage",
+    "_analysis_scope",
+    "_ai_verification_expectations",
+    "_ai_verification_checks",
+    "_language_engine_reports",
+    "_module_root_path",
+    "_project_root",
+    "pattern_trackers",
+    "_global_abc_classes",
+    "_global_protocol_classes",
+    "_global_abstract_methods",
+    "_global_abc_implementers",
+    "_global_protocol_implementers",
+    "_global_protocol_method_names",
+    "_global_django_path_converter_classes",
+    "_duck_typed_implementers",
+    "_dotted_variable_simple_name_counts",
+    "_global_type_map",
+    "_all_used_attr_names",
+    "_all_used_attr_context",
+    "_param_method_refs",
+    "_call_arg_types",
+    "_grep_verify_report",
+    "_dead_code_liveness_report",
+    "ts_consumed_exports",
+    "_ts_wildcard_edges",
+    "_ts_importers_of",
+    "_ts_demoted_exports",
+)
 
 
 def _merge_project_config_overrides(project_cfg, overrides):
@@ -150,23 +179,6 @@ def _python_verification_surface_root(surface_root):
     ):
         return root.parent
     return root
-
-
-def _finding_is_inline_ignored(
-    finding,
-    ignore_lines,
-    ignore_rules_by_line,
-):
-    line = finding.get("line")
-    if ignore_lines and line in ignore_lines:
-        return True
-
-    rule_id = str(finding.get("rule_id") or "").upper()
-    return bool(
-        rule_id
-        and ignore_rules_by_line
-        and rule_id in ignore_rules_by_line.get(line, set())
-    )
 
 
 def _extend_unsuppressed_danger_findings(
@@ -422,15 +434,6 @@ def _entrypoint_module_name(qname: str) -> str | None:
     return module_name or None
 
 
-def _architecture_iad_strict(architecture_cfg) -> bool:
-    if not isinstance(architecture_cfg, dict):
-        return False
-    for key in ("enforce_iad", "strict_iad"):
-        if key in architecture_cfg:
-            return bool(architecture_cfg.get(key))
-    return False
-
-
 def _base_class_leaf_names(class_def) -> set[str]:
     leaves: set[str] = set()
     for base in getattr(class_def, "base_classes", []):
@@ -440,65 +443,6 @@ def _base_class_leaf_names(class_def) -> set[str]:
 
 def _class_has_base_leaf(class_def, leaf_names: set[str]) -> bool:
     return bool(_base_class_leaf_names(class_def) & leaf_names)
-
-
-def _expand_reexported_entrypoint_modules(
-    entrypoint_qnames: set[str],
-    entrypoint_modules: set[str],
-    raw_imports_by_file: dict[Path, list],
-    modmap: dict[Path, str],
-    module_files: dict[str, str],
-) -> set[str]:
-    modules = set(entrypoint_modules)
-    known_modules = set(module_files)
-
-    for qname in entrypoint_qnames:
-        if "." not in qname:
-            continue
-
-        entry_module, entry_symbol = qname.rsplit(".", 1)
-        for file_path, raw_imports in raw_imports_by_file.items():
-            if modmap.get(file_path) != entry_module:
-                continue
-
-            for import_module, _line, import_type, imported_names in raw_imports:
-                if import_type != "from_import":
-                    continue
-                if entry_symbol not in imported_names:
-                    continue
-                if import_module in known_modules:
-                    modules.add(import_module)
-
-    return modules
-
-
-def _find_package_boundary_modules(
-    raw_imports_by_file: dict[Path, list],
-    modmap: dict[Path, str],
-    module_files: dict[str, str],
-) -> set[str]:
-    modules: set[str] = set()
-    known_modules = set(module_files)
-
-    for file_path, raw_imports in raw_imports_by_file.items():
-        package_module = modmap.get(file_path)
-        if not package_module or Path(file_path).name != "__init__.py":
-            continue
-
-        for import_module, _line, import_type, imported_names in raw_imports:
-            if import_type != "from_import":
-                continue
-
-            targets = _resolve_from_import_targets(
-                import_module,
-                imported_names,
-                known_modules,
-            )
-            for target in targets:
-                if target != package_module and target.startswith(package_module + "."):
-                    modules.add(target)
-
-    return modules
 
 
 def _is_secret_config_candidate(path: Path) -> bool:
@@ -1091,10 +1035,17 @@ def _annotate_dead_code_evidence_sources(defs, test_flags, framework_flags) -> N
 
 class Skylos:
     def __init__(self):
+        self._has_analyzed = False
+        self._reset_run_state()
+
+    def _reset_run_state(self) -> None:
         self.defs = {}
         self.refs = []
         self.dynamic = set()
         self.exports = defaultdict(set)
+        self._module_alias_prefix_values = ()
+        for attribute in _OPTIONAL_RUN_STATE_ATTRIBUTES:
+            self.__dict__.pop(attribute, None)
 
     def _module(self, root, f):
         p = list(f.relative_to(root).parts)
@@ -1730,7 +1681,7 @@ class Skylos:
             if target_fqn in non_import_defs:
                 return target_fqn
 
-            for prefix in getattr(self, "_module_alias_prefixes", ()):
+            for prefix in self._module_alias_prefix_values:
                 if target_fqn.startswith(prefix + "."):
                     stripped_target = target_fqn[len(prefix) + 1 :]
                     if stripped_target in non_import_defs:
@@ -2517,6 +2468,9 @@ class Skylos:
         if not (0 <= thr <= 100):
             raise ValueError(f"thr must be 0-100, got {thr}")
 
+        if self._has_analyzed:
+            self._reset_run_state()
+        self._has_analyzed = True
         clear_go_cache()
         self._sca_coverage = None
 
@@ -2573,6 +2527,7 @@ class Skylos:
             "excluded_folders": list(exclude_folders or []),
             "changed_files_only": changed_files is not None,
         }
+        self._project_root = project_root
 
         files, root = self._discover_files(path, exclude_folders)
         verification_surface_root = _verification_surface_root(
@@ -2818,7 +2773,7 @@ class Skylos:
 
         module_root = self._module_root(root, project_root)
         self._module_root_path = module_root
-        self._module_alias_prefixes = self._module_alias_prefixes(root)
+        self._module_alias_prefix_values = self._module_alias_prefixes(root)
         modmap = {}
         for f in files:
             modmap[f] = self._module(module_root, f)
@@ -2863,8 +2818,6 @@ class Skylos:
                 )
 
         root = project_root
-        self._project_root = project_root
-
         if trace_file is not False:
             trace_path = (
                 project_root / ".skylos_trace"
@@ -2951,6 +2904,7 @@ class Skylos:
                 enable_quality_rules=enable_quality,
                 enable_danger_rules=enable_danger,
                 config_file=config_file,
+                project_root=project_root,
             )
 
             if os.getenv("SKYLOS_DEBUG"):
@@ -4300,64 +4254,6 @@ class Skylos:
         return json.dumps(result, indent=2)
 
 
-def _is_truly_empty_or_docstring_only(tree):
-    if not isinstance(tree, ast.Module):
-        return False
-
-    if not tree.body:
-        return True
-
-    if len(tree.body) != 1:
-        return False
-
-    only = tree.body[0]
-    return (
-        isinstance(only, ast.Expr)
-        and isinstance(only.value, ast.Constant)
-        and isinstance(only.value.value, str)
-    )
-
-
-def _analysis_error_payload(file, error, *, kind=None):
-    is_syntax_error = isinstance(error, SyntaxError)
-    message = getattr(error, "msg", None) if is_syntax_error else None
-    message = str(message or error or type(error).__name__)
-    message = " ".join(message.splitlines())[:500]
-
-    line = getattr(error, "lineno", None) or 1
-    column = getattr(error, "offset", None) or 1
-    try:
-        line = max(1, int(line))
-    except (TypeError, ValueError):
-        line = 1
-    try:
-        column = max(1, int(column))
-    except (TypeError, ValueError):
-        column = 1
-
-    payload = {
-        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
-        "severity": "HIGH",
-        "kind": kind or ("syntax_error" if is_syntax_error else "processing_error"),
-        "error_type": type(error).__name__,
-        "message": message,
-        "file": str(file),
-        "line": line,
-        "column": column,
-        "python_version": (
-            f"{sys.version_info.major}.{sys.version_info.minor}."
-            f"{sys.version_info.micro}"
-        ),
-    }
-    if is_syntax_error:
-        payload["suggestion"] = (
-            "Fix the reported syntax, or use a Python runtime that supports the "
-            "project's syntax; official container images provide matching "
-            "-pythonX.Y tags."
-        )
-    return payload
-
-
 def proc_file(
     file_or_args,
     mod=None,
@@ -4369,290 +4265,24 @@ def proc_file(
     enable_quality_rules=True,
     enable_danger_rules=True,
     config_file=None,
-) -> dict | None:
-    if mod is None and isinstance(file_or_args, tuple):
-        file, mod = file_or_args
-    else:
-        file = file_or_args
-
-    cfg = load_config(file, config_file=config_file)
-
-    non_python_out = scan_non_python_file(
-        file,
-        cfg,
+    project_root=None,
+) -> tuple | None:
+    return process_file(
+        file_or_args,
+        mod,
+        extra_visitors=extra_visitors,
+        full_scan=full_scan,
+        collect_clone_fragments=collect_clone_fragments,
+        clone_cfg=clone_cfg,
+        collect_architecture_metrics=collect_architecture_metrics,
         enable_quality_rules=enable_quality_rules,
         enable_danger_rules=enable_danger_rules,
+        config_file=config_file,
+        project_root=project_root,
+        visitor_class=Visitor,
+        test_aware_visitor_class=TestAwareVisitor,
+        framework_aware_visitor_class=FrameworkAwareVisitor,
     )
-    if non_python_out is not None:
-        return non_python_out
-
-    try:
-        source = Path(file).read_text(encoding="utf-8")
-        ignore_lines = get_skylos_ignore_lines(source)
-        ignore_rules_by_line = get_skylos_ignore_rules_by_line(source)
-        noqa_codes_by_line = get_noqa_codes_by_line(source)
-
-        tree = ast.parse(source, filename=str(file))
-        # ast.parse() can accept ASTs that Python later rejects, such as
-        # functions with duplicate argument names. Compile without executing
-        # so every compile-time SyntaxError follows the incomplete-analysis path.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", SyntaxWarning)
-            compile(tree, str(file), "exec", dont_inherit=True)
-
-        raw_imports = collect_python_raw_imports(tree, file, mod)
-
-        empty_file_finding = None
-
-        basename = Path(file).name
-        skip_empty_report = basename in {"__init__.py", "__main__.py", "main.py"}
-
-        if (
-            _is_truly_empty_or_docstring_only(tree)
-            and not skip_empty_report
-            and "SKY-E002" not in cfg["ignore"]
-        ):
-            empty_file_finding = {
-                "rule_id": "SKY-E002",
-                "message": "Empty Python file (no code, or docstring-only)",
-                "file": str(file),
-                "line": 1,
-                "severity": "LOW",
-                "category": "DEAD_CODE",
-            }
-
-        from skylos.analysis.ast_mask import (
-            apply_body_mask,
-            default_mask_spec_from_config,
-        )
-
-        mask = default_mask_spec_from_config(cfg)
-        tree, masked = apply_body_mask(tree, mask)
-
-        if masked and os.getenv("SKYLOS_DEBUG"):
-            logger.info(f"{file}: masked {masked} bodies (skipped inner analysis)")
-
-        quality_findings = []
-        danger_findings = []
-
-        if full_scan and enable_quality_rules:
-            quality_findings = scan_python_quality(tree, source, file, cfg)
-            if Path(file).suffix == ".pyi":
-                quality_findings = [
-                    finding
-                    for finding in quality_findings
-                    if finding.get("rule_id") not in {"SKY-L026", "SKY-L033"}
-                ]
-
-        if full_scan and enable_danger_rules:
-            d_rules = [DangerousCallsRule()]
-            set_linter_node_types(d_rules)
-            linter_d = LinterVisitor(d_rules, str(file))
-            linter_d.visit(tree)
-            danger_findings = linter_d.findings
-
-            from skylos.rules.danger.danger import scan_file_with_tree
-
-            taint_findings = []
-            try:
-                scan_file_with_tree(tree, Path(file), taint_findings, source=source)
-            except Exception:
-                logger.debug("Taint analysis failed for %s", file, exc_info=True)
-            if taint_findings:
-                danger_findings.extend(taint_findings)
-
-        pro_findings = []
-        if extra_visitors:
-            for VisitorClass in extra_visitors:
-                checker = VisitorClass(file, pro_findings)
-                checker.visit(tree)
-
-        suppressed_findings = []
-        if ignore_lines or ignore_rules_by_line:
-            sup_q = [
-                f
-                for f in quality_findings
-                if _finding_is_inline_ignored(
-                    f,
-                    ignore_lines,
-                    ignore_rules_by_line,
-                )
-            ]
-            sup_d = [
-                f
-                for f in danger_findings
-                if _finding_is_inline_ignored(
-                    f,
-                    ignore_lines,
-                    ignore_rules_by_line,
-                )
-            ]
-            quality_findings = [
-                f
-                for f in quality_findings
-                if not _finding_is_inline_ignored(
-                    f,
-                    ignore_lines,
-                    ignore_rules_by_line,
-                )
-            ]
-            danger_findings = [
-                f
-                for f in danger_findings
-                if not _finding_is_inline_ignored(
-                    f,
-                    ignore_lines,
-                    ignore_rules_by_line,
-                )
-            ]
-            for f in sup_q:
-                suppressed_findings.append(
-                    {**f, "category": "quality", "reason": "inline ignore comment"}
-                )
-            for f in sup_d:
-                suppressed_findings.append(
-                    {**f, "category": "security", "reason": "inline ignore comment"}
-                )
-
-        tv = TestAwareVisitor(filename=file)
-        tv.visit(tree)
-        tv.ignore_lines = ignore_lines
-        tv.noqa_codes_by_line = noqa_codes_by_line
-
-        fv = FrameworkAwareVisitor(filename=file)
-        fv.visit(tree)
-        fv.finalize()
-        v = Visitor(mod, file)
-        v.visit(tree)
-        v.finalize()
-
-        fv.dataclass_fields = getattr(v, "dataclass_fields", set())
-        fv.first_read_lineno = getattr(v, "first_read_lineno", {})
-        fv.protocol_classes = getattr(v, "protocol_classes", set())
-        fv.namedtuple_classes = getattr(v, "namedtuple_classes", set())
-        fv.enum_classes = getattr(v, "enum_classes", set())
-        fv.attrs_classes = getattr(v, "attrs_classes", set())
-        fv.orm_model_classes = getattr(v, "orm_model_classes", set())
-        fv.type_alias_names = getattr(v, "type_alias_names", set())
-        fv.abc_classes = getattr(v, "abc_classes", set())
-        fv.abstract_methods = getattr(v, "abstract_methods", {})
-        fv.abc_implementers = getattr(v, "abc_implementers", {})
-        fv.protocol_implementers = getattr(v, "protocol_implementers", {})
-        fv.protocol_method_names = getattr(v, "protocol_method_names", {})
-        fv.version_conditional_lines = getattr(v, "version_conditional_lines", set())
-
-        architecture_metrics = None
-        if collect_architecture_metrics:
-            try:
-                architecture_tree = None
-                if masked:
-                    architecture_tree = ast.parse(source)
-                else:
-                    architecture_tree = tree
-
-                from skylos.analysis.architecture import (
-                    _compute_abstractness,
-                    _has_main_guard,
-                )
-
-                architecture_metrics = {
-                    "abstractness": _compute_abstractness(architecture_tree),
-                    "has_main_guard": _has_main_guard(architecture_tree),
-                    "loc": sum(
-                        1
-                        for line in source.splitlines()
-                        if line.strip() and not line.strip().startswith("#")
-                    ),
-                }
-            except Exception:
-                logger.debug(
-                    "Architecture metric extraction failed for %s",
-                    file,
-                    exc_info=True,
-                )
-
-        clone_fragments = []
-        if (
-            collect_clone_fragments
-            and clone_cfg is not None
-            and "SKY-C401" not in cfg.get("ignore", [])
-        ):
-            try:
-                clone_tree = None if masked else tree
-                clone_fragments = extract_fragments(
-                    Path(file), source, clone_cfg, tree=clone_tree
-                )
-            except Exception:
-                logger.debug(
-                    "Clone fragment extraction failed for %s", file, exc_info=True
-                )
-
-        return (
-            v.defs,
-            v.refs,
-            v.dyn,
-            v.exports,
-            tv,
-            fv,
-            quality_findings,
-            danger_findings,
-            pro_findings,
-            v.pattern_tracker,
-            empty_file_finding,
-            cfg,
-            raw_imports,
-            ignore_lines,
-            suppressed_findings,
-            v.inferred_types,
-            v.instance_attr_types,
-            getattr(v, "_used_attr_names", set()),
-            getattr(v, "_used_attr_names_with_context", set()),
-            source.splitlines(True),
-            getattr(v, "param_method_refs", {}),
-            getattr(v, "call_arg_types", {}),
-            clone_fragments,
-            architecture_metrics,
-            getattr(v, "top_level_refs", set()),
-            None,
-            ignore_rules_by_line,
-        )
-
-    except Exception as e:
-        logger.error(f"{file}: {e}")
-        if os.getenv("SKYLOS_DEBUG"):
-            logger.error(traceback.format_exc())
-        dummy_visitor = TestAwareVisitor(filename=file)
-        dummy_visitor.ignore_lines = set()
-        dummy_framework_visitor = FrameworkAwareVisitor(filename=file)
-        return (
-            [],
-            [],
-            set(),
-            set(),
-            dummy_visitor,
-            dummy_framework_visitor,
-            [],
-            [],
-            [],
-            None,
-            None,
-            cfg,
-            [],
-            set(),
-            [],
-            {},
-            {},
-            set(),
-            set(),
-            [],
-            {},
-            {},
-            [],
-            None,
-            set(),
-            _analysis_error_payload(file, e),
-            {},
-        )
 
 
 def analyze(

--- a/skylos/core/safe_cache_io.py
+++ b/skylos/core/safe_cache_io.py
@@ -27,6 +27,10 @@ def read_text_no_symlink(
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
 
     fd: int | None = None
     try:
@@ -96,6 +100,10 @@ def read_project_text_no_symlink(
         flags = os.O_RDONLY
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_NONBLOCK"):
+            flags |= os.O_NONBLOCK
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
         file_fd = os.open(relative.parts[-1], flags, dir_fd=directory_fd)
         file_stat = os.fstat(file_fd)
         if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_size > max_bytes:

--- a/skylos/reporting/architecture_result.py
+++ b/skylos/reporting/architecture_result.py
@@ -5,6 +5,11 @@ import os
 import traceback
 from pathlib import Path
 
+from skylos.analysis.architecture_support import (
+    architecture_iad_strict,
+    expand_reexported_entrypoint_modules,
+    find_package_boundary_modules,
+)
 from skylos.analysis.circular_deps import CircularDependencyRule
 
 _MAX_ARCHITECTURE_SOURCE_BYTES = 2_000_000
@@ -115,7 +120,6 @@ def _architecture_findings(
     pyproject_entrypoint_modules,
 ):
     from skylos.analysis.architecture import get_architecture_findings
-    from skylos.analyzer import _architecture_iad_strict
 
     dep_graph = dict(circular_rule._analyzer.architecture_dependencies)
     mod_files = dict(circular_rule._analyzer.modules)
@@ -138,7 +142,7 @@ def _architecture_findings(
         entrypoint_modules=entrypoint_modules,
         package_boundary_modules=package_modules,
         layer_policy=project_cfg.get("architecture"),
-        iad_findings_advisory=not _architecture_iad_strict(
+        iad_findings_advisory=not architecture_iad_strict(
             project_cfg.get("architecture")
         ),
     )
@@ -152,10 +156,8 @@ def _architecture_entrypoint_modules(
     modmap,
     mod_files,
 ):
-    from skylos.analyzer import _expand_reexported_entrypoint_modules
-
     entrypoint_modules = pyproject_entrypoint_modules | architecture_main_guard_modules
-    return _expand_reexported_entrypoint_modules(
+    return expand_reexported_entrypoint_modules(
         pyproject_entrypoint_qnames,
         entrypoint_modules,
         all_raw_imports,
@@ -165,9 +167,7 @@ def _architecture_entrypoint_modules(
 
 
 def _package_boundary_modules(all_raw_imports, modmap, mod_files):
-    from skylos.analyzer import _find_package_boundary_modules
-
-    return _find_package_boundary_modules(all_raw_imports, modmap, mod_files)
+    return find_package_boundary_modules(all_raw_imports, modmap, mod_files)
 
 
 def _architecture_module_trees(files, modmap, architecture_abstractness):

--- a/skylos/scale/parallel_static.py
+++ b/skylos/scale/parallel_static.py
@@ -16,6 +16,7 @@ def _worker(
     enable_quality_rules=True,
     enable_danger_rules=True,
     config_file=None,
+    project_root=None,
 ):
     from skylos.analyzer import proc_file
 
@@ -30,6 +31,7 @@ def _worker(
         enable_quality_rules=enable_quality_rules,
         enable_danger_rules=enable_danger_rules,
         config_file=config_file,
+        project_root=project_root,
     )
     return str(file_path), out
 
@@ -48,6 +50,7 @@ def run_proc_file_parallel(
     enable_quality_rules=True,
     enable_danger_rules=True,
     config_file=None,
+    project_root=None,
 ):
     import os
 
@@ -72,6 +75,7 @@ def run_proc_file_parallel(
             enable_quality_rules=enable_quality_rules,
             enable_danger_rules=enable_danger_rules,
             config_file=config_file,
+            project_root=project_root,
         )
 
     if any(str(f).endswith(".go") for f in files):
@@ -89,6 +93,7 @@ def run_proc_file_parallel(
             enable_quality_rules=enable_quality_rules,
             enable_danger_rules=enable_danger_rules,
             config_file=config_file,
+            project_root=project_root,
         )
 
     pending = []
@@ -113,6 +118,7 @@ def run_proc_file_parallel(
                 enable_quality_rules,
                 enable_danger_rules,
                 config_file,
+                project_root,
             )
             fut_to_file[fut] = f
 
@@ -146,6 +152,7 @@ def run_proc_file_parallel(
                         enable_quality_rules=enable_quality_rules,
                         enable_danger_rules=enable_danger_rules,
                         config_file=config_file,
+                        project_root=project_root,
                     )
                 except Exception:
                     logger.error(
@@ -182,6 +189,7 @@ def _run_mixed_files_with_serial_go(
     enable_quality_rules=True,
     enable_danger_rules=True,
     config_file=None,
+    project_root=None,
 ):
     go_files = []
     other_files = []
@@ -216,6 +224,7 @@ def _run_mixed_files_with_serial_go(
             enable_quality_rules=enable_quality_rules,
             enable_danger_rules=enable_danger_rules,
             config_file=config_file,
+            project_root=project_root,
         )
         for f, out in zip(other_files, other_outs):
             results[str(f)] = out
@@ -233,6 +242,7 @@ def _run_mixed_files_with_serial_go(
             enable_quality_rules=enable_quality_rules,
             enable_danger_rules=enable_danger_rules,
             config_file=config_file,
+            project_root=project_root,
         )
         for f, out in zip(go_files, go_outs):
             results[str(f)] = out
@@ -252,6 +262,7 @@ def _run_proc_files_serial(
     enable_quality_rules=True,
     enable_danger_rules=True,
     config_file=None,
+    project_root=None,
 ):
     outs = []
     total = len(files)
@@ -273,6 +284,7 @@ def _run_proc_files_serial(
             enable_quality_rules=enable_quality_rules,
             enable_danger_rules=enable_danger_rules,
             config_file=config_file,
+            project_root=project_root,
         )
         outs.append(out)
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -139,6 +139,63 @@ class TestSkylos:
         assert skylos.dynamic == set()
         assert isinstance(skylos.exports, defaultdict)
 
+    def test_instance_can_be_reused_without_leaking_prior_scan_state(
+        self, skylos, tmp_path
+    ):
+        old_module = tmp_path / "old_module.py"
+        old_module.write_text("def old_helper():\n    return 1\n", encoding="utf-8")
+
+        first = json.loads(
+            skylos.analyze(str(tmp_path), thr=0, grep_verify=False, trace_file=False)
+        )
+
+        old_module.unlink()
+        new_module = tmp_path / "new_module.py"
+        new_module.write_text("def new_helper():\n    return 2\n", encoding="utf-8")
+        second = json.loads(
+            skylos.analyze(str(tmp_path), thr=0, grep_verify=False, trace_file=False)
+        )
+
+        first_names = {finding["simple_name"] for finding in first["unused_functions"]}
+        second_names = {
+            finding["simple_name"] for finding in second["unused_functions"]
+        }
+        assert "old_helper" in first_names
+        assert "old_helper" not in second_names
+        assert "new_helper" in second_names
+
+    def test_reused_instance_clears_full_scan_caches_before_empty_scan(
+        self, skylos, tmp_path
+    ):
+        source_root = tmp_path / "source"
+        source_root.mkdir()
+        (source_root / "module.py").write_text(
+            "def helper():\n    return 1\n", encoding="utf-8"
+        )
+
+        skylos.analyze(str(source_root), thr=0, grep_verify=False, trace_file=False)
+        stale_only_attributes = {
+            "_module_root_path",
+            "pattern_trackers",
+            "_global_type_map",
+            "_grep_verify_report",
+            "_dead_code_liveness_report",
+            "ts_consumed_exports",
+            "_ts_demoted_exports",
+        }
+        assert stale_only_attributes <= skylos.__dict__.keys()
+
+        empty_root = tmp_path / "empty"
+        empty_root.mkdir()
+        result = json.loads(
+            skylos.analyze(str(empty_root), thr=0, grep_verify=False, trace_file=False)
+        )
+
+        assert result["analysis_summary"]["total_files"] == 0
+        assert stale_only_attributes.isdisjoint(skylos.__dict__)
+        assert skylos._project_root == empty_root
+        assert skylos._analysis_scope["repository_root"] == str(empty_root)
+
     def test_module_name_generation(self, skylos):
         root = Path("/project")
 
@@ -1856,6 +1913,7 @@ class TestClass:
 
                     mock_visitor_class.assert_called_once_with("test_module", f.name)
                     mock_visitor.visit.assert_called_once()
+                    mock_framework_visitor_class.assert_called_once_with()
 
                     assert defs == []
                     assert refs == []
@@ -1870,6 +1928,63 @@ class TestClass:
                     assert empty_file_finding is None
             finally:
                 Path(f.name).unlink()
+
+    def test_proc_file_rejects_symlinked_python_source(self, tmp_path):
+        scan_root = tmp_path / "repo"
+        scan_root.mkdir()
+        outside = tmp_path / "outside.py"
+        outside.write_text(
+            "def outside_helper():\n    return 'secret'\n",
+            encoding="utf-8",
+        )
+        source_link = scan_root / "linked.py"
+        source_link.symlink_to(outside)
+
+        result = proc_file(
+            str(source_link),
+            "linked",
+            project_root=scan_root,
+        )
+
+        assert len(result) == 27
+        assert result[0] == []
+        assert result[19] == []
+        assert result[25]["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+        assert result[25]["kind"] == "source_read_error"
+        assert result[25]["error_type"] == "SourceReadError"
+
+    def test_proc_file_rejects_oversized_python_source(self, monkeypatch, tmp_path):
+        from skylos.analysis import file_worker
+
+        monkeypatch.setattr(file_worker, "MAX_PYTHON_SOURCE_BYTES", 32)
+        source = tmp_path / "oversized.py"
+        source.write_bytes(b"#" * 33)
+
+        result = proc_file(str(source), "oversized", project_root=tmp_path)
+
+        assert len(result) == 27
+        assert result[0] == []
+        assert result[19] == []
+        assert result[25]["kind"] == "source_read_error"
+        assert result[25]["error_type"] == "SourceReadError"
+
+    def test_proc_file_accepts_source_at_size_limit(self, monkeypatch, tmp_path):
+        from skylos.analysis import file_worker
+
+        source_text = "value = 1\n"
+        monkeypatch.setattr(
+            file_worker,
+            "MAX_PYTHON_SOURCE_BYTES",
+            len(source_text.encode("utf-8")),
+        )
+        source = tmp_path / "bounded.py"
+        source.write_text(source_text, encoding="utf-8")
+
+        result = proc_file(str(source), "bounded", project_root=tmp_path)
+
+        assert len(result) == 27
+        assert result[19] == [source_text]
+        assert result[25] is None
 
     def test_proc_file_with_invalid_python(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:

--- a/test/test_parallel_static.py
+++ b/test/test_parallel_static.py
@@ -67,7 +67,10 @@ def test_parallel_path_preserves_order(monkeypatch, tmp_path):
 
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
 
+    project_roots = []
+
     def fake_proc_file(file_path, mod, extra_visitors=None, full_scan=True, **kwargs):
+        project_roots.append(kwargs.get("project_root"))
         return ("ok", str(file_path), mod)
 
     import skylos.analyzer
@@ -77,11 +80,17 @@ def test_parallel_path_preserves_order(monkeypatch, tmp_path):
     files = [tmp_path / "x.py", tmp_path / "y.py", tmp_path / "z.py"]
     modmap = {files[0]: "mx", files[1]: "my", files[2]: "mz"}
 
-    out = ps.run_proc_file_parallel(files, modmap, jobs=2)
+    out = ps.run_proc_file_parallel(
+        files,
+        modmap,
+        jobs=2,
+        project_root=tmp_path,
+    )
 
     assert out[0] == ("ok", str(files[0]), "mx")
     assert out[1] == ("ok", str(files[1]), "my")
     assert out[2] == ("ok", str(files[2]), "mz")
+    assert project_roots == [tmp_path, tmp_path, tmp_path]
 
 
 def test_go_files_use_serial_path_to_keep_module_cache_effective(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

  - Split the analyzer into smaller and more focused modules
  - Reset analyzer state between scans to prevent stale findings and caches.
  - Safely reject symlinked or oversized Python source files.

  ## Tests

  - `pytest .`
