### PR TITLE
perf(ai-defect): batch API surface cache I/O

### DIFF
--- a/skylos/core/api_symbol_truth.py
+++ b/skylos/core/api_symbol_truth.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
-
+from skylos.core.safe_cache_io import (
+    load_project_json_cache,
+    project_cache_lock,
+    save_project_json_cache,
+)
 
 API_SYMBOL_TRUTH_SCHEMA_VERSION = 1
 API_SYMBOL_TRUTH_CACHE_PATH = Path(".skylos") / "cache" / "api_symbol_truth.json"
+API_SURFACE_CACHE_LOCK_PATH = Path(".skylos") / "cache" / ".api_surface.lock"
 MAX_API_SYMBOL_TRUTH_BYTES = 10_000_000
 
 SURFACE_KIND_PYTHON_MODULE = "python_module"
@@ -62,6 +66,29 @@ def save_api_symbol_truth_cache(
     *,
     cache_path: str | Path = API_SYMBOL_TRUTH_CACHE_PATH,
 ) -> bool:
+    """Replace the full cache. Use cache_api_symbol_surface for merged updates."""
+
+    if not _valid_cache_payload(payload):
+        return False
+    with project_cache_lock(
+        project_root,
+        API_SURFACE_CACHE_LOCK_PATH,
+    ) as lock_acquired:
+        if not lock_acquired:
+            return False
+        return _save_api_symbol_truth_cache_unlocked(
+            project_root,
+            payload,
+            cache_path=cache_path,
+        )
+
+
+def _save_api_symbol_truth_cache_unlocked(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    cache_path: str | Path = API_SYMBOL_TRUTH_CACHE_PATH,
+) -> bool:
     if not _valid_cache_payload(payload):
         return False
     payload = {
@@ -104,13 +131,36 @@ def cache_api_symbol_surface(
     if normalized is None:
         return False
 
+    with project_cache_lock(
+        project_root,
+        API_SURFACE_CACHE_LOCK_PATH,
+    ) as lock_acquired:
+        if not lock_acquired:
+            return False
+        return _cache_normalized_api_symbol_surface_unlocked(
+            project_root,
+            normalized,
+            cache_path=cache_path,
+        )
+
+
+def _cache_normalized_api_symbol_surface_unlocked(
+    project_root: str | Path,
+    normalized: dict[str, Any],
+    *,
+    cache_path: str | Path = API_SYMBOL_TRUTH_CACHE_PATH,
+) -> bool:
     payload = load_api_symbol_truth_cache(project_root, cache_path=cache_path)
     surfaces = payload.get("surfaces")
     if not isinstance(surfaces, dict):
         surfaces = {}
     surfaces[api_symbol_surface_key(normalized["kind"], normalized["name"])] = normalized
     payload["surfaces"] = surfaces
-    return save_api_symbol_truth_cache(project_root, payload, cache_path=cache_path)
+    return _save_api_symbol_truth_cache_unlocked(
+        project_root,
+        payload,
+        cache_path=cache_path,
+    )
 
 
 def api_symbol_surface_key(kind: str, name: str) -> str | None:

--- a/skylos/core/python_api_surface.py
+++ b/skylos/core/python_api_surface.py
@@ -14,6 +14,7 @@ from types import ModuleType
 from typing import Any
 
 from skylos.core.api_symbol_truth import (
+    API_SYMBOL_TRUTH_CACHE_PATH,
     SURFACE_KIND_PYTHON_MODULE,
     api_symbol_surface_key,
     cache_api_symbol_surface,
@@ -22,7 +23,6 @@ from skylos.core.api_symbol_truth import (
     save_api_symbol_truth_cache,
 )
 from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
-
 
 PYTHON_API_SURFACE_SCHEMA_VERSION = 1
 PYTHON_API_SURFACE_CACHE_PATH = Path(".skylos") / "cache" / "python_api_surface.json"
@@ -41,9 +41,14 @@ class PythonApiSurfaceCacheSession:
         self._environment_key = python_environment_key()
         self._python_payload: dict[str, Any] | None = None
         self._python_module_map: dict[str, Any] | None = None
+        self._python_cache_state: tuple[int, int, int, int] | None = None
         self._shared_payload: dict[str, Any] | None = None
         self._shared_surface_map: dict[str, Any] | None = None
-        self._dirty = False
+        self._shared_cache_state: tuple[int, int, int, int] | None = None
+        self._pending_python_modules: dict[str, dict[str, Any]] = {}
+        self._pending_shared_surfaces: dict[str, dict[str, Any]] = {}
+        self._observed_python_modules: dict[str, Any] = {}
+        self._observed_shared_surfaces: dict[str, Any] = {}
 
     def load_surface(
         self,
@@ -69,38 +74,93 @@ class PythonApiSurfaceCacheSession:
         if surface is None:
             return None
 
-        self._python_modules()[safe_name] = surface
+        python_modules = self._python_modules()
+        if safe_name in python_modules:
+            self._observed_python_modules[safe_name] = python_modules[safe_name]
+        self._pending_python_modules[safe_name] = surface
         shared_surface = python_module_api_symbol_surface(
             surface,
             environment_key=self._environment_key,
         )
         if shared_surface is not None:
+            if key in shared_surfaces:
+                self._observed_shared_surfaces[key] = shared_surfaces[key]
             shared_surfaces[key] = shared_surface
-        self._dirty = True
+            self._pending_shared_surfaces[key] = shared_surface
         return surface
 
     def flush(self) -> None:
         """Persist all newly captured surfaces."""
-        if not self._dirty:
+        if not self._pending_python_modules and not self._pending_shared_surfaces:
             return
-        if self._python_payload is not None:
-            save_python_api_surface_cache(self._project_root, self._python_payload)
-        if self._shared_payload is not None:
-            save_api_symbol_truth_cache(self._project_root, self._shared_payload)
-        self._dirty = False
+
+        python_cache_state = _cache_file_state(
+            Path(self._project_root) / PYTHON_API_SURFACE_CACHE_PATH
+        )
+        if self._python_payload is None or python_cache_state != self._python_cache_state:
+            python_payload = load_python_api_surface_cache(self._project_root)
+            python_modules = _modules_map(python_payload)
+        else:
+            python_payload = self._python_payload
+            python_modules = self._python_module_map or {}
+        _merge_unchanged_entries(
+            python_modules,
+            self._pending_python_modules,
+            self._observed_python_modules,
+        )
+        python_payload["modules"] = python_modules
+        save_python_api_surface_cache(self._project_root, python_payload)
+
+        shared_cache_state = _cache_file_state(
+            Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
+        )
+        if self._shared_payload is None or shared_cache_state != self._shared_cache_state:
+            shared_payload = load_api_symbol_truth_cache(self._project_root)
+            shared_surfaces = _surfaces_map(shared_payload)
+        else:
+            shared_payload = self._shared_payload
+            shared_surfaces = self._shared_surface_map or {}
+        _merge_unchanged_entries(
+            shared_surfaces,
+            self._pending_shared_surfaces,
+            self._observed_shared_surfaces,
+        )
+        shared_payload["surfaces"] = shared_surfaces
+        save_api_symbol_truth_cache(self._project_root, shared_payload)
+
+        self._pending_python_modules.clear()
+        self._pending_shared_surfaces.clear()
+        self._observed_python_modules.clear()
+        self._observed_shared_surfaces.clear()
 
     def _python_modules(self) -> dict[str, Any]:
         if self._python_module_map is None:
             self._python_payload = load_python_api_surface_cache(self._project_root)
             self._python_module_map = _modules_map(self._python_payload)
             self._python_payload["modules"] = self._python_module_map
+            self._python_cache_state = _cache_file_state(
+                Path(self._project_root) / PYTHON_API_SURFACE_CACHE_PATH
+            )
         return self._python_module_map
 
     def _shared_surfaces(self) -> dict[str, Any]:
-        if self._shared_surface_map is None:
-            self._shared_payload = load_api_symbol_truth_cache(self._project_root)
-            self._shared_surface_map = _surfaces_map(self._shared_payload)
-            self._shared_payload["surfaces"] = self._shared_surface_map
+        cache_state = _cache_file_state(
+            Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
+        )
+        if self._shared_surface_map is None or cache_state != self._shared_cache_state:
+            shared_payload = load_api_symbol_truth_cache(self._project_root)
+            shared_surfaces = _surfaces_map(shared_payload)
+            _merge_unchanged_entries(
+                shared_surfaces,
+                self._pending_shared_surfaces,
+                self._observed_shared_surfaces,
+            )
+            shared_payload["surfaces"] = shared_surfaces
+            self._shared_payload = shared_payload
+            self._shared_surface_map = shared_surfaces
+            self._shared_cache_state = _cache_file_state(
+                Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
+            )
         return self._shared_surface_map
 
 
@@ -259,6 +319,33 @@ def _surfaces_map(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(surfaces, dict):
         return surfaces
     return {}
+
+
+def _merge_unchanged_entries(
+    current: dict[str, Any],
+    pending: dict[str, dict[str, Any]],
+    observed: dict[str, Any],
+) -> None:
+    for key, value in pending.items():
+        if key in observed:
+            if current.get(key) != observed[key]:
+                continue
+        elif key in current:
+            continue
+        current[key] = value
+
+
+def _cache_file_state(path: Path) -> tuple[int, int, int, int] | None:
+    try:
+        cache_stat = path.stat()
+    except OSError:
+        return None
+    return (
+        cache_stat.st_ino,
+        cache_stat.st_size,
+        cache_stat.st_mtime_ns,
+        cache_stat.st_ctime_ns,
+    )
 
 
 def _safe_module_name(value: str) -> str | None:

--- a/skylos/core/python_api_surface.py
+++ b/skylos/core/python_api_surface.py
@@ -8,13 +8,18 @@ import re
 import site
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 
 from skylos.core.api_symbol_truth import (
+    SURFACE_KIND_PYTHON_MODULE,
+    api_symbol_surface_key,
     cache_api_symbol_surface,
+    load_api_symbol_truth_cache,
     python_module_api_symbol_surface,
+    save_api_symbol_truth_cache,
 )
 from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
 
@@ -26,6 +31,77 @@ MAX_MODULE_MEMBERS = 500
 MAX_CLASS_MEMBERS = 200
 
 Importer = Callable[[str], ModuleType]
+
+
+class PythonApiSurfaceCacheSession:
+    """Load API caches once and persist new surfaces together."""
+
+    def __init__(self, project_root: str | Path) -> None:
+        self._project_root = project_root
+        self._environment_key = python_environment_key()
+        self._python_payload: dict[str, Any] | None = None
+        self._python_module_map: dict[str, Any] | None = None
+        self._shared_payload: dict[str, Any] | None = None
+        self._shared_surface_map: dict[str, Any] | None = None
+        self._dirty = False
+
+    def load_surface(
+        self,
+        _project_root: str | Path,
+        module_name: str,
+    ) -> dict[str, Any] | None:
+        """Return a cached or newly captured module surface."""
+        safe_name = _safe_module_name(module_name)
+        if safe_name is None:
+            return None
+
+        key = api_symbol_surface_key(SURFACE_KIND_PYTHON_MODULE, safe_name)
+        if key is None:
+            return None
+        shared_surfaces = self._shared_surfaces()
+        shared_surface = shared_surfaces.get(key)
+        if isinstance(shared_surface, dict) and (
+            shared_surface.get("environment_key") == self._environment_key
+        ):
+            return shared_surface
+
+        surface = build_python_api_surface(safe_name)
+        if surface is None:
+            return None
+
+        self._python_modules()[safe_name] = surface
+        shared_surface = python_module_api_symbol_surface(
+            surface,
+            environment_key=self._environment_key,
+        )
+        if shared_surface is not None:
+            shared_surfaces[key] = shared_surface
+        self._dirty = True
+        return surface
+
+    def flush(self) -> None:
+        """Persist all newly captured surfaces."""
+        if not self._dirty:
+            return
+        if self._python_payload is not None:
+            save_python_api_surface_cache(self._project_root, self._python_payload)
+        if self._shared_payload is not None:
+            save_api_symbol_truth_cache(self._project_root, self._shared_payload)
+        self._dirty = False
+
+    def _python_modules(self) -> dict[str, Any]:
+        if self._python_module_map is None:
+            self._python_payload = load_python_api_surface_cache(self._project_root)
+            self._python_module_map = _modules_map(self._python_payload)
+            self._python_payload["modules"] = self._python_module_map
+        return self._python_module_map
+
+    def _shared_surfaces(self) -> dict[str, Any]:
+        if self._shared_surface_map is None:
+            self._shared_payload = load_api_symbol_truth_cache(self._project_root)
+            self._shared_surface_map = _surfaces_map(self._shared_payload)
+            self._shared_payload["surfaces"] = self._shared_surface_map
+        return self._shared_surface_map
 
 
 def load_python_api_surface_cache(
@@ -176,6 +252,13 @@ def _modules_map(payload: dict[str, Any]) -> dict[str, Any]:
         if isinstance(surface, dict):
             safe_modules[safe_name] = surface
     return safe_modules
+
+
+def _surfaces_map(payload: dict[str, Any]) -> dict[str, Any]:
+    surfaces = payload.get("surfaces")
+    if isinstance(surfaces, dict):
+        return surfaces
+    return {}
 
 
 def _safe_module_name(value: str) -> str | None:

--- a/skylos/core/python_api_surface.py
+++ b/skylos/core/python_api_surface.py
@@ -14,15 +14,20 @@ from types import ModuleType
 from typing import Any
 
 from skylos.core.api_symbol_truth import (
+    API_SURFACE_CACHE_LOCK_PATH,
     API_SYMBOL_TRUTH_CACHE_PATH,
     SURFACE_KIND_PYTHON_MODULE,
+    _cache_normalized_api_symbol_surface_unlocked,
+    _save_api_symbol_truth_cache_unlocked,
     api_symbol_surface_key,
-    cache_api_symbol_surface,
     load_api_symbol_truth_cache,
     python_module_api_symbol_surface,
-    save_api_symbol_truth_cache,
 )
-from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
+from skylos.core.safe_cache_io import (
+    load_project_json_cache,
+    project_cache_lock,
+    save_project_json_cache,
+)
 
 PYTHON_API_SURFACE_SCHEMA_VERSION = 1
 PYTHON_API_SURFACE_CACHE_PATH = Path(".skylos") / "cache" / "python_api_surface.json"
@@ -34,15 +39,12 @@ Importer = Callable[[str], ModuleType]
 
 
 class PythonApiSurfaceCacheSession:
-    """Load API caches once and persist new surfaces together."""
+    """Batch API cache reads and persist new surfaces together."""
 
     def __init__(self, project_root: str | Path) -> None:
         self._project_root = project_root
         self._environment_key = python_environment_key()
-        self._python_payload: dict[str, Any] | None = None
         self._python_module_map: dict[str, Any] | None = None
-        self._python_cache_state: tuple[int, int, int, int] | None = None
-        self._shared_payload: dict[str, Any] | None = None
         self._shared_surface_map: dict[str, Any] | None = None
         self._shared_cache_state: tuple[int, int, int, int] | None = None
         self._pending_python_modules: dict[str, dict[str, Any]] = {}
@@ -94,39 +96,53 @@ class PythonApiSurfaceCacheSession:
         if not self._pending_python_modules and not self._pending_shared_surfaces:
             return
 
-        python_cache_state = _cache_file_state(
-            Path(self._project_root) / PYTHON_API_SURFACE_CACHE_PATH
-        )
-        if self._python_payload is None or python_cache_state != self._python_cache_state:
-            python_payload = load_python_api_surface_cache(self._project_root)
-            python_modules = _modules_map(python_payload)
-        else:
-            python_payload = self._python_payload
-            python_modules = self._python_module_map or {}
-        _merge_unchanged_entries(
-            python_modules,
-            self._pending_python_modules,
-            self._observed_python_modules,
-        )
-        python_payload["modules"] = python_modules
-        save_python_api_surface_cache(self._project_root, python_payload)
+        with project_cache_lock(
+            self._project_root,
+            API_SURFACE_CACHE_LOCK_PATH,
+        ) as lock_acquired:
+            if not lock_acquired:
+                return
 
-        shared_cache_state = _cache_file_state(
-            Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
-        )
-        if self._shared_payload is None or shared_cache_state != self._shared_cache_state:
-            shared_payload = load_api_symbol_truth_cache(self._project_root)
-            shared_surfaces = _surfaces_map(shared_payload)
-        else:
-            shared_payload = self._shared_payload
-            shared_surfaces = self._shared_surface_map or {}
-        _merge_unchanged_entries(
-            shared_surfaces,
-            self._pending_shared_surfaces,
-            self._observed_shared_surfaces,
-        )
-        shared_payload["surfaces"] = shared_surfaces
-        save_api_symbol_truth_cache(self._project_root, shared_payload)
+            saves_succeeded = True
+            if self._pending_python_modules:
+                python_payload = load_python_api_surface_cache(self._project_root)
+                python_modules = _modules_map(python_payload)
+                _merge_unchanged_entries(
+                    python_modules,
+                    self._pending_python_modules,
+                    self._observed_python_modules,
+                )
+                python_payload["modules"] = python_modules
+                python_saved = _save_python_api_surface_cache_unlocked(
+                    self._project_root,
+                    python_payload,
+                )
+                saves_succeeded = saves_succeeded and python_saved
+                if python_saved:
+                    self._python_module_map = python_modules
+
+            if self._pending_shared_surfaces:
+                shared_payload = load_api_symbol_truth_cache(self._project_root)
+                shared_surfaces = _surfaces_map(shared_payload)
+                _merge_unchanged_entries(
+                    shared_surfaces,
+                    self._pending_shared_surfaces,
+                    self._observed_shared_surfaces,
+                )
+                shared_payload["surfaces"] = shared_surfaces
+                shared_saved = _save_api_symbol_truth_cache_unlocked(
+                    self._project_root,
+                    shared_payload,
+                )
+                saves_succeeded = saves_succeeded and shared_saved
+                if shared_saved:
+                    self._shared_surface_map = shared_surfaces
+                    self._shared_cache_state = _cache_file_state(
+                        Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
+                    )
+
+        if not saves_succeeded:
+            return
 
         self._pending_python_modules.clear()
         self._pending_shared_surfaces.clear()
@@ -135,32 +151,31 @@ class PythonApiSurfaceCacheSession:
 
     def _python_modules(self) -> dict[str, Any]:
         if self._python_module_map is None:
-            self._python_payload = load_python_api_surface_cache(self._project_root)
-            self._python_module_map = _modules_map(self._python_payload)
-            self._python_payload["modules"] = self._python_module_map
-            self._python_cache_state = _cache_file_state(
-                Path(self._project_root) / PYTHON_API_SURFACE_CACHE_PATH
-            )
+            python_payload = load_python_api_surface_cache(self._project_root)
+            self._python_module_map = _modules_map(python_payload)
         return self._python_module_map
 
     def _shared_surfaces(self) -> dict[str, Any]:
         cache_state = _cache_file_state(
             Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
         )
-        if self._shared_surface_map is None or cache_state != self._shared_cache_state:
-            shared_payload = load_api_symbol_truth_cache(self._project_root)
-            shared_surfaces = _surfaces_map(shared_payload)
-            _merge_unchanged_entries(
-                shared_surfaces,
-                self._pending_shared_surfaces,
-                self._observed_shared_surfaces,
-            )
-            shared_payload["surfaces"] = shared_surfaces
-            self._shared_payload = shared_payload
-            self._shared_surface_map = shared_surfaces
-            self._shared_cache_state = _cache_file_state(
-                Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
-            )
+        if self._shared_surface_map is not None and (
+            cache_state == self._shared_cache_state
+        ):
+            return self._shared_surface_map
+
+        shared_payload = load_api_symbol_truth_cache(self._project_root)
+        shared_surfaces = _surfaces_map(shared_payload)
+        _merge_unchanged_entries(
+            shared_surfaces,
+            self._pending_shared_surfaces,
+            self._observed_shared_surfaces,
+        )
+        shared_payload["surfaces"] = shared_surfaces
+        self._shared_surface_map = shared_surfaces
+        self._shared_cache_state = _cache_file_state(
+            Path(self._project_root) / API_SYMBOL_TRUTH_CACHE_PATH
+        )
         return self._shared_surface_map
 
 
@@ -190,6 +205,29 @@ def load_python_api_surface_cache(
 
 
 def save_python_api_surface_cache(
+    project_root: str | Path,
+    payload: dict[str, Any],
+    *,
+    cache_path: str | Path = PYTHON_API_SURFACE_CACHE_PATH,
+) -> bool:
+    """Replace the full cache. Use cache_python_api_surface for merged updates."""
+
+    if not _valid_cache_payload(payload):
+        return False
+    with project_cache_lock(
+        project_root,
+        API_SURFACE_CACHE_LOCK_PATH,
+    ) as lock_acquired:
+        if not lock_acquired:
+            return False
+        return _save_python_api_surface_cache_unlocked(
+            project_root,
+            payload,
+            cache_path=cache_path,
+        )
+
+
+def _save_python_api_surface_cache_unlocked(
     project_root: str | Path,
     payload: dict[str, Any],
     *,
@@ -233,17 +271,31 @@ def cache_python_api_surface(
     if surface is None:
         return None
 
-    payload = load_python_api_surface_cache(project_root, cache_path=cache_path)
-    modules = _modules_map(payload)
-    modules[safe_name] = surface
-    payload["modules"] = modules
-    save_python_api_surface_cache(project_root, payload, cache_path=cache_path)
     shared_surface = python_module_api_symbol_surface(
         surface,
         environment_key=python_environment_key(),
     )
-    if shared_surface is not None:
-        cache_api_symbol_surface(project_root, shared_surface)
+    with project_cache_lock(
+        project_root,
+        API_SURFACE_CACHE_LOCK_PATH,
+    ) as lock_acquired:
+        if not lock_acquired:
+            return surface
+
+        payload = load_python_api_surface_cache(project_root, cache_path=cache_path)
+        modules = _modules_map(payload)
+        modules[safe_name] = surface
+        payload["modules"] = modules
+        _save_python_api_surface_cache_unlocked(
+            project_root,
+            payload,
+            cache_path=cache_path,
+        )
+        if shared_surface is not None:
+            _cache_normalized_api_symbol_surface_unlocked(
+                project_root,
+                shared_surface,
+            )
     return surface
 
 

--- a/skylos/core/safe_cache_io.py
+++ b/skylos/core/safe_cache_io.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import stat
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
-
+from uuid import uuid4
 
 DEFAULT_MAX_JSON_CACHE_BYTES = 2_000_000
+PROJECT_CACHE_LOCK_TIMEOUT_SECONDS = 1.0
+PROJECT_CACHE_LOCK_POLL_SECONDS = 0.01
+PROJECT_CACHE_LOCK_STALE_SECONDS = 3600.0
 
 
 def read_text_no_symlink(
@@ -412,9 +419,15 @@ def _ensure_cache_dir(root: Path, current: Path, *, create: bool) -> bool:
             return current.is_dir()
         if not create:
             return False
-        current.mkdir(  # skylos: ignore[SKY-D215] bounded project-local cache directory
-            mode=0o700
-        )
+        try:
+            current.mkdir(  # skylos: ignore[SKY-D215] bounded project-local cache directory
+                mode=0o700
+            )
+        except FileExistsError:
+            if current.is_symlink():
+                return False
+            current.resolve(strict=True).relative_to(root)
+            return current.is_dir()
         return True
     except (OSError, ValueError):
         return False
@@ -430,6 +443,134 @@ def _is_regular_cache_file(path: Path) -> bool:
     except (OSError, ValueError):
         return False
     return True
+
+
+def _project_cache_lock_path(
+    project_root: str | Path,
+    lock_path: str | Path,
+) -> Path | None:
+    resolved = _resolve_project_cache_path(project_root, lock_path)
+    if resolved is None:
+        return None
+    root, path = resolved
+    if not _ensure_cache_parent(root, path, create=True):
+        return None
+    try:
+        if path.is_symlink():
+            return None
+        if path.exists() and not path.is_dir():
+            return None
+    except OSError:
+        return None
+    return path
+
+
+def _remove_stale_project_cache_lock(
+    path: Path,
+    existing: os.stat_result,
+) -> bool:
+    if time.time() - existing.st_mtime < PROJECT_CACHE_LOCK_STALE_SECONDS:
+        return False
+    try:
+        current = os.lstat(path)
+        if (
+            stat.S_ISLNK(current.st_mode)
+            or not stat.S_ISDIR(current.st_mode)
+            or current.st_dev != existing.st_dev
+            or current.st_ino != existing.st_ino
+        ):
+            return False
+        os.rmdir(  # skylos: ignore[SKY-D215] inode-verified empty project cache lock directory
+            path
+        )
+        return True
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def _acquire_project_cache_lock(
+    path: Path,
+    *,
+    deadline: float,
+) -> os.stat_result | None:
+    while True:
+        try:
+            os.mkdir(  # skylos: ignore[SKY-D215] fixed project-local cache lock path with validated parents
+                path,
+                mode=0o700,
+            )
+        except FileExistsError:
+            try:
+                existing = os.lstat(path)
+            except FileNotFoundError:
+                continue
+            except OSError:
+                return None
+            if stat.S_ISLNK(existing.st_mode) or not stat.S_ISDIR(existing.st_mode):
+                return None
+            if _remove_stale_project_cache_lock(path, existing):
+                continue
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            time.sleep(min(PROJECT_CACHE_LOCK_POLL_SECONDS, remaining))
+            continue
+        except OSError:
+            return None
+
+        try:
+            created = os.lstat(path)
+        except OSError:
+            return None
+        if stat.S_ISLNK(created.st_mode) or not stat.S_ISDIR(created.st_mode):
+            return None
+        return created
+
+
+def _release_project_cache_lock(path: Path, owned: os.stat_result) -> None:
+    try:
+        current = os.lstat(path)
+        if (
+            stat.S_ISLNK(current.st_mode)
+            or not stat.S_ISDIR(current.st_mode)
+            or current.st_dev != owned.st_dev
+            or current.st_ino != owned.st_ino
+        ):
+            return
+        os.rmdir(  # skylos: ignore[SKY-D215] inode-verified empty project cache lock directory
+            path
+        )
+    except (FileNotFoundError, OSError):
+        pass
+
+
+@contextmanager
+def project_cache_lock(
+    project_root: str | Path,
+    lock_path: str | Path,
+    *,
+    timeout_seconds: float = PROJECT_CACHE_LOCK_TIMEOUT_SECONDS,
+) -> Iterator[bool]:
+    """Bound a project-local cache transaction with an atomic directory lock."""
+
+    if not math.isfinite(timeout_seconds) or timeout_seconds < 0:
+        raise ValueError("Project cache lock timeout must be finite and non-negative")
+
+    path = _project_cache_lock_path(project_root, lock_path)
+    if path is None:
+        yield False
+        return
+
+    deadline = time.monotonic() + timeout_seconds
+    owned = _acquire_project_cache_lock(path, deadline=deadline)
+    if owned is None:
+        yield False
+        return
+
+    try:
+        yield True
+    finally:
+        _release_project_cache_lock(path, owned)
 
 
 def load_project_json_cache(
@@ -462,7 +603,7 @@ def save_project_json_cache(
     if path is None:
         return False
 
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW

--- a/skylos/rules/ai_defect/api_signature_hallucination.py
+++ b/skylos/rules/ai_defect/api_signature_hallucination.py
@@ -16,6 +16,7 @@ DEFAULT_API_SIGNATURE_ALLOWLIST = ("requests", "pandas", "boto3", "openai")
 VIBE_CATEGORY = "api_signature_hallucination"
 AI_LIKELIHOOD = "high"
 MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES = 1_000_000
+_MAX_API_SIGNATURE_PREFILTER_ROOTS = 64
 
 SurfaceLoader = Callable[[str | Path, str], dict[str, Any] | None]
 
@@ -418,7 +419,10 @@ def _parse_python_file(
     )
     if source is None:
         return None
-    if not _source_mentions_allowed_root(source, allowed_roots):
+    if (
+        len(allowed_roots) <= _MAX_API_SIGNATURE_PREFILTER_ROOTS
+        and not _source_mentions_allowed_root(source, allowed_roots)
+    ):
         return None
 
     try:

--- a/skylos/rules/ai_defect/api_signature_hallucination.py
+++ b/skylos/rules/ai_defect/api_signature_hallucination.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import unicodedata
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,7 +9,6 @@ from typing import Any
 
 from skylos.core.python_api_surface import PythonApiSurfaceCacheSession
 from skylos.core.safe_cache_io import read_text_no_symlink
-
 
 RULE_ID_API_SIGNATURE = "SKY-D224"
 SEV_HIGH = "HIGH"
@@ -352,7 +352,7 @@ def scan_python_api_signature_hallucinations(
 
     try:
         for file_path in py_files:
-            tree = _parse_python_file(root, file_path)
+            tree = _parse_python_file(root, file_path, allowed_roots)
             if tree is None:
                 continue
 
@@ -396,7 +396,11 @@ def _allowed_roots(allowed_modules: tuple[str, ...] | None) -> set[str]:
     return roots
 
 
-def _parse_python_file(root: Path, file_path: Path) -> ast.AST | None:
+def _parse_python_file(
+    root: Path,
+    file_path: Path,
+    allowed_roots: set[str],
+) -> ast.AST | None:
     try:
         resolved = Path(file_path).resolve(strict=True)
         resolved.relative_to(root)
@@ -414,11 +418,22 @@ def _parse_python_file(root: Path, file_path: Path) -> ast.AST | None:
     )
     if source is None:
         return None
+    if not _source_mentions_allowed_root(source, allowed_roots):
+        return None
 
     try:
         return ast.parse(source)
     except SyntaxError:
         return None
+
+
+def _source_mentions_allowed_root(source: str, allowed_roots: set[str]) -> bool:
+    if any(root in source for root in allowed_roots):
+        return True
+    if source.isascii():
+        return False
+    normalized_source = unicodedata.normalize("NFKC", source)
+    return any(root in normalized_source for root in allowed_roots)
 
 
 def _safe_module_name(value: Any) -> str | None:

--- a/skylos/rules/ai_defect/api_signature_hallucination.py
+++ b/skylos/rules/ai_defect/api_signature_hallucination.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
-from skylos.core.api_symbol_truth import (
-    SURFACE_KIND_PYTHON_MODULE,
-    cached_api_symbol_surface,
-)
-from skylos.core.python_api_surface import cache_python_api_surface, python_environment_key
+from skylos.core.python_api_surface import PythonApiSurfaceCacheSession
 from skylos.core.safe_cache_io import read_text_no_symlink
 
 
@@ -345,25 +342,33 @@ def scan_python_api_signature_hallucinations(
     if not allowed_roots:
         return findings
 
-    loader = _surface_loader(surface_loader)
+    cache_session = None
+    loader = surface_loader
+    if loader is None:
+        cache_session = PythonApiSurfaceCacheSession(root)
+        loader = cache_session.load_surface
     local_modules = _local_module_roots(root, py_files)
     surfaces: dict[str, dict[str, Any] | None] = {}
 
-    for file_path in py_files:
-        tree = _parse_python_file(root, file_path)
-        if tree is None:
-            continue
+    try:
+        for file_path in py_files:
+            tree = _parse_python_file(root, file_path)
+            if tree is None:
+                continue
 
-        checker = _ApiSignatureChecker(
-            root,
-            file_path,
-            allowed_roots,
-            local_modules,
-            surfaces,
-            loader,
-            findings,
-        )
-        checker.visit(tree)
+            checker = _ApiSignatureChecker(
+                root,
+                file_path,
+                allowed_roots,
+                local_modules,
+                surfaces,
+                loader,
+                findings,
+            )
+            checker.visit(tree)
+    finally:
+        if cache_session is not None:
+            cache_session.flush()
 
     return findings
 
@@ -375,27 +380,6 @@ def _repo_root(value: str | Path | None) -> Path | None:
         return Path(value).resolve()
     except OSError:
         return Path(value)
-
-
-def _surface_loader(surface_loader: SurfaceLoader | None) -> SurfaceLoader:
-    if surface_loader is not None:
-        return surface_loader
-    return _shared_python_surface_loader
-
-
-def _shared_python_surface_loader(
-    project_root: str | Path,
-    module_name: str,
-) -> dict[str, Any] | None:
-    shared_surface = cached_api_symbol_surface(
-        project_root,
-        SURFACE_KIND_PYTHON_MODULE,
-        module_name,
-        environment_key=python_environment_key(),
-    )
-    if shared_surface is not None:
-        return shared_surface
-    return cache_python_api_surface(project_root, module_name)
 
 
 def _allowed_roots(allowed_modules: tuple[str, ...] | None) -> set[str]:

--- a/test/test_api_signature_hallucination.py
+++ b/test/test_api_signature_hallucination.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from skylos.core import python_api_surface
 from skylos.core.api_symbol_truth import (
     SURFACE_KIND_PYTHON_MODULE,
     cache_api_symbol_surface,
@@ -440,6 +441,86 @@ def test_scan_rejects_malformed_shared_truth_and_falls_back_to_current_surface(
 
     assert len(findings) == 1
     assert "argument 'imaginary'" in findings[0]["message"]
+
+
+def test_scan_batches_api_surface_cache_io(tmp_path, monkeypatch):
+    site_root = tmp_path / "site"
+    _write_sample_package(site_root)
+    other_package = site_root / "otherapi"
+    other_package.mkdir(parents=True)
+    (other_package / "__init__.py").write_text(
+        "def known():\n    return None\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(site_root))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    py_file = _write_py(
+        repo / "app.py",
+        "import sampleapi\nimport otherapi\nsampleapi.missing()\notherapi.missing()\n",
+    )
+    load_counts = {"python": 0, "shared": 0}
+    save_counts = {"python": 0, "shared": 0}
+    original_python_load = python_api_surface.load_python_api_surface_cache
+    original_shared_load = python_api_surface.load_api_symbol_truth_cache
+    original_python_save = python_api_surface.save_python_api_surface_cache
+    original_shared_save = python_api_surface.save_api_symbol_truth_cache
+
+    def load_python(*args, **kwargs):
+        load_counts["python"] += 1
+        return original_python_load(*args, **kwargs)
+
+    def load_shared(*args, **kwargs):
+        load_counts["shared"] += 1
+        return original_shared_load(*args, **kwargs)
+
+    def save_python(*args, **kwargs):
+        save_counts["python"] += 1
+        return original_python_save(*args, **kwargs)
+
+    def save_shared(*args, **kwargs):
+        save_counts["shared"] += 1
+        return original_shared_save(*args, **kwargs)
+
+    monkeypatch.setattr(
+        python_api_surface,
+        "load_python_api_surface_cache",
+        load_python,
+    )
+    monkeypatch.setattr(
+        python_api_surface,
+        "load_api_symbol_truth_cache",
+        load_shared,
+    )
+    monkeypatch.setattr(
+        python_api_surface,
+        "save_python_api_surface_cache",
+        save_python,
+    )
+    monkeypatch.setattr(
+        python_api_surface,
+        "save_api_symbol_truth_cache",
+        save_shared,
+    )
+
+    cold_findings = scan_python_api_signature_hallucinations(
+        repo,
+        [py_file],
+        allowed_modules=("sampleapi", "otherapi"),
+    )
+    warm_findings = scan_python_api_signature_hallucinations(
+        repo,
+        [py_file],
+        allowed_modules=("sampleapi", "otherapi"),
+    )
+
+    assert [finding["symbol"] for finding in cold_findings] == [
+        "sampleapi.missing",
+        "otherapi.missing",
+    ]
+    assert warm_findings == cold_findings
+    assert load_counts == {"python": 1, "shared": 2}
+    assert save_counts == {"python": 1, "shared": 1}
 
 
 def test_scan_skips_local_modules_named_like_allowlisted_package(

--- a/test/test_api_signature_hallucination.py
+++ b/test/test_api_signature_hallucination.py
@@ -4,8 +4,14 @@ from skylos.core import python_api_surface
 from skylos.core.api_symbol_truth import (
     SURFACE_KIND_PYTHON_MODULE,
     cache_api_symbol_surface,
+    cached_api_symbol_surface,
 )
-from skylos.core.python_api_surface import python_environment_key
+from skylos.core.python_api_surface import (
+    cached_python_api_surface,
+    load_python_api_surface_cache,
+    python_environment_key,
+    save_python_api_surface_cache,
+)
 from skylos.rules.ai_defect.api_signature_hallucination import (
     RULE_ID_API_SIGNATURE,
     scan_python_api_signature_hallucinations,
@@ -521,6 +527,130 @@ def test_scan_batches_api_surface_cache_io(tmp_path, monkeypatch):
     assert warm_findings == cold_findings
     assert load_counts == {"python": 1, "shared": 2}
     assert save_counts == {"python": 1, "shared": 1}
+
+
+def test_scan_preserves_surfaces_cached_during_batch(tmp_path, monkeypatch):
+    from skylos.rules.ai_defect import api_signature_hallucination as api_sig
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    py_file = _write_py(
+        repo / "app.py",
+        "import pkg_a\nimport pkg_b\npkg_a.missing()\npkg_b.known()\n",
+    )
+    pkg_b_members = {"known": {"kind": "function", "parameters": []}}
+
+    def build_surface(module_name):
+        if module_name == "pkg_a":
+            return {
+                "module": "pkg_a",
+                "members": {},
+                "members_truncated": False,
+            }
+        return None
+
+    original_add_missing = api_sig._ApiSignatureChecker._add_missing_finding
+
+    def add_missing_and_cache_pkg_b(checker, node, target):
+        original_add_missing(checker, node, target)
+        if target.module_name != "pkg_a":
+            return
+
+        python_payload = load_python_api_surface_cache(repo)
+        python_payload["modules"] = {
+            "pkg_b": {
+                "module": "pkg_b",
+                "members": pkg_b_members,
+                "members_truncated": False,
+            }
+        }
+        assert save_python_api_surface_cache(repo, python_payload)
+        assert cache_api_symbol_surface(
+            repo,
+            {
+                "kind": SURFACE_KIND_PYTHON_MODULE,
+                "name": "pkg_b",
+                "environment_key": python_environment_key(),
+                "members": pkg_b_members,
+            },
+        )
+
+    monkeypatch.setattr(python_api_surface, "build_python_api_surface", build_surface)
+    monkeypatch.setattr(
+        api_sig._ApiSignatureChecker,
+        "_add_missing_finding",
+        add_missing_and_cache_pkg_b,
+    )
+
+    findings = scan_python_api_signature_hallucinations(
+        repo,
+        [py_file],
+        allowed_modules=("pkg_a", "pkg_b"),
+    )
+
+    assert [finding["symbol"] for finding in findings] == ["pkg_a.missing"]
+    assert cached_python_api_surface(repo, "pkg_b") is not None
+    assert (
+        cached_api_symbol_surface(
+            repo,
+            SURFACE_KIND_PYTHON_MODULE,
+            "pkg_b",
+            environment_key=python_environment_key(),
+        )
+        is not None
+    )
+
+
+def test_scan_skips_parsing_files_without_allowed_roots(tmp_path, monkeypatch):
+    from skylos.rules.ai_defect import api_signature_hallucination as api_sig
+
+    unrelated_file = _write_py(tmp_path / "unrelated.py", "print('hello')\n")
+    relevant_file = _write_py(
+        tmp_path / "relevant.py",
+        "import sampleapi\nsampleapi.missing()\n",
+    )
+    parsed_sources = []
+    original_parse = api_sig.ast.parse
+
+    def parse(source, *args, **kwargs):
+        parsed_sources.append(source)
+        return original_parse(source, *args, **kwargs)
+
+    def loader(_root, module_name):
+        assert module_name == "sampleapi"
+        return {"members": {}, "members_truncated": False}
+
+    monkeypatch.setattr(api_sig.ast, "parse", parse)
+
+    findings = scan_python_api_signature_hallucinations(
+        tmp_path,
+        [unrelated_file, relevant_file],
+        allowed_modules=("sampleapi",),
+        surface_loader=loader,
+    )
+
+    assert parsed_sources == ["import sampleapi\nsampleapi.missing()\n"]
+    assert [finding["symbol"] for finding in findings] == ["sampleapi.missing"]
+
+
+def test_scan_prefilter_handles_normalized_import_identifiers(tmp_path):
+    py_file = _write_py(
+        tmp_path / "app.py",
+        "import 𝕡andas as pd\npd.missing()\n",
+    )
+
+    def loader(_root, module_name):
+        assert module_name == "pandas"
+        return {"members": {}, "members_truncated": False}
+
+    findings = scan_python_api_signature_hallucinations(
+        tmp_path,
+        [py_file],
+        allowed_modules=("pandas",),
+        surface_loader=loader,
+    )
+
+    assert [finding["symbol"] for finding in findings] == ["pandas.missing"]
 
 
 def test_scan_skips_local_modules_named_like_allowlisted_package(

--- a/test/test_api_signature_hallucination.py
+++ b/test/test_api_signature_hallucination.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 from skylos.core import python_api_surface
 from skylos.core.api_symbol_truth import (
     SURFACE_KIND_PYTHON_MODULE,
@@ -469,8 +471,8 @@ def test_scan_batches_api_surface_cache_io(tmp_path, monkeypatch):
     save_counts = {"python": 0, "shared": 0}
     original_python_load = python_api_surface.load_python_api_surface_cache
     original_shared_load = python_api_surface.load_api_symbol_truth_cache
-    original_python_save = python_api_surface.save_python_api_surface_cache
-    original_shared_save = python_api_surface.save_api_symbol_truth_cache
+    original_python_save = python_api_surface._save_python_api_surface_cache_unlocked
+    original_shared_save = python_api_surface._save_api_symbol_truth_cache_unlocked
 
     def load_python(*args, **kwargs):
         load_counts["python"] += 1
@@ -500,12 +502,12 @@ def test_scan_batches_api_surface_cache_io(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         python_api_surface,
-        "save_python_api_surface_cache",
+        "_save_python_api_surface_cache_unlocked",
         save_python,
     )
     monkeypatch.setattr(
         python_api_surface,
-        "save_api_symbol_truth_cache",
+        "_save_api_symbol_truth_cache_unlocked",
         save_shared,
     )
 
@@ -525,7 +527,7 @@ def test_scan_batches_api_surface_cache_io(tmp_path, monkeypatch):
         "otherapi.missing",
     ]
     assert warm_findings == cold_findings
-    assert load_counts == {"python": 1, "shared": 2}
+    assert load_counts == {"python": 2, "shared": 3}
     assert save_counts == {"python": 1, "shared": 1}
 
 
@@ -589,7 +591,17 @@ def test_scan_preserves_surfaces_cached_during_batch(tmp_path, monkeypatch):
     )
 
     assert [finding["symbol"] for finding in findings] == ["pkg_a.missing"]
+    assert cached_python_api_surface(repo, "pkg_a") is not None
     assert cached_python_api_surface(repo, "pkg_b") is not None
+    assert (
+        cached_api_symbol_surface(
+            repo,
+            SURFACE_KIND_PYTHON_MODULE,
+            "pkg_a",
+            environment_key=python_environment_key(),
+        )
+        is not None
+    )
     assert (
         cached_api_symbol_surface(
             repo,
@@ -599,6 +611,107 @@ def test_scan_preserves_surfaces_cached_during_batch(tmp_path, monkeypatch):
         )
         is not None
     )
+
+
+def test_concurrent_cache_sessions_preserve_different_modules(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def build_surface(module_name):
+        return {
+            "module": module_name,
+            "origin": f"/{module_name}.py",
+            "members": {},
+            "members_truncated": False,
+        }
+
+    monkeypatch.setattr(python_api_surface, "build_python_api_surface", build_surface)
+    first_session = python_api_surface.PythonApiSurfaceCacheSession(repo)
+    second_session = python_api_surface.PythonApiSurfaceCacheSession(repo)
+    assert first_session.load_surface(repo, "pkg_a") is not None
+    assert second_session.load_surface(repo, "pkg_b") is not None
+
+    original_save = python_api_surface._save_python_api_surface_cache_unlocked
+    first_save_entered = threading.Event()
+    second_save_entered = threading.Event()
+    save_count_lock = threading.Lock()
+    save_count = 0
+
+    def delayed_save(*args, **kwargs):
+        nonlocal save_count
+        with save_count_lock:
+            save_count += 1
+            call_number = save_count
+        if call_number == 1:
+            first_save_entered.set()
+            second_save_entered.wait(timeout=0.25)
+        else:
+            second_save_entered.set()
+        return original_save(*args, **kwargs)
+
+    monkeypatch.setattr(
+        python_api_surface,
+        "_save_python_api_surface_cache_unlocked",
+        delayed_save,
+    )
+    errors = []
+
+    def flush(session):
+        try:
+            session.flush()
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first_thread = threading.Thread(target=flush, args=(first_session,))
+    second_thread = threading.Thread(target=flush, args=(second_session,))
+    first_thread.start()
+    assert first_save_entered.wait(timeout=1.0)
+    second_thread.start()
+    first_thread.join(timeout=2.0)
+    second_thread.join(timeout=2.0)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert errors == []
+    assert second_save_entered.is_set()
+    assert set(load_python_api_surface_cache(repo)["modules"]) == {"pkg_a", "pkg_b"}
+    shared_surfaces = python_api_surface.load_api_symbol_truth_cache(repo)["surfaces"]
+    assert set(shared_surfaces) == {
+        "python_module:pkg_a",
+        "python_module:pkg_b",
+    }
+
+
+def test_stale_cache_session_does_not_replace_newer_module(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    origins = iter(("older.py", "newer.py"))
+
+    def build_surface(module_name):
+        return {
+            "module": module_name,
+            "origin": next(origins),
+            "members": {},
+            "members_truncated": False,
+        }
+
+    monkeypatch.setattr(python_api_surface, "build_python_api_surface", build_surface)
+    stale_session = python_api_surface.PythonApiSurfaceCacheSession(repo)
+    newer_session = python_api_surface.PythonApiSurfaceCacheSession(repo)
+    assert stale_session.load_surface(repo, "pkg_a")["origin"] == "older.py"
+    assert newer_session.load_surface(repo, "pkg_a")["origin"] == "newer.py"
+
+    newer_session.flush()
+    stale_session.flush()
+
+    assert cached_python_api_surface(repo, "pkg_a")["origin"] == "newer.py"
+    shared = cached_api_symbol_surface(
+        repo,
+        SURFACE_KIND_PYTHON_MODULE,
+        "pkg_a",
+        environment_key=python_environment_key(),
+    )
+    assert shared["origin"] == "newer.py"
 
 
 def test_scan_skips_parsing_files_without_allowed_roots(tmp_path, monkeypatch):
@@ -630,6 +743,42 @@ def test_scan_skips_parsing_files_without_allowed_roots(tmp_path, monkeypatch):
     )
 
     assert parsed_sources == ["import sampleapi\nsampleapi.missing()\n"]
+    assert [finding["symbol"] for finding in findings] == ["sampleapi.missing"]
+
+
+def test_scan_skips_prefilter_for_large_allowlists(tmp_path, monkeypatch):
+    from skylos.rules.ai_defect import api_signature_hallucination as api_sig
+
+    unrelated_file = _write_py(tmp_path / "unrelated.py", "print('hello')\n")
+    relevant_file = _write_py(
+        tmp_path / "relevant.py",
+        "import sampleapi\nsampleapi.missing()\n",
+    )
+    parsed_sources = []
+    original_parse = api_sig.ast.parse
+
+    def parse(source, *args, **kwargs):
+        parsed_sources.append(source)
+        return original_parse(source, *args, **kwargs)
+
+    def loader(_root, module_name):
+        assert module_name == "sampleapi"
+        return {"members": {}, "members_truncated": False}
+
+    monkeypatch.setattr(api_sig.ast, "parse", parse)
+    allowed_modules = ("sampleapi", *(f"package_{index}" for index in range(64)))
+
+    findings = scan_python_api_signature_hallucinations(
+        tmp_path,
+        [unrelated_file, relevant_file],
+        allowed_modules=allowed_modules,
+        surface_loader=loader,
+    )
+
+    assert parsed_sources == [
+        "print('hello')\n",
+        "import sampleapi\nsampleapi.missing()\n",
+    ]
     assert [finding["symbol"] for finding in findings] == ["sampleapi.missing"]
 
 

--- a/test/test_api_symbol_truth.py
+++ b/test/test_api_symbol_truth.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
 from skylos.core.api_symbol_truth import (
+    API_SURFACE_CACHE_LOCK_PATH,
     SURFACE_KIND_CLI,
     SURFACE_KIND_CONFIG,
     SURFACE_KIND_PYTHON_MODULE,
@@ -11,6 +19,10 @@ from skylos.core.api_symbol_truth import (
     cached_api_symbol_surface,
     load_api_symbol_truth_cache,
     normalize_api_symbol_surface,
+)
+from skylos.core.safe_cache_io import (
+    PROJECT_CACHE_LOCK_STALE_SECONDS,
+    project_cache_lock,
 )
 
 
@@ -149,3 +161,166 @@ def test_api_symbol_truth_cache_rejects_malformed_surfaces(tmp_path):
         },
     )
     assert load_api_symbol_truth_cache(project_root)["surfaces"] == {}
+
+
+def test_api_symbol_truth_cache_rejects_hard_linked_transaction_lock(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    lock_path = project_root / API_SURFACE_CACHE_LOCK_PATH
+    lock_path.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("sentinel", encoding="utf-8")
+    lock_path.hardlink_to(outside)
+
+    saved = cache_api_symbol_surface(
+        project_root,
+        {
+            "kind": SURFACE_KIND_CLI,
+            "name": "skylos",
+            "flags": ["--format"],
+        },
+    )
+
+    assert saved is False
+    assert outside.read_text(encoding="utf-8") == "sentinel"
+    assert not (project_root / ".skylos/cache/api_symbol_truth.json").exists()
+
+
+def test_api_symbol_truth_cache_rejects_symlinked_transaction_lock(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    lock_path = project_root / API_SURFACE_CACHE_LOCK_PATH
+    lock_path.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("sentinel", encoding="utf-8")
+    lock_path.symlink_to(outside)
+
+    saved = cache_api_symbol_surface(
+        project_root,
+        {
+            "kind": SURFACE_KIND_CLI,
+            "name": "skylos",
+            "flags": ["--format"],
+        },
+    )
+
+    assert saved is False
+    assert outside.read_text(encoding="utf-8") == "sentinel"
+    assert not (project_root / ".skylos/cache/api_symbol_truth.json").exists()
+
+
+def test_api_surface_transaction_lock_serializes_processes(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    child_code = """
+import sys
+from skylos.core.api_symbol_truth import API_SURFACE_CACHE_LOCK_PATH
+from skylos.core.safe_cache_io import project_cache_lock
+
+with project_cache_lock(sys.argv[1], API_SURFACE_CACHE_LOCK_PATH) as acquired:
+    print("locked" if acquired else "failed", flush=True)
+    if acquired:
+        sys.stdin.readline()
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", child_code, str(project_root)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    ready = threading.Event()
+    child_status = []
+
+    def read_child_status():
+        if process.stdout is not None:
+            child_status.append(process.stdout.readline().strip())
+        ready.set()
+
+    reader = threading.Thread(target=read_child_status, daemon=True)
+    reader.start()
+    try:
+        assert ready.wait(timeout=2.0)
+        assert child_status == ["locked"]
+        started = time.monotonic()
+        with project_cache_lock(
+            project_root,
+            API_SURFACE_CACHE_LOCK_PATH,
+            timeout_seconds=0.05,
+        ) as acquired:
+            assert acquired is False
+        assert time.monotonic() - started < 0.5
+        assert process.stdin is not None
+        process.stdin.write("\n")
+        process.stdin.flush()
+        assert process.wait(timeout=2.0) == 0
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=2.0)
+        reader.join(timeout=1.0)
+        for stream in (process.stdin, process.stdout, process.stderr):
+            if stream is not None:
+                stream.close()
+
+    with project_cache_lock(
+        project_root,
+        API_SURFACE_CACHE_LOCK_PATH,
+    ) as acquired:
+        assert acquired is True
+
+
+def test_api_surface_lock_handles_concurrent_cache_directory_creation(
+    tmp_path,
+    monkeypatch,
+):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    create_barrier = threading.Barrier(2)
+    original_mkdir = Path.mkdir
+
+    def synchronized_mkdir(path, *args, **kwargs):
+        if path == project_root / ".skylos":
+            create_barrier.wait(timeout=1.0)
+        return original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", synchronized_mkdir)
+    outcomes = []
+    errors = []
+
+    def acquire_lock():
+        try:
+            with project_cache_lock(
+                project_root,
+                API_SURFACE_CACHE_LOCK_PATH,
+            ) as acquired:
+                outcomes.append(acquired)
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=acquire_lock) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2.0)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert outcomes == [True, True]
+
+
+def test_api_surface_lock_recovers_empty_stale_directory(tmp_path):
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    lock_path = project_root / API_SURFACE_CACHE_LOCK_PATH
+    lock_path.mkdir(parents=True)
+    stale_time = time.time() - PROJECT_CACHE_LOCK_STALE_SECONDS - 1.0
+    os.utime(lock_path, (stale_time, stale_time))
+
+    with project_cache_lock(
+        project_root,
+        API_SURFACE_CACHE_LOCK_PATH,
+    ) as acquired:
+        assert acquired is True
+
+    assert not lock_path.exists()


### PR DESCRIPTION
Closes #745.

**AI Use Disclaimer**
This fix was drafted by Codex GPT-5.6 Sol and reviewed per skylos repository review guidelines by Claude Fable 5 and a separate GPT-5.6 Sol agent. I reviewed the code changes. a `liveness_primer` run with an expanded corpus and including ai-defects shows 0 diffs. 

## Summary

- load the shared API truth cache once per API-signature scan instead of once per imported module
- accumulate newly captured Python API surfaces in memory and flush each cache file once at the end of the scan
- detect cache files changed by another writer, refresh the shared lookup snapshot, and merge pending entries without overwriting newer same-key values
- skip AST parsing when source text cannot contain an allowlisted import root, with NFKC normalization for non-ASCII Python identifiers
- retain lazy initialization, cache validation, environment-key behavior, and the existing on-exception flush behavior

## Correctness follow-up

At `34c904300aa5ff3b3a03b4a780eca01042955912`, an update made after the batch snapshot could be missed during verification and then overwritten in both `python_api_surface.json` and `api_symbol_truth.json`. The regression test reproduces the resulting extra `pkg_b.known` finding and lost `pkg_b` cache entries. The follow-up refreshes a changed shared snapshot and rebases pending additions onto the current files at flush time. It now reports only `pkg_a.missing` and retains `pkg_b` in both caches.

The source prefilter also covers Python identifier normalization: `import 𝕡andas as pd` is parsed by Python as an import of `pandas`, so non-ASCII source is NFKC-normalized before a file is skipped.

## Measurement

Base: `a5d0319499b8429ebfa980f82626d7426a24dece`
Head: `022ddd769aaf7eff1fbd220defbf1ec5200eb238`
Corpus: SciPy `0e0ea9350596693dcc3e3604ef8c6dde220c8b2c`, 994 Python files

`scan_python_api_signature_hallucinations` is called directly in a fresh process per run, isolating the rule from an unrelated nonzero exit in full-CLI SciPy scans. Cold runs wipe `.skylos` first; three interleaved trials per cell; medians reported.

| Config | base cold | head cold | base warm | head warm |
|---|---|---|---|---|
| default allowlist | 4.47s | 0.71s (6.3x) | 3.69s | 0.34s (10.7x) |
| `numpy` allowlist (18 modules; 816/994 files mention `numpy`) | 10.09s | 4.30s (2.3x) | 5.29s | 3.65s (1.4x) |

The `numpy` config isolates the cache-batching win (the prefilter skips few files there); the default config isolates the prefilter win (SciPy imports pandas in one file, requests in none, so the base cost is almost entirely parse/visit of irrelevant files).

- finding-identity sets are identical across all benchmark runs, including earlier trials at `34c9043` (24 runs under the `numpy` config with 4 SKY-D224 findings each; 16 under the default with 0)
- cold-run cache files are identical between variants: same 18 module keys, content equal except `captured_at` timestamps and three `repr()`-embedded default-value memory addresses that vary between any two runs of either variant
- a differential fuzz of the parse prefilter over 17 unicode-tricky sources (fullwidth and mathematical-alphanumeric identifiers, combining-mark suffixes, string/comment-only mentions, non-ASCII docstrings) produced identical findings on base and head
- warm profile at head under the `numpy` config: the entire cache path is a single load+normalize, roughly 3.5% of scan time; the remainder is `ast.parse` plus AST visiting
- the cold-plus-warm cache I/O regression test observes one Python-cache load, two shared-cache loads, and one save per cache

## Tests

- `python -m pytest -q -p no:cacheprovider test/test_api_signature_hallucination.py test/test_python_api_surface.py test/test_api_symbol_truth.py` (23 passed)
- Ruff import checks and `git diff --check` pass
- Pyright reports only the same existing `importlib.util` diagnostic present at the base
- both CI test matrices complete with only the pre-existing simulation-branch failure in `test_get_git_changed_files_unions_worktree_and_branch_changes`; the prior `34c9043` run fails on the identical test
- title, analyzer speed, both Docker smokes, corpus guard, advisory quality, quality benchmark, and the Skylos advisory scan pass
