### PR TITLE
fix(analyzer): scope diff verification to changed files

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -110,6 +110,7 @@ _OPTIONAL_RUN_STATE_ATTRIBUTES = (
     "_call_arg_types",
     "_grep_verify_report",
     "_grep_verify_incomplete_candidates",
+    "_dead_code_scope_keys",
     "_dead_code_liveness_report",
     "ts_consumed_exports",
     "_ts_wildcard_edges",
@@ -1076,10 +1077,52 @@ def _grep_verify_rescue_priority(candidate: dict) -> tuple:
     )
 
 
-def _collect_grep_verify_candidates(definitions: dict) -> tuple[list[dict], dict]:
+def _canonical_analysis_path(value: str | Path, project_root: Path) -> str:
+    path = Path(value)
+    if not path.is_absolute():
+        path = project_root / path
+    try:
+        resolved = path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        resolved = Path(os.path.abspath(path))
+    return os.path.normcase(str(resolved))
+
+
+def _changed_definition_keys(
+    definitions: dict,
+    project_root: str | Path,
+    changed_files,
+) -> frozenset | None:
+    """Select definitions eligible for changed-file dead-code reporting.
+
+    Diff scans still analyze and search the complete repository so references
+    remain sound. Only definitions that can be reported in the changed-file
+    result need the comparatively expensive grep-verification pass.
+    """
+    if changed_files is None:
+        return None
+
+    root = Path(project_root)
+    changed_paths = {
+        _canonical_analysis_path(changed_file, root)
+        for changed_file in changed_files
+    }
+    return frozenset(
+        key
+        for key, definition in definitions.items()
+        if _canonical_analysis_path(definition.filename, root) in changed_paths
+    )
+
+
+def _collect_grep_verify_candidates(
+    definitions: dict,
+    candidate_keys: frozenset | None = None,
+) -> tuple[list[dict], dict]:
     candidates: list[dict] = []
     candidate_defs: dict = {}
-    for defn in definitions.values():
+    for key, defn in definitions.items():
+        if candidate_keys is not None and key not in candidate_keys:
+            continue
         if defn.references != 0 or defn.is_exported or defn.confidence <= 0:
             continue
         payload = defn.to_dict()
@@ -1742,7 +1785,10 @@ class Skylos:
         ):
             report.pop(key, None)
 
-        candidates, candidate_defs = _collect_grep_verify_candidates(self.defs)
+        candidates, candidate_defs = _collect_grep_verify_candidates(
+            self.defs,
+            getattr(self, "_dead_code_scope_keys", None),
+        )
         if not candidates:
             return 0
 
@@ -4375,6 +4421,11 @@ class Skylos:
             "enabled": bool(grep_verify),
             "rescued_count": 0,
         }
+        self._dead_code_scope_keys = _changed_definition_keys(
+            self.defs,
+            project_root,
+            requested_changed_files,
+        )
         self._grep_verify_report = grep_verify_report
         if grep_verify:
             grep_verify_report["project_cache_enabled"] = bool(grep_cache)

--- a/skylos/reporting/dead_code_result.py
+++ b/skylos/reporting/dead_code_result.py
@@ -200,8 +200,12 @@ def unused_definitions(analyzer, thr, dead_code_evidence_payload):
 
 def dead_code_candidate_decisions(analyzer, thr, dead_code_evidence_payload):
     evidence_by_name = _evidence_by_name(dead_code_evidence_payload)
+    scoped_keys = getattr(analyzer, "_dead_code_scope_keys", None)
     dispositions = {}
     for key, definition in analyzer.defs.items():
