### PR TITLE
fix(analyzer): fail closed on incomplete grep verification

### DIFF
--- a/docs/cli-output.md
+++ b/docs/cli-output.md
@@ -113,6 +113,13 @@ the grade and clean-code claim, and exits with status `2` in every output mode.
 `--force` and advisory gate settings do not convert incomplete analysis into a
 passing result.
 
+The same contract applies when grep verification exceeds
+`SKYLOS_GREP_BUDGET` (30 seconds by default). Skylos discards the partial grep
+verdicts, records the affected dead-code candidates as abstentions, emits
+`SKY-ANALYSIS-INCOMPLETE`, and exits with status `2`. JSON consumers can inspect
+`analysis_summary.grep_verify.status` and `incomplete_reason`; increase the
+budget and rerun before treating the dead-code result as complete.
+
 The legacy flags still work:
 
 ```bash

--- a/skylos/analysis/errors.py
+++ b/skylos/analysis/errors.py
@@ -1,7 +1,28 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Mapping
 from typing import Any
+
+
+def analysis_result_incomplete(result: object) -> bool:
+    """Return whether a serialized analyzer result is unsafe to trust as complete."""
+    if not isinstance(result, Mapping):
+        return True
+    if result.get("analysis_errors"):
+        return True
+    summary = result.get("analysis_summary")
+    if not isinstance(summary, Mapping):
+        return False
+    grep_verify = summary.get("grep_verify")
+    return bool(
+        summary.get("incomplete_languages")
+        or summary.get("grade_unavailable_reason") == "analysis_incomplete"
+        or (
+            isinstance(grep_verify, Mapping)
+            and grep_verify.get("complete") is False
+        )
+    )
 
 
 def analysis_error_payload(

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -109,6 +109,7 @@ _OPTIONAL_RUN_STATE_ATTRIBUTES = (
     "_param_method_refs",
     "_call_arg_types",
     "_grep_verify_report",
+    "_grep_verify_incomplete_candidates",
     "_dead_code_liveness_report",
     "ts_consumed_exports",
     "_ts_wildcard_edges",
@@ -725,6 +726,54 @@ def _secret_config_read_error_payload(path: Path) -> dict:
         message = f"Secret scan could not safely read {path.name}"
 
     return _analysis_error_payload(path, RuntimeError(message), kind=kind)
+
+
+def _grep_verify_error_payload(
+    path: Path,
+    report: dict,
+    candidates: tuple[dict, ...] | list[dict] = (),
+) -> dict:
+    reason = str(report.get("incomplete_reason") or "verification_incomplete")
+    if reason == "budget_exhausted":
+        budget = report.get("time_budget_seconds", 30)
+        message = (
+            f"Grep verification exceeded its {budget:g}-second budget. "
+            "Dead-code findings that required grep verification were withheld. "
+            "Increase SKYLOS_GREP_BUDGET and rerun."
+        )
+        kind = "grep_budget_exhausted"
+    else:
+        message = (
+            "Grep verification could not complete safely. Dead-code findings "
+            "that required grep verification were withheld."
+        )
+        kind = "grep_verification_incomplete"
+    located_candidates = sorted(
+        (
+            candidate
+            for candidate in candidates
+            if isinstance(candidate, dict) and candidate.get("file")
+        ),
+        key=lambda candidate: (
+            str(candidate.get("file")),
+            int(candidate.get("line") or 0),
+        ),
+    )
+    error_path = (
+        Path(str(located_candidates[0]["file"])) if located_candidates else path
+    )
+    payload = _analysis_error_payload(
+        error_path,
+        RuntimeError(message),
+        kind=kind,
+    )
+    if located_candidates:
+        payload["line"] = max(1, int(located_candidates[0].get("line") or 1))
+    payload["affected_file_count"] = max(
+        1,
+        int(report.get("candidate_file_count") or 0),
+    )
+    return payload
 
 
 _GREP_VERIFY_TYPE_PRIORITY = {
@@ -1674,6 +1723,25 @@ class Skylos:
         from skylos.core.grep_cache import GrepCache
         from skylos.core.grep_verify import grep_verify_findings
 
+        self.__dict__.pop("_grep_verify_incomplete_candidates", None)
+        report = getattr(self, "_grep_verify_report", None)
+        if not isinstance(report, dict):
+            report = {
+                "enabled": True,
+                "rescued_count": 0,
+                "project_cache_enabled": bool(use_project_cache),
+            }
+            self._grep_verify_report = report
+        for key in (
+            "complete",
+            "status",
+            "candidate_count",
+            "candidate_file_count",
+            "time_budget_seconds",
+            "incomplete_reason",
+        ):
+            report.pop(key, None)
+
         candidates, candidate_defs = _collect_grep_verify_candidates(self.defs)
         if not candidates:
             return 0
@@ -1697,6 +1765,31 @@ class Skylos:
         finally:
             if use_project_cache:
                 grep_cache.save(grep_root)
+
+        if not getattr(verdicts, "complete", True):
+            self._grep_verify_incomplete_candidates = tuple(candidates)
+            candidate_file_count = len(
+                {
+                    str(candidate.get("file"))
+                    for candidate in candidates
+                    if candidate.get("file")
+                }
+            )
+            report.update(
+                {
+                    "complete": False,
+                    "status": "incomplete",
+                    "candidate_count": len(candidates),
+                    "candidate_file_count": candidate_file_count,
+                    "time_budget_seconds": grep_budget,
+                    "incomplete_reason": getattr(
+                        verdicts,
+                        "incomplete_reason",
+                        "verification_incomplete",
+                    ),
+                }
+            )
+            return 0
 
         rescued = _apply_grep_verify_verdicts(candidate_defs, verdicts)
 
@@ -4282,6 +4375,7 @@ class Skylos:
             "enabled": bool(grep_verify),
             "rescued_count": 0,
         }
+        self._grep_verify_report = grep_verify_report
         if grep_verify:
             grep_verify_report["project_cache_enabled"] = bool(grep_cache)
             if progress_callback:
@@ -4289,7 +4383,14 @@ class Skylos:
             grep_verify_report["rescued_count"] = self._grep_verify(
                 use_project_cache=grep_cache
             )
-        self._grep_verify_report = grep_verify_report
+            if grep_verify_report.get("complete") is False:
+                analysis_errors.append(
+                    _grep_verify_error_payload(
+                        project_root,
+                        grep_verify_report,
+                        getattr(self, "_grep_verify_incomplete_candidates", ()),
+                    )
+                )
 
         dead_ts_files = self._find_dead_ts_files(
             files, exclude_folders, workspace_inventory=workspace_inventory

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -1553,6 +1553,13 @@ def _display_filter_items(items, file_filter, min_rank):
     return kept
 
 
+def _incomplete_grep_verify_report(summary):
+    report = summary.get("grep_verify") if isinstance(summary, dict) else None
+    if isinstance(report, dict) and report.get("complete") is False:
+        return report
+    return None
+
+
 def _apply_display_filters(result, severity=None, category=None, file_filter=None):
     import copy
 
@@ -1573,9 +1580,12 @@ def _apply_display_filters(result, severity=None, category=None, file_filter=Non
         filtered[key] = _display_filter_items(items, file_filter, min_rank)
 
     summary = copy.copy(result.get("analysis_summary") or {})
+    incomplete_grep_verify = _incomplete_grep_verify_report(summary)
     summary.pop("by_directory", None)
     summary.pop("dead_code_evidence", None)
     summary.pop("grep_verify", None)
+    if incomplete_grep_verify is not None:
+        summary["grep_verify"] = incomplete_grep_verify
     for key, count_key in _RULE_SELECTION_SUMMARY_COUNTS.items():
         if key in result or count_key in summary:
             summary[count_key] = len(filtered.get(key) or [])
@@ -1650,10 +1660,13 @@ def _apply_rule_selection(result: dict, selectors) -> dict:
         ]
 
     summary = copy.copy(result.get("analysis_summary") or {})
+    incomplete_grep_verify = _incomplete_grep_verify_report(summary)
     summary["selected_rules"] = selected_rules
     summary.pop("by_directory", None)
     summary.pop("dead_code_evidence", None)
     summary.pop("grep_verify", None)
+    if incomplete_grep_verify is not None:
+        summary["grep_verify"] = incomplete_grep_verify
     for category, count_key in _RULE_SELECTION_SUMMARY_COUNTS.items():
         if category in result or count_key in summary:
             summary[count_key] = len(filtered.get(category) or [])

--- a/skylos/commands/agent_verify_cmd.py
+++ b/skylos/commands/agent_verify_cmd.py
@@ -10,6 +10,8 @@ from typing import Any, Callable
 from rich.console import Console
 from rich.table import Table
 
+from skylos.analysis.errors import analysis_result_incomplete
+
 
 UploadAgentRun = Callable[..., None]
 
@@ -131,6 +133,12 @@ def run_agent_verify_command(
         conf=args.conf,
         exclude_folders=exclude_folders,
     )
+    if analysis_result_incomplete(static_result):
+        console.print(
+            "[bad]Static analysis did not complete; refusing to verify or "
+            "generate fixes.[/bad]"
+        )
+        return 2
     all_findings = _collect_dead_code_findings(static_result)
     defs_map = static_result.get("definitions", {})
 

--- a/skylos/core/baseline.py
+++ b/skylos/core/baseline.py
@@ -114,11 +114,20 @@ def filter_new_findings(result: dict, baseline: dict) -> dict:
 
     if "analysis_summary" in result:
         summary = dict(result.get("analysis_summary") or {})
+        grep_verify = summary.get("grep_verify")
+        incomplete_grep_verify = (
+            grep_verify
+            if isinstance(grep_verify, dict)
+            and grep_verify.get("complete") is False
+            else None
+        )
         for section, count_key in _SUMMARY_COUNT_KEYS.items():
             if section in result or count_key in summary:
                 summary[count_key] = len(filtered.get(section) or [])
         for key in _STALE_SUMMARY_AGGREGATES:
             summary.pop(key, None)
+        if incomplete_grep_verify is not None:
+            summary["grep_verify"] = incomplete_grep_verify
         filtered["analysis_summary"] = summary
 
     for key in _STALE_RESULT_AGGREGATES:

--- a/skylos/core/grep_verify.py
+++ b/skylos/core/grep_verify.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from skylos.core.grep_verify_common import (
     GrepRequest,
+    _GrepDeadlineExceeded,
     _GrepEvidence,
     _GrepExecutionIncomplete,
     _run_grep,
@@ -49,6 +50,7 @@ __all__ = [
     "_STRONG_ALIVE_STRATEGIES",
     "GrepStrategy",
     "GrepVerdict",
+    "GrepVerificationResult",
     "_cached_group_results",
     "_deterministic_suppress_multilang",
     "_run_go_strategies",
@@ -76,6 +78,31 @@ class GrepVerdict:
     suppression_code: str | None = None
     rationale: str = ""
     evidence: list[str] = field(default_factory=list)
+
+
+class GrepVerificationResult(dict[str, GrepVerdict]):
+    """Verdicts plus whether every candidate was safely verified.
+
+    This remains a ``dict`` so existing callers can keep using membership,
+    indexing, and equality without an API migration.
+    """
+
+    def __init__(
+        self,
+        verdicts: dict[str, GrepVerdict] | None = None,
+        *,
+        candidate_count: int,
+        verified_count: int,
+        time_budget: float,
+        incomplete_reason: str | None = None,
+    ) -> None:
+        super().__init__(verdicts or {})
+        self.candidate_count = candidate_count
+        self.verified_count = verified_count
+        self.time_budget = time_budget
+        self.incomplete_reason = incomplete_reason
+        self.complete = incomplete_reason is None
+        self.budget_exhausted = incomplete_reason == "budget_exhausted"
 
 
 @dataclass
@@ -348,34 +375,59 @@ def _execute_pending_findings(
     project_root: str,
     cache: Any,
     deadline: float,
-) -> dict[str, GrepVerdict]:
+) -> tuple[dict[str, GrepVerdict], int, str | None]:
     requests = [request for item in pending for request in item.requests]
-    batch_results = execute_grep_batch(requests, deadline=deadline)
+    try:
+        batch_results = execute_grep_batch(requests, deadline=deadline)
+    except _GrepExecutionIncomplete as exc:
+        reason = (
+            "budget_exhausted"
+            if isinstance(exc, _GrepDeadlineExceeded)
+            or time.monotonic() >= deadline
+            else "verification_incomplete"
+        )
+        return {}, 0, reason
     incomplete_requests = getattr(batch_results, "incomplete_requests", set())
     verdicts: dict[str, GrepVerdict] = {}
-    for item in pending:
+    verified_count = 0
+    for index, item in enumerate(pending):
         if time.monotonic() >= deadline:
-            break
+            return verdicts, verified_count, "budget_exhausted"
         if any(request not in batch_results for request in item.requests):
-            continue
+            reason = (
+                "budget_exhausted"
+                if time.monotonic() >= deadline
+                else "verification_incomplete"
+            )
+            return verdicts, verified_count, reason
         try:
             with replay_grep_results(batch_results, deadline=deadline):
                 search_results = multi_strategy_search(item.finding, project_root)
         except _GrepExecutionIncomplete as exc:
             logger.debug("grep replay was incomplete: %s", exc)
-            continue
-        if time.monotonic() >= deadline:
-            break
-        if not any(
+            reason = (
+                "budget_exhausted"
+                if isinstance(exc, _GrepDeadlineExceeded)
+                or time.monotonic() >= deadline
+                else "verification_incomplete"
+            )
+            return verdicts, verified_count, reason
+        request_incomplete = any(
             request in incomplete_requests for request in item.requests
-        ):
+        )
+        if not request_incomplete:
             _store_cached_group_results(
                 cache, item.group_name, item.finding, search_results
             )
         verdict = _apply_deterministic_rules(search_results, item.finding)
+        if request_incomplete and not (verdict and verdict.alive):
+            return verdicts, verified_count, "verification_incomplete"
         if verdict:
             verdicts[_finding_full_name(item.finding)] = verdict
-    return verdicts
+        verified_count += 1
+        if time.monotonic() >= deadline and index + 1 < len(pending):
+            return verdicts, verified_count, "budget_exhausted"
+    return verdicts, verified_count, None
 
 
 def _grep_verify_findings_batched(
@@ -384,38 +436,62 @@ def _grep_verify_findings_batched(
     time_budget: float,
     cache: Any,
     start_time: float,
-) -> dict[str, GrepVerdict]:
+) -> GrepVerificationResult:
+    eligible_findings = [finding for finding in findings if _finding_full_name(finding)]
     verdicts: dict[str, GrepVerdict] = {}
     pending: list[_PendingBatchFinding] = []
     deadline = start_time + time_budget
+    verified_count = 0
+    incomplete_reason: str | None = None
 
-    for finding in findings:
+    for finding in eligible_findings:
         if time.monotonic() >= deadline:
+            incomplete_reason = "budget_exhausted"
             break
         full_name = _finding_full_name(finding)
-        if not full_name:
-            continue
 
         verdict, planned = _plan_batched_finding(finding, project_root, cache)
         if verdict:
             verdicts[full_name] = verdict
         if planned:
             pending.append(planned)
+        else:
+            verified_count += 1
         if len(pending) < _GREP_FINDING_BATCH_SIZE:
             continue
         if time.monotonic() >= deadline:
+            incomplete_reason = "budget_exhausted"
             break
-        verdicts.update(
+        batch_verdicts, batch_verified, incomplete_reason = (
             _execute_pending_findings(pending, project_root, cache, deadline)
         )
+        verdicts.update(batch_verdicts)
+        verified_count += batch_verified
         pending.clear()
+        if incomplete_reason:
+            break
 
-    if pending and time.monotonic() < deadline:
-        verdicts.update(
-            _execute_pending_findings(pending, project_root, cache, deadline)
-        )
+    if pending and incomplete_reason is None:
+        if time.monotonic() >= deadline:
+            incomplete_reason = "budget_exhausted"
+        else:
+            batch_verdicts, batch_verified, incomplete_reason = (
+                _execute_pending_findings(pending, project_root, cache, deadline)
+            )
+            verdicts.update(batch_verdicts)
+            verified_count += batch_verified
 
-    return verdicts
+    candidate_count = len(eligible_findings)
+    if incomplete_reason is None and verified_count != candidate_count:
+        incomplete_reason = "verification_incomplete"
+
+    return GrepVerificationResult(
+        verdicts if incomplete_reason is None else {},
+        candidate_count=candidate_count,
+        verified_count=verified_count,
+        time_budget=time_budget,
+        incomplete_reason=incomplete_reason,
+    )
 
 
 def _process_finding(
@@ -446,7 +522,7 @@ def _submit_next_finding(
     search_fn: Callable[[dict], dict[str, list[str]]],
     deadline: float,
 ) -> bool:
-    if time.monotonic() > deadline:
+    if time.monotonic() >= deadline:
         return False
     for finding in findings:
         if not _finding_full_name(finding):
@@ -461,15 +537,35 @@ def _submit_next_finding(
 def _collect_finished_findings(
     done: set[_FindingFuture],
     verdicts: dict[str, GrepVerdict],
-) -> None:
+    deadline: float | None = None,
+) -> tuple[int, str | None]:
+    completed: list[tuple[str, GrepVerdict | None]] = []
+    incomplete_reasons: set[str] = set()
     for future in done:
         try:
-            full_name, verdict = future.result()
+            completed.append(future.result())
         except Exception as exc:
             logger.debug("grep verification failed: %s", exc)
-            continue
+            incomplete_reasons.add(
+                "budget_exhausted"
+                if isinstance(exc, _GrepDeadlineExceeded)
+                or (
+                    isinstance(exc, _GrepExecutionIncomplete)
+                    and deadline is not None
+                    and time.monotonic() >= deadline
+                )
+                else "verification_incomplete"
+            )
+    for full_name, verdict in sorted(completed, key=lambda item: item[0]):
         if full_name and verdict:
             verdicts[full_name] = verdict
+    if "verification_incomplete" in incomplete_reasons:
+        reason = "verification_incomplete"
+    elif "budget_exhausted" in incomplete_reasons:
+        reason = "budget_exhausted"
+    else:
+        reason = None
+    return len(completed), reason
 
 
 def _grep_verify_findings_parallel(
@@ -478,13 +574,16 @@ def _grep_verify_findings_parallel(
     time_budget: float,
     max_workers: int,
     start_time: float,
-) -> dict[str, GrepVerdict]:
+) -> GrepVerificationResult:
+    eligible_findings = [finding for finding in findings if _finding_full_name(finding)]
     verdicts: dict[str, GrepVerdict] = {}
     worker_count = max(1, int(max_workers or _DEFAULT_GREP_WORKERS))
     deadline = start_time + time_budget
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=worker_count)
     pending: set[_FindingFuture] = set()
-    findings_iter = iter(findings)
+    findings_iter = iter(eligible_findings)
+    verified_count = 0
+    incomplete_reason: str | None = None
 
     try:
         for _ in range(worker_count):
@@ -493,7 +592,7 @@ def _grep_verify_findings_parallel(
             ):
                 break
 
-        while pending and time.monotonic() <= deadline:
+        while pending and time.monotonic() < deadline:
             remaining = max(0.0, deadline - time.monotonic())
             done, pending = concurrent.futures.wait(
                 pending,
@@ -502,7 +601,12 @@ def _grep_verify_findings_parallel(
             )
             if not done:
                 break
-            _collect_finished_findings(done, verdicts)
+            newly_verified, incomplete_reason = _collect_finished_findings(
+                done, verdicts, deadline
+            )
+            verified_count += newly_verified
+            if incomplete_reason:
+                break
             for _ in done:
                 _submit_next_finding(
                     executor, pending, findings_iter, search_fn, deadline
@@ -512,7 +616,20 @@ def _grep_verify_findings_parallel(
             future.cancel()
         executor.shutdown(wait=True, cancel_futures=True)
 
-    return verdicts
+    candidate_count = len(eligible_findings)
+    if incomplete_reason is None and verified_count != candidate_count:
+        incomplete_reason = (
+            "budget_exhausted"
+            if time.monotonic() >= deadline
+            else "verification_incomplete"
+        )
+    return GrepVerificationResult(
+        verdicts if incomplete_reason is None else {},
+        candidate_count=candidate_count,
+        verified_count=verified_count,
+        time_budget=time_budget,
+        incomplete_reason=incomplete_reason,
+    )
 
 
 def grep_verify_findings(
@@ -523,7 +640,7 @@ def grep_verify_findings(
     parallel: bool = False,
     max_workers: int = _DEFAULT_GREP_WORKERS,
     cache: Any = None,
-) -> dict[str, GrepVerdict]:
+) -> GrepVerificationResult:
     cache_binder = getattr(type(cache), "bind_repository", None)
     if callable(cache_binder):
         cache_binder(cache, project_root)

--- a/skylos/reporting/dead_code_result.py
+++ b/skylos/reporting/dead_code_result.py
@@ -33,7 +33,12 @@ def dead_code_evidence(analyzer, path, pyproject_entrypoint_qnames, threshold=No
         if evidence_root.is_file():
             evidence_root = evidence_root.parent
 
-    from skylos.deadcode.evidence import build_dead_code_evidence
+    from skylos.deadcode.evidence import (
+        EvidenceEvent,
+        EvidenceKind,
+        SymbolKey,
+        build_dead_code_evidence,
+    )
 
     ledger = build_dead_code_evidence(
         analyzer.defs,
@@ -41,6 +46,15 @@ def dead_code_evidence(analyzer, path, pyproject_entrypoint_qnames, threshold=No
         pyproject_entrypoint_qnames=pyproject_entrypoint_qnames,
         threshold=threshold,
     )
+    for finding in getattr(analyzer, "_grep_verify_incomplete_candidates", ()):
+        ledger.add(
+            SymbolKey.from_finding(finding),
+            EvidenceEvent(
+                kind=EvidenceKind.UNCERTAINTY,
+                reason="grep verification did not complete",
+                source="grep_verify",
+            ),
+        )
     return ledger, ledger.to_dict(
         evidence_root,
         definitions=analyzer.defs,

--- a/skylos/ui/rich_report.py
+++ b/skylos/ui/rich_report.py
@@ -54,6 +54,12 @@ def _grep_verify_pill(summary):
         return None
     if not grep_verify.get("enabled"):
         return "[muted]Grep verify: off[/muted]"
+    if grep_verify.get("complete") is False:
+        candidate_count = int(grep_verify.get("candidate_count") or 0)
+        return (
+            "[warn]Grep verify: incomplete[/warn] "
+            f"[muted]({candidate_count} candidates affected)[/muted]"
+        )
     rescued_count = int(grep_verify.get("rescued_count") or 0)
     return f"[brand]Grep verify: on[/brand] [muted](rescued {rescued_count})[/muted]"
 

--- a/skylos_mcp/server.py
+++ b/skylos_mcp/server.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from skylos.analysis.errors import analysis_result_incomplete
 from skylos_mcp.auth import (
     build_mcp_network_auth,
     check_mcp_client_context,
@@ -797,6 +798,8 @@ def _is_architecture_finding(finding: dict) -> bool:
 def _make_summary(result: dict, focus: str | None = None) -> dict:
     summary = result.get("analysis_summary", {})
     out: dict[str, Any] = {"analysis_summary": summary}
+    if result.get("analysis_errors"):
+        out["analysis_errors"] = result["analysis_errors"]
 
     workspace_info = result.get("workspaces") or {}
     if (
@@ -1136,6 +1139,19 @@ def _register_tools(mcp):
 
             raw = run_analyze(str(path), conf=confidence, exclude_folders=excl)
             static_result = json.loads(raw) if isinstance(raw, str) else raw
+            if analysis_result_incomplete(static_result):
+                return json.dumps(
+                    {
+                        "error": "Cannot verify dead code from incomplete analysis.",
+                        "analysis_errors": static_result.get(
+                            "analysis_errors", []
+                        ),
+                        "incomplete_languages": static_result.get(
+                            "analysis_summary", {}
+                        ).get("incomplete_languages", []),
+                    },
+                    indent=2,
+                )
 
             all_findings = []
             for key in (
@@ -1203,8 +1219,8 @@ def _register_tools(mcp):
 
         try:
             from skylos.analyzer import analyze as run_static
-            from skylos.dead_code import collect_dead_code_findings
-            from skylos.fixgen import (
+            from skylos.deadcode.collect import collect_dead_code_findings
+            from skylos.remediation.fixgen import (
                 generate_removal_plan,
                 generate_unified_diff,
                 apply_patches,
@@ -1222,11 +1238,54 @@ def _register_tools(mcp):
                 enable_secrets=False,
             )
             static_result = json.loads(raw) if isinstance(raw, str) else raw
+            analysis_errors = static_result.get("analysis_errors") or []
+            incomplete_languages = (
+                static_result.get("analysis_summary", {}).get(
+                    "incomplete_languages"
+                )
+                or []
+            )
+            if analysis_result_incomplete(static_result):
+                return json.dumps(
+                    {
+                        "error": "Cannot generate fixes from incomplete analysis.",
+                        "analysis_errors": analysis_errors,
+                        "incomplete_languages": incomplete_languages,
+                    },
+                    indent=2,
+                )
             all_findings = collect_dead_code_findings(static_result)
             defs_map = static_result.get("definitions", {})
 
             # use grep verification to filter
-            verdicts = grep_verify_findings(all_findings, target, time_budget=30.0)
+            grep_budget = float(os.getenv("SKYLOS_GREP_BUDGET", "30"))
+            verdicts = grep_verify_findings(
+                all_findings,
+                target,
+                time_budget=grep_budget,
+            )
+            if not getattr(verdicts, "complete", True):
+                return json.dumps(
+                    {
+                        "error": (
+                            "Cannot generate fixes because grep verification "
+                            "did not complete. Increase SKYLOS_GREP_BUDGET and rerun."
+                        ),
+                        "grep_verify": {
+                            "complete": False,
+                            "candidate_count": getattr(
+                                verdicts, "candidate_count", len(all_findings)
+                            ),
+                            "time_budget_seconds": grep_budget,
+                            "incomplete_reason": getattr(
+                                verdicts,
+                                "incomplete_reason",
+                                "verification_incomplete",
+                            ),
+                        },
+                    },
+                    indent=2,
+                )
             dead_findings = [
                 f
                 for f in all_findings

--- a/test/test_agent_integration.py
+++ b/test/test_agent_integration.py
@@ -458,6 +458,60 @@ def test_agent_verify_json_uses_harness_and_writes_metadata(tmp_path):
     assert kwargs["verification_mode"] == "judge_all"
 
 
+def test_agent_verify_refuses_fixes_from_incomplete_static_analysis(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("def old_func():\n    pass\n")
+    collect = MagicMock()
+    verify = MagicMock()
+
+    with (
+        patch(
+            "skylos.analyzer.analyze",
+            return_value=json.dumps(
+                {
+                    "analysis_summary": {
+                        "grade_unavailable_reason": "analysis_incomplete"
+                    },
+                    "analysis_errors": [
+                        {
+                            "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                            "kind": "grep_budget_exhausted",
+                        }
+                    ],
+                }
+            ),
+        ),
+        patch(
+            "skylos.deadcode.collect.collect_dead_code_findings",
+            collect,
+        ),
+        patch("skylos.llm.harness.run_verification_harness", verify),
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch(
+            "sys.argv",
+            [
+                "skylos",
+                "agent",
+                "verify",
+                str(sample),
+                "--fix",
+                "--apply",
+            ],
+        ),
+    ):
+        from skylos.cli import main
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 2
+    collect.assert_not_called()
+    verify.assert_not_called()
+
+
 def _write_sample_harness_run(tmp_path):
     from skylos.llm.harness.runner import HarnessRunner
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -1843,7 +1843,11 @@ max_args = false
                     None,
                 )
 
-                result_json = skylos.analyze("/fake/path", thr=60)
+                result_json = skylos.analyze(
+                    "/fake/path",
+                    thr=60,
+                    grep_verify=False,
+                )
                 result = json.loads(result_json)
 
                 assert len(result["unused_functions"]) == 1

--- a/test/test_baseline.py
+++ b/test/test_baseline.py
@@ -211,3 +211,17 @@ class TestFilterNewFindings:
         assert "grade" not in filtered
         assert "ai_security_stats" not in filtered
         assert "provenance_summary" not in filtered
+
+    def test_preserves_incomplete_grep_status(self):
+        result = _sample_result()
+        grep_verify = {
+            "enabled": True,
+            "complete": False,
+            "status": "incomplete",
+            "incomplete_reason": "budget_exhausted",
+        }
+        result["analysis_summary"] = {"grep_verify": grep_verify}
+
+        filtered = filter_new_findings(result, {"fingerprints": []})
+
+        assert filtered["analysis_summary"]["grep_verify"] == grep_verify

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -588,6 +588,25 @@ def test_apply_display_filters_severity_filters_without_crashing():
     assert filtered["analysis_summary"]["quality_count"] == 2
 
 
+def test_apply_display_filters_preserves_incomplete_grep_status():
+    grep_verify = {
+        "enabled": True,
+        "complete": False,
+        "status": "incomplete",
+        "incomplete_reason": "budget_exhausted",
+    }
+    result = {
+        "analysis_summary": {"total_files": 1, "grep_verify": grep_verify},
+        "analysis_errors": [{"kind": "grep_budget_exhausted"}],
+        "quality": [],
+    }
+
+    filtered = cli._apply_display_filters(result, severity="high")
+
+    assert filtered["analysis_summary"]["grep_verify"] == grep_verify
+    assert filtered["analysis_errors"] == result["analysis_errors"]
+
+
 def test_apply_display_filters_combines_category_file_and_severity():
     result = {
         "analysis_summary": {"total_files": 1},
@@ -749,6 +768,25 @@ def test_apply_rule_selection_filters_exact_ids_and_preserves_analysis_errors():
     assert filtered["danger"] == []
     assert filtered["unused_functions"] == []
     assert filtered["analysis_summary"]["selected_rules"] == ["SKY-L012"]
+
+
+def test_apply_rule_selection_preserves_incomplete_grep_status():
+    grep_verify = {
+        "enabled": True,
+        "complete": False,
+        "status": "incomplete",
+        "incomplete_reason": "budget_exhausted",
+    }
+    result = {
+        "analysis_summary": {"total_files": 1, "grep_verify": grep_verify},
+        "analysis_errors": [{"kind": "grep_budget_exhausted"}],
+        "quality": [{"rule_id": "SKY-Q301", "file": "app.py", "line": 1}],
+    }
+
+    filtered = cli._apply_rule_selection(result, ["SKY-Q301"])
+
+    assert filtered["analysis_summary"]["grep_verify"] == grep_verify
+    assert filtered["analysis_errors"] == result["analysis_errors"]
 
 
 def test_apply_rule_selection_uses_public_ids_for_dead_code_without_rule_ids():
@@ -1330,6 +1368,37 @@ def test_render_results_shows_grep_verify_summary():
     assert "rescued 3" in printed
 
 
+def test_render_results_shows_incomplete_grep_verification():
+    console = Mock()
+    result = {
+        "analysis_summary": {
+            "total_files": 1,
+            "grep_verify": {
+                "enabled": True,
+                "rescued_count": 0,
+                "complete": False,
+                "candidate_count": 12,
+            },
+        },
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_parameters": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "quality": [],
+        "danger": [],
+        "secrets": [],
+    }
+
+    cli.render_results(console, result, tree=False, root_path="/root")
+
+    printed = "\n".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "Grep verify: incomplete" in printed
+    assert "12 candidates affected" in printed
+
+
 def test_render_results_shows_analysis_errors_without_grade():
     console = Mock()
     result = {
@@ -1341,6 +1410,7 @@ def test_render_results_shows_analysis_errors_without_grade():
                 "file": "/root/future.py",
                 "line": 1,
                 "python_version": "3.12.13",
+                "affected_file_count": 7,
             }
         ],
         "unused_functions": [],
@@ -1367,6 +1437,7 @@ def test_render_results_shows_analysis_errors_without_grade():
         if call.args and isinstance(call.args[0], cli.Panel)
     ]
     assert any("Analysis incomplete" in str(panel.renderable) for panel in panels)
+    assert any("7 affected files" in str(panel.renderable) for panel in panels)
     assert all("Codebase Grade" not in str(panel.renderable) for panel in panels)
 
 

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -13,6 +13,8 @@ from skylos.core import grep_verify as grep_verify_module
 from skylos.core.grep_cache import GrepCache
 from skylos.core.grep_verify import (
     GrepStrategy,
+    GrepVerdict,
+    GrepVerificationResult,
     _deterministic_suppress_multilang,
     _store_cached_group_results,
     detect_language,
@@ -30,7 +32,9 @@ from skylos.core.grep_verify import (
 from skylos.core.grep_verify_common import (
     GrepRequest,
     _GrepBatchResults,
+    _GrepDeadlineExceeded,
     _GrepEvidence,
+    _GrepExecutionIncomplete,
     _GrepOutputLimitExceeded,
     _is_python_source_reference,
     _python_regex,
@@ -416,7 +420,93 @@ class TestGrepVerifyFindings:
             for i in range(100)
         ]
         verdicts = grep_verify_findings(findings, str(tmp_path), time_budget=0.0)
-        assert len(verdicts) < 50
+        assert verdicts == {}
+        assert verdicts.complete is False
+        assert verdicts.budget_exhausted is True
+        assert verdicts.candidate_count == 100
+        assert verdicts.verified_count == 0
+
+    def test_different_deadline_prefixes_produce_the_same_fail_closed_result(
+        self, tmp_path
+    ):
+        findings = [
+            {
+                "name": f"func_{index}",
+                "full_name": f"mod.func_{index}",
+                "simple_name": f"func_{index}",
+                "type": "function",
+                "file": str(tmp_path / "mod.py"),
+                "line": index + 1,
+                "confidence": 80,
+            }
+            for index in range(3)
+        ]
+
+        def run_with_clock(clock):
+            with (
+                patch(
+                    "skylos.core.grep_verify.time.monotonic",
+                    side_effect=clock,
+                ),
+                patch(
+                    "skylos.core.grep_verify._plan_batched_finding",
+                    side_effect=lambda finding, *_args: (
+                        GrepVerdict(alive=True, rationale=finding["full_name"]),
+                        None,
+                    ),
+                ),
+            ):
+                return grep_verify_findings(
+                    findings,
+                    str(tmp_path),
+                    time_budget=0.15,
+                )
+
+        one_candidate_checked = run_with_clock([0.0, 0.1, 0.2])
+        two_candidates_checked = run_with_clock([0.0, 0.05, 0.1, 0.2])
+
+        assert one_candidate_checked == two_candidates_checked == {}
+        assert one_candidate_checked.verified_count == 1
+        assert two_candidates_checked.verified_count == 2
+        assert one_candidate_checked.budget_exhausted is True
+        assert two_candidates_checked.budget_exhausted is True
+
+    def test_last_candidate_finishing_at_deadline_is_complete(self, tmp_path):
+        finding = {
+            "name": "helper",
+            "full_name": "mod.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(tmp_path / "mod.py"),
+            "line": 1,
+            "confidence": 80,
+        }
+        now = [0.0]
+
+        def complete_at_deadline(*_args):
+            now[0] = 0.5
+            return None, None
+
+        with (
+            patch(
+                "skylos.core.grep_verify.time.monotonic",
+                side_effect=lambda: now[0],
+            ),
+            patch(
+                "skylos.core.grep_verify._plan_batched_finding",
+                side_effect=complete_at_deadline,
+            ),
+        ):
+            verdicts = grep_verify_findings(
+                [finding],
+                str(tmp_path),
+                time_budget=0.5,
+            )
+
+        assert verdicts == {}
+        assert verdicts.complete is True
+        assert verdicts.candidate_count == 1
+        assert verdicts.verified_count == 1
 
     def test_import_rescues(self, tmp_path):
         (tmp_path / "types.py").write_text("class MyType:\n    pass\n")
@@ -1464,6 +1554,8 @@ class TestBatchedGrepVerify:
             )
 
         assert verdicts == {}
+        assert verdicts.complete is False
+        assert verdicts.incomplete_reason == "verification_incomplete"
         assert cache.size == 0
 
     def test_conservative_partial_match_can_rescue_but_is_not_cached(
@@ -1501,6 +1593,43 @@ class TestBatchedGrepVerify:
             )
 
         assert set(verdicts) == {"library.helper"}
+        assert verdicts.complete is True
+        assert cache.size == 0
+
+    def test_incomplete_request_without_alive_evidence_fails_closed(
+        self, tmp_path
+    ):
+        library = tmp_path / "library.py"
+        library.write_text("def helper():\n    return 1\n")
+        finding = {
+            "name": "helper",
+            "full_name": "library.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(library),
+            "line": 1,
+            "confidence": 80,
+        }
+        cache = GrepCache()
+
+        def incomplete_negative_results(requests, **_kwargs):
+            results = _GrepBatchResults()
+            for request in requests:
+                results[request] = ()
+            results.incomplete_requests.add(requests[0])
+            return results
+
+        with patch(
+            "skylos.core.grep_verify.execute_grep_batch",
+            side_effect=incomplete_negative_results,
+        ):
+            verdicts = grep_verify_findings(
+                [finding], str(tmp_path), cache=cache, time_budget=1.0
+            )
+
+        assert verdicts == {}
+        assert verdicts.complete is False
+        assert verdicts.incomplete_reason == "verification_incomplete"
         assert cache.size == 0
 
     def test_malformed_cached_group_is_treated_as_a_cache_miss(self, tmp_path):
@@ -1700,6 +1829,8 @@ class TestBatchedGrepVerify:
             verdicts = grep_verify_findings([finding], str(tmp_path), time_budget=0.5)
 
         assert verdicts == {}
+        assert verdicts.complete is False
+        assert verdicts.budget_exhausted is True
         mock_batch.assert_not_called()
 
     def test_batched_and_legacy_verdicts_match(self, tmp_path):
@@ -1818,6 +1949,94 @@ class TestQualifiedReferenceSubstring:
 
 
 class TestAnalyzerIntegration:
+    def test_exhausted_budget_withholds_candidates_and_marks_scan_incomplete(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "app.py").write_text(
+            "import os\n\ndef orphan(unused_arg):\n    return 1\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "utils.py").write_text(
+            "def another_orphan():\n    return 2\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("SKYLOS_GREP_BUDGET", "0")
+
+        from skylos import cli
+        from skylos.analyzer import analyze
+
+        result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=True))
+
+        assert result["analysis_errors"][0]["rule_id"] == (
+            "SKY-ANALYSIS-INCOMPLETE"
+        )
+        assert result["analysis_errors"][0]["kind"] == "grep_budget_exhausted"
+        assert result["analysis_summary"]["grep_verify"] == {
+            "enabled": True,
+            "rescued_count": 0,
+            "project_cache_enabled": True,
+            "complete": False,
+            "status": "incomplete",
+            "candidate_count": 4,
+            "candidate_file_count": 2,
+            "time_budget_seconds": 0.0,
+            "incomplete_reason": "budget_exhausted",
+        }
+        assert result["analysis_errors"][0]["file"] == str(tmp_path / "app.py")
+        assert result["analysis_errors"][0]["affected_file_count"] == 2
+        assert "grade" not in result
+        assert result["analysis_summary"]["grade_unavailable_reason"] == (
+            "analysis_incomplete"
+        )
+        assert cli._analysis_incomplete_exit_code(result) == 2
+
+        assert result["unused_functions"] == []
+        assert result["unused_imports"] == []
+        assert result["unused_parameters"] == []
+        abstentions = result["dead_code_abstentions"]
+        assert {finding["type"] for finding in abstentions} >= {
+            "function",
+            "import",
+            "parameter",
+        }
+        grep_uncertainty = [
+            evidence
+            for finding in abstentions
+            for evidence in finding.get("dead_code_evidence", [])
+            if evidence.get("source") == "grep_verify"
+        ]
+        assert grep_uncertainty
+        assert all(
+            evidence["kind"] == "uncertainty" for evidence in grep_uncertainty
+        )
+
+    def test_incomplete_grep_state_is_reset_between_analyzer_runs(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "app.py").write_text(
+            "def orphan():\n    return 1\n",
+            encoding="utf-8",
+        )
+
+        from skylos.analyzer import Skylos
+
+        analyzer = Skylos()
+        monkeypatch.setenv("SKYLOS_GREP_BUDGET", "0")
+        incomplete = json.loads(
+            analyzer.analyze(str(tmp_path), thr=0, grep_verify=True)
+        )
+        complete = json.loads(
+            analyzer.analyze(str(tmp_path), thr=0, grep_verify=False)
+        )
+
+        assert incomplete["unused_functions"] == []
+        assert incomplete["dead_code_abstentions"]
+        assert complete["analysis_errors"] == []
+        assert complete["dead_code_abstentions"] == []
+        assert {item["simple_name"] for item in complete["unused_functions"]} == {
+            "orphan"
+        }
+
     def test_grep_cache_invalidates_when_repository_evidence_changes(self, tmp_path):
         target = tmp_path / "target.py"
         evidence = tmp_path / "evidence.py"
@@ -1945,6 +2164,51 @@ result = PublicClass.used_method()
 
 
 class TestAnalyzerGrepVerifyOrdering:
+    def test_incomplete_result_does_not_apply_partial_rescues(
+        self, tmp_path, monkeypatch
+    ):
+        from skylos.analyzer import Skylos
+        from skylos.visitors.base import Definition
+
+        source = tmp_path / "mod.py"
+        source.write_text("def helper():\n    return 1\n")
+        analyzer = Skylos()
+        analyzer._project_root = tmp_path
+        definition = Definition("mod.helper", "function", source, 1)
+        definition.confidence = 80
+        analyzer.defs = {"mod.helper": definition}
+        incomplete = GrepVerificationResult(
+            {"mod.helper": GrepVerdict(alive=True)},
+            candidate_count=1,
+            verified_count=0,
+            time_budget=0.0,
+            incomplete_reason="budget_exhausted",
+        )
+        monkeypatch.setenv("SKYLOS_GREP_BUDGET", "0")
+
+        with patch(
+            "skylos.core.grep_verify.grep_verify_findings",
+            return_value=incomplete,
+        ):
+            rescued = analyzer._grep_verify()
+
+        assert rescued == 0
+        assert definition.references == 0
+        assert definition.heuristic_refs.get("grep_verify") is None
+        assert analyzer._grep_verify_report["complete"] is False
+        assert analyzer._grep_verify_incomplete_candidates[0]["full_name"] == (
+            "mod.helper"
+        )
+
+        with patch(
+            "skylos.core.grep_verify.grep_verify_findings",
+            return_value={},
+        ):
+            analyzer._grep_verify()
+
+        assert not hasattr(analyzer, "_grep_verify_incomplete_candidates")
+        assert "complete" not in analyzer._grep_verify_report
+
     def test_candidates_are_sorted_by_rescue_priority(self, tmp_path):
         from skylos.analyzer import Skylos
         from skylos.visitors.base import Definition
@@ -2353,6 +2617,60 @@ class TestParallelMultiStrategySearch:
 
 
 class TestGrepVerifyParallel:
+    def test_parallel_incomplete_operation_at_deadline_is_budget_exhaustion(self):
+        incomplete = grep_verify_module.concurrent.futures.Future()
+        incomplete.set_exception(_GrepExecutionIncomplete("request timed out"))
+
+        with patch("skylos.core.grep_verify.time.monotonic", return_value=1.0):
+            verified_count, reason = (
+                grep_verify_module._collect_finished_findings(
+                    {incomplete}, {}, deadline=1.0
+                )
+            )
+
+        assert verified_count == 0
+        assert reason == "budget_exhausted"
+
+    def test_parallel_completion_reason_is_order_independent(self):
+        success = grep_verify_module.concurrent.futures.Future()
+        success.set_result(("lib.helper", GrepVerdict(alive=True)))
+        deadline = grep_verify_module.concurrent.futures.Future()
+        deadline.set_exception(_GrepDeadlineExceeded("budget"))
+        failure = grep_verify_module.concurrent.futures.Future()
+        failure.set_exception(RuntimeError("backend failed"))
+        verdicts = {}
+
+        verified_count, reason = grep_verify_module._collect_finished_findings(
+            {deadline, success, failure}, verdicts
+        )
+
+        assert verified_count == 1
+        assert reason == "verification_incomplete"
+        assert set(verdicts) == {"lib.helper"}
+
+    def test_parallel_budget_exhaustion_discards_partial_results(self, tmp_path):
+        finding = {
+            "name": "helper",
+            "full_name": "lib.helper",
+            "simple_name": "helper",
+            "type": "function",
+            "file": str(tmp_path / "lib.py"),
+            "line": 1,
+            "confidence": 80,
+        }
+
+        verdicts = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            time_budget=0.0,
+            parallel=True,
+            max_workers=1,
+        )
+
+        assert verdicts == {}
+        assert verdicts.complete is False
+        assert verdicts.budget_exhausted is True
+
     def test_parallel_mode(self, tmp_path):
         (tmp_path / "lib.py").write_text("def helper():\n    return 42\n")
         (tmp_path / "main.py").write_text("from lib import helper\nhelper()\n")

--- a/test/test_mcp_summary.py
+++ b/test/test_mcp_summary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import Mock
 
 import skylos_mcp.server as mcp_server
 from skylos_mcp.server import (
@@ -9,6 +10,24 @@ from skylos_mcp.server import (
     _make_summary,
     _register_tools,
 )
+
+
+class _FakeMCP:
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self):
+        def decorate(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return decorate
+
+    def resource(self, *_args, **_kwargs):
+        def decorate(fn):
+            return fn
+
+        return decorate
 
 
 def test_make_summary_includes_workspace_report_when_present():
@@ -40,6 +59,243 @@ def test_make_summary_omits_empty_workspace_report():
     summary = _make_summary(result)
 
     assert "workspaces" not in summary
+
+
+def test_make_summary_preserves_analysis_errors():
+    error = {
+        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+        "kind": "grep_budget_exhausted",
+    }
+    summary = _make_summary(
+        {
+            "analysis_summary": {"total_files": 1},
+            "analysis_errors": [error],
+        }
+    )
+
+    assert summary["analysis_errors"] == [error]
+
+
+def test_generate_fix_rejects_explicit_incomplete_grep_summary(
+    monkeypatch, tmp_path
+):
+    import skylos.analyzer as analyzer_module
+    import skylos.deadcode.collect as dead_code_module
+
+    fake = _FakeMCP()
+    _register_tools(fake)
+    monkeypatch.setattr(mcp_server, "_gate", lambda _tool_name: None)
+    monkeypatch.setattr(
+        analyzer_module,
+        "analyze",
+        lambda *_args, **_kwargs: json.dumps(
+            {
+                "analysis_summary": {
+                    "grep_verify": {"complete": False, "status": "incomplete"}
+                },
+                "analysis_errors": [],
+            }
+        ),
+    )
+    collect = Mock(side_effect=AssertionError("must not collect partial findings"))
+    monkeypatch.setattr(dead_code_module, "collect_dead_code_findings", collect)
+
+    result = json.loads(fake.tools["generate_fix"](str(tmp_path), apply=True))
+
+    assert result["error"] == "Cannot generate fixes from incomplete analysis."
+    collect.assert_not_called()
+
+
+def test_generate_fix_rejects_incomplete_static_analysis(monkeypatch, tmp_path):
+    import skylos.analyzer as analyzer_module
+    import skylos.deadcode.collect as dead_code_module
+
+    fake = _FakeMCP()
+    _register_tools(fake)
+    monkeypatch.setattr(mcp_server, "_gate", lambda _tool_name: None)
+    monkeypatch.setattr(
+        analyzer_module,
+        "analyze",
+        lambda *_args, **_kwargs: json.dumps(
+            {
+                "analysis_summary": {},
+                "analysis_errors": [
+                    {
+                        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                        "kind": "grep_budget_exhausted",
+                    }
+                ],
+            }
+        ),
+    )
+    collect = Mock(side_effect=AssertionError("must not collect partial findings"))
+    monkeypatch.setattr(dead_code_module, "collect_dead_code_findings", collect)
+
+    result = json.loads(
+        fake.tools["generate_fix"](str(tmp_path), apply=True)
+    )
+
+    assert result["error"] == "Cannot generate fixes from incomplete analysis."
+    assert result["analysis_errors"][0]["kind"] == "grep_budget_exhausted"
+    collect.assert_not_called()
+
+
+def test_verify_dead_code_rejects_incomplete_static_analysis(
+    monkeypatch, tmp_path
+):
+    import skylos.analyzer as analyzer_module
+    import skylos.llm.verify_orchestrator as verify_module
+
+    fake = _FakeMCP()
+    _register_tools(fake)
+    monkeypatch.setattr(mcp_server, "_gate", lambda _tool_name: None)
+    monkeypatch.setattr(
+        analyzer_module,
+        "analyze",
+        lambda *_args, **_kwargs: json.dumps(
+            {
+                "analysis_summary": {
+                    "grade_unavailable_reason": "analysis_incomplete"
+                },
+                "analysis_errors": [
+                    {
+                        "rule_id": "SKY-ANALYSIS-INCOMPLETE",
+                        "kind": "grep_budget_exhausted",
+                    }
+                ],
+                "unused_functions": [{"full_name": "app.orphan"}],
+            }
+        ),
+    )
+    verify = Mock(side_effect=AssertionError("must not verify partial analysis"))
+    monkeypatch.setattr(verify_module, "run_verification", verify)
+
+    result = json.loads(fake.tools["verify_dead_code"](str(tmp_path)))
+
+    assert result["error"] == (
+        "Cannot verify dead code from incomplete analysis."
+    )
+    assert result["analysis_errors"][0]["kind"] == "grep_budget_exhausted"
+    verify.assert_not_called()
+
+
+def test_generate_fix_rejects_incomplete_direct_grep(monkeypatch, tmp_path):
+    import skylos.analyzer as analyzer_module
+    import skylos.core.grep_verify as grep_verify_module
+    import skylos.deadcode.collect as dead_code_module
+    import skylos.remediation.fixgen as fixgen_module
+
+    class IncompleteVerdicts(dict):
+        complete = False
+        candidate_count = 1
+        incomplete_reason = "budget_exhausted"
+
+    finding = {
+        "name": "orphan",
+        "full_name": "app.orphan",
+        "file": str(tmp_path / "app.py"),
+        "line": 1,
+        "type": "function",
+    }
+    fake = _FakeMCP()
+    _register_tools(fake)
+    monkeypatch.setattr(mcp_server, "_gate", lambda _tool_name: None)
+    monkeypatch.setenv("SKYLOS_GREP_BUDGET", "0.25")
+    monkeypatch.setattr(
+        analyzer_module,
+        "analyze",
+        lambda *_args, **_kwargs: json.dumps(
+            {
+                "analysis_summary": {},
+                "analysis_errors": [],
+                "definitions": {},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        dead_code_module,
+        "collect_dead_code_findings",
+        lambda _result: [finding],
+    )
+    grep = Mock(return_value=IncompleteVerdicts())
+    monkeypatch.setattr(grep_verify_module, "grep_verify_findings", grep)
+    plan = Mock(side_effect=AssertionError("must not plan from partial grep"))
+    monkeypatch.setattr(fixgen_module, "generate_removal_plan", plan)
+
+    result = json.loads(
+        fake.tools["generate_fix"](str(tmp_path), apply=True)
+    )
+
+    assert "grep verification did not complete" in result["error"]
+    assert result["grep_verify"]["complete"] is False
+    assert result["grep_verify"]["time_budget_seconds"] == 0.25
+    assert grep.call_args.kwargs["time_budget"] == 0.25
+    plan.assert_not_called()
+
+
+def test_generate_fix_keeps_complete_mapping_compatibility(monkeypatch, tmp_path):
+    import skylos.analyzer as analyzer_module
+    import skylos.core.grep_verify as grep_verify_module
+    import skylos.deadcode.collect as dead_code_module
+    import skylos.remediation.fixgen as fixgen_module
+
+    finding = {
+        "name": "orphan",
+        "full_name": "app.orphan",
+        "file": str(tmp_path / "app.py"),
+        "line": 1,
+        "type": "function",
+    }
+    fake = _FakeMCP()
+    _register_tools(fake)
+    monkeypatch.setattr(mcp_server, "_gate", lambda _tool_name: None)
+    monkeypatch.setattr(
+        analyzer_module,
+        "analyze",
+        lambda *_args, **_kwargs: json.dumps(
+            {
+                "analysis_summary": {},
+                "analysis_errors": [],
+                "definitions": {},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        dead_code_module,
+        "collect_dead_code_findings",
+        lambda _result: [finding],
+    )
+    monkeypatch.setattr(
+        grep_verify_module,
+        "grep_verify_findings",
+        lambda *_args, **_kwargs: {},
+    )
+    plan = Mock(return_value=[])
+    monkeypatch.setattr(fixgen_module, "generate_removal_plan", plan)
+    monkeypatch.setattr(fixgen_module, "validate_patches", lambda *_args: [])
+    monkeypatch.setattr(
+        fixgen_module,
+        "generate_unified_diff",
+        lambda _patches, _target: "",
+    )
+    monkeypatch.setattr(
+        fixgen_module,
+        "generate_fix_summary",
+        lambda _patches: {"files": 0},
+    )
+    monkeypatch.setattr(mcp_server, "_store_result", Mock())
+
+    result = json.loads(fake.tools["generate_fix"](str(tmp_path)))
+
+    assert result["patches"] == 0
+    assert result["errors"] == []
+    plan.assert_called_once_with(
+        [finding],
+        {},
+        str(tmp_path),
+        mode="delete",
+        min_safety=0.0,
+    )
 
 
 def test_architecture_payload_filters_architecture_findings():


### PR DESCRIPTION
  Closes #714
## Summary

  - make grep verification fail closed when its time budget is exceeded
  - when grep verification times out, don't report uncertain dead code findings
  - preserve incomplete status across CLI filters, baselines and JSON output
  - prevent agent and MCP fix workflows from using incomplete results

  ## Tests

  - `pytest .`

