### PR TITLE
fix(analyzer): bound oversized fixed-string grep batches

### DIFF
--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -89,6 +89,12 @@ _GREP_BATCH_MAX_STDERR_BYTES = 128 * 1024
 _GREP_BATCH_MAX_MATCHES = _GREP_BATCH_SIZE * 256
 _GREP_ORDERED_MAX_PATHS = 64
 _GREP_ORDERED_MAX_PATH_BYTES = 64 * 1024
+# Bounds the canonical evidence an ordered sweep may retain, accounted as
+# the evidence bytes each distinct match contributes to results. Counting
+# a match's fields beyond its evidence would halve the usable window and
+# push full hot batches on scipy-sized trees into a pointless sweep that
+# is then redone in split halves.
+_GREP_ORDERED_MAX_RETAINED_BYTES = _GREP_BATCH_MAX_OUTPUT_BYTES
 _GREP_UNICODE_MAX_INPUT_BYTES = 512 * 1024
 # Every request in a bounded batch must receive the same Unicode-boundary
 # adjudication. Skipping later requests makes a successful batch partial and
@@ -976,12 +982,8 @@ def _record_ordered_fixed_string_match(
     ]
     if not matched_requests:
         return
-    retained_bytes = (
-        len(match.path.encode("utf-8"))
-        + len(match.content.encode("utf-8"))
-        + len(match.evidence.encode("utf-8"))
-    )
-    if search.retained_bytes + retained_bytes > _GREP_BATCH_MAX_OUTPUT_BYTES:
+    retained_bytes = len(match.evidence.encode("utf-8"))
+    if search.retained_bytes + retained_bytes > _GREP_ORDERED_MAX_RETAINED_BYTES:
         raise _GrepOutputLimitExceeded(
             "ordered ripgrep matches exceeded the retained-data limit"
         )

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -218,6 +218,12 @@ class _BoundedProcessState:
     timed_out: bool = False
 
 
+# One ordered sweep's file inventory per (project root, include globs).
+# None records that the inventory could not be resolved, so the rest of a
+# splitting batch stops repaying a failure that will not change.
+_OrderedInventory = dict[tuple[str, tuple[str, ...]], list[str] | None]
+
+
 @dataclass(slots=True)
 class _OrderedFixedStringState:
     active: set[GrepRequest]