+        if scoped_keys is not None and key not in scoped_keys:
+            dispositions[key] = None
+            continue
         dispositions[key] = _candidate_disposition(
             definition,
             thr,

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -2161,6 +2161,125 @@ result = PublicClass.used_method()
 
 
 class TestAnalyzerGrepVerifyOrdering:
+    @pytest.mark.parametrize("changed_file_style", ["absolute", "relative"])
+    def test_changed_file_scan_only_verifies_reportable_definitions(
+        self, tmp_path, changed_file_style
+    ):
+        from skylos.analyzer import analyze
+
+        changed = tmp_path / "changed.py"
+        unchanged = tmp_path / "unchanged.py"
+        changed.write_text("def _changed_dead():\n    return 1\n", encoding="utf-8")
+        unchanged.write_text(
+            "def _unchanged_dead():\n    return 2\n", encoding="utf-8"
+        )
+        selected = (
+            str(changed.resolve())
+            if changed_file_style == "absolute"
+            else changed.name
+        )
+
+        with patch(
+            "skylos.core.grep_verify.grep_verify_findings", return_value={}
+        ) as mock_grep:
+            result = json.loads(
+                analyze(
+                    str(tmp_path),
+                    conf=0,
+                    changed_files={selected},
+                    grep_verify=True,
+                )
+            )
+
+        candidates = mock_grep.call_args.args[0]
+        assert {Path(item["file"]).resolve() for item in candidates} == {
+            changed.resolve()
+        }
+        assert Path(mock_grep.call_args.args[1]).resolve() == tmp_path.resolve()
+        assert {
+            Path(item["file"]).resolve()
+            for item in result["unused_functions"]
+        } == {changed.resolve()}
+
+    def test_changed_definition_can_be_rescued_from_unchanged_repository_file(
+        self, tmp_path
+    ):
+        from skylos.analyzer import analyze
+
+        changed = tmp_path / "handlers.py"
+        changed.write_text(
+            "def payment_webhook():\n    return 'ok'\n", encoding="utf-8"
+        )
+        (tmp_path / "routes.yaml").write_text(
+            "handler_module: handlers.py\n", encoding="utf-8"
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                changed_files={str(changed)},
+                grep_verify=True,
+                grep_cache=False,
+            )
+        )
+
+        assert not result["unused_functions"]
+        assert result["analysis_summary"]["grep_verify"]["rescued_count"] == 1
+
+    def test_empty_changed_file_scope_skips_dead_code_verification(self, tmp_path):
+        from skylos.analyzer import analyze
+
+        (tmp_path / "unchanged.py").write_text(
+            "def _unchanged_dead():\n    return 1\n", encoding="utf-8"
+        )
+
+        with patch(
+            "skylos.core.grep_verify.grep_verify_findings"
+        ) as mock_grep:
+            result = json.loads(
+                analyze(
+                    str(tmp_path),
+                    conf=0,
+                    changed_files=set(),
+                    grep_verify=True,
+                )
+            )
+
+        mock_grep.assert_not_called()
+        assert result["unused_functions"] == []
+        assert result["analysis_errors"] == []
+
+    def test_full_scan_keeps_all_dead_code_candidates(self, tmp_path):
+        from skylos.analyzer import Skylos
+
+        first = tmp_path / "first.py"
+        second = tmp_path / "second.py"
+        first.write_text("def _first_dead():\n    return 1\n", encoding="utf-8")
+        second.write_text("def _second_dead():\n    return 2\n", encoding="utf-8")
+
+        analyzer = Skylos()
+        scoped = json.loads(
+            analyzer.analyze(
+                str(tmp_path),
+                thr=0,
+                changed_files={str(first)},
+                grep_verify=False,
+            )
+        )
+        result = json.loads(
+            analyzer.analyze(str(tmp_path), thr=0, grep_verify=False)
+        )
+
+        assert {
+            Path(item["file"]).resolve()
+            for item in scoped["unused_functions"]
+        } == {first.resolve()}
+        assert {
+            Path(item["file"]).resolve()
+            for item in result["unused_functions"]
+        } == {first.resolve(), second.resolve()}
+
     def test_incomplete_result_does_not_apply_partial_rescues(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary

  - verify only changed file dead-code candidates during diff scans
  - continue searching the whole repo for references
  - prevent unchanged file findings from leaking into diff reports

Fixes the main CI failure where a small diff attempted to verify all 940 repo candidates and exhausted the 120s budget.
