### PR TITLE
fix(ai-defect): avoid oversized registry metadata false negatives

### DIFF
--- a/skylos/rules/ai_defect/manifest_dependency_hallucination.py
+++ b/skylos/rules/ai_defect/manifest_dependency_hallucination.py
@@ -1989,22 +1989,31 @@ def _check_npm_version(name: str, version: str) -> str:
     if package_path is None:
         return STATUS_UNKNOWN
 
-    url = f"{NPM_REGISTRY_ORIGIN}/{package_path}"
+    raw_version = version.strip()
+    if not raw_version:
+        return STATUS_UNKNOWN
+
+    safe_version = quote(raw_version, safe="")
+    version_url = f"{NPM_REGISTRY_ORIGIN}/{package_path}/{safe_version}"
     try:
-        data = _fetch_json(url, user_agent="skylos-npm-dep-scanner/1.0")
+        _fetch_json(version_url, user_agent="skylos-npm-dep-scanner/1.0")
+        return STATUS_PRESENT
+    except urllib.error.HTTPError as exc:
+        if exc.code != 404:
+            return STATUS_UNKNOWN
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return STATUS_UNKNOWN
+
+    package_url = f"{NPM_REGISTRY_ORIGIN}/{package_path}"
+    try:
+        _fetch_head(package_url, user_agent="skylos-npm-dep-scanner/1.0")
+        return STATUS_MISSING_VERSION
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             return STATUS_MISSING_PACKAGE
         return STATUS_UNKNOWN
     except (urllib.error.URLError, TimeoutError, OSError, ValueError):
         return STATUS_UNKNOWN
-
-    versions = data.get("versions")
-    if not isinstance(versions, dict):
-        return STATUS_UNKNOWN
-    if version in versions:
-        return STATUS_PRESENT
-    return STATUS_MISSING_VERSION
 
 
 def _check_go_version(name: str, version: str) -> str:
@@ -2138,6 +2147,19 @@ def _fetch_json(url: str, *, user_agent: str) -> dict[str, Any]:
     if isinstance(data, dict):
         return data
     return {}
+
+
+def _fetch_head(url: str, *, user_agent: str) -> None:
+    if not _allowed_registry_url(url):
+        raise ValueError("Registry URL host is not allowed")
+
+    request = urllib.request.Request(url, method="HEAD")
+    request.add_header("User-Agent", user_agent)
+    with urllib.request.urlopen(  # skylos: ignore[SKY-D216] URL is validated against fixed registry hosts above.
+        request,
+        timeout=5,
+    ):
+        pass
 
 
 def _fetch_text(url: str, *, user_agent: str) -> str:

