### PR TITLE
perf(dead-code): index documented method references

### DIFF
--- a/skylos/deadcode/liveness.py
+++ b/skylos/deadcode/liveness.py
@@ -496,10 +496,9 @@ def _qualified_documented_method_keys(
         for name, keys in qualified.items()
         if keys - word_candidates
     }
-    if unusual_qualified:
-        qualified_pattern = _literal_alternation(unusual_qualified)
-        for match in re.finditer(rf"(?=\b({qualified_pattern})\b)", text):
-            referenced.update(unusual_qualified[match.group(1)])
+    for qualified_name, keys in unusual_qualified.items():
+        if re.search(rf"\b{re.escape(qualified_name)}\b", text):
+            referenced.update(keys)
     return referenced
 
 
@@ -525,9 +524,6 @@ def _long_call_documented_method_keys(
         for method_name, keys in by_method.items()
         if "_" in method_name and len(method_name) >= 10
     }
-    if not long_methods:
-        return referenced
-
     for match in re.finditer(r"\.[ \t]*([^\W\d]\w*)\(", text):
         referenced.update(long_methods.get(match.group(1), ()))
 
@@ -536,18 +532,10 @@ def _long_call_documented_method_keys(
         for method_name, keys in long_methods.items()
         if not _is_regex_word_identifier(method_name)
     }
-    if not unusual_methods:
-        return referenced
-
-    method_pattern = _literal_alternation(unusual_methods)
-    for match in re.finditer(rf"\.[ \t]*({method_pattern})\(", text):
-        referenced.update(unusual_methods[match.group(1)])
+    for method_name, keys in unusual_methods.items():
+        if re.search(rf"\.[ \t]*{re.escape(method_name)}\(", text):
+            referenced.update(keys)
     return referenced
-
-
-def _literal_alternation(values: Iterable[str]) -> str:
-    ordered = sorted(values, key=lambda value: (-len(value), value))
-    return "|".join(re.escape(value) for value in ordered)
 
 
 def _is_regex_word_identifier(value: str) -> bool:

--- a/skylos/deadcode/liveness.py
+++ b/skylos/deadcode/liveness.py
@@ -507,7 +507,10 @@ def _sphinx_documented_method_keys(
     by_method: dict[str, set[tuple[str, str]]],
 ) -> set[tuple[str, str]]:
     referenced: set[tuple[str, str]] = set()
-    role_targets = re.findall(r":meth:`([^`]*)`", text)
+    role_targets = [
+        match.group(1)
+        for match in re.finditer(r"(?=:meth:`([^`]*)`)", text)
+    ]
     for method_name, keys in by_method.items():
         if any(target.endswith(method_name) for target in role_targets):
             referenced.update(keys)

--- a/skylos/deadcode/liveness.py
+++ b/skylos/deadcode/liveness.py
@@ -428,6 +428,7 @@ def _rescue_documented_public_methods(
 ) -> None:
     if not docs_text:
         return
+    candidates: list[tuple[Any, tuple[str, str]]] = []
     for owner, methods in class_methods.items():
         if not _owner_live(classes, owner):
             continue
