### PR TITLE
feat(sca): scan peerDependencies and optionalDependencies in package.json

### DIFF
--- a/skylos/rules/sca/vulnerability_scanner.py
+++ b/skylos/rules/sca/vulnerability_scanner.py
@@ -141,6 +141,16 @@ def _requirements_declaration_count(text: str) -> int:
     )
 
 
+_PACKAGE_JSON_DEPENDENCY_SECTIONS = frozenset(
+    {
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    }
+)
+
+
 def _package_json_declaration_count(text: str) -> int:
     try:
         data = json.loads(text)
@@ -148,7 +158,7 @@ def _package_json_declaration_count(text: str) -> int:
         return 0
     return sum(
         len(section)
-        for key in ("dependencies", "devDependencies")
+        for key in _PACKAGE_JSON_DEPENDENCY_SECTIONS
         if isinstance((section := data.get(key)), dict)
     )
 
@@ -541,7 +551,7 @@ _NPM_JSON_STRUCTURAL_RE = re.compile(r'["{}\[\]:,]')
 
 
 def _npm_dependency_lines(
-    text: str, sections: tuple[str, ...]
+    text: str, sections: frozenset[str]
 ) -> dict[tuple[str, str], int]:
     """Map (section, dependency name) to the 1-indexed line of its declaring key.
 
@@ -625,9 +635,9 @@ def _parse_package_json(path: Path, *, allow_version_ranges: bool) -> list[dict]
     except Exception:
         return deps
 
-    dependency_lines = _npm_dependency_lines(txt, ("dependencies", "devDependencies"))
+    dependency_lines = _npm_dependency_lines(txt, _PACKAGE_JSON_DEPENDENCY_SECTIONS)
 
-    for section in ("dependencies", "devDependencies"):
+    for section in sorted(_PACKAGE_JSON_DEPENDENCY_SECTIONS):
         pkg_deps = data.get(section, {})
         if not isinstance(pkg_deps, dict):
             continue

--- a/test/test_sca_cache.py
+++ b/test/test_sca_cache.py
@@ -1,3 +1,5 @@
+import json
+
 from skylos.rules.sca import vulnerability_scanner as sca
 
 
@@ -238,9 +240,10 @@ def test_npm_finding_line_anchors_correctly_when_section_is_a_single_line(tmp_pa
 
 
 def test_npm_finding_line_ignores_same_name_nested_under_overrides(tmp_path):
-    # This scanner only ever reads the top-level "dependencies" and
-    # "devDependencies" objects (overrides are not scanned as candidates at
-    # all), so a same-named key nested inside "overrides" must never hijack
+    # This scanner only ever reads the top-level objects named by
+    # _PACKAGE_JSON_DEPENDENCY_SECTIONS (overrides are not scanned as
+    # candidates at all), so a same-named key nested inside "overrides"
+    # must never hijack
     # the line reported for the real top-level entry, however deeply nested
     # or however many times the name repeats underneath it.
     package_json = tmp_path / "package.json"
@@ -264,6 +267,75 @@ def test_npm_finding_line_ignores_same_name_nested_under_overrides(tmp_path):
     [item] = sca.parse_package_json_candidates(package_json)
     assert item["name"] == "foo"
     assert item["line"] == 2
+
+
+def test_npm_scans_peer_and_optional_dependency_sections(tmp_path):
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        """
+{
+  "dependencies": { "runtime-dep": "1.0.0" },
+  "devDependencies": { "dev-dep": "2.0.0" },
+  "peerDependencies": { "peer-dep": "3.0.0" },
+  "optionalDependencies": { "optional-dep": "4.0.0" }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # Sections are walked in sorted order, so results stay in the same order
+    # from run to run even though the section names live in a frozenset.
+    assert [
+        (item["name"], item["version"], item["line"])
+        for item in sca.parse_package_json(package_json)
+    ] == [
+        ("runtime-dep", "1.0.0", 2),
+        ("dev-dep", "2.0.0", 3),
+        ("optional-dep", "4.0.0", 5),
+        ("peer-dep", "3.0.0", 4),
+    ]
+
+
+def test_npm_finding_line_anchors_peer_and_optional_entries(tmp_path):
+    # The same name declared as both a peer and an optional dependency has to
+    # anchor to its own declaring section rather than to the first textual
+    # occurrence of the name (here, one line above inside "keywords").
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        """
+{
+  "keywords": ["react"],
+  "peerDependencies": { "react": "18.0.0" },
+  "optionalDependencies": {
+    "react": "17.0.0"
+  }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert [
+        (item["version"], item["line"])
+        for item in sca.parse_package_json_candidates(package_json)
+    ] == [("17.0.0", 5), ("18.0.0", 3)]
+
+
+def test_npm_declaration_count_tracks_every_scanned_section(tmp_path):
+    # _package_json_declaration_count feeds unresolved_dependency_count as
+    # declared_count - len(parsed), so it has to count exactly the sections
+    # the parser walks. Building the manifest from the shared constant means
+    # adding a section without teaching both sides fails here.
+    sections = sorted(sca._PACKAGE_JSON_DEPENDENCY_SECTIONS)
+    text = json.dumps(
+        {section: {f"pkg-{index}": "1.0.0"} for index, section in enumerate(sections)}
+    )
+    package_json = tmp_path / "package.json"
+    package_json.write_text(text, encoding="utf-8")
+
+    assert sca._declared_dependency_count("package.json", text) == len(sections)
+    assert len(sca.parse_package_json(package_json)) == len(sections)
 
 
 def test_poetry_multiple_constraint_versions_are_preserved(tmp_path):
@@ -351,6 +423,39 @@ def test_scan_receipt_counts_unresolved_ranges(monkeypatch, tmp_path):
 
     assert [(item["name"], item["version"]) for item in queried] == [("exact", "1.2.3")]
     assert result.receipt["unresolved_dependency_count"] == 1
+    assert result.receipt["status"] == "complete_with_unresolved_versions"
+
+
+def test_scan_receipt_counts_unresolved_peer_and_optional_ranges(monkeypatch, tmp_path):
+    monkeypatch.setattr(sca, "_requests", object())
+    (tmp_path / "package.json").write_text(
+        '{"peerDependencies":{"peer-exact":"1.2.3","peer-range":"^2.0.0"},'
+        '"optionalDependencies":{"optional-range":"^3.0.0"}}',
+        encoding="utf-8",
+    )
+    queried = []
+
+    def fake_query(deps, cache):
+        queried.extend(deps)
+        return sca.OsvQueryResult(
+            [],
+            receipt={
+                "status": "complete",
+                "complete": True,
+                "requested_batches": 1,
+                "successful_batches": 1,
+                "failed_batches": 0,
+            },
+        )
+
+    monkeypatch.setattr(sca, "_query_osv_batch", fake_query)
+
+    result = sca.scan_dependencies(tmp_path)
+
+    assert [(item["name"], item["version"]) for item in queried] == [
+        ("peer-exact", "1.2.3")
+    ]
+    assert result.receipt["unresolved_dependency_count"] == 2
     assert result.receipt["status"] == "complete_with_unresolved_versions"
 
 


### PR DESCRIPTION
Small follow-up commit to #748 based on review/discussion with @AmirF194, adding the two missing dependency sections that are present elsewhere. I didn't open an issue because it is small and already described in the comments, but I can if @duriantaco prefers a strict always-close-a-linked-issue policy.

Note: Arguably, a regular tuple would have been just as good or better here (theoretical but microscopic perf win), but I preserved the frozenset to make it _identical_ to the other frozenset in the codebase.

**AI Use Disclosure**
I designed the change exactly, and Claude Opus 5.0 drafted the unit tests to ensure it landed. A separate Opus 5.0 agent and GPT-5.6 sol reviewed the change according to repository llm review guidelines. I verified with `liveness_primer` on an expanded corpus that the change produces 0 diffs in the current available corpus (expected limitation; well-maintained production codebases should have few recall anchors for hallucinated dependencies).

**Review Note**
Both llm reviewers flagged that currently, this could theoretically flag hallucinated optionalDependencies or peerDependencies declaration that can never _actually_ be installed. My opinion was that flagging in that case is justifiable as more conservative behavior, and that is, if anything, the most plausible way that a hallucinated dependency declaration could subtly creep into a production deployment. 

**Note for @AmirF194**
I had already drafted this when you mentioned interest in doing it; I'm not going to do the override scanning part that I also mentioned right now (its not quite such a micro change) so if that part was still in the scope of what you wanted to do go for it.

## Problem

The SCA scanner only reads `dependencies` and `devDependencies` out of `package.json`. `peerDependencies` and `optionalDependencies` are skipped entirely, so a pinned vulnerable version declared there is never queried against OSV, and the manifest hallucination rule never verifies those names against the npm registry.

This also makes `vulnerability_scanner.py` the odd one out. `skylos/rules/ai_defect/diff_dependencies.py` has walked all four sections since #628, and `skylos/visitors/languages/typescript/workspace.py` walks all four too — only the SCA path was narrow.

## Change

Introduce `_PACKAGE_JSON_DEPENDENCY_SECTIONS`, a frozenset shared by the three places that need the section list:

- `_parse_package_json`, which produces the dependency candidates;
- `_npm_dependency_lines`, the line-anchoring pass added in #748 (it only membership-tests its `sections` argument, so it takes the frozenset directly);
- `_package_json_declaration_count`, which feeds `unresolved_dependency_count` as `declared_count - len(parsed)` and therefore has to count exactly the sections the parser walks.

Those three lists cannot drift apart now. The parse loop iterates `sorted()` so finding order stays stable under hash randomization — `list(frozenset)` of these four names differs from sorted order on every `PYTHONHASHSEED` I tried, so this is load-bearing, and the sorted order preserves the existing `dependencies` → `devDependencies` relative ordering.

## Tests

Four tests over the widened section list, each verified to fail against the pre-change scanner:

- peer and optional entries parse with the right names, versions and line anchors, in the deterministic sorted-section order;
- a name declared in both `peerDependencies` and `optionalDependencies` anchors to its own declaring section rather than the first textual match, including when a section is written on a single line (this is #748's walker doing the work for the new sections);
- `_package_json_declaration_count` counts exactly what the parser walks — the manifest is built from the shared constant, so re-hardcoding a divergent list in either place fails here;
- `unresolved_dependency_count` stays correct end to end when the new sections carry version ranges.

Full suite: 7073 passed, 7 skipped. The two failures in `test_agent_behavior_contract.py` / `test_agent_behavior_openai.py` (`..._reject_excessive_json_nesting_without_crashing`) reproduce identically on unmodified `main` here and are unrelated to this change.

Beyond the suite I ran two 4000-case fuzz passes over randomized four-section manifests (compact, indented, single-line sections, `overrides` decoys, `peerDependenciesMeta`, scoped/escaped/non-ASCII names): every reported line contains its declaring key, repeat parses are identical, and parsed name/version pairs match an independent reimplementation of the section walk and version-resolution rules for both the exact-only and candidate parsers.

## Notes

Worth flagging for review: peer and optional deps are not necessarily installed by the scanned project, and no dep dict in this file carries a section marker, so a peer-dep finding currently reads the same as a runtime one. Also expect `unresolved_dependency_count` to tick up on repos with peer ranges, flipping receipt status to `complete_with_unresolved_versions` more often. Both seem like separate follow-ups rather than something to fold in here — happy to add a `section` field if you'd prefer it in this PR.

Draft because I'd like your read on the peer/optional scanning question above before it's finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