@@ -951,6 +957,48 @@ def _ordered_fixed_string_paths(
     return ordered
 
 
+def _ordered_fixed_string_inventory(
+    request: GrepRequest,
+    rg: str,
+    *,
+    deadline: float | None,
+    inventory: _OrderedInventory | None,
+) -> list[str]:
+    """Resolve one root's ordered file list at most once per batch.
+
+    _execute_grep_chunk retries the ordered path at every node of its
+    split cascade, so an inventory that keeps failing would otherwise
+    cost 2N-1 full-tree walks for an N-request batch that keeps
+    overflowing. A deadline failure stays uncached because it says
+    nothing about whether the walk itself can complete.
+    """
+    if inventory is None:
+        return _ordered_fixed_string_paths(request, rg, deadline=deadline)
+    key = (request.project_root, request.include_globs)
+    if key in inventory:
+        cached = inventory[key]
+        if cached is None:
+            raise _GrepExecutionIncomplete(
+                "ordered inventory is unavailable for this root"
+            )
+        return cached
+    try:
+        paths = _ordered_fixed_string_paths(request, rg, deadline=deadline)
+    except _GrepDeadlineExceeded:
+        raise
+    except (
+        _GrepExecutionIncomplete,
+        OSError,
+        subprocess.TimeoutExpired,
+        UnicodeError,
+        ValueError,
+    ):
+        inventory[key] = None
+        raise
+    inventory[key] = paths
+    return paths
+
+
 def _ordered_fixed_string_path_chunks(
     paths: Sequence[str],
 ) -> Iterator[list[str]]:
@@ -996,31 +1044,87 @@ def _record_ordered_fixed_string_match(
             search.active.remove(request)
 
 
+def _reject_converted_binary_file(event: Mapping[str, object]) -> None:
+    """Refuse a file whose binary handling an ordered sweep cannot match.
+
+    ripgrep quits at the first NUL byte in a file it walked to, but for a
+    path named explicitly on the command line it converts NUL to a line
+    terminator and keeps searching. The ordered sweep names every path
+    explicitly, so such a file can yield both extra matches and shifted
+    line numbers that the canonical batch never produces. Ripgrep reports
+    the offset it detected on the file's end event, so fail closed there
+    and let the split path answer this batch. Files that matched nothing
+    never reach this check: ripgrep does not bracket them at all.
+    """
+    data = event.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("ripgrep end event has no data object")
+    if data.get("binary_offset") is not None:
+        raise _GrepExecutionIncomplete(
+            "ripgrep found binary content in an explicitly listed file"
+        )
+
+
+def _ordered_ripgrep_file_matches(
+    process: subprocess.Popen[bytes],
+) -> Iterator[list[_GrepMatch]]:
+    """Yield each searched file's retainable matches, in Skylos order.
+
+    A file's matches are held until ripgrep reports its end event, whose
+    binary-detection offset is the only signal that the file was searched
+    in a way a canonical walk would not reproduce. Releasing matches any
+    earlier would let a saturating sweep stop before that verdict lands.
+    One file may not buffer more evidence than the whole sweep is allowed
+    to retain.
+    """
+    pipe = process.stdout
+    assert pipe is not None
+    previous_key: tuple[str, int, str] | None = None
+    buffered: list[_GrepMatch] = []
+    buffered_bytes = 0
+    while raw_line := pipe.readline(_GREP_BATCH_MAX_OUTPUT_BYTES + 1):
+        if len(raw_line) > _GREP_BATCH_MAX_OUTPUT_BYTES:
+            raise _GrepOutputLimitExceeded(
+                "ripgrep emitted an oversized JSON event"
+            )
+        event = _load_ripgrep_json_event(raw_line.decode("utf-8"))
+        match = _ripgrep_match_from_event(event)
+        if match is None:
+            if event.get("type") == "end":
+                _reject_converted_binary_file(event)
+                yield buffered
+                buffered = []
+                buffered_bytes = 0
+            continue
+        if _is_ignored_grep_path(match.path):
+            continue
+        key = _grep_match_sort_key(match)
+        if previous_key is not None and key < previous_key:
+            raise _GrepExecutionIncomplete(
+                "ripgrep sorted output disagrees with Skylos ordering"
+            )
+        previous_key = key
+        buffered_bytes += len(match.evidence.encode("utf-8"))
+        if buffered_bytes > _GREP_ORDERED_MAX_RETAINED_BYTES:
+            raise _GrepOutputLimitExceeded(
+                "one ripgrep file exceeded the retained-data limit"
+            )
+        buffered.append(match)
+    if buffered:
+        raise _GrepExecutionIncomplete(
+            "ripgrep ended its output without closing the last file"
+        )
+
+
 def _read_ordered_fixed_string_output(
     process: subprocess.Popen[bytes],
     state: _BoundedProcessState,
     search: _OrderedFixedStringState,
 ) -> None:
-    pipe = process.stdout
-    assert pipe is not None
-    previous_key: tuple[str, int, str] | None = None
     try:
-        while raw_line := pipe.readline(_GREP_BATCH_MAX_OUTPUT_BYTES + 1):
-            if len(raw_line) > _GREP_BATCH_MAX_OUTPUT_BYTES:
-                raise _GrepOutputLimitExceeded(
-                    "ripgrep emitted an oversized JSON event"
-                )
-            event = _load_ripgrep_json_event(raw_line.decode("utf-8"))
-            match = _ripgrep_match_from_event(event)
-            if match is None or _is_ignored_grep_path(match.path):
-                continue
-            key = _grep_match_sort_key(match)
-            if previous_key is not None and key < previous_key:
-                raise _GrepExecutionIncomplete(
-                    "ripgrep sorted output disagrees with Skylos ordering"
-                )
-            previous_key = key
-            _record_ordered_fixed_string_match(match, search)
+        for file_matches in _ordered_ripgrep_file_matches(process):
+            for match in file_matches:
+                _record_ordered_fixed_string_match(match, search)
             if not search.active:
                 state.short_circuited.set()
                 _terminate_process(process)
@@ -1141,6 +1245,7 @@ def _run_ordered_fixed_string_batch(
     rg: str,
     *,
     deadline: float | None,
+    inventory: _OrderedInventory | None = None,
 ) -> _GrepBatchResults:
     if not _supports_ordered_fixed_string_batch(requests):
         raise _GrepExecutionIncomplete(
@@ -1153,8 +1258,11 @@ def _run_ordered_fixed_string_batch(
         ordered_deadline = deadline
         if ordered_deadline is None:
             ordered_deadline = time.monotonic() + _GREP_BATCH_TIMEOUT_SECONDS
-        paths = _ordered_fixed_string_paths(
-            representative, rg, deadline=ordered_deadline
+        paths = _ordered_fixed_string_inventory(
+            representative,
+            rg,
+            deadline=ordered_deadline,
+            inventory=inventory,
         )
         for path_chunk in _ordered_fixed_string_path_chunks(paths):
             # A line whose only matching patterns belong to saturated
@@ -1534,6 +1642,7 @@ def _execute_grep_chunk(
     rg: str,
     *,
     deadline: float | None = None,
+    inventory: _OrderedInventory | None = None,
 ) -> _GrepBatchResults:
     try:
         return _run_ripgrep_batch(requests, rg, deadline=deadline)
@@ -1543,7 +1652,7 @@ def _execute_grep_chunk(
         ):
             try:
                 return _run_ordered_fixed_string_batch(
-                    requests, rg, deadline=deadline
+                    requests, rg, deadline=deadline, inventory=inventory
                 )
             except (
                 _GrepExecutionIncomplete,
@@ -1565,13 +1674,16 @@ def _execute_grep_chunk(
         results = _GrepBatchResults()
         results.merge(
             _execute_grep_chunk(
-                requests[:midpoint], rg, deadline=deadline
+                requests[:midpoint], rg, deadline=deadline, inventory=inventory
             )
         )
         if not _deadline_expired(deadline):
             results.merge(
                 _execute_grep_chunk(
-                    requests[midpoint:], rg, deadline=deadline
+                    requests[midpoint:],
+                    rg,
+                    deadline=deadline,
+                    inventory=inventory,
                 )
             )
         return results
@@ -1633,11 +1745,16 @@ def execute_grep_batch(
         return _run_serial_grep_requests(unique_requests, deadline=deadline)
 
     results = _GrepBatchResults()
+    inventory: _OrderedInventory = {}
     for group_requests in _group_grep_requests(unique_requests).values():
         for chunk in _grep_request_chunks(group_requests):
             if _deadline_expired(deadline):
                 return results
-            results.merge(_execute_grep_chunk(chunk, rg, deadline=deadline))
+            results.merge(
+                _execute_grep_chunk(
+                    chunk, rg, deadline=deadline, inventory=inventory
+                )
+            )
     return results
 
 

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -87,6 +87,8 @@ _GREP_BATCH_MAX_PATTERN_BYTES = 64 * 1024
 _GREP_BATCH_MAX_OUTPUT_BYTES = 8 * 1024 * 1024
 _GREP_BATCH_MAX_STDERR_BYTES = 128 * 1024
 _GREP_BATCH_MAX_MATCHES = _GREP_BATCH_SIZE * 256
+_GREP_ORDERED_MAX_PATHS = 64
+_GREP_ORDERED_MAX_PATH_BYTES = 64 * 1024
 _GREP_UNICODE_MAX_INPUT_BYTES = 512 * 1024
 # Every request in a bounded batch must receive the same Unicode-boundary
 # adjudication. Skipping later requests makes a successful batch partial and
@@ -888,6 +890,257 @@ def _parse_ripgrep_json_matches(
     return sorted(matches, key=_grep_match_sort_key)
 
 
+def _ordered_fixed_string_paths(
+    request: GrepRequest,
+    rg: str,
+    *,
+    deadline: float | None,
+) -> list[str]:
+    if request.project_root_is_file:
+        return [os.path.abspath(request.project_root)]
+    cmd = [rg, "--no-config", "--hidden", "--no-ignore"]
+    for glob in request.include_globs:
+        cmd.extend(["-g", glob])
+    for directory in _GREP_EXCLUDE_DIRS:
+        cmd.extend(["-g", f"!**/{directory}/**"])
+    cmd.extend(
+        [
+            "--files",
+            "--null",
+            "--",
+            os.path.abspath(request.project_root),
+        ]
+    )
+    result = _run_bounded_subprocess(
+        cmd,
+        input_text="",
+        timeout=_remaining_timeout(deadline, _GREP_REQUEST_TIMEOUT_SECONDS),
+    )
+    if result.returncode not in (0, 1):
+        message = result.stderr.strip() or f"exit status {result.returncode}"
+        raise _GrepExecutionIncomplete(message)
+    paths = [path for path in result.stdout.split("\0") if path]
+    ordered = sorted(paths, key=lambda path: path.replace("\\", "/"))
+    sort_keys = [path.replace("\\", "/") for path in ordered]
+    if len(sort_keys) != len(set(sort_keys)):
+        raise _GrepExecutionIncomplete(
+            "distinct ripgrep paths have the same Skylos sort key"
+        )
+    return ordered
+
+
+def _ordered_fixed_string_path_chunks(
+    paths: Sequence[str],
+) -> Iterator[list[str]]:
+    chunk: list[str] = []
+    chunk_bytes = 0
+    for path in paths:
+        path_bytes = len(path.encode("utf-8")) + 1
+        if chunk and (
+            len(chunk) >= _GREP_ORDERED_MAX_PATHS
+            or chunk_bytes + path_bytes > _GREP_ORDERED_MAX_PATH_BYTES
+        ):
+            yield chunk
+            chunk = []
+            chunk_bytes = 0
+        chunk.append(path)
+        chunk_bytes += path_bytes
+    if chunk:
+        yield chunk
+
+
+def _record_ordered_fixed_string_match(
+    match: _GrepMatch,
+    active: set[GrepRequest],
+    matches: dict[GrepRequest, list[_GrepMatch]],
+) -> None:
+    for request in tuple(active):
+        if request.pattern not in match.content:
+            continue
+        request_matches = matches[request]
+        request_matches.append(match)
+        limit = max(request.max_results, _GREP_BATCH_RESULT_FLOOR)
+        if len(request_matches) >= limit:
+            active.remove(request)
+
+
+def _read_ordered_fixed_string_output(
+    process: subprocess.Popen[bytes],
+    state: _BoundedProcessState,
+    active: set[GrepRequest],
+    matches: dict[GrepRequest, list[_GrepMatch]],
+) -> None:
+    pipe = process.stdout
+    assert pipe is not None
+    previous_key: tuple[str, int, str] | None = None
+    try:
+        while raw_line := pipe.readline(_GREP_BATCH_MAX_OUTPUT_BYTES + 1):
+            if len(raw_line) > _GREP_BATCH_MAX_OUTPUT_BYTES:
+                raise _GrepOutputLimitExceeded(
+                    "ripgrep emitted an oversized JSON event"
+                )
+            event = _load_ripgrep_json_event(raw_line.decode("utf-8"))
+            match = _ripgrep_match_from_event(event)
+            if match is None or _is_ignored_grep_path(match.path):
+                continue
+            key = _grep_match_sort_key(match)
+            if previous_key is not None and key < previous_key:
+                raise _GrepExecutionIncomplete(
+                    "ripgrep sorted output disagrees with Skylos ordering"
+                )
+            previous_key = key
+            _record_ordered_fixed_string_match(match, active, matches)
+    except (
+        _GrepExecutionIncomplete,
+        OSError,
+        UnicodeError,
+        ValueError,
+    ) as exc:
+        state.thread_errors.append(exc)
+        _terminate_process(process)
+
+
+def _ordered_fixed_string_process_threads(
+    process: subprocess.Popen[bytes],
+    encoded_input: bytes,
+    state: _BoundedProcessState,
+    active: set[GrepRequest],
+    matches: dict[GrepRequest, list[_GrepMatch]],
+) -> None:
+    state.readers = [
+        threading.Thread(
+            target=_read_ordered_fixed_string_output,
+            args=(process, state, active, matches),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_read_bounded_process_pipe,
+            args=(
+                process,
+                "stderr",
+                _GREP_BATCH_MAX_STDERR_BYTES,
+                state,
+            ),
+            daemon=True,
+        ),
+    ]
+    state.writer = threading.Thread(
+        target=_write_bounded_process_input,
+        args=(process, encoded_input, state),
+        daemon=True,
+    )
+
+
+def _ordered_fixed_string_pattern_input(
+    requests: Sequence[GrepRequest],
+) -> bytes:
+    patterns = "\n".join(
+        dict.fromkeys(
+            request.pattern for request in requests if request.max_results > 0
+        )
+    )
+    encoded_input = f"{patterns}\n".encode()
+    if len(encoded_input) > _GREP_BATCH_MAX_PATTERN_BYTES:
+        raise _GrepInputLimitExceeded("grep subprocess input is too large")
+    return encoded_input
+
+
+def _run_ordered_fixed_string_path_chunk(
+    cmd: Sequence[str],
+    encoded_input: bytes,
+    active: set[GrepRequest],
+    matches: dict[GrepRequest, list[_GrepMatch]],
+    *,
+    timeout: float,
+) -> None:
+    process = _open_grep_process(cmd)
+    state = _BoundedProcessState()
+    _ordered_fixed_string_process_threads(
+        process, encoded_input, state, active, matches
+    )
+    _run_bounded_process_workers(process, state, timeout)
+    _raise_for_bounded_process_failure(cmd, timeout, state)
+    if process.returncode not in (0, 1):
+        stderr = b"".join(state.captured["stderr"]).decode("utf-8").strip()
+        raise _GrepBatchRejected(stderr or f"exit status {process.returncode}")
+
+
+def _ordered_fixed_string_request_state(
+    requests: Sequence[GrepRequest],
+) -> tuple[
+    dict[GrepRequest, list[_GrepMatch]],
+    set[GrepRequest],
+]:
+    matches: dict[GrepRequest, list[_GrepMatch]] = {}
+    active: set[GrepRequest] = set()
+    for request in requests:
+        matches[request] = []
+        if request.max_results > 0:
+            active.add(request)
+    return matches, active
+
+
+def _ordered_fixed_string_results(
+    requests: Sequence[GrepRequest],
+    matches: Mapping[GrepRequest, Sequence[_GrepMatch]],
+) -> _GrepBatchResults:
+    results = _GrepBatchResults()
+    for request in requests:
+        results[request] = tuple(
+            match.legacy_line() for match in matches[request]
+        )
+    return results
+
+
+def _supports_ordered_fixed_string_batch(
+    requests: Sequence[GrepRequest],
+) -> bool:
+    return bool(requests) and all(
+        request.fixed_string and not _requires_direct_grep(request)
+        for request in requests
+    )
+
+
+def _run_ordered_fixed_string_batch(
+    requests: Sequence[GrepRequest],
+    rg: str,
+    *,
+    deadline: float | None,
+) -> _GrepBatchResults:
+    if not _supports_ordered_fixed_string_batch(requests):
+        raise _GrepExecutionIncomplete(
+            "ordered prefix search requires fixed-string requests"
+        )
+    matches, active = _ordered_fixed_string_request_state(requests)
+    if not active:
+        return _ordered_fixed_string_results(requests, matches)
+
+    representative = requests[0]
+    ordered_deadline = deadline
+    if ordered_deadline is None:
+        ordered_deadline = time.monotonic() + _GREP_BATCH_TIMEOUT_SECONDS
+    paths = _ordered_fixed_string_paths(
+        representative, rg, deadline=ordered_deadline
+    )
+    encoded_input = _ordered_fixed_string_pattern_input(requests)
+
+    for path_chunk in _ordered_fixed_string_path_chunks(paths):
+        cmd = _ripgrep_command(representative, rg)
+        cmd.extend(
+            ["--threads", "1", "--json", "-f", "-", "--", *path_chunk]
+        )
+        timeout = _remaining_timeout(
+            ordered_deadline, _GREP_BATCH_TIMEOUT_SECONDS
+        )
+        _run_ordered_fixed_string_path_chunk(
+            cmd, encoded_input, active, matches, timeout=timeout
+        )
+        if not active:
+            break
+
+    return _ordered_fixed_string_results(requests, matches)
+
+
 def _batch_group_key(request: GrepRequest) -> tuple[str, tuple[str, ...], bool]:
     return request.project_root, request.include_globs, request.fixed_string
 
@@ -1245,6 +1498,25 @@ def _execute_grep_chunk(
     try:
         return _run_ripgrep_batch(requests, rg, deadline=deadline)
     except (_GrepOutputLimitExceeded, _GrepInputLimitExceeded) as exc:
+        if isinstance(exc, _GrepOutputLimitExceeded) and not _deadline_expired(
+            deadline
+        ):
+            try:
+                return _run_ordered_fixed_string_batch(
+                    requests, rg, deadline=deadline
+                )
+            except (
+                _GrepExecutionIncomplete,
+                _GrepBatchRejected,
+                OSError,
+                subprocess.TimeoutExpired,
+                UnicodeError,
+                ValueError,
+            ) as ordered_exc:
+                logger.debug(
+                    "ordered fixed-string grep was unavailable: %s",
+                    ordered_exc,
+                )
         if len(requests) <= 1 or _deadline_expired(deadline):
             logger.debug("grep request exceeded a resource limit: %s", exc)
             return _GrepBatchResults()

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -201,6 +201,7 @@ class _BoundedProcessResult:
 @dataclass(slots=True)
 class _BoundedProcessState:
     overflow: threading.Event = field(default_factory=threading.Event)
+    short_circuited: threading.Event = field(default_factory=threading.Event)
     captured: dict[str, list[bytes]] = field(
         default_factory=lambda: {"stdout": [], "stderr": []}
     )
@@ -209,6 +210,13 @@ class _BoundedProcessState:
     writer: threading.Thread | None = None
     started_threads: list[threading.Thread] = field(default_factory=list)
     timed_out: bool = False
+
+
+@dataclass(slots=True)
+class _OrderedFixedStringState:
+    active: set[GrepRequest]
+    matches: dict[GrepRequest, list[_GrepMatch]]
+    retained_bytes: int = 0
 
 
 class _GrepExecutionIncomplete(RuntimeError):
@@ -574,7 +582,7 @@ def _write_bounded_process_input(
         pipe.write(encoded_input)
         pipe.flush()
     except (BrokenPipeError, OSError, ValueError) as exc:
-        if process.poll() is None:
+        if process.poll() is None and not state.short_circuited.is_set():
             state.thread_errors.append(exc)
     finally:
         try:
@@ -672,6 +680,14 @@ def _raise_for_bounded_process_failure(
     assert writer is not None
     if writer.is_alive() or any(thread.is_alive() for thread in state.readers):
         raise _GrepExecutionIncomplete("ripgrep pipe did not close cleanly")
+    if state.short_circuited.is_set():
+        if state.overflow.is_set():
+            raise _GrepOutputLimitExceeded(
+                "ripgrep output exceeded its size limit"
+            )
+        if state.thread_errors:
+            raise OSError(str(state.thread_errors[0]))
+        return
     if state.timed_out:
         raise subprocess.TimeoutExpired(list(cmd), timeout)
     if state.overflow.is_set():
@@ -951,24 +967,37 @@ def _ordered_fixed_string_path_chunks(
 
 def _record_ordered_fixed_string_match(
     match: _GrepMatch,
-    active: set[GrepRequest],
-    matches: dict[GrepRequest, list[_GrepMatch]],
+    search: _OrderedFixedStringState,
 ) -> None:
-    for request in tuple(active):
-        if request.pattern not in match.content:
-            continue
-        request_matches = matches[request]
+    matched_requests = [
+        request
+        for request in tuple(search.active)
+        if request.pattern in match.content
+    ]
+    if not matched_requests:
+        return
+    retained_bytes = (
+        len(match.path.encode("utf-8"))
+        + len(match.content.encode("utf-8"))
+        + len(match.evidence.encode("utf-8"))
+    )
+    if search.retained_bytes + retained_bytes > _GREP_BATCH_MAX_OUTPUT_BYTES:
+        raise _GrepOutputLimitExceeded(
+            "ordered ripgrep matches exceeded the retained-data limit"
+        )
+    search.retained_bytes += retained_bytes
+    for request in matched_requests:
+        request_matches = search.matches[request]
         request_matches.append(match)
         limit = max(request.max_results, _GREP_BATCH_RESULT_FLOOR)
         if len(request_matches) >= limit:
-            active.remove(request)
+            search.active.remove(request)
 
 
 def _read_ordered_fixed_string_output(
     process: subprocess.Popen[bytes],
     state: _BoundedProcessState,
-    active: set[GrepRequest],
-    matches: dict[GrepRequest, list[_GrepMatch]],
+    search: _OrderedFixedStringState,
 ) -> None:
     pipe = process.stdout
     assert pipe is not None
@@ -989,7 +1018,14 @@ def _read_ordered_fixed_string_output(
                     "ripgrep sorted output disagrees with Skylos ordering"
                 )
             previous_key = key
-            _record_ordered_fixed_string_match(match, active, matches)
+            _record_ordered_fixed_string_match(match, search)
+            if not search.active:
+                state.short_circuited.set()
+                _terminate_process(process)
+                return
+    except _GrepOutputLimitExceeded:
+        state.overflow.set()
+        _terminate_process(process)
     except (
         _GrepExecutionIncomplete,
         OSError,
@@ -1004,13 +1040,12 @@ def _ordered_fixed_string_process_threads(
     process: subprocess.Popen[bytes],
     encoded_input: bytes,
     state: _BoundedProcessState,
-    active: set[GrepRequest],
-    matches: dict[GrepRequest, list[_GrepMatch]],
+    search: _OrderedFixedStringState,
 ) -> None:
     state.readers = [
         threading.Thread(
             target=_read_ordered_fixed_string_output,
-            args=(process, state, active, matches),
+            args=(process, state, search),
             daemon=True,
         ),
         threading.Thread(
@@ -1048,36 +1083,35 @@ def _ordered_fixed_string_pattern_input(
 def _run_ordered_fixed_string_path_chunk(
     cmd: Sequence[str],
     encoded_input: bytes,
-    active: set[GrepRequest],
-    matches: dict[GrepRequest, list[_GrepMatch]],
+    search: _OrderedFixedStringState,
     *,
     timeout: float,
 ) -> None:
     process = _open_grep_process(cmd)
     state = _BoundedProcessState()
     _ordered_fixed_string_process_threads(
-        process, encoded_input, state, active, matches
+        process, encoded_input, state, search
     )
     _run_bounded_process_workers(process, state, timeout)
     _raise_for_bounded_process_failure(cmd, timeout, state)
-    if process.returncode not in (0, 1):
+    if (
+        not state.short_circuited.is_set()
+        and process.returncode not in (0, 1)
+    ):
         stderr = b"".join(state.captured["stderr"]).decode("utf-8").strip()
         raise _GrepBatchRejected(stderr or f"exit status {process.returncode}")
 
 
 def _ordered_fixed_string_request_state(
     requests: Sequence[GrepRequest],
-) -> tuple[
-    dict[GrepRequest, list[_GrepMatch]],
-    set[GrepRequest],
-]:
+) -> _OrderedFixedStringState:
     matches: dict[GrepRequest, list[_GrepMatch]] = {}
     active: set[GrepRequest] = set()
     for request in requests:
         matches[request] = []
         if request.max_results > 0:
             active.add(request)
-    return matches, active
+    return _OrderedFixedStringState(active=active, matches=matches)
 
 
 def _ordered_fixed_string_results(
@@ -1111,8 +1145,8 @@ def _run_ordered_fixed_string_batch(
             "ordered prefix search requires fixed-string requests"
         )
     batched, direct = _partition_grep_requests(requests)
-    matches, active = _ordered_fixed_string_request_state(batched)
-    if active:
+    search = _ordered_fixed_string_request_state(batched)
+    if search.active:
         representative = batched[0]
         ordered_deadline = deadline
         if ordered_deadline is None:
@@ -1125,7 +1159,7 @@ def _run_ordered_fixed_string_batch(
             # requests is discarded during recording, so retired patterns
             # can be dropped from later chunks without changing results.
             encoded_input = _ordered_fixed_string_pattern_input(
-                [request for request in batched if request in active]
+                [request for request in batched if request in search.active]
             )
             cmd = _ripgrep_command(representative, rg)
             cmd.extend(
@@ -1135,12 +1169,12 @@ def _run_ordered_fixed_string_batch(
                 ordered_deadline, _GREP_BATCH_TIMEOUT_SECONDS
             )
             _run_ordered_fixed_string_path_chunk(
-                cmd, encoded_input, active, matches, timeout=timeout
+                cmd, encoded_input, search, timeout=timeout
             )
-            if not active:
+            if not search.active:
                 break
 
-    results = _ordered_fixed_string_results(batched, matches)
+    results = _ordered_fixed_string_results(batched, search.matches)
     results.merge(_run_serial_grep_requests(direct, deadline=deadline))
     return results
 

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -1096,8 +1096,7 @@ def _supports_ordered_fixed_string_batch(
     requests: Sequence[GrepRequest],
 ) -> bool:
     return bool(requests) and all(
-        request.fixed_string and not _requires_direct_grep(request)
-        for request in requests
+        request.fixed_string for request in requests
     )
 
 
@@ -1111,34 +1110,39 @@ def _run_ordered_fixed_string_batch(
         raise _GrepExecutionIncomplete(
             "ordered prefix search requires fixed-string requests"
         )
-    matches, active = _ordered_fixed_string_request_state(requests)
-    if not active:
-        return _ordered_fixed_string_results(requests, matches)
-
-    representative = requests[0]
-    ordered_deadline = deadline
-    if ordered_deadline is None:
-        ordered_deadline = time.monotonic() + _GREP_BATCH_TIMEOUT_SECONDS
-    paths = _ordered_fixed_string_paths(
-        representative, rg, deadline=ordered_deadline
-    )
-    encoded_input = _ordered_fixed_string_pattern_input(requests)
-
-    for path_chunk in _ordered_fixed_string_path_chunks(paths):
-        cmd = _ripgrep_command(representative, rg)
-        cmd.extend(
-            ["--threads", "1", "--json", "-f", "-", "--", *path_chunk]
+    batched, direct = _partition_grep_requests(requests)
+    matches, active = _ordered_fixed_string_request_state(batched)
+    if active:
+        representative = batched[0]
+        ordered_deadline = deadline
+        if ordered_deadline is None:
+            ordered_deadline = time.monotonic() + _GREP_BATCH_TIMEOUT_SECONDS
+        paths = _ordered_fixed_string_paths(
+            representative, rg, deadline=ordered_deadline
         )
-        timeout = _remaining_timeout(
-            ordered_deadline, _GREP_BATCH_TIMEOUT_SECONDS
-        )
-        _run_ordered_fixed_string_path_chunk(
-            cmd, encoded_input, active, matches, timeout=timeout
-        )
-        if not active:
-            break
+        for path_chunk in _ordered_fixed_string_path_chunks(paths):
+            # A line whose only matching patterns belong to saturated
+            # requests is discarded during recording, so retired patterns
+            # can be dropped from later chunks without changing results.
+            encoded_input = _ordered_fixed_string_pattern_input(
+                [request for request in batched if request in active]
+            )
+            cmd = _ripgrep_command(representative, rg)
+            cmd.extend(
+                ["--threads", "1", "--json", "-f", "-", "--", *path_chunk]
+            )
+            timeout = _remaining_timeout(
+                ordered_deadline, _GREP_BATCH_TIMEOUT_SECONDS
+            )
+            _run_ordered_fixed_string_path_chunk(
+                cmd, encoded_input, active, matches, timeout=timeout
+            )
+            if not active:
+                break
 
-    return _ordered_fixed_string_results(requests, matches)
+    results = _ordered_fixed_string_results(batched, matches)
+    results.merge(_run_serial_grep_requests(direct, deadline=deadline))
+    return results
 
 
 def _batch_group_key(request: GrepRequest) -> tuple[str, tuple[str, ...], bool]:

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1327,10 +1327,6 @@ class TestBatchedGrepVerify:
                 side_effect=fake_open,
             ),
             patch(
-                "skylos.core.grep_verify_common._GREP_BATCH_MAX_OUTPUT_BYTES",
-                1_024,
-            ),
-            patch(
                 "skylos.core.grep_verify_common._GREP_ORDERED_MAX_PATHS",
                 1,
             ),
@@ -1408,6 +1404,124 @@ class TestBatchedGrepVerify:
             f"{first}:1:alpha beta",
             f"{second}:1:alpha beta",
         )
+
+    def test_ordered_search_stops_saturated_current_chunk(self, tmp_path):
+        source = tmp_path / "a.py"
+        request = GrepRequest(
+            pattern="alpha",
+            project_root=str(tmp_path),
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=1,
+        )
+        output = _rg_json_output((str(source), 1, "alpha used\n"))
+
+        def fake_open(_cmd):
+            script = (
+                "import sys, time; "
+                f"sys.stdout.write({output!r}); sys.stdout.flush(); "
+                "time.sleep(5)"
+            )
+            return subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(source)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_RESULT_FLOOR",
+                1,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_TIMEOUT_SECONDS",
+                0.1,
+            ),
+        ):
+            results = execute_grep_batch([request])
+
+        assert results[request] == (f"{source}:1:alpha used",)
+
+    def test_ordered_search_bounds_aggregate_retained_match_bytes(
+        self, tmp_path
+    ):
+        first = tmp_path / "a.py"
+        second = tmp_path / "b.py"
+        request = GrepRequest(
+            pattern="needle",
+            project_root=str(tmp_path),
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=2,
+        )
+        content = f"needle {'x' * 200}\n"
+
+        def fake_open(cmd):
+            output = _rg_json_output((cmd[-1], 1, content))
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.stdout.write({output!r})",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(first), str(second)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ) as mock_open,
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_RESULT_FLOOR",
+                2,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_MAX_OUTPUT_BYTES",
+                1_024,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_ORDERED_MAX_PATHS",
+                1,
+            ),
+        ):
+            results = execute_grep_batch([request])
+
+        assert request not in results
+        assert mock_open.call_count == 2
 
     def test_direct_grep_requests_do_not_veto_the_ordered_retry(
         self, tmp_path

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -37,11 +37,15 @@ from skylos.core.grep_verify_common import (
     _GrepEvidence,
     _GrepExecutionIncomplete,
     _GrepOutputLimitExceeded,
+    _BoundedProcessResult,
     _is_python_source_reference,
+    _ordered_fixed_string_paths,
     _python_regex,
     _run_bounded_subprocess,
     _run_grep,
     _run_grep_request,
+    _run_ordered_fixed_string_batch,
+    _run_ripgrep_batch,
     _trusted_which,
     execute_grep_batch,
     replay_grep_results,
@@ -67,8 +71,60 @@ def _rg_json_match(path: str, line_number: int, content: str) -> str:
     )
 
 
-def _rg_json_output(*matches: tuple[str, int, str]) -> str:
-    return "\n".join(_rg_json_match(*match) for match in matches) + "\n"
+def _rg_json_file_event(
+    event_type: str, path: str, binary_offset: int | None = None
+) -> str:
+    data: dict[str, object] = {"path": {"text": path}}
+    if event_type == "end":
+        data["binary_offset"] = binary_offset
+    return json.dumps({"type": event_type, "data": data})
+
+
+def _rg_json_output(
+    *matches: tuple[str, int, str],
+    binary_paths: frozenset[str] = frozenset(),
+    close_last_file: bool = True,
+) -> str:
+    """Render a ripgrep --json stream, bracketing each file as rg does."""
+    events: list[str] = []
+    current: str | None = None
+    for path, line_number, content in matches:
+        if path != current:
+            if current is not None:
+                events.append(
+                    _rg_json_file_event(
+                        "end",
+                        current,
+                        1 if current in binary_paths else None,
+                    )
+                )
+            events.append(_rg_json_file_event("begin", path))
+            current = path
+        events.append(_rg_json_match(path, line_number, content))
+    if current is not None and close_last_file:
+        events.append(
+            _rg_json_file_event(
+                "end", current, 1 if current in binary_paths else None
+            )
+        )
+    return "\n".join(events) + "\n"
+
+
+def _fixed_request(root, pattern: str, **overrides) -> GrepRequest:
+    fields = {
+        "project_root": str(root),
+        "use_regex": False,
+        "include_globs": ("*.py", "*.txt"),
+        "fixed_string": True,
+        "max_results": 5,
+    }
+    fields.update(overrides)
+    return GrepRequest(pattern=pattern, **fields)
+
+
+requires_ripgrep = pytest.mark.skipif(
+    shutil.which("rg") is None, reason="ripgrep is not installed"
+)
 
 
 class TestIsDefinitionLine:
@@ -1235,7 +1291,7 @@ class TestBatchedGrepVerify:
         assert results == ordered
         mock_batch.assert_called_once()
         mock_ordered.assert_called_once_with(
-            requests, "/usr/bin/rg", deadline=None
+            requests, "/usr/bin/rg", deadline=None, inventory={}
         )
 
     def test_fixed_ordered_retry_failure_preserves_split_fallback(self):
@@ -1650,6 +1706,371 @@ class TestBatchedGrepVerify:
         assert results[batched] == (f"{source}:1:alpha used",)
         assert results[direct] == serial_results[direct]
         mock_serial.assert_called_once_with([direct], deadline=None)
+
+    @requires_ripgrep
+    def test_ordered_inventory_lists_searchable_paths_in_skylos_order(
+        self, tmp_path
+    ):
+        # Same-prefix file and directory: "." sorts before "/", so the
+        # inventory has to agree with _grep_match_sort_key, not with the
+        # order ripgrep happens to walk in.
+        (tmp_path / "release.py").write_text("numpy\n")
+        (tmp_path / "release").mkdir()
+        (tmp_path / "release" / "template.py").write_text("numpy\n")
+        (tmp_path / "notes.rst").write_text("numpy\n")
+        (tmp_path / "__pycache__").mkdir()
+        (tmp_path / "__pycache__" / "cached.py").write_text("numpy\n")
+        (tmp_path / ".venv").mkdir()
+        (tmp_path / ".venv" / "vendored.py").write_text("numpy\n")
+        request = _fixed_request(tmp_path, "numpy", include_globs=("*.py",))
+
+        paths = _ordered_fixed_string_paths(
+            request, shutil.which("rg"), deadline=None
+        )
+
+        assert paths == [
+            str(tmp_path / "release.py"),
+            str(tmp_path / "release" / "template.py"),
+        ]
+
+    @requires_ripgrep
+    def test_ordered_inventory_of_a_single_file_root_is_that_file(
+        self, tmp_path
+    ):
+        source = tmp_path / "only.py"
+        source.write_text("numpy\n")
+        request = _fixed_request(source, "numpy")
+
+        paths = _ordered_fixed_string_paths(
+            request, shutil.which("rg"), deadline=None
+        )
+
+        assert paths == [str(source)]
+
+    def test_ordered_inventory_rejects_colliding_sort_keys(self, tmp_path):
+        # A file literally named "sub\\name.py" and the file "sub/name.py"
+        # are distinct on POSIX but share one Skylos sort key, so no chunk
+        # order can reproduce the canonical window and the sweep has to
+        # refuse the tree. Ripgrep's listing is stubbed so the guard is
+        # exercised wherever the suite runs.
+        request = _fixed_request(tmp_path, "numpy", include_globs=("*.py",))
+        listing = "\0".join(
+            [
+                str(tmp_path / "sub" / "name.py"),
+                str(tmp_path) + "/sub\\name.py",
+            ]
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=_BoundedProcessResult(
+                    returncode=0, stdout=listing, stderr=""
+                ),
+            ),
+            pytest.raises(_GrepExecutionIncomplete, match="same Skylos sort"),
+        ):
+            _ordered_fixed_string_paths(request, "/usr/bin/rg", deadline=None)
+
+    @requires_ripgrep
+    def test_ordered_retry_reproduces_the_canonical_batch_exactly(
+        self, tmp_path
+    ):
+        # Same-prefix names, CRLF, non-ASCII content, an excluded cache
+        # directory, and a file the globs do not cover.
+        (tmp_path / "release.py").write_text("numpy one\narray one\n")
+        (tmp_path / "release").mkdir()
+        (tmp_path / "release" / "template.py").write_bytes(
+            b"numpy two\r\narray two\r\n"
+        )
+        (tmp_path / "unicode.txt").write_text("numpy \u2118 three\n")
+        (tmp_path / "skipped.rst").write_text("numpy four\n")
+        (tmp_path / "__pycache__").mkdir()
+        (tmp_path / "__pycache__" / "cached.py").write_text("numpy five\n")
+        requests = [
+            _fixed_request(tmp_path, "numpy", max_results=1),
+            _fixed_request(tmp_path, "array", max_results=5),
+        ]
+        rg = shutil.which("rg")
+
+        canonical = _run_ripgrep_batch(requests, rg, deadline=None)
+        with patch(
+            "skylos.core.grep_verify_common._GREP_ORDERED_MAX_PATHS", 1
+        ):
+            ordered = _run_ordered_fixed_string_batch(
+                requests, rg, deadline=None
+            )
+
+        assert ordered == canonical
+        assert canonical[requests[1]]
+
+    @requires_ripgrep
+    def test_ordered_retry_refuses_a_tree_holding_binary_content(
+        self, tmp_path
+    ):
+        # ripgrep quits at the NUL when it walks to a file but converts it
+        # for an explicitly named one, which would add both extra matches
+        # and shifted line numbers. The sweep must abstain, not guess.
+        (tmp_path / "binary.py").write_bytes(b"numpy one\n\x00\nnumpy two\n")
+        (tmp_path / "plain.py").write_text("numpy plain\n")
+        request = _fixed_request(tmp_path, "numpy")
+        rg = shutil.which("rg")
+
+        canonical = _run_ripgrep_batch([request], rg, deadline=None)
+        with pytest.raises((OSError, _GrepExecutionIncomplete)):
+            _run_ordered_fixed_string_batch([request], rg, deadline=None)
+
+        assert canonical[request] == (
+            f"{tmp_path / 'plain.py'}:1:numpy plain",
+        )
+
+    @requires_ripgrep
+    def test_ordered_retry_accepts_binary_files_that_matched_nothing(
+        self, tmp_path
+    ):
+        # A canonical walk searches a prefix of what an explicit path gets
+        # converted into, so a converted file with no match cannot hide
+        # one either. Abstaining here would be pure lost throughput.
+        (tmp_path / "binary.py").write_bytes(b"unrelated\n\x00\nalso\n")
+        (tmp_path / "plain.py").write_text("numpy plain\n")
+        request = _fixed_request(tmp_path, "numpy")
+        rg = shutil.which("rg")
+
+        canonical = _run_ripgrep_batch([request], rg, deadline=None)
+        ordered = _run_ordered_fixed_string_batch([request], rg, deadline=None)
+
+        assert ordered == canonical
+        assert canonical[request] == (
+            f"{tmp_path / 'plain.py'}:1:numpy plain",
+        )
+
+    def test_ordered_retry_abstains_when_a_saturating_file_was_converted(
+        self, tmp_path
+    ):
+        # The request saturates on the converted file's first match, so the
+        # binary verdict only arrives if matches are held to the end event.
+        source = tmp_path / "a.py"
+        request = GrepRequest(
+            pattern="numpy",
+            project_root=str(tmp_path),
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=1,
+        )
+        output = _rg_json_output(
+            (str(source), 1, "numpy one\n"),
+            (str(source), 4, "numpy two\n"),
+            binary_paths=frozenset({str(source)}),
+        )
+
+        def fake_open(_cmd):
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.stdout.write({output!r})",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(source)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_RESULT_FLOOR", 1
+            ),
+            pytest.raises((OSError, _GrepExecutionIncomplete)),
+        ):
+            _run_ordered_fixed_string_batch(
+                [request], "/usr/bin/rg", deadline=None
+            )
+
+    def test_ordered_retry_rejects_a_stream_that_never_closes_its_file(
+        self, tmp_path
+    ):
+        # Matches with no end event carry no binary verdict, so treating
+        # them as complete would answer from unvetted evidence.
+        source = tmp_path / "a.py"
+        request = _fixed_request(tmp_path, "numpy")
+        output = _rg_json_output(
+            (str(source), 1, "numpy one\n"), close_last_file=False
+        )
+
+        def fake_open(_cmd):
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.stdout.write({output!r})",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(source)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+            pytest.raises((OSError, _GrepExecutionIncomplete)),
+        ):
+            _run_ordered_fixed_string_batch(
+                [request], "/usr/bin/rg", deadline=None
+            )
+
+    def _run_ordered_against_stream(self, tmp_path, output, request):
+        def fake_open(_cmd):
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.stdout.write({output!r})",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(tmp_path / "a.py")],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+        ):
+            return _run_ordered_fixed_string_batch(
+                [request], "/usr/bin/rg", deadline=None
+            )
+
+    def test_ordered_retry_rejects_output_that_leaves_skylos_order(
+        self, tmp_path
+    ):
+        request = _fixed_request(tmp_path, "numpy")
+        output = _rg_json_output(
+            (str(tmp_path / "b.py"), 1, "numpy later\n"),
+            (str(tmp_path / "a.py"), 1, "numpy earlier\n"),
+        )
+
+        with pytest.raises((OSError, _GrepExecutionIncomplete)):
+            self._run_ordered_against_stream(tmp_path, output, request)
+
+    def test_ordered_retry_rejects_a_malformed_file_end_event(self, tmp_path):
+        request = _fixed_request(tmp_path, "numpy")
+        source = str(tmp_path / "a.py")
+        output = (
+            _rg_json_file_event("begin", source)
+            + "\n"
+            + _rg_json_match(source, 1, "numpy one\n")
+            + "\n"
+            + json.dumps({"type": "end", "data": "not-an-object"})
+            + "\n"
+        )
+
+        with pytest.raises((OSError, _GrepExecutionIncomplete)):
+            self._run_ordered_against_stream(tmp_path, output, request)
+
+    def test_ordered_retry_bounds_one_file_to_the_retained_data_limit(
+        self, tmp_path
+    ):
+        request = _fixed_request(tmp_path, "numpy", max_results=10)
+        source = str(tmp_path / "a.py")
+        content = f"numpy {'x' * 200}\n"
+        output = _rg_json_output(
+            (source, 1, content), (source, 2, content)
+        )
+
+        # Overflow abstains rather than answering from a truncated file.
+        with (
+            patch(
+                "skylos.core.grep_verify_common."
+                "_GREP_ORDERED_MAX_RETAINED_BYTES",
+                len(f"{source}:1:{content.rstrip()}".encode()) * 3 // 2,
+            ),
+            pytest.raises(_GrepOutputLimitExceeded),
+        ):
+            self._run_ordered_against_stream(tmp_path, output, request)
+
+    def test_ordered_inventory_is_resolved_once_for_a_splitting_batch(self):
+        requests = [
+            GrepRequest(
+                pattern=pattern,
+                project_root="/repo",
+                use_regex=False,
+                include_globs=("*.py",),
+                fixed_string=True,
+                max_results=5,
+            )
+            for pattern in ("a", "b", "c", "d")
+        ]
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                side_effect=_GrepExecutionIncomplete("inventory failed"),
+            ) as mock_inventory,
+        ):
+            results = execute_grep_batch(requests)
+
+        # Every one of the 2N-1 split nodes retries the ordered path; only
+        # the first may pay for the tree walk.
+        assert results == _GrepBatchResults()
+        assert mock_inventory.call_count == 1
+
+    def test_ordered_inventory_deadline_failures_are_not_cached(self):
+        requests = [
+            GrepRequest(
+                pattern=pattern,
+                project_root="/repo",
+                use_regex=False,
+                include_globs=("*.py",),
+                fixed_string=True,
+                max_results=5,
+            )
+            for pattern in ("a", "b")
+        ]
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                side_effect=_GrepDeadlineExceeded("deadline exceeded"),
+            ) as mock_inventory,
+        ):
+            execute_grep_batch(requests)
+
+        assert mock_inventory.call_count == 3
 
     def test_unicode_adjudication_covers_every_request_in_a_bounded_batch(self):
         common = {

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1196,6 +1196,153 @@ class TestBatchedGrepVerify:
         assert results == {request: () for request in requests}
         assert mock_batch.call_count == 3
 
+    def test_fixed_output_limit_uses_ordered_retry_before_splitting(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": False,
+            "include_globs": ("*.py",),
+            "fixed_string": True,
+            "max_results": 5,
+        }
+        requests = [
+            GrepRequest(pattern=pattern, **common)
+            for pattern in ("numpy", "array")
+        ]
+        ordered = _GrepBatchResults()
+        ordered.update(
+            {
+                requests[0]: (_GrepEvidence("/repo/a.py", 1, "numpy"),),
+                requests[1]: (_GrepEvidence("/repo/a.py", 2, "array"),),
+            }
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ) as mock_batch,
+            patch(
+                "skylos.core.grep_verify_common._run_ordered_fixed_string_batch",
+                return_value=ordered,
+            ) as mock_ordered,
+        ):
+            results = execute_grep_batch(requests)
+
+        assert results == ordered
+        mock_batch.assert_called_once()
+        mock_ordered.assert_called_once_with(
+            requests, "/usr/bin/rg", deadline=None
+        )
+
+    def test_fixed_ordered_retry_failure_preserves_split_fallback(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": False,
+            "include_globs": ("*.py",),
+            "fixed_string": True,
+            "max_results": 5,
+        }
+        requests = [
+            GrepRequest(pattern=pattern, **common)
+            for pattern in ("numpy", "array")
+        ]
+
+        def limited_batch(chunk, _rg, **_kwargs):
+            if len(chunk) > 1:
+                raise _GrepOutputLimitExceeded("forced output cap")
+            return {chunk[0]: ()}
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=limited_batch,
+            ) as mock_batch,
+            patch(
+                "skylos.core.grep_verify_common."
+                "_ordered_fixed_string_paths",
+                side_effect=_GrepExecutionIncomplete("inventory failed"),
+            ) as mock_ordered,
+        ):
+            results = execute_grep_batch(requests)
+
+        assert results == {request: () for request in requests}
+        assert mock_batch.call_count == 3
+        mock_ordered.assert_called_once()
+        assert mock_ordered.call_args.args == (requests[0], "/usr/bin/rg")
+        assert isinstance(mock_ordered.call_args.kwargs["deadline"], float)
+
+    def test_oversized_fixed_search_returns_canonical_prefix_across_chunks(
+        self, tmp_path
+    ):
+        first = tmp_path / "release.py"
+        second = tmp_path / "release" / "template.py"
+        request = GrepRequest(
+            pattern="numpy",
+            project_root=str(tmp_path),
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=5,
+        )
+
+        def fake_open(cmd):
+            path = cmd[-1]
+            output = _rg_json_output(
+                *((path, line, "numpy\n") for line in range(1, 201))
+            )
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.stdout.write({output!r})",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(first), str(second)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_MAX_OUTPUT_BYTES",
+                1_024,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_ORDERED_MAX_PATHS",
+                1,
+            ),
+        ):
+            results = execute_grep_batch([request])
+
+        assert len(results[request]) == 256
+        assert results[request][0] == f"{first}:1:numpy"
+        assert results[request][199] == f"{first}:200:numpy"
+        assert results[request][200] == f"{second}:1:numpy"
+        assert results[request][-1] == f"{second}:56:numpy"
+
     def test_unicode_adjudication_covers_every_request_in_a_bounded_batch(self):
         common = {
             "project_root": "/repo",

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1343,6 +1343,132 @@ class TestBatchedGrepVerify:
         assert results[request][200] == f"{second}:1:numpy"
         assert results[request][-1] == f"{second}:56:numpy"
 
+    def test_ordered_search_drops_saturated_patterns_from_later_chunks(
+        self, tmp_path
+    ):
+        first = tmp_path / "a.py"
+        second = tmp_path / "b.py"
+        stdin_log = tmp_path / "stdin.log"
+        common = {
+            "project_root": str(tmp_path),
+            "use_regex": False,
+            "include_globs": ("*.py",),
+            "fixed_string": True,
+        }
+        saturating = GrepRequest(pattern="alpha", max_results=1, **common)
+        remaining = GrepRequest(pattern="beta", max_results=5, **common)
+
+        def fake_open(cmd):
+            path = cmd[-1]
+            output = _rg_json_output((path, 1, "alpha beta\n"))
+            script = (
+                "import sys; data = sys.stdin.read(); "
+                f"open({str(stdin_log)!r}, 'a').write(data + chr(0)); "
+                f"sys.stdout.write({output!r})"
+            )
+            return subprocess.Popen(
+                [sys.executable, "-c", script],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(first), str(second)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_RESULT_FLOOR",
+                1,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_ORDERED_MAX_PATHS",
+                1,
+            ),
+        ):
+            results = execute_grep_batch([saturating, remaining])
+
+        stdin_payloads = stdin_log.read_text().split("\0")[:-1]
+        assert stdin_payloads == ["alpha\nbeta\n", "beta\n"]
+        assert results[saturating] == (f"{first}:1:alpha beta",)
+        assert results[remaining] == (
+            f"{first}:1:alpha beta",
+            f"{second}:1:alpha beta",
+        )
+
+    def test_direct_grep_requests_do_not_veto_the_ordered_retry(
+        self, tmp_path
+    ):
+        source = tmp_path / "a.py"
+        common = {
+            "project_root": str(tmp_path),
+            "use_regex": False,
+            "include_globs": ("*.py",),
+            "fixed_string": True,
+            "max_results": 5,
+        }
+        batched = GrepRequest(pattern="alpha", **common)
+        direct = GrepRequest(pattern="π", **common)
+        serial_results = _GrepBatchResults()
+        serial_results[direct] = (
+            _GrepEvidence(str(source), 2, "π = 3"),
+        )
+
+        def fake_open(cmd):
+            path = cmd[-1]
+            output = _rg_json_output((path, 1, "alpha used\n"))
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.stdout.write({output!r})",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(source)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_serial_grep_requests",
+                return_value=serial_results,
+            ) as mock_serial,
+        ):
+            results = execute_grep_batch([batched, direct])
+
+        assert results[batched] == (f"{source}:1:alpha used",)
+        assert results[direct] == serial_results[direct]
+        mock_serial.assert_called_once_with([direct], deadline=None)
+
     def test_unicode_adjudication_covers_every_request_in_a_bounded_batch(self):
         common = {
             "project_root": "/repo",

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1510,8 +1510,8 @@ class TestBatchedGrepVerify:
                 2,
             ),
             patch(
-                "skylos.core.grep_verify_common._GREP_BATCH_MAX_OUTPUT_BYTES",
-                1_024,
+                "skylos.core.grep_verify_common._GREP_ORDERED_MAX_RETAINED_BYTES",
+                len(f"{first}:1:{content.rstrip()}".encode()) * 3 // 2,
             ),
             patch(
                 "skylos.core.grep_verify_common._GREP_ORDERED_MAX_PATHS",
@@ -1522,6 +1522,74 @@ class TestBatchedGrepVerify:
 
         assert request not in results
         assert mock_open.call_count == 2
+
+    def test_ordered_retention_counts_each_match_as_its_evidence_bytes(
+        self, tmp_path
+    ):
+        first = tmp_path / "a.py"
+        second = tmp_path / "b.py"
+        request = GrepRequest(
+            pattern="needle",
+            project_root=str(tmp_path),
+            use_regex=False,
+            include_globs=("*.py",),
+            fixed_string=True,
+            max_results=2,
+        )
+        content = f"needle {'x' * 200}\n"
+        evidence_bytes = len(f"{first}:1:{content.rstrip()}".encode())
+
+        def fake_open(cmd):
+            output = _rg_json_output((cmd[-1], 1, content))
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    f"import sys; sys.stdout.write({output!r})",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._ordered_fixed_string_paths",
+                return_value=[str(first), str(second)],
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=fake_open,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_BATCH_RESULT_FLOOR",
+                2,
+            ),
+            # Two matches fit only when each is accounted once as its
+            # evidence bytes; double-counting match fields would abstain.
+            patch(
+                "skylos.core.grep_verify_common._GREP_ORDERED_MAX_RETAINED_BYTES",
+                evidence_bytes * 5 // 2,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_ORDERED_MAX_PATHS",
+                1,
+            ),
+        ):
+            results = execute_grep_batch([request])
+
+        assert results[request] == (
+            f"{first}:1:{content.rstrip()}",
+            f"{second}:1:{content.rstrip()}",
+        )
 
     def test_direct_grep_requests_do_not_veto_the_ordered_retry(
         self, tmp_path


### PR DESCRIPTION
Closes #742 

**AI Use Disclosure**
The initial commits were generated by Codex GPT-5.6 Sol and some follow-ups were done by Claude. Review was done according to skylos repository guidelines using Claude Fable 5 and a separate Codex GPT-5.6 Sol agent. I reviewed the changes myself.  I verified skylos can now run without failure on numpy and scipy. `liveness_primer` with an expanded corpus shows 0 diffs.


## What changed
- Retry fixed-string batches that exceed the aggregate output cap using a bounded, streamed search.
- Inventory and Python-sort eligible files, then search bounded explicit-path chunks with one ripgrep worker.
- Retain only each request canonical 256-result evidence window and stop scheduling chunks once every request is saturated.
- Rebuild each chunk's pattern file from the still-active requests only, so a saturated request's pattern is no longer searched, and partition mixed chunks so one direct-grep pattern does not veto the ordered retry for the rest of its chunk.
- Account a retained match once, as the bytes of the evidence string it contributes to results, against a dedicated retained-data constant. The earlier accounting summed the match's path, content, and evidence, roughly twice the evidence bytes, so a full batch of hot patterns on a scipy-sized tree sat within 12% of the cap and crossed it under a longer checkout prefix, discarding a nearly finished sweep and redoing all of it in split halves.
- Hold a file's matches until ripgrep reports its end event and refuse the sweep when that event carries a binary offset. Ripgrep quits at the first NUL byte in a file it walked to but converts NUL to a line terminator in a path named explicitly, so an explicit-path sweep would otherwise return matches the canonical batch never produces, at line numbers shifted by the conversion.
- Resolve the ordered inventory at most once per batch, since the split cascade retries the ordered path at every node and a failing inventory otherwise costs 2N-1 full-tree walks.
- Fail closed to the existing split path if inventory, ordering, binary, retention, process, or deadline checks cannot complete.

## Regression coverage
- Forces the original aggregate output-cap path.
- Proves exact canonical output across the same-prefix file/directory ordering edge case.
- Covers successful ordered retry and conservative fallback when inventory is unavailable.
- Pins single-counted retention accounting, and abstention when one file or one sweep exceeds the retained-data limit.
- Covers the binary-conversion refusal, including the case where a request saturates on the converted file, plus refusal of a truncated stream and of a malformed file end event.
- Runs real ripgrep down both the canonical and ordered paths over one tree and asserts the results are identical.
- Covers the file inventory directly, including its exclusion globs, single-file roots, and the sort-key collision guard.
- Asserts the inventory is resolved once for a batch that splits, and that a deadline failure is not cached as a permanent one.

## Validation
- test/test_grep_verify.py: 173 passed
- Full suite: 7085 passed, no new failures
- Pyright: 0 errors; ruff check clean
- Differential against the canonical batch with the ordered chunk size forced to 3: 600 randomized trees without NUL bytes agree exactly with no abstentions; 400 trees seeded with NUL bytes agree exactly, abstaining 175 times
- pydantic, 128 hottest identifiers, output cap lowered to force the retry: the ordered retry answers 128/128 requests in 0.38s where splitting answers 24/128 in 2.0s
- NumPy commit 6d743ffd3adee7cc754fd0267948ff60ac6bdc23 with SKYLOS_JOBS=1: exit 0, parseable 91.6 MB JSON, analysis_error_count 0

Base SHA: 780432d
Head SHA: db88898
