### PR TITLE
fix(secrets): skip untracked generated grep cache

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 import traceback
 from pathlib import Path
 from collections import Counter, defaultdict
@@ -365,6 +366,8 @@ def _scan_ai_defect_diff_signals(
 
 
 MAX_SECRET_CONFIG_BYTES = 8_000_000
+_GENERATED_GREP_CACHE_RELATIVE = Path(".skylos/cache/grep_results.json")
+_GIT_TRACKING_TIMEOUT_SECONDS = 5
 
 _TS_JS_SOURCE_EXTS = (
     ".ts",
@@ -519,6 +522,70 @@ def _absolute_secret_scan_targets(scan_target) -> tuple[Path, ...]:
     return tuple(targets)
 
 
+def _is_generated_grep_cache(candidate: Path, root: Path) -> bool:
+    try:
+        return candidate.relative_to(root) == _GENERATED_GREP_CACHE_RELATIVE
+    except ValueError:
+        return False
+
+
+def _explicitly_targets_generated_grep_cache(
+    candidate: Path,
+    scan_target,
+) -> bool:
+    if scan_target is None:
+        return False
+    cache_dir = candidate.parent
+    cache_root = cache_dir.parent
+    return any(
+        target in {candidate, cache_dir, cache_root}
+        for target in _absolute_secret_scan_targets(scan_target)
+    )
+
+
+def _git_tracking_status(candidate: Path) -> bool | None:
+    try:
+        candidate = candidate.resolve(strict=False)
+    except OSError:
+        return None
+    git_root = find_git_root(candidate.parent)
+    if git_root is None:
+        return False
+    try:
+        relative = candidate.relative_to(git_root).as_posix()
+        result = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=git_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_GIT_TRACKING_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _should_scan_generated_grep_cache(
+    candidate: Path,
+    *,
+    root: Path,
+    scan_target,
+    selected_by_changed_files: bool,
+) -> bool:
+    if not _is_generated_grep_cache(candidate, root):
+        return True
+    if selected_by_changed_files:
+        return True
+    if _explicitly_targets_generated_grep_cache(candidate, scan_target):
+        return True
+    return _git_tracking_status(candidate) is not False
+
+
 def _is_within_secret_scan_targets(
     candidate: Path, scan_targets: tuple[Path, ...]
 ) -> bool:
@@ -566,6 +633,8 @@ def _scan_secret_config_candidate(
     root: Path,
     excluded: set[str],
     scanned: set[str],
+    scan_target=None,
+    selected_by_changed_files: bool = False,
     analysis_errors: list[dict] | None = None,
 ) -> list[dict]:
     resolved = _resolve_secret_config_candidate(candidate, root)
@@ -574,6 +643,14 @@ def _scan_secret_config_candidate(
     try:
         rel = str(resolved.relative_to(root))
         if excluded.intersection(Path(rel).parts):
+            return []
+        if not _should_scan_generated_grep_cache(
+            resolved,
+            root=root,
+            scan_target=scan_target,
+            selected_by_changed_files=selected_by_changed_files,
+        ):
+            scanned.add(str(resolved))
             return []
         scanned.add(str(resolved))
         source = read_project_text_no_symlink(
@@ -623,6 +700,8 @@ def _scan_secret_config_candidates(
                 root=root,
                 excluded=excluded,
                 scanned=scanned,
+                scan_target=scan_target,
+                selected_by_changed_files=changed_files is not None,
                 analysis_errors=analysis_errors,
             )
         )
@@ -3135,6 +3214,8 @@ class Skylos:
                             root=root,
                             excluded=excluded,
                             scanned=scanned,
+                            scan_target=secret_scan_target,
+                            selected_by_changed_files=secret_changed_files is not None,
                             analysis_errors=analysis_errors,
                         )
                     )

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3807,7 +3807,7 @@ def _issue_706_cache_file(root):
     github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
     cache_file = root / ".skylos" / "cache" / "grep_results.json"
     cache_file.parent.mkdir(parents=True)
-    cache_file.write_text(
+    cache_file.write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
         json.dumps(
             {
                 "version": 1,
@@ -3835,7 +3835,9 @@ def _issue_706_cache_findings(result):
 
 def _issue_706_init_ignored_cache_repo(root):
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
-    (root / ".gitignore").write_text(".skylos/\n", encoding="utf-8")
+    (root / ".gitignore").write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
+        ".skylos/\n", encoding="utf-8"
+    )
 
 
 def test_recursive_secret_scan_skips_untracked_generated_grep_cache(tmp_path):
@@ -4019,7 +4021,9 @@ def test_grep_cache_lookalike_paths_remain_scannable(tmp_path, relative_path):
     github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
     lookalike = tmp_path / relative_path
     lookalike.parent.mkdir(parents=True, exist_ok=True)
-    lookalike.write_text(json.dumps({"token": github_token}), encoding="utf-8")
+    lookalike.write_text(  # skylos: ignore[SKY-D215,SKY-D324] literal pytest parametrization under tmp_path
+        json.dumps({"token": github_token}), encoding="utf-8"
+    )
 
     result = json.loads(
         analyze(str(tmp_path), enable_secrets=True, grep_verify=False)

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3803,6 +3803,274 @@ def test_computed_checksum_field_does_not_hide_real_secret_in_analyzer(tmp_path)
     )
 
 
+def _issue_706_cache_file(root):
+    github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    cache_file = root / ".skylos" / "cache" / "grep_results.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": {
+                    "stale": {
+                        "results": [f"app.py:1:cached_helper(); token={github_token}"],
+                        "last_access": 1,
+                        "created": 1,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return cache_file
+
+
+def _issue_706_cache_findings(result):
+    return [
+        finding
+        for finding in result.get("secrets", [])
+        if finding.get("file") == ".skylos/cache/grep_results.json"
+    ]
+
+
+def _issue_706_init_ignored_cache_repo(root):
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    (root / ".gitignore").write_text(".skylos/\n", encoding="utf-8")
+
+
+def test_recursive_secret_scan_skips_untracked_generated_grep_cache(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    _issue_706_cache_file(tmp_path)
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result) == []
+
+
+def test_non_git_project_skips_its_generated_grep_cache(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_cache_file(tmp_path)
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result) == []
+
+
+def test_removed_secret_in_grep_evidence_does_not_reappear_from_cache(tmp_path):
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    (tmp_path / "target.py").write_text(
+        "def cached_helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    evidence = tmp_path / "evidence.yaml"
+    evidence.write_text(
+        f"entry: target.py # {github_token}\n",
+        encoding="utf-8",
+    )
+
+    first = json.loads(
+        analyze(
+            str(tmp_path),
+            conf=0,
+            enable_secrets=True,
+            grep_verify=True,
+        )
+    )
+    cache_file = tmp_path / ".skylos" / "cache" / "grep_results.json"
+
+    assert cache_file.exists()
+    assert github_token in cache_file.read_text(encoding="utf-8")
+    assert any(
+        finding.get("file") == "evidence.yaml"
+        and finding.get("provider") == "github"
+        for finding in first.get("secrets", [])
+    )
+    assert not any(
+        finding.get("full_name") == "target.cached_helper"
+        for finding in first.get("unused_functions", [])
+    )
+
+    evidence.write_text("entry: target.py\n", encoding="utf-8")
+    second = json.loads(
+        analyze(
+            str(tmp_path),
+            conf=0,
+            enable_secrets=True,
+            grep_verify=True,
+        )
+    )
+
+    assert github_token in cache_file.read_text(encoding="utf-8")
+    assert _issue_706_cache_findings(second) == []
+    assert second.get("secrets", []) == []
+    assert not any(
+        finding.get("full_name") == "target.cached_helper"
+        for finding in second.get("unused_functions", [])
+    )
+
+
+def test_recursive_secret_scan_keeps_tracked_grep_cache_visible(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    cache_file = _issue_706_cache_file(tmp_path)
+    subprocess.run(
+        ["git", "add", "-f", "--", ".skylos/cache/grep_results.json"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    cache_findings = _issue_706_cache_findings(result)
+    assert cache_findings
+    assert any(finding.get("provider") == "github" for finding in cache_findings)
+    assert cache_file.exists()
+
+
+def test_nested_git_repo_uses_its_own_tracked_cache_state(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(nested)
+    _issue_706_cache_file(nested)
+    subprocess.run(
+        ["git", "add", "-f", "--", ".skylos/cache/grep_results.json"],
+        cwd=nested,
+        check=True,
+    )
+
+    result = json.loads(
+        analyze(str(nested), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result)
+
+
+def test_generated_grep_cache_git_probe_failure_scans_fail_closed(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_cache_file(tmp_path)
+    monkeypatch.setattr("skylos.analyzer._git_tracking_status", lambda _path: None)
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert _issue_706_cache_findings(result)
+
+
+@pytest.mark.parametrize("target_kind", ["file", "cache_dir", "cache_root"])
+def test_explicit_generated_grep_cache_scan_is_not_suppressed(tmp_path, target_kind):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    cache_file = _issue_706_cache_file(tmp_path)
+    targets = {
+        "file": cache_file,
+        "cache_dir": cache_file.parent,
+        "cache_root": cache_file.parent.parent,
+    }
+
+    result = json.loads(
+        analyze(str(targets[target_kind]), enable_secrets=True, grep_verify=False)
+    )
+
+    assert any(
+        finding.get("provider") == "github"
+        for finding in result.get("secrets", [])
+    )
+
+
+def test_changed_files_explicitly_selected_grep_cache_is_scanned(tmp_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    _issue_706_init_ignored_cache_repo(tmp_path)
+    cache_file = _issue_706_cache_file(tmp_path)
+
+    result = json.loads(
+        analyze(
+            str(tmp_path),
+            enable_secrets=True,
+            grep_verify=False,
+            changed_files={str(cache_file)},
+        )
+    )
+
+    assert _issue_706_cache_findings(result)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        ".skylos/cache/other.json",
+        "src/.skylos/cache/grep_results.json",
+    ],
+)
+def test_grep_cache_lookalike_paths_remain_scannable(tmp_path, relative_path):
+    (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
+    github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
+    lookalike = tmp_path / relative_path
+    lookalike.parent.mkdir(parents=True, exist_ok=True)
+    lookalike.write_text(json.dumps({"token": github_token}), encoding="utf-8")
+
+    result = json.loads(
+        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
+    )
+
+    assert any(
+        finding.get("file") == relative_path
+        and finding.get("provider") == "github"
+        for finding in result.get("secrets", [])
+    )
+
+
+@pytest.mark.parametrize(
+    "returncode,expected",
+    [(0, True), (1, False), (2, None)],
+)
+def test_generated_grep_cache_tracking_status_is_fail_closed(
+    tmp_path, returncode, expected
+):
+    from skylos.analyzer import _git_tracking_status
+
+    (tmp_path / ".git").mkdir()
+    candidate = tmp_path / ".skylos" / "cache" / "grep_results.json"
+    with patch(
+        "skylos.analyzer.subprocess.run",
+        return_value=subprocess.CompletedProcess([], returncode),
+    ) as git_run:
+        actual = _git_tracking_status(candidate)
+
+    assert actual is expected
+    assert git_run.call_args.args[0] == [
+        "git",
+        "ls-files",
+        "--error-unmatch",
+        "--",
+        ".skylos/cache/grep_results.json",
+    ]
+
+
+def test_generated_grep_cache_tracking_timeout_is_unknown(tmp_path):
+    from skylos.analyzer import _git_tracking_status
+
+    (tmp_path / ".git").mkdir()
+    candidate = tmp_path / ".skylos" / "cache" / "grep_results.json"
+    with patch(
+        "skylos.analyzer.subprocess.run",
+        side_effect=subprocess.TimeoutExpired("git", 5),
+    ):
+        assert _git_tracking_status(candidate) is None
+
+
 _ISSUE_693_UV_LOCK = """\
 version = 1
 revision = 1


### PR DESCRIPTION
Closes #706

## Summary

  - Stop stale secrets in Skylos’s untracked grep cache from being reported.
  - Continue scanning tracked or explicitly targeted cache files.

  ## Tests

  - pytest test/test_analyzer.py test/test_grep_cache.py test/test_grep_verify.py
  - python scripts/security_benchmark.py
