### PR TITLE
fix(quality): handle positional-only boolean traps and setters

### DIFF
--- a/skylos/rules/quality/logic_maintainability.py
+++ b/skylos/rules/quality/logic_maintainability.py
@@ -480,6 +480,32 @@ _BOOLEAN_TRAP_ALLOWED_NAMES = {
 }
 
 
+def _property_setter_value_arg(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    positional_args: list[ast.arg],
+) -> ast.arg | None:
+    setter_decorators = (
+        decorator
+        for decorator in node.decorator_list
+        if isinstance(decorator, ast.Attribute) and decorator.attr == "setter"
+    )
+    is_matching_setter = any(
+        (isinstance(decorator.value, ast.Name) and decorator.value.id == node.name)
+        or (
+            isinstance(decorator.value, ast.Attribute)
+            and decorator.value.attr == node.name
+        )
+        for decorator in setter_decorators
+    )
+    if not is_matching_setter:
+        return None
+
+    if len(positional_args) < 2:
+        return None
+
+    return positional_args[1]
+
+
 class BooleanTrapRule(SkylosRule):
     rule_id = "SKY-L029"
     name = "Boolean Trap"
@@ -493,7 +519,8 @@ class BooleanTrapRule(SkylosRule):
             return None
 
         args = node.args
-        positional_args = args.args
+        positional_args = [*args.posonlyargs, *args.args]
+        setter_value_arg = _property_setter_value_arg(node, positional_args)
 
         num_defaults = len(args.defaults)
         num_positional = len(positional_args)
@@ -504,6 +531,8 @@ class BooleanTrapRule(SkylosRule):
         for i, arg in enumerate(positional_args):
             arg_name = arg.arg
             if arg_name in ("self", "cls"):
+                continue
+            if arg is setter_value_arg:
                 continue
             if arg_name in _BOOLEAN_TRAP_ALLOWED_NAMES:
                 continue

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3531,6 +3531,48 @@ class SupportsRead(Protocol):
         ]
         assert findings == []
 
+    def test_analyze_handles_positional_only_boolean_traps_and_setters(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("SKYLOS_JOBS", "1")
+        src = tmp_path / "boolean_traps.py"
+        src.write_text(
+            """
+def render_page(page: str, recurse: bool = True, /, name: str = "index") -> str:
+    return page
+
+def paginate(page: str, deep=True, /, name: str = "index") -> str:
+    return page
+
+class Settings:
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self._enabled = value
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
+        )
+        assert result.get("analysis_errors", []) == []
+        findings = [
+            finding
+            for finding in result.get("quality", [])
+            if finding.get("rule_id") == "SKY-L029"
+        ]
+        assert [finding["simple_name"] for finding in findings] == [
+            "recurse",
+            "deep",
+        ]
+
     def test_analyze_flags_no_effect_statement(self, tmp_path):
         src = tmp_path / "app.py"
         src.write_text(

--- a/test/test_quality_rules.py
+++ b/test/test_quality_rules.py
@@ -722,6 +722,117 @@ def process(data, count=5):
         findings = check_code(rule, code)
         assert not any(f["rule_id"] == "SKY-L029" for f in findings)
 
+    def test_positional_only_bool_params(self):
+        code = """
+def render_page(page: str, recurse: bool = True, /, name: str = "index") -> str:
+    return page
+
+def paginate(page: str, deep=True, /, name: str = "index") -> str:
+    return page
+
+def log_page(verbose: bool = True, /) -> None:
+    return None
+"""
+        rule = BooleanTrapRule()
+        findings = check_code(rule, code)
+        l029 = [finding for finding in findings if finding["rule_id"] == "SKY-L029"]
+
+        assert [finding["simple_name"] for finding in l029] == [
+            "recurse",
+            "deep",
+        ]
+
+    def test_positional_only_bool_variants_preserve_default_alignment(self):
+        code = """
+async def refresh(active: "bool", /) -> None:
+    return None
+
+def configure(label="plain", /, enabled=False) -> None:
+    return None
+"""
+        rule = BooleanTrapRule()
+        findings = check_code(rule, code)
+        l029 = [finding for finding in findings if finding["rule_id"] == "SKY-L029"]
+
+        assert [finding["simple_name"] for finding in l029] == [
+            "active",
+            "enabled",
+        ]
+
+    def test_property_setter_value_is_not_a_boolean_trap_with_custom_receiver(self):
+        code = """
+class Settings:
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(instance, value: bool, /) -> None:
+        instance._enabled = value
+"""
+        rule = BooleanTrapRule()
+        findings = check_code(rule, code)
+
+        assert not any(finding["rule_id"] == "SKY-L029" for finding in findings)
+
+    def test_qualified_property_setter_value_is_not_a_boolean_trap(self):
+        code = """
+class Base:
+    @property
+    def enabled(self) -> bool:
+        return False
+
+class Settings(Base):
+    @Base.enabled.setter
+    def enabled(self, value: bool) -> None:
+        self._enabled = value
+"""
+        rule = BooleanTrapRule()
+        findings = check_code(rule, code)
+
+        assert not any(finding["rule_id"] == "SKY-L029" for finding in findings)
+
+    def test_property_setter_only_exempts_value_parameter(self):
+        code = """
+class Settings:
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool, announce: bool = False) -> None:
+        self._enabled = value
+"""
+        rule = BooleanTrapRule()
+        findings = check_code(rule, code)
+        l029 = [finding for finding in findings if finding["rule_id"] == "SKY-L029"]
+
+        assert [finding["simple_name"] for finding in l029] == ["announce"]
+
+    def test_setter_lookalikes_do_not_exempt_parameter(self):
+        code = """
+@setter
+def configure(enabled: bool) -> None:
+    return None
+
+@registry.setter
+def publish(active: bool) -> None:
+    return None
+
+@broken.setter
+def broken(value: bool) -> None:
+    return None
+"""
+        rule = BooleanTrapRule()
+        findings = check_code(rule, code)
+        l029 = [finding for finding in findings if finding["rule_id"] == "SKY-L029"]
+
+        assert [finding["simple_name"] for finding in l029] == [
+            "enabled",
+            "active",
+            "value",
+        ]
+
 
 # --- SKY-L017: Error Disclosure ---
 


### PR DESCRIPTION
Fixes #711

## Summary

  - Detect boolean traps in positional-only parameters.
  - Stop flagging property-setter values as boolean traps.
  - Keep reporting invalid setter lookalikes and additional boolean parameters.

  ## Tests

  - `pytest .`