@@ -436,26 +437,121 @@ def _rescue_documented_public_methods(
             if _is_support_file(method):
                 continue
             name = getattr(method, "simple_name", "")
-            if _is_public_name(name) and _docs_reference_method(
-                docs_text, class_name, name
-            ):
-                _mark(method, "documented_public_api", report)
+            if _is_public_name(name):
+                candidates.append((method, (class_name, name)))
+
+    referenced = _documented_method_keys(
+        docs_text,
+        {key for _method, key in candidates},
+    )
+    for method, key in candidates:
+        if key in referenced:
+            _mark(method, "documented_public_api", report)
 
 
-def _docs_reference_method(text: str, class_name: str, method_name: str) -> bool:
-    escaped_class = re.escape(class_name)
-    escaped_method = re.escape(method_name)
-    patterns = [
-        rf"\b{escaped_class}\.{escaped_method}\b",
-        rf":meth:`[^`]*{escaped_class}\.{escaped_method}`",
-        rf":meth:`[^`]*{escaped_method}`",
-    ]
-    if "_" in method_name and len(method_name) >= 10:
-        patterns.append(rf"\.[ \t]*{escaped_method}\(")
-    for pattern in patterns:
-        if re.search(pattern, text):
-            return True
-    return False
+def _documented_method_keys(
+    text: str,
+    candidates: set[tuple[str, str]],
+) -> set[tuple[str, str]]:
+    if not text or not candidates:
+        return set()
+
+    qualified, by_method = _documented_method_candidates(candidates)
+    referenced = _qualified_documented_method_keys(text, candidates, qualified)
+    referenced.update(_sphinx_documented_method_keys(text, by_method))
+    referenced.update(_long_call_documented_method_keys(text, by_method))
+    return referenced
+
+
+def _documented_method_candidates(
+    candidates: set[tuple[str, str]],
+) -> tuple[dict[str, set[tuple[str, str]]], dict[str, set[tuple[str, str]]]]:
+    qualified: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    by_method: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    for key in candidates:
+        class_name, method_name = key
+        qualified[f"{class_name}.{method_name}"].add(key)
+        by_method[method_name].add(key)
+    return qualified, by_method
+
+
+def _qualified_documented_method_keys(
+    text: str,
+    candidates: set[tuple[str, str]],
+    qualified: dict[str, set[tuple[str, str]]],
+) -> set[tuple[str, str]]:
+    referenced: set[tuple[str, str]] = set()
+    word_candidates = {
+        key
+        for key in candidates
+        if _is_regex_word_identifier(key[0]) and _is_regex_word_identifier(key[1])
+    }
+    for match in re.finditer(r"(?=\b([^\W\d]\w*)\.([^\W\d]\w*)\b)", text):
+        key = match.group(1), match.group(2)
+        if key in word_candidates:
+            referenced.add(key)
+
+    unusual_qualified = {
+        name: keys - word_candidates
+        for name, keys in qualified.items()
+        if keys - word_candidates
+    }
+    if unusual_qualified:
+        qualified_pattern = _literal_alternation(unusual_qualified)
+        for match in re.finditer(rf"(?=\b({qualified_pattern})\b)", text):
+            referenced.update(unusual_qualified[match.group(1)])
+    return referenced
+
+
+def _sphinx_documented_method_keys(
+    text: str,
+    by_method: dict[str, set[tuple[str, str]]],
+) -> set[tuple[str, str]]:
+    referenced: set[tuple[str, str]] = set()
+    role_targets = re.findall(r":meth:`([^`]*)`", text)
+    for method_name, keys in by_method.items():
+        if any(target.endswith(method_name) for target in role_targets):
+            referenced.update(keys)
+    return referenced
+
+
+def _long_call_documented_method_keys(
+    text: str,
+    by_method: dict[str, set[tuple[str, str]]],
+) -> set[tuple[str, str]]:
+    referenced: set[tuple[str, str]] = set()
+    long_methods = {
+        method_name: keys
+        for method_name, keys in by_method.items()
+        if "_" in method_name and len(method_name) >= 10
+    }
+    if not long_methods:
+        return referenced
+
+    for match in re.finditer(r"\.[ \t]*([^\W\d]\w*)\(", text):
+        referenced.update(long_methods.get(match.group(1), ()))
+
+    unusual_methods = {
+        method_name: keys
+        for method_name, keys in long_methods.items()
+        if not _is_regex_word_identifier(method_name)
+    }
+    if not unusual_methods:
+        return referenced
+
+    method_pattern = _literal_alternation(unusual_methods)
+    for match in re.finditer(rf"\.[ \t]*({method_pattern})\(", text):
+        referenced.update(unusual_methods[match.group(1)])
+    return referenced
+
+
+def _literal_alternation(values: Iterable[str]) -> str:
+    ordered = sorted(values, key=lambda value: (-len(value), value))
+    return "|".join(re.escape(value) for value in ordered)
+
+
+def _is_regex_word_identifier(value: str) -> bool:
+    return re.fullmatch(r"[^\W\d]\w*", value) is not None
 
 
 def _rescue_unique_external_attr_calls(

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -228,28 +228,69 @@ def test_documented_method_index_preserves_legacy_match_forms():
     candidates = {
         ("Dataset", "sel"),
         ("Widget", "from_role"),
+        ("Widget", "foo-bar"),
+        ("Widget", "foo-bar-baz"),
         ("OtherWidget", "from_role"),
         ("Widget", "open_instance_resource"),
         ("Widget", "tiny_name"),
         ("Widget", "absent"),
         ("कु", "मूल"),
+        ("कु", "m1"),
+        ("कु", "m1℮y"),
     }
     docs = """
     xarray.Dataset.sel(value)
     :meth:`~package.Widget.from_role`
+    Widget.foo-bar-baz(value)
     proxy. open_instance_resource(value)
     proxy.tiny_name(value)
     Widget.absentExtra(value)
     package.कु.मूल(value)
+    package.कु.m1℮y(value)
     """
 
     assert liveness._documented_method_keys(docs, candidates) == {
         ("Dataset", "sel"),
         ("Widget", "from_role"),
+        ("Widget", "foo-bar"),
+        ("Widget", "foo-bar-baz"),
         ("OtherWidget", "from_role"),
         ("Widget", "open_instance_resource"),
         ("कु", "मूल"),
+        ("कु", "m1"),
+        ("कु", "m1℮y"),
     }
+
+
+def test_documented_kotlin_backtick_method_prefixes_are_live(tmp_path):
+    _write(
+        tmp_path / "app.kt",
+        """
+        class Widget {
+            fun `foo-bar`() = Unit
+            fun `foo-bar-baz`() = Unit
+        }
+
+        fun main() {
+            Widget()
+        }
+        """,
+    )
+    _write(
+        tmp_path / "README.md",
+        """
+        Call `Widget.foo-bar-baz()` to use the widget.
+        """,
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    rescues = {
+        item["name"]
+        for item in result["analysis_summary"]["dead_code_liveness"]["rescued"]
+        if item["reason"] == "documented_public_api"
+    }
+
+    assert {"Widget.foo-bar", "Widget.foo-bar-baz"} <= rescues
 
 
 def test_framework_proxy_attr_call_is_live(tmp_path):

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -2,6 +2,7 @@ import json
 import textwrap
 
 from skylos.analyzer import analyze
+from skylos.deadcode import liveness
 
 
 def _write(path, body):
@@ -221,6 +222,34 @@ def test_documented_public_method_is_live(tmp_path):
     result = json.loads(analyze(str(tmp_path), grep_verify=False))
 
     assert "app.App.open_instance_resource" not in _unused_function_names(result)
+
+
+def test_documented_method_index_preserves_legacy_match_forms():
+    candidates = {
+        ("Dataset", "sel"),
+        ("Widget", "from_role"),
+        ("OtherWidget", "from_role"),
+        ("Widget", "open_instance_resource"),
+        ("Widget", "tiny_name"),
+        ("Widget", "absent"),
+        ("कु", "मूल"),
+    }
+    docs = """
+    xarray.Dataset.sel(value)
+    :meth:`~package.Widget.from_role`
+    proxy. open_instance_resource(value)
+    proxy.tiny_name(value)
+    Widget.absentExtra(value)
+    package.कु.मूल(value)
+    """
+
+    assert liveness._documented_method_keys(docs, candidates) == {
+        ("Dataset", "sel"),
+        ("Widget", "from_role"),
+        ("OtherWidget", "from_role"),
+        ("Widget", "open_instance_resource"),
+        ("कु", "मूल"),
+    }
 
 
 def test_framework_proxy_attr_call_is_live(tmp_path):

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -262,6 +262,21 @@ def test_documented_method_index_preserves_legacy_match_forms():
     }
 
 
+def test_documented_method_index_preserves_overlapping_sphinx_roles():
+    candidates = {("Widget", "foo")}
+    docs = ":meth:`broken :meth:`foo`"
+
+    assert liveness._documented_method_keys(docs, candidates) == candidates
+
+
+def test_documented_method_index_preserves_role_after_unclosed_joined_doc():
+    candidates = {("Widget", "foo")}
+    # _read_public_docs joins each document with a newline.
+    docs = ":meth:`broken\n:meth:`foo`"
+
+    assert liveness._documented_method_keys(docs, candidates) == candidates
+
+
 def test_documented_kotlin_backtick_method_prefixes_are_live(tmp_path):
     _write(
         tmp_path / "app.kt",


### PR DESCRIPTION
Closes #743

**AI Use Disclosure** This fix was based on a cProfile run of skylos on xarray. Codex GPT-5.6 Sol drafted the fix and it was reviewed according to repository review guidelines by Claude Fable 5 and a separate GPT-5.6 Sol agent. `liveness_primer` shows 0 diffs on an expanded test corpus beyond what is currently used in the CI. I reviewed the code fixes myself.

## Summary

- index qualified method references in documentation in one pass instead of rescanning the complete documentation corpus for every candidate
- preserve the existing qualified-name, Sphinx `:meth:` suffix, long underscore-call, Unicode identifier, and overlapping escaped-name behavior
- keep independent legacy-equivalent checks for rare identifiers outside Python regex `\w` semantics
- add direct Unicode-prefix and end-to-end Kotlin backtick regressions

## Measurement

Base: `a5d0319499b8429ebfa980f82626d7426a24dece`
Corpus: xarray `c2998a75ef32f6cf4d62cd946f2200ca953550d9` (`SKYLOS_JOBS=1`, `--no-grep-verify`)

- documentation rescue helper: 9.3943s -> 0.0275s (342x)
- latest complete scan wall time: 29.36s -> 20.76s (1.41x)
- all six dead-code finding buckets matched exactly
- all 680 liveness rescues matched exactly

## Tests

- `python -m pytest -q -p no:cacheprovider test/test_dead_code_liveness.py` (12 passed)
- `python -m pytest -q -p no:cacheprovider test/test_dead_code*.py test/test_framework_aware.py` (83 passed)
- self-scan confirms the new helpers add no SKY-Q301/SKY-Q306 findings


