### PR TITLE
perf(analyzer): batch grep verification searches

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 import traceback
 from pathlib import Path
 from collections import Counter, defaultdict
@@ -365,6 +366,8 @@ def _scan_ai_defect_diff_signals(
 
 
 MAX_SECRET_CONFIG_BYTES = 8_000_000
+_GENERATED_GREP_CACHE_RELATIVE = Path(".skylos/cache/grep_results.json")
+_GIT_TRACKING_TIMEOUT_SECONDS = 5
 
 _TS_JS_SOURCE_EXTS = (
     ".ts",
@@ -519,6 +522,70 @@ def _absolute_secret_scan_targets(scan_target) -> tuple[Path, ...]:
     return tuple(targets)
 
 
+def _is_generated_grep_cache(candidate: Path, root: Path) -> bool:
+    try:
+        return candidate.relative_to(root) == _GENERATED_GREP_CACHE_RELATIVE
+    except ValueError:
+        return False
+
+
+def _explicitly_targets_generated_grep_cache(
+    candidate: Path,
+    scan_target,
+) -> bool:
+    if scan_target is None:
+        return False
+    cache_dir = candidate.parent
+    cache_root = cache_dir.parent
+    return any(
+        target in {candidate, cache_dir, cache_root}
+        for target in _absolute_secret_scan_targets(scan_target)
+    )
+
+
+def _git_tracking_status(candidate: Path) -> bool | None:
+    try:
+        candidate = candidate.resolve(strict=False)
+    except OSError:
+        return None
+    git_root = find_git_root(candidate.parent)
+    if git_root is None:
+        return False
+    try:
+        relative = candidate.relative_to(git_root).as_posix()
+        result = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=git_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_GIT_TRACKING_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _should_scan_generated_grep_cache(
+    candidate: Path,
+    *,
+    root: Path,
+    scan_target,
+    selected_by_changed_files: bool,
+) -> bool:
+    if not _is_generated_grep_cache(candidate, root):
+        return True
+    if selected_by_changed_files:
+        return True
+    if _explicitly_targets_generated_grep_cache(candidate, scan_target):
+        return True
+    return _git_tracking_status(candidate) is not False
+
+
 def _is_within_secret_scan_targets(
     candidate: Path, scan_targets: tuple[Path, ...]
 ) -> bool:
@@ -566,6 +633,8 @@ def _scan_secret_config_candidate(
     root: Path,
     excluded: set[str],
     scanned: set[str],
+    scan_target=None,
+    selected_by_changed_files: bool = False,
     analysis_errors: list[dict] | None = None,
 ) -> list[dict]:
     resolved = _resolve_secret_config_candidate(candidate, root)
@@ -574,6 +643,14 @@ def _scan_secret_config_candidate(
     try:
         rel = str(resolved.relative_to(root))
         if excluded.intersection(Path(rel).parts):
+            return []
+        if not _should_scan_generated_grep_cache(
+            resolved,
+            root=root,
+            scan_target=scan_target,
+            selected_by_changed_files=selected_by_changed_files,
+        ):
+            scanned.add(str(resolved))
             return []
         scanned.add(str(resolved))
         source = read_project_text_no_symlink(
@@ -623,6 +700,8 @@ def _scan_secret_config_candidates(
                 root=root,
                 excluded=excluded,
                 scanned=scanned,
+                scan_target=scan_target,
+                selected_by_changed_files=changed_files is not None,
                 analysis_errors=analysis_errors,
             )
         )
@@ -3135,6 +3214,8 @@ class Skylos:
                             root=root,
                             excluded=excluded,
                             scanned=scanned,
+                            scan_target=secret_scan_target,
+                            selected_by_changed_files=secret_changed_files is not None,
                             analysis_errors=analysis_errors,
                         )
                     )

--- a/skylos/core/grep_cache.py
+++ b/skylos/core/grep_cache.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
-import logging
 import os
 import threading
 import time
@@ -12,13 +10,12 @@ from typing import Any
 
 from skylos.core.grep_verify_common import _ALL_SOURCE_GLOBS, _GREP_EXCLUDE_DIRS
 
-logger = logging.getLogger(__name__)
-
+# Legacy identifiers remain importable, but GrepCache never reads or writes them.
 CACHE_DIR = ".skylos/cache"
 CACHE_FILE = "grep_results.json"
 MAX_ENTRIES = 10_000
+MAX_RESULT_CHARS = 5 * 1024 * 1024
 HASH_BYTES = 8192
-MAX_CACHE_BYTES = 5 * 1024 * 1024
 
 
 def file_content_hash(file_path: str | Path) -> str:
@@ -129,7 +126,7 @@ class GrepCache:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._entries: dict[str, dict[str, Any]] = {}
-        self._dirty = False
+        self._result_chars = 0
         self._repository_fingerprint: str | None = None
         self._fingerprint_root: Path | None = None
 
@@ -142,6 +139,11 @@ class GrepCache:
         try:
             root = Path(project_root).resolve(strict=True)
         except OSError:
+            with self._lock:
+                self._entries.clear()
+                self._result_chars = 0
+                self._fingerprint_root = None
+                self._repository_fingerprint = None
             return None
         if root.is_file():
             root = root.parent
@@ -149,12 +151,15 @@ class GrepCache:
         with self._lock:
             if self._fingerprint_root == root:
                 return self._repository_fingerprint
-
-        fingerprint = repository_evidence_fingerprint(root)
-        with self._lock:
+            if self._fingerprint_root is not None:
+                self._entries.clear()
+                self._result_chars = 0
+            namespace = hashlib.sha256(
+                b"skylos-grep-process-local-v1\0" + os.fsencode(root)
+            ).hexdigest()[:20]
             self._fingerprint_root = root
-            self._repository_fingerprint = fingerprint
-        return fingerprint
+            self._repository_fingerprint = namespace
+            return namespace
 
     def get(self, key: str) -> list[str] | None:
         with self._lock:
@@ -162,193 +167,72 @@ class GrepCache:
             if entry is None:
                 return None
             entry["last_access"] = time.time()
-            self._dirty = True
-            return entry["results"]
+            return list(entry["results"])
 
     def put(self, key: str, results: list[str]) -> None:
+        stored_results = list(results)
+        if not all(isinstance(result, str) for result in stored_results):
+            return
+        result_chars = sum(len(result) for result in stored_results)
+        if result_chars > MAX_RESULT_CHARS:
+            return
         with self._lock:
+            previous = self._entries.pop(key, None)
+            if previous is not None:
+                self._result_chars -= previous["result_chars"]
             self._entries[key] = {
-                "results": results,
+                "results": stored_results,
+                "result_chars": result_chars,
                 "last_access": time.time(),
                 "created": time.time(),
             }
-            self._dirty = True
+            self._result_chars += result_chars
             self._evict_if_needed()
 
     def _evict_if_needed(self) -> None:
-        if len(self._entries) <= MAX_ENTRIES:
+        if (
+            len(self._entries) <= MAX_ENTRIES
+            and self._result_chars <= MAX_RESULT_CHARS
+        ):
             return
         sorted_keys = sorted(
             self._entries.keys(),
             key=lambda k: self._entries[k].get("last_access", 0),
         )
-        to_remove = len(self._entries) - MAX_ENTRIES
-        for key in sorted_keys[:to_remove]:
-            del self._entries[key]
+        for key in sorted_keys:
+            if (
+                len(self._entries) <= MAX_ENTRIES
+                and self._result_chars <= MAX_RESULT_CHARS
+            ):
+                break
+            removed = self._entries.pop(key)
+            self._result_chars -= removed["result_chars"]
 
     def invalidate_by_hash(self, content_hash: str) -> int:
         with self._lock:
             to_remove = [k for k in self._entries if content_hash in k]
             for k in to_remove:
-                del self._entries[k]
-            if to_remove:
-                self._dirty = True
+                removed = self._entries.pop(k)
+                self._result_chars -= removed["result_chars"]
             return len(to_remove)
 
     def clear(self) -> None:
         with self._lock:
             self._entries.clear()
-            self._dirty = True
+            self._result_chars = 0
 
     @property
     def size(self) -> int:
         with self._lock:
             return len(self._entries)
 
-    def _cache_path(
-        self, project_root: str | Path, *, create: bool = False
-    ) -> Path | None:
-        try:
-            root = Path(project_root).resolve(strict=True)
-        except OSError:
-            return None
-
-        cache_dir = root / CACHE_DIR
-        for directory in (root / ".skylos", cache_dir):
-            try:
-                if directory.is_symlink():
-                    return None
-                if directory.exists():
-                    resolved = directory.resolve(strict=True)
-                    resolved.relative_to(root)
-                    if not directory.is_dir():
-                        return None
-                elif create:
-                    directory.mkdir(mode=0o700)
-                else:
-                    return None
-            except (OSError, ValueError):
-                return None
-
-        path = cache_dir / CACHE_FILE
-        try:
-            if path.is_symlink():
-                return None
-            if path.exists():
-                resolved = path.resolve(strict=True)
-                resolved.relative_to(cache_dir.resolve(strict=True))
-                if not path.is_file():
-                    return None
-        except (OSError, ValueError):
-            return None
-
-        return path
-
-    def _read_cache_text(self, path: Path) -> str | None:
-        flags = os.O_RDONLY
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
-        try:
-            fd = os.open(  # skylos: ignore[SKY-D215] guarded local cache path
-                path, flags
-            )
-        except OSError:
-            return None
-        try:
-            with os.fdopen(fd, "r", encoding="utf-8") as f:
-                return f.read(MAX_CACHE_BYTES + 1)
-        except OSError:
-            return None
-
-    def _normalize_entries(self, raw_entries: Any) -> dict[str, dict[str, Any]]:
-        if not isinstance(raw_entries, dict):
-            return {}
-
-        normalized: dict[str, dict[str, Any]] = {}
-        for key, value in raw_entries.items():
-            if len(normalized) >= MAX_ENTRIES:
-                break
-            if not isinstance(key, str) or not isinstance(value, dict):
-                continue
-            results = value.get("results")
-            if not isinstance(results, list) or not all(
-                isinstance(item, str) for item in results
-            ):
-                continue
-            normalized[key] = {
-                "results": results,
-                "last_access": _coerce_timestamp(value.get("last_access")),
-                "created": _coerce_timestamp(value.get("created")),
-            }
-        return normalized
-
     def load(self, project_root: str | Path) -> None:
+        """Bind a process-local namespace without reading repository state."""
         self.bind_repository(project_root)
-        path = self._cache_path(project_root)
-        if path is None:
-            return
-        try:
-            if path.stat().st_size > MAX_CACHE_BYTES:
-                return
-            text = self._read_cache_text(path)
-            if text is None or len(text.encode("utf-8")) > MAX_CACHE_BYTES:
-                return
-            data = json.loads(text)
-            entries = self._normalize_entries(data.get("entries", {}))
-            with self._lock:
-                self._entries = entries
-                self._dirty = False
-            logger.debug("Loaded %d grep cache entries", len(self._entries))
-        except Exception as e:
-            logger.debug("Failed to load grep cache: %s", e)
 
     def save(self, project_root: str | Path) -> None:
-        with self._lock:
-            if not self._dirty:
-                return
-            data = {"version": 1, "entries": dict(self._entries)}
-            self._dirty = False
-
-        path = self._cache_path(project_root, create=True)
-        if path is None:
-            with self._lock:
-                self._dirty = True
-            return
-
-        payload = json.dumps(data)
-        temp_path = path.with_name(
-            f".{CACHE_FILE}.{os.getpid()}.{threading.get_ident()}.tmp"
-        )
-        try:
-            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-            if hasattr(os, "O_NOFOLLOW"):
-                flags |= os.O_NOFOLLOW
-            fd = os.open(  # skylos: ignore[SKY-D215] guarded local cache temp
-                temp_path, flags, 0o600
-            )
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    f.write(payload)
-                    f.flush()
-                    os.fsync(f.fileno())
-            except Exception:
-                try:
-                    os.close(fd)
-                except OSError:
-                    pass
-                raise
-            os.replace(temp_path, path)
-            logger.debug("Saved %d grep cache entries", len(data["entries"]))
-        except Exception as e:
-            logger.debug("Failed to save grep cache: %s", e)
-            with self._lock:
-                self._dirty = True
-        finally:
-            try:
-                if temp_path.exists() and not temp_path.is_symlink():
-                    temp_path.unlink()
-            except OSError:
-                pass
+        """Keep grep results process-local; project directories are untrusted."""
+        del project_root
 
     def cached_search(
         self,
@@ -369,10 +253,3 @@ class GrepCache:
         results = search_fn()
         self.put(key, results)
         return results
-
-
-def _coerce_timestamp(value: Any) -> float:
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0

--- a/skylos/core/grep_verify.py
+++ b/skylos/core/grep_verify.py
@@ -10,10 +10,13 @@ from typing import Any
 
 from skylos.core.grep_verify_common import (
     GrepRequest,
+    _GrepEvidence,
+    _GrepExecutionIncomplete,
     _run_grep,
     detect_language,
     execute_grep_batch,
     filter_grep_results,
+    grep_execution_deadline,
     is_definition_line,
     is_substring_match,
     module_candidates,
@@ -99,10 +102,11 @@ class _PendingBatchFinding:
     requests: tuple[GrepRequest, ...]
 
 
-_GREP_VERIFY_CACHE_VERSION = "v6"
-# The deadline is checked between groups. This bounds overshoot while ensuring
-# a started group produces complete, replayable findings instead of none.
+_GREP_VERIFY_CACHE_VERSION = "v8"
 _GREP_FINDING_BATCH_SIZE = 32
+_GREP_CACHE_MAX_STRATEGIES = 64
+_GREP_CACHE_MAX_LINES_PER_STRATEGY = 256
+_GREP_CACHE_MAX_EVIDENCE_CHARS = 1_000_000
 
 _DETERMINISTIC_RULES: list[tuple[str, str, str]] = [
     ("method_calls", "real_method_call", "Direct method-call usage found via grep"),
@@ -160,10 +164,38 @@ def _load_cached_group_results(
     if cached is None:
         return None
     try:
-        return _json.loads(cached[0]) if cached else {}
+        decoded = _json.loads(cached[0]) if cached else {}
     except (_json.JSONDecodeError, TypeError, ValueError) as exc:
         logger.debug("Ignoring invalid grep verification cache entry: %s", exc)
         return None
+
+    return _normalize_cached_group_results(decoded)
+
+
+def _normalize_cached_group_results(
+    decoded: object,
+) -> dict[str, list[str]] | None:
+    if not isinstance(decoded, dict) or len(decoded) > _GREP_CACHE_MAX_STRATEGIES:
+        logger.debug("Ignoring invalid grep verification cache result shape")
+        return None
+
+    normalized: dict[str, list[str]] = {}
+    evidence_chars = 0
+    for strategy, lines in decoded.items():
+        if (
+            not isinstance(strategy, str)
+            or not isinstance(lines, list)
+            or len(lines) > _GREP_CACHE_MAX_LINES_PER_STRATEGY
+            or not all(isinstance(line, str) for line in lines)
+        ):
+            logger.debug("Ignoring invalid grep verification cache strategy")
+            return None
+        evidence_chars += sum(len(line) for line in lines)
+        if evidence_chars > _GREP_CACHE_MAX_EVIDENCE_CHARS:
+            logger.debug("Ignoring oversized grep verification cache evidence")
+            return None
+        normalized[strategy] = lines
+    return normalized
 
 
 def _store_cached_group_results(
@@ -172,11 +204,21 @@ def _store_cached_group_results(
     finding: dict,
     results: dict[str, list[str]],
 ) -> None:
+    normalized = _normalize_cached_group_results(results)
+    if normalized is None:
+        return
+    if any(
+        isinstance(line, _GrepEvidence) and ":" in line.path
+        for lines in normalized.values()
+        for line in lines
+    ):
+        logger.debug("Skipping cache entry with an ambiguous legacy evidence path")
+        return
     cache_key = _cache_key(cache, group_name, finding)
     if cache_key is None:
         return
     try:
-        cache.put(cache_key, [_json.dumps(results)])
+        cache.put(cache_key, [_json.dumps(normalized)])
     except (AttributeError, OSError, TypeError, ValueError) as exc:
         logger.debug("Failed to write grep verification cache entry: %s", exc)
 
@@ -305,16 +347,31 @@ def _execute_pending_findings(
     pending: list[_PendingBatchFinding],
     project_root: str,
     cache: Any,
+    deadline: float,
 ) -> dict[str, GrepVerdict]:
     requests = [request for item in pending for request in item.requests]
-    batch_results = execute_grep_batch(requests)
+    batch_results = execute_grep_batch(requests, deadline=deadline)
+    incomplete_requests = getattr(batch_results, "incomplete_requests", set())
     verdicts: dict[str, GrepVerdict] = {}
     for item in pending:
-        with replay_grep_results(batch_results):
-            search_results = multi_strategy_search(item.finding, project_root)
-        _store_cached_group_results(
-            cache, item.group_name, item.finding, search_results
-        )
+        if time.monotonic() >= deadline:
+            break
+        if any(request not in batch_results for request in item.requests):
+            continue
+        try:
+            with replay_grep_results(batch_results, deadline=deadline):
+                search_results = multi_strategy_search(item.finding, project_root)
+        except _GrepExecutionIncomplete as exc:
+            logger.debug("grep replay was incomplete: %s", exc)
+            continue
+        if time.monotonic() >= deadline:
+            break
+        if not any(
+            request in incomplete_requests for request in item.requests
+        ):
+            _store_cached_group_results(
+                cache, item.group_name, item.finding, search_results
+            )
         verdict = _apply_deterministic_rules(search_results, item.finding)
         if verdict:
             verdicts[_finding_full_name(item.finding)] = verdict
@@ -333,7 +390,7 @@ def _grep_verify_findings_batched(
     deadline = start_time + time_budget
 
     for finding in findings:
-        if time.monotonic() > deadline:
+        if time.monotonic() >= deadline:
             break
         full_name = _finding_full_name(finding)
         if not full_name:
@@ -346,11 +403,17 @@ def _grep_verify_findings_batched(
             pending.append(planned)
         if len(pending) < _GREP_FINDING_BATCH_SIZE:
             continue
-        verdicts.update(_execute_pending_findings(pending, project_root, cache))
+        if time.monotonic() >= deadline:
+            break
+        verdicts.update(
+            _execute_pending_findings(pending, project_root, cache, deadline)
+        )
         pending.clear()
 
-    if pending:
-        verdicts.update(_execute_pending_findings(pending, project_root, cache))
+    if pending and time.monotonic() < deadline:
+        verdicts.update(
+            _execute_pending_findings(pending, project_root, cache, deadline)
+        )
 
     return verdicts
 
@@ -358,6 +421,7 @@ def _grep_verify_findings_batched(
 def _process_finding(
     finding: dict,
     search_fn: Callable[[dict], dict[str, list[str]]],
+    deadline: float | None = None,
 ) -> tuple[str, GrepVerdict | None]:
     full_name = _finding_full_name(finding)
     if not full_name:
@@ -367,7 +431,8 @@ def _process_finding(
     if deterministic_verdict:
         return full_name, deterministic_verdict
 
-    search_results = search_fn(finding)
+    with grep_execution_deadline(deadline):
+        search_results = search_fn(finding)
     return full_name, _apply_deterministic_rules(search_results, finding)
 
 
@@ -386,7 +451,9 @@ def _submit_next_finding(
     for finding in findings:
         if not _finding_full_name(finding):
             continue
-        pending.add(executor.submit(_process_finding, finding, search_fn))
+        pending.add(
+            executor.submit(_process_finding, finding, search_fn, deadline)
+        )
         return True
     return False
 

--- a/skylos/core/grep_verify.py
+++ b/skylos/core/grep_verify.py
@@ -4,21 +4,25 @@ import concurrent.futures
 import json as _json
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 from skylos.core.grep_verify_common import (
+    GrepRequest,
     _run_grep,
     detect_language,
+    execute_grep_batch,
     filter_grep_results,
     is_definition_line,
     is_substring_match,
     module_candidates,
     parameter_owner_name,
+    record_grep_requests,
+    replay_grep_results,
     repo_relative_path,
     source_globs_for_language,
 )
-from skylos.core.grep_verify_parallel import parallel_multi_strategy_search_impl
 from skylos.core.grep_verify_language_strategies import (
     _deterministic_suppress_multilang,
     _run_go_strategies,
@@ -26,6 +30,7 @@ from skylos.core.grep_verify_language_strategies import (
     _run_rust_strategies,
     _run_ts_strategies,
 )
+from skylos.core.grep_verify_parallel import parallel_multi_strategy_search_impl
 from skylos.core.grep_verify_python_strategy import (
     multi_strategy_search as _multi_strategy_search_impl,
 )
@@ -38,9 +43,9 @@ from skylos.core.grep_verify_strategies import (
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "_STRONG_ALIVE_STRATEGIES",
     "GrepStrategy",
     "GrepVerdict",
-    "_STRONG_ALIVE_STRATEGIES",
     "_cached_group_results",
     "_deterministic_suppress_multilang",
     "_run_go_strategies",
@@ -87,7 +92,14 @@ class GrepStrategy:
         return self.result_key or self.name
 
 
-_GREP_VERIFY_CACHE_VERSION = "v5"
+@dataclass(frozen=True, slots=True)
+class _PendingBatchFinding:
+    finding: dict
+    group_name: str
+    requests: tuple[GrepRequest, ...]
+
+
+_GREP_VERIFY_CACHE_VERSION = "v6"
 
 _DETERMINISTIC_RULES: list[tuple[str, str, str]] = [
     ("method_calls", "real_method_call", "Direct method-call usage found via grep"),
@@ -106,37 +118,64 @@ def _cached_group_results(
     finding: dict,
     search_fn: Callable[[], dict[str, list[str]]],
 ) -> dict[str, list[str]]:
-    if cache is None or not group_name:
-        return search_fn()
+    cached = _load_cached_group_results(cache, group_name, finding)
+    if cached is not None:
+        return cached
+    results = search_fn()
+    _store_cached_group_results(cache, group_name, finding, results)
+    return results
 
-    from skylos.core.grep_cache import file_content_hash as _fch
+
+def _cache_key(cache: Any, group_name: str, finding: dict) -> str | None:
+    if cache is None or not group_name:
+        return None
 
     repository_fingerprint = getattr(cache, "repository_fingerprint", None)
     if not isinstance(repository_fingerprint, str) or not repository_fingerprint:
-        return search_fn()
+        return None
+
+    from skylos.core.grep_cache import file_content_hash as _fch
 
     simple_name = finding.get("simple_name", finding.get("name", ""))
     finding_file = finding.get("file", "")
     content_hash = _fch(finding_file) if finding_file else ""
-    cache_key = (
+    return (
         f"{_GREP_VERIFY_CACHE_VERSION}:group:{group_name}:"
         f"{simple_name}:{finding.get('full_name', '')}:"
         f"{finding.get('type', '')}:{content_hash}:"
         f"repo:{repository_fingerprint}"
     )
-    cached = cache.get(cache_key)
-    if cached is not None:
-        try:
-            return _json.loads(cached[0]) if cached else {}
-        except (_json.JSONDecodeError, TypeError, ValueError) as exc:
-            logger.debug("Ignoring invalid grep verification cache entry: %s", exc)
 
-    results = search_fn()
+
+def _load_cached_group_results(
+    cache: Any, group_name: str, finding: dict
+) -> dict[str, list[str]] | None:
+    cache_key = _cache_key(cache, group_name, finding)
+    if cache_key is None:
+        return None
+    cached = cache.get(cache_key)
+    if cached is None:
+        return None
+    try:
+        return _json.loads(cached[0]) if cached else {}
+    except (_json.JSONDecodeError, TypeError, ValueError) as exc:
+        logger.debug("Ignoring invalid grep verification cache entry: %s", exc)
+        return None
+
+
+def _store_cached_group_results(
+    cache: Any,
+    group_name: str,
+    finding: dict,
+    results: dict[str, list[str]],
+) -> None:
+    cache_key = _cache_key(cache, group_name, finding)
+    if cache_key is None:
+        return
     try:
         cache.put(cache_key, [_json.dumps(results)])
     except (AttributeError, OSError, TypeError, ValueError) as exc:
         logger.debug("Failed to write grep verification cache entry: %s", exc)
-    return results
 
 
 def _finding_simple_name(finding: dict) -> str:
@@ -230,6 +269,82 @@ def _apply_deterministic_rules(
     return None
 
 
+def _serial_group_name(finding: dict) -> str:
+    language = _finding_language(finding)
+    return "python_core" if language == "python" else f"serial_{language}"
+
+
+def _grep_verify_findings_batched(
+    findings: list[dict],
+    project_root: str,
+    time_budget: float,
+    cache: Any,
+    start_time: float,
+) -> dict[str, GrepVerdict]:
+    verdicts: dict[str, GrepVerdict] = {}
+    pending: list[_PendingBatchFinding] = []
+    requests: list[GrepRequest] = []
+
+    for finding in findings:
+        if time.monotonic() - start_time > time_budget:
+            break
+        full_name = _finding_full_name(finding)
+        if not full_name:
+            continue
+
+        deterministic_verdict = _deterministic_suppression_verdict(finding)
+        if deterministic_verdict:
+            verdicts[full_name] = deterministic_verdict
+            continue
+
+        group_name = _serial_group_name(finding)
+        cached = _load_cached_group_results(cache, group_name, finding)
+        if cached is not None:
+            verdict = _apply_deterministic_rules(cached, finding)
+            if verdict:
+                verdicts[full_name] = verdict
+            continue
+
+        with record_grep_requests() as recorded:
+            planned_results = multi_strategy_search(finding, project_root)
+        unique_requests = tuple(dict.fromkeys(recorded))
+        if not unique_requests:
+            _store_cached_group_results(cache, group_name, finding, planned_results)
+            verdict = _apply_deterministic_rules(planned_results, finding)
+            if verdict:
+                verdicts[full_name] = verdict
+            continue
+
+        pending.append(
+            _PendingBatchFinding(
+                finding=finding,
+                group_name=group_name,
+                requests=unique_requests,
+            )
+        )
+        requests.extend(unique_requests)
+
+    if not requests:
+        return verdicts
+
+    batch_results, completed = execute_grep_batch(
+        requests, deadline=start_time + time_budget
+    )
+    for item in pending:
+        if not set(item.requests).issubset(completed):
+            continue
+        with replay_grep_results(batch_results):
+            search_results = multi_strategy_search(item.finding, project_root)
+        _store_cached_group_results(
+            cache, item.group_name, item.finding, search_results
+        )
+        verdict = _apply_deterministic_rules(search_results, item.finding)
+        if verdict:
+            verdicts[_finding_full_name(item.finding)] = verdict
+
+    return verdicts
+
+
 def grep_verify_findings(
     findings: list[dict],
     project_root: str,
@@ -244,6 +359,11 @@ def grep_verify_findings(
     if callable(cache_binder):
         cache_binder(cache, project_root)
     start_time = time.monotonic()
+    if not parallel:
+        return _grep_verify_findings_batched(
+            findings, project_root, time_budget, cache, start_time
+        )
+
     search_fn = _build_grep_search_fn(
         project_root,
         parallel=False,

--- a/skylos/core/grep_verify.py
+++ b/skylos/core/grep_verify.py
@@ -4,7 +4,7 @@ import concurrent.futures
 import json as _json
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -100,6 +100,9 @@ class _PendingBatchFinding:
 
 
 _GREP_VERIFY_CACHE_VERSION = "v6"
+# The deadline is checked between groups. This bounds overshoot while ensuring
+# a started group produces complete, replayable findings instead of none.
+_GREP_FINDING_BATCH_SIZE = 32
 
 _DETERMINISTIC_RULES: list[tuple[str, str, str]] = [
     ("method_calls", "real_method_call", "Direct method-call usage found via grep"),
@@ -274,6 +277,50 @@ def _serial_group_name(finding: dict) -> str:
     return "python_core" if language == "python" else f"serial_{language}"
 
 
+def _plan_batched_finding(
+    finding: dict,
+    project_root: str,
+    cache: Any,
+) -> tuple[GrepVerdict | None, _PendingBatchFinding | None]:
+    deterministic_verdict = _deterministic_suppression_verdict(finding)
+    if deterministic_verdict:
+        return deterministic_verdict, None
+
+    group_name = _serial_group_name(finding)
+    cached = _load_cached_group_results(cache, group_name, finding)
+    if cached is not None:
+        return _apply_deterministic_rules(cached, finding), None
+
+    with record_grep_requests() as recorded:
+        planned_results = multi_strategy_search(finding, project_root)
+    unique_requests = tuple(dict.fromkeys(recorded))
+    if unique_requests:
+        return None, _PendingBatchFinding(finding, group_name, unique_requests)
+
+    _store_cached_group_results(cache, group_name, finding, planned_results)
+    return _apply_deterministic_rules(planned_results, finding), None
+
+
+def _execute_pending_findings(
+    pending: list[_PendingBatchFinding],
+    project_root: str,
+    cache: Any,
+) -> dict[str, GrepVerdict]:
+    requests = [request for item in pending for request in item.requests]
+    batch_results = execute_grep_batch(requests)
+    verdicts: dict[str, GrepVerdict] = {}
+    for item in pending:
+        with replay_grep_results(batch_results):
+            search_results = multi_strategy_search(item.finding, project_root)
+        _store_cached_group_results(
+            cache, item.group_name, item.finding, search_results
+        )
+        verdict = _apply_deterministic_rules(search_results, item.finding)
+        if verdict:
+            verdicts[_finding_full_name(item.finding)] = verdict
+    return verdicts
+
+
 def _grep_verify_findings_batched(
     findings: list[dict],
     project_root: str,
@@ -283,64 +330,120 @@ def _grep_verify_findings_batched(
 ) -> dict[str, GrepVerdict]:
     verdicts: dict[str, GrepVerdict] = {}
     pending: list[_PendingBatchFinding] = []
-    requests: list[GrepRequest] = []
+    deadline = start_time + time_budget
 
     for finding in findings:
-        if time.monotonic() - start_time > time_budget:
+        if time.monotonic() > deadline:
             break
         full_name = _finding_full_name(finding)
         if not full_name:
             continue
 
-        deterministic_verdict = _deterministic_suppression_verdict(finding)
-        if deterministic_verdict:
-            verdicts[full_name] = deterministic_verdict
-            continue
-
-        group_name = _serial_group_name(finding)
-        cached = _load_cached_group_results(cache, group_name, finding)
-        if cached is not None:
-            verdict = _apply_deterministic_rules(cached, finding)
-            if verdict:
-                verdicts[full_name] = verdict
-            continue
-
-        with record_grep_requests() as recorded:
-            planned_results = multi_strategy_search(finding, project_root)
-        unique_requests = tuple(dict.fromkeys(recorded))
-        if not unique_requests:
-            _store_cached_group_results(cache, group_name, finding, planned_results)
-            verdict = _apply_deterministic_rules(planned_results, finding)
-            if verdict:
-                verdicts[full_name] = verdict
-            continue
-
-        pending.append(
-            _PendingBatchFinding(
-                finding=finding,
-                group_name=group_name,
-                requests=unique_requests,
-            )
-        )
-        requests.extend(unique_requests)
-
-    if not requests:
-        return verdicts
-
-    batch_results, completed = execute_grep_batch(
-        requests, deadline=start_time + time_budget
-    )
-    for item in pending:
-        if not set(item.requests).issubset(completed):
-            continue
-        with replay_grep_results(batch_results):
-            search_results = multi_strategy_search(item.finding, project_root)
-        _store_cached_group_results(
-            cache, item.group_name, item.finding, search_results
-        )
-        verdict = _apply_deterministic_rules(search_results, item.finding)
+        verdict, planned = _plan_batched_finding(finding, project_root, cache)
         if verdict:
-            verdicts[_finding_full_name(item.finding)] = verdict
+            verdicts[full_name] = verdict
+        if planned:
+            pending.append(planned)
+        if len(pending) < _GREP_FINDING_BATCH_SIZE:
+            continue
+        verdicts.update(_execute_pending_findings(pending, project_root, cache))
+        pending.clear()
+
+    if pending:
+        verdicts.update(_execute_pending_findings(pending, project_root, cache))
+
+    return verdicts
+
+
+def _process_finding(
+    finding: dict,
+    search_fn: Callable[[dict], dict[str, list[str]]],
+) -> tuple[str, GrepVerdict | None]:
+    full_name = _finding_full_name(finding)
+    if not full_name:
+        return "", None
+
+    deterministic_verdict = _deterministic_suppression_verdict(finding)
+    if deterministic_verdict:
+        return full_name, deterministic_verdict
+
+    search_results = search_fn(finding)
+    return full_name, _apply_deterministic_rules(search_results, finding)
+
+
+_FindingFuture = concurrent.futures.Future[tuple[str, GrepVerdict | None]]
+
+
+def _submit_next_finding(
+    executor: concurrent.futures.ThreadPoolExecutor,
+    pending: set[_FindingFuture],
+    findings: Iterator[dict],
+    search_fn: Callable[[dict], dict[str, list[str]]],
+    deadline: float,
+) -> bool:
+    if time.monotonic() > deadline:
+        return False
+    for finding in findings:
+        if not _finding_full_name(finding):
+            continue
+        pending.add(executor.submit(_process_finding, finding, search_fn))
+        return True
+    return False
+
+
+def _collect_finished_findings(
+    done: set[_FindingFuture],
+    verdicts: dict[str, GrepVerdict],
+) -> None:
+    for future in done:
+        try:
+            full_name, verdict = future.result()
+        except Exception as exc:
+            logger.debug("grep verification failed: %s", exc)
+            continue
+        if full_name and verdict:
+            verdicts[full_name] = verdict
+
+
+def _grep_verify_findings_parallel(
+    findings: list[dict],
+    search_fn: Callable[[dict], dict[str, list[str]]],
+    time_budget: float,
+    max_workers: int,
+    start_time: float,
+) -> dict[str, GrepVerdict]:
+    verdicts: dict[str, GrepVerdict] = {}
+    worker_count = max(1, int(max_workers or _DEFAULT_GREP_WORKERS))
+    deadline = start_time + time_budget
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=worker_count)
+    pending: set[_FindingFuture] = set()
+    findings_iter = iter(findings)
+
+    try:
+        for _ in range(worker_count):
+            if not _submit_next_finding(
+                executor, pending, findings_iter, search_fn, deadline
+            ):
+                break
+
+        while pending and time.monotonic() <= deadline:
+            remaining = max(0.0, deadline - time.monotonic())
+            done, pending = concurrent.futures.wait(
+                pending,
+                timeout=remaining,
+                return_when=concurrent.futures.FIRST_COMPLETED,
+            )
+            if not done:
+                break
+            _collect_finished_findings(done, verdicts)
+            for _ in done:
+                _submit_next_finding(
+                    executor, pending, findings_iter, search_fn, deadline
+                )
+    finally:
+        for future in pending:
+            future.cancel()
+        executor.shutdown(wait=True, cancel_futures=True)
 
     return verdicts
 
@@ -354,7 +457,6 @@ def grep_verify_findings(
     max_workers: int = _DEFAULT_GREP_WORKERS,
     cache: Any = None,
 ) -> dict[str, GrepVerdict]:
-    verdicts: dict[str, GrepVerdict] = {}
     cache_binder = getattr(type(cache), "bind_repository", None)
     if callable(cache_binder):
         cache_binder(cache, project_root)
@@ -370,82 +472,9 @@ def grep_verify_findings(
         max_workers=max_workers,
         cache=cache,
     )
-
-    def process_finding(finding: dict) -> tuple[str, GrepVerdict | None]:
-        full_name = _finding_full_name(finding)
-        if not full_name:
-            return "", None
-
-        deterministic_verdict = _deterministic_suppression_verdict(finding)
-        if deterministic_verdict:
-            return full_name, deterministic_verdict
-
-        search_results = search_fn(finding)
-        return full_name, _apply_deterministic_rules(search_results, finding)
-
-    verified_names = set(verdicts)
-    remaining_findings = [
-        finding
-        for finding in findings
-        if _finding_full_name(finding)
-        and _finding_full_name(finding) not in verified_names
-    ]
-
-    if parallel:
-        max_workers = max(1, int(max_workers or _DEFAULT_GREP_WORKERS))
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-        pending: set[concurrent.futures.Future] = set()
-        findings_iter = iter(remaining_findings)
-
-        def submit_next() -> bool:
-            if time.monotonic() - start_time > time_budget:
-                return False
-            for finding in findings_iter:
-                if not _finding_full_name(finding):
-                    continue
-                pending.add(executor.submit(process_finding, finding))
-                return True
-            return False
-
-        try:
-            for _ in range(max_workers):
-                if not submit_next():
-                    break
-
-            while pending and time.monotonic() - start_time <= time_budget:
-                remaining = max(0.0, time_budget - (time.monotonic() - start_time))
-                done, pending = concurrent.futures.wait(
-                    pending,
-                    timeout=remaining,
-                    return_when=concurrent.futures.FIRST_COMPLETED,
-                )
-                if not done:
-                    break
-                for future in done:
-                    try:
-                        full_name, verdict = future.result()
-                    except Exception as e:
-                        logger.debug("grep verification failed: %s", e)
-                        continue
-                    if full_name and verdict:
-                        verdicts[full_name] = verdict
-                    submit_next()
-        finally:
-            for future in pending:
-                future.cancel()
-            executor.shutdown(wait=True, cancel_futures=True)
-
-        return verdicts
-
-    for finding in remaining_findings:
-        if time.monotonic() - start_time > time_budget:
-            break
-
-        full_name, verdict = process_finding(finding)
-        if verdict:
-            verdicts[full_name] = verdict
-
-    return verdicts
+    return _grep_verify_findings_parallel(
+        findings, search_fn, time_budget, max_workers, start_time
+    )
 
 
 def _build_grep_search_fn(

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -5,7 +5,6 @@ import logging
 import re
 import shutil
 import subprocess
-import time
 import tokenize
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
@@ -88,11 +87,25 @@ _GREP_EXCLUDE_DIRS = (
 )
 
 _GREP_BATCH_SIZE = 128
+# Classification precedes strategy-specific definition filtering. Keep a
+# wider deterministic window so early definitions do not crowd out usages.
+_GREP_BATCH_RESULT_FLOOR = 256
+_DEFAULT_GREP_GLOBS = (
+    "*.py",
+    "*.rst",
+    "*.md",
+    "*.yaml",
+    "*.yml",
+    "*.toml",
+    "*.cfg",
+    "*.ini",
+    "*.txt",
+)
 # Python's classifier must preserve the same leftmost-first semantics as each
 # original ripgrep pattern. Keep this translation deliberately narrow: an
 # unsupported POSIX class falls back to the legacy one-pattern subprocess.
 _PYTHON_REGEX_TRANSLATIONS = {
-    "[[:space:]]": r"\s",
+    "[[:space:]]": r"[ \t\n\r\f\v]",
     "[[:alnum:]_]": r"[A-Za-z0-9_]",
 }
 _POSIX_CLASS = re.compile(r"\[\[:[^]]+:\]\]")
@@ -166,20 +179,6 @@ def replay_grep_results(
         _GREP_RESULT_REPLAY.reset(token)
 
 
-def _default_grep_globs() -> tuple[str, ...]:
-    return (
-        "*.py",
-        "*.rst",
-        "*.md",
-        "*.yaml",
-        "*.yml",
-        "*.toml",
-        "*.cfg",
-        "*.ini",
-        "*.txt",
-    )
-
-
 def _make_grep_request(
     pattern: str,
     project_root: str,
@@ -194,7 +193,7 @@ def _make_grep_request(
         project_root=project_root,
         use_regex=use_regex,
         include_globs=(
-            tuple(include_globs) if include_globs is not None else _default_grep_globs()
+            tuple(include_globs) if include_globs is not None else _DEFAULT_GREP_GLOBS
         ),
         fixed_string=fixed_string,
         max_results=max_results,
@@ -291,11 +290,28 @@ def _batch_group_key(request: GrepRequest) -> tuple[str, tuple[str, ...], bool]:
     return request.project_root, request.include_globs, request.fixed_string
 
 
-def _run_ripgrep_batch(
+def _requires_direct_grep(request: GrepRequest) -> bool:
+    if "\n" in request.pattern or "\r" in request.pattern:
+        return True
+    if not request.pattern.isascii():
+        return True
+    return not request.fixed_string and _python_regex(request.pattern) is None
+
+
+def _partition_grep_requests(
     requests: Sequence[GrepRequest],
-    rg: str,
-    timeout: float,
-) -> tuple[dict[GrepRequest, tuple[str, ...]], set[GrepRequest]]:
+) -> tuple[list[GrepRequest], list[GrepRequest]]:
+    batched: list[GrepRequest] = []
+    direct: list[GrepRequest] = []
+    for request in requests:
+        target = direct if _requires_direct_grep(request) else batched
+        target.append(request)
+    return batched, direct
+
+
+def _run_ripgrep_pattern_file(
+    requests: Sequence[GrepRequest], rg: str, timeout: float
+) -> list[str]:
     representative = requests[0]
     cmd = _ripgrep_command(representative, rg)
     cmd.extend(["-f", "-", "--", representative.project_root])
@@ -311,99 +327,105 @@ def _run_ripgrep_batch(
     if result.returncode not in (0, 1):
         msg = result.stderr.strip() or f"exit status {result.returncode}"
         raise RuntimeError(msg)
+    return sorted(_filter_grep_output(result.stdout), key=_grep_line_sort_key)
 
-    lines = sorted(_filter_grep_output(result.stdout), key=_grep_line_sort_key)
-    line_contents = [(line, _grep_line_content(line)) for line in lines]
-    compiled: dict[GrepRequest, re.Pattern[str]] = {}
-    direct_requests: set[GrepRequest] = set()
-    for request in requests:
-        if request.fixed_string:
+
+def _request_matches_line(
+    request: GrepRequest,
+    regex: re.Pattern[str] | None,
+    content: str,
+) -> bool:
+    if request.fixed_string:
+        return request.pattern in content
+    return regex is not None and regex.search(content) is not None
+
+
+def _classify_grep_request(
+    request: GrepRequest,
+    line_contents: Sequence[tuple[str, str]],
+) -> tuple[str, ...]:
+    if request.max_results <= 0:
+        return ()
+    regex = None if request.fixed_string else _python_regex(request.pattern)
+    limit = max(request.max_results, _GREP_BATCH_RESULT_FLOOR)
+    matches: list[str] = []
+    for line, content in line_contents:
+        if not _request_matches_line(request, regex, content):
             continue
-        pattern = _python_regex(request.pattern)
-        if pattern is None:
-            direct_requests.add(request)
-        else:
-            compiled[request] = pattern
+        matches.append(line)
+        if len(matches) >= limit:
+            break
+    return tuple(matches)
 
+
+def _run_serial_grep_requests(
+    requests: Sequence[GrepRequest],
+) -> dict[GrepRequest, tuple[str, ...]]:
+    return {request: tuple(_run_grep_request(request)) for request in requests}
+
+
+def _run_ripgrep_batch(
+    requests: Sequence[GrepRequest],
+    rg: str,
+    timeout: float = 30.0,
+) -> dict[GrepRequest, tuple[str, ...]]:
+    batched, direct = _partition_grep_requests(requests)
     batch_results: dict[GrepRequest, tuple[str, ...]] = {}
-    completed: set[GrepRequest] = set()
-    for request in requests:
-        if request in direct_requests:
-            continue
-        matches: list[str] = []
-        if request.max_results <= 0:
-            batch_results[request] = ()
-            completed.add(request)
-            continue
-        regex = compiled.get(request)
-        for line, content in line_contents:
-            is_match = (
-                request.pattern in content
-                if request.fixed_string
-                else regex is not None and regex.search(content) is not None
-            )
-            if not is_match:
-                continue
-            matches.append(line)
-            if len(matches) >= request.max_results:
-                break
-        batch_results[request] = tuple(matches)
-        completed.add(request)
+    if not batched:
+        return _run_serial_grep_requests(direct)
 
-    for request in direct_requests:
-        batch_results[request] = tuple(_run_grep_request(request))
-        completed.add(request)
-    return batch_results, completed
+    lines = _run_ripgrep_pattern_file(batched, rg, timeout)
+    line_contents = [(line, _grep_line_content(line)) for line in lines]
+    batch_results.update(
+        (request, _classify_grep_request(request, line_contents)) for request in batched
+    )
+    batch_results.update(_run_serial_grep_requests(direct))
+    return batch_results
+
+
+def _group_grep_requests(
+    requests: Sequence[GrepRequest],
+) -> dict[tuple[str, tuple[str, ...], bool], list[GrepRequest]]:
+    groups: dict[tuple[str, tuple[str, ...], bool], list[GrepRequest]] = {}
+    for request in requests:
+        groups.setdefault(_batch_group_key(request), []).append(request)
+    return groups
+
+
+def _execute_grep_chunk(
+    requests: Sequence[GrepRequest], rg: str
+) -> dict[GrepRequest, tuple[str, ...]]:
+    try:
+        return _run_ripgrep_batch(requests, rg)
+    except (
+        OSError,
+        RuntimeError,
+        subprocess.SubprocessError,
+        UnicodeError,
+        ValueError,
+    ) as exc:
+        logger.debug("batched grep failed; using serial fallback: %s", exc)
+        return _run_serial_grep_requests(requests)
 
 
 def execute_grep_batch(
     requests: Sequence[GrepRequest],
-    *,
-    deadline: float,
-) -> tuple[dict[GrepRequest, tuple[str, ...]], set[GrepRequest]]:
+) -> dict[GrepRequest, tuple[str, ...]]:
     """Execute compatible grep requests in fixed-size batches."""
     unique_requests = list(dict.fromkeys(requests))
     if not unique_requests:
-        return {}, set()
+        return {}
 
     rg = shutil.which("rg")
     if not rg:
-        results: dict[GrepRequest, tuple[str, ...]] = {}
-        completed: set[GrepRequest] = set()
-        for request in unique_requests:
-            if time.monotonic() >= deadline:
-                break
-            results[request] = tuple(_run_grep_request(request))
-            completed.add(request)
-        return results, completed
-
-    groups: dict[tuple[str, tuple[str, ...], bool], list[GrepRequest]] = {}
-    for request in unique_requests:
-        groups.setdefault(_batch_group_key(request), []).append(request)
+        return _run_serial_grep_requests(unique_requests)
 
     results: dict[GrepRequest, tuple[str, ...]] = {}
-    completed: set[GrepRequest] = set()
-    for group_requests in groups.values():
+    for group_requests in _group_grep_requests(unique_requests).values():
         for start in range(0, len(group_requests), _GREP_BATCH_SIZE):
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return results, completed
             chunk = group_requests[start : start + _GREP_BATCH_SIZE]
-            try:
-                chunk_results, chunk_completed = _run_ripgrep_batch(
-                    chunk, rg, min(30.0, remaining)
-                )
-            except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
-                logger.debug("batched grep failed; using serial fallback: %s", exc)
-                for request in chunk:
-                    if time.monotonic() >= deadline:
-                        return results, completed
-                    results[request] = tuple(_run_grep_request(request))
-                    completed.add(request)
-            else:
-                results.update(chunk_results)
-                completed.update(chunk_completed)
-    return results, completed
+            results.update(_execute_grep_chunk(chunk, rg))
+    return results
 
 
 def _run_grep(
@@ -429,7 +451,11 @@ def _run_grep(
 
     replay = _GREP_RESULT_REPLAY.get()
     if replay is not None:
-        return list(replay.get(request, ()))[:max_results]
+        replayed = replay.get(request)
+        if replayed is not None:
+            return list(replayed)
+        logger.warning("grep replay miss for pattern %r; executing directly", pattern)
+        return _run_grep_request(request)
 
     return _run_grep_request(request)
 

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -330,6 +330,51 @@ def _run_ripgrep_pattern_file(
     return sorted(_filter_grep_output(result.stdout), key=_grep_line_sort_key)
 
 
+def _ripgrep_stdin_match_positions(
+    pattern: str, contents: Sequence[str], rg: str
+) -> set[int]:
+    """Return the 0-based positions of the given lines that ripgrep matches."""
+    result = subprocess.run(
+        [rg, "-n", "--no-heading", "--color", "never", "--", pattern, "-"],
+        input="\n".join(contents) + "\n",
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        msg = result.stderr.strip() or f"exit status {result.returncode}"
+        raise RuntimeError(msg)
+    positions: set[int] = set()
+    for line in result.stdout.splitlines():
+        prefix = line.split(":", 1)[0]
+        if prefix.isdigit():
+            positions.add(int(prefix) - 1)
+    return positions
+
+
+def _non_ascii_line_overrides(
+    request: GrepRequest,
+    non_ascii_lines: Sequence[tuple[int, str]],
+    rg: str,
+) -> dict[int, bool] | None:
+    # After POSIX-class translation the only engine-sensitive construct left
+    # in classifier patterns is \b: ripgrep's UTS#18 word class includes
+    # combining marks, join controls, and non-decimal numerics that Python's
+    # re does not (and vice versa). Let ripgrep itself adjudicate non-ASCII
+    # lines so batched attribution matches what a per-pattern search returns.
+    # Fixed strings are byte-exact substring checks and never diverge.
+    if request.fixed_string or not non_ascii_lines:
+        return None
+    matched = _ripgrep_stdin_match_positions(
+        request.pattern, [content for _, content in non_ascii_lines], rg
+    )
+    return {
+        index: position in matched
+        for position, (index, _) in enumerate(non_ascii_lines)
+    }
+
+
 def _request_matches_line(
     request: GrepRequest,
     regex: re.Pattern[str] | None,
@@ -343,14 +388,21 @@ def _request_matches_line(
 def _classify_grep_request(
     request: GrepRequest,
     line_contents: Sequence[tuple[str, str]],
+    overrides: dict[int, bool] | None = None,
 ) -> tuple[str, ...]:
     if request.max_results <= 0:
         return ()
     regex = None if request.fixed_string else _python_regex(request.pattern)
     limit = max(request.max_results, _GREP_BATCH_RESULT_FLOOR)
     matches: list[str] = []
-    for line, content in line_contents:
-        if not _request_matches_line(request, regex, content):
+    for index, (line, content) in enumerate(line_contents):
+        override = overrides.get(index) if overrides is not None else None
+        is_match = (
+            override
+            if override is not None
+            else _request_matches_line(request, regex, content)
+        )
+        if not is_match:
             continue
         matches.append(line)
         if len(matches) >= limit:
@@ -376,8 +428,21 @@ def _run_ripgrep_batch(
 
     lines = _run_ripgrep_pattern_file(batched, rg, timeout)
     line_contents = [(line, _grep_line_content(line)) for line in lines]
+    non_ascii_lines = [
+        (index, content)
+        for index, (_, content) in enumerate(line_contents)
+        if not content.isascii()
+    ]
     batch_results.update(
-        (request, _classify_grep_request(request, line_contents)) for request in batched
+        (
+            request,
+            _classify_grep_request(
+                request,
+                line_contents,
+                _non_ascii_line_overrides(request, non_ascii_lines, rg),
+            ),
+        )
+        for request in batched
     )
     batch_results.update(_run_serial_grep_requests(direct))
     return batch_results

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -5,7 +5,12 @@ import logging
 import re
 import shutil
 import subprocess
+import time
 import tokenize
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -82,6 +87,36 @@ _GREP_EXCLUDE_DIRS = (
     "*.egg-info",
 )
 
+_GREP_BATCH_SIZE = 128
+# Python's classifier must preserve the same leftmost-first semantics as each
+# original ripgrep pattern. Keep this translation deliberately narrow: an
+# unsupported POSIX class falls back to the legacy one-pattern subprocess.
+_PYTHON_REGEX_TRANSLATIONS = {
+    "[[:space:]]": r"\s",
+    "[[:alnum:]_]": r"[A-Za-z0-9_]",
+}
+_POSIX_CLASS = re.compile(r"\[\[:[^]]+:\]\]")
+
+
+@dataclass(frozen=True, slots=True)
+class GrepRequest:
+    """One repository grep request."""
+
+    pattern: str
+    project_root: str
+    use_regex: bool
+    include_globs: tuple[str, ...]
+    fixed_string: bool
+    max_results: int
+
+
+_GREP_REQUEST_RECORDER: ContextVar[list[GrepRequest] | None] = ContextVar(
+    "grep_request_recorder", default=None
+)
+_GREP_RESULT_REPLAY: ContextVar[Mapping[GrepRequest, tuple[str, ...]] | None] = (
+    ContextVar("grep_result_replay", default=None)
+)
+
 
 def detect_language(file_path: str) -> str:
     ext = Path(file_path).suffix.lower()
@@ -108,6 +143,269 @@ def source_globs_for_language(lang: str) -> list[str]:
     return _LANG_GLOBS.get(lang, _LANG_GLOBS["python"])
 
 
+@contextmanager
+def record_grep_requests() -> Iterator[list[GrepRequest]]:
+    """Record grep requests without executing them."""
+    requests: list[GrepRequest] = []
+    token = _GREP_REQUEST_RECORDER.set(requests)
+    try:
+        yield requests
+    finally:
+        _GREP_REQUEST_RECORDER.reset(token)
+
+
+@contextmanager
+def replay_grep_results(
+    results: Mapping[GrepRequest, tuple[str, ...]],
+) -> Iterator[None]:
+    """Replay previously collected grep results."""
+    token = _GREP_RESULT_REPLAY.set(results)
+    try:
+        yield
+    finally:
+        _GREP_RESULT_REPLAY.reset(token)
+
+
+def _default_grep_globs() -> tuple[str, ...]:
+    return (
+        "*.py",
+        "*.rst",
+        "*.md",
+        "*.yaml",
+        "*.yml",
+        "*.toml",
+        "*.cfg",
+        "*.ini",
+        "*.txt",
+    )
+
+
+def _make_grep_request(
+    pattern: str,
+    project_root: str,
+    *,
+    use_regex: bool,
+    include_globs: list[str] | None,
+    fixed_string: bool,
+    max_results: int,
+) -> GrepRequest:
+    return GrepRequest(
+        pattern=pattern,
+        project_root=project_root,
+        use_regex=use_regex,
+        include_globs=(
+            tuple(include_globs) if include_globs is not None else _default_grep_globs()
+        ),
+        fixed_string=fixed_string,
+        max_results=max_results,
+    )
+
+
+def _ripgrep_command(request: GrepRequest, rg: str) -> list[str]:
+    cmd = [
+        rg,
+        "-n",
+        "--no-heading",
+        "--color",
+        "never",
+        "--hidden",
+        "--no-ignore",
+    ]
+    if request.fixed_string:
+        cmd.append("-F")
+    for glob in request.include_globs:
+        cmd.extend(["-g", glob])
+    for directory in _GREP_EXCLUDE_DIRS:
+        cmd.extend(["-g", f"!**/{directory}/**"])
+    return cmd
+
+
+def _filter_grep_output(stdout: str) -> list[str]:
+    filtered: list[str] = []
+    for line in stdout.strip().splitlines():
+        normalized = line.replace("\\", "/")
+        if any(part in normalized for part in _IGNORED_GREP_PATH_PARTS):
+            continue
+        filtered.append(line)
+    return filtered
+
+
+def _run_grep_request(request: GrepRequest) -> list[str]:
+    try:
+        rg = shutil.which("rg")
+        if rg:
+            cmd = _ripgrep_command(request, rg)
+            cmd.extend(["--", request.pattern, request.project_root])
+        else:
+            grep_flags = ["-rn"]
+            if request.fixed_string:
+                grep_flags.append("-F")
+            elif request.use_regex:
+                grep_flags.append("-E")
+
+            includes: list[str] = []
+            for glob in request.include_globs:
+                includes.extend(["--include", glob])
+            excludes: list[str] = []
+            for directory in _GREP_EXCLUDE_DIRS:
+                excludes.extend(["--exclude-dir", directory])
+
+            cmd = [
+                "grep",
+                *grep_flags,
+                *includes,
+                *excludes,
+                request.pattern,
+                request.project_root,
+            ]
+
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=10, check=False
+        )
+        return _filter_grep_output(result.stdout)[: request.max_results]
+    except (OSError, subprocess.SubprocessError, UnicodeError, ValueError) as exc:
+        logger.debug("grep failed for pattern %r: %s", request.pattern, exc)
+        return []
+
+
+def _python_regex(pattern: str) -> re.Pattern[str] | None:
+    translated = pattern
+    for source, replacement in _PYTHON_REGEX_TRANSLATIONS.items():
+        translated = translated.replace(source, replacement)
+    if _POSIX_CLASS.search(translated):
+        return None
+    try:
+        return re.compile(translated)
+    except re.error:
+        return None
+
+
+def _grep_line_sort_key(line: str) -> tuple[str, int, str]:
+    parts = line.split(":", 2)
+    if len(parts) >= 3 and parts[1].strip().isdigit():
+        return parts[0].replace("\\", "/"), int(parts[1]), parts[2]
+    return line.replace("\\", "/"), 0, ""
+
+
+def _batch_group_key(request: GrepRequest) -> tuple[str, tuple[str, ...], bool]:
+    return request.project_root, request.include_globs, request.fixed_string
+
+
+def _run_ripgrep_batch(
+    requests: Sequence[GrepRequest],
+    rg: str,
+    timeout: float,
+) -> tuple[dict[GrepRequest, tuple[str, ...]], set[GrepRequest]]:
+    representative = requests[0]
+    cmd = _ripgrep_command(representative, rg)
+    cmd.extend(["-f", "-", "--", representative.project_root])
+    patterns = "\n".join(dict.fromkeys(request.pattern for request in requests))
+    result = subprocess.run(
+        cmd,
+        input=f"{patterns}\n",
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        msg = result.stderr.strip() or f"exit status {result.returncode}"
+        raise RuntimeError(msg)
+
+    lines = sorted(_filter_grep_output(result.stdout), key=_grep_line_sort_key)
+    line_contents = [(line, _grep_line_content(line)) for line in lines]
+    compiled: dict[GrepRequest, re.Pattern[str]] = {}
+    direct_requests: set[GrepRequest] = set()
+    for request in requests:
+        if request.fixed_string:
+            continue
+        pattern = _python_regex(request.pattern)
+        if pattern is None:
+            direct_requests.add(request)
+        else:
+            compiled[request] = pattern
+
+    batch_results: dict[GrepRequest, tuple[str, ...]] = {}
+    completed: set[GrepRequest] = set()
+    for request in requests:
+        if request in direct_requests:
+            continue
+        matches: list[str] = []
+        if request.max_results <= 0:
+            batch_results[request] = ()
+            completed.add(request)
+            continue
+        regex = compiled.get(request)
+        for line, content in line_contents:
+            is_match = (
+                request.pattern in content
+                if request.fixed_string
+                else regex is not None and regex.search(content) is not None
+            )
+            if not is_match:
+                continue
+            matches.append(line)
+            if len(matches) >= request.max_results:
+                break
+        batch_results[request] = tuple(matches)
+        completed.add(request)
+
+    for request in direct_requests:
+        batch_results[request] = tuple(_run_grep_request(request))
+        completed.add(request)
+    return batch_results, completed
+
+
+def execute_grep_batch(
+    requests: Sequence[GrepRequest],
+    *,
+    deadline: float,
+) -> tuple[dict[GrepRequest, tuple[str, ...]], set[GrepRequest]]:
+    """Execute compatible grep requests in fixed-size batches."""
+    unique_requests = list(dict.fromkeys(requests))
+    if not unique_requests:
+        return {}, set()
+
+    rg = shutil.which("rg")
+    if not rg:
+        results: dict[GrepRequest, tuple[str, ...]] = {}
+        completed: set[GrepRequest] = set()
+        for request in unique_requests:
+            if time.monotonic() >= deadline:
+                break
+            results[request] = tuple(_run_grep_request(request))
+            completed.add(request)
+        return results, completed
+
+    groups: dict[tuple[str, tuple[str, ...], bool], list[GrepRequest]] = {}
+    for request in unique_requests:
+        groups.setdefault(_batch_group_key(request), []).append(request)
+
+    results: dict[GrepRequest, tuple[str, ...]] = {}
+    completed: set[GrepRequest] = set()
+    for group_requests in groups.values():
+        for start in range(0, len(group_requests), _GREP_BATCH_SIZE):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return results, completed
+            chunk = group_requests[start : start + _GREP_BATCH_SIZE]
+            try:
+                chunk_results, chunk_completed = _run_ripgrep_batch(
+                    chunk, rg, min(30.0, remaining)
+                )
+            except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+                logger.debug("batched grep failed; using serial fallback: %s", exc)
+                for request in chunk:
+                    if time.monotonic() >= deadline:
+                        return results, completed
+                    results[request] = tuple(_run_grep_request(request))
+                    completed.add(request)
+            else:
+                results.update(chunk_results)
+                completed.update(chunk_completed)
+    return results, completed
+
+
 def _run_grep(
     pattern: str,
     project_root: str,
@@ -116,69 +414,24 @@ def _run_grep(
     fixed_string: bool = False,
     max_results: int = 20,
 ) -> list[str]:
-    if include_globs is None:
-        include_globs = [
-            "*.py",
-            "*.rst",
-            "*.md",
-            "*.yaml",
-            "*.yml",
-            "*.toml",
-            "*.cfg",
-            "*.ini",
-            "*.txt",
-        ]
-
-    try:
-        rg = shutil.which("rg")
-        if rg:
-            cmd = [
-                rg,
-                "-n",
-                "--no-heading",
-                "--color",
-                "never",
-                "--hidden",
-                "--no-ignore",
-            ]
-            if fixed_string:
-                cmd.append("-F")
-            for g in include_globs:
-                cmd.extend(["-g", g])
-            for d in _GREP_EXCLUDE_DIRS:
-                if any(ch in d for ch in "*?["):
-                    cmd.extend(["-g", f"!**/{d}/**"])
-                else:
-                    cmd.extend(["-g", f"!**/{d}/**"])
-            cmd.extend(["--", pattern, project_root])
-        else:
-            grep_flags = ["-rn"]
-            if fixed_string:
-                grep_flags.append("-F")
-            elif use_regex:
-                grep_flags.append("-E")
-
-            includes = []
-            for g in include_globs:
-                includes.extend(["--include", g])
-            excludes = []
-            for d in _GREP_EXCLUDE_DIRS:
-                excludes.extend(["--exclude-dir", d])
-
-            cmd = ["grep", *grep_flags, *includes, *excludes, pattern, project_root]
-
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        lines = result.stdout.strip().splitlines()
-        filtered = []
-        for line in lines:
-            normalized = line.replace("\\", "/")
-            if any(part in normalized for part in _IGNORED_GREP_PATH_PARTS):
-                continue
-            filtered.append(line)
-        return filtered[:max_results]
-    except Exception as e:
-        logger.debug("grep failed for pattern %r: %s", pattern, e)
+    request = _make_grep_request(
+        pattern,
+        project_root,
+        use_regex=use_regex,
+        include_globs=include_globs,
+        fixed_string=fixed_string,
+        max_results=max_results,
+    )
+    recorder = _GREP_REQUEST_RECORDER.get()
+    if recorder is not None:
+        recorder.append(request)
         return []
+
+    replay = _GREP_RESULT_REPLAY.get()
+    if replay is not None:
+        return list(replay.get(request, ()))[:max_results]
+
+    return _run_grep_request(request)
 
 
 def repo_relative_path(file_path: str, project_root: str | Path) -> str:

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
+import ntpath
+import os
 import re
 import shutil
 import subprocess
+import threading
+import time
 import tokenize
+import unicodedata
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -61,18 +67,6 @@ _LANG_GLOBS: dict[str, list[str]] = {
     "kotlin": ["*.kt", "*.kts"],
 }
 
-_IGNORED_GREP_PATH_PARTS = (
-    "/.git/",
-    "/.mypy_cache/",
-    "/.pytest_cache/",
-    "/.ruff_cache/",
-    "/.skylos/",
-    "/.venv/",
-    "/venv/",
-    "/__pycache__/",
-    "/node_modules/",
-    ".egg-info",
-)
 _GREP_EXCLUDE_DIRS = (
     ".git",
     ".mypy_cache",
@@ -87,6 +81,16 @@ _GREP_EXCLUDE_DIRS = (
 )
 
 _GREP_BATCH_SIZE = 128
+_GREP_BATCH_TIMEOUT_SECONDS = 30.0
+_GREP_REQUEST_TIMEOUT_SECONDS = 10.0
+_GREP_BATCH_MAX_PATTERN_BYTES = 64 * 1024
+_GREP_BATCH_MAX_OUTPUT_BYTES = 8 * 1024 * 1024
+_GREP_BATCH_MAX_STDERR_BYTES = 128 * 1024
+_GREP_BATCH_MAX_MATCHES = _GREP_BATCH_SIZE * 256
+_GREP_UNICODE_MAX_INPUT_BYTES = 512 * 1024
+_GREP_UNICODE_MAX_ADJUDICATIONS = 16
+_GREP_PIPE_READ_BYTES = 64 * 1024
+_GREP_PROCESS_CLEANUP_SECONDS = 0.25
 # Classification precedes strategy-specific definition filtering. Keep a
 # wider deterministic window so early definitions do not crowd out usages.
 _GREP_BATCH_RESULT_FLOOR = 256
@@ -101,6 +105,10 @@ _DEFAULT_GREP_GLOBS = (
     "*.ini",
     "*.txt",
 )
+_GREP_EVIDENCE_SUFFIXES = frozenset(
+    {glob[1:].lower() for glob in _ALL_SOURCE_GLOBS if glob.startswith("*.")}
+    | {".go", ".java", ".php", ".rs", ".dart", ".kt", ".kts"}
+)
 # Python's classifier must preserve the same leftmost-first semantics as each
 # original ripgrep pattern. Keep this translation deliberately narrow: an
 # unsupported POSIX class falls back to the legacy one-pattern subprocess.
@@ -109,6 +117,13 @@ _PYTHON_REGEX_TRANSLATIONS = {
     "[[:alnum:]_]": r"[A-Za-z0-9_]",
 }
 _POSIX_CLASS = re.compile(r"\[\[:[^]]+:\]\]")
+_UNICODE_WORD_PATTERN = re.compile(r"\\[bBwW]")
+_UNICODE_CASE_INSENSITIVE_PATTERN = re.compile(r"\(\?[a-z-]*i")
+_ENGINE_SENSITIVE_SPACE_PATTERN = re.compile(r"\\[sS]")
+_MAX_GREP_LINE_NUMBER = 999_999_999
+_MAX_GREP_LINE_CANDIDATES = 256
+_GREP_LINE_NUMBER = re.compile(r":([1-9][0-9]{0,8}):")
+_HOST_PATH_CASE_INSENSITIVE = os.name == "nt"
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,6 +136,108 @@ class GrepRequest:
     include_globs: tuple[str, ...]
     fixed_string: bool
     max_results: int
+    project_root_is_file: bool = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Remember single-file roots before a later filesystem race."""
+        try:
+            is_file = Path(self.project_root).is_file()
+        except OSError:
+            is_file = False
+        object.__setattr__(self, "project_root_is_file", is_file)
+
+
+class _GrepEvidence(str):
+    """Legacy evidence text carrying unambiguous structured match fields."""
+
+    __slots__ = ("path", "line_number", "content")
+
+    def __new__(
+        cls, path: str, line_number: int, content: str
+    ) -> _GrepEvidence:
+        value = super().__new__(cls, f"{path}:{line_number}:{content}")
+        value.path = path
+        value.line_number = line_number
+        value.content = content
+        return value
+
+    def __reduce__(self) -> tuple[object, tuple[str, int, str]]:
+        return (
+            _GrepEvidence,
+            (self.path, self.line_number, self.content),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _GrepMatch:
+    path: str
+    line_number: int
+    content: str
+    evidence: _GrepEvidence = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "evidence",
+            _GrepEvidence(self.path, self.line_number, self.content),
+        )
+
+    def legacy_line(self) -> _GrepEvidence:
+        return self.evidence
+
+
+@dataclass(frozen=True, slots=True)
+class _BoundedProcessResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(slots=True)
+class _BoundedProcessState:
+    overflow: threading.Event = field(default_factory=threading.Event)
+    captured: dict[str, list[bytes]] = field(
+        default_factory=lambda: {"stdout": [], "stderr": []}
+    )
+    thread_errors: list[BaseException] = field(default_factory=list)
+    readers: list[threading.Thread] = field(default_factory=list)
+    writer: threading.Thread | None = None
+    started_threads: list[threading.Thread] = field(default_factory=list)
+    timed_out: bool = False
+
+
+class _GrepExecutionIncomplete(RuntimeError):
+    """A bounded grep operation did not produce a complete result."""
+
+
+class _GrepDeadlineExceeded(_GrepExecutionIncomplete):
+    """The shared grep verification deadline was exhausted."""
+
+
+class _GrepOutputLimitExceeded(_GrepExecutionIncomplete):
+    """A grep operation exceeded its bounded output allowance."""
+
+
+class _GrepInputLimitExceeded(_GrepExecutionIncomplete):
+    """A grep operation exceeded its bounded input allowance."""
+
+
+class _GrepBatchRejected(RuntimeError):
+    """Ripgrep rejected a combined pattern batch."""
+
+
+class _GrepBatchResults(dict[GrepRequest, tuple[str, ...]]):
+    """Completed and conservative partial results from one grep execution."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.incomplete_requests: set[GrepRequest] = set()
+
+    def merge(self, other: Mapping[GrepRequest, tuple[str, ...]]) -> None:
+        self.update(other)
+        self.incomplete_requests.update(
+            getattr(other, "incomplete_requests", ())
+        )
 
 
 _GREP_REQUEST_RECORDER: ContextVar[list[GrepRequest] | None] = ContextVar(
@@ -128,6 +245,12 @@ _GREP_REQUEST_RECORDER: ContextVar[list[GrepRequest] | None] = ContextVar(
 )
 _GREP_RESULT_REPLAY: ContextVar[Mapping[GrepRequest, tuple[str, ...]] | None] = (
     ContextVar("grep_result_replay", default=None)
+)
+_GREP_REPLAY_DEADLINE: ContextVar[float | None] = ContextVar(
+    "grep_replay_deadline", default=None
+)
+_GREP_EXECUTION_DEADLINE: ContextVar[float | None] = ContextVar(
+    "grep_execution_deadline", default=None
 )
 
 
@@ -170,13 +293,27 @@ def record_grep_requests() -> Iterator[list[GrepRequest]]:
 @contextmanager
 def replay_grep_results(
     results: Mapping[GrepRequest, tuple[str, ...]],
+    *,
+    deadline: float | None = None,
 ) -> Iterator[None]:
     """Replay previously collected grep results."""
-    token = _GREP_RESULT_REPLAY.set(results)
+    replay_token = _GREP_RESULT_REPLAY.set(results)
+    deadline_token = _GREP_REPLAY_DEADLINE.set(deadline)
     try:
         yield
     finally:
-        _GREP_RESULT_REPLAY.reset(token)
+        _GREP_REPLAY_DEADLINE.reset(deadline_token)
+        _GREP_RESULT_REPLAY.reset(replay_token)
+
+
+@contextmanager
+def grep_execution_deadline(deadline: float | None) -> Iterator[None]:
+    """Apply one absolute deadline to direct grep calls in this context."""
+    token = _GREP_EXECUTION_DEADLINE.set(deadline)
+    try:
+        yield
+    finally:
+        _GREP_EXECUTION_DEADLINE.reset(token)
 
 
 def _make_grep_request(
@@ -203,6 +340,7 @@ def _make_grep_request(
 def _ripgrep_command(request: GrepRequest, rg: str) -> list[str]:
     cmd = [
         rg,
+        "--no-config",
         "-n",
         "--no-heading",
         "--color",
@@ -219,51 +357,442 @@ def _ripgrep_command(request: GrepRequest, rg: str) -> list[str]:
     return cmd
 
 
-def _filter_grep_output(stdout: str) -> list[str]:
+def _path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _trusted_which(
+    executable: str,
+    project_roots: Sequence[str] = (),
+) -> str | None:
+    """Resolve a backend without ever executing one supplied by target code."""
+    candidate = shutil.which(executable)
+    if not candidate:
+        return None
+    try:
+        candidate_path = Path(candidate)
+        absolute_candidate = (
+            candidate_path
+            if candidate_path.is_absolute()
+            else Path.cwd() / candidate_path
+        )
+        resolved_candidate = candidate_path.resolve()
+        current_directory = Path.cwd().resolve()
+        untrusted_roots = []
+        if not project_roots:
+            untrusted_roots.append(current_directory)
+        for root in project_roots:
+            resolved_root = Path(root).resolve()
+            untrusted_roots.append(
+                resolved_root.parent if resolved_root.is_file() else resolved_root
+            )
+    except (OSError, RuntimeError):
+        return None
+    directly_from_cwd = (
+        not candidate_path.is_absolute()
+        or absolute_candidate.parent == current_directory
+    )
+    if directly_from_cwd or any(
+        _path_is_within(candidate, root)
+        for root in untrusted_roots
+        for candidate in (absolute_candidate, resolved_candidate)
+    ):
+        logger.warning(
+            "Ignoring %s executable resolved inside an untrusted directory: %s",
+            executable,
+            resolved_candidate,
+        )
+        return None
+    return str(resolved_candidate)
+
+
+def _request_trust_root(request: GrepRequest) -> str:
+    """Return the directory whose contents may control backend resolution."""
+    if request.project_root_is_file:
+        return os.path.dirname(os.path.abspath(request.project_root))
+    return request.project_root
+
+
+def _deadline_expired(deadline: float | None) -> bool:
+    return deadline is not None and time.monotonic() >= deadline
+
+
+def _remaining_timeout(deadline: float | None, maximum: float) -> float:
+    if deadline is None:
+        return maximum
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise _GrepDeadlineExceeded("grep verification deadline exceeded")
+    return min(maximum, remaining)
+
+
+def _looks_like_source_path(path: str) -> bool:
+    filename = path.replace("\\", "/").rsplit("/", 1)[-1]
+    suffix = Path(filename).suffix.lower()
+    return suffix in _GREP_EVIDENCE_SUFFIXES
+
+
+def _split_grep_evidence(line: str) -> tuple[str, int | None, str]:
+    if isinstance(line, _GrepEvidence):
+        return line.path, line.line_number, line.content
+
+    selected = None
+    fallback = None
+    for index, candidate in enumerate(_GREP_LINE_NUMBER.finditer(line)):
+        if fallback is None:
+            fallback = candidate
+        if _looks_like_source_path(line[: candidate.start()]):
+            selected = candidate
+            break
+        if index + 1 >= _MAX_GREP_LINE_CANDIDATES:
+            break
+    selected = selected or fallback
+    if selected is None:
+        return "", None, line
+    return (
+        line[: selected.start()],
+        int(selected.group(1)),
+        line[selected.end() :],
+    )
+
+
+def _is_ignored_grep_path(path: str) -> bool:
+    components = [
+        component
+        for component in path.replace("\\", "/").split("/")
+        if component
+    ]
+    ignored_names = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".skylos",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "node_modules",
+    }
+    return any(
+        component in ignored_names or component.endswith(".egg-info")
+        for component in components
+    )
+
+
+def _filter_null_grep_output(stdout: str) -> list[str]:
     filtered: list[str] = []
-    for line in stdout.strip().splitlines():
-        normalized = line.replace("\\", "/")
-        if any(part in normalized for part in _IGNORED_GREP_PATH_PARTS):
-            continue
-        filtered.append(line)
+    output = stdout.strip("\r\n")
+    if not output:
+        return filtered
+    for raw_line in output.split("\n"):
+        line = raw_line[:-1] if raw_line.endswith("\r") else raw_line
+        path, separator, remainder = line.partition("\0")
+        line_text, number_separator, content = remainder.partition(":")
+        if (
+            not separator
+            or not number_separator
+            or not line_text.isdigit()
+            or len(line_text) > 9
+        ):
+            raise _GrepExecutionIncomplete("grep emitted malformed null output")
+        evidence = _GrepEvidence(path, int(line_text), content)
+        if not _is_ignored_grep_path(path):
+            filtered.append(evidence)
     return filtered
 
 
-def _run_grep_request(request: GrepRequest) -> list[str]:
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    cleanup_deadline = time.monotonic() + _GREP_PROCESS_CLEANUP_SECONDS
     try:
-        rg = shutil.which("rg")
-        if rg:
-            cmd = _ripgrep_command(request, rg)
-            cmd.extend(["--", request.pattern, request.project_root])
-        else:
-            grep_flags = ["-rn"]
-            if request.fixed_string:
-                grep_flags.append("-F")
-            elif request.use_regex:
-                grep_flags.append("-E")
+        process.terminate()
+        process.wait(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+    except (OSError, subprocess.TimeoutExpired):
+        try:
+            process.kill()
+            remaining = max(0.0, cleanup_deadline - time.monotonic())
+            if remaining:
+                process.wait(timeout=remaining)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
 
-            includes: list[str] = []
-            for glob in request.include_globs:
-                includes.extend(["--include", glob])
-            excludes: list[str] = []
-            for directory in _GREP_EXCLUDE_DIRS:
-                excludes.extend(["--exclude-dir", directory])
 
-            cmd = [
-                "grep",
-                *grep_flags,
-                *includes,
-                *excludes,
-                request.pattern,
-                request.project_root,
-            ]
-
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=10, check=False
+def _open_grep_process(cmd: Sequence[str]) -> subprocess.Popen[bytes]:
+    executable = Path(cmd[0])
+    if not executable.is_absolute():
+        raise _GrepExecutionIncomplete(
+            "grep subprocess executable was not fully qualified"
         )
-        return _filter_grep_output(result.stdout)[: request.max_results]
+    return subprocess.Popen(
+        list(cmd),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(executable.parent),
+    )
+
+
+def _read_bounded_process_pipe(
+    process: subprocess.Popen[bytes],
+    name: str,
+    limit: int,
+    state: _BoundedProcessState,
+) -> None:
+    pipe = process.stdout if name == "stdout" else process.stderr
+    assert pipe is not None
+    total = 0
+    try:
+        while chunk := pipe.read(_GREP_PIPE_READ_BYTES):
+            total += len(chunk)
+            if total > limit:
+                state.overflow.set()
+                _terminate_process(process)
+                return
+            state.captured[name].append(chunk)
+    except (OSError, ValueError) as exc:
+        state.thread_errors.append(exc)
+
+
+def _write_bounded_process_input(
+    process: subprocess.Popen[bytes],
+    encoded_input: bytes,
+    state: _BoundedProcessState,
+) -> None:
+    pipe = process.stdin
+    assert pipe is not None
+    try:
+        pipe.write(encoded_input)
+        pipe.flush()
+    except (BrokenPipeError, OSError, ValueError) as exc:
+        if process.poll() is None:
+            state.thread_errors.append(exc)
+    finally:
+        try:
+            pipe.close()
+        except (OSError, ValueError):
+            pass
+
+
+def _bounded_process_threads(
+    process: subprocess.Popen[bytes],
+    encoded_input: bytes,
+    state: _BoundedProcessState,
+) -> None:
+    state.readers = [
+        threading.Thread(
+            target=_read_bounded_process_pipe,
+            args=(
+                process,
+                "stdout",
+                _GREP_BATCH_MAX_OUTPUT_BYTES,
+                state,
+            ),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_read_bounded_process_pipe,
+            args=(
+                process,
+                "stderr",
+                _GREP_BATCH_MAX_STDERR_BYTES,
+                state,
+            ),
+            daemon=True,
+        ),
+    ]
+    state.writer = threading.Thread(
+        target=_write_bounded_process_input,
+        args=(process, encoded_input, state),
+        daemon=True,
+    )
+
+
+def _cleanup_bounded_process(
+    process: subprocess.Popen[bytes],
+    started_threads: Sequence[threading.Thread],
+) -> None:
+    cleanup_deadline = time.monotonic() + _GREP_PROCESS_CLEANUP_SECONDS
+    if process.poll() is None:
+        _terminate_process(process)
+    for thread in started_threads:
+        thread.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+    for pipe in (process.stdin, process.stdout, process.stderr):
+        if pipe is None:
+            continue
+        try:
+            pipe.close()
+        except (OSError, ValueError):
+            pass
+    for thread in started_threads:
+        if thread.is_alive():
+            thread.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+
+
+def _run_bounded_process_workers(
+    process: subprocess.Popen[bytes],
+    state: _BoundedProcessState,
+    timeout: float,
+) -> None:
+    writer = state.writer
+    assert writer is not None
+    try:
+        for thread in state.readers:
+            thread.start()
+            state.started_threads.append(thread)
+        writer.start()
+        state.started_threads.append(writer)
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            state.timed_out = True
+    except RuntimeError as exc:
+        raise _GrepExecutionIncomplete(
+            "grep subprocess worker could not start"
+        ) from exc
+    finally:
+        _cleanup_bounded_process(process, state.started_threads)
+
+
+def _raise_for_bounded_process_failure(
+    cmd: Sequence[str],
+    timeout: float,
+    state: _BoundedProcessState,
+) -> None:
+    writer = state.writer
+    assert writer is not None
+    if writer.is_alive() or any(thread.is_alive() for thread in state.readers):
+        raise _GrepExecutionIncomplete("ripgrep pipe did not close cleanly")
+    if state.timed_out:
+        raise subprocess.TimeoutExpired(list(cmd), timeout)
+    if state.overflow.is_set():
+        raise _GrepOutputLimitExceeded("ripgrep output exceeded its size limit")
+    if state.thread_errors:
+        raise OSError(str(state.thread_errors[0]))
+
+
+def _run_bounded_subprocess(
+    cmd: Sequence[str],
+    *,
+    input_text: str,
+    timeout: float,
+    input_limit: int = _GREP_BATCH_MAX_PATTERN_BYTES,
+) -> _BoundedProcessResult:
+    """Run ripgrep with bounded stdin/stdout/stderr memory and wall time."""
+    encoded_input = input_text.encode("utf-8")
+    if len(encoded_input) > input_limit:
+        raise _GrepInputLimitExceeded("grep subprocess input is too large")
+
+    process = _open_grep_process(cmd)
+    state = _BoundedProcessState()
+    _bounded_process_threads(process, encoded_input, state)
+    _run_bounded_process_workers(process, state, timeout)
+    _raise_for_bounded_process_failure(cmd, timeout, state)
+
+    return _BoundedProcessResult(
+        returncode=process.returncode,
+        stdout=b"".join(state.captured["stdout"]).decode("utf-8"),
+        stderr=b"".join(state.captured["stderr"]).decode("utf-8"),
+    )
+
+
+def _grep_fallback_command(
+    request: GrepRequest,
+    grep: str,
+    target: str,
+) -> list[str]:
+    grep_flags = ["-rn", "--null"]
+    if request.fixed_string:
+        grep_flags.append("-F")
+    elif request.use_regex:
+        grep_flags.append("-E")
+
+    includes: list[str] = []
+    for glob in request.include_globs:
+        includes.extend(["--include", glob])
+    excludes: list[str] = []
+    for directory in _GREP_EXCLUDE_DIRS:
+        excludes.extend(["--exclude-dir", directory])
+    return [
+        grep,
+        *grep_flags,
+        *includes,
+        *excludes,
+        "-e",
+        request.pattern,
+        "--",
+        target,
+    ]
+
+
+def _direct_grep_command(request: GrepRequest) -> tuple[list[str], bool]:
+    trust_root = _request_trust_root(request)
+    target = os.path.abspath(request.project_root)
+    rg = _trusted_which("rg", (trust_root,))
+    if rg:
+        command = _ripgrep_command(request, rg)
+        command.extend(["--json", "--", request.pattern, target])
+        return command, True
+
+    grep = _trusted_which("grep", (trust_root,))
+    if not grep:
+        raise _GrepExecutionIncomplete("no grep executable is available")
+    return _grep_fallback_command(request, grep, target), False
+
+
+def _direct_grep_results(
+    request: GrepRequest,
+    result: _BoundedProcessResult,
+    *,
+    used_ripgrep: bool,
+    deadline: float | None,
+) -> list[str]:
+    if result.returncode not in (0, 1):
+        message = result.stderr.strip() or f"exit status {result.returncode}"
+        raise _GrepExecutionIncomplete(message)
+    if used_ripgrep:
+        matches = _parse_ripgrep_json_matches(result.stdout, deadline=deadline)
+        return [match.legacy_line() for match in matches[: request.max_results]]
+    return _filter_null_grep_output(result.stdout)[: request.max_results]
+
+
+def _run_grep_request(
+    request: GrepRequest,
+    *,
+    deadline: float | None = None,
+    require_complete: bool = False,
+) -> list[str]:
+    try:
+        cmd, used_ripgrep = _direct_grep_command(request)
+        result = _run_bounded_subprocess(
+            cmd,
+            input_text="",
+            timeout=_remaining_timeout(deadline, _GREP_REQUEST_TIMEOUT_SECONDS),
+        )
+        return _direct_grep_results(
+            request,
+            result,
+            used_ripgrep=used_ripgrep,
+            deadline=deadline,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.debug("grep timed out for pattern %r: %s", request.pattern, exc)
+        if deadline is not None or require_complete:
+            raise _GrepExecutionIncomplete("direct grep request timed out") from exc
+        return []
+    except _GrepExecutionIncomplete as exc:
+        logger.debug("grep was incomplete for pattern %r: %s", request.pattern, exc)
+        if deadline is not None or require_complete:
+            raise
+        return []
     except (OSError, subprocess.SubprocessError, UnicodeError, ValueError) as exc:
         logger.debug("grep failed for pattern %r: %s", request.pattern, exc)
+        if deadline is not None or require_complete:
+            raise _GrepExecutionIncomplete("direct grep request failed") from exc
         return []
 
 
@@ -279,11 +808,81 @@ def _python_regex(pattern: str) -> re.Pattern[str] | None:
         return None
 
 
-def _grep_line_sort_key(line: str) -> tuple[str, int, str]:
-    parts = line.split(":", 2)
-    if len(parts) >= 3 and parts[1].strip().isdigit():
-        return parts[0].replace("\\", "/"), int(parts[1]), parts[2]
-    return line.replace("\\", "/"), 0, ""
+def _grep_match_sort_key(match: _GrepMatch) -> tuple[str, int, str]:
+    return match.path.replace("\\", "/"), match.line_number, match.content
+
+
+def _remove_one_line_ending(content: str) -> str:
+    if content.endswith("\r\n"):
+        return content[:-2]
+    if content.endswith(("\n", "\r")):
+        return content[:-1]
+    return content
+
+
+def _ripgrep_json_text(value: object, field_name: str) -> str:
+    if not isinstance(value, dict) or not isinstance(value.get("text"), str):
+        raise ValueError(f"ripgrep match has non-text {field_name}")
+    return value["text"]
+
+
+def _load_ripgrep_json_event(raw_line: str) -> dict[str, object]:
+    try:
+        event = json.loads(raw_line)
+    except json.JSONDecodeError as exc:
+        raise ValueError("ripgrep emitted malformed JSON") from exc
+    if not isinstance(event, dict):
+        raise ValueError("ripgrep emitted a non-object JSON event")
+    return event
+
+
+def _ripgrep_line_number(data: Mapping[str, object]) -> int:
+    line_number = data.get("line_number")
+    if (
+        not isinstance(line_number, int)
+        or isinstance(line_number, bool)
+        or line_number <= 0
+        or line_number > _MAX_GREP_LINE_NUMBER
+    ):
+        raise ValueError("ripgrep match has an invalid line number")
+    return line_number
+
+
+def _ripgrep_match_from_event(event: Mapping[str, object]) -> _GrepMatch | None:
+    if event.get("type") != "match":
+        return None
+    data = event.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("ripgrep match has no data object")
+    path = _ripgrep_json_text(data.get("path"), "path")
+    content = _remove_one_line_ending(
+        _ripgrep_json_text(data.get("lines"), "lines")
+    )
+    return _GrepMatch(
+        path=path,
+        line_number=_ripgrep_line_number(data),
+        content=content,
+    )
+
+
+def _parse_ripgrep_json_matches(
+    stdout: str,
+    *,
+    deadline: float | None,
+) -> list[_GrepMatch]:
+    matches: list[_GrepMatch] = []
+    for index, raw_line in enumerate(stdout.split("\n")):
+        if index % 256 == 0 and _deadline_expired(deadline):
+            raise _GrepDeadlineExceeded("deadline exceeded while parsing ripgrep")
+        if not raw_line:
+            continue
+        match = _ripgrep_match_from_event(_load_ripgrep_json_event(raw_line))
+        if match is None or _is_ignored_grep_path(match.path):
+            continue
+        matches.append(match)
+        if len(matches) > _GREP_BATCH_MAX_MATCHES:
+            raise _GrepOutputLimitExceeded("ripgrep emitted too many matches")
+    return sorted(matches, key=_grep_match_sort_key)
 
 
 def _batch_group_key(request: GrepRequest) -> tuple[str, tuple[str, ...], bool]:
@@ -294,6 +893,10 @@ def _requires_direct_grep(request: GrepRequest) -> bool:
     if "\n" in request.pattern or "\r" in request.pattern:
         return True
     if not request.pattern.isascii():
+        return True
+    if not request.fixed_string and _ENGINE_SENSITIVE_SPACE_PATTERN.search(
+        request.pattern
+    ):
         return True
     return not request.fixed_string and _python_regex(request.pattern) is None
 
@@ -310,53 +913,135 @@ def _partition_grep_requests(
 
 
 def _run_ripgrep_pattern_file(
-    requests: Sequence[GrepRequest], rg: str, timeout: float
-) -> list[str]:
+    requests: Sequence[GrepRequest],
+    rg: str,
+    timeout: float = _GREP_BATCH_TIMEOUT_SECONDS,
+    *,
+    deadline: float | None = None,
+) -> list[_GrepMatch]:
     representative = requests[0]
     cmd = _ripgrep_command(representative, rg)
-    cmd.extend(["-f", "-", "--", representative.project_root])
+    cmd.extend(
+        [
+            "--json",
+            "-f",
+            "-",
+            "--",
+            os.path.abspath(representative.project_root),
+        ]
+    )
     patterns = "\n".join(dict.fromkeys(request.pattern for request in requests))
-    result = subprocess.run(
+    result = _run_bounded_subprocess(
         cmd,
-        input=f"{patterns}\n",
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
+        input_text=f"{patterns}\n",
+        timeout=_remaining_timeout(deadline, timeout),
     )
     if result.returncode not in (0, 1):
         msg = result.stderr.strip() or f"exit status {result.returncode}"
-        raise RuntimeError(msg)
-    return sorted(_filter_grep_output(result.stdout), key=_grep_line_sort_key)
+        raise _GrepBatchRejected(msg)
+    return _parse_ripgrep_json_matches(result.stdout, deadline=deadline)
 
 
 def _ripgrep_stdin_match_positions(
-    pattern: str, contents: Sequence[str], rg: str
+    pattern: str,
+    contents: Sequence[str],
+    rg: str,
+    *,
+    deadline: float | None = None,
 ) -> set[int]:
     """Return the 0-based positions of the given lines that ripgrep matches."""
-    result = subprocess.run(
-        [rg, "-n", "--no-heading", "--color", "never", "--", pattern, "-"],
-        input="\n".join(contents) + "\n",
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
+    stdin = "\n".join(contents) + "\n"
+    result = _run_bounded_subprocess(
+        [
+            rg,
+            "--no-config",
+            "-n",
+            "--no-heading",
+            "--color",
+            "never",
+            "--",
+            pattern,
+            "-",
+        ],
+        input_text=stdin,
+        timeout=_remaining_timeout(deadline, _GREP_REQUEST_TIMEOUT_SECONDS),
+        input_limit=_GREP_UNICODE_MAX_INPUT_BYTES,
     )
     if result.returncode not in (0, 1):
         msg = result.stderr.strip() or f"exit status {result.returncode}"
         raise RuntimeError(msg)
     positions: set[int] = set()
-    for line in result.stdout.splitlines():
+    for line in result.stdout.split("\n"):
         prefix = line.split(":", 1)[0]
         if prefix.isdigit():
             positions.add(int(prefix) - 1)
     return positions
 
 
+def _rust_and_python_word_classes_can_differ(
+    content: str,
+    *,
+    deadline: float | None = None,
+) -> bool:
+    for index, character in enumerate(content):
+        if index % 4096 == 0 and _deadline_expired(deadline):
+            raise _GrepDeadlineExceeded(
+                "deadline exceeded while checking Unicode classes"
+            )
+        if character.isascii():
+            continue
+        category = unicodedata.category(character)
+        python_word = character.isalnum() or character == "_"
+        rust_word = (
+            category[0] in {"L", "M"}
+            or category == "Nd"
+            or category == "Pc"
+            or character in {"\u200c", "\u200d"}
+        )
+        if python_word != rust_word:
+            return True
+    return False
+
+
+def _word_divergent_lines(
+    non_ascii_lines: Sequence[tuple[int, str]],
+    *,
+    deadline: float | None,
+) -> list[tuple[int, str]]:
+    divergent: list[tuple[int, str]] = []
+    for index, line in enumerate(non_ascii_lines):
+        if index % 64 == 0 and _deadline_expired(deadline):
+            raise _GrepDeadlineExceeded(
+                "deadline exceeded while checking non-ASCII lines"
+            )
+        if _rust_and_python_word_classes_can_differ(
+            line[1], deadline=deadline
+        ):
+            divergent.append(line)
+    return divergent
+
+
+def _unicode_sensitive_lines(
+    request: GrepRequest,
+    non_ascii_lines: Sequence[tuple[int, str]],
+    word_divergent_lines: Sequence[tuple[int, str]],
+) -> list[tuple[int, str]]:
+    if request.fixed_string or not non_ascii_lines:
+        return []
+    if _UNICODE_CASE_INSENSITIVE_PATTERN.search(request.pattern):
+        return list(non_ascii_lines)
+    if not _UNICODE_WORD_PATTERN.search(request.pattern):
+        return []
+    return list(word_divergent_lines)
+
+
 def _non_ascii_line_overrides(
     request: GrepRequest,
     non_ascii_lines: Sequence[tuple[int, str]],
+    word_divergent_lines: Sequence[tuple[int, str]],
     rg: str,
+    *,
+    deadline: float | None = None,
 ) -> dict[int, bool] | None:
     # After POSIX-class translation the only engine-sensitive construct left
     # in classifier patterns is \b: ripgrep's UTS#18 word class includes
@@ -364,14 +1049,20 @@ def _non_ascii_line_overrides(
     # re does not (and vice versa). Let ripgrep itself adjudicate non-ASCII
     # lines so batched attribution matches what a per-pattern search returns.
     # Fixed strings are byte-exact substring checks and never diverge.
-    if request.fixed_string or not non_ascii_lines:
+    sensitive_lines = _unicode_sensitive_lines(
+        request, non_ascii_lines, word_divergent_lines
+    )
+    if not sensitive_lines:
         return None
     matched = _ripgrep_stdin_match_positions(
-        request.pattern, [content for _, content in non_ascii_lines], rg
+        request.pattern,
+        [content for _, content in sensitive_lines],
+        rg,
+        deadline=deadline,
     )
     return {
         index: position in matched
-        for position, (index, _) in enumerate(non_ascii_lines)
+        for position, (index, _) in enumerate(sensitive_lines)
     }
 
 
@@ -387,24 +1078,28 @@ def _request_matches_line(
 
 def _classify_grep_request(
     request: GrepRequest,
-    line_contents: Sequence[tuple[str, str]],
+    grep_matches: Sequence[_GrepMatch],
     overrides: dict[int, bool] | None = None,
+    *,
+    deadline: float | None = None,
 ) -> tuple[str, ...]:
     if request.max_results <= 0:
         return ()
     regex = None if request.fixed_string else _python_regex(request.pattern)
     limit = max(request.max_results, _GREP_BATCH_RESULT_FLOOR)
     matches: list[str] = []
-    for index, (line, content) in enumerate(line_contents):
+    for index, grep_match in enumerate(grep_matches):
+        if index % 256 == 0 and _deadline_expired(deadline):
+            raise _GrepDeadlineExceeded("deadline exceeded while classifying grep")
         override = overrides.get(index) if overrides is not None else None
         is_match = (
             override
             if override is not None
-            else _request_matches_line(request, regex, content)
+            else _request_matches_line(request, regex, grep_match.content)
         )
         if not is_match:
             continue
-        matches.append(line)
+        matches.append(grep_match.legacy_line())
         if len(matches) >= limit:
             break
     return tuple(matches)
@@ -412,39 +1107,120 @@ def _classify_grep_request(
 
 def _run_serial_grep_requests(
     requests: Sequence[GrepRequest],
-) -> dict[GrepRequest, tuple[str, ...]]:
-    return {request: tuple(_run_grep_request(request)) for request in requests}
+    *,
+    deadline: float | None = None,
+) -> _GrepBatchResults:
+    results = _GrepBatchResults()
+    for request in requests:
+        if _deadline_expired(deadline):
+            break
+        try:
+            direct_results = _run_grep_request(
+                request,
+                deadline=deadline,
+                require_complete=True,
+            )
+        except _GrepExecutionIncomplete:
+            continue
+        results[request] = tuple(direct_results)
+    return results
 
 
 def _run_ripgrep_batch(
     requests: Sequence[GrepRequest],
     rg: str,
-    timeout: float = 30.0,
-) -> dict[GrepRequest, tuple[str, ...]]:
+    timeout: float = _GREP_BATCH_TIMEOUT_SECONDS,
+    *,
+    deadline: float | None = None,
+) -> _GrepBatchResults:
     batched, direct = _partition_grep_requests(requests)
-    batch_results: dict[GrepRequest, tuple[str, ...]] = {}
+    batch_results = _GrepBatchResults()
     if not batched:
-        return _run_serial_grep_requests(direct)
+        return _run_serial_grep_requests(direct, deadline=deadline)
 
-    lines = _run_ripgrep_pattern_file(batched, rg, timeout)
-    line_contents = [(line, _grep_line_content(line)) for line in lines]
-    non_ascii_lines = [
-        (index, content)
-        for index, (_, content) in enumerate(line_contents)
-        if not content.isascii()
-    ]
-    batch_results.update(
-        (
-            request,
-            _classify_grep_request(
-                request,
-                line_contents,
-                _non_ascii_line_overrides(request, non_ascii_lines, rg),
-            ),
-        )
-        for request in batched
+    grep_matches = _run_ripgrep_pattern_file(
+        batched, rg, timeout, deadline=deadline
     )
-    batch_results.update(_run_serial_grep_requests(direct))
+    non_ascii_lines = [
+        (index, match.content)
+        for index, match in enumerate(grep_matches)
+        if not match.content.isascii()
+    ]
+    word_divergent_lines = _word_divergent_lines(
+        non_ascii_lines, deadline=deadline
+    )
+    unicode_adjudications = 0
+    for request in batched:
+        if _deadline_expired(deadline):
+            break
+        sensitive_lines = _unicode_sensitive_lines(
+            request, non_ascii_lines, word_divergent_lines
+        )
+        overrides: dict[int, bool] | None = None
+        request_incomplete = False
+        if sensitive_lines:
+            unresolved = {index: False for index, _ in sensitive_lines}
+            if unicode_adjudications < _GREP_UNICODE_MAX_ADJUDICATIONS:
+                unicode_adjudications += 1
+                try:
+                    overrides = _non_ascii_line_overrides(
+                        request,
+                        non_ascii_lines,
+                        word_divergent_lines,
+                        rg,
+                        deadline=deadline,
+                    )
+                except (
+                    _GrepExecutionIncomplete,
+                    OSError,
+                    RuntimeError,
+                    subprocess.SubprocessError,
+                    UnicodeError,
+                    ValueError,
+                ) as exc:
+                    if _deadline_expired(deadline):
+                        break
+                    logger.debug(
+                        "Treating unresolved non-ASCII matches as non-matches "
+                        "for %r: %s",
+                        request.pattern,
+                        exc,
+                    )
+                    overrides = unresolved
+                    request_incomplete = True
+            else:
+                logger.debug(
+                    "Unicode adjudication cap reached for %r; retaining only "
+                    "unambiguous matches",
+                    request.pattern,
+                )
+                overrides = unresolved
+                request_incomplete = True
+        try:
+            batch_results[request] = _classify_grep_request(
+                request,
+                grep_matches,
+                overrides,
+                deadline=deadline,
+            )
+            if request_incomplete:
+                batch_results.incomplete_requests.add(request)
+        except (
+            _GrepExecutionIncomplete,
+            OSError,
+            RuntimeError,
+            subprocess.SubprocessError,
+            UnicodeError,
+            ValueError,
+        ) as exc:
+            logger.debug(
+                "Grep attribution was incomplete for %r: %s",
+                request.pattern,
+                exc,
+            )
+    batch_results.merge(
+        _run_serial_grep_requests(direct, deadline=deadline)
+    )
     return batch_results
 
 
@@ -458,38 +1234,95 @@ def _group_grep_requests(
 
 
 def _execute_grep_chunk(
-    requests: Sequence[GrepRequest], rg: str
-) -> dict[GrepRequest, tuple[str, ...]]:
+    requests: Sequence[GrepRequest],
+    rg: str,
+    *,
+    deadline: float | None = None,
+) -> _GrepBatchResults:
     try:
-        return _run_ripgrep_batch(requests, rg)
+        return _run_ripgrep_batch(requests, rg, deadline=deadline)
+    except (_GrepOutputLimitExceeded, _GrepInputLimitExceeded) as exc:
+        if len(requests) <= 1 or _deadline_expired(deadline):
+            logger.debug("grep request exceeded a resource limit: %s", exc)
+            return _GrepBatchResults()
+        midpoint = len(requests) // 2
+        logger.debug("splitting oversized grep batch of %d requests", len(requests))
+        results = _GrepBatchResults()
+        results.merge(
+            _execute_grep_chunk(
+                requests[:midpoint], rg, deadline=deadline
+            )
+        )
+        if not _deadline_expired(deadline):
+            results.merge(
+                _execute_grep_chunk(
+                    requests[midpoint:], rg, deadline=deadline
+                )
+            )
+        return results
+    except (
+        _GrepExecutionIncomplete,
+        subprocess.TimeoutExpired,
+    ) as exc:
+        logger.debug("batched grep was incomplete; not retrying: %s", exc)
+        return _GrepBatchResults()
     except (
         OSError,
         RuntimeError,
-        subprocess.SubprocessError,
         UnicodeError,
         ValueError,
     ) as exc:
         logger.debug("batched grep failed; using serial fallback: %s", exc)
-        return _run_serial_grep_requests(requests)
+        return _run_serial_grep_requests(requests, deadline=deadline)
+
+
+def _grep_request_chunks(
+    requests: Sequence[GrepRequest],
+) -> Iterator[list[GrepRequest]]:
+    chunk: list[GrepRequest] = []
+    pattern_bytes = 0
+    for request in requests:
+        request_bytes = len(request.pattern.encode("utf-8")) + 1
+        if chunk and (
+            len(chunk) >= _GREP_BATCH_SIZE
+            or pattern_bytes + request_bytes > _GREP_BATCH_MAX_PATTERN_BYTES
+        ):
+            yield chunk
+            chunk = []
+            pattern_bytes = 0
+        chunk.append(request)
+        pattern_bytes += request_bytes
+    if chunk:
+        yield chunk
 
 
 def execute_grep_batch(
     requests: Sequence[GrepRequest],
-) -> dict[GrepRequest, tuple[str, ...]]:
-    """Execute compatible grep requests in fixed-size batches."""
+    *,
+    deadline: float | None = None,
+) -> _GrepBatchResults:
+    """Execute compatible grep requests within one optional absolute deadline.
+
+    A present empty tuple means a completed search with no matches. A missing
+    request means bounded verification could not complete and must not be
+    cached as a negative result.
+    """
     unique_requests = list(dict.fromkeys(requests))
     if not unique_requests:
-        return {}
+        return _GrepBatchResults()
 
-    rg = shutil.which("rg")
+    rg = _trusted_which(
+        "rg", tuple(_request_trust_root(request) for request in unique_requests)
+    )
     if not rg:
-        return _run_serial_grep_requests(unique_requests)
+        return _run_serial_grep_requests(unique_requests, deadline=deadline)
 
-    results: dict[GrepRequest, tuple[str, ...]] = {}
+    results = _GrepBatchResults()
     for group_requests in _group_grep_requests(unique_requests).values():
-        for start in range(0, len(group_requests), _GREP_BATCH_SIZE):
-            chunk = group_requests[start : start + _GREP_BATCH_SIZE]
-            results.update(_execute_grep_chunk(chunk, rg))
+        for chunk in _grep_request_chunks(group_requests):
+            if _deadline_expired(deadline):
+                return results
+            results.merge(_execute_grep_chunk(chunk, rg, deadline=deadline))
     return results
 
 
@@ -520,9 +1353,19 @@ def _run_grep(
         if replayed is not None:
             return list(replayed)
         logger.warning("grep replay miss for pattern %r; executing directly", pattern)
-        return _run_grep_request(request)
+        deadline = _GREP_REPLAY_DEADLINE.get()
+        return (
+            _run_grep_request(request)
+            if deadline is None
+            else _run_grep_request(request, deadline=deadline)
+        )
 
-    return _run_grep_request(request)
+    deadline = _GREP_EXECUTION_DEADLINE.get()
+    return (
+        _run_grep_request(request)
+        if deadline is None
+        else _run_grep_request(request, deadline=deadline)
+    )
 
 
 def repo_relative_path(file_path: str, project_root: str | Path) -> str:
@@ -651,24 +1494,28 @@ def parameter_owner_name(finding: dict) -> str:
     return full_name.rsplit(".", 1)[0]
 
 
+def _grep_paths_equal(first: str, second: str) -> bool:
+    normalized_first = first.replace("\\", "/")
+    normalized_second = second.replace("\\", "/")
+    if _HOST_PATH_CASE_INSENSITIVE:
+        return ntpath.normcase(normalized_first) == ntpath.normcase(
+            normalized_second
+        )
+    return normalized_first == normalized_second
+
+
 def is_definition_line(grep_line: str, finding: dict) -> bool:
     file_path = finding.get("file", "")
     line_num = finding.get("line", 0)
+    path, match_line, content = _split_grep_evidence(grep_line)
 
-    if file_path and file_path in grep_line:
-        try:
-            parts = grep_line.split(":")
-            if len(parts) >= 2 and parts[1].strip().isdigit():
-                match_line = int(parts[1].strip())
-                if abs(match_line - line_num) <= 2:
-                    return True
-        except (ValueError, IndexError):
-            pass
-
-    if ":" in grep_line:
-        content = grep_line.split(":", 2)[-1]
-    else:
-        content = grep_line
+    if (
+        file_path
+        and match_line is not None
+        and _grep_paths_equal(str(file_path), path)
+        and abs(match_line - line_num) <= 2
+    ):
+        return True
 
     simple_name = finding.get("simple_name", "")
     definition_patterns = [
@@ -754,10 +1601,7 @@ def filter_grep_results(
 
 def is_substring_match(grep_line: str, simple_name: str) -> bool:
     """Check if the match is a false positive due to substring matching."""
-    if ":" in grep_line:
-        content = grep_line.split(":", 2)[-1]
-    else:
-        content = grep_line
+    content = _grep_line_content(grep_line)
 
     for match in re.finditer(re.escape(simple_name), content):
         start, end = match.start(), match.end()
@@ -769,17 +1613,15 @@ def is_substring_match(grep_line: str, simple_name: str) -> bool:
 
 
 def _grep_line_path(grep_line: str) -> str:
-    parts = grep_line.split(":", 2)
-    if len(parts) >= 2 and parts[1].strip().isdigit():
-        return parts[0]
-    return ""
+    return _split_grep_evidence(grep_line)[0]
+
+
+def _grep_line_number(grep_line: str) -> int | None:
+    return _split_grep_evidence(grep_line)[1]
 
 
 def _grep_line_content(grep_line: str) -> str:
-    parts = grep_line.split(":", 2)
-    if len(parts) >= 3 and parts[1].strip().isdigit():
-        return parts[2]
-    return grep_line
+    return _split_grep_evidence(grep_line)[2]
 
 
 def _python_line_has_name_token(grep_line: str, simple_name: str) -> bool:
@@ -856,11 +1698,12 @@ def _deduplicate_grep_results(
         seen_in_strategy: set[str] = set()
         unique = []
         for line in lines:
-            parts = line.split(":", 2)
-            if len(parts) >= 2 and parts[1].strip().isdigit():
-                key = f"{parts[0]}:{parts[1]}"
-            else:
-                key = line
+            path, line_number, _ = _split_grep_evidence(line)
+            key = (
+                f"{path}\0{line_number}"
+                if line_number is not None
+                else str(line)
+            )
             if key not in seen_in_strategy:
                 seen_in_strategy.add(key)
                 unique.append(line)

--- a/skylos/core/grep_verify_python_strategy.py
+++ b/skylos/core/grep_verify_python_strategy.py
@@ -5,6 +5,9 @@ import re
 from skylos.core.grep_verify_common import (
     _deduplicate_grep_results,
     _filter_other_owner_same_method_calls,
+    _grep_line_content,
+    _grep_line_number,
+    _grep_line_path,
     _is_python_source_reference,
     _run_grep,
     filter_grep_results,
@@ -59,11 +62,10 @@ def _parameter_contract_search(
         line_value = finding.get("line", 0)
         line_num = int(line_value) if isinstance(line_value, (int, float)) else 0
         for ref in signature_refs:
-            parts = ref.split(":", 2)
-            if len(parts) < 2 or not parts[1].isdigit():
+            match_file = _grep_line_path(ref)
+            match_line = _grep_line_number(ref)
+            if not match_file or match_line is None:
                 continue
-            match_file = parts[0]
-            match_line = int(parts[1])
             if match_file == file_path and abs(match_line - line_num) <= 3:
                 continue
             override_refs.append(ref)
@@ -396,7 +398,7 @@ def multi_strategy_search(
                 ]
                 api_refs = []
                 for ref in doc_refs:
-                    ref_path = ref.split(":", 1)[0].replace("\\", "/").lower()
+                    ref_path = _grep_line_path(ref).replace("\\", "/").lower()
                     in_docs_dir = (
                         ref_path.startswith("docs/")
                         or ref_path.startswith("doc/")
@@ -426,10 +428,7 @@ def multi_strategy_search(
                 if class_refs:
                     usage_lines = []
                     for cr in class_refs:
-                        if ":" in cr:
-                            line_text = cr.split(":", 2)[-1]
-                        else:
-                            line_text = cr
+                        line_text = _grep_line_content(cr)
                         if re.search(
                             rf"^\s*class\s+{re.escape(class_name)}", line_text
                         ):

--- a/skylos/llm/verify_orchestrator.py
+++ b/skylos/llm/verify_orchestrator.py
@@ -71,6 +71,10 @@ from skylos.core.grep_verify import (
     parameter_owner_name as _parameter_owner_name,
     detect_language as _detect_language,
 )
+from skylos.core.grep_verify_common import (
+    _grep_line_number,
+    _grep_line_path,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -333,14 +337,10 @@ def _find_git_root(path: Path) -> Path | None:
 
 def _read_context_around_match(grep_line: str, context_lines: int = 8) -> str | None:
     try:
-        parts = grep_line.split(":")
-        if len(parts) < 2:
+        file_path = _grep_line_path(grep_line)
+        line_num = _grep_line_number(grep_line)
+        if not file_path or line_num is None:
             return None
-        file_path = parts[0]
-        line_str = parts[1].strip()
-        if not line_str.isdigit():
-            return None
-        line_num = int(line_str)
 
         with open(file_path, "r", errors="replace") as f:
             all_lines = f.readlines()
@@ -367,7 +367,7 @@ def _enrich_search_results(
 ) -> dict[str, str]:
     enriched = {}
     total_contexts = 0
-    seen_file_lines: set[str] = set()  # cross-strategy dedup
+    seen_file_lines: set[object] = set()  # cross-strategy dedup
 
     enrich_strategies = [
         "references",
@@ -400,11 +400,13 @@ def _enrich_search_results(
         for line in lines[:2]:
             if total_contexts >= max_contexts:
                 break
-            parts = line.split(":", 2)
-            if len(parts) >= 2 and parts[1].strip().isdigit():
-                key = f"{parts[0]}:{parts[1]}"
-            else:
-                key = line
+            file_path = _grep_line_path(line)
+            line_number = _grep_line_number(line)
+            key = (
+                (file_path, line_number)
+                if file_path and line_number is not None
+                else line
+            )
             if key in seen_file_lines:
                 continue
             seen_file_lines.add(key)
@@ -492,7 +494,7 @@ def _find_parent_class_info_ts(
         )
         if parent_class_refs:
             for ref in parent_class_refs:
-                parent_file = ref.split(":")[0]
+                parent_file = _grep_line_path(ref)
                 method_in_parent = _run_grep(
                     rf"(?:public|protected|private)?\s*(?:async\s+)?{re.escape(simple_name)}\s*[\(<]",
                     parent_file,
@@ -522,7 +524,7 @@ def _find_parent_class_info_ts(
                 )
                 if dts_refs:
                     for ref in dts_refs:
-                        dts_file = ref.split(":")[0]
+                        dts_file = _grep_line_path(ref)
                         method_in_dts = _run_grep(
                             rf"{re.escape(simple_name)}\s*[\(<]",
                             dts_file,
@@ -726,7 +728,7 @@ def _find_parent_class_info(
             )
             if parent_method_refs:
                 for ref in parent_method_refs:
-                    parent_file = ref.split(":")[0]
+                    parent_file = _grep_line_path(ref)
                     method_in_parent = _run_grep(
                         rf"def\s+{re.escape(simple_name)}\s*\(",
                         parent_file,
@@ -785,7 +787,7 @@ def _find_parent_class_info(
                         )
                         if parent_method_refs:
                             for pmr in parent_method_refs:
-                                parent_file = pmr.split(":")[0]
+                                parent_file = _grep_line_path(pmr)
                                 class_in_file = _run_grep(
                                     rf"class\s+{re.escape(base_name)}",
                                     parent_file,

--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -8,6 +8,8 @@ import re
 from bisect import bisect_right
 from dataclasses import dataclass
 from hashlib import blake2s
+from html import unescape
+from html.parser import HTMLParser
 from math import log2
 
 try:
@@ -278,11 +280,11 @@ INTEGRITY_FIELD_VALUE_RE = re.compile(
     (?P<field_quote>['"]?)(?:integrity|narhash|contenthash)(?P=field_quote)
     (?![A-Za-z0-9_-])
     (?:
-        \s*[:=]\s*(?P<q>['"])(?P<quoted>[^'"]{16,})(?P=q)
+        \s*(?::=|[:=])\s*(?P<q>['"])(?P<quoted>[^'"]{16,})(?P=q)
         |
-        \s*[:=]\s*(?P<assigned_bare>[^'"\s,}\]]{16,})
+        \s*(?::=|[:=])\s*`(?P<template>(?:\\[^\r\n]|[^`\\\r\n])*)`
         |
-        \s+(?P<bare_q>['"]?)(?P<bare>[^'"\s,}\]]{16,})(?P=bare_q)
+        \s+(?P<bare_q>['"])(?P<bare>[^'"]{16,})(?P=bare_q)
     )
 """
 )
@@ -292,11 +294,26 @@ HASH_FIELD_VALUE_RE = re.compile(
     (?P<field_quote>['"]?)(?:hash|checksum)(?P=field_quote)
     (?![A-Za-z0-9_-])
     (?:
-        \s*[:=]\s*(?P<q>['"])(?P<quoted>[^'"]{16,})(?P=q)
+        \s*(?::=|[:=])\s*(?P<q>['"])(?P<quoted>[^'"]{16,})(?P=q)
         |
-        \s*[:=]\s*(?P<assigned_bare>[^'"\s,}\]]{16,})
+        \s*(?::=|[:=])\s*`(?P<template>(?:\\[^\r\n]|[^`\\\r\n])*)`
     )
 """
+)
+_DOTENV_ASSIGNMENT_RE = re.compile(
+    r"(?i)^[ \t]*(?:export[ \t]+)?"
+    r"(?:'(?P<quoted_field>[A-Za-z_][A-Za-z0-9_.-]*)'|"
+    r"(?P<field>[A-Za-z_][A-Za-z0-9_.-]*))[ \t]*="
+    r"[ \t]*(?P<value>[^\r\n]*)$"
+)
+_INI_CHECKSUM_VALUE_RE = re.compile(
+    r"(?i)^[ \t]*(?P<field>integrity|narhash|contenthash|hash|checksum)"
+    r"[ \t]*[:=][ \t]*(?P<value>[^'\"\r\n][^\r\n]*?)"
+    r"(?:[ \t]+[;#][^\r\n]*)?$"
+)
+_INI_OPTION_RE = re.compile(r"^[ \t]*(?P<key>[^:=\s][^:=]*?)[ \t]*(?P<delimiter>[:=])")
+_CHECKSUM_FIELD_NAMES = frozenset(
+    {"integrity", "narhash", "contenthash", "hash", "checksum"}
 )
 YAML_DECORATED_VALUE_RE = re.compile(
     r"(?<!\S)(?:(?:&[A-Za-z0-9_-]+|!!?[A-Za-z0-9_:/.-]+)\s+)+"
@@ -309,9 +326,6 @@ SRI_CANDIDATE_RE = re.compile(
     r"(?i)(?<![A-Za-z0-9+/_-])"
     r"(?P<token>sha(?:1|224|256|384|512)-[A-Za-z0-9+/_-]+={0,2})"
     r"(?![A-Za-z0-9+/_-])"
-)
-HTML_INTEGRITY_ATTRIBUTE_RE = re.compile(
-    r"(?i)\bintegrity\s*=\s*(?P<quote>['\"])(?P<value>[^'\"]+)(?P=quote)"
 )
 NPM_SRI_VALUE_RE = re.compile(
     r"^(?P<algorithm>sha(?:256|384|512))-(?P<digest>[A-Za-z0-9+/]+={0,2})$"
@@ -475,8 +489,8 @@ def _decorated_generic_candidates(
 def _integrity_value_group(match):
     if match.group("quoted") is not None:
         return "quoted"
-    if match.group("assigned_bare") is not None:
-        return "assigned_bare"
+    if match.group("template") is not None:
+        return "template"
     return "bare"
 
 
@@ -487,36 +501,107 @@ def _trimmed_match_value(match, group):
     return value, start, start + len(value)
 
 
+def _first_unescaped_js_interpolation(value: str) -> int | None:
+    search_start = 0
+    while True:
+        marker = value.find("${", search_start)
+        if marker < 0:
+            return None
+        backslashes = 0
+        index = marker - 1
+        while index >= 0 and value[index] == "\\":
+            backslashes += 1
+            index -= 1
+        if backslashes % 2 == 0:
+            return marker
+        search_start = marker + 2
+
+
+def _looks_like_secret_template_prefix(value: str) -> bool:
+    if len(value) < 16:
+        return False
+    if any(char in "$+/=" for char in value):
+        return True
+
+    character_classes = []
+    for char in value:
+        if char.islower():
+            character_classes.append("lower")
+        elif char.isupper():
+            character_classes.append("upper")
+        elif char.isdigit():
+            character_classes.append("digit")
+    transitions = sum(
+        left != right
+        for left, right in zip(character_classes, character_classes[1:])
+    )
+    return transitions >= 10
+
+
+def _checksum_match_values(
+    match, group: str, rel_name: str
+) -> tuple[tuple[str, int, int], ...]:
+    value, start, end = _trimmed_match_value(match, group)
+    if group == "template":
+        normalized = rel_name.lower()
+        if normalized.endswith(".go"):
+            return ((value, start, end),) if len(value) >= 16 else ()
+        if not normalized.endswith((*JS_TS_SUFFIXES, ".html", ".htm")):
+            return ()
+        interpolation = _first_unescaped_js_interpolation(value)
+        if interpolation is not None:
+            prefix = value[:interpolation].rstrip()
+            if not _looks_like_secret_template_prefix(prefix):
+                return ()
+            return ((prefix, start, start + len(prefix)),)
+        return ((value, start, end),) if len(value) >= 16 else ()
+    return ((value, start, end),)
+
+
 def _integrity_field_candidates(
-    line_content: str, keyed_spans, context_spans, approved_spans
+    line_content: str,
+    keyed_spans,
+    context_spans,
+    approved_spans,
+    *,
+    rel_name: str,
 ):
     candidates = []
     value_spans = []
     for match in INTEGRITY_FIELD_VALUE_RE.finditer(line_content):
-        value, start, end = _trimmed_match_value(match, _integrity_value_group(match))
-        value_spans.append((start, end))
-        if _is_covered_by_span(
-            value, start, keyed_spans, context_spans, approved_spans
-        ):
-            continue
-        candidates.append((start, 1, value, False, end))
+        group = _integrity_value_group(match)
+        for value, start, end in _checksum_match_values(match, group, rel_name):
+            value_spans.append((start, end))
+            if _is_covered_by_span(
+                value, start, keyed_spans, context_spans, approved_spans
+            ):
+                continue
+            candidates.append((start, 1, value, False, end))
     return candidates, value_spans
 
 
 def _hash_field_candidates(
-    line_content: str, keyed_spans, context_spans, approved_spans
+    line_content: str,
+    keyed_spans,
+    context_spans,
+    approved_spans,
+    *,
+    rel_name: str,
 ):
     candidates = []
     value_spans = []
     for match in HASH_FIELD_VALUE_RE.finditer(line_content):
-        group = "quoted" if match.group("quoted") is not None else "assigned_bare"
-        value, start, end = _trimmed_match_value(match, group)
-        value_spans.append((start, end))
-        if _is_conventional_lowercase_hash(value) or _is_covered_by_span(
-            value, start, keyed_spans, context_spans, approved_spans
-        ):
-            continue
-        candidates.append((start, 1, value, False, end))
+        if match.group("quoted") is not None:
+            group = "quoted"
+        else:
+            group = "template"
+        for value, start, end in _checksum_match_values(match, group, rel_name):
+            value_spans.append((start, end))
+            if _is_conventional_lowercase_hash(value) or _is_covered_by_span(
+                value, start, keyed_spans, context_spans, approved_spans
+            ):
+                continue
+            candidates.append((start, 1, value, False, end))
     return candidates, value_spans
 
 
@@ -558,7 +643,21 @@ def _find_generic_values(
     *,
     approved_structural_spans: tuple[tuple[int, int], ...],
     structural_contexts: tuple[tuple[int, int, str, str], ...],
+    rel_name: str,
 ):
+    if rel_name == "yarn.lock":
+        yarn_match = YARN_INTEGRITY_RE.fullmatch(line_content)
+        if yarn_match is not None:
+            value = yarn_match.group("value")
+            structural_contexts = (
+                *structural_contexts,
+                (
+                    yarn_match.start("value"),
+                    yarn_match.end("value"),
+                    value,
+                    value,
+                ),
+            )
     approved_spans = _merge_spans(approved_structural_spans)
     context_spans = _merge_spans(
         (start, end) for start, end, _, _ in structural_contexts
@@ -573,10 +672,18 @@ def _find_generic_values(
         line_content, keyed_spans, context_spans, approved_spans
     )
     integrity, field_spans = _integrity_field_candidates(
-        line_content, keyed_spans, context_spans, approved_spans
+        line_content,
+        keyed_spans,
+        context_spans,
+        approved_spans,
+        rel_name=rel_name,
     )
     hashes, hash_spans = _hash_field_candidates(
-        line_content, keyed_spans, context_spans, approved_spans
+        line_content,
+        keyed_spans,
+        context_spans,
+        approved_spans,
+        rel_name=rel_name,
     )
     candidates.extend((*decorated, *integrity, *hashes))
     integrity_spans.extend((*decorated_spans, *field_spans, *hash_spans))
@@ -731,10 +838,18 @@ _MAX_JSON_DEPTH = 256
 _MAX_JSON_NODES = 500_000
 _MAX_JSON_CAPTURED_STRINGS = 100_000
 _MAX_PNPM_YAML_NODES = 500_000
+_MAX_GENERIC_YAML_EVENTS = 500_000
+_MAX_GENERIC_YAML_NODES = 500_000
 _MAX_YARN_ENTRIES = 100_000
 _MAX_YARN_HEADER_LENGTH = 65_536
 _MAX_YARN_SELECTORS = 4_096
 _MAX_YARN_ENTRY_DEPENDENCIES = 100_000
+
+
+class _SecretContextLimit(ValueError):
+    def __init__(self, message: str, line: int):
+        super().__init__(message)
+        self.line = max(1, line)
 
 
 class _JsonSpanParser:
@@ -1583,8 +1698,15 @@ def _yaml_scalar_content_span(source: str, event):
     start = event.start_mark.index
     end = event.end_mark.index
     if event.style in {'"', "'"}:
-        start += 1
+        quote_offset = source.find(event.style, start, end)
+        if quote_offset < 0:
+            return None
+        start = quote_offset + 1
         end -= 1
+    elif source.startswith(event.value, end - len(event.value), end):
+        # Event start marks include an optional tag/anchor prefix. Anchor
+        # aliases should report the scalar itself, not the `&name` marker.
+        start = end - len(event.value)
     if start > end:
         return None
     return start, end
@@ -1759,23 +1881,513 @@ def _pnpm_integrity_spans(file_lines: list[str]):
     return _finish_pnpm_spans(source, document, scalar_spans)
 
 
+def _yaml_checksum_kind(key):
+    if not isinstance(key, str):
+        return None
+    normalized = key.lower()
+    if normalized in {"hash", "checksum"}:
+        return "hash"
+    if normalized in _CHECKSUM_FIELD_NAMES:
+        return "integrity"
+    return None
+
+
+class _YamlChecksumCollector:
+    def __init__(self, source: str, scalar_spans):
+        self.source = source
+        self.scalar_spans = scalar_spans
+        self.stack = []
+        self.scalar_anchors = {}
+        self.event_count = 0
+        self.node_count = 0
+
+    def collect(self, loader):
+        for event in yaml.parse(self.source, Loader=loader):
+            self._handle_event(event)
+
+    @staticmethod
+    def _event_line(event) -> int:
+        return getattr(getattr(event, "start_mark", None), "line", 0) + 1
+
+    def _count_event(self, event) -> int:
+        self.event_count += 1
+        event_line = self._event_line(event)
+        if self.event_count > _MAX_GENERIC_YAML_EVENTS:
+            raise _SecretContextLimit("YAML event limit exceeded", event_line)
+        return event_line
+
+    def _count_node(self, event_line: int):
+        self.node_count += 1
+        if self.node_count > _MAX_GENERIC_YAML_NODES:
+            raise _SecretContextLimit("YAML node limit exceeded", event_line)
+
+    def _start_document(self):
+        if self.stack:
+            raise ValueError("nested YAML document")
+        self.scalar_anchors.clear()
+
+    def _end_document(self):
+        if self.stack:
+            raise ValueError("incomplete YAML document")
+
+    def _consume_parent_collection(self):
+        if not self.stack or not self.stack[-1][0]:
+            return
+        parent = self.stack[-1]
+        parent[1] = not parent[1]
+        parent[2] = None
+
+    def _start_collection(self, event, event_line: int):
+        self._count_node(event_line)
+        self._consume_parent_collection()
+        is_mapping = isinstance(event, yaml.events.MappingStartEvent)
+        self.stack.append([is_mapping, True, None])
+
+    def _end_collection(self, event):
+        expected_mapping = isinstance(event, yaml.events.MappingEndEvent)
+        if not self.stack or self.stack[-1][0] != expected_mapping:
+            raise ValueError("unexpected YAML collection end")
+        self.stack.pop()
+
+    def _consume_mapping_scalar(self, value):
+        if not self.stack or not self.stack[-1][0]:
+            return None
+        parent = self.stack[-1]
+        if parent[1]:
+            parent[1] = False
+            parent[2] = value
+            return None
+        kind = _yaml_checksum_kind(parent[2])
+        parent[1] = True
+        parent[2] = None
+        return kind
+
+    def _capture(self, kind, value, span, event_line: int):
+        if kind is None or span is None:
+            return
+        if len(self.scalar_spans) >= _MAX_JSON_CAPTURED_STRINGS:
+            raise _SecretContextLimit("YAML capture limit exceeded", event_line)
+        self.scalar_spans.append((kind, value, *span))
+
+    def _handle_scalar(self, event, event_line: int):
+        self._count_node(event_line)
+        span = _yaml_scalar_content_span(self.source, event)
+        if event.anchor is not None and span is not None:
+            self.scalar_anchors[event.anchor] = (event.value, *span)
+        kind = self._consume_mapping_scalar(event.value)
+        self._capture(kind, event.value, span, event_line)
+
+    def _handle_alias(self, event, event_line: int):
+        self._count_node(event_line)
+        anchored = self.scalar_anchors.get(event.anchor)
+        value = anchored[0] if anchored is not None else None
+        kind = self._consume_mapping_scalar(value)
+        self._capture(kind, value, anchored[1:] if anchored else None, event_line)
+
+    def _handle_event(self, event):
+        event_line = self._count_event(event)
+        if isinstance(event, yaml.events.DocumentStartEvent):
+            self._start_document()
+        elif isinstance(event, yaml.events.DocumentEndEvent):
+            self._end_document()
+        elif isinstance(
+            event, (yaml.events.StreamStartEvent, yaml.events.StreamEndEvent)
+        ):
+            return
+        elif isinstance(
+            event, (yaml.events.MappingStartEvent, yaml.events.SequenceStartEvent)
+        ):
+            self._start_collection(event, event_line)
+        elif isinstance(
+            event, (yaml.events.MappingEndEvent, yaml.events.SequenceEndEvent)
+        ):
+            self._end_collection(event)
+        elif isinstance(event, yaml.events.ScalarEvent):
+            self._handle_scalar(event, event_line)
+        elif isinstance(event, yaml.events.AliasEvent):
+            self._handle_alias(event, event_line)
+        else:
+            raise ValueError("unsupported YAML event")
+
+
+def _collect_yaml_checksum_spans(source: str, loader, scalar_spans):
+    _YamlChecksumCollector(source, scalar_spans).collect(loader)
+
+
+def _yaml_checksum_context_spans(file_lines: list[str]):
+    if yaml is None:
+        return {}, {}, None
+
+    source = "".join(file_lines)
+    loader = getattr(yaml, "CSafeLoader", None) or yaml.SafeLoader
+    scalar_spans = []
+    incomplete_line = None
+    try:
+        _collect_yaml_checksum_spans(source, loader, scalar_spans)
+    except MemoryError:
+        return {}, {}, 1
+    except _SecretContextLimit as exc:
+        incomplete_line = exc.line
+    except RecursionError:
+        incomplete_line = 1
+    except yaml.YAMLError as exc:
+        incomplete_line = getattr(getattr(exc, "problem_mark", None), "line", 0) + 1
+    except ValueError:
+        incomplete_line = 1
+
+    all_contexts = []
+    single_line_contexts = []
+    for kind, value, start, end in scalar_spans:
+        raw_value = source[start:end]
+        context = (start, end, value)
+        all_contexts.append(context)
+        if "\n" in raw_value or "\r" in raw_value:
+            # Mapping a decoded multiline scalar back to one physical line is
+            # ambiguous for generic entropy. Keep it for decoded provider
+            # signatures, whose location can safely point to the scalar start.
+            continue
+        if kind == "hash" and _is_conventional_lowercase_hash(value.strip()):
+            continue
+        single_line_contexts.append(context)
+    return (
+        _line_contexts(source, single_line_contexts),
+        _line_contexts(source, all_contexts),
+        incomplete_line,
+    )
+
+
+def _line_value_context(line: str, raw_value: str, value_start: int):
+    value = raw_value.strip()
+    if not value or value[0] in {'"', "'"}:
+        return None
+    start = value_start + len(raw_value) - len(raw_value.lstrip())
+    end = start + len(value)
+    return start, end, value, line[start:end]
+
+
+def _trimmed_line_context(match, line: str):
+    return _line_value_context(line, match.group("value"), match.start("value"))
+
+
+def _closing_quote_index(value: str, quote: str, start: int) -> int | None:
+    for index in range(start, len(value)):
+        if value[index] != quote:
+            continue
+        backslashes = 0
+        preceding = index - 1
+        while preceding >= 0 and value[preceding] == "\\":
+            backslashes += 1
+            preceding -= 1
+        if backslashes % 2 == 0:
+            return index
+    return None
+
+
+def _is_dotenv_name(rel_name: str) -> bool:
+    normalized = rel_name.lower()
+    return (
+        normalized == ".env"
+        or normalized.startswith(".env.")
+        or normalized.endswith(".env")
+    )
+
+
+def _dotenv_line_details(line: str):
+    assignment = _DOTENV_ASSIGNMENT_RE.fullmatch(line)
+    if assignment is None:
+        return None, None, None
+
+    field = (assignment.group("quoted_field") or assignment.group("field")).lower()
+    raw_value = assignment.group("value")
+    leading = len(raw_value) - len(raw_value.lstrip())
+    stripped_value = raw_value[leading:]
+    if stripped_value.startswith(("'", '"')):
+        quote = stripped_value[0]
+        if _closing_quote_index(stripped_value, quote, 1) is not None:
+            return None, None, None
+        context = None
+        if field in _CHECKSUM_FIELD_NAMES:
+            quoted_content = stripped_value[1:]
+            context = _line_value_context(
+                line,
+                quoted_content,
+                assignment.start("value") + leading + 1,
+            )
+        return quote, field, context
+
+    comment = re.search(r"[ \t]+#", raw_value)
+    if comment is not None:
+        raw_value = raw_value[: comment.start()]
+    if field not in _CHECKSUM_FIELD_NAMES:
+        return None, None, None
+    return (
+        None,
+        field,
+        _line_value_context(line, raw_value, assignment.start("value")),
+    )
+
+
+class _ChecksumContextAccumulator:
+    def __init__(self):
+        self.generic_by_line = {}
+        self.incomplete_line = None
+
+    def add(self, line_number, field, context):
+        if context is None:
+            return
+        if field in {"hash", "checksum"} and _is_conventional_lowercase_hash(
+            context[2]
+        ):
+            return
+        if len(self.generic_by_line) >= _MAX_JSON_CAPTURED_STRINGS:
+            if self.incomplete_line is None:
+                self.incomplete_line = line_number
+            return
+        self.generic_by_line[line_number] = (context,)
+
+    def result(self):
+        return self.generic_by_line, {}, self.incomplete_line
+
+
+class _DotenvChecksumContexts(_ChecksumContextAccumulator):
+    def __init__(self):
+        super().__init__()
+        self.quote = None
+        self.pending = []
+        self.pending_overflow_line = None
+
+    def consume(self, line_number: int, line: str):
+        if self.quote is None:
+            self._consume_assignment(line_number, line)
+        else:
+            self._consume_quoted_line(line_number, line)
+
+    def _consume_assignment(self, line_number: int, line: str):
+        opened_quote, field, context = _dotenv_line_details(line)
+        if opened_quote is None:
+            self.add(line_number, field, context)
+            return
+        self.quote = opened_quote
+        if context is not None:
+            self.pending.append((line_number, field, context))
+
+    def _consume_quoted_line(self, line_number: int, line: str):
+        if _closing_quote_index(line, self.quote, 0) is not None:
+            self.quote = None
+            self.pending.clear()
+            self.pending_overflow_line = None
+            return
+        _, field, context = _dotenv_line_details(line)
+        if context is None:
+            return
+        if len(self.pending) < _MAX_JSON_CAPTURED_STRINGS:
+            self.pending.append((line_number, field, context))
+        elif self.pending_overflow_line is None:
+            self.pending_overflow_line = line_number
+
+    def finish(self):
+        if self.quote is None:
+            return self.result()
+        for line_number, field, context in self.pending:
+            self.add(line_number, field, context)
+        if self.pending_overflow_line is not None and self.incomplete_line is None:
+            self.incomplete_line = self.pending_overflow_line
+        return self.result()
+
+
+def _dotenv_checksum_contexts(file_lines: list[str]):
+    contexts = _DotenvChecksumContexts()
+    for index, raw_line in enumerate(file_lines):
+        contexts.consume(index + 1, raw_line.rstrip("\r\n"))
+    return contexts.finish()
+
+
+def _ini_checksum_contexts(file_lines: list[str]):
+    contexts = _ChecksumContextAccumulator()
+    option_indent = None
+    for index, raw_line in enumerate(file_lines):
+        line = raw_line.rstrip("\r\n")
+        stripped = line.lstrip(" \t")
+        if not stripped or stripped.startswith(("#", ";")):
+            continue
+        indent = len(line) - len(stripped)
+        if option_indent is not None and indent > option_indent:
+            continue
+        if stripped.startswith("["):
+            option_indent = None
+            continue
+        option = _INI_OPTION_RE.match(line)
+        if option is None:
+            continue
+        option_indent = indent
+        match = _INI_CHECKSUM_VALUE_RE.fullmatch(line)
+        if match is None:
+            continue
+        context = _trimmed_line_context(match, line)
+        contexts.add(index + 1, match.group("field").lower(), context)
+    return contexts.result()
+
+
+def _line_config_checksum_contexts(rel_name: str, file_lines: list[str]):
+    normalized = rel_name.lower()
+    if _is_dotenv_name(normalized):
+        return _dotenv_checksum_contexts(file_lines)
+    if normalized.endswith((".ini", ".cfg", ".conf")):
+        return _ini_checksum_contexts(file_lines)
+    return {}, {}, None
+
+
+def _merge_context_maps(*context_maps):
+    merged = {}
+    for contexts_by_line in context_maps:
+        for line_number, contexts in contexts_by_line.items():
+            merged.setdefault(line_number, []).extend(contexts)
+    return {
+        line_number: tuple(sorted(set(contexts)))
+        for line_number, contexts in merged.items()
+    }
+
+
+def _data_checksum_context_spans(rel_name: str, file_lines: list[str]):
+    normalized = rel_name.lower()
+    if normalized.endswith((".yaml", ".yml")) and normalized != "pnpm-lock.yaml":
+        return _yaml_checksum_context_spans(file_lines)
+    return _line_config_checksum_contexts(normalized, file_lines)
+
+
+def _skip_html_whitespace(raw_tag: str, index: int) -> int:
+    while index < len(raw_tag) and raw_tag[index].isspace():
+        index += 1
+    return index
+
+
+def _html_token_end(raw_tag: str, index: int, forbidden: str) -> int:
+    while (
+        index < len(raw_tag)
+        and not raw_tag[index].isspace()
+        and raw_tag[index] not in forbidden
+    ):
+        index += 1
+    return index
+
+
+def _html_attribute_value_span(raw_tag: str, index: int):
+    length = len(raw_tag)
+    index = _skip_html_whitespace(raw_tag, index)
+    if index >= length or raw_tag[index] != "=":
+        return None
+
+    index = _skip_html_whitespace(raw_tag, index + 1)
+    if index >= length:
+        return None
+    if raw_tag[index] not in {'"', "'"}:
+        value_end = _html_token_end(raw_tag, index, "<=>")
+        return index, value_end, value_end
+
+    value_start = index + 1
+    value_end = raw_tag.find(raw_tag[index], value_start)
+    if value_end < 0:
+        return value_start, length, length
+    return value_start, value_end, value_end + 1
+
+
+def _iter_html_attributes(raw_tag: str):
+    length = len(raw_tag)
+    index = _html_token_end(raw_tag, 1, "/>")
+
+    while index < length:
+        index = _skip_html_whitespace(raw_tag, index)
+        if index >= length or raw_tag[index] in "/>":
+            return
+
+        name_start = index
+        index = _html_token_end(raw_tag, index, "/=>")
+        if index == name_start:
+            index += 1
+            continue
+        name = raw_tag[name_start:index]
+
+        value_span = _html_attribute_value_span(raw_tag, index)
+        if value_span is None:
+            index = _skip_html_whitespace(raw_tag, index)
+            continue
+        value_start, value_end, index = value_span
+        yield name, value_start, value_end
+
+
+class _HtmlIntegrityParser(HTMLParser):
+    def __init__(self, source: str):
+        super().__init__(convert_charrefs=False)
+        self.source = source
+        self.line_starts = [0]
+        # HTMLParser.getpos() advances lines on LF only; bare CR remains part
+        # of the current column even though scan_ctx later treats it as EOL.
+        self.line_starts.extend(match.end() for match in re.finditer("\n", source))
+        self.tag_count = 0
+        self.contexts = []
+
+    def handle_starttag(self, tag, attrs):
+        del tag, attrs
+        self.tag_count += 1
+        line_number, line_offset = self.getpos()
+        if self.tag_count > _MAX_JSON_NODES:
+            raise _SecretContextLimit("HTML tag limit exceeded", line_number)
+        raw_tag = self.get_starttag_text()
+        if not raw_tag:
+            return
+        tag_start = self.line_starts[line_number - 1] + line_offset
+        for name, relative_start, relative_end in _iter_html_attributes(raw_tag):
+            if name.lower() != "integrity":
+                continue
+            start = tag_start + relative_start
+            end = tag_start + relative_end
+            raw_value = self.source[start:end]
+            if "\n" in raw_value or "\r" in raw_value:
+                continue
+            if len(self.contexts) >= _MAX_JSON_CAPTURED_STRINGS:
+                raise _SecretContextLimit(
+                    "HTML integrity capture limit exceeded", line_number
+                )
+            self.contexts.append((start, end, unescape(raw_value)))
+
+
+def _html_integrity_spans(file_lines: list[str]):
+    source = "".join(file_lines)
+    parser = _HtmlIntegrityParser(source)
+    incomplete_line = None
+    try:
+        parser.feed(source)
+        parser.close()
+    except MemoryError:
+        return {}, {}, 1
+    except _SecretContextLimit as exc:
+        incomplete_line = exc.line
+    except (RecursionError, ValueError):
+        incomplete_line = 1
+
+    approved = [
+        (start, end)
+        for start, end, value in parser.contexts
+        if _is_valid_sri_list(value, _is_valid_sri_token)
+    ]
+    return (
+        _line_spans(source, approved),
+        _line_contexts(source, parser.contexts),
+        incomplete_line,
+    )
+
+
 def _lockfile_integrity_spans(rel_name: str, file_lines: list[str]):
     if rel_name.lower().endswith((".html", ".htm")):
-        approved_by_line = {}
-        for line_number, line in enumerate(file_lines, start=1):
-            spans = [
-                (match.start("value"), match.end("value"))
-                for match in HTML_INTEGRITY_ATTRIBUTE_RE.finditer(line)
-                if _is_valid_sri_list(match.group("value"), _is_valid_sri_token)
-            ]
-            if spans:
-                approved_by_line[line_number] = tuple(spans)
-        return approved_by_line, {}
+        return _html_integrity_spans(file_lines)
     if rel_name == "yarn.lock":
-        return _yarn_integrity_spans(file_lines)
+        approved, contexts = _yarn_integrity_spans(file_lines)
+        return approved, contexts, None
     if rel_name == "pnpm-lock.yaml":
-        return _pnpm_integrity_spans(file_lines)
-    return _json_integrity_spans(rel_name, file_lines)
+        approved, contexts = _pnpm_integrity_spans(file_lines)
+        return approved, contexts, None
+    approved, contexts = _json_integrity_spans(rel_name, file_lines)
+    return approved, contexts, None
 
 
 def _docstring_lines(tree):
@@ -2636,6 +3248,27 @@ def _append_client_analysis_incomplete(
     )
 
 
+def _append_secret_context_incomplete(findings, *, rel_path: str, line: int) -> None:
+    findings.append(
+        {
+            "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+            "severity": "HIGH",
+            "kind": "processing_error",
+            "message": (
+                "Secret-field context analysis reached its safety limit; "
+                "later contextual findings may be incomplete."
+            ),
+            "file": rel_path,
+            "line": max(1, line),
+            "col": 0,
+            "metadata": {
+                "analysis_complete": False,
+                "analysis_diagnostics": ["secret_context_limit"],
+            },
+        }
+    )
+
+
 def scan_ctx(
     ctx,
     *,
@@ -2668,8 +3301,29 @@ def scan_ctx(
         client_context_diagnostics,
     ) = _client_exposure_context_with_status(rel_path, file_lines)
     syntax_tree = ctx.get("tree")
-    approved_structural_spans, structural_context_spans = _lockfile_integrity_spans(
-        rel_name, file_lines
+    (
+        approved_structural_spans,
+        structural_context_spans,
+        lock_context_incomplete_line,
+    ) = _lockfile_integrity_spans(rel_name, file_lines)
+    (
+        data_context_spans,
+        data_decoded_context_spans,
+        data_context_incomplete_line,
+    ) = _data_checksum_context_spans(rel_name, file_lines)
+    incomplete_lines = [
+        line
+        for line in (lock_context_incomplete_line, data_context_incomplete_line)
+        if line is not None
+    ]
+    context_incomplete_line = min(incomplete_lines) if incomplete_lines else None
+    decoded_context_spans = _merge_context_maps(
+        structural_context_spans,
+        data_decoded_context_spans,
+    )
+    structural_context_spans = _merge_context_maps(
+        structural_context_spans,
+        data_context_spans,
     )
 
     allowlist_regexes = []
@@ -2684,6 +3338,12 @@ def scan_ctx(
         docstring_lines = _docstring_lines(syntax_tree)
 
     findings = []
+    if context_incomplete_line is not None:
+        _append_secret_context_incomplete(
+            findings,
+            rel_path=rel_path,
+            line=min(context_incomplete_line, max(1, len(file_lines))),
+        )
 
     for line_number, raw_line in enumerate(file_lines, start=1):
         line_content = raw_line.rstrip("\n")
@@ -2740,14 +3400,14 @@ def scan_ctx(
                 findings.append(finding)
 
         decoded_provider_matches = set()
-        structural_contexts = structural_context_spans.get(line_number, ())
+        decoded_contexts = decoded_context_spans.get(line_number, ())
         line_approved_spans = approved_structural_spans.get(line_number, ())
         for (
             context_start,
             context_end,
             decoded_value,
             raw_context,
-        ) in structural_contexts:
+        ) in decoded_contexts:
             if raw_context != decoded_value:
                 for provider_name, pattern_regex in PROVIDER_PATTERNS:
                     raw_provider_tokens = {
@@ -2861,6 +3521,7 @@ def scan_ctx(
                     line_number, ()
                 ),
                 structural_contexts=structural_context_spans.get(line_number, ()),
+                rel_name=rel_name,
             )
             if rel_name.lower().endswith((".html", ".htm", ".css", ".map")):
                 # Client artifacts commonly contain SRI hashes, content hashes,

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3803,6 +3803,278 @@ def test_computed_checksum_field_does_not_hide_real_secret_in_analyzer(tmp_path)
     )
 
 
+def _issue_706_cache_file(root):
+    github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    cache_file = root / ".skylos" / "cache" / "grep_results.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
+        json.dumps(
+            {
+                "version": 1,
+                "entries": {
+                    "stale": {
+                        "results": [f"app.py:1:cached_helper(); token={github_token}"],
+                        "last_access": 1,
+                        "created": 1,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return cache_file
+
+
+def _issue_706_cache_findings(result):
+    return [
+        finding
+        for finding in result.get("secrets", [])
+        if finding.get("file") == ".skylos/cache/grep_results.json"
+    ]
+
+
+def _issue_706_init_ignored_cache_repo(root):
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    (root / ".gitignore").write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
+        ".skylos/\n", encoding="utf-8"
+    )
+
+
+def test_recursive_secret_scan_skips_untracked_generated_grep_cache(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    _issue_706_cache_file(tmp_path)
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result) == []
+
+
+def test_non_git_project_skips_its_generated_grep_cache(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_cache_file(tmp_path)
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result) == []
+
+
+def test_removed_secret_in_grep_evidence_does_not_reappear_from_cache(tmp_path):
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    (tmp_path / "target.py").write_text(
+        "def cached_helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    evidence = tmp_path / "evidence.yaml"
+    evidence.write_text(
+        f"entry: target.py # {github_token}\n",
+        encoding="utf-8",
+    )
+
+    first = json.loads(
+        analyze(
+            str(tmp_path),
+            conf=0,
+            enable_secrets=True,
+            grep_verify=True,
+        )
+    )
+    cache_file = tmp_path / ".skylos" / "cache" / "grep_results.json"
+
+    assert cache_file.exists()
+    assert github_token in cache_file.read_text(encoding="utf-8")
+    assert any(
+        finding.get("file") == "evidence.yaml"
+        and finding.get("provider") == "github"
+        for finding in first.get("secrets", [])
+    )
+    assert not any(
+        finding.get("full_name") == "target.cached_helper"
+        for finding in first.get("unused_functions", [])
+    )
+
+    evidence.write_text("entry: target.py\n", encoding="utf-8")
+    second = json.loads(
+        analyze(
+            str(tmp_path),
+            conf=0,
+            enable_secrets=True,
+            grep_verify=True,
+        )
+    )
+
+    assert github_token in cache_file.read_text(encoding="utf-8")
+    assert _issue_706_cache_findings(second) == []
+    assert second.get("secrets", []) == []
+    assert not any(
+        finding.get("full_name") == "target.cached_helper"
+        for finding in second.get("unused_functions", [])
+    )
+
+
+def test_recursive_secret_scan_keeps_tracked_grep_cache_visible(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    cache_file = _issue_706_cache_file(tmp_path)
+    subprocess.run(
+        ["git", "add", "-f", "--", ".skylos/cache/grep_results.json"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    cache_findings = _issue_706_cache_findings(result)
+    assert cache_findings
+    assert any(finding.get("provider") == "github" for finding in cache_findings)
+    assert cache_file.exists()
+
+
+def test_nested_git_repo_uses_its_own_tracked_cache_state(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(nested)
+    _issue_706_cache_file(nested)
+    subprocess.run(
+        ["git", "add", "-f", "--", ".skylos/cache/grep_results.json"],
+        cwd=nested,
+        check=True,
+    )
+
+    result = json.loads(
+        analyze(str(nested), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result)
+
+
+def test_generated_grep_cache_git_probe_failure_scans_fail_closed(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_cache_file(tmp_path)
+    monkeypatch.setattr("skylos.analyzer._git_tracking_status", lambda _path: None)
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result)
+
+
+@pytest.mark.parametrize("target_kind", ["file", "cache_dir", "cache_root"])
+def test_explicit_generated_grep_cache_scan_is_not_suppressed(tmp_path, target_kind):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    cache_file = _issue_706_cache_file(tmp_path)
+    targets = {
+        "file": cache_file,
+        "cache_dir": cache_file.parent,
+        "cache_root": cache_file.parent.parent,
+    }
+
+    result = json.loads(
+        analyze(str(targets[target_kind]), enable_secrets=True, grep_verify=False)
+    )
+
+    assert any(
+        finding.get("provider") == "github"
+        for finding in result.get("secrets", [])
+    )
+
+
+def test_changed_files_explicitly_selected_grep_cache_is_scanned(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    cache_file = _issue_706_cache_file(tmp_path)
+
+    result = json.loads(
+        analyze(
+            str(tmp_path),
+            enable_secrets=True,
+            grep_verify=False,
+            changed_files={str(cache_file)},
+        )
+    )
+
+    assert _issue_706_cache_findings(result)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        ".skylos/cache/other.json",
+        "src/.skylos/cache/grep_results.json",
+    ],
+)
+def test_grep_cache_lookalike_paths_remain_scannable(tmp_path, relative_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    lookalike = tmp_path / relative_path
+    lookalike.parent.mkdir(parents=True, exist_ok=True)
+    lookalike.write_text(  # skylos: ignore[SKY-D215,SKY-D324] literal pytest parametrization under tmp_path
+        json.dumps({"token": github_token}), encoding="utf-8"
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert any(
+        finding.get("file") == relative_path
+        and finding.get("provider") == "github"
+        for finding in result.get("secrets", [])
+    )
+
+
+@pytest.mark.parametrize(
+    "returncode,expected",
+    [(0, True), (1, False), (2, None)],
+)
+def test_generated_grep_cache_tracking_status_is_fail_closed(
+    tmp_path, returncode, expected
+):
+    from skylos.analyzer import _git_tracking_status
+
+    (tmp_path / ".git").mkdir()
+    candidate = tmp_path / ".skylos" / "cache" / "grep_results.json"
+    with patch(
+        "skylos.analyzer.subprocess.run",
+        return_value=subprocess.CompletedProcess([], returncode),
+    ) as git_run:
+        actual = _git_tracking_status(candidate)
+
+    assert actual is expected
+    assert git_run.call_args.args[0] == [
+        "git",
+        "ls-files",
+        "--error-unmatch",
+        "--",
+        ".skylos/cache/grep_results.json",
+    ]
+
+
+def test_generated_grep_cache_tracking_timeout_is_unknown(tmp_path):
+    from skylos.analyzer import _git_tracking_status
+
+    (tmp_path / ".git").mkdir()
+    candidate = tmp_path / ".skylos" / "cache" / "grep_results.json"
+    with patch(
+        "skylos.analyzer.subprocess.run",
+        side_effect=subprocess.TimeoutExpired("git", 5),
+    ):
+        assert _git_tracking_status(candidate) is None
+
+
 _ISSUE_693_UV_LOCK = """\
 version = 1
 revision = 1

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3780,6 +3780,29 @@ def test_changed_files_scans_dotenv_for_secrets(tmp_path):
     assert ".env" in scanned
 
 
+def test_computed_checksum_field_does_not_hide_real_secret_in_analyzer(tmp_path):
+    github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    (tmp_path / "app.py").write_text(
+        "integrity = sum(len(project.integrity_warnings) "
+        "for project in report.projects)\n"
+        f'checksum = "{github_token}"\n',
+        encoding="utf-8",
+    )
+
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
+    findings = [
+        finding
+        for finding in result.get("secrets", [])
+        if finding.get("rule_id") == "SKY-S101" and finding.get("file") == "app.py"
+    ]
+
+    assert not any(finding.get("line") == 1 for finding in findings)
+    assert any(
+        finding.get("line") == 2 and finding.get("provider") == "github"
+        for finding in findings
+    )
+
+
 _ISSUE_693_UV_LOCK = """\
 version = 1
 revision = 1

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3863,7 +3863,7 @@ def test_non_git_project_skips_its_generated_grep_cache(tmp_path):
     assert _issue_706_cache_findings(result) == []
 
 
-def test_removed_secret_in_grep_evidence_does_not_reappear_from_cache(tmp_path):
+def test_grep_evidence_with_secret_is_not_persisted_in_project(tmp_path):
     _issue_706_init_ignored_cache_repo(tmp_path)
     github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
     (tmp_path / "target.py").write_text(
@@ -3886,8 +3886,7 @@ def test_removed_secret_in_grep_evidence_does_not_reappear_from_cache(tmp_path):
     )
     cache_file = tmp_path / ".skylos" / "cache" / "grep_results.json"
 
-    assert cache_file.exists()
-    assert github_token in cache_file.read_text(encoding="utf-8")
+    assert list(cache_file.parent.glob(cache_file.name)) == []
     assert any(
         finding.get("file") == "evidence.yaml"
         and finding.get("provider") == "github"
@@ -3908,7 +3907,7 @@ def test_removed_secret_in_grep_evidence_does_not_reappear_from_cache(tmp_path):
         )
     )
 
-    assert github_token in cache_file.read_text(encoding="utf-8")
+    assert list(cache_file.parent.glob(cache_file.name)) == []
     assert _issue_706_cache_findings(second) == []
     assert second.get("secrets", []) == []
     assert not any(

--- a/test/test_grep_cache.py
+++ b/test/test_grep_cache.py
@@ -9,7 +9,7 @@ from skylos.core.grep_cache import (
     CACHE_DIR,
     CACHE_FILE,
     MAX_ENTRIES,
-    MAX_CACHE_BYTES,
+    MAX_RESULT_CHARS,
     GrepCache,
     _make_key,
     file_content_hash,
@@ -165,6 +165,35 @@ class TestEviction:
             cache.put(f"k{i}", [])
         assert cache.size == 10
 
+    def test_oversized_result_is_not_cached(self) -> None:
+        cache = GrepCache()
+
+        cache.put("large", ["x" * (MAX_RESULT_CHARS + 1)])
+
+        assert cache.get("large") is None
+
+    def test_total_result_size_evicts_oldest_entry(self) -> None:
+        cache = GrepCache()
+        chunk = "x" * (MAX_RESULT_CHARS // 2 + 1)
+        cache.put("old", [chunk])
+
+        cache.put("new", [chunk])
+
+        assert cache.get("old") is None
+        assert cache.get("new") == [chunk]
+
+    def test_cached_results_do_not_share_mutable_lists(self) -> None:
+        cache = GrepCache()
+        original = ["one"]
+        cache.put("key", original)
+        original.append("two")
+
+        loaded = cache.get("key")
+        assert loaded == ["one"]
+        assert loaded is not None
+        loaded.append("three")
+        assert cache.get("key") == ["one"]
+
 
 class TestInvalidateByHash:
     def test_removes_matching_entries(self) -> None:
@@ -221,75 +250,120 @@ class TestSize:
         assert cache.size == 1
 
 
-class TestLoadSave:
-    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+class TestDiskPersistenceDisabled:
+    def test_load_binds_stable_process_local_namespace(self, tmp_path: Path) -> None:
         cache = GrepCache()
-        cache.put("k1", ["r1", "r2"])
-        cache.put("k2", ["r3"])
-        cache.save(tmp_path)
-
-        cache2 = GrepCache()
-        cache2.load(tmp_path)
-        assert cache2.get("k1") == ["r1", "r2"]
-        assert cache2.get("k2") == ["r3"]
-        assert cache2.size == 2
-
-    def test_save_creates_directory(self, tmp_path: Path) -> None:
-        cache = GrepCache()
-        cache.put("k", ["v"])
-        cache.save(tmp_path)
-        assert (tmp_path / CACHE_DIR / CACHE_FILE).exists()
-
-    def test_save_skips_when_not_dirty(self, tmp_path: Path) -> None:
-        cache = GrepCache()
-        cache.put("k", ["v"])
-        cache.save(tmp_path)
-        path = tmp_path / CACHE_DIR / CACHE_FILE
-        path.write_text('{"version": 1, "entries": {}}')
-        cache.save(tmp_path)
-        data = json.loads(path.read_text())
-        assert data["entries"] == {}
-
-    def test_load_nonexistent_file(self, tmp_path: Path) -> None:
-        cache = GrepCache()
-        # should not raise
         cache.load(tmp_path)
-        assert cache.size == 0
+        first = cache.repository_fingerprint
+        cache.load(tmp_path)
 
-    def test_load_corrupt_json(self, tmp_path: Path) -> None:
+        assert isinstance(first, str)
+        assert len(first) == 20
+        assert cache.repository_fingerprint == first
+
+    def test_load_does_not_hash_repository_evidence(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        def reject_fingerprint(*_args, **_kwargs):
+            raise AssertionError("process-local cache must not hash the repository")
+
+        monkeypatch.setattr(
+            "skylos.core.grep_cache.repository_evidence_fingerprint",
+            reject_fingerprint,
+        )
+
+        cache = GrepCache()
+        cache.load(tmp_path)
+
+        assert len(cache.repository_fingerprint or "") == 20
+
+    def test_switching_repository_clears_process_local_entries(
+        self, tmp_path: Path
+    ) -> None:
+        first_root = tmp_path / "first"
+        second_root = tmp_path / "second"
+        first_root.mkdir()
+        second_root.mkdir()
+        cache = GrepCache()
+        cache.load(first_root)
+        first_namespace = cache.repository_fingerprint
+        cache.put("local", ["main.py:1:helper()"])
+
+        cache.load(second_root)
+
+        assert cache.get("local") is None
+        assert cache.repository_fingerprint != first_namespace
+
+    def test_failed_repository_bind_clears_process_local_entries(
+        self, tmp_path: Path
+    ) -> None:
+        cache = GrepCache()
+        cache.load(tmp_path)
+        cache.put("local", ["main.py:1:helper()"])
+
+        cache.load(tmp_path / "missing")
+
+        assert cache.get("local") is None
+        assert cache.repository_fingerprint is None
+
+    def test_load_never_imports_legacy_project_cache(self, tmp_path: Path) -> None:
         path = tmp_path / CACHE_DIR / CACHE_FILE
         path.parent.mkdir(parents=True)
-        path.write_text("NOT VALID JSON!!!")
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "entries": {
+                        "attacker": {"results": ["fake.py:1:helper()"]}
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
         cache = GrepCache()
-        # should not raise
         cache.load(tmp_path)
+
+        assert cache.get("attacker") is None
         assert cache.size == 0
 
-    def test_load_missing_entries_key(self, tmp_path: Path) -> None:
+    def test_load_never_opens_legacy_project_cache(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         path = tmp_path / CACHE_DIR / CACHE_FILE
         path.parent.mkdir(parents=True)
-        path.write_text('{"version": 1}')
-        cache = GrepCache()
-        cache.load(tmp_path)
-        assert cache.size == 0
+        path.write_text('{"entries": {}}', encoding="utf-8")
 
-    def test_save_file_contains_version(self, tmp_path: Path) -> None:
-        cache = GrepCache()
-        cache.put("k", ["v"])
-        cache.save(tmp_path)
-        data = json.loads((tmp_path / CACHE_DIR / CACHE_FILE).read_text())
-        assert data["version"] == 1
+        def reject_disk_open(*args, **kwargs):
+            raise AssertionError(f"unexpected disk cache read: {args!r} {kwargs!r}")
 
-    def test_load_clears_dirty_flag(self, tmp_path: Path) -> None:
+        monkeypatch.setattr("skylos.core.grep_cache.os.open", reject_disk_open)
+
+        GrepCache().load(tmp_path)
+
+    def test_save_never_creates_project_cache(self, tmp_path: Path) -> None:
         cache = GrepCache()
-        cache.put("k", ["v"])
+        cache.put("maintainer", ["real.py:1:helper()"])
+
         cache.save(tmp_path)
-        cache2 = GrepCache()
-        cache2.load(tmp_path)
-        assert cache2._dirty is False
+
+        assert not (tmp_path / ".skylos").exists()
+        assert cache.get("maintainer") == ["real.py:1:helper()"]
+
+    def test_save_never_overwrites_legacy_project_cache(self, tmp_path: Path) -> None:
+        path = tmp_path / CACHE_DIR / CACHE_FILE
+        path.parent.mkdir(parents=True)
+        original = '{"repository_owned": true}'
+        path.write_text(original, encoding="utf-8")
+        cache = GrepCache()
+        cache.put("maintainer", ["real.py:1:helper()"])
+
+        cache.save(tmp_path)
+
+        assert path.read_text(encoding="utf-8") == original
 
     def test_save_rejects_symlinked_cache_file(self, tmp_path: Path) -> None:
-        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside = tmp_path.parent / f"{tmp_path.name}-outside-file"
         outside.mkdir()
         target = outside / "target.txt"
         target.write_text("DO_NOT_CLOBBER", encoding="utf-8")
@@ -310,7 +384,7 @@ class TestLoadSave:
         assert cache_path.is_symlink()
 
     def test_save_rejects_symlinked_cache_directory(self, tmp_path: Path) -> None:
-        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside = tmp_path.parent / f"{tmp_path.name}-outside-directory"
         outside.mkdir()
         cache_dir = tmp_path / ".skylos" / "cache"
         cache_dir.parent.mkdir()
@@ -328,9 +402,9 @@ class TestLoadSave:
         assert not (outside / CACHE_FILE).exists()
 
     def test_load_rejects_symlinked_cache_file(self, tmp_path: Path) -> None:
-        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside = tmp_path.parent / f"{tmp_path.name}-outside-load"
         outside.mkdir()
-        target = outside / "grep_results.json"
+        target = outside / CACHE_FILE
         target.write_text(
             json.dumps({"version": 1, "entries": {"k": {"results": ["v"]}}}),
             encoding="utf-8",
@@ -348,11 +422,12 @@ class TestLoadSave:
         cache.load(tmp_path)
 
         assert cache.size == 0
+        assert cache.get("k") is None
 
     def test_load_rejects_oversized_cache_file(self, tmp_path: Path) -> None:
         cache_path = tmp_path / CACHE_DIR / CACHE_FILE
         cache_path.parent.mkdir(parents=True)
-        cache_path.write_text(" " * (MAX_CACHE_BYTES + 1), encoding="utf-8")
+        cache_path.write_text(" " * (MAX_RESULT_CHARS + 1), encoding="utf-8")
 
         cache = GrepCache()
         cache.load(tmp_path)
@@ -367,8 +442,8 @@ class TestLoadSave:
                 {
                     "version": 1,
                     "entries": {
-                        "bad": {"results": [1, 2]},
-                        "ok": {"results": ["match"], "last_access": "bad"},
+                        "invalid": {"results": [1, 2]},
+                        "otherwise_valid": {"results": ["match"]},
                     },
                 }
             ),
@@ -378,8 +453,27 @@ class TestLoadSave:
         cache = GrepCache()
         cache.load(tmp_path)
 
-        assert cache.size == 1
-        assert cache.get("ok") == ["match"]
+        assert cache.get("invalid") is None
+        assert cache.get("otherwise_valid") is None
+        assert cache.size == 0
+
+    def test_load_preserves_process_local_entries(self, tmp_path: Path) -> None:
+        cache = GrepCache()
+        cache.put("local", ["main.py:1:helper()"])
+
+        cache.load(tmp_path)
+
+        assert cache.get("local") == ["main.py:1:helper()"]
+
+    def test_entries_are_not_shared_across_instances(self, tmp_path: Path) -> None:
+        cache = GrepCache()
+        cache.put("local", ["main.py:1:helper()"])
+        cache.save(tmp_path)
+
+        loaded = GrepCache()
+        loaded.load(tmp_path)
+
+        assert loaded.get("local") is None
 
 
 class TestCachedSearch:

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1,4 +1,6 @@
+import shutil
 import time
+from collections.abc import Sequence
 from unittest.mock import Mock, patch
 
 from skylos.core.grep_cache import GrepCache
@@ -20,7 +22,9 @@ from skylos.core.grep_verify import (
 from skylos.core.grep_verify_common import (
     GrepRequest,
     _python_regex,
+    _run_grep,
     execute_grep_batch,
+    replay_grep_results,
 )
 
 
@@ -458,6 +462,13 @@ class TestBatchedGrepVerify:
     def test_python_regex_rejects_untranslated_posix_classes(self):
         assert _python_regex("[[:digit:]]+") is None
 
+    def test_python_regex_preserves_ascii_posix_space_semantics(self):
+        regex = _python_regex(r"\.helper[[:space:]]*\(")
+
+        assert regex is not None
+        assert regex.search(".helper \t(") is not None
+        assert regex.search(".helper\N{NO-BREAK SPACE}(") is None
+
     def test_compatible_requests_share_one_ripgrep_process(self):
         common = {
             "project_root": "/repo",
@@ -486,12 +497,9 @@ class TestBatchedGrepVerify:
                 return_value=process_result,
             ) as mock_run,
         ):
-            results, completed = execute_grep_batch(
-                [foo_request, bar_request], deadline=time.monotonic() + 10
-            )
+            results = execute_grep_batch([foo_request, bar_request])
 
         assert mock_run.call_count == 1
-        assert completed == {foo_request, bar_request}
         assert results[foo_request] == (
             "/repo/a.py:3:foo(); bar()",
             "/repo/z.py:2:foo()",
@@ -501,6 +509,188 @@ class TestBatchedGrepVerify:
             "/repo/z.py:9:bar()",
         )
         assert mock_run.call_args.kwargs["input"] == r"\bfoo\b" "\n" r"\bbar\b" "\n"
+
+    def test_non_ascii_and_newline_patterns_run_directly(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        ascii_request = GrepRequest(pattern=r"\bascii\b", **common)
+        unicode_request = GrepRequest(pattern=r"\bकु\b", **common)
+        newline_request = GrepRequest(pattern="first\nsecond", **common)
+        process_result = Mock(
+            returncode=0,
+            stdout="/repo/a.py:1:ascii()\n",
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common.subprocess.run",
+                return_value=process_result,
+            ) as mock_run,
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                side_effect=lambda request: [f"direct:{request.pattern}"],
+            ) as mock_direct,
+        ):
+            results = execute_grep_batch(
+                [ascii_request, unicode_request, newline_request]
+            )
+
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.kwargs["input"] == r"\bascii\b" "\n"
+        assert mock_direct.call_args_list[0].args == (unicode_request,)
+        assert mock_direct.call_args_list[1].args == (newline_request,)
+        assert results[unicode_request] == (r"direct:\bकु\b",)
+        assert results[newline_request] == ("direct:first\nsecond",)
+
+    def test_batch_decode_failure_falls_back_to_legacy_results(self):
+        request = GrepRequest(
+            pattern=r"\bhelper\b",
+            project_root="/repo",
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        decode_error = UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=decode_error,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                return_value=["/repo/main.py:1:helper()"],
+            ) as mock_direct,
+        ):
+            results = execute_grep_batch([request])
+
+        assert results == {request: ("/repo/main.py:1:helper()",)}
+        mock_direct.assert_called_once_with(request)
+
+    def test_no_ripgrep_uses_legacy_requests(self):
+        request = GrepRequest(
+            pattern="helper",
+            project_root="/repo",
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=5,
+        )
+
+        with (
+            patch("skylos.core.grep_verify_common.shutil.which", return_value=None),
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                return_value=["/repo/main.py:1:helper()"],
+            ) as mock_direct,
+        ):
+            results = execute_grep_batch([request])
+
+        assert results == {request: ("/repo/main.py:1:helper()",)}
+        mock_direct.assert_called_once_with(request)
+
+    def test_replay_miss_executes_legacy_request(self):
+        with (
+            replay_grep_results({}),
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                return_value=["/repo/main.py:1:helper()"],
+            ) as mock_direct,
+        ):
+            results = _run_grep(
+                "helper",
+                "/repo",
+                include_globs=["*.py"],
+                fixed_string=True,
+                max_results=5,
+            )
+
+        assert results == ["/repo/main.py:1:helper()"]
+        mock_direct.assert_called_once()
+
+    def test_non_utf8_matching_line_does_not_abort_verification(self, tmp_path):
+        assert shutil.which("rg") is not None
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        (tmp_path / "invalid.py").write_bytes(b"helper()  # \xe9\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+
+        batched = grep_verify_findings([finding], str(tmp_path))
+        legacy = grep_verify_findings([finding], str(tmp_path), parallel=True)
+
+        assert batched == legacy == {}
+
+    def test_sorted_over_cap_definitions_do_not_hide_late_usage(self, tmp_path):
+        for index in range(30):
+            (tmp_path / f"a{index:02}.py").write_text(
+                "def helper():\n    return None\n"
+            )
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        (tmp_path / "z_usage.py").write_text("helper()\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+
+        verdicts = grep_verify_findings([finding], str(tmp_path))
+
+        assert set(verdicts) == {"library.helper"}
+
+    def test_started_finding_batch_completes_after_deadline(self, tmp_path):
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        (tmp_path / "main.py").write_text("helper()\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+
+        def slow_batch(
+            requests: Sequence[GrepRequest],
+        ) -> dict[GrepRequest, tuple[str, ...]]:
+            time.sleep(0.02)
+            return execute_grep_batch(requests)
+
+        with patch(
+            "skylos.core.grep_verify.execute_grep_batch", side_effect=slow_batch
+        ):
+            verdicts = grep_verify_findings([finding], str(tmp_path), time_budget=0.01)
+
+        assert set(verdicts) == {"library.helper"}
 
     def test_batched_and_legacy_verdicts_match(self, tmp_path):
         library = tmp_path / "library.py"

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1,8 +1,10 @@
-from unittest.mock import patch
+import time
+from unittest.mock import Mock, patch
 
 from skylos.core.grep_cache import GrepCache
 from skylos.core.grep_verify import (
     GrepStrategy,
+    _deterministic_suppress_multilang,
     detect_language,
     filter_grep_results,
     grep_verify_findings,
@@ -14,7 +16,11 @@ from skylos.core.grep_verify import (
     parameter_owner_name,
     repo_relative_path,
     source_globs_for_language,
-    _deterministic_suppress_multilang,
+)
+from skylos.core.grep_verify_common import (
+    GrepRequest,
+    _python_regex,
+    execute_grep_batch,
 )
 
 
@@ -433,12 +439,122 @@ class TestGrepVerifyFindings:
         cache = GrepCache()
 
         with patch(
-            "skylos.core.grep_verify._cached_group_results", return_value={}
-        ) as mock_cached_group:
+            "skylos.core.grep_verify._load_cached_group_results", return_value={}
+        ) as mock_cache_load:
             grep_verify_findings([finding], str(tmp_path), cache=cache)
 
-        assert mock_cached_group.call_args.args[0] is cache
-        assert mock_cached_group.call_args.args[1] == "serial_typescript"
+        assert mock_cache_load.call_args.args[0] is cache
+        assert mock_cache_load.call_args.args[1] == "serial_typescript"
+
+
+class TestBatchedGrepVerify:
+    def test_python_regex_preserves_ascii_posix_alnum_semantics(self):
+        regex = _python_regex(r"\.[[:alnum:]_]+")
+
+        assert regex is not None
+        assert regex.search(".ascii_name") is not None
+        assert regex.fullmatch(".café") is None
+
+    def test_python_regex_rejects_untranslated_posix_classes(self):
+        assert _python_regex("[[:digit:]]+") is None
+
+    def test_compatible_requests_share_one_ripgrep_process(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        foo_request = GrepRequest(pattern=r"\bfoo\b", **common)
+        bar_request = GrepRequest(pattern=r"\bbar\b", **common)
+        process_result = Mock(
+            returncode=0,
+            stdout=(
+                "/repo/z.py:9:bar()\n/repo/z.py:2:foo()\n/repo/a.py:3:foo(); bar()\n"
+            ),
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common.subprocess.run",
+                return_value=process_result,
+            ) as mock_run,
+        ):
+            results, completed = execute_grep_batch(
+                [foo_request, bar_request], deadline=time.monotonic() + 10
+            )
+
+        assert mock_run.call_count == 1
+        assert completed == {foo_request, bar_request}
+        assert results[foo_request] == (
+            "/repo/a.py:3:foo(); bar()",
+            "/repo/z.py:2:foo()",
+        )
+        assert results[bar_request] == (
+            "/repo/a.py:3:foo(); bar()",
+            "/repo/z.py:9:bar()",
+        )
+        assert mock_run.call_args.kwargs["input"] == r"\bfoo\b" "\n" r"\bbar\b" "\n"
+
+    def test_batched_and_legacy_verdicts_match(self, tmp_path):
+        library = tmp_path / "library.py"
+        library.write_text(
+            "def helper():\n    return 1\n\ndef orphan():\n    return 2\n"
+        )
+        (tmp_path / "main.py").write_text("from library import helper\nhelper()\n")
+        findings = [
+            {
+                "name": name,
+                "full_name": f"library.{name}",
+                "simple_name": name,
+                "type": "function",
+                "file": str(library),
+                "line": line,
+                "confidence": 80,
+            }
+            for name, line in (("helper", 1), ("orphan", 4))
+        ]
+
+        batched = grep_verify_findings(findings, str(tmp_path))
+        legacy = grep_verify_findings(
+            findings, str(tmp_path), parallel=True, max_workers=2
+        )
+
+        assert set(batched) == set(legacy) == {"library.helper"}
+        assert (
+            batched["library.helper"].suppression_code
+            == legacy["library.helper"].suppression_code
+        )
+
+    def test_warm_cache_skips_batch_execution(self, tmp_path):
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        (tmp_path / "main.py").write_text("from library import helper\nhelper()\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+        cache = GrepCache()
+
+        with patch(
+            "skylos.core.grep_verify.execute_grep_batch", wraps=execute_grep_batch
+        ) as mock_batch:
+            first = grep_verify_findings([finding], str(tmp_path), cache=cache)
+            second = grep_verify_findings([finding], str(tmp_path), cache=cache)
+
+        assert set(first) == set(second) == {"library.helper"}
+        assert mock_batch.call_count == 1
 
 
 class TestMethodCallWhitespace:
@@ -508,8 +624,9 @@ class TestAnalyzerIntegration:
         target.write_text("def _cached_helper() -> None:\n    pass\n")
         evidence.write_text("from target import _cached_helper\n\n_cached_helper()\n")
 
-        from skylos.analyzer import analyze
         import json
+
+        from skylos.analyzer import analyze
 
         def unused_functions():
             result = json.loads(analyze(str(target), conf=0, grep_verify=True))
@@ -533,8 +650,9 @@ class TestAnalyzerIntegration:
             'def unrelated(unused_value: str) -> None:\n    pass\n\nunrelated("x")\n'
         )
 
-        from skylos.analyzer import analyze
         import json
+
+        from skylos.analyzer import analyze
 
         result_on = json.loads(analyze(str(tmp_path), conf=0, grep_verify=True))
         result_off = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
@@ -559,8 +677,9 @@ class TestAnalyzerIntegration:
             'import plugin\ngetattr(plugin, "handle_event")()\n'
         )
 
-        from skylos.analyzer import analyze
         import json
+
+        from skylos.analyzer import analyze
 
         result_on = json.loads(analyze(str(tmp_path), conf=60, grep_verify=True))
         result_off = json.loads(analyze(str(tmp_path), conf=60, grep_verify=False))
@@ -612,8 +731,9 @@ result = PublicClass.used_method()
             encoding="utf-8",
         )
 
-        from skylos.analyzer import analyze
         import json
+
+        from skylos.analyzer import analyze
 
         result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=True))
         unused_methods = {

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1,14 +1,20 @@
+import json
+import os
 import shutil
 import subprocess
 import sys
 import time
-from collections.abc import Sequence
+from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
+
+from skylos.core import grep_verify as grep_verify_module
 from skylos.core.grep_cache import GrepCache
 from skylos.core.grep_verify import (
     GrepStrategy,
     _deterministic_suppress_multilang,
+    _store_cached_group_results,
     detect_language,
     filter_grep_results,
     grep_verify_findings,
@@ -23,28 +29,41 @@ from skylos.core.grep_verify import (
 )
 from skylos.core.grep_verify_common import (
     GrepRequest,
+    _GrepBatchResults,
+    _GrepEvidence,
+    _GrepOutputLimitExceeded,
+    _is_python_source_reference,
     _python_regex,
+    _run_bounded_subprocess,
     _run_grep,
+    _run_grep_request,
+    _trusted_which,
     execute_grep_batch,
     replay_grep_results,
 )
 
 
 def _invalid_utf8_decode_error() -> UnicodeDecodeError:
-    try:
-        subprocess.run(
-            [
-                sys.executable,
-                "-c",
-                "import sys; sys.stdout.buffer.write(b'helper() # \\xe9\\n')",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except UnicodeDecodeError as exc:
-        return exc
-    raise AssertionError("invalid UTF-8 output did not raise UnicodeDecodeError")
+    return UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid UTF-8")
+
+
+def _rg_json_match(path: str, line_number: int, content: str) -> str:
+    return json.dumps(
+        {
+            "type": "match",
+            "data": {
+                "path": {"text": path},
+                "lines": {"text": content},
+                "line_number": line_number,
+                "absolute_offset": 0,
+                "submatches": [],
+            },
+        }
+    )
+
+
+def _rg_json_output(*matches: tuple[str, int, str]) -> str:
+    return "\n".join(_rg_json_match(*match) for match in matches) + "\n"
 
 
 class TestIsDefinitionLine:
@@ -67,6 +86,71 @@ class TestIsDefinitionLine:
     def test_usage_not_definition(self):
         finding = {"file": "/repo/foo.py", "line": 10, "simple_name": "bar"}
         assert not is_definition_line("/repo/other.py:50:    bar()", finding)
+
+    def test_posix_paths_remain_case_sensitive(self):
+        finding = {"file": "/repo/Foo.py", "line": 10, "simple_name": "helper"}
+        assert not is_definition_line("/repo/foo.py:10:helper()", finding)
+
+    def test_windows_drive_paths_compare_case_insensitively(self):
+        finding = {
+            "file": r"C:\Repo\Foo.py",
+            "line": 10,
+            "simple_name": "helper",
+        }
+        with patch(
+            "skylos.core.grep_verify_common._HOST_PATH_CASE_INSENSITIVE",
+            True,
+        ):
+            assert is_definition_line(r"c:\repo\foo.py:10:helper()", finding)
+
+    def test_windows_path_comparison_does_not_expand_unicode(self):
+        finding = {
+            "file": r"C:\Repo\straße.py",
+            "line": 10,
+            "simple_name": "helper",
+        }
+        with patch(
+            "skylos.core.grep_verify_common._HOST_PATH_CASE_INSENSITIVE",
+            True,
+        ):
+            assert not is_definition_line(
+                r"C:\Repo\strasse.py:10:helper()", finding
+            )
+
+    def test_drive_shaped_posix_paths_remain_case_sensitive(self):
+        finding = {
+            "file": "C:/Repo/Foo.py",
+            "line": 10,
+            "simple_name": "helper",
+        }
+
+        with patch(
+            "skylos.core.grep_verify_common._HOST_PATH_CASE_INSENSITIVE",
+            False,
+        ):
+            assert not is_definition_line("c:/repo/foo.py:10:helper()", finding)
+
+    def test_unbounded_plain_line_number_is_treated_as_unstructured(self):
+        huge_line = "/repo/foo.py:" + ("9" * 5_000) + ":helper()"
+        finding = {
+            "file": "/repo/foo.py",
+            "line": 10,
+            "simple_name": "helper",
+        }
+
+        assert not is_definition_line(huge_line, finding)
+
+    def test_plain_evidence_candidate_search_is_bounded(self):
+        evidence = "prefix" + (":1:value" * 10_000)
+        finding = {"file": "/repo/foo.py", "line": 1, "simple_name": "helper"}
+
+        with patch(
+            "skylos.core.grep_verify_common._looks_like_source_path",
+            return_value=False,
+        ) as looks_like_path:
+            assert not is_definition_line(evidence, finding)
+
+        assert looks_like_path.call_count == 256
 
     def test_typevar_definition(self):
         finding = {"file": "/repo/foo.py", "line": 2, "simple_name": "T"}
@@ -500,8 +584,10 @@ class TestBatchedGrepVerify:
         bar_request = GrepRequest(pattern=r"\bbar\b", **common)
         process_result = Mock(
             returncode=0,
-            stdout=(
-                "/repo/z.py:9:bar()\n/repo/z.py:2:foo()\n/repo/a.py:3:foo(); bar()\n"
+            stdout=_rg_json_output(
+                ("/repo/z.py", 9, "bar()\n"),
+                ("/repo/z.py", 2, "foo()\n"),
+                ("/repo/a.py", 3, "foo(); bar()\n"),
             ),
             stderr="",
         )
@@ -512,7 +598,7 @@ class TestBatchedGrepVerify:
                 return_value="/usr/bin/rg",
             ),
             patch(
-                "skylos.core.grep_verify_common.subprocess.run",
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
                 return_value=process_result,
             ) as mock_run,
         ):
@@ -527,7 +613,149 @@ class TestBatchedGrepVerify:
             "/repo/a.py:3:foo(); bar()",
             "/repo/z.py:9:bar()",
         )
-        assert mock_run.call_args.kwargs["input"] == r"\bfoo\b" "\n" r"\bbar\b" "\n"
+        assert results[foo_request][0] is results[bar_request][0]
+        assert "--json" in mock_run.call_args.args[0]
+        assert mock_run.call_args.kwargs["input_text"] == (
+            r"\bfoo\b" "\n" r"\bbar\b" "\n"
+        )
+
+    def test_batch_classifier_never_matches_a_symbol_from_the_path(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        ghost_request = GrepRequest(pattern=r"\bghost\b", **common)
+        used_request = GrepRequest(pattern=r"\bused\b", **common)
+
+        for path in (
+            r"C:\repo\ghost\module.py",
+            "/repo/pkg:ghost/module.py",
+            "/repo/pkg:123:ghost/module.py",
+        ):
+            process_result = Mock(
+                returncode=0,
+                stdout=_rg_json_output((path, 9, "used()\n")),
+                stderr="",
+            )
+            with (
+                patch(
+                    "skylos.core.grep_verify_common.shutil.which",
+                    return_value="/usr/bin/rg",
+                ),
+                patch(
+                    "skylos.core.grep_verify_common._run_bounded_subprocess",
+                    return_value=process_result,
+                ),
+            ):
+                results = execute_grep_batch([ghost_request, used_request])
+
+            assert results[ghost_request] == ()
+            assert results[used_request] == (f"{path}:9:used()",)
+
+    def test_json_match_preserves_colon_path_and_crlf_content(self):
+        request = GrepRequest(
+            pattern=r"\bcall\b",
+            project_root="/repo",
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        path = r"C:\repo\pkg:part\a.py"
+        process_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output((path, 12, "call()\r\n")),
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ),
+        ):
+            results = execute_grep_batch([request])
+
+        assert results[request] == (f"{path}:12:call()",)
+
+    def test_structured_colon_path_remains_unambiguous_downstream(self):
+        request = GrepRequest(
+            pattern=r"\bhelper\b",
+            project_root="/repo",
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        for path in (r"C:\repo\lib.py", "/repo/pkg:123:part/lib.py"):
+            process_result = Mock(
+                returncode=0,
+                stdout=_rg_json_output((path, 1, "helper=1\n")),
+                stderr="",
+            )
+            with (
+                patch(
+                    "skylos.core.grep_verify_common.shutil.which",
+                    return_value="/usr/bin/rg",
+                ),
+                patch(
+                    "skylos.core.grep_verify_common._run_bounded_subprocess",
+                    return_value=process_result,
+                ),
+            ):
+                evidence = execute_grep_batch([request])[request][0]
+
+            definitions, usages = filter_grep_results(
+                [evidence],
+                {
+                    "file": path,
+                    "line": 1,
+                    "simple_name": "helper",
+                    "type": "variable",
+                },
+            )
+            assert definitions == [evidence]
+            assert usages == []
+
+        assert not _is_python_source_reference(
+            r"C:\repo\README.md:1:helper", "helper"
+        )
+
+    def test_json_content_with_path_fragments_and_unicode_separator_survives(self):
+        request = GrepRequest(
+            pattern="value",
+            project_root="/repo",
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=5,
+        )
+        content = 'value = "/.git/hooks/\u2028/node_modules/pkg"'
+        json_line = _rg_json_match("/repo/main.py", 4, f"{content}\n").replace(
+            r"\u2028", "\u2028"
+        )
+        process_result = Mock(returncode=0, stdout=f"{json_line}\n", stderr="")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ),
+        ):
+            results = execute_grep_batch([request])
+
+        assert results[request] == (f"/repo/main.py:4:{content}",)
 
     def test_non_ascii_and_newline_patterns_run_directly(self):
         common = {
@@ -542,7 +770,7 @@ class TestBatchedGrepVerify:
         newline_request = GrepRequest(pattern="first\nsecond", **common)
         process_result = Mock(
             returncode=0,
-            stdout="/repo/a.py:1:ascii()\n",
+            stdout=_rg_json_output(("/repo/a.py", 1, "ascii()\n")),
             stderr="",
         )
 
@@ -552,12 +780,14 @@ class TestBatchedGrepVerify:
                 return_value="/usr/bin/rg",
             ),
             patch(
-                "skylos.core.grep_verify_common.subprocess.run",
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
                 return_value=process_result,
             ) as mock_run,
             patch(
                 "skylos.core.grep_verify_common._run_grep_request",
-                side_effect=lambda request: [f"direct:{request.pattern}"],
+                side_effect=lambda request, **_kwargs: [
+                    f"direct:{request.pattern}"
+                ],
             ) as mock_direct,
         ):
             results = execute_grep_batch(
@@ -565,7 +795,7 @@ class TestBatchedGrepVerify:
             )
 
         assert mock_run.call_count == 1
-        assert mock_run.call_args.kwargs["input"] == r"\bascii\b" "\n"
+        assert mock_run.call_args.kwargs["input_text"] == r"\bascii\b" "\n"
         assert mock_direct.call_args_list[0].args == (unicode_request,)
         assert mock_direct.call_args_list[1].args == (newline_request,)
         assert results[unicode_request] == (r"direct:\bकु\b",)
@@ -587,10 +817,20 @@ class TestBatchedGrepVerify:
         }
         foo_request = GrepRequest(pattern=r"\bpkg\.foo\b", **common)
         bar_request = GrepRequest(pattern=r"\bpkg\.bar\b", **common)
+        literal_request = GrepRequest(pattern=r"pkg\.literal", **common)
+
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(
+                ("/repo/code.py", 1, f"{content}\n"),
+                ("/repo/other.py", 2, "pkg.literalé()\n"),
+            ),
+            stderr="",
+        )
 
         def fake_run(cmd, **kwargs):
-            if "-f" in cmd:
-                return Mock(returncode=0, stdout=f"{line}\n", stderr="")
+            if "--json" in cmd:
+                return batch_result
             pattern = cmd[-2]
             if pattern == foo_request.pattern:
                 return Mock(returncode=1, stdout="", stderr="")
@@ -602,15 +842,21 @@ class TestBatchedGrepVerify:
                 return_value="/usr/bin/rg",
             ),
             patch(
-                "skylos.core.grep_verify_common.subprocess.run",
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
                 side_effect=fake_run,
             ) as mock_run,
         ):
-            results = execute_grep_batch([foo_request, bar_request])
+            results = execute_grep_batch(
+                [foo_request, bar_request, literal_request]
+            )
 
-        assert mock_run.call_count == 3
+        adjudication_calls = [
+            call for call in mock_run.call_args_list if "--json" not in call.args[0]
+        ]
+        assert len(adjudication_calls) == 2
         assert results[foo_request] == ()
         assert results[bar_request] == (line,)
+        assert results[literal_request] == ("/repo/other.py:2:pkg.literalé()",)
 
     def test_batched_and_legacy_verdicts_match_on_non_ascii_content(self, tmp_path):
         package = tmp_path / "pkg.py"
@@ -674,7 +920,638 @@ class TestBatchedGrepVerify:
             results = execute_grep_batch([request])
 
         assert results == {request: ("/repo/main.py:1:helper()",)}
-        mock_direct.assert_called_once_with(request)
+        mock_direct.assert_called_once_with(
+            request, deadline=None, require_complete=True
+        )
+
+    def test_structured_bytes_match_falls_back_to_legacy_results(self):
+        request = GrepRequest(
+            pattern=r"\bhelper\b",
+            project_root="/repo",
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        process_result = Mock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "type": "match",
+                    "data": {
+                        "path": {"bytes": "L3JlcG8vaW52YWxpZC5weQ=="},
+                        "lines": {"text": "helper()\n"},
+                        "line_number": 1,
+                    },
+                }
+            )
+            + "\n",
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                return_value=["/repo/main.py:1:helper()"],
+            ) as mock_direct,
+        ):
+            results = execute_grep_batch([request])
+
+        assert results == {request: ("/repo/main.py:1:helper()",)}
+        mock_direct.assert_called_once_with(
+            request, deadline=None, require_complete=True
+        )
+
+    def test_batch_timeout_never_retries_every_request_serially(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        requests = [
+            GrepRequest(pattern=rf"\bsymbol_{index}\b", **common)
+            for index in range(4)
+        ]
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=subprocess.TimeoutExpired("rg", 0.01),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request"
+            ) as mock_direct,
+        ):
+            results = execute_grep_batch(requests, deadline=time.monotonic() + 1)
+
+        assert results == {}
+        mock_direct.assert_not_called()
+
+    def test_serial_fallback_stops_at_the_shared_deadline(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        first = GrepRequest(pattern=r"\bfirst\b", **common)
+        second = GrepRequest(pattern=r"\bsecond\b", **common)
+        now = [0.0]
+
+        def finish_first(*_args, **_kwargs):
+            now[0] = 2.0
+            return ["/repo/main.py:1:first()"]
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=RuntimeError("combined pattern rejected"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common.time.monotonic",
+                side_effect=lambda: now[0],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                side_effect=finish_first,
+            ) as mock_direct,
+        ):
+            results = execute_grep_batch([first, second], deadline=1.0)
+
+        assert results == {first: ("/repo/main.py:1:first()",)}
+        mock_direct.assert_called_once_with(
+            first, deadline=1.0, require_complete=True
+        )
+
+    def test_large_request_sets_are_split_into_bounded_chunks(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        requests = [
+            GrepRequest(pattern=rf"\bsymbol_{index}\b", **common)
+            for index in range(129)
+        ]
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=lambda chunk, _rg, **_kwargs: {
+                    request: () for request in chunk
+                },
+            ) as mock_batch,
+        ):
+            results = execute_grep_batch(requests)
+
+        assert len(results) == 129
+        assert [len(call.args[0]) for call in mock_batch.call_args_list] == [128, 1]
+
+    def test_output_limit_splits_batch_without_losing_quiet_requests(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        requests = [
+            GrepRequest(pattern=rf"\bsymbol_{index}\b", **common)
+            for index in range(2)
+        ]
+
+        def limited_batch(chunk, _rg, **_kwargs):
+            if len(chunk) > 1:
+                raise _GrepOutputLimitExceeded("forced output cap")
+            return {chunk[0]: ()}
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=limited_batch,
+            ) as mock_batch,
+        ):
+            results = execute_grep_batch(requests)
+
+        assert results == {request: () for request in requests}
+        assert mock_batch.call_count == 3
+
+    def test_unicode_adjudication_cap_keeps_unambiguous_ascii_matches(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        requests = [
+            GrepRequest(pattern=rf"\bsymbol_{index}\b", **common)
+            for index in range(20)
+        ]
+        matches = [("/repo/nfd.py", 1, "unrelated\u0301\n")]
+        matches.extend(
+            (f"/repo/use_{index}.py", 1, f"symbol_{index}()\n")
+            for index in range(20)
+        )
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(*matches),
+            stderr="",
+        )
+
+        def fake_run(cmd, **_kwargs):
+            if "--json" in cmd:
+                return batch_result
+            return Mock(returncode=1, stdout="", stderr="")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_UNICODE_MAX_ADJUDICATIONS",
+                1,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                side_effect=fake_run,
+            ) as mock_run,
+        ):
+            results = execute_grep_batch(requests)
+
+        assert set(results) == set(requests)
+        for index, request in enumerate(requests):
+            assert results[request] == (
+                f"/repo/use_{index}.py:1:symbol_{index}()",
+            )
+        assert mock_run.call_count == 2
+        assert results.incomplete_requests == set(requests[1:])
+
+    def test_bounded_subprocess_rejects_oversized_output(self):
+        with (
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_MAX_OUTPUT_BYTES",
+                64,
+            ),
+            pytest.raises(_GrepOutputLimitExceeded),
+        ):
+            _run_bounded_subprocess(
+                [sys.executable, "-c", "print('x' * 10000)"],
+                input_text="",
+                timeout=2.0,
+            )
+
+    def test_thread_start_failure_leaves_request_incomplete(self):
+        request = GrepRequest(
+            pattern=r"\bhelper\b",
+            project_root="/repo",
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value=sys.executable,
+            ),
+            patch(
+                "skylos.core.grep_verify_common.threading.Thread.start",
+                side_effect=RuntimeError("cannot start thread"),
+            ),
+        ):
+            results = execute_grep_batch([request])
+
+        assert request not in results
+
+    def test_repo_planted_search_backends_are_never_executed(self, tmp_path):
+        request = GrepRequest(
+            pattern=r"\bhelper\b",
+            project_root=str(tmp_path),
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        planted = {
+            "rg": str(tmp_path / "rg.exe"),
+            "grep": str(tmp_path / "grep.exe"),
+        }
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                side_effect=lambda executable: planted[executable],
+            ),
+            patch("skylos.core.grep_verify_common.subprocess.Popen") as popen,
+        ):
+            results = execute_grep_batch([request])
+
+        assert request not in results
+        popen.assert_not_called()
+
+    def test_single_file_scan_rejects_sibling_search_backends(self, tmp_path):
+        target = tmp_path / "target.py"
+        target.write_text("helper()\n", encoding="utf-8")
+        request = GrepRequest(
+            pattern=r"\bhelper\b",
+            project_root=str(target),
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        planted = {
+            "rg": str(tmp_path / "rg.exe"),
+            "grep": str(tmp_path / "grep.exe"),
+        }
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                side_effect=lambda executable: planted[executable],
+            ),
+            patch("skylos.core.grep_verify_common.subprocess.Popen") as popen,
+        ):
+            results = execute_grep_batch([request])
+
+        assert request not in results
+        popen.assert_not_called()
+
+    def test_deleted_single_file_still_rejects_sibling_search_backends(
+        self, tmp_path
+    ):
+        target = tmp_path / "target.py"
+        target.write_text("helper()\n", encoding="utf-8")
+        request = GrepRequest(
+            pattern=r"\bhelper\b",
+            project_root=str(target),
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        target.unlink()
+        planted = {
+            "rg": str(tmp_path / "rg.exe"),
+            "grep": str(tmp_path / "grep.exe"),
+        }
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                side_effect=lambda executable: planted[executable],
+            ),
+            patch("skylos.core.grep_verify_common.subprocess.Popen") as popen,
+        ):
+            results = execute_grep_batch([request])
+
+        assert request not in results
+        popen.assert_not_called()
+
+    def test_filesystem_root_cwd_does_not_reject_system_backend(self):
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common.Path.cwd",
+                return_value=Path("/"),
+            ),
+        ):
+            resolved = _trusted_which("rg", ("/workspace/repo",))
+
+        assert resolved == "/usr/bin/rg"
+
+    def test_home_cwd_does_not_reject_user_installed_backend(self):
+        expected = str(Path("/home/alice/.local/bin/rg").resolve())
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/home/alice/.local/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common.Path.cwd",
+                return_value=Path("/home/alice"),
+            ),
+        ):
+            resolved = _trusted_which("rg", ("/workspace/repo",))
+
+        assert resolved == expected
+
+    def test_unrelated_cwd_backend_is_rejected(self):
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/untrusted/rg.exe",
+            ),
+            patch(
+                "skylos.core.grep_verify_common.Path.cwd",
+                return_value=Path("/untrusted"),
+            ),
+        ):
+            resolved = _trusted_which("rg", ("/workspace/repo",))
+
+        assert resolved is None
+
+    def test_missing_search_executables_leave_request_incomplete(self):
+        request = GrepRequest(
+            pattern="helper",
+            project_root="/repo",
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=5,
+        )
+
+        with patch(
+            "skylos.core.grep_verify_common.shutil.which", return_value=None
+        ):
+            results = execute_grep_batch([request])
+
+        assert request not in results
+
+    def test_grep_fallback_treats_pattern_and_root_as_operands(self):
+        request = GrepRequest(
+            pattern="--include=*",
+            project_root="-repo",
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        process_result = Mock(returncode=1, stdout="", stderr="")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                side_effect=lambda executable: (
+                    None if executable == "rg" else "/usr/bin/grep"
+                ),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ) as mock_run,
+        ):
+            assert _run_grep_request(request, require_complete=True) == []
+
+        assert mock_run.call_args.args[0][-4:] == [
+            "-e",
+            "--include=*",
+            "--",
+            os.path.abspath("-repo"),
+        ]
+
+    def test_direct_ripgrep_preserves_colon_path(self):
+        request = GrepRequest(
+            pattern=r"helper\s*\(",
+            project_root="/repo",
+            use_regex=True,
+            include_globs=("*.py",),
+            fixed_string=False,
+            max_results=5,
+        )
+        path = "/repo/release.v1:123/pkg/lib.py"
+        process_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output((path, 7, "helper()\n")),
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ) as mock_run,
+        ):
+            evidence = _run_grep_request(request, require_complete=True)[0]
+
+        assert evidence == f"{path}:7:helper()"
+        assert isinstance(evidence, _GrepEvidence)
+        assert evidence.path == path
+        assert "--json" in mock_run.call_args.args[0]
+
+    def test_grep_fallback_preserves_colon_path(self):
+        request = GrepRequest(
+            pattern="helper",
+            project_root="/repo",
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=5,
+        )
+        path = "/repo/release.v1:123/pkg/lib.py"
+        process_result = Mock(
+            returncode=0,
+            stdout=f"{path}\0" "7:helper()\n",
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                side_effect=lambda executable: (
+                    None if executable == "rg" else "/usr/bin/grep"
+                ),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ),
+        ):
+            evidence = _run_grep_request(request, require_complete=True)[0]
+
+        assert evidence == f"{path}:7:helper()"
+        assert isinstance(evidence, _GrepEvidence)
+        assert evidence.path == path
+
+    def test_incomplete_batch_is_not_replayed_or_cached(self, tmp_path):
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+        cache = GrepCache()
+
+        with patch(
+            "skylos.core.grep_verify.execute_grep_batch", return_value={}
+        ):
+            verdicts = grep_verify_findings(
+                [finding], str(tmp_path), cache=cache, time_budget=1.0
+            )
+
+        assert verdicts == {}
+        assert cache.size == 0
+
+    def test_conservative_partial_match_can_rescue_but_is_not_cached(
+        self, tmp_path
+    ):
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        usage = tmp_path / "usage.py"
+        usage.write_text("helper()\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+        cache = GrepCache()
+
+        def partial_results(requests, **_kwargs):
+            results = _GrepBatchResults()
+            evidence = _GrepEvidence(str(usage), 1, "helper()")
+            for request in requests:
+                results[request] = (evidence,)
+            results.incomplete_requests.add(requests[0])
+            return results
+
+        with patch(
+            "skylos.core.grep_verify.execute_grep_batch",
+            side_effect=partial_results,
+        ):
+            verdicts = grep_verify_findings(
+                [finding], str(tmp_path), cache=cache, time_budget=1.0
+            )
+
+        assert set(verdicts) == {"library.helper"}
+        assert cache.size == 0
+
+    def test_malformed_cached_group_is_treated_as_a_cache_miss(self, tmp_path):
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+        cache = GrepCache()
+
+        with (
+            patch.object(cache, "get", return_value=["[]"]),
+            patch(
+                "skylos.core.grep_verify.execute_grep_batch", return_value={}
+            ) as mock_batch,
+        ):
+            verdicts = grep_verify_findings(
+                [finding], str(tmp_path), cache=cache, time_budget=1.0
+            )
+
+        assert verdicts == {}
+        mock_batch.assert_called_once()
+
+    def test_oversized_group_result_is_not_stored(self, tmp_path):
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+        }
+        cache = GrepCache()
+        cache.bind_repository(tmp_path)
+
+        _store_cached_group_results(
+            cache,
+            "python_core",
+            finding,
+            {"references": ["x" * 1_000_001]},
+        )
+
+        assert cache.size == 0
 
     def test_no_ripgrep_uses_legacy_requests(self):
         request = GrepRequest(
@@ -696,7 +1573,9 @@ class TestBatchedGrepVerify:
             results = execute_grep_batch([request])
 
         assert results == {request: ("/repo/main.py:1:helper()",)}
-        mock_direct.assert_called_once_with(request)
+        mock_direct.assert_called_once_with(
+            request, deadline=None, require_complete=True
+        )
 
     def test_replay_miss_executes_legacy_request(self):
         with (
@@ -750,14 +1629,16 @@ class TestBatchedGrepVerify:
         library.write_text("def helper():\n    return 1\n")
         usage = tmp_path / "z_usage.py"
         usage.write_text("helper()\n")
-        output_lines = [
-            f"{tmp_path / f'a{index:02}.py'}:1:def helper():" for index in range(30)
+        output_matches = [
+            (str(tmp_path / f"a{index:02}.py"), 1, "def helper():\n")
+            for index in range(30)
         ]
-        output_lines.extend((f"{library}:1:def helper():", f"{usage}:1:helper()"))
-        stdout = "\n".join(output_lines) + "\n"
+        output_matches.extend(
+            ((str(library), 1, "def helper():\n"), (str(usage), 1, "helper()\n"))
+        )
         process_result = Mock(
             returncode=0,
-            stdout=stdout,
+            stdout=_rg_json_output(*output_matches),
             stderr="",
         )
         finding = {
@@ -776,7 +1657,7 @@ class TestBatchedGrepVerify:
                 return_value="/usr/bin/rg",
             ),
             patch(
-                "skylos.core.grep_verify_common.subprocess.run",
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
                 return_value=process_result,
             ),
         ):
@@ -784,7 +1665,7 @@ class TestBatchedGrepVerify:
 
         assert set(verdicts) == {"library.helper"}
 
-    def test_started_finding_batch_completes_after_deadline(self, tmp_path):
+    def test_final_finding_batch_is_not_started_after_deadline(self, tmp_path):
         library = tmp_path / "library.py"
         library.write_text("def helper():\n    return 1\n")
         (tmp_path / "main.py").write_text("helper()\n")
@@ -797,19 +1678,29 @@ class TestBatchedGrepVerify:
             "line": 1,
             "confidence": 80,
         }
+        now = [0.0]
+        original_plan = grep_verify_module._plan_batched_finding
 
-        def slow_batch(
-            requests: Sequence[GrepRequest],
-        ) -> dict[GrepRequest, tuple[str, ...]]:
-            time.sleep(0.02)
-            return execute_grep_batch(requests)
+        def plan_then_expire(*args, **kwargs):
+            planned = original_plan(*args, **kwargs)
+            now[0] = 1.0
+            return planned
 
-        with patch(
-            "skylos.core.grep_verify.execute_grep_batch", side_effect=slow_batch
+        with (
+            patch(
+                "skylos.core.grep_verify.time.monotonic",
+                side_effect=lambda: now[0],
+            ),
+            patch(
+                "skylos.core.grep_verify._plan_batched_finding",
+                side_effect=plan_then_expire,
+            ),
+            patch("skylos.core.grep_verify.execute_grep_batch") as mock_batch,
         ):
-            verdicts = grep_verify_findings([finding], str(tmp_path), time_budget=0.01)
+            verdicts = grep_verify_findings([finding], str(tmp_path), time_budget=0.5)
 
-        assert set(verdicts) == {"library.helper"}
+        assert verdicts == {}
+        mock_batch.assert_not_called()
 
     def test_batched_and_legacy_verdicts_match(self, tmp_path):
         library = tmp_path / "library.py"

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1,6 +1,6 @@
-import shutil
 import time
 from collections.abc import Sequence
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from skylos.core.grep_cache import GrepCache
@@ -26,6 +26,15 @@ from skylos.core.grep_verify_common import (
     execute_grep_batch,
     replay_grep_results,
 )
+
+
+def _write_fake_ripgrep(tmp_path: Path, stdout: bytes) -> str:
+    executable = tmp_path / "rg"
+    executable.write_text(
+        f"#!/usr/bin/env python3\nimport sys\nsys.stdout.buffer.write({stdout!r})\n"
+    )
+    executable.chmod(0o755)
+    return str(executable)
 
 
 class TestIsDefinitionLine:
@@ -624,10 +633,12 @@ class TestBatchedGrepVerify:
         mock_direct.assert_called_once()
 
     def test_non_utf8_matching_line_does_not_abort_verification(self, tmp_path):
-        assert shutil.which("rg") is not None
         library = tmp_path / "library.py"
         library.write_text("def helper():\n    return 1\n")
-        (tmp_path / "invalid.py").write_bytes(b"helper()  # \xe9\n")
+        invalid = tmp_path / "invalid.py"
+        invalid.write_bytes(b"helper()  # \xe9\n")
+        output = f"{invalid}:1:helper()  # ".encode() + b"\xe9\n"
+        fake_rg = _write_fake_ripgrep(tmp_path, output)
         finding = {
             "name": "helper",
             "full_name": "library.helper",
@@ -638,8 +649,9 @@ class TestBatchedGrepVerify:
             "confidence": 80,
         }
 
-        batched = grep_verify_findings([finding], str(tmp_path))
-        legacy = grep_verify_findings([finding], str(tmp_path), parallel=True)
+        with patch("skylos.core.grep_verify_common.shutil.which", return_value=fake_rg):
+            batched = grep_verify_findings([finding], str(tmp_path))
+            legacy = grep_verify_findings([finding], str(tmp_path), parallel=True)
 
         assert batched == legacy == {}
 
@@ -650,7 +662,14 @@ class TestBatchedGrepVerify:
             )
         library = tmp_path / "library.py"
         library.write_text("def helper():\n    return 1\n")
-        (tmp_path / "z_usage.py").write_text("helper()\n")
+        usage = tmp_path / "z_usage.py"
+        usage.write_text("helper()\n")
+        output_lines = [
+            f"{tmp_path / f'a{index:02}.py'}:1:def helper():" for index in range(30)
+        ]
+        output_lines.extend((f"{library}:1:def helper():", f"{usage}:1:helper()"))
+        fake_output = "\n".join(output_lines).encode() + b"\n"
+        fake_rg = _write_fake_ripgrep(tmp_path, fake_output)
         finding = {
             "name": "helper",
             "full_name": "library.helper",
@@ -661,7 +680,8 @@ class TestBatchedGrepVerify:
             "confidence": 80,
         }
 
-        verdicts = grep_verify_findings([finding], str(tmp_path))
+        with patch("skylos.core.grep_verify_common.shutil.which", return_value=fake_rg):
+            verdicts = grep_verify_findings([finding], str(tmp_path))
 
         assert set(verdicts) == {"library.helper"}
 

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 import sys
 import time
@@ -638,7 +639,12 @@ class TestBatchedGrepVerify:
             findings, str(tmp_path), parallel=True, max_workers=2
         )
 
-        assert set(batched) == set(legacy) == {"pkg.bar"}
+        # Batched replay must agree with the per-pattern engine either way;
+        # only ripgrep's UTS#18 \b excludes the NFD line from the foo pattern,
+        # so the strict set is asserted only when ripgrep does the searching.
+        assert set(batched) == set(legacy)
+        if shutil.which("rg"):
+            assert set(batched) == {"pkg.bar"}
 
     def test_batch_decode_failure_falls_back_to_legacy_results(self):
         request = GrepRequest(

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1,6 +1,7 @@
+import subprocess
+import sys
 import time
 from collections.abc import Sequence
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 from skylos.core.grep_cache import GrepCache
@@ -28,13 +29,21 @@ from skylos.core.grep_verify_common import (
 )
 
 
-def _write_fake_ripgrep(tmp_path: Path, stdout: bytes) -> str:
-    executable = tmp_path / "rg"
-    executable.write_text(
-        f"#!/usr/bin/env python3\nimport sys\nsys.stdout.buffer.write({stdout!r})\n"
-    )
-    executable.chmod(0o755)
-    return str(executable)
+def _invalid_utf8_decode_error() -> UnicodeDecodeError:
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write(b'helper() # \\xe9\\n')",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except UnicodeDecodeError as exc:
+        return exc
+    raise AssertionError("invalid UTF-8 output did not raise UnicodeDecodeError")
 
 
 class TestIsDefinitionLine:
@@ -637,8 +646,6 @@ class TestBatchedGrepVerify:
         library.write_text("def helper():\n    return 1\n")
         invalid = tmp_path / "invalid.py"
         invalid.write_bytes(b"helper()  # \xe9\n")
-        output = f"{invalid}:1:helper()  # ".encode() + b"\xe9\n"
-        fake_rg = _write_fake_ripgrep(tmp_path, output)
         finding = {
             "name": "helper",
             "full_name": "library.helper",
@@ -649,9 +656,12 @@ class TestBatchedGrepVerify:
             "confidence": 80,
         }
 
-        with patch("skylos.core.grep_verify_common.shutil.which", return_value=fake_rg):
+        with patch(
+            "skylos.core.grep_verify_common._run_ripgrep_batch",
+            side_effect=_invalid_utf8_decode_error(),
+        ):
             batched = grep_verify_findings([finding], str(tmp_path))
-            legacy = grep_verify_findings([finding], str(tmp_path), parallel=True)
+        legacy = grep_verify_findings([finding], str(tmp_path), parallel=True)
 
         assert batched == legacy == {}
 
@@ -668,8 +678,12 @@ class TestBatchedGrepVerify:
             f"{tmp_path / f'a{index:02}.py'}:1:def helper():" for index in range(30)
         ]
         output_lines.extend((f"{library}:1:def helper():", f"{usage}:1:helper()"))
-        fake_output = "\n".join(output_lines).encode() + b"\n"
-        fake_rg = _write_fake_ripgrep(tmp_path, fake_output)
+        stdout = "\n".join(output_lines) + "\n"
+        process_result = Mock(
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
         finding = {
             "name": "helper",
             "full_name": "library.helper",
@@ -680,7 +694,16 @@ class TestBatchedGrepVerify:
             "confidence": 80,
         }
 
-        with patch("skylos.core.grep_verify_common.shutil.which", return_value=fake_rg):
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common.subprocess.run",
+                return_value=process_result,
+            ),
+        ):
             verdicts = grep_verify_findings([finding], str(tmp_path))
 
         assert set(verdicts) == {"library.helper"}

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -570,6 +570,76 @@ class TestBatchedGrepVerify:
         assert results[unicode_request] == (r"direct:\bकु\b",)
         assert results[newline_request] == ("direct:first\nsecond",)
 
+    def test_non_ascii_content_uses_ripgrep_boundary_semantics(self):
+        # NFD: "foo" + combining acute accent. Ripgrep's UTS#18 \b treats
+        # the mark as a word character (no boundary, so no foo match); Python
+        # re does not, so unadjudicated replay would credit foo with a line
+        # ripgrep never matched for it.
+        content = "pkg.foo\u0301 = 1; pkg.bar()"
+        line = f"/repo/code.py:1:{content}"
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        foo_request = GrepRequest(pattern=r"\bpkg\.foo\b", **common)
+        bar_request = GrepRequest(pattern=r"\bpkg\.bar\b", **common)
+
+        def fake_run(cmd, **kwargs):
+            if "-f" in cmd:
+                return Mock(returncode=0, stdout=f"{line}\n", stderr="")
+            pattern = cmd[-2]
+            if pattern == foo_request.pattern:
+                return Mock(returncode=1, stdout="", stderr="")
+            return Mock(returncode=0, stdout=f"1:{content}\n", stderr="")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common.subprocess.run",
+                side_effect=fake_run,
+            ) as mock_run,
+        ):
+            results = execute_grep_batch([foo_request, bar_request])
+
+        assert mock_run.call_count == 3
+        assert results[foo_request] == ()
+        assert results[bar_request] == (line,)
+
+    def test_batched_and_legacy_verdicts_match_on_non_ascii_content(self, tmp_path):
+        package = tmp_path / "pkg.py"
+        package.write_text(
+            "def foo():\n    return 1\n\ndef bar():\n    return 2\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "other.py").write_text(
+            "pkg.foo\u0301 = 1; pkg.bar()\n", encoding="utf-8"
+        )
+        findings = [
+            {
+                "name": name,
+                "full_name": f"pkg.{name}",
+                "simple_name": name,
+                "type": "function",
+                "file": str(package),
+                "line": line,
+                "confidence": 80,
+            }
+            for name, line in (("foo", 1), ("bar", 4))
+        ]
+
+        batched = grep_verify_findings(findings, str(tmp_path))
+        legacy = grep_verify_findings(
+            findings, str(tmp_path), parallel=True, max_workers=2
+        )
+
+        assert set(batched) == set(legacy) == {"pkg.bar"}
+
     def test_batch_decode_failure_falls_back_to_legacy_results(self):
         request = GrepRequest(
             pattern=r"\bhelper\b",

--- a/test/test_secrets.py
+++ b/test/test_secrets.py
@@ -4,7 +4,11 @@ import time
 import tracemalloc
 
 import pytest
-from skylos.rules.secrets import _yarn_integrity_spans, scan_ctx
+from skylos.rules.secrets import (
+    _yaml_checksum_context_spans,
+    _yarn_integrity_spans,
+    scan_ctx,
+)
 
 ELLIPSIS = "…"
 NPM_SRI = (
@@ -235,6 +239,686 @@ def test_bare_generic_token_still_detected():
     assert generic[0]["col"] == src.index(token)
 
 
+@pytest.mark.parametrize(
+    "relpath,src",
+    [
+        (
+            "reproduce.py",
+            "integrity = sum(len(project.integrity_warnings) "
+            "for project in report.projects)\n",
+        ),
+        ("app.py", "hash = calculate_digest(project.generated_contents)\n"),
+        ("app.py", "checksum = values[artifact_key]\n"),
+        ("app.ts", "const narHash = buildNarHash(pkg.derivationOutputs);\n"),
+        ("app.js", "const contentHash = computeContentHash(asset.generatedBytes);\n"),
+        (
+            "app.py",
+            "# integrity = sum(len(project.integrity_warnings) "
+            "for project in report.projects)\n",
+        ),
+        (
+            "app.py",
+            'text = "integrity = sum(len(project.integrity_warnings) '
+            'for project in report.projects)"\n',
+        ),
+        ("app.go", "checksum := calculateChecksum(artifactContents)\n"),
+        ("app.rs", "let hash = calculate_hash(artifact_contents);\n"),
+        ("app.dart", "final contentHash = calculateContentHash(assetBytes);\n"),
+        ("app.js", "const integrity = `${computeIntegrity(payload)}`;\n"),
+        (
+            "app.ts",
+            "const checksum = `checksum-${artifact.generatedIdentifier}`;\n",
+        ),
+        ("app.php", "$integrity = `calculate-integrity $artifact`;\n"),
+        (
+            "index.html",
+            "<script>const integrity = calculateDigest(artifact.contents);</script>\n",
+        ),
+        (
+            "index.html",
+            "<script>const integrity = `${computeIntegrity(payload)}`;</script>\n",
+        ),
+        (
+            "styles.css",
+            "/* integrity = calculateDigest(project.generatedContents) */\n",
+        ),
+        ("metadata.yaml", "# integrity: calculateDigest(project.contents)\n"),
+        (
+            "metadata.yaml",
+            'text: "integrity = calculateDigest(project.generatedContents)"\n',
+        ),
+        (
+            "metadata.json",
+            '{"text":"integrity = calculateDigest(project.generatedContents)"}\n',
+        ),
+        (
+            "bundle.js.map",
+            '{"text":"integrity = calculateDigest(project.generatedContents)"}\n',
+        ),
+    ],
+)
+def test_computed_checksum_fields_in_source_are_not_secrets(relpath, src):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=relpath))
+        if finding["provider"] == "generic"
+    ]
+
+    assert generic == []
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["integrity", "hash", "checksum", "narHash", "contentHash"],
+)
+def test_quoted_checksum_fields_in_source_still_detect_secrets(field):
+    token = "aB3dE5fG7hJ9$kL2mN4pQ"
+    src = f'{field} = "{token}"\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="app.py"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["col"] == src.index(token)
+    assert generic[0]["end_col"] == src.index(token) + len(token)
+
+
+@pytest.mark.parametrize(
+    "relpath,src",
+    [
+        ("app.js", "const integrity = `aB3dE5fG7hJ9kL2mN4pQ`;\n"),
+        (
+            "app.js",
+            "const integrity = `aB3dE5fG7hJ9kL2mN4pQ\\${literal}`;\n",
+        ),
+        (
+            "app.js",
+            "const integrity = `prefix\\`aB3dE5fG7hJ9$kL2mN4pQ`;\n",
+        ),
+        ("app.go", "checksum := `aB3dE5fG7hJ9kL2mN4pQ`\n"),
+        (
+            "app.go",
+            "checksum := `aB3dE5fG7hJ9kL2mN4pQ${literal}`\n",
+        ),
+        (
+            "index.html",
+            "<script>const integrity = `aB3dE5fG7hJ9kL2mN4pQ`;</script>\n",
+        ),
+        ("app.js", "const integrity = `AbCdEfGhIjKlMnOpQrStUvWxYz`;\n"),
+        ("app.go", "checksum := `AbCdEfGhIjKlMnOpQrStUvWxYz`\n"),
+        (
+            "index.html",
+            "<script>const integrity = `AbCdEfGhIjKlMnOpQrStUvWxYz`;</script>\n",
+        ),
+    ],
+)
+def test_static_backtick_checksum_fields_still_detect_secrets(relpath, src):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=relpath))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+@pytest.mark.parametrize(
+    "src,expected_line",
+    [
+        (
+            "<script src=x integrity=aB3dE5fG7hJ9$kL2mN4pQ></script>\n",
+            1,
+        ),
+        (
+            "<script\n  integrity=aB3dE5fG7hJ9$kL2mN4pQ\n  src=x></script>\n",
+            2,
+        ),
+    ],
+)
+def test_unquoted_html_integrity_values_still_detect_secrets(src, expected_line):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="index.html"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == expected_line
+
+
+def test_html_attribute_text_is_not_mistaken_for_integrity_attribute():
+    src = '<div data-note="integrity=aB3dE5fG7hJ9$kL2mN4pQ">metadata</div>\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="index.html"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert generic == []
+
+
+def test_html_integrity_location_handles_mixed_cr_and_lf():
+    token = "aB3dE5fG7hJ9$kL2mN4pQ"
+    src = f"<div>one</div>\rnoise\n<script integrity={token}>\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="index.html"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == 3
+    assert generic[0]["col"] == src.splitlines()[2].index(token)
+
+
+def test_html_context_budget_fails_closed(monkeypatch):
+    monkeypatch.setattr("skylos.rules.secrets._MAX_JSON_CAPTURED_STRINGS", 1)
+    src = (
+        "<script integrity=aB3dE5fG7hJ9$kL2mN4pQ></script>\n"
+        "<script integrity=bC4eF6gH8iK0$lM3nP5qR></script>\n"
+    )
+
+    findings = list(scan_ctx(_ctx_from_source(src, rel="index.html")))
+
+    assert any(finding["rule_id"] == "SKY-ANALYSIS-INCOMPLETE" for finding in findings)
+
+
+@pytest.mark.parametrize(
+    "relpath,src",
+    [
+        ("metadata.yaml", "integrity: aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        ("metadata.yml", "HASH: aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (".env", "checksum=aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (
+            ".env",
+            "checksum=aB3dE5fG7hJ9#kL2mN4pQ\n",
+        ),
+        (
+            ".env",
+            "checksum=aB3dE5fG7hJ9$kL2mN4pQ  # deployment value\n",
+        ),
+        (".env", "  checksum=aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (".env", "checksum=`aB3dE5fG7hJ9$kL2mN4pQ`\n"),
+        (".env", "checksum=#aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (".env", "'checksum'=aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (".env", "export 'checksum'=aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        ("example.env", "checksum=aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (".env.production", "export checksum=aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        ("settings.ini", "checksum=aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (
+            "settings.ini",
+            "checksum=aB3dE5fG7hJ9$kL2mN4pQ ; deployment value\n",
+        ),
+        (
+            "settings.ini",
+            "[artifact]\n  checksum=aB3dE5fG7hJ9$kL2mN4pQ\n",
+        ),
+        ("settings.ini", "checksum=`aB3dE5fG7hJ9$kL2mN4pQ`\n"),
+        ("settings.ini", "checksum=;aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        ("settings.cfg", "NARHASH: aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        (
+            "metadata.yaml",
+            "- integrity: aB3dE5fG7hJ9$kL2mN4pQ\n",
+        ),
+        (
+            "metadata.yaml",
+            "metadata: {name: pkg, integrity: aB3dE5fG7hJ9$kL2mN4pQ}\n",
+        ),
+    ],
+)
+def test_unquoted_checksum_fields_in_data_files_still_detect_secrets(relpath, src):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=relpath))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+@pytest.mark.parametrize(
+    "relpath,src",
+    [
+        ("metadata.yaml", f"hash: {LOWERCASE_SHA256_HEX}\n"),
+        ("metadata.yaml", f"checksum: sha256:{LOWERCASE_SHA256_HEX}\n"),
+        (".env", f"hash={LOWERCASE_SHA256_HEX}\n"),
+        ("settings.ini", f"checksum={LOWERCASE_SHA256_HEX}\n"),
+    ],
+)
+def test_conventional_unquoted_config_hashes_are_not_secrets(relpath, src):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=relpath))
+        if finding["provider"] == "generic"
+    ]
+
+    assert generic == []
+
+
+@pytest.mark.parametrize(
+    "relpath,src",
+    [
+        ("metadata.yaml", f"integrity: {LOWERCASE_SHA256_HEX}\n"),
+        (".env", f"integrity={LOWERCASE_SHA256_HEX}\n"),
+    ],
+)
+def test_integrity_fields_do_not_inherit_hash_exemptions(relpath, src):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=relpath))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+def test_pnpm_wrong_path_integrity_does_not_inherit_hash_exemption():
+    src = f"metadata:\n  integrity: {LOWERCASE_SHA256_HEX}\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="pnpm-lock.yaml"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+@pytest.mark.parametrize(
+    "relpath,src",
+    [
+        (
+            "metadata.yaml",
+            "description: |\n"
+            "  integrity = calculateDigest(project.generatedContents)\n",
+        ),
+        (
+            "metadata.yaml",
+            "integrity: >\n  calculateDigest(project.generatedContents)\n",
+        ),
+        (
+            "metadata.yaml",
+            "description: verify generated metadata,\n"
+            "  integrity = calculateDigest(project.generatedContents)\n",
+        ),
+        (
+            "metadata.toml",
+            'description = """\n'
+            "integrity = calculateDigest(project.generatedContents)\n"
+            '"""\n',
+        ),
+        (
+            "settings.ini",
+            "[metadata]\n"
+            "description = verify generated metadata\n"
+            "  integrity = calculateDigest(project.generatedContents)\n",
+        ),
+        (
+            ".env",
+            "MESSAGE=verify package, integrity="
+            "calculateDigest(project.generatedContents)\n",
+        ),
+        (
+            ".env",
+            "'message'=verify package, integrity="
+            "calculateDigest(project.generatedContents)\n",
+        ),
+        (
+            ".env",
+            '"checksum"=calculateDigest(project.generatedContents)\n',
+        ),
+        (
+            ".env",
+            'MESSAGE="first line\nchecksum=aB3dE5fG7hJ9$kL2mN4pQ\n"\n',
+        ),
+    ],
+)
+def test_checksum_lookalikes_inside_multiline_or_other_values_are_clean(relpath, src):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=relpath))
+        if finding["provider"] == "generic"
+    ]
+
+    assert generic == []
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        (
+            "defaults: &defaults\n"
+            "  description: tagged metadata\n"
+            "checksum: aB3dE5fG7hJ9$kL2mN4pQ\n"
+        ),
+        "description: !!str metadata\nhash: aB3dE5fG7hJ9$kL2mN4pQ\n",
+        ("description: first\ndescription: second\nintegrity: aB3dE5fG7hJ9$kL2mN4pQ\n"),
+        ("description: first document\n---\ncontentHash: aB3dE5fG7hJ9$kL2mN4pQ\n"),
+    ],
+)
+def test_valid_yaml_features_do_not_disable_checksum_scanning(src):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+        if finding.get("provider") == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+def test_yaml_checksum_before_malformed_tail_is_still_scanned():
+    src = "checksum: aB3dE5fG7hJ9$kL2mN4pQ\nbroken: [\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+        if finding.get("provider") == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == 1
+
+
+def test_deep_yaml_checksum_value_is_not_silently_skipped():
+    token = "aB3dE5fG7hJ9$kL2mN4pQ"
+    src = ("[" * 300) + f"{{integrity: {token}}}" + ("]" * 300) + "\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+def test_malformed_yaml_before_checksum_fails_closed():
+    src = "broken: [\nintegrity: aB3dE5fG7hJ9$kL2mN4pQ\n"
+
+    findings = list(scan_ctx(_ctx_from_source(src, rel="metadata.yaml")))
+
+    assert any(finding["rule_id"] == "SKY-ANALYSIS-INCOMPLETE" for finding in findings)
+
+
+def test_yaml_context_budget_fails_closed(monkeypatch):
+    monkeypatch.setattr("skylos.rules.secrets._MAX_GENERIC_YAML_EVENTS", 32)
+    src = "items: [" + ("x, " * 40) + ("x]\nintegrity: aB3dE5fG7hJ9$kL2mN4pQ\n")
+
+    findings = list(scan_ctx(_ctx_from_source(src, rel="metadata.yaml")))
+
+    assert any(finding["rule_id"] == "SKY-ANALYSIS-INCOMPLETE" for finding in findings)
+
+
+def test_yaml_checksum_alias_scans_the_anchored_scalar():
+    src = "value: &artifact_hash aB3dE5fG7hJ9$kL2mN4pQ\nintegrity: *artifact_hash\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == 1
+    assert generic[0]["col"] == src.splitlines()[0].index("aB3")
+
+
+def test_yaml_complex_key_does_not_leave_stale_checksum_state():
+    src = (
+        "? [integrity]\n"
+        ": harmless\n"
+        "checksum: aB3dE5fG7hJ9$kL2mN4pQ\n"
+    )
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == 3
+
+
+def test_yaml_scalar_alias_can_supply_checksum_mapping_key():
+    src = (
+        "field: &checksum_field integrity\n"
+        "*checksum_field: aB3dE5fG7hJ9$kL2mN4pQ\n"
+    )
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == 2
+
+
+def test_yaml_aliases_do_not_cross_document_boundaries():
+    src = (
+        "value: &artifact_hash aB3dE5fG7hJ9$kL2mN4pQ\n---\nintegrity: *artifact_hash\n"
+    )
+
+    generic_contexts, decoded_contexts, incomplete_line = _yaml_checksum_context_spans(
+        src.splitlines(True)
+    )
+
+    assert generic_contexts == {}
+    assert decoded_contexts == {}
+    assert incomplete_line is None
+
+
+def test_generic_yaml_multiline_escape_cannot_hide_provider_signature():
+    src = f'checksum: "S\\\n  {_TWILIO_DIGEST_PREFIX[1:]}"\n'
+
+    providers = {
+        finding["provider"]
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+    }
+
+    assert "twilio" in providers
+
+
+def test_many_yaml_checksum_fields_remain_bounded():
+    token = "aB3dE5fG7hJ9$kL2mN4pQ"
+    src = "items: [" + ", ".join(f"{{integrity: {token}}}" for _ in range(600)) + "]\n"
+
+    started_at = time.perf_counter()
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="metadata.yaml"))
+        if finding["provider"] == "generic"
+    ]
+    elapsed = time.perf_counter() - started_at
+
+    assert len(generic) == 600
+    assert elapsed < 2.0
+
+
+def test_computed_checksum_field_does_not_hide_provider_secret():
+    token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    src = f'integrity = build("{token}")\n'
+
+    providers = {finding["provider"] for finding in scan_ctx(_ctx_from_source(src))}
+
+    assert "github" in providers
+
+
+def test_dynamic_checksum_template_does_not_hide_provider_secret():
+    token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    src = (
+        "const integrity = `prefix-${suffix}-"
+        f"{token}`;\n"
+    )
+
+    providers = {
+        finding["provider"] for finding in scan_ctx(_ctx_from_source(src, rel="app.js"))
+    }
+
+    assert "github" in providers
+
+
+def test_dynamic_checksum_template_does_not_hide_long_bare_secret():
+    src = f"const integrity = `${{prefix}}-{GENERIC_SECRET}`;\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="app.js"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    token_col = src.index(GENERIC_SECRET)
+    assert generic[0]["col"] <= token_col < generic[0]["end_col"]
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "aB3dE5fG7hJ9$kL2mN4pQ",
+        "AbCdEfGhIjKlMnOpQrStUvWxYz",
+    ],
+)
+def test_dynamic_checksum_template_preserves_suspicious_literal_prefix(prefix):
+    src = f"const integrity = `{prefix}-${{suffix}}`;\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="app.js"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["col"] == src.index(prefix)
+    assert generic[0]["end_col"] == src.index("${")
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "const integrity = `integrity-checksum-for-build-${artifact.id}`;\n",
+        "const integrity = `calculateIntegrityChecksum2-${artifact.id}`;\n",
+        "const integrity = `integrity-sha256-checksum-${artifact.id}`;\n",
+        "const integrity = `calculateSHA256Integrity-${artifact.id}`;\n",
+        "const integrity = `sha512ChecksumGenerated-${artifact.id}`;\n",
+        "const integrity = `contentHashV2ForDeployment-${artifact.id}`;\n",
+        "const integrity = `version20260815Integrity-${artifact.id}`;\n",
+    ],
+)
+def test_readable_dynamic_checksum_template_is_not_a_secret(src):
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="app.js"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert generic == []
+
+
+def test_dotenv_backslash_does_not_suppress_next_assignment():
+    src = "MESSAGE=abc\\\nchecksum=aB3dE5fG7hJ9$kL2mN4pQ\n"
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=".env"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == 2
+
+
+def test_unterminated_dotenv_quote_recovers_later_assignment():
+    src = 'MESSAGE="unterminated\nchecksum=aB3dE5fG7hJ9$kL2mN4pQ\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel=".env"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["line"] == 2
+
+
+def test_closed_dotenv_multiline_clears_pending_context_budget(monkeypatch):
+    monkeypatch.setattr("skylos.rules.secrets._MAX_JSON_CAPTURED_STRINGS", 1)
+    src = (
+        'MESSAGE="first line\n'
+        "checksum=aB3dE5fG7hJ9$kL2mN4pQ\n"
+        "integrity=bC4eF6gH8iK0$lM3nP5qR\n"
+        '"\n'
+        "checksum=cD5fG7hI9jL1$mN4pQ6rS\n"
+    )
+
+    findings = list(scan_ctx(_ctx_from_source(src, rel=".env")))
+    generic = [finding for finding in findings if finding.get("provider") == "generic"]
+
+    assert [finding["line"] for finding in generic] == [5]
+    assert not any(
+        finding["rule_id"] == "SKY-ANALYSIS-INCOMPLETE" for finding in findings
+    )
+
+
+def test_unterminated_dotenv_multiline_reports_first_context_overflow(monkeypatch):
+    monkeypatch.setattr("skylos.rules.secrets._MAX_JSON_CAPTURED_STRINGS", 2)
+    src = (
+        'MESSAGE="unterminated\n'
+        "checksum=aB3dE5fG7hJ9$kL2mN4pQ\n"
+        "integrity=bC4eF6gH8iK0$lM3nP5qR\n"
+        "narHash=cD5fG7hI9jL1$mN4pQ6rS\n"
+    )
+
+    findings = list(scan_ctx(_ctx_from_source(src, rel=".env")))
+    generic = [finding for finding in findings if finding.get("provider") == "generic"]
+    incomplete = [
+        finding
+        for finding in findings
+        if finding["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+    ]
+
+    assert [finding["line"] for finding in generic] == [2, 3]
+    assert len(incomplete) == 1
+    assert incomplete[0]["line"] == 4
+
+
+def test_config_context_budget_fails_closed(monkeypatch):
+    monkeypatch.setattr("skylos.rules.secrets._MAX_JSON_CAPTURED_STRINGS", 2)
+    src = (
+        "integrity=aB3dE5fG7hJ9$kL2mN4pQ\n"
+        "narHash=bC4eF6gH8iK0$lM3nP5qR\n"
+        "contentHash=cD5fG7hI9jL1$mN4pQ6rS\n"
+    )
+
+    findings = list(scan_ctx(_ctx_from_source(src, rel=".env")))
+
+    assert any(finding["rule_id"] == "SKY-ANALYSIS-INCOMPLETE" for finding in findings)
+
+
+def test_deep_computed_checksum_expression_is_bounded():
+    expression = ("(" * 5_000) + "value" + (")" * 5_000)
+    src = f"integrity = calculate({expression})\n"
+
+    started_at = time.perf_counter()
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src))
+        if finding["provider"] == "generic"
+    ]
+    elapsed = time.perf_counter() - started_at
+
+    assert generic == []
+    assert elapsed < 1.0
+
+
 def test_generic_scan_handles_long_non_secret_token_without_quadratic_retry():
     src = ("a" * 12_000) + "\n"
     ctx = _ctx_from_source(src)
@@ -273,6 +957,47 @@ def test_known_lockfile_integrity_values_not_flagged_as_generic(line, relpath):
     ctx = _ctx_from_source(src, rel=relpath)
     generic = [f for f in scan_ctx(ctx) if f["provider"] == "generic"]
     assert generic == []
+
+
+def test_yarn_invalid_integrity_value_remains_visible():
+    src = (
+        YARN_V1_PREAMBLE
+        + "pkg@^1.0.0:\n"
+        + '  version "1.0.0"\n'
+        + "  integrity aB3dE5fG7hJ9$kL2mN4pQ\n"
+    )
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="yarn.lock"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+@pytest.mark.parametrize(
+    "src,expected_line",
+    [
+        (
+            YARN_V1_PREAMBLE
+            + "pkg@^1.0.0:\n"
+            + '  version "1.0.0"\n'
+            + f"  integrity {NPM_SRI}\n"
+            + "  integrity aB3dE5fG7hJ9$kL2mN4pQ\n",
+            6,
+        ),
+        ("  integrity aB3dE5fG7hJ9$kL2mN4pQ\n", 1),
+    ],
+)
+def test_yarn_integrity_values_survive_invalid_structure(src, expected_line):
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src, rel="yarn.lock"))
+        if finding["provider"] == "generic"
+    ]
+
+    assert any(finding["line"] == expected_line for finding in generic)
 
 
 @pytest.mark.parametrize(

--- a/test/test_verify_orchestrator.py
+++ b/test/test_verify_orchestrator.py
@@ -18,6 +18,8 @@ from skylos.llm.verify_orchestrator import (
     _is_public_library_symbol,
     _finding_complexity_tier,
     _entry_point_cache_path,
+    _find_parent_class_info,
+    _find_parent_class_info_ts,
     _config_files_hash,
     discover_entry_points,
     verify_with_graph_context,
@@ -28,12 +30,81 @@ from skylos.llm.verify_orchestrator import (
     SuppressionDecision,
     SurvivorVerdict,
     VerifyStats,
+    _enrich_search_results,
+    _read_context_around_match,
 )
 from skylos.llm.dead_code_verifier import (
     DeadCodeVerifierAgent,
     Verdict,
     VerificationResult,
 )
+from skylos.core.grep_verify_common import _GrepEvidence
+
+
+def test_grep_context_enrichment_preserves_colon_path(tmp_path):
+    source_dir = tmp_path / "release.v1:123"
+    source_dir.mkdir()
+    source = source_dir / "module.py"
+    source.write_text("first\nhelper()\nthird\n", encoding="utf-8")
+    evidence = _GrepEvidence(str(source), 2, "helper()")
+
+    context = _read_context_around_match(evidence, context_lines=1)
+    enriched = _enrich_search_results({"references": [evidence]})
+
+    assert context is not None
+    assert "2 >>> helper()" in context
+    assert enriched == {"references": context}
+
+
+@pytest.mark.parametrize(
+    ("finder", "file_name", "source", "class_pattern", "method_pattern"),
+    [
+        (
+            _find_parent_class_info,
+            "child.py",
+            "class Child(Parent):\n    def helper(self): ...\n",
+            r"class\s+Parent",
+            r"def\s+helper\s*\(",
+        ),
+        (
+            _find_parent_class_info_ts,
+            "child.ts",
+            "class Child extends Parent { helper() {} }\n",
+            r"class\s+Parent",
+            r"(?:public|protected|private)?\s*(?:async\s+)?helper\s*[\(<]",
+        ),
+    ],
+)
+def test_override_lookup_preserves_structured_colon_path(
+    tmp_path, finder, file_name, source, class_pattern, method_pattern
+):
+    child = tmp_path / file_name
+    parent = tmp_path / "release.v1:123" / file_name
+    parent.parent.mkdir()
+    finding = {
+        "simple_name": "helper",
+        "full_name": "pkg.Child.helper",
+        "type": "method",
+        "file": str(child),
+    }
+    roots = []
+
+    def fake_grep(pattern, root, **_kwargs):
+        roots.append(root)
+        if pattern == class_pattern:
+            return [_GrepEvidence(str(parent), 1, "class Parent")]
+        if pattern == method_pattern and root == str(parent):
+            return [_GrepEvidence(str(parent), 2, "helper")]
+        return []
+
+    with patch(
+        "skylos.llm.verify_orchestrator._run_grep", side_effect=fake_grep
+    ):
+        info = finder(finding, {str(child): source}, str(tmp_path))
+
+    assert info is not None
+    assert "CONFIRMED" in info
+    assert str(parent) in roots
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #722

## What this does

Grep verification was repeatedly traversing the repository for individual findings. This PR records compatible requests, executes them in deterministic batches with `rg`, and replays the results through Skylos's existing strategy and verdict logic.

The original contributor benchmark measured:

| Scope | `main` | batched | speedup |
| --- | ---: | ---: | ---: |
| 15 pinned corpus projects | 265.66 s | 57.31 s | 4.64x |
| mitmproxy | 88.29 s | 14.10 s | 6.26x |

The same corpus comparison reported 819 findings on both sides, with no added, dropped, or changed findings.

## Maintainer hardening

- preserves paths, line numbers, and content using ripgrep JSON or NUL-delimited grep output, including Windows and colon-containing paths
- keeps Python and ripgrep regex behavior aligned for Unicode boundaries and engine-sensitive patterns
- applies one shared deadline and bounded input, output, match-count, and cleanup limits
- isolates noisy batches without turning a timed-out batch into unbounded serial work
- rejects grep executables resolved from the scanned repository, single-file scan directory, or current working directory
- keeps verification caching bounded and process-local; repository-owned cache files are not trusted, read, or written
- preserves structured evidence through LLM verification and TypeScript/Python override paths

All six contributor commits remain in the branch, followed by two focused maintainer hardening commits.

## Validation

- `pytest -q -W error::ResourceWarning test/test_grep_cache.py test/test_grep_verify.py test/test_verify_orchestrator.py` — 283 passed
- analyzer grep/cache regression set — 15 passed
- security benchmark — 67 cases, 0 failures, 100/100
- corpus guard — 47 cases, 0 failures
- Skylos self-scan — 0 danger findings and 0 analysis errors
- staged security, secrets, quality, and AI-defect gate — passed
- full local suite — 6,899 passed and 15 skipped; remaining failures were confined to optional-language parser/benchmark areas, with no failures in the changed grep/cache/LLM suites

## Attribution

Thanks @mcdigman for the performance investigation, batching design, implementation, benchmarks, and follow-up fixes. The contributor history and attribution are preserved.

## AI use disclosure

The contributor disclosed Codex GPT-5.6 Sol and Claude Fable 5 assistance for the original implementation and review. Maintainer hardening was implemented and independently reviewed with Codex agents under the repository's agent guidelines.
