### PR TITLE
fix(quality): break SKY-C401 clone-type ties deterministically

### DIFF
--- a/skylos/rules/quality/clones.py
+++ b/skylos/rules/quality/clones.py
@@ -501,7 +501,11 @@ def _group_connected(
                     types.append(p.clone_type)
 
         avg_sim = sum(sims) / len(sims) if sims else cfg.grouping_threshold
-        clone_type = max(set(types), key=types.count) if types else CloneType.TYPE3
+        clone_type = (
+            min(set(types), key=lambda t: (-types.count(t), t.value))
+            if types
+            else CloneType.TYPE3
+        )
 
         groups.append(
             CloneGroup(

--- a/test/test_clone_type_determinism.py
+++ b/test/test_clone_type_determinism.py
@@ -1,0 +1,254 @@
+"""SKY-C401 clone-type labels must not depend on the interpreter hash seed.
+
+`_group_connected` picks a group's clone type by majority vote over its pair
+types. When that vote ties, the winner used to be decided by `set` iteration
+order, which CPython randomizes per process via `PYTHONHASHSEED`, so identical
+input could be reported as `type1` on one run and `type2` on the next.
+
+The fixture below is reduced from `httpx/_api.py`, where the tie was first
+observed: four request helpers whose bodies normalize identically (so every
+pair is type2-similar), three of which share a keyword-only parameter order
+(so those three pairs are also type1-similar). That splits the six pair votes
+exactly 3/3.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from skylos.rules.quality import clones as clones_mod
+
+HASH_SEEDS = ("0", "1", "2", "3", "4", "5", "6", "7")
+
+CLONE_SOURCE = '''\
+DEFAULT_TIMEOUT_CONFIG = 5.0
+
+
+def request(method, url, **kwargs):
+    return (method, url, kwargs)
+
+
+def get(
+    url,
+    *,
+    params=None,
+    headers=None,
+    cookies=None,
+    auth=None,
+    proxy=None,
+    follow_redirects=False,
+    timeout=DEFAULT_TIMEOUT_CONFIG,
+    verify=True,
+    trust_env=True,
+):
+    """Send a GET request."""
+    return request(
+        "GET",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        follow_redirects=follow_redirects,
+        timeout=timeout,
+        verify=verify,
+        trust_env=trust_env,
+    )
+
+
+def options(
+    url,
+    *,
+    params=None,
+    headers=None,
+    cookies=None,
+    auth=None,
+    proxy=None,
+    follow_redirects=False,
+    timeout=DEFAULT_TIMEOUT_CONFIG,
+    verify=True,
+    trust_env=True,
+):
+    """Send an OPTIONS request."""
+    return request(
+        "OPTIONS",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        follow_redirects=follow_redirects,
+        timeout=timeout,
+        verify=verify,
+        trust_env=trust_env,
+    )
+
+
+def head(
+    url,
+    *,
+    params=None,
+    headers=None,
+    cookies=None,
+    auth=None,
+    proxy=None,
+    follow_redirects=False,
+    timeout=DEFAULT_TIMEOUT_CONFIG,
+    verify=True,
+    trust_env=True,
+):
+    """Send a HEAD request."""
+    return request(
+        "HEAD",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        follow_redirects=follow_redirects,
+        timeout=timeout,
+        verify=verify,
+        trust_env=trust_env,
+    )
+
+
+def delete(
+    url,
+    *,
+    params=None,
+    headers=None,
+    cookies=None,
+    auth=None,
+    proxy=None,
+    timeout=DEFAULT_TIMEOUT_CONFIG,
+    follow_redirects=False,
+    verify=True,
+    trust_env=True,
+):
+    """Send a DELETE request."""
+    return request(
+        "DELETE",
+        url,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        auth=auth,
+        proxy=proxy,
+        follow_redirects=follow_redirects,
+        timeout=timeout,
+        verify=verify,
+        trust_env=trust_env,
+    )
+'''
+
+# Mirrors the CloneConfig the analyzer builds for --quality.
+CLONE_CONFIG_KWARGS = {
+    "grouping_mode": clones_mod.GroupingMode.CONNECTED,
+    "grouping_threshold": 0.80,
+    "k_core_k": 2,
+    "similarity_threshold": 0.90,
+    "ignore_identifiers": True,
+    "ignore_literals": True,
+    "skip_docstrings": True,
+}
+
+# Runs the same pipeline in a fresh interpreter so PYTHONHASHSEED takes effect.
+CHILD_SCRIPT = """\
+import sys
+from pathlib import Path
+
+from skylos.rules.quality import clones as clones_mod
+
+clones_mod._fast_similarity = None
+path = Path(sys.argv[1])
+cfg = clones_mod.CloneConfig(
+    grouping_mode=clones_mod.GroupingMode.CONNECTED,
+    grouping_threshold=0.80,
+    k_core_k=2,
+    similarity_threshold=0.90,
+    ignore_identifiers=True,
+    ignore_literals=True,
+    skip_docstrings=True,
+)
+fragments = clones_mod.extract_fragments(path, path.read_text(), cfg)
+groups = clones_mod.group_pairs(clones_mod.detect_pairs(fragments, cfg), cfg)
+print(groups[0].clone_type.value)
+"""
+
+
+def _group_tied_clone_fixture(tmp_path):
+    """Run the clone pipeline over the fixture and return its single group."""
+    source_path = tmp_path / "api.py"
+    source_path.write_text(CLONE_SOURCE)
+    cfg = clones_mod.CloneConfig(**CLONE_CONFIG_KWARGS)
+    fragments = clones_mod.extract_fragments(source_path, CLONE_SOURCE, cfg)
+    groups = clones_mod.group_pairs(clones_mod.detect_pairs(fragments, cfg), cfg)
+    assert len(groups) == 1
+    return groups[0], fragments, cfg
+
+
+def test_fixture_splits_pair_votes_evenly(tmp_path, monkeypatch):
+    """The fixture must actually tie, or the determinism tests prove nothing."""
+    monkeypatch.setattr(clones_mod, "_fast_similarity", None)
+    group, fragments, cfg = _group_tied_clone_fixture(tmp_path)
+
+    assert sorted(f.name for f in group.fragments) == [
+        "delete",
+        "get",
+        "head",
+        "options",
+    ]
+
+    votes = []
+    for i in range(len(fragments)):
+        for j in range(i + 1, len(fragments)):
+            result = clones_mod.classify_clone(fragments[i], fragments[j], cfg)
+            if result:
+                votes.append(result[0])
+    assert votes.count(clones_mod.CloneType.TYPE1) == 3
+    assert votes.count(clones_mod.CloneType.TYPE2) == 3
+
+
+def test_tied_vote_prefers_the_stricter_clone_type(tmp_path, monkeypatch):
+    """A tie resolves to the lowest clone type, not to whatever `set` yields."""
+    monkeypatch.setattr(clones_mod, "_fast_similarity", None)
+    group, _, _ = _group_tied_clone_fixture(tmp_path)
+
+    assert group.clone_type is clones_mod.CloneType.TYPE1
+
+
+def test_tied_vote_is_stable_across_hash_seeds(tmp_path):
+    """Identical input must yield one clone type for every PYTHONHASHSEED."""
+    source_path = tmp_path / "api.py"
+    source_path.write_text(CLONE_SOURCE)
+    script_path = tmp_path / "vote.py"
+    script_path.write_text(CHILD_SCRIPT)
+    repo_root = Path(clones_mod.__file__).resolve().parents[3]
+
+    observed = {}
+    for seed in HASH_SEEDS:
+        completed = subprocess.run(
+            [sys.executable, str(script_path), str(source_path)],
+            capture_output=True,
+            check=False,
+            cwd=tmp_path,
+            env={"PATH": "", "PYTHONHASHSEED": seed, "PYTHONPATH": str(repo_root)},
+            text=True,
+            timeout=120,
+        )
+        if completed.returncode != 0:
+            pytest.fail(
+                f"clone grouping failed at PYTHONHASHSEED={seed}: "
+                f"{textwrap.shorten(completed.stderr.strip(), 500)}"
+            )
+        observed[seed] = completed.stdout.strip()
+
+    assert set(observed.values()) == {"type1"}, (
+        f"clone type varied with the hash seed: {observed}"
+    )


### PR DESCRIPTION
Closes #733 

## What does this PR do?

Makes the SKY-C401 clone-group **type label** deterministic. One line in
`_group_connected`; the rest is a regression test.

**AI Use Disclosure**
The issue was isolated by `liveness_primer` running on the corpus source httpx. Claude Opus 5.0 drafted the one-line fix, and it was reviewed by me before pushing. A GPT-5.6 Sol reviewer using repository llm agent guidelines had no findings.

## Why?


`similarity` is the mean over all pairs, so it is unaffected by the label — which
is why this presented as message-only. 

It is *not* purely cosmetic: the finding's
`value` field (`"type1 1.00"` vs `"type2 1.00"`) flips in every case, and a
TYPE2/TYPE3 tie would also flip **severity**, since `analyzer.py` only buckets
TYPE1/TYPE2 into `MEDIUM`.

### Why the httpx group ties

`get`, `options`, `head` and `delete` form one connected component, so six pairs vote:

| pair | text sim | AST sim | type |
| --- | --- | --- | --- |
| `get` / `options` | 0.99194 | 1.00000 | type1 |
| `get` / `head` | 0.99434 | 1.00000 | type1 |
| `options` / `head` | 0.99114 | 1.00000 | type1 |
| `get` / `delete` | 0.91525 | 1.00000 | type2 |
| `options` / `delete` | 0.91231 | 1.00000 | type2 |
| `head` / `delete` | 0.91452 | 1.00000 | type2 |

Exactly 3 type1 and 3 type2 — a perfect tie.

The split arises because the two metrics see different text. `classify_clone`
tries type1 first on `text_norm`, tokenized from the fragment's raw source lines
and therefore including the **signature**; type2 runs on an identifier- and
literal-normalized AST dump of the **body** only. All four bodies are a single
`request(...)` call that normalizes identically, giving AST similarity 1.0
everywhere. In the signatures, `delete` declares `timeout` in a different
position than the other three, dropping its raw token similarity below the 0.98
type1 threshold while the other three stay above it.


## How to test

The new `test/test_clone_type_determinism.py` adds three tests around a fixture
reduced from the httpx group (four request helpers, six pair votes split 3/3):

- `test_fixture_splits_pair_votes_evenly` — guards that the fixture actually
  ties, so the other two tests can't silently stop testing anything.
- `test_tied_vote_prefers_the_stricter_clone_type` — the tie resolves to TYPE1.
- `test_tied_vote_is_stable_across_hash_seeds` — runs the pipeline in a fresh
  interpreter under `PYTHONHASHSEED` 0–7 and asserts all eight agree.

Against the current code, the third test fails on **every** run (seeds 0–7
produce a mix), and the second fails on roughly half of runs. Both pass
consistently with the fix.

```console
$ python -m pytest test/test_clone_type_determinism.py -q
3 passed
```

Both tests pin `_fast_similarity = None`, matching the existing convention in
`test_quality_rules.py`, so results don't depend on whether the Rust extension
is built.


## Checklist

- [x] Tests pass (`python3 -m pytest test/`)
- [x] No new false positives introduced (if modifying analysis logic)


