### PR TITLE
fix(quality): detect concrete ellipsis defaults

### DIFF
--- a/QUALITY.md
+++ b/QUALITY.md
@@ -60,7 +60,7 @@ advisory checks first.
 | Error disclosure | SKY-L017 | Exception details returned from handlers |
 | Broad file permissions | SKY-L020 | World-writable or overly broad file modes |
 | Stale mock | SKY-L024 | Tests mocking symbols that no longer exist |
-| Unfinished generation | SKY-L026 | Placeholder/generated functions left incomplete |
+| Unfinished generation | SKY-L026 | Incomplete functions or unhandled `...` defaults |
 | Duplicate string literal | SKY-L027 | Repeated long literals that should be named constants |
 | Too many returns | SKY-L028 | Functions with excessive exit paths |
 | Boolean trap | SKY-L029 | Public APIs with unclear boolean flags |

--- a/dictionary.md
+++ b/dictionary.md
@@ -480,7 +480,7 @@ use the `SKY-A` prefix.
 | L020 | HIGH | Overly broad file permissions | Python |
 | L021 | HIGH | Security control regression | Diff-aware review |
 | L024 | HIGH | Stale mock target | Python |
-| L026 | MEDIUM | Unfinished generated function | Python |
+| L026 | MEDIUM | Unfinished function or placeholder default | Python |
 | L027 | LOW-MEDIUM | Duplicate string literal | Python |
 | L028 | MEDIUM | Too many return statements | Python |
 | L029 | MEDIUM | Boolean positional parameter trap | Python |

