### PR TITLE
ci(analyzer): add real-world blast radius check

### DIFF
--- a/.github/workflows/liveness-primer.yml
+++ b/.github/workflows/liveness-primer.yml
@@ -1,0 +1,85 @@
+name: Analyzer Blast Radius
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "skylos/**"
+      - "pyproject.toml"
+      - "MANIFEST.in"
+      - ".github/workflows/liveness-primer.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: liveness-primer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  blast-radius:
+    name: Python dead-code blast radius
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out pinned liveness_primer
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: mcdigman/liveness_primer
+          ref: d6f3118a2cfc465426500eab449005fe56845c58 # v0.1.0
+          path: _liveness_primer
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
+        with:
+          version: "0.12.5"
+          python-version: "3.13"
+          enable-cache: false
+
+      - name: Compare base with the pull request merge result
+        env:
+          SKYLOS_REPOSITORY: https://github.com/duriantaco/skylos
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # The base repository owns this synthetic merge commit, including
+          # for fork PRs, so the comparison tests what would actually land.
+          MERGE_SHA: ${{ github.sha }}
+          REPORT_JSON: liveness-primer-report.json
+          REPORT_MARKDOWN: liveness-primer-report.md
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for revision in "$BASE_SHA" "$MERGE_SHA"; do
+            if [[ ! "$revision" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid comparison revision" >&2
+              exit 1
+            fi
+          done
+
+          uv run --project _liveness_primer --locked liveness-primer run \
+            --tool skylos \
+            --repo "$SKYLOS_REPOSITORY" \
+            --old "$BASE_SHA" \
+            --new "$MERGE_SHA" \
+            --all \
+            --output github \
+            --json-out "$REPORT_JSON" \
+            --jobs 2 \
+            --timeout 300 \
+            | tee "$REPORT_MARKDOWN" >> "$GITHUB_STEP_SUMMARY"
+
+          test -s "$REPORT_JSON"
+
+      - name: Upload blast-radius evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: liveness-primer-report
+          path: |
+            liveness-primer-report.md
+            liveness-primer-report.json
+          if-no-files-found: error
+          retention-days: 14

--- a/test/test_liveness_primer_workflow.py
+++ b/test/test_liveness_primer_workflow.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+
+import yaml
+
+from skylos.rules.config.cicd.github_actions import scan_github_actions_file
+
+
+WORKFLOW_PATH = Path(".github/workflows/liveness-primer.yml")
+
+
+def _workflow():
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _comparison_step(workflow):
+    return next(
+        step
+        for step in workflow["jobs"]["blast-radius"]["steps"]
+        if step.get("name") == "Compare base with the pull request merge result"
+    )
+
+
+def test_liveness_primer_workflow_is_scoped_read_only_and_advisory():
+    workflow = _workflow()
+    triggers = workflow.get("on", workflow.get(True))
+
+    assert set(triggers) == {"pull_request"}
+    pull_request = triggers["pull_request"]
+    assert pull_request["types"] == [
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+    ]
+    assert set(pull_request["paths"]) == {
+        "skylos/**",
+        "pyproject.toml",
+        "MANIFEST.in",
+        ".github/workflows/liveness-primer.yml",
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": "liveness-primer-${{ github.event.pull_request.number }}",
+        "cancel-in-progress": True,
+    }
+
+    job = workflow["jobs"]["blast-radius"]
+    assert job["if"] == "github.event.pull_request.draft == false"
+    assert job["runs-on"] == "ubuntu-24.04"
+    assert job["timeout-minutes"] == 45
+
+    comparison = _comparison_step(workflow)
+    assert "--all" in comparison["run"]
+    assert "--fail-on" not in comparison["run"]
+    assert "continue-on-error" not in comparison
+    assert "continue-on-error" not in job
+
+
+def test_liveness_primer_workflow_pins_actions_and_toolchain():
+    workflow = _workflow()
+    steps = workflow["jobs"]["blast-radius"]["steps"]
+    action_steps = [step for step in steps if "uses" in step]
+
+    assert {step["uses"] for step in action_steps} == {
+        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+        "astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f",
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+    }
+    for step in action_steps:
+        action_ref = step["uses"].split("@", 1)[1]
+        assert len(action_ref) == 40
+        assert all(character in "0123456789abcdef" for character in action_ref)
+
+    checkout = next(
+        step
+        for step in steps
+        if step.get("name") == "Check out pinned liveness_primer"
+    )
+    assert checkout["with"] == {
+        "repository": "mcdigman/liveness_primer",
+        "ref": "d6f3118a2cfc465426500eab449005fe56845c58",
+        "path": "_liveness_primer",
+        "persist-credentials": False,
+    }
+
+    setup_uv = next(step for step in steps if step.get("name") == "Install uv")
+    assert setup_uv["with"] == {
+        "version": "0.12.5",
+        "python-version": "3.13",
+        "enable-cache": False,
+    }
+
+
+def test_liveness_primer_workflow_uses_locked_comparison_contract():
+    workflow = _workflow()
+    comparison = _comparison_step(workflow)
+    assert comparison["env"] == {
+        "SKYLOS_REPOSITORY": "https://github.com/duriantaco/skylos",
+        "BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+        "MERGE_SHA": "${{ github.sha }}",
+        "REPORT_JSON": "liveness-primer-report.json",
+        "REPORT_MARKDOWN": "liveness-primer-report.md",
+    }
+    script = comparison["run"]
+    assert "${{" not in script
+    assert '[[ ! "$revision" =~ ^[0-9a-f]{40}$ ]]' in script
+    assert "uv run --project _liveness_primer --locked liveness-primer run" in script
+    assert "--tool skylos" in script
+    assert '--repo "$SKYLOS_REPOSITORY"' in script
+    assert '--old "$BASE_SHA"' in script
+    assert '--new "$MERGE_SHA"' in script
+    assert "--output github" in script
+    assert '--json-out "$REPORT_JSON"' in script
+    assert "--jobs 2" in script
+    assert "--timeout 300" in script
+    assert "set -euo pipefail" in script
+    assert '| tee "$REPORT_MARKDOWN" >> "$GITHUB_STEP_SUMMARY"' in script
+    assert 'test -s "$REPORT_JSON"' in script
+
+
+def test_liveness_primer_workflow_preserves_evidence_without_write_access():
+    workflow_source = WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow = _workflow()
+    steps = workflow["jobs"]["blast-radius"]["steps"]
+
+    artifact = next(
+        step
+        for step in steps
+        if step.get("name") == "Upload blast-radius evidence"
+    )
+    assert artifact["if"] == "always()"
+    assert artifact["with"]["name"] == "liveness-primer-report"
+    assert artifact["with"]["if-no-files-found"] == "error"
+    assert artifact["with"]["retention-days"] == 14
+    assert set(artifact["with"]["path"].splitlines()) == {
+        "liveness-primer-report.md",
+        "liveness-primer-report.json",
+    }
+
+    assert "pull_request_target" not in workflow_source
+    assert "secrets." not in workflow_source
+    assert "pull-requests: write" not in workflow_source
+    assert "gh pr comment" not in workflow_source
+    assert scan_github_actions_file(WORKFLOW_PATH, root=".") == []


### PR DESCRIPTION
Closes #720

## Summary

  - add a read-only PR workflow that compares the base revision against the proposed merge
  - run both Skylos revisions across 15 pinned real-world Python projects
  - show new, dropped and changed findings without blocking intentional analyzer changes
  - fail on crashes, timeouts, incomplete analysis or invalid reports

  ## Tests

  - `pytest test/test_liveness_primer_workflow.py test/test_github_actions_security.py test/test_cicd_*.py`
  - Zizmor reported no findings

