### PR TITLE
fix(analyzer): complete batched unicode verification

### DIFF
--- a/.github/workflows/skylos.yaml
+++ b/.github/workflows/skylos.yaml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -101,6 +102,9 @@ jobs:
         env:
           REPORT: skylos_${{ github.run_number }}_${{ github.sha }}.json
           DIFF_BASE: ${{ steps.diff.outputs.base }}
+          # Give the large self-scan additional verification time while
+          # retaining a two-minute grep-verification limit.
+          SKYLOS_GREP_BUDGET: "120"
           SKYLOS_GO_BIN: ${{ format('{0}/skylos-go-engine/skylos-go', runner.temp) }}
         shell: bash
         run: |

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -88,7 +88,10 @@ _GREP_BATCH_MAX_OUTPUT_BYTES = 8 * 1024 * 1024
 _GREP_BATCH_MAX_STDERR_BYTES = 128 * 1024
 _GREP_BATCH_MAX_MATCHES = _GREP_BATCH_SIZE * 256
 _GREP_UNICODE_MAX_INPUT_BYTES = 512 * 1024
-_GREP_UNICODE_MAX_ADJUDICATIONS = 16
+# Every request in a bounded batch must receive the same Unicode-boundary
+# adjudication. Skipping later requests makes a successful batch partial and
+# forces the analyzer to abstain from all grep-verified dead-code candidates.
+_GREP_UNICODE_MAX_ADJUDICATIONS = _GREP_BATCH_SIZE
 _GREP_PIPE_READ_BYTES = 64 * 1024
 _GREP_PROCESS_CLEANUP_SECONDS = 0.25
 # Classification precedes strategy-specific definition filtering. Keep a

--- a/test/test_github_actions_security.py
+++ b/test/test_github_actions_security.py
@@ -631,10 +631,14 @@ def test_skylos_pr_workflow_builds_go_engine_from_immutable_base():
 
 
 def test_skylos_workflow_reports_incomplete_scan_before_preserving_exit_code():
-    steps = _skylos_workflow()["jobs"]["scan"]["steps"]
+    scan_job = _skylos_workflow()["jobs"]["scan"]
+    assert scan_job["timeout-minutes"] == 20
+
+    steps = scan_job["steps"]
     scan_step = next(s for s in steps if s.get("name") == "Run Skylos")
     scan_script = scan_step["run"]
 
+    assert scan_step["env"]["SKYLOS_GREP_BUDGET"] == "120"
     assert "set +e" in scan_script
     assert "SCAN_STATUS=$?" in scan_script
     assert 'echo "status=$SCAN_STATUS" >> "$GITHUB_OUTPUT"' in scan_script

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -31,6 +31,7 @@ from skylos.core.grep_verify import (
 )
 from skylos.core.grep_verify_common import (
     GrepRequest,
+    _GREP_BATCH_SIZE,
     _GrepBatchResults,
     _GrepDeadlineExceeded,
     _GrepEvidence,
@@ -1195,7 +1196,7 @@ class TestBatchedGrepVerify:
         assert results == {request: () for request in requests}
         assert mock_batch.call_count == 3
 
-    def test_unicode_adjudication_cap_keeps_unambiguous_ascii_matches(self):
+    def test_unicode_adjudication_covers_every_request_in_a_bounded_batch(self):
         common = {
             "project_root": "/repo",
             "use_regex": True,
@@ -1205,12 +1206,12 @@ class TestBatchedGrepVerify:
         }
         requests = [
             GrepRequest(pattern=rf"\bsymbol_{index}\b", **common)
-            for index in range(20)
+            for index in range(_GREP_BATCH_SIZE)
         ]
         matches = [("/repo/nfd.py", 1, "unrelated\u0301\n")]
         matches.extend(
             (f"/repo/use_{index}.py", 1, f"symbol_{index}()\n")
-            for index in range(20)
+            for index in range(_GREP_BATCH_SIZE)
         )
         batch_result = Mock(
             returncode=0,
@@ -1229,10 +1230,6 @@ class TestBatchedGrepVerify:
                 return_value="/usr/bin/rg",
             ),
             patch(
-                "skylos.core.grep_verify_common._GREP_UNICODE_MAX_ADJUDICATIONS",
-                1,
-            ),
-            patch(
                 "skylos.core.grep_verify_common._run_bounded_subprocess",
                 side_effect=fake_run,
             ) as mock_run,
@@ -1244,8 +1241,8 @@ class TestBatchedGrepVerify:
             assert results[request] == (
                 f"/repo/use_{index}.py:1:symbol_{index}()",
             )
-        assert mock_run.call_count == 2
-        assert results.incomplete_requests == set(requests[1:])
+        assert mock_run.call_count == len(requests) + 1
+        assert results.incomplete_requests == set()
 
     def test_bounded_subprocess_rejects_oversized_output(self):
         with (


### PR DESCRIPTION
## Summary

  - check unicode sensitive request in each bounded grep batch
  - keep incomplete verification fail closed
  - give the advisory self-scan 2 grep budget and a 20 min job timeout