--- a/skylos/benchmarks/ai_code_defects.py
+++ b/skylos/benchmarks/ai_code_defects.py
@@ -25,7 +25,10 @@ from skylos.verify_change import verify_change_path
 
 AI_CODE_DEFECT_TAXONOMY: dict[str, str] = {
     "hallucinated_reference": "Generated code references symbols that do not exist.",
-    "incomplete_generation": "Generated code leaves stubs or unfinished bodies behind.",
+    "incomplete_generation": (
+        "Generated code leaves stubs, placeholder defaults, or unfinished bodies "
+        "behind."
+    ),
     "dependency_hallucination": "Generated manifests cite packages or versions that do not exist.",
     "api_signature_hallucination": "Generated calls use real packages with invented APIs.",
     "assertion_weakening": "Generated test edits weaken assertions instead of preserving behavior.",

--- a/skylos/core/verify_change_schema.py
+++ b/skylos/core/verify_change_schema.py
@@ -55,7 +55,10 @@ SUGGESTED_FIX_BY_VIBE = {
     "hallucinated_reference": (
         "Define or import the referenced symbol, or replace it with an existing helper."
     ),
-    "incomplete_generation": "Implement the stub or remove the unfinished code path.",
+    "incomplete_generation": (
+        "Implement the stub, replace or handle placeholder defaults, or remove "
+        "the unfinished code path."
+    ),
     "ghost_config": "Define the referenced config value or remove the stale flag check.",
     "stale_reference": "Update the reference to the renamed symbol or remove it.",
     "missing_resilience_control": "Add the missing timeout or resilience control.",

--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -77,7 +77,7 @@ _RULES = (
     RuleCatalogEntry("SKY-L021", "Security regression", "quality"),
     RuleCatalogEntry("SKY-L023", "Phantom decorator", "ai_defect"),
     RuleCatalogEntry("SKY-L024", "Stale mock", "quality"),
-    RuleCatalogEntry("SKY-L026", "Unfinished generated code", "quality"),
+    RuleCatalogEntry("SKY-L026", "Unfinished code or placeholder default", "quality"),
     RuleCatalogEntry("SKY-L027", "Duplicate string literal", "quality"),
     RuleCatalogEntry("SKY-L028", "Too many returns", "quality"),
     RuleCatalogEntry("SKY-L029", "Boolean trap", "quality"),

--- a/skylos/rules/quality/_function_defaults.py
+++ b/skylos/rules/quality/_function_defaults.py
@@ -1,0 +1,208 @@
+import ast
+
+
+def ellipsis_type_bindings(module):
+    names = set()
+    modules = set()
+    for stmt in module.body:
+        if isinstance(stmt, ast.ImportFrom) and stmt.module == "types":
+            for imported in stmt.names:
+                if imported.name == "EllipsisType":
+                    names.add(imported.asname or imported.name)
+        elif isinstance(stmt, ast.Import):
+            for imported in stmt.names:
+                if imported.name == "types":
+                    modules.add(imported.asname or imported.name)
+    return names, modules
+
+
+def iter_arg_defaults(func_node):
+    args = func_node.args
+    positional_args = [*args.posonlyargs, *args.args]
+    offset = len(positional_args) - len(args.defaults)
+
+    for index, default in enumerate(args.defaults):
+        if default:
+            yield positional_args[offset + index], default
+    for arg, default in zip(args.kwonlyargs, args.kw_defaults):
+        if default:
+            yield arg, default
+
+
+def is_ellipsis_literal(node):
+    return isinstance(node, ast.Constant) and node.value is Ellipsis
+
+
+def annotation_accepts_ellipsis(annotation, *, type_names, type_modules):
+    """Return whether an annotation explicitly accepts types.EllipsisType."""
+    if annotation is None:
+        return False
+    if _is_bound_ellipsis_type(annotation, type_names, type_modules):
+        return True
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        return _annotations_accept_ellipsis(
+            (annotation.left, annotation.right),
+            type_names,
+            type_modules,
+        )
+    if isinstance(annotation, ast.Subscript):
+        return _subscript_accepts_ellipsis(annotation, type_names, type_modules)
+    return False
+
+
+def _is_bound_ellipsis_type(annotation, type_names, type_modules):
+    if isinstance(annotation, ast.Name):
+        return annotation.id in type_names
+    return (
+        isinstance(annotation, ast.Attribute)
+        and annotation.attr == "EllipsisType"
+        and isinstance(annotation.value, ast.Name)
+        and annotation.value.id in type_modules
+    )
+
+
+def _annotations_accept_ellipsis(annotations, type_names, type_modules):
+    return any(
+        annotation_accepts_ellipsis(
+            annotation,
+            type_names=type_names,
+            type_modules=type_modules,
+        )
+        for annotation in annotations
+    )
+
+
+def _subscript_accepts_ellipsis(annotation, type_names, type_modules):
+    members = _subscript_members(annotation.slice)
+    container = _qualified_tail(annotation.value)
+    if container in {"Union", "Optional"}:
+        return _annotations_accept_ellipsis(members, type_names, type_modules)
+    if container not in {"Annotated", "Required", "NotRequired"} or not members:
+        return False
+    return annotation_accepts_ellipsis(
+        members[0],
+        type_names=type_names,
+        type_modules=type_modules,
+    )
+
+
+def function_handles_ellipsis_parameter(node, parameter):
+    """Recognize explicit sentinel handling or transparent keyword delegation."""
+    nodes, parents = _function_body_graph(node)
+    if any(
+        isinstance(candidate, ast.Compare)
+        and _compares_parameter_to_ellipsis(candidate, parameter)
+        for candidate in nodes
+    ):
+        return True
+
+    loads = [
+        candidate
+        for candidate in nodes
+        if isinstance(candidate, ast.Name)
+        and isinstance(candidate.ctx, ast.Load)
+        and candidate.id == parameter
+    ]
+    return bool(loads) and all(
+        _is_same_name_keyword_passthrough(load, parents, parameter) for load in loads
+    )
+
+
+def _qualified_tail(node):
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _subscript_members(node):
+    return list(node.elts) if isinstance(node, ast.Tuple) else [node]
+
+
+def _is_ellipsis_reference(node):
+    if is_ellipsis_literal(node):
+        return True
+    if isinstance(node, ast.Name):
+        return node.id == "Ellipsis"
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "Ellipsis"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "builtins"
+    )
+
+
+def _compares_parameter_to_ellipsis(node, parameter):
+    operands = [node.left, *node.comparators]
+    for left, operator, right in zip(operands, node.ops, operands[1:]):
+        if not isinstance(operator, (ast.Is, ast.IsNot, ast.Eq, ast.NotEq)):
+            continue
+        if (
+            isinstance(left, ast.Name)
+            and left.id == parameter
+            and _is_ellipsis_reference(right)
+        ) or (
+            isinstance(right, ast.Name)
+            and right.id == parameter
+            and _is_ellipsis_reference(left)
+        ):
+            return True
+    return False
+
+
+def _function_body_graph(node):
+    nodes = []
+    parents = {}
+    pending = [(stmt, node) for stmt in reversed(node.body)]
+    while pending:
+        candidate, parent = pending.pop()
+        nodes.append(candidate)
+        parents[id(candidate)] = parent
+        if isinstance(
+            candidate,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
+        ):
+            continue
+        pending.extend(
+            (child, candidate)
+            for child in reversed(list(ast.iter_child_nodes(candidate)))
+        )
+    return nodes, parents
+
+
+def _is_same_name_keyword_passthrough(node, parents, parameter):
+    keyword = parents.get(id(node))
+    if not (
+        isinstance(keyword, ast.keyword)
+        and keyword.arg == parameter
+        and keyword.value is node
+    ):
+        return False
+    call = parents.get(id(keyword))
+    return (
+        isinstance(call, ast.Call)
+        and keyword in call.keywords
+        and _call_has_passthrough_context(call, parents)
+    )
+
+
+def _call_has_passthrough_context(node, parents):
+    current = node
+    while (parent := parents.get(id(current))) is not None:
+        if isinstance(parent, ast.Await):
+            current = parent
+            continue
+        if isinstance(parent, ast.keyword) and parent.value is current:
+            current = parent
+            continue
+        if isinstance(parent, ast.Starred) and parent.value is current:
+            current = parent
+            continue
+        if isinstance(parent, ast.Call) and (
+            current in parent.args or current in parent.keywords
+        ):
+            current = parent
+            continue
+        return isinstance(parent, (ast.Expr, ast.Return, ast.Assign, ast.AnnAssign))
+    return False

--- a/skylos/rules/quality/_protocols.py
+++ b/skylos/rules/quality/_protocols.py
@@ -65,3 +65,57 @@ def protocol_method_ids(module: ast.Module) -> set[int]:
         for stmt in candidate.body
         if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
+
+
+def _type_checking_import_bindings(module: ast.Module) -> tuple[set[str], set[str]]:
+    type_checking_names: set[str] = set()
+    typing_modules: set[str] = set()
+
+    for stmt in module.body:
+        if isinstance(stmt, ast.ImportFrom) and stmt.module in _PROTOCOL_MODULES:
+            for imported in stmt.names:
+                if imported.name == "TYPE_CHECKING":
+                    type_checking_names.add(imported.asname or imported.name)
+        elif isinstance(stmt, ast.Import):
+            for imported in stmt.names:
+                if imported.name in _PROTOCOL_MODULES:
+                    typing_modules.add(imported.asname or imported.name)
+
+    return type_checking_names, typing_modules
+
+
+def _is_type_checking_guard(
+    test: ast.expr,
+    type_checking_names: set[str],
+    typing_modules: set[str],
+) -> bool:
+    if isinstance(test, ast.Name):
+        return test.id in type_checking_names
+    return (
+        isinstance(test, ast.Attribute)
+        and test.attr == "TYPE_CHECKING"
+        and isinstance(test.value, ast.Name)
+        and test.value.id in typing_modules
+    )
+
+
+def type_checking_function_ids(module: ast.Module) -> set[int]:
+    type_checking_names, typing_modules = _type_checking_import_bindings(module)
+    if not type_checking_names and not typing_modules:
+        return set()
+
+    function_ids: set[int] = set()
+    for candidate in ast.walk(module):
+        if not isinstance(candidate, ast.If) or not _is_type_checking_guard(
+            candidate.test,
+            type_checking_names,
+            typing_modules,
+        ):
+            continue
+        for stmt in candidate.body:
+            function_ids.update(
+                id(child)
+                for child in ast.walk(stmt)
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+    return function_ids

--- a/skylos/rules/quality/logic_security.py
+++ b/skylos/rules/quality/logic_security.py
@@ -4,7 +4,17 @@ from functools import lru_cache
 from pathlib import Path
 
 from skylos.rules.base import SkylosRule
-from skylos.rules.quality._protocols import protocol_method_ids
+from skylos.rules.quality._function_defaults import (
+    annotation_accepts_ellipsis,
+    ellipsis_type_bindings,
+    function_handles_ellipsis_parameter,
+    is_ellipsis_literal,
+    iter_arg_defaults as _iter_arg_defaults,
+)
+from skylos.rules.quality._protocols import (
+    protocol_method_ids,
+    type_checking_function_ids,
+)
 from skylos.rules.quality.logic_foundation import _string_literal_value
 from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
@@ -345,14 +355,26 @@ class UnfinishedGenerationRule(SkylosRule):
 
     def __init__(self):
         self._protocol_method_ids: set[int] = set()
+        self._type_checking_function_ids: set[int] = set()
+        self._ellipsis_type_names: set[str] = set()
+        self._ellipsis_type_modules: set[str] = set()
 
     def visit_node(self, node, context):
         if isinstance(node, ast.Module):
             self._protocol_method_ids = protocol_method_ids(node)
+            self._type_checking_function_ids = type_checking_function_ids(node)
+            (
+                self._ellipsis_type_names,
+                self._ellipsis_type_modules,
+            ) = ellipsis_type_bindings(node)
             return None
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             return None
-        if id(node) in self._protocol_method_ids:
+        node_id = id(node)
+        if (
+            node_id in self._protocol_method_ids
+            or node_id in self._type_checking_function_ids
+        ):
             return None
 
         filename = context.get("filename", "")
@@ -367,36 +389,44 @@ class UnfinishedGenerationRule(SkylosRule):
                 return None
 
         basename = Path(filename).name
-        if basename == "__init__.py":
-            return None
         if basename.startswith("test_") or basename.startswith("conftest"):
             return None
 
+        default_findings = _ellipsis_default_findings(
+            node,
+            filename=filename,
+            basename=basename,
+            ellipsis_type_names=self._ellipsis_type_names,
+            ellipsis_type_modules=self._ellipsis_type_modules,
+        )
+
+        if basename == "__init__.py":
+            return default_findings or None
         if node.name.startswith("__") and node.name.endswith("__"):
-            return None
+            return default_findings or None
 
         body = node.body
         if not body:
-            return None
+            return default_findings or None
 
         stmts = body
         if isinstance(body[0], ast.Expr) and _string_literal_value(body[0].value):
             stmts = body[1:]
 
         if not stmts:
-            return None
+            return default_findings or None
 
         if len(stmts) != 1:
-            return None
+            return default_findings or None
 
         stmt = stmts[0]
         marker = _unfinished_generation_marker(stmt)
         marker_line = stmt.lineno
 
         if not marker:
-            return None
+            return default_findings or None
         if _is_empty_collection_route_response(marker, node):
-            return None
+            return default_findings or None
 
         return [
             {
@@ -421,6 +451,57 @@ class UnfinishedGenerationRule(SkylosRule):
                 "ai_likelihood": "medium",
             }
         ]
+
+
+def _ellipsis_default_findings(
+    node,
+    *,
+    filename,
+    basename,
+    ellipsis_type_names,
+    ellipsis_type_modules,
+):
+    findings = []
+    for arg, default in _iter_arg_defaults(node):
+        if not is_ellipsis_literal(default):
+            continue
+
+        parameter = arg.arg
+        if annotation_accepts_ellipsis(
+            arg.annotation,
+            type_names=ellipsis_type_names,
+            type_modules=ellipsis_type_modules,
+        ):
+            continue
+        if function_handles_ellipsis_parameter(node, parameter):
+            continue
+
+        findings.append(
+            {
+                "rule_id": "SKY-L026",
+                "kind": "logic",
+                "severity": "MEDIUM",
+                "type": "function",
+                "name": node.name,
+                "simple_name": node.name,
+                "parameter": parameter,
+                "value": "...",
+                "threshold": 0,
+                "message": (
+                    f"Function '{node.name}' uses `...` as the default for "
+                    f"parameter '{parameter}'. Calls that omit this argument "
+                    "receive Ellipsis at runtime; use a real default or handle "
+                    "Ellipsis explicitly."
+                ),
+                "file": filename,
+                "basename": basename,
+                "line": getattr(default, "lineno", getattr(node, "lineno", 1)),
+                "col": getattr(default, "col_offset", getattr(node, "col_offset", 0)),
+                "vibe_category": "incomplete_generation",
+                "ai_likelihood": "medium",
+            }
+        )
+    return findings
 
 
 def _unfinished_generation_marker(stmt):
@@ -1333,21 +1414,6 @@ class MockPlaceholderDataRule(SkylosRule):
                 "col": col,
             }
         )
-
-
-def _iter_arg_defaults(func_node):
-    args = func_node.args
-    num_defaults = len(args.defaults)
-    positional_args = [*args.posonlyargs, *args.args]
-    num_args = len(positional_args)
-    offset = num_args - num_defaults
-
-    for i, default in enumerate(args.defaults):
-        if default:
-            yield positional_args[offset + i], default
-    for arg, default in zip(args.kwonlyargs, args.kw_defaults):
-        if default:
-            yield arg, default
 
 
 _HTTP_RESPONSE_CONSTRUCTORS = {

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -3507,6 +3507,36 @@ def fake_call():
             "low_entropy_uuid",
         }
 
+    def test_analyze_flags_concrete_ellipsis_default(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("SKYLOS_JOBS", "1")
+        src = tmp_path / "app.py"
+        src.write_text(
+            "def read(length: int = ...) -> int:\n"
+            "    return length + 5\n"
+            "\n"
+            "read()\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
+        )
+        findings = [
+            finding
+            for finding in result.get("quality", [])
+            if finding.get("rule_id") == "SKY-L026"
+        ]
+
+        assert result.get("analysis_errors", []) == []
+        assert len(findings) == 1
+        assert findings[0]["name"] == "read"
+        assert findings[0]["parameter"] == "length"
+        assert findings[0]["line"] == 1
+
     def test_analyze_handles_protocol_positional_only_ellipsis_default(
         self,
         tmp_path,
@@ -3530,10 +3560,37 @@ class SupportsRead(Protocol):
             analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
         )
         assert result.get("analysis_errors", []) == []
-        findings = [
+        l032 = [
             f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L032"
         ]
-        assert findings == []
+        l026 = [
+            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L026"
+        ]
+        assert l032 == []
+        assert l026 == []
+
+    def test_analyze_keeps_ellipsis_defaults_valid_in_stub_files(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("SKYLOS_JOBS", "1")
+        (tmp_path / "contracts.pyi").write_text(
+            "def read(length: int = ...) -> int: ...\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
+        )
+        l026 = [
+            finding
+            for finding in result.get("quality", [])
+            if finding.get("rule_id") == "SKY-L026"
+        ]
+
+        assert result.get("analysis_errors", []) == []
+        assert l026 == []
 
     def test_analyze_handles_positional_only_boolean_traps_and_setters(
         self,

--- a/test/test_vibe_rules.py
+++ b/test/test_vibe_rules.py
@@ -2027,6 +2027,348 @@ class TestUnfinishedGeneration:
         findings = check_code(UnfinishedGenerationRule(), code)
         assert any(f["rule_id"] == "SKY-L026" for f in findings)
 
+    def test_concrete_ellipsis_default_is_flagged(self):
+        code = """
+        def read(length: int = ...) -> int:
+            return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert len(l026) == 1
+        assert l026[0]["name"] == "read"
+        assert l026[0]["simple_name"] == "read"
+        assert l026[0]["parameter"] == "length"
+        assert l026[0]["value"] == "..."
+        assert "receive Ellipsis at runtime" in l026[0]["message"]
+
+    def test_ellipsis_defaults_preserve_argument_kinds_and_order(self):
+        code = """
+        def configure(
+            required: int,
+            positional: int = ...,
+            /,
+            regular: int = 1,
+            *,
+            keyword: int = ...,
+        ) -> int:
+            return required + regular
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == [
+            "positional",
+            "keyword",
+        ]
+        assert [finding["line"] for finding in l026] == [
+            4,
+            8,
+        ]
+
+    def test_async_method_ellipsis_default_is_flagged(self):
+        code = """
+        class Reader:
+            async def read(self, length: int = ...) -> int:
+                return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            """
+            if length is ...:
+                length = 0
+            return length + 5
+            """,
+            """
+            if Ellipsis == length:
+                length = 0
+            return length + 5
+            """,
+            "return consume(length=length)",
+            "callback = partial(run, length=length)\nreturn schedule(callback)",
+        ],
+    )
+    def test_intentional_ellipsis_sentinel_is_not_flagged(self, body):
+        code = "def read(length: object = ...):\n" + textwrap.indent(
+            textwrap.dedent(body).strip(),
+            "    ",
+        )
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert l026 == []
+
+    def test_forwarding_does_not_hide_a_later_unsafe_use(self):
+        code = """
+        def read(length: int = ...):
+            print(length)
+            return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "return int(length)",
+            "return int(length) + 5",
+            "result = convert(length)\nreturn result",
+            "return consume(value=length)",
+            "consume(length=length)\nreturn length + 5",
+        ],
+    )
+    def test_call_does_not_prove_the_callee_accepts_ellipsis(self, body):
+        code = "def read(length: int = ...):\n" + textwrap.indent(body, "    ")
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
+
+    def test_nested_sentinel_comparison_does_not_exempt_outer_default(self):
+        code = """
+        def read(length: int = ...):
+            def normalize():
+                return length is ...
+            return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
+
+    def test_each_ellipsis_default_is_checked_independently(self):
+        code = """
+        def combine(left: int = ..., right: int = ...):
+            if left is ...:
+                left = 0
+            return left + right
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["right"]
+
+    @pytest.mark.parametrize(
+        ("import_statement", "annotation"),
+        [
+            ("from types import EllipsisType", "int | EllipsisType"),
+            ("from types import EllipsisType as ET", "int | ET"),
+            ("import types as runtime_types", "runtime_types.EllipsisType | int"),
+            (
+                "from types import EllipsisType\nfrom typing import Union",
+                "Union[int, EllipsisType]",
+            ),
+            (
+                "from types import EllipsisType\nfrom typing import Optional",
+                "Optional[EllipsisType]",
+            ),
+            (
+                "from types import EllipsisType\nfrom typing import Annotated",
+                "Annotated[int | EllipsisType, 'sentinel']",
+            ),
+        ],
+    )
+    def test_ellipsis_type_annotation_marks_an_intentional_sentinel(
+        self,
+        import_statement,
+        annotation,
+    ):
+        code = (
+            f"{import_statement}\n\n"
+            f"def read(length: {annotation} = ...):\n"
+            "    return length\n"
+        )
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert l026 == []
+
+    @pytest.mark.parametrize(
+        "annotation",
+        [
+            "Callable[[EllipsisType], int]",
+            "list[EllipsisType]",
+            "Annotated[int, EllipsisType]",
+        ],
+    )
+    def test_nested_ellipsis_type_annotation_does_not_exempt_default(
+        self,
+        annotation,
+    ):
+        code = f"""
+        from collections.abc import Callable
+        from types import EllipsisType
+        from typing import Annotated
+
+        def register(callback: {annotation} = ...):
+            return callback + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["callback"]
+
+    def test_unrelated_ellipsis_type_name_does_not_exempt_default(self):
+        code = """
+        import application_types
+
+        def read(length: int | application_types.EllipsisType = ...):
+            return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
+
+    def test_ellipsis_in_an_unrelated_annotation_does_not_exempt_default(self):
+        code = """
+        from collections.abc import Callable
+
+        def register(callback: Callable[..., int] = ...):
+            return callback()
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["callback"]
+
+    @pytest.mark.parametrize(
+        ("import_statement", "guard"),
+        [
+            ("from typing import TYPE_CHECKING", "TYPE_CHECKING"),
+            ("import typing as t", "t.TYPE_CHECKING"),
+            (
+                "from typing_extensions import TYPE_CHECKING as CHECKING",
+                "CHECKING",
+            ),
+        ],
+    )
+    def test_type_checking_only_signatures_are_not_flagged(
+        self,
+        import_statement,
+        guard,
+    ):
+        code = f"""
+        {import_statement}
+
+        if {guard}:
+            def read(length: int = ...) -> int:
+                return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert l026 == []
+
+    def test_runtime_branch_under_not_type_checking_is_still_flagged(self):
+        code = """
+        from typing import TYPE_CHECKING
+
+        if not TYPE_CHECKING:
+            def read(length: int = ...) -> int:
+                return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
+
+    def test_ellipsis_default_and_stub_body_emit_one_finding(self):
+        code = """
+        def read(length: int = ...) -> int:
+            ...
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert len(l026) == 1
+        assert l026[0]["name"] == "read"
+        assert "parameter" not in l026[0]
+        assert "only `...` in its body" in l026[0]["message"]
+
     def test_not_implemented_error(self):
         code = """
         def send_notification(user, message):
@@ -2082,12 +2424,37 @@ class TestUnfinishedGeneration:
 
         class Base:
             @abstractmethod
-            def process(self):
+            def process(self, value = ...):
                 pass
         """
         findings = check_code(UnfinishedGenerationRule(), code)
         l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
         assert len(l026) == 0
+
+    def test_overloads_are_exempt_but_concrete_implementation_is_flagged(self):
+        code = """
+        from typing import overload
+
+        @overload
+        def parse(value: int = ...) -> int: ...
+
+        @overload
+        def parse(value: str = ...) -> str: ...
+
+        def parse(value = ...):
+            return value + 1
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert len(l026) == 1
+        assert l026[0]["name"] == "parse"
+        assert l026[0]["parameter"] == "value"
 
     def test_runtime_checkable_protocol_methods_not_flagged(self):
         code = """
@@ -2137,6 +2504,29 @@ class TestUnfinishedGeneration:
         findings = check_code(UnfinishedGenerationRule(), code)
         l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
         assert [finding["name"] for finding in l026] == ["operation"]
+
+    def test_protocol_default_is_exempt_but_concrete_default_is_flagged(self):
+        code = """
+        from typing import Protocol
+
+        class ReaderContract(Protocol):
+            def read(self, length: int = ...) -> int: ...
+
+        class Reader(ReaderContract):
+            def read(self, length: int = ...) -> int:
+                return length + 5
+        """
+
+        findings = check_code(
+            UnfinishedGenerationRule(),
+            code,
+            filename="app.py",
+        )
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert len(l026) == 1
+        assert l026[0]["name"] == "read"
+        assert l026[0]["parameter"] == "length"
 
     def test_generic_protocol_method_not_flagged(self):
         code = """
@@ -2207,6 +2597,16 @@ class TestUnfinishedGeneration:
         l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
         assert len(l026) == 0
 
+    def test_concrete_default_in_init_file_is_still_flagged(self):
+        code = """
+        def read(length: int = ...):
+            return length + 5
+        """
+        findings = check_code(UnfinishedGenerationRule(), code, filename="__init__.py")
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
+
     def test_dunder_method_not_flagged(self):
         code = """
         class MyClass:
@@ -2216,6 +2616,17 @@ class TestUnfinishedGeneration:
         findings = check_code(UnfinishedGenerationRule(), code)
         l026 = [f for f in findings if f["rule_id"] == "SKY-L026"]
         assert len(l026) == 0
+
+    def test_concrete_default_in_dunder_method_is_still_flagged(self):
+        code = """
+        class Reader:
+            def __call__(self, length: int = ...):
+                return length + 5
+        """
+        findings = check_code(UnfinishedGenerationRule(), code, filename="app.py")
+        l026 = [finding for finding in findings if finding["rule_id"] == "SKY-L026"]
+
+        assert [finding["parameter"] for finding in l026] == ["length"]
 
     def test_async_function_flagged(self):
         code = """


### PR DESCRIPTION
Closes #708

## Summary

  - flag unsafe ... defaults in concrete Python functions with SKY-L026
  - avoid flagging protocols, overloads, abstract methods, stubs, and intentional Ellipsis sentinels
 
  ## Tests

  - pytest test/test_vibe_rules.py test/test_quality_rules.py test/test_analyzer.py test/test_ai_code_defect_benchmark.py test/test_verify_change.py

