### PR TITLE
perf(analyzer): batch engine-sensitive space patterns

### DIFF
--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -123,6 +123,9 @@ _POSIX_CLASS = re.compile(r"\[\[:[^]]+:\]\]")
 _UNICODE_WORD_PATTERN = re.compile(r"\\[bBwW]")
 _UNICODE_CASE_INSENSITIVE_PATTERN = re.compile(r"\(\?[a-z-]*i")
 _ENGINE_SENSITIVE_SPACE_PATTERN = re.compile(r"\\[sS]")
+# Python's re \s matches U+001C-U+001F; ripgrep's Unicode White_Space \s does
+# not. Those four characters are the complete divergence in both directions.
+_ENGINE_DIVERGENT_SPACE_CHARS = ("\x1c", "\x1d", "\x1e", "\x1f")
 _MAX_GREP_LINE_NUMBER = 999_999_999
 _MAX_GREP_LINE_CANDIDATES = 256
 _GREP_LINE_NUMBER = re.compile(r":([1-9][0-9]{0,8}):")
@@ -897,10 +900,6 @@ def _requires_direct_grep(request: GrepRequest) -> bool:
         return True
     if not request.pattern.isascii():
         return True
-    if not request.fixed_string and _ENGINE_SENSITIVE_SPACE_PATTERN.search(
-        request.pattern
-    ):
-        return True
     return not request.fixed_string and _python_regex(request.pattern) is None
 
 