--- a/skylos/rules/ai_defect/manifest_dependency_hallucination.py
+++ b/skylos/rules/ai_defect/manifest_dependency_hallucination.py
@@ -29,6 +29,7 @@ from skylos.rules.sca.vulnerability_scanner import (
     ECOSYSTEM_GO,
     ECOSYSTEM_NPM,
     ECOSYSTEM_PYPI,
+    _extract_exact_npm_version,
     parse_go_mod,
     parse_package_json_candidates,
     parse_pyproject_toml_candidates,
@@ -1992,7 +1993,11 @@ def _check_npm_version(name: str, version: str) -> str:
     if not raw_version:
         return STATUS_UNKNOWN
 
-    safe_version = quote(raw_version, safe="")
+    exact_version = _extract_exact_npm_version(raw_version)
+    if exact_version is None:
+        return _check_npm_package(package_path)
+
+    safe_version = quote(exact_version, safe="")
     version_url = f"{NPM_REGISTRY_ORIGIN}/{package_path}/{safe_version}"
     try:
         _fetch_head(version_url, user_agent="skylos-npm-dep-scanner/1.0")
@@ -2003,10 +2008,17 @@ def _check_npm_version(name: str, version: str) -> str:
     except (urllib.error.URLError, TimeoutError, OSError, ValueError):
         return STATUS_UNKNOWN
 
+    package_status = _check_npm_package(package_path)
+    if package_status == STATUS_PRESENT:
+        return STATUS_MISSING_VERSION
+    return package_status
+
+
+def _check_npm_package(package_path: str) -> str:
     package_url = f"{NPM_REGISTRY_ORIGIN}/{package_path}"
     try:
         _fetch_head(package_url, user_agent="skylos-npm-dep-scanner/1.0")
-        return STATUS_MISSING_VERSION
+        return STATUS_PRESENT
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             return STATUS_MISSING_PACKAGE

--- a/skylos/rules/ai_defect/manifest_dependency_hallucination.py
+++ b/skylos/rules/ai_defect/manifest_dependency_hallucination.py
@@ -52,7 +52,6 @@ STATUS_UNKNOWN = "unknown"
 VERSION_CACHE_SCHEMA_VERSION = 1
 VERSION_CACHE_PATH = Path(".skylos") / "cache" / "dependency_versions.json"
 MAX_VERSION_CACHE_BYTES = 5_000_000
-MAX_REGISTRY_RESPONSE_BYTES = 1_000_000
 MAX_INSTALL_SURFACE_BYTES = 1_000_000
 NPM_REGISTRY_ORIGIN = "https://registry.npmjs.org"
 GO_PROXY_ORIGIN = "https://proxy.golang.org"
@@ -1964,7 +1963,7 @@ def _check_pypi_version(name: str, version: str) -> str:
     safe_version = quote(version.strip(), safe="")
     version_url = f"{PYPI_JSON_ORIGIN}/{package_path}/{safe_version}/json"
     try:
-        _fetch_json(version_url, user_agent="skylos-pypi-dep-scanner/1.0")
+        _fetch_head(version_url, user_agent="skylos-pypi-dep-scanner/1.0")
         return STATUS_PRESENT
     except urllib.error.HTTPError as exc:
         if exc.code != 404:
@@ -1974,7 +1973,7 @@ def _check_pypi_version(name: str, version: str) -> str:
 
     package_url = f"{PYPI_JSON_ORIGIN}/{package_path}/json"
     try:
-        _fetch_json(package_url, user_agent="skylos-pypi-dep-scanner/1.0")
+        _fetch_head(package_url, user_agent="skylos-pypi-dep-scanner/1.0")
         return STATUS_MISSING_VERSION
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -1996,7 +1995,7 @@ def _check_npm_version(name: str, version: str) -> str:
     safe_version = quote(raw_version, safe="")
     version_url = f"{NPM_REGISTRY_ORIGIN}/{package_path}/{safe_version}"
     try:
-        _fetch_json(version_url, user_agent="skylos-npm-dep-scanner/1.0")
+        _fetch_head(version_url, user_agent="skylos-npm-dep-scanner/1.0")
         return STATUS_PRESENT
     except urllib.error.HTTPError as exc:
         if exc.code != 404:
@@ -2025,7 +2024,7 @@ def _check_go_version(name: str, version: str) -> str:
     safe_go_version = quote(go_version, safe="")
     info_url = f"{GO_PROXY_ORIGIN}/{module_path}/@v/{safe_go_version}.info"
     try:
-        _fetch_text(info_url, user_agent="skylos-go-dep-scanner/1.0")
+        _fetch_head(info_url, user_agent="skylos-go-dep-scanner/1.0")
         return STATUS_PRESENT
     except urllib.error.HTTPError as exc:
         if exc.code != 404:
@@ -2035,7 +2034,7 @@ def _check_go_version(name: str, version: str) -> str:
 
     list_url = f"{GO_PROXY_ORIGIN}/{module_path}/@v/list"
     try:
-        _fetch_text(list_url, user_agent="skylos-go-dep-scanner/1.0")
+        _fetch_head(list_url, user_agent="skylos-go-dep-scanner/1.0")
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             return STATUS_MISSING_PACKAGE
@@ -2141,14 +2140,6 @@ def _safe_go_path_part(value: str) -> bool:
     return True
 
 
-def _fetch_json(url: str, *, user_agent: str) -> dict[str, Any]:
-    text = _fetch_text(url, user_agent=user_agent)
-    data = json.loads(text)
-    if isinstance(data, dict):
-        return data
-    return {}
-
-
 def _fetch_head(url: str, *, user_agent: str) -> None:
     if not _allowed_registry_url(url):
         raise ValueError("Registry URL host is not allowed")
@@ -2160,24 +2151,6 @@ def _fetch_head(url: str, *, user_agent: str) -> None:
         timeout=5,
     ):
         pass
