### PR TITLE
fix(sca): scope npm dependency line anchoring to its declaring section

### DIFF
--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
-import logging
+from json.decoder import scanstring
 from pathlib import Path
 
 try:
@@ -536,25 +537,77 @@ def parse_pyproject_toml_candidates(path: Path) -> list[dict]:
     )
 
 
-def _npm_dependency_source(text: str, section: str, name: str) -> tuple[int, str]:
-    in_section = False
+_NPM_JSON_STRUCTURAL_RE = re.compile(r'["{}\[\]:,]')
+
+
+def _npm_dependency_lines(
+    text: str, sections: tuple[str, ...]
+) -> dict[tuple[str, str], int]:
+    """Map (section, dependency name) to the 1-indexed line of its declaring key.
+
+    Walks the raw text via its own structural characters rather than line-by-line
+    (json.loads exposes no position info), so a section object written on a single
+    line -- open and close brace on the same line as its entries -- is anchored
+    exactly like a multi-line one; the prior line-scoped scan closed such a section
+    immediately after opening it and fell back to the first textual occurrence of
+    the name anywhere in the file. A key is only recorded while directly inside a
+    TOP-LEVEL object literally named by `sections` (depth == section_depth + 1), so
+    a same-named key nested elsewhere (an `overrides` block, a description) cannot
+    hijack the line, and `sections` never includes `overrides` here in the first
+    place -- this file does not scan it.
+    """
+    lines: dict[tuple[str, str], int] = {}
     depth = 0
-    section_key = f'"{section}"'
-    for lineno, raw_line in enumerate(text.splitlines(), 1):
-        line = raw_line.strip()
-        if not in_section:
-            if line.startswith(section_key) and ":" in line:
-                in_section = True
-                depth = line.count("{") - line.count("}")
-                if depth <= 0:
-                    in_section = False
+    section: str | None = None
+    section_depth = 0
+    pending_key: str | None = None
+    expect_value = False
+    scanned = 0
+    lineno = 1
+    pos = 0
+
+    while True:
+        match = _NPM_JSON_STRUCTURAL_RE.search(text, pos)
+        if match is None:
+            return lines
+        char = match.group()
+        pos = match.end()
+
+        if char == '"':
+            key_start = match.start()
+            try:
+                key, pos = scanstring(text, pos)
+            except ValueError:
+                return lines
+            if expect_value:
+                pending_key = None
+                expect_value = False
+                continue
+            pending_key = key
+            if section is not None and depth == section_depth + 1:
+                lineno += text.count("\n", scanned, key_start)
+                scanned = key_start
+                lines[(section, key)] = lineno
             continue
-        if line.startswith(f'"{name}"') and ":" in line:
-            return lineno, line
-        depth += line.count("{") - line.count("}")
-        if depth <= 0:
-            in_section = False
-    return _find_line(text, f'"{name}"'), name
+
+        if char == ":":
+            expect_value = True
+            continue
+        if char == ",":
+            pending_key = None
+            expect_value = False
+            continue
+        if char in "{[":
+            if char == "{" and depth == 1 and expect_value and pending_key in sections:
+                section = pending_key
+                section_depth = depth
+            depth += 1
+        else:
+            depth -= 1
+            if section is not None and depth <= section_depth:
+                section = None
+        pending_key = None
+        expect_value = False
 
 
 def _parse_package_json(path: Path, *, allow_version_ranges: bool) -> list[dict]:
@@ -571,6 +624,8 @@ def _parse_package_json(path: Path, *, allow_version_ranges: bool) -> list[dict]
         data = json.loads(txt)
     except Exception:
         return deps
+
+    dependency_lines = _npm_dependency_lines(txt, ("dependencies", "devDependencies"))
 
     for section in ("dependencies", "devDependencies"):
         pkg_deps = data.get(section, {})
@@ -593,7 +648,9 @@ def _parse_package_json(path: Path, *, allow_version_ranges: bool) -> list[dict]
                     continue
                 version = exact_match.group(1)
 