@@ -1024,18 +1023,33 @@ def _word_divergent_lines(
     return divergent
 
 
+def _space_divergent_lines(
+    grep_matches: Sequence[_GrepMatch],
+) -> list[tuple[int, str]]:
+    return [
+        (index, match.content)
+        for index, match in enumerate(grep_matches)
+        if any(char in match.content for char in _ENGINE_DIVERGENT_SPACE_CHARS)
+    ]
+
+
 def _unicode_sensitive_lines(
     request: GrepRequest,
     non_ascii_lines: Sequence[tuple[int, str]],
     word_divergent_lines: Sequence[tuple[int, str]],
+    space_divergent_lines: Sequence[tuple[int, str]] = (),
 ) -> list[tuple[int, str]]:
-    if request.fixed_string or not non_ascii_lines:
+    if request.fixed_string:
         return []
-    if _UNICODE_CASE_INSENSITIVE_PATTERN.search(request.pattern):
-        return list(non_ascii_lines)
-    if not _UNICODE_WORD_PATTERN.search(request.pattern):
-        return []
-    return list(word_divergent_lines)
+    sensitive: dict[int, str] = {}
+    if _ENGINE_SENSITIVE_SPACE_PATTERN.search(request.pattern):
+        sensitive.update(space_divergent_lines)
+    if non_ascii_lines:
+        if _UNICODE_CASE_INSENSITIVE_PATTERN.search(request.pattern):
+            sensitive.update(non_ascii_lines)
+        elif _UNICODE_WORD_PATTERN.search(request.pattern):
+            sensitive.update(word_divergent_lines)
+    return sorted(sensitive.items())
 
 
 def _non_ascii_line_overrides(
@@ -1044,16 +1058,18 @@ def _non_ascii_line_overrides(
     word_divergent_lines: Sequence[tuple[int, str]],
     rg: str,
     *,
+    space_divergent_lines: Sequence[tuple[int, str]] = (),
     deadline: float | None = None,
 ) -> dict[int, bool] | None:
-    # After POSIX-class translation the only engine-sensitive construct left
-    # in classifier patterns is \b: ripgrep's UTS#18 word class includes
-    # combining marks, join controls, and non-decimal numerics that Python's
-    # re does not (and vice versa). Let ripgrep itself adjudicate non-ASCII
-    # lines so batched attribution matches what a per-pattern search returns.
-    # Fixed strings are byte-exact substring checks and never diverge.
+    # After POSIX-class translation two engine-sensitive constructs remain in
+    # classifier patterns. \b: ripgrep's UTS#18 word class includes combining
+    # marks, join controls, and non-decimal numerics that Python's re does not
+    # (and vice versa). \s: Python's re matches U+001C-U+001F, which ripgrep's
+    # Unicode White_Space class excludes. Let ripgrep itself adjudicate the
+    # affected lines so batched attribution matches what a per-pattern search
+    # returns. Fixed strings are byte-exact substring checks and never diverge.
     sensitive_lines = _unicode_sensitive_lines(
-        request, non_ascii_lines, word_divergent_lines
+        request, non_ascii_lines, word_divergent_lines, space_divergent_lines
     )
     if not sensitive_lines:
         return None
@@ -1152,12 +1168,13 @@ def _run_ripgrep_batch(
     word_divergent_lines = _word_divergent_lines(
         non_ascii_lines, deadline=deadline
     )
+    space_divergent_lines = _space_divergent_lines(grep_matches)
     unicode_adjudications = 0
     for request in batched:
         if _deadline_expired(deadline):
             break
         sensitive_lines = _unicode_sensitive_lines(
-            request, non_ascii_lines, word_divergent_lines
+            request, non_ascii_lines, word_divergent_lines, space_divergent_lines
         )
         overrides: dict[int, bool] | None = None
         request_incomplete = False
@@ -1171,6 +1188,7 @@ def _run_ripgrep_batch(
                         non_ascii_lines,
                         word_divergent_lines,
                         rg,
+                        space_divergent_lines=space_divergent_lines,
                         deadline=deadline,
                     )
                 except (

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -944,6 +944,33 @@ def _run_ripgrep_pattern_file(
     return _parse_ripgrep_json_matches(result.stdout, deadline=deadline)
 
 
+def _grep_stdin_chunks(
+    contents: Sequence[str],
+    limit: int,
+) -> Iterator[tuple[int, list[str]]]:
+    """Yield ``(offset, lines)`` groups whose encoded stdin fits in ``limit``.
+
+    A single line wider than the cap cannot be sent at all, so it keeps the
+    fail-closed behavior rather than being silently dropped from adjudication.
+    """
+    chunk: list[str] = []
+    chunk_bytes = 0
+    offset = 0
+    for index, content in enumerate(contents):
+        line_bytes = len(content.encode("utf-8")) + 1
+        if line_bytes > limit:
+            raise _GrepInputLimitExceeded("grep adjudication line is too large")
+        if chunk and chunk_bytes + line_bytes > limit:
+            yield offset, chunk
+            chunk = []
+            chunk_bytes = 0
+            offset = index
+        chunk.append(content)
+        chunk_bytes += line_bytes
+    if chunk:
+        yield offset, chunk
+
+
 def _ripgrep_stdin_match_positions(
     pattern: str,
     contents: Sequence[str],
@@ -951,32 +978,42 @@ def _ripgrep_stdin_match_positions(
     *,
     deadline: float | None = None,
 ) -> set[int]:
-    """Return the 0-based positions of the given lines that ripgrep matches."""
-    stdin = "\n".join(contents) + "\n"
-    result = _run_bounded_subprocess(
-        [
-            rg,
-            "--no-config",
-            "-n",
-            "--no-heading",
-            "--color",
-            "never",
-            "--",
-            pattern,
-            "-",
-        ],
-        input_text=stdin,
-        timeout=_remaining_timeout(deadline, _GREP_REQUEST_TIMEOUT_SECONDS),
-        input_limit=_GREP_UNICODE_MAX_INPUT_BYTES,
-    )
-    if result.returncode not in (0, 1):
-        msg = result.stderr.strip() or f"exit status {result.returncode}"
-        raise RuntimeError(msg)
+    """Return the 0-based positions of the given lines that ripgrep matches.
+
+    The candidate lines are adjudicated in stdin-sized chunks. A repository
+    can hold more divergent lines than one bounded stdin write allows, and a
+    direct per-pattern search would have resolved all of them, so refusing the
+    whole request there would drop real evidence.
+    """
     positions: set[int] = set()
-    for line in result.stdout.split("\n"):
-        prefix = line.split(":", 1)[0]
-        if prefix.isdigit():
-            positions.add(int(prefix) - 1)
+    for offset, chunk in _grep_stdin_chunks(
+        contents, _GREP_UNICODE_MAX_INPUT_BYTES
+    ):
+        if _deadline_expired(deadline):
+            raise _GrepDeadlineExceeded("deadline exceeded while adjudicating grep")
+        result = _run_bounded_subprocess(
+            [
+                rg,
+                "--no-config",
+                "-n",
+                "--no-heading",
+                "--color",
+                "never",
+                "--",
+                pattern,
+                "-",
+            ],
+            input_text="\n".join(chunk) + "\n",
+            timeout=_remaining_timeout(deadline, _GREP_REQUEST_TIMEOUT_SECONDS),
+            input_limit=_GREP_UNICODE_MAX_INPUT_BYTES,
+        )
+        if result.returncode not in (0, 1):
+            msg = result.stderr.strip() or f"exit status {result.returncode}"
+            raise RuntimeError(msg)
+        for line in result.stdout.split("\n"):
+            prefix = line.split(":", 1)[0]
+            if prefix.isdigit():
+                positions.add(offset + int(prefix) - 1)
     return positions
 
 

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -36,6 +36,7 @@ from skylos.core.grep_verify_common import (
     _GrepDeadlineExceeded,
     _GrepEvidence,
     _GrepExecutionIncomplete,
+    _GrepInputLimitExceeded,
     _GrepOutputLimitExceeded,
     _is_python_source_reference,
     _python_regex,
@@ -1035,6 +1036,90 @@ class TestBatchedGrepVerify:
         assert len(adjudication_calls) == 1
         assert results[space_request] == ()
         assert results[companion_request] == (f"/repo/code.py:1:{content}",)
+
+    def test_large_space_adjudication_payload_is_chunked(self):
+        # Adjudication stdin is capped. A repository with more divergent
+        # candidate lines than that cap must still be adjudicated, because a
+        # direct per-pattern search would have completed. Alternating lines
+        # match under ripgrep semantics and do not, so a chunked adjudication
+        # that mismapped positions would surface here as wrong evidence.
+        padding = "p" * 190
+        contents = [
+            f"alpha omega\x1c{padding}"
+            if index % 2 == 0
+            else f"alpha\x1comega{padding}"
+            for index in range(40)
+        ]
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 100,
+        }
+        space_request = GrepRequest(pattern=r"alpha\somega", **common)
+
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(
+                *(
+                    (f"/repo/code{index:02d}.py", 1, f"{content}\n")
+                    for index, content in enumerate(contents)
+                )
+            ),
+            stderr="",
+        )
+
+        def fake_run(cmd, **kwargs):
+            if "--json" in cmd:
+                return batch_result
+            payload = kwargs["input_text"]
+            if len(payload.encode("utf-8")) > kwargs["input_limit"]:
+                raise _GrepInputLimitExceeded("grep subprocess input is too large")
+            # Ripgrep's \s excludes U+001C, so only the space lines match.
+            matched = [
+                f"{position}:{line}"
+                for position, line in enumerate(payload.split("\n")[:-1], start=1)
+                if "alpha omega" in line
+            ]
+            return Mock(
+                returncode=0 if matched else 1,
+                stdout="".join(f"{line}\n" for line in matched),
+                stderr="",
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_UNICODE_MAX_INPUT_BYTES",
+                4096,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                side_effect=fake_run,
+            ) as mock_run,
+        ):
+            results = execute_grep_batch([space_request])
+
+        adjudication_calls = [
+            call for call in mock_run.call_args_list if "--json" not in call.args[0]
+        ]
+        assert len(adjudication_calls) > 1
+        for call in adjudication_calls:
+            assert (
+                len(call.kwargs["input_text"].encode("utf-8"))
+                <= call.kwargs["input_limit"]
+            )
+        # Sorted by path, so the fixture names are zero-padded to keep
+        # lexicographic and numeric order the same.
+        assert results[space_request] == tuple(
+            f"/repo/code{index:02d}.py:1:{content}"
+            for index, content in enumerate(contents)
+            if index % 2 == 0
+        )
 
     def test_batched_and_legacy_verdicts_match_on_non_ascii_content(self, tmp_path):
         package = tmp_path / "pkg.py"

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -949,6 +949,93 @@ class TestBatchedGrepVerify:
         assert results[bar_request] == (line,)
         assert results[literal_request] == ("/repo/other.py:2:pkg.literalé()",)
 
+    def test_engine_sensitive_space_patterns_are_batched(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        space_request = GrepRequest(pattern=r"alpha\somega", **common)
+        negated_request = GrepRequest(pattern=r"alpha\Somega", **common)
+        process_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(("/repo/a.py", 1, "alpha omega\n")),
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ) as mock_run,
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                side_effect=AssertionError("space patterns must stay batched"),
+            ),
+        ):
+            results = execute_grep_batch([space_request, negated_request])
+
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.kwargs["input_text"] == (
+            "alpha\\somega\nalpha\\Somega\n"
+        )
+        assert results[space_request] == ("/repo/a.py:1:alpha omega",)
+        assert results[negated_request] == ()
+
+    def test_ascii_separator_content_uses_ripgrep_space_semantics(self):
+        # U+001C-U+001F are the complete divergence between Python re \s and
+        # ripgrep's Unicode White_Space \s: Python matches them, ripgrep does
+        # not. They are ASCII, so the non-ASCII sensitivity check never sees
+        # them and unadjudicated replay would credit a line ripgrep never
+        # matched for that pattern.
+        content = "alpha\x1comega = 1"
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        space_request = GrepRequest(pattern=r"alpha\somega", **common)
+        companion_request = GrepRequest(pattern=r"alpha", **common)
+
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(("/repo/code.py", 1, f"{content}\n")),
+            stderr="",
+        )
+
+        def fake_run(cmd, **kwargs):
+            if "--json" in cmd:
+                return batch_result
+            assert cmd[-2] == space_request.pattern
+            return Mock(returncode=1, stdout="", stderr="")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                side_effect=fake_run,
+            ) as mock_run,
+        ):
+            results = execute_grep_batch([space_request, companion_request])
+
+        adjudication_calls = [
+            call for call in mock_run.call_args_list if "--json" not in call.args[0]
+        ]
+        assert len(adjudication_calls) == 1
+        assert results[space_request] == ()
+        assert results[companion_request] == (f"/repo/code.py:1:{content}",)
+
     def test_batched_and_legacy_verdicts_match_on_non_ascii_content(self, tmp_path):
         package = tmp_path / "pkg.py"
         package.write_text(


### PR DESCRIPTION
## Context

Follow-up to #721, with @duriantaco 's additional commits on top of mine.

I verified the maintainer's commits hold the line with 0 diffs on the `liveness_primer` corpus, e.g.

`liveness-primer run  --tool skylos   --repo https://github.com/duriantaco/skylos   --old 8edf98625dac90a45e636295542e38da7d97e938   --new d4459a8c58a303255a5dc43982c3132c915daa13   --output text --all  --max-results 200   --excerpt-lines 5   --jobs 1   --timeout 600` 

shows 0 diffs. However, it does show a meaningful performance regression; with the maintainer's commits and a cold cache `liveness_primer` is ~40-60% slower overall than just my commits, enough to matter if CI minutes are a maintainer consideration for whether to deploy it as a CI.

Therefore, the goal of this follow-up commit is to recover the full original performance improvement while preserving the maintainer's hardening and identical empirical behavior/0 `liveness_primer` diffs.

With this PR, performance is restored and `liveness_primer` with `--jobs 1` takes ~120s on my laptop for the full corpus (e.g. two full, cold skylos runs on all 15 corpus sources), consistent with the original performance.

## What does this PR do?


The merged hardening added a rule to `_requires_direct_grep` that excludes any pattern containing `\s` or `\S` from batching, giving each one its own full-repository ripgrep traversal. Skylos usage strategies emit `\s` constantly (`cast\([^,]+,\s*[^)]*\bMockServer\b`, and similar), so this reintroduces most of the per-finding traversal cost #721 removed.

Instrumenting `rg` on the pinned mitmproxy corpus checkout at current `main` (`3f2cc94`):

| | single-pattern full-repo traversals | batched traversals |
| --- | ---: | ---: |
| `main` | 577 | 178 |
| this PR | 0 | 182 |

cProfile attributes 13.3 s of the 22.2 s grep verification phase to those 577 direct runs, against 4.7 s for all batched traversals combined. The rest of the merged hardening is not a meaningful cost: ripgrep JSON parsing is 0.96 s across 75k events, classification 1.13 s, Unicode adjudication 0.2 s.

## The divergence being guarded

The rule guards a real difference, but a narrower one than a pattern-level test can express. Measured across U+0001-U+3000, Python's `re` `\s` matches exactly four characters that ripgrep's Unicode `White_Space` `\s` does not: **U+001C-U+001F**. Nothing diverges in the other direction.

The llm's empirical check above can be confirmed by comparing [rust's documented whitespace list](https://www.unicode.org/Public/17.0.0/ucd/PropList.txt) with [python's documented divergence from that list](https://www.unicode.org/Public/17.0.0/ucd/PropList.txt), noting that
Python Unicode re-\s, through str.isspace(), additionally matches U+001C–U+001F. Ripgrep’s default Rust regex engine defines Unicode \s using the Unicode White_Space property, which excludes those four code points. \S has the corresponding inverse difference.

Those four are ASCII, so `_unicode_sensitive_lines` never sees them via the non-ASCII path. That is presumably why direct routing was chosen rather than adjudication.

## Approach

Handle `\s` exactly the way `\b` is already handled: keep the pattern in the batch, and let ripgrep adjudicate only the candidate lines that actually contain a divergent character. `_space_divergent_lines` computes that set once per batch, and it feeds the existing `_unicode_sensitive_lines` / `_non_ascii_line_overrides` machinery, including the existing adjudication cap. Real source typically contains none of these characters, so in practice zero lines are adjudicated and the traversal is shared.

## Correctness

A repository containing `alpha\x1comega`, with `alpha\somega` batched alongside a companion pattern:

| variant | result for `alpha\somega` |
| --- | --- |
| direct per-pattern `rg` (ground truth) | no match |
| `main` (blanket direct routing) | no match |
| deleting the rule with no adjudication | **false match** |
| this PR | no match |

The middle failure is the exact bug the rule was added for, so it is covered by a regression test rather than left to review.

## Follow-up commit: chunked adjudication input

The second commit (`e059851`) fixes a capacity cliff in the adjudication path the first commit routes `\s` patterns through. Adjudication sent every divergent candidate line to ripgrep in one bounded stdin write; past `_GREP_UNICODE_MAX_INPUT_BYTES` (512 KB) that write raises `_GrepInputLimitExceeded`, the request is marked incomplete, and the #727 fail-closed machinery then discards the run's verdicts: every grep-verified dead-code finding is withheld and an analysis error is reported. No live symbol is misreported — the failure is that a single oversized payload, one a direct per-pattern search would have resolved in full, silently turns off grep verification for the entire run. The pre-existing `\b` path shares the helper and had the same unbounded payload.

The fix adjudicates in stdin-sized chunks, offsetting the reported positions per chunk. A single line wider than the cap still fails closed, since it cannot be sent at all: the chunker raises before any partial result can be returned. Chunk byte accounting matches `_run_bounded_subprocess`'s limit check exactly, both new raise sites (`_GrepInputLimitExceeded`, `_GrepDeadlineExceeded`) are subclasses of `_GrepExecutionIncomplete` and flow into the same per-request fail-closed handler, and the deadline is checked between chunks. Worst-case chunk count is bounded by the existing 8 MB batch output cap (≤16 chunks per request), each chunk under its own subprocess timeout.

End-to-end at the real 512 KB cap, on a repository with 2000 divergent-candidate lines (~594 KB, alternating lines that ripgrep does and does not match, with a companion pattern pulling all of them into the batch):

| variant | result for `alpha\somega` | incomplete? |
| --- | --- | --- |
| direct per-pattern `rg` (ground truth) | 1000 matches | — |
| first commit alone | 0 matches | yes (run's findings withheld) |
| with this fix | the exact 1000 ground-truth lines | no |

The alternating layout means any cross-chunk position mismapping would surface as wrong lines rather than a wrong count. The chunk path cannot fire on real corpora — it needs more than 512 KB of divergent candidate lines in a single batch — so the mitmproxy numbers below are unaffected (re-verified at this head: identical finding identity sets, same ~2x speedup).

## Tests

- `test/test_grep_verify.py`: 150 passed (147 on `main` plus 3 added).
- The first two added tests fail on unmodified `main` and pass here:
  - `test_engine_sensitive_space_patterns_are_batched`
  - `test_ascii_separator_content_uses_ripgrep_space_semantics`
- The third, `test_large_space_adjudication_payload_is_chunked`, fails on the first commit of this branch alone and passes with the follow-up fix. It shrinks the stdin cap, feeds alternating match/non-match divergent lines, and asserts every adjudication payload fits the cap and every position maps back correctly.
- `ruff check` and `ruff format --check` report the same 7 pre-existing findings before and after; none are in the changed code.

## Behavior preservation and performance

Full skylos run over the pinned mitmproxy corpus checkout, `SKYLOS_GREP_BUDGET=150`, two trials each, alternating:

| | trial 1 | trial 2 |
| --- | ---: | ---: |
| `main` (`3f2cc94`) | 28.15 s | 27.82 s |
| this PR | 14.91 s | 14.93 s |

1316 findings on both sides, with identical finding identity sets. The only field-level differences are ordering within `unused_functions.calls`, and two runs of unmodified `main` differ from each other in exactly the same way (6 such differences), so that is pre-existing ordering nondeterminism rather than an effect of this change.

## LLM Noted Side-issue

While profiling, `_execute_pending_findings` skips a finding whose requests are missing from the batch results (`if any(request not in batch_results ...): continue`). Under deadline pressure that silently drops verification for that finding rather than failing closed, which shows up as run-to-run finding nondeterminism. Not touched here.

## LLM-reviewer noted nits (maintainer discretion whether to fix or not):
1. _space_divergent_lines is computed for every batch even when no batched pattern contains \s/\S. With matches capped at 32 k lines the scan is microseconds, so this is style, not perf — could be gated on any-pattern-has-\s.
2. _ENGINE_SENSITIVE_SPACE_PATTERN (\\[sS]) false-positives on an escaped literal backslash-s (\\s), but only in the conservative direction (extra adjudication), and the existing \b detection has the identical idiom — pre-existing, not worth touching here.

## AI Use Disclosure

The code for this commit was written by Claude Opus 5 after the regression was identified by me. It was reviewed per repository agent guidelines by Claude Fable 5 and GPT-5.6 Sol. The follow-up chunking commit was likewise written by Claude Opus 5 and independently verified by Claude Fable 5 (fail-closed exception routing, chunk byte accounting, the end-to-end reproduction at the real cap above, and benchmark/finding-identity parity at the new head). `liveness_primer` shows 0 diffs and a slight (possibly noise) performance *improvement* over my original commit, now coming in at just about 2 minutes to run the entire corpus from cold cache on my laptop. I manually inspected the code in both commits.