-
-
-def _fetch_text(url: str, *, user_agent: str) -> str:
-    if not _allowed_registry_url(url):
-        raise ValueError("Registry URL host is not allowed")
-
-    request = urllib.request.Request(url, method="GET")
-    request.add_header("User-Agent", user_agent)
-    with (
-        urllib.request.urlopen(  # skylos: ignore[SKY-D216] URL is validated against fixed registry hosts above.
-            request,
-            timeout=5,
-        ) as response
-    ):
-        raw = response.read(MAX_REGISTRY_RESPONSE_BYTES + 1)
-    if len(raw) > MAX_REGISTRY_RESPONSE_BYTES:
-        raise ValueError("Registry response exceeds size limit")
-    return raw.decode("utf-8", errors="replace")
 
 
 def _allowed_registry_url(url: str) -> bool:

--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -45,6 +45,9 @@ ECOSYSTEM_NPM = "npm"
 ECOSYSTEM_GO = "Go"
 
 _VERSION_RE = re.compile(r"([=~!<>]=?)\s*([A-Za-z0-9._*+-]+)")
+_NPM_EXACT_VERSION_RE = re.compile(
+    r"=?v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)"
+)
 _REQ_LINE_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
 _DIRECT_REFERENCE_RE = re.compile(
     r"\s@\s*(?:[A-Za-z][A-Za-z0-9+.-]*:|[A-Za-z0-9+.-]+\+|/|\.{1,2}/)"
@@ -75,6 +78,13 @@ def _extract_pinned_version(spec: str) -> str | None:
         if op == "==" and "*" not in ver:
             return ver
     return None
+
+
+def _extract_exact_npm_version(spec: str) -> str | None:
+    match = _NPM_EXACT_VERSION_RE.fullmatch(spec.strip())
+    if match is None:
+        return None
+    return match.group(1)
 
 
 def _extract_version_candidate(spec: str) -> str | None:
@@ -560,17 +570,17 @@ def _parse_package_json(path: Path, *, allow_version_ranges: bool) -> list[dict]
             if not isinstance(version_spec, str):
                 continue
 
-            if allow_version_ranges:
-                version = re.sub(r"^[\^~>=<]+", "", version_spec).strip()
-                if not version or not version[0].isdigit():
+            raw_version_spec = version_spec.strip()
+            exact_version = _extract_exact_npm_version(raw_version_spec)
+            if exact_version is not None:
+                version = exact_version
+            elif allow_version_ranges:
+                range_start = re.sub(r"^[\^~>=<]+", "", raw_version_spec).strip()
+                if not range_start or not range_start[0].isdigit():
                     continue
+                version = raw_version_spec
             else:
-                exact_match = re.fullmatch(
-                    r"=?v?([0-9][0-9A-Za-z._+-]*)", version_spec.strip()
-                )
-                if exact_match is None:
-                    continue
-                version = exact_match.group(1)
+                continue
 
             lineno = _find_line(txt, f'"{name}"')
             deps.append(

--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -46,7 +46,7 @@ ECOSYSTEM_GO = "Go"
 
 _VERSION_RE = re.compile(r"([=~!<>]=?)\s*([A-Za-z0-9._*+-]+)")
 _NPM_EXACT_VERSION_RE = re.compile(
-    r"=?v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)"
+    r"(?:=\s*)?v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)"
 )
 _REQ_LINE_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
 _DIRECT_REFERENCE_RE = re.compile(

--- a/test/test_manifest_dependency_hallucination.py
+++ b/test/test_manifest_dependency_hallucination.py
@@ -735,7 +735,7 @@ def test_scan_npm_missing_version_uses_bodyless_package_probe_and_caches(
     assert [finding["rule_id"] for finding in first] == [RULE_ID_VERSION_HALLUCINATION]
     assert [finding["rule_id"] for finding in second] == [RULE_ID_VERSION_HALLUCINATION]
     assert _request_calls(urlopen) == [
-        (version_url, "GET", 5),
+        (version_url, "HEAD", 5),
         (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/react", "HEAD", 5),
     ]
     package_response.read.assert_not_called()
@@ -743,26 +743,35 @@ def test_scan_npm_missing_version_uses_bodyless_package_probe_and_caches(
     assert cache["statuses"]["npm:react:999999.0.0"] == STATUS_MISSING_VERSION
 
 
-def test_scan_npm_present_version_uses_version_document_and_caches(
+def test_scan_npm_large_present_version_preserves_lookalike_check_and_cache(
     tmp_path,
     monkeypatch,
 ):
     repo = tmp_path / "repo"
     repo.mkdir()
-    manifest = {"dependencies": {"react": "19.1.0"}}
+    manifest = {"dependencies": {"recat": "1.2.3"}}
     (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
-    response = _registry_response(b'{"name":"react","version":"19.1.0"}')
+    response = _registry_response()
+    response.read.side_effect = AssertionError("HEAD response body was read")
     urlopen = MagicMock(return_value=response)
     monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
 
-    assert scan_manifest_dependency_hallucinations(repo) == []
-    assert scan_manifest_dependency_hallucinations(repo) == []
-    assert _request_calls(urlopen) == [
-        (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/react/19.1.0", "GET", 5),
+    first = scan_manifest_dependency_hallucinations(repo)
+    second = scan_manifest_dependency_hallucinations(repo)
+
+    assert [finding["rule_id"] for finding in first] == [
+        RULE_ID_DEPENDENCY_HALLUCINATION
     ]
-    response.read.assert_called_once_with(manifest_rule.MAX_REGISTRY_RESPONSE_BYTES + 1)
+    assert [finding["rule_id"] for finding in second] == [
+        RULE_ID_DEPENDENCY_HALLUCINATION
+    ]
+    assert first[0]["metadata"]["dependency_truth_state"] == "suspicious_existing"
+    assert _request_calls(urlopen) == [
+        (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/recat/1.2.3", "HEAD", 5),
+    ]
+    response.read.assert_not_called()
     cache = json.loads((repo / VERSION_CACHE_PATH).read_text(encoding="utf-8"))
-    assert cache["statuses"]["npm:react:19.1.0"] == STATUS_PRESENT
+    assert cache["statuses"]["npm:recat:1.2.3"] == STATUS_PRESENT
 
 
 def test_scan_npm_missing_package_uses_version_then_package_probe(
@@ -785,34 +794,69 @@ def test_scan_npm_missing_package_uses_version_then_package_probe(
         RULE_ID_DEPENDENCY_HALLUCINATION
     ]
     assert _request_calls(urlopen) == [
-        (version_url, "GET", 5),
+        (version_url, "HEAD", 5),
         (package_url, "HEAD", 5),
     ]
 
 
-def test_scan_npm_oversized_version_document_is_bounded_and_not_cached(
+def test_scan_pypi_large_package_missing_version_is_reported_and_cached(
     tmp_path,
     monkeypatch,
 ):
     repo = tmp_path / "repo"
     repo.mkdir()
-    manifest = {"dependencies": {"oversized-package": "1.2.3"}}
-    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
-    response = _registry_response(
-        b"x" * (manifest_rule.MAX_REGISTRY_RESPONSE_BYTES + 1)
-    )
-    urlopen = MagicMock(return_value=response)
+    (repo / "requirements.txt").write_text("numpy==999999.0.0\n", encoding="utf-8")
+    version_url = f"{manifest_rule.PYPI_JSON_ORIGIN}/numpy/999999.0.0/json"
+    package_url = f"{manifest_rule.PYPI_JSON_ORIGIN}/numpy/json"
+    package_response = _registry_response()
+    package_response.read.side_effect = AssertionError("HEAD response body was read")
+    urlopen = MagicMock(side_effect=[_not_found(version_url), package_response])
     monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
 
-    assert scan_manifest_dependency_hallucinations(repo) == []
-    assert scan_manifest_dependency_hallucinations(repo) == []
-    version_url = f"{manifest_rule.NPM_REGISTRY_ORIGIN}/oversized-package/1.2.3"
+    first = scan_manifest_dependency_hallucinations(repo)
+    second = scan_manifest_dependency_hallucinations(repo)
+
+    assert [finding["rule_id"] for finding in first] == [RULE_ID_VERSION_HALLUCINATION]
+    assert [finding["rule_id"] for finding in second] == [RULE_ID_VERSION_HALLUCINATION]
     assert _request_calls(urlopen) == [
-        (version_url, "GET", 5),
-        (version_url, "GET", 5),
+        (version_url, "HEAD", 5),
+        (package_url, "HEAD", 5),
     ]
-    assert response.read.call_count == 2
-    assert not (repo / VERSION_CACHE_PATH).exists()
+    package_response.read.assert_not_called()
+    cache = json.loads((repo / VERSION_CACHE_PATH).read_text(encoding="utf-8"))
+    assert cache["statuses"]["PyPI:numpy:999999.0.0"] == STATUS_MISSING_VERSION
+
+
+def test_scan_go_large_module_missing_version_is_reported_and_cached(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    module = "github.com/stretchr/testify"
+    (repo / "go.mod").write_text(
+        f"module example.com/demo\n\ngo 1.22\n\nrequire {module} v999.0.0\n",
+        encoding="utf-8",
+    )
+    info_url = f"{manifest_rule.GO_PROXY_ORIGIN}/{module}/@v/v999.0.0.info"
+    list_url = f"{manifest_rule.GO_PROXY_ORIGIN}/{module}/@v/list"
+    list_response = _registry_response()
+    list_response.read.side_effect = AssertionError("HEAD response body was read")
+    urlopen = MagicMock(side_effect=[_not_found(info_url), list_response])
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
+
+    first = scan_manifest_dependency_hallucinations(repo)
+    second = scan_manifest_dependency_hallucinations(repo)
+
+    assert [finding["rule_id"] for finding in first] == [RULE_ID_VERSION_HALLUCINATION]
+    assert [finding["rule_id"] for finding in second] == [RULE_ID_VERSION_HALLUCINATION]
+    assert _request_calls(urlopen) == [
+        (info_url, "HEAD", 5),
+        (list_url, "HEAD", 5),
+    ]
+    list_response.read.assert_not_called()
+    cache = json.loads((repo / VERSION_CACHE_PATH).read_text(encoding="utf-8"))
+    assert cache["statuses"][f"Go:{module}:999.0.0"] == STATUS_MISSING_VERSION
 
 
 def test_scan_manifest_dependency_cache_key_normalizes_pypi_identity(tmp_path):

--- a/test/test_manifest_dependency_hallucination.py
+++ b/test/test_manifest_dependency_hallucination.py
@@ -89,7 +89,7 @@ def test_scan_package_json_flags_missing_npm_package_and_version(tmp_path):
     manifest = {
         "dependencies": {
             "leftpadz": "9.9.9",
-            "stale-version": "^99.0.0",
+            "stale-version": "99.0.0",
             "realpkg": "1.2.3",
         },
         "devDependencies": {
@@ -123,6 +123,65 @@ def test_scan_package_json_flags_missing_npm_package_and_version(tmp_path):
     assert any("leftpadz" in message for message in _messages(findings))
     assert any("stale-version@99.0.0" in message for message in _messages(findings))
     assert (ECOSYSTEM_NPM, "realpkg", "1.2.3") in calls
+
+
+def test_scan_npm_ranges_check_package_without_literal_version_false_positives(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = {
+        "dependencies": {
+            "through2": ">=2",
+            "react": ">=16",
+            "ghost-range": ">=2",
+            "recat": "^1.0.0",
+        }
+    }
+    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    response = _registry_response()
+    response.read.side_effect = AssertionError("HEAD response body was read")
+    missing_url = f"{manifest_rule.NPM_REGISTRY_ORIGIN}/ghost-range"
+
+    def registry_response(
+        request: urllib.request.Request,
+        *,
+        timeout: int,
+    ) -> MagicMock:
+        assert timeout == 5
+        if request.full_url == missing_url:
+            raise _not_found(request.full_url)
+        return response
+
+    urlopen = MagicMock(side_effect=registry_response)
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
+
+    first = scan_manifest_dependency_hallucinations(repo)
+    second = scan_manifest_dependency_hallucinations(repo)
+
+    assert {finding["metadata"]["package_name"] for finding in first} == {
+        "ghost-range",
+        "recat",
+    }
+    assert {finding["rule_id"] for finding in first} == {
+        RULE_ID_DEPENDENCY_HALLUCINATION
+    }
+    assert second == first
+    assert _request_calls(urlopen) == [
+        (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/through2", "HEAD", 5),
+        (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/react", "HEAD", 5),
+        (missing_url, "HEAD", 5),
+        (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/recat", "HEAD", 5),
+    ]
+    response.read.assert_not_called()
+    cache = json.loads((repo / VERSION_CACHE_PATH).read_text(encoding="utf-8"))
+    assert cache["statuses"] == {
+        "npm:ghost-range:>=2": STATUS_MISSING_PACKAGE,
+        "npm:react:>=16": STATUS_PRESENT,
+        "npm:recat:^1.0.0": STATUS_PRESENT,
+        "npm:through2:>=2": STATUS_PRESENT,
+    }
 
 
 def test_scan_go_mod_flags_missing_go_module_and_version(tmp_path):

--- a/test/test_manifest_dependency_hallucination.py
+++ b/test/test_manifest_dependency_hallucination.py
@@ -774,13 +774,13 @@ def test_scan_manifest_dependency_statuses_are_cached(tmp_path):
     assert calls == [(ECOSYSTEM_NPM, "stale-version", "99.0.0")]
 
 
-def test_scan_npm_missing_version_uses_bodyless_package_probe_and_caches(
+def test_scan_npm_spaced_equality_checks_exact_version_and_caches(
     tmp_path,
     monkeypatch,
 ):
     repo = tmp_path / "repo"
     repo.mkdir()
-    manifest = {"dependencies": {"react": "999999.0.0"}}
+    manifest = {"dependencies": {"react": "= 999999.0.0"}}
     (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
     version_url = f"{manifest_rule.NPM_REGISTRY_ORIGIN}/react/999999.0.0"
     package_response = _registry_response()

--- a/test/test_manifest_dependency_hallucination.py
+++ b/test/test_manifest_dependency_hallucination.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import json
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock
 
+from skylos.rules.ai_defect import manifest_dependency_hallucination as manifest_rule
+from skylos.rules.ai_defect.dependency_truth import (
+    DependencyTruthState,
+    normalize_dependency_truth_state,
+)
 from skylos.rules.ai_defect.manifest_dependency_hallucination import (
+    INSTALL_SURFACE_SOURCE,
     RULE_ID_DEPENDENCY_HALLUCINATION,
     RULE_ID_VERSION_HALLUCINATION,
-    INSTALL_SURFACE_SOURCE,
     STATUS_EXISTS,
     STATUS_MISSING_PACKAGE,
     STATUS_MISSING_VERSION,
@@ -16,15 +24,31 @@ from skylos.rules.ai_defect.manifest_dependency_hallucination import (
     VERSION_CACHE_SCHEMA_VERSION,
     scan_manifest_dependency_hallucinations,
 )
-from skylos.rules.ai_defect.dependency_truth import (
-    DependencyTruthState,
-    normalize_dependency_truth_state,
-)
 from skylos.rules.sca.vulnerability_scanner import (
     ECOSYSTEM_GO,
     ECOSYSTEM_NPM,
     ECOSYSTEM_PYPI,
 )
+
+
+def _registry_response(body: bytes = b"{}") -> MagicMock:
+    response = MagicMock()
+    response.read.return_value = body
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
+
+
+def _not_found(url: str) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url, 404, "Not Found", None, None)
+
+
+def _request_calls(urlopen: MagicMock) -> list[tuple[str, str, int]]:
+    calls: list[tuple[str, str, int]] = []
+    for call in urlopen.call_args_list:
+        request: urllib.request.Request = call.args[0]
+        calls.append((request.full_url, request.get_method(), call.kwargs["timeout"]))
+    return calls
 
 
 def _status_checker(statuses, calls):
@@ -689,6 +713,106 @@ def test_scan_manifest_dependency_statuses_are_cached(tmp_path):
     assert len(first) == 1
     assert len(second) == 1
     assert calls == [(ECOSYSTEM_NPM, "stale-version", "99.0.0")]
+
+
+def test_scan_npm_missing_version_uses_bodyless_package_probe_and_caches(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = {"dependencies": {"react": "999999.0.0"}}
+    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    version_url = f"{manifest_rule.NPM_REGISTRY_ORIGIN}/react/999999.0.0"
+    package_response = _registry_response()
+    package_response.read.side_effect = AssertionError("HEAD response body was read")
+    urlopen = MagicMock(side_effect=[_not_found(version_url), package_response])
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
+
+    first = scan_manifest_dependency_hallucinations(repo)
+    second = scan_manifest_dependency_hallucinations(repo)
+
+    assert [finding["rule_id"] for finding in first] == [RULE_ID_VERSION_HALLUCINATION]
+    assert [finding["rule_id"] for finding in second] == [RULE_ID_VERSION_HALLUCINATION]
+    assert _request_calls(urlopen) == [
+        (version_url, "GET", 5),
+        (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/react", "HEAD", 5),
+    ]
+    package_response.read.assert_not_called()
+    cache = json.loads((repo / VERSION_CACHE_PATH).read_text(encoding="utf-8"))
+    assert cache["statuses"]["npm:react:999999.0.0"] == STATUS_MISSING_VERSION
+
+
+def test_scan_npm_present_version_uses_version_document_and_caches(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = {"dependencies": {"react": "19.1.0"}}
+    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    response = _registry_response(b'{"name":"react","version":"19.1.0"}')
+    urlopen = MagicMock(return_value=response)
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
+
+    assert scan_manifest_dependency_hallucinations(repo) == []
+    assert scan_manifest_dependency_hallucinations(repo) == []
+    assert _request_calls(urlopen) == [
+        (f"{manifest_rule.NPM_REGISTRY_ORIGIN}/react/19.1.0", "GET", 5),
+    ]
+    response.read.assert_called_once_with(manifest_rule.MAX_REGISTRY_RESPONSE_BYTES + 1)
+    cache = json.loads((repo / VERSION_CACHE_PATH).read_text(encoding="utf-8"))
+    assert cache["statuses"]["npm:react:19.1.0"] == STATUS_PRESENT
+
+
+def test_scan_npm_missing_package_uses_version_then_package_probe(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    package = "definitely-not-a-real-skylos-package"
+    manifest = {"dependencies": {package: "1.2.3"}}
+    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    package_url = f"{manifest_rule.NPM_REGISTRY_ORIGIN}/{package}"
+    version_url = f"{package_url}/1.2.3"
+    urlopen = MagicMock(side_effect=[_not_found(version_url), _not_found(package_url)])
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
+
+    findings = scan_manifest_dependency_hallucinations(repo)
+
+    assert [finding["rule_id"] for finding in findings] == [
+        RULE_ID_DEPENDENCY_HALLUCINATION
+    ]
+    assert _request_calls(urlopen) == [
+        (version_url, "GET", 5),
+        (package_url, "HEAD", 5),
+    ]
+
+
+def test_scan_npm_oversized_version_document_is_bounded_and_not_cached(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = {"dependencies": {"oversized-package": "1.2.3"}}
+    (repo / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+    response = _registry_response(
+        b"x" * (manifest_rule.MAX_REGISTRY_RESPONSE_BYTES + 1)
+    )
+    urlopen = MagicMock(return_value=response)
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", urlopen)
+
+    assert scan_manifest_dependency_hallucinations(repo) == []
+    assert scan_manifest_dependency_hallucinations(repo) == []
+    version_url = f"{manifest_rule.NPM_REGISTRY_ORIGIN}/oversized-package/1.2.3"
+    assert _request_calls(urlopen) == [
+        (version_url, "GET", 5),
+        (version_url, "GET", 5),
+    ]
+    assert response.read.call_count == 2
+    assert not (repo / VERSION_CACHE_PATH).exists()
 
 
 def test_scan_manifest_dependency_cache_key_normalizes_pypi_identity(tmp_path):

--- a/test/test_sca_cache.py
+++ b/test/test_sca_cache.py
@@ -148,7 +148,8 @@ def test_manifest_parsers_query_only_exact_versions(tmp_path):
     )
     package_json = tmp_path / "package.json"
     package_json.write_text(
-        '{"dependencies":{"exact":"1.2.3","caret":"^2.0.0","tag":"latest"}}',
+        '{"dependencies":{"exact":"1.2.3","equals":"=2.3.4",'
+        '"spaced_equals":"= 3.4.5","caret":"^2.0.0","tag":"latest"}}',
         encoding="utf-8",
     )
     pyproject = tmp_path / "pyproject.toml"
@@ -163,7 +164,11 @@ def test_manifest_parsers_query_only_exact_versions(tmp_path):
     ] == [("exact", "1.2.3")]
     assert [
         (item["name"], item["version"]) for item in sca.parse_package_json(package_json)
-    ] == [("exact", "1.2.3")]
+    ] == [
+        ("exact", "1.2.3"),
+        ("equals", "2.3.4"),
+        ("spaced_equals", "3.4.5"),
+    ]
     assert [
         (item["name"], item["version"]) for item in sca.parse_pyproject_toml(pyproject)
     ] == [("exact", "1.2.3")]


### PR DESCRIPTION
The first fix surfaced a latent false-positive that would cause noise downstream; they need to be fixed in the same release version to avoid that, so I thought to just combine them into the same PR to guarantee that.

Closes #735
Closes #737 



## Second issue surfaced
#737 was quasi-latent before the original fix, but would have gotten worse due to it becoming more apparent on specifically large packages; for example, in addition to the #737 reproducer, the original fix would have cause a FP in skylos itself at `editors/vscode/package.json`:
```
+  SKY-D225  NA  HIGH      ai_defect  editors/vscode/package.json:L16  typescript@5.0.0  Hallucinated npm dependency version 'typescript@5.0.0'. Version   -
                                                                                         does not exist in the npm registry.
  ```
  which is caused because `"typescript": "^5.0.0"` specified there *actually* does not exist exactly (5.0.0 was a dev version and has a corresponding qualifier in the version name), but npm still resolves it fine anyway, to 5.9.x.
  
 The fix approach I chose here is the one that minimizes false positives, which is to only have SKY-D225 fire on npm for exact pins; other rules can fire on ranges. Note that part of the fix isn't really needed for pypi, because the pypi api uses PEP 440 normalization which will respond as expected in most stripped cases unless it is given a reference version that actually does not exist, in which case firing SKY-D225 seems fine.
 
 **Use of HEAD**
 Using HEAD instead of GET eliminates the 1 MB fix completely, and maybe closes some incidental network edge cases; it is also probably better/non-inferior performance-wise, although I haven't tested the profiling impact as this isn't specifically a perf PR.
 
**AI Use Disclaimer**

Codex GPT-5.6 Sol drafted this fix, and it was reviewed according to skylos repository standards by Claude Fable 5.0 and a separate GPT-5.6 Sol Agent. I inspected the code fixes manually and they look as expected.
## Summary

- query version-scoped registry resources instead of full npm package metadata
- use bodyless `HEAD` probes for npm, PyPI, and Go version/package existence checks
- distinguish npm SemVer ranges from exact pins, checking ranges for package existence only
- preserve authoritative present/missing cache entries without caching unknown results
- remove the now-unused registry response body reader and its 1 MB cutoff

## Reproduction

Before this change, scanning `numpy==999999.0.0` returned no AI defect because the version request returned 404 and the 3,616,753-byte package-wide PyPI response exceeded the 1 MB limit. That degraded the result to `unknown`, suppressed `SKY-D225`, and did not warm the cache.

After this change, the same real-registry CLI reproduction reports `SKY-D225` and records `PyPI:numpy:999999.0.0 = missing_version`.

Live probes also confirmed the expected `HEAD` 200/404 behavior for representative existing and missing npm versions, PyPI versions/packages, and Go `.info`/`@v/list` resources.


Issue #737 also reproduced on the PR head: `through2: ">=2"` and `react: ">=16"` were reduced to literal versions `2` and `16`, producing false `SKY-D225` findings. Range specs are now preserved and use package-only probes. Exact full SemVer pins still receive version-level validation, while missing ranged packages and suspicious existing lookalikes remain detectable. A real scan of `editors/vscode/package.json` likewise produces no finding for `typescript: "^5.0.0"` and caches that range as a present package.

## Tests

- focused manifest/parser/diff suites — 60 passed
- full suite — 7,071 passed, 7 skipped; two unrelated existing agent-behavior error-message assertions failed

Regression coverage verifies:

- oversized npm version metadata cannot suppress suspicious-existing lookalike detection
- npm, PyPI, and Go missing-version findings survive to scanner output
- package-wide fallback bodies are never read
- authoritative results are persisted and reused without a second registry request
- npm ranges do not produce literal-version `SKY-D225` false positives
- ranged missing packages and suspicious lookalikes still produce `SKY-D222`

No no-network behavior is changed by this PR.