-            lineno, _ = _npm_dependency_source(txt, section, name)
+            lineno = dependency_lines.get((section, name)) or _find_line(
+                txt, f'"{name}"'
+            )
             deps.append(
                 {
                     "name": name,

--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -536,6 +536,27 @@ def parse_pyproject_toml_candidates(path: Path) -> list[dict]:
     )
 
 
+def _npm_dependency_source(text: str, section: str, name: str) -> tuple[int, str]:
+    in_section = False
+    depth = 0
+    section_key = f'"{section}"'
+    for lineno, raw_line in enumerate(text.splitlines(), 1):
+        line = raw_line.strip()
+        if not in_section:
+            if line.startswith(section_key) and ":" in line:
+                in_section = True
+                depth = line.count("{") - line.count("}")
+                if depth <= 0:
+                    in_section = False
+            continue
+        if line.startswith(f'"{name}"') and ":" in line:
+            return lineno, line
+        depth += line.count("{") - line.count("}")
+        if depth <= 0:
+            in_section = False
+    return _find_line(text, f'"{name}"'), name
+
+
 def _parse_package_json(path: Path, *, allow_version_ranges: bool) -> list[dict]:
     deps = []
     txt = read_text_no_symlink(
@@ -572,7 +593,7 @@ def _parse_package_json(path: Path, *, allow_version_ranges: bool) -> list[dict]
                     continue
                 version = exact_match.group(1)
 
-            lineno = _find_line(txt, f'"{name}"')
+            lineno, _ = _npm_dependency_source(txt, section, name)
             deps.append(
                 {
                     "name": name,

--- a/test/test_sca_cache.py
+++ b/test/test_sca_cache.py
@@ -214,6 +214,58 @@ def test_npm_finding_line_distinguishes_same_name_in_dependencies_and_devdepende
     assert lines == [3, 6]
 
 
+def test_npm_finding_line_anchors_correctly_when_section_is_a_single_line(tmp_path):
+    # A section object written entirely on one line closes its brace on the
+    # same line it opens, so a line-scoped "am I still inside the section"
+    # scan sees depth return to zero before it ever inspects that line's
+    # content and falls back to the first textual occurrence of the name
+    # anywhere in the file -- here, inside "keywords" one line above the
+    # real declaring entry.
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        """
+{
+  "keywords": ["lodash"],
+  "dependencies": { "lodash": "4.17.20" }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    [item] = sca.parse_package_json_candidates(package_json)
+    assert item["line"] == 3
+
+
+def test_npm_finding_line_ignores_same_name_nested_under_overrides(tmp_path):
+    # This scanner only ever reads the top-level "dependencies" and
+    # "devDependencies" objects (overrides are not scanned as candidates at
+    # all), so a same-named key nested inside "overrides" must never hijack
+    # the line reported for the real top-level entry, however deeply nested
+    # or however many times the name repeats underneath it.
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        """
+{
+  "dependencies": { "foo": "1.0.0" },
+  "overrides": {
+    "bar": {
+      "dependencies": {
+        "foo": "2.0.0"
+      }
+    }
+  }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    [item] = sca.parse_package_json_candidates(package_json)
+    assert item["name"] == "foo"
+    assert item["line"] == 2
+
+
 def test_poetry_multiple_constraint_versions_are_preserved(tmp_path):
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(

--- a/test/test_sca_cache.py
+++ b/test/test_sca_cache.py
@@ -169,6 +169,51 @@ def test_manifest_parsers_query_only_exact_versions(tmp_path):
     ] == [("exact", "1.2.3")]
 
 
+def test_npm_finding_line_anchors_to_dependency_entry_not_first_occurrence(tmp_path):
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        """
+{
+  "name": "line-anchor-mre",
+  "keywords": [
+    "through2"
+  ],
+  "dependencies": {
+    "through2": "999999.0.0"
+  }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    [item] = sca.parse_package_json_candidates(package_json)
+    assert item["line"] == 7
+
+
+def test_npm_finding_line_distinguishes_same_name_in_dependencies_and_devdependencies(
+    tmp_path,
+):
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        """
+{
+  "dependencies": {
+    "react": "18.0.0"
+  },
+  "devDependencies": {
+    "react": "17.0.0"
+  }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    lines = [item["line"] for item in sca.parse_package_json_candidates(package_json)]
+    assert lines == [3, 6]
+
+
 def test_poetry_multiple_constraint_versions_are_preserved(tmp_path):
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(


### PR DESCRIPTION
## What does this PR do?

`_find_line()` anchors an SCA finding to the first textual occurrence of the
needle string anywhere in the manifest file, not the declaring entry. The npm
path in `_parse_package_json` calls it unscoped (`_find_line(txt, f'"{name}"')`),
so any earlier occurrence of the same quoted string elsewhere in the file
(a `keywords` entry, a description, the same name in the other dependency
section) hijacks the reported line. `_poetry_dependency_source` already avoids
this for pyproject.toml with a section-scoped line walk; the npm path had no
equivalent.

Adds `_npm_dependency_source()`, mirroring the poetry helper's shape: track
whether the walk is inside the `dependencies`/`devDependencies` object being
parsed, match the key only within that scope, and fall back to `_find_line`
if no scoped match is found.

## Why?

Fixes #738. SKY-D225 (hallucinated npm dependency version) reported line 4
for the issue's repro when the actual `through2` entry was at line 7, because
line 4 held an unrelated `"through2"` string in a `keywords` array. Wrong line
numbers make the finding's code snippet unusable for diff review.

## How to test

```
python -m pytest test/test_sca_cache.py -k npm_finding_line -v
```

Both new tests fail on `main` and pass on this branch:
- `test_npm_finding_line_anchors_to_dependency_entry_not_first_occurrence`:
  the issue's own repro (name repeated in `keywords`, line 4 vs line 7).
- `test_npm_finding_line_distinguishes_same_name_in_dependencies_and_devdependencies`:
  the same dependency name declared in both sections previously collapsed to
  one line.

## Precision Impact

Output-only: reported `line`/`snippet` for existing findings. No change to
which dependencies are flagged or their version comparison.

## Checklist

- [x] Tests pass (`python3 -m pytest test/`): full suite, both before and
      after this change, 7027 passed / 46 skipped / 3 pre-existing failures
      unrelated to this file (`test_agent_remediate`, `test_dead_code_benchmark`,
      `test_security_benchmark`; identical on `main`, traced to the Go
      analyzer engine not being built in this environment, not to this diff).
- [ ] No new false positives (N/A, line attribution only, not a detection change)
- [ ] Corpus case (N/A, not a precision/detection change)
- [ ] CHANGELOG (auto-generated by release-please from this PR's commits)

Not verified: the repo's Go-engine-dependent CI legs (`docker-smoke`,
`analyzer-speed`, `corpus`, `parity`, `quality-benchmark`) and the full
`test-matrix` install target, since building the Go engine and Rust toolchain
was out of scope for a Python-only SCA parsing fix. `skylos/rules/sca/`
does not touch either engine.
