### PR TITLE
fix(dead-code): preserve signature contract parameters

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -58,6 +58,7 @@ from skylos.core.file_discovery import (
 )
 from skylos.core.safe_cache_io import read_project_text_no_symlink
 from skylos.core.linter import LinterVisitor
+from skylos.deadcode.signature_contracts import mark_signature_contract_parameters
 
 from skylos.rules.quality.policy import analyze_repo_policy
 from skylos.rules.vibe_dictionary import build_vibe_dictionary
@@ -4373,6 +4374,7 @@ class Skylos:
             progress_callback(0, 1, Path("PHASE: mark refs"))
         self._mark_refs(progress_callback=progress_callback)
         self._mark_call_arg_method_refs()
+        mark_signature_contract_parameters(self.defs)
 
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: dead-code liveness"))

--- a/skylos/deadcode/signature_contracts.py
+++ b/skylos/deadcode/signature_contracts.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from collections.abc import Mapping
+from typing import Any
+
+
+def _shared_signature_parameters(
+    child: ast.FunctionDef | ast.AsyncFunctionDef,
+    parent: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[set[str], set[str]]:
+    """Return child and parent parameter names occupying shared API slots."""
+    child_names: set[str] = set()
+    parent_names: set[str] = set()
+
+    for child_arg, parent_arg in zip(
+        child.args.posonlyargs, parent.args.posonlyargs
+    ):
+        child_names.add(child_arg.arg)
+        parent_names.add(parent_arg.arg)
+
+    shared_positional_names = {
+        arg.arg for arg in child.args.args
+    } & {arg.arg for arg in parent.args.args}
+    child_names.update(shared_positional_names)
+    parent_names.update(shared_positional_names)
+
+    shared_keyword_names = {
+        arg.arg for arg in child.args.kwonlyargs
+    } & {arg.arg for arg in parent.args.kwonlyargs}
+    child_names.update(shared_keyword_names)
+    parent_names.update(shared_keyword_names)
+
+    if child.args.vararg is not None and parent.args.vararg is not None:
+        child_names.add(child.args.vararg.arg)
+        parent_names.add(parent.args.vararg.arg)
+    if child.args.kwarg is not None and parent.args.kwarg is not None:
+        child_names.add(child.args.kwarg.arg)
+        parent_names.add(parent.args.kwarg.arg)
+
+    return child_names, parent_names
+
+
+def _joined_string_static_affixes(expr: ast.expr) -> tuple[str, str] | None:
+    if not isinstance(expr, ast.JoinedStr):
+        return None
+
+    dynamic_indexes = [
+        index
+        for index, value in enumerate(expr.values)
+        if isinstance(value, ast.FormattedValue)
+    ]
+    if len(dynamic_indexes) != 1:
+        return None
+
+    dynamic_index = dynamic_indexes[0]
+    dynamic_value = expr.values[dynamic_index]
+    if (
+        not isinstance(dynamic_value, ast.FormattedValue)
+        or isinstance(dynamic_value.value, ast.Constant)
+        or dynamic_value.conversion != -1
+        or dynamic_value.format_spec is not None
+    ):
+        return None
+    prefix_parts: list[str] = []
+    suffix_parts: list[str] = []
+    for index, value in enumerate(expr.values):
+        if index == dynamic_index:
+            continue
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            return None
+        target = prefix_parts if index < dynamic_index else suffix_parts
+        target.append(value.value)
+
+    prefix = "".join(prefix_parts)
+    suffix = "".join(suffix_parts)
+    return (prefix, suffix) if prefix or suffix else None
+
+
+def _dynamic_dispatch_keyword_contracts(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    binding_kind: str,
+) -> set[tuple[str, str]]:
+    """Return method-name affixes for dispatchers that forward ``**kwargs``."""
+    positional_args = [*node.args.posonlyargs, *node.args.args]
+    if (
+        node.args.kwarg is None
+        or binding_kind == "static"
+        or not positional_args
+        or _function_binds_name(node, "getattr")
+    ):
+        return set()
+
+    kwarg_name = node.args.kwarg.arg
+    receiver_name = positional_args[0].arg
+    contracts: set[tuple[str, str]] = set()
+    stack: list[ast.AST] = list(reversed(node.body))
+    while stack:
+        candidate = stack.pop()
+        if isinstance(
+            candidate,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
+        ):
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(candidate))))
+
+        call = candidate
+        if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Call):
+            continue
+
+        getter = call.func
+        if (
+            not isinstance(getter.func, ast.Name)
+            or getter.func.id != "getattr"
+            or len(getter.args) < 2
+            or not isinstance(getter.args[0], ast.Name)
+            or getter.args[0].id != receiver_name
+        ):
+            continue
+
+        affixes = _joined_string_static_affixes(getter.args[1])
+        if affixes is None:
+            continue
+
+        forwards_kwargs = any(
+            keyword.arg is None
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == kwarg_name
+            for keyword in call.keywords
+        )
+        if forwards_kwargs:
+            contracts.add(affixes)
+
+    return contracts
+
+
+def _mark_contract_parameter(parameter_def: Any) -> None:
+    parameter_def.references = max(parameter_def.references, 1)
+    heuristic_refs = getattr(parameter_def, "heuristic_refs", None)
+    if isinstance(heuristic_refs, dict):
+        heuristic_refs["signature_contract"] = max(
+            heuristic_refs.get("signature_contract", 0.0), 1.0
+        )
+
+
+def _method_binding_kind(method_def: Any) -> str:
+    decorator_names = {
+        decorator.rsplit(".", 1)[-1]
+        for decorator in getattr(method_def, "decorators", [])
+    }
+    if "staticmethod" in decorator_names:
+        return "static"
+    if "classmethod" in decorator_names:
+        return "class"
+    return "instance"
+
+
+class _ClassBindingCollector(ast.NodeVisitor):
+    """Collect names a compound class-body statement may bind."""
+
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.names.add(node.id)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.names.add(node.name)
+        self._visit_function_header(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.names.add(node.name)
+        self._visit_function_header(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.names.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+
+    def _visit_function_header(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in node.args.defaults:
+            self.visit(default)
+        for default in node.args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self.names.update(
+            imported.asname or imported.name.split(".", 1)[0]
+            for imported in node.names
+        )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        self.names.update(
+            imported.asname or imported.name for imported in node.names
+        )
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name is not None:
+            self.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node: ast.MatchAs) -> None:
+        if node.name is not None:
+            self.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchStar(self, node: ast.MatchStar) -> None:
+        if node.name is not None:
+            self.names.add(node.name)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+        if node.rest is not None:
+            self.names.add(node.rest)
+        self.generic_visit(node)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node.generators, node.elt)
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node.generators, node.elt)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node.generators, node.elt)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node.generators, node.key, node.value)
+
+    def _visit_comprehension(
+        self,
+        generators: list[ast.comprehension],
+        *values: ast.expr,
+    ) -> None:
+        for generator in generators:
+            self.visit(generator.iter)
+            for condition in generator.ifs:
+                self.visit(condition)
+        for value in values:
+            self.visit(value)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in node.args.defaults:
+            self.visit(default)
+        for default in node.args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+
+
+def _function_binds_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    name: str,
+) -> bool:
+    parameters = {
+        argument.arg
+        for argument in (
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+        )
+    }
+    if node.args.vararg is not None:
+        parameters.add(node.args.vararg.arg)
+    if node.args.kwarg is not None:
+        parameters.add(node.args.kwarg.arg)
+    if name in parameters:
+        return True
+
+    collector = _ClassBindingCollector()
+    for statement in node.body:
+        collector.visit(statement)
+    return name in collector.names
+
+
+def _compound_class_bindings(statement: ast.stmt) -> set[str]:
+    collector = _ClassBindingCollector()
+    collector.visit(statement)
+    return collector.names
+
+
+def _class_namespace_members(
+    class_def: Any,
+    methods: Mapping[str, Any],
+) -> dict[str, Any | None]:
+    """Return conservative final bindings for a class namespace."""
+    members: dict[str, Any | None] = {}
+    for statement in class_def.node.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for name in _compound_class_bindings(statement):
+                members[name] = None
+            members[statement.name] = methods.get(statement.name)
+            continue
+        if isinstance(statement, ast.ClassDef):
+            for name in _compound_class_bindings(statement):
+                members[name] = None
+            continue
+        for name in _compound_class_bindings(statement):
+            members[name] = None
+    return members
+
+
+def _merge_c3_mro(sequences: list[list[str]]) -> list[str] | None:
+    merged: list[str] = []
+    while True:
+        sequences = [sequence for sequence in sequences if sequence]
+        if not sequences:
+            return merged
+
+        candidate = next(
+            (
+                sequence[0]
+                for sequence in sequences
+                if not any(sequence[0] in other[1:] for other in sequences)
+            ),
+            None,
+        )
+        if candidate is None:
+            return None
+        merged.append(candidate)
+        for sequence in sequences:
+            if sequence and sequence[0] == candidate:
+                sequence.pop(0)
+
+
+def mark_signature_contract_parameters(
+    definitions: Mapping[str, Any],
+) -> None:
+    """Keep parameters required by resolvable override and dispatch contracts."""
+    class_defs = {
+        defn.name: defn
+        for defn in definitions.values()
+        if defn.type == "class" and isinstance(defn.node, ast.ClassDef)
+    }
+    if not class_defs:
+        return
+
+    suffix_to_classes: dict[str, set[str]] = defaultdict(set)
+    for class_qname in class_defs:
+        parts = class_qname.split(".")
+        for index in range(len(parts)):
+            suffix_to_classes[".".join(parts[index:])].add(class_qname)
+
+    def resolve_class(raw_qname: str) -> str | None:
+        if raw_qname in class_defs:
+            return raw_qname
+        candidates = suffix_to_classes.get(raw_qname, set())
+        if len(candidates) == 1:
+            return next(iter(candidates))
+        return None
+
+    parents_of: dict[str, set[str]] = defaultdict(set)
+    ordered_parents_of: dict[str, tuple[str, ...]] = {}
+    hierarchy_is_complete: dict[str, bool] = {}
+    for class_qname, class_def in class_defs.items():
+        raw_bases = list(getattr(class_def, "base_classes", []))
+        ordered_parents: list[str] = []
+        hierarchy_is_complete[class_qname] = len(raw_bases) == len(
+            class_def.node.bases
+        )
+        for raw_base in raw_bases:
+            resolved = resolve_class(raw_base)
+            if resolved is not None and resolved != class_qname:
+                parents_of[class_qname].add(resolved)
+                if resolved not in ordered_parents:
+                    ordered_parents.append(resolved)
+            elif resolved is None:
+                hierarchy_is_complete[class_qname] = False
+        ordered_parents_of[class_qname] = tuple(ordered_parents)
+
+    class_methods = defaultdict(dict)
+    for defn in definitions.values():
+        if (
+            defn.type != "method"
+            or not isinstance(defn.node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            or "." not in defn.name
+        ):
+            continue
+        owner, method_name = defn.name.rsplit(".", 1)
+        if owner in class_defs:
+            class_methods[owner][method_name] = defn
+
+    class_members = {
+        class_qname: _class_namespace_members(
+            class_def,
+            class_methods.get(class_qname, {}),
+        )
+        for class_qname, class_def in class_defs.items()
+    }
+
+    parameter_defs = {
+        defn.name: defn
+        for defn in definitions.values()
+        if defn.type == "parameter"
+    }
+
+    def mark_parameters(method_def: Any, parameter_names: set[str]) -> None:
+        for parameter_name in parameter_names:
+            parameter_def = parameter_defs.get(f"{method_def.name}.{parameter_name}")
+            if parameter_def is not None:
+                _mark_contract_parameter(parameter_def)
+
+    ancestor_cache: dict[str, frozenset[str]] = {}
+    def ancestors(class_qname: str) -> frozenset[str]:
+        cached = ancestor_cache.get(class_qname)
+        if cached is not None:
+            return cached
+        found: set[str] = set()
+        stack = list(parents_of.get(class_qname, set()))
+        while stack:
+            parent = stack.pop()
+            if parent in found:
+                continue
+            found.add(parent)
+            stack.extend(parents_of.get(parent, set()))
+        result = frozenset(found)
+        ancestor_cache[class_qname] = result
+        return result
+
+    for child_qname, child_methods in class_methods.items():
+        for parent_qname in ancestors(child_qname):
+            parent_methods = class_methods.get(parent_qname, {})
+            for method_name in child_methods.keys() & parent_methods.keys():
+                if method_name.startswith("__") and not method_name.endswith(
+                    "__"
+                ):
+                    continue
+                child_method = child_methods[method_name]
+                parent_method = parent_methods[method_name]
+                if (
+                    class_members.get(child_qname, {}).get(method_name)
+                    is not child_method
+                    or class_members.get(parent_qname, {}).get(method_name)
+                    is not parent_method
+                ):
+                    continue
+                if _method_binding_kind(child_method) != _method_binding_kind(
+                    parent_method
+                ):
+                    continue
+                child_names, parent_names = _shared_signature_parameters(
+                    child_method.node, parent_method.node
+                )
+                mark_parameters(child_method, child_names)
+                mark_parameters(parent_method, parent_names)
+
+    dynamic_contracts_by_method: dict[str, set[tuple[str, str]]] = {}
+    dispatcher_names: set[str] = set()
+    for class_qname, methods in class_methods.items():
+        module_qname = class_qname.rsplit(".", 1)[0]
+        module_shadows_getattr = bool(
+            getattr(class_defs[class_qname], "module_shadows_getattr", False)
+            or f"{module_qname}.getattr" in definitions
+        )
+        for dispatcher_name, method_def in methods.items():
+            if module_shadows_getattr:
+                continue
+            contracts = _dynamic_dispatch_keyword_contracts(
+                method_def.node,
+                _method_binding_kind(method_def),
+            )
+            if not contracts:
+                continue
+            dynamic_contracts_by_method[method_def.name] = contracts
+            dispatcher_names.add(dispatcher_name)
+
+    if not dynamic_contracts_by_method:
+        return
+
+    mro_cache: dict[str, tuple[str, ...] | None] = {}
+
+    def class_mro(
+        class_qname: str,
+        visiting: frozenset[str] = frozenset(),
+    ) -> tuple[str, ...] | None:
+        if class_qname in mro_cache:
+            return mro_cache[class_qname]
+        if class_qname in visiting or not hierarchy_is_complete.get(
+            class_qname, False
+        ):
+            mro_cache[class_qname] = None
+            return None
+
+        parent_mros: list[list[str]] = []
+        next_visiting = visiting | {class_qname}
+        for parent_qname in ordered_parents_of.get(class_qname, ()):
+            parent_mro = class_mro(parent_qname, next_visiting)
+            if parent_mro is None:
+                mro_cache[class_qname] = None
+                return None
+            parent_mros.append(list(parent_mro))
+
+        merged = _merge_c3_mro(
+            [*parent_mros, list(ordered_parents_of.get(class_qname, ()))]
+        )
+        if merged is None:
+            mro_cache[class_qname] = None
+            return None
+        result = (class_qname, *merged)
+        mro_cache[class_qname] = result
+        return result
+
+    def visible_member(
+        mro: tuple[str, ...],
+        member_name: str,
+    ) -> tuple[bool, Any | None]:
+        for owner_qname in mro:
+            members = class_members.get(owner_qname, {})
+            if member_name in members:
+                return True, members[member_name]
+        return False, None
+
+    for class_qname in class_defs:
+        resolved_mro = class_mro(class_qname)
+        mro = resolved_mro if resolved_mro is not None else (class_qname,)
+        visible_names = {
+            member_name
+            for owner_qname in mro
+            for member_name in class_members.get(owner_qname, {})
+        }
+        for dispatcher_name in dispatcher_names:
+            found_dispatcher, dispatcher_method = visible_member(
+                mro, dispatcher_name
+            )
+            if not found_dispatcher or dispatcher_method is None:
+                continue
+            contracts = dynamic_contracts_by_method.get(dispatcher_method.name)
+            if not contracts:
+                continue
+            for method_prefix, method_suffix in contracts:
+                for method_name in visible_names:
+                    if not (
+                        method_name.startswith(method_prefix)
+                        and method_name.endswith(method_suffix)
+                        and len(method_name)
+                        >= len(method_prefix) + len(method_suffix)
+                    ):
+                        continue
+                    found_handler, handler_method = visible_member(mro, method_name)
+                    if not found_handler or handler_method is None:
+                        continue
+                    method_node = handler_method.node
+                    if method_node.args.kwarg is not None:
+                        mark_parameters(
+                            handler_method,
+                            {method_node.args.kwarg.arg},
+                        )

--- a/skylos/rules/quality/_protocols.py
+++ b/skylos/rules/quality/_protocols.py
@@ -1,6 +1,5 @@
 import ast
 
-
 _PROTOCOL_MODULES = frozenset({"typing", "typing_extensions"})
 
 
@@ -67,23 +66,6 @@ def protocol_method_ids(module: ast.Module) -> set[int]:
     }
 
 
-def _type_checking_import_bindings(module: ast.Module) -> tuple[set[str], set[str]]:
-    type_checking_names: set[str] = set()
-    typing_modules: set[str] = set()
-
-    for stmt in module.body:
-        if isinstance(stmt, ast.ImportFrom) and stmt.module in _PROTOCOL_MODULES:
-            for imported in stmt.names:
-                if imported.name == "TYPE_CHECKING":
-                    type_checking_names.add(imported.asname or imported.name)
-        elif isinstance(stmt, ast.Import):
-            for imported in stmt.names:
-                if imported.name in _PROTOCOL_MODULES:
-                    typing_modules.add(imported.asname or imported.name)
-
-    return type_checking_names, typing_modules
-
-
 def _is_type_checking_guard(
     test: ast.expr,
     type_checking_names: set[str],
@@ -100,22 +82,461 @@ def _is_type_checking_guard(
 
 
 def type_checking_function_ids(module: ast.Module) -> set[int]:
-    type_checking_names, typing_modules = _type_checking_import_bindings(module)
-    if not type_checking_names and not typing_modules:
-        return set()
-
     function_ids: set[int] = set()
-    for candidate in ast.walk(module):
-        if not isinstance(candidate, ast.If) or not _is_type_checking_guard(
-            candidate.test,
-            type_checking_names,
-            typing_modules,
-        ):
-            continue
-        for stmt in candidate.body:
-            function_ids.update(
-                id(child)
-                for child in ast.walk(stmt)
-                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+
+    class BindingCollector(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.names: set[str] = set()
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if isinstance(node.ctx, (ast.Store, ast.Del)):
+                self.names.add(node.id)
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.names.add(node.name)
+            self._visit_function_header(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self.names.add(node.name)
+            self._visit_function_header(node)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            self.names.add(node.name)
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for base in node.bases:
+                self.visit(base)
+            for keyword in node.keywords:
+                self.visit(keyword.value)
+
+        def _visit_function_header(
+            self,
+            node: ast.FunctionDef | ast.AsyncFunctionDef,
+        ) -> None:
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for default in node.args.defaults:
+                self.visit(default)
+            for default in node.args.kw_defaults:
+                if default is not None:
+                    self.visit(default)
+
+        def visit_Import(self, node: ast.Import) -> None:
+            self.names.update(
+                imported.asname or imported.name.split(".", 1)[0]
+                for imported in node.names
             )
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            self.names.update(
+                imported.asname or imported.name for imported in node.names
+            )
+
+        def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+            if node.name is not None:
+                self.names.add(node.name)
+            self.generic_visit(node)
+
+        def visit_MatchAs(self, node: ast.MatchAs) -> None:
+            if node.name is not None:
+                self.names.add(node.name)
+            self.generic_visit(node)
+
+        def visit_MatchStar(self, node: ast.MatchStar) -> None:
+            if node.name is not None:
+                self.names.add(node.name)
+
+        def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+            if node.rest is not None:
+                self.names.add(node.rest)
+            self.generic_visit(node)
+
+        def visit_ListComp(self, node: ast.ListComp) -> None:
+            self._visit_comprehension(node.generators, node.elt)
+
+        def visit_SetComp(self, node: ast.SetComp) -> None:
+            self._visit_comprehension(node.generators, node.elt)
+
+        def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+            self._visit_comprehension(node.generators, node.elt)
+
+        def visit_DictComp(self, node: ast.DictComp) -> None:
+            self._visit_comprehension(node.generators, node.key, node.value)
+
+        def _visit_comprehension(
+            self,
+            generators: list[ast.comprehension],
+            *values: ast.expr,
+        ) -> None:
+            for generator in generators:
+                self.visit(generator.iter)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            for value in values:
+                self.visit(value)
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            for default in node.args.defaults:
+                self.visit(default)
+            for default in node.args.kw_defaults:
+                if default is not None:
+                    self.visit(default)
+
+    class FunctionBindingCollector(BindingCollector):
+        def __init__(self) -> None:
+            super().__init__()
+            self.nonlocal_names: set[str] = set()
+
+        def visit_Global(self, node: ast.Global) -> None:
+            self.nonlocal_names.update(node.names)
+
+        def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+            self.nonlocal_names.update(node.names)
+
+    class ClosureAliasCollector(BindingCollector):
+        def __init__(self) -> None:
+            super().__init__()
+            self.typing_kinds: dict[str, set[str]] = {}
+
+        def _record_typing_kind(self, name: str, kind: str) -> None:
+            self.typing_kinds.setdefault(name, set()).add(kind)
+
+        def visit_Import(self, node: ast.Import) -> None:
+            for imported in node.names:
+                local_name = imported.asname or imported.name.split(".", 1)[0]
+                if imported.name in _PROTOCOL_MODULES:
+                    self._record_typing_kind(local_name, "module")
+                else:
+                    self.names.add(local_name)
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            for imported in node.names:
+                local_name = imported.asname or imported.name
+                if (
+                    node.module in _PROTOCOL_MODULES
+                    and imported.name == "TYPE_CHECKING"
+                ):
+                    self._record_typing_kind(local_name, "sentinel")
+                else:
+                    self.names.add(local_name)
+
+    def bound_names(node: ast.AST) -> set[str]:
+        collector = BindingCollector()
+        collector.visit(node)
+        return collector.names
+
+    def function_local_names(
+        function: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> set[str]:
+        collector = FunctionBindingCollector()
+        collector.names.update(
+            argument.arg
+            for argument in (
+                *function.args.posonlyargs,
+                *function.args.args,
+                *function.args.kwonlyargs,
+            )
+        )
+        if function.args.vararg is not None:
+            collector.names.add(function.args.vararg.arg)
+        if function.args.kwarg is not None:
+            collector.names.add(function.args.kwarg.arg)
+        for child_statement in function.body:
+            collector.visit(child_statement)
+        return collector.names - collector.nonlocal_names
+
+    def closure_unsafe_names(
+        statements: list[ast.stmt],
+        parameters: set[str] | None = None,
+    ) -> set[str]:
+        collector = ClosureAliasCollector()
+        if parameters:
+            collector.names.update(parameters)
+        for statement in statements:
+            collector.visit(statement)
+        collector.names.update(
+            name
+            for name, kinds in collector.typing_kinds.items()
+            if len(kinds) != 1
+        )
+        return collector.names
+
+    def discard_bindings(
+        names: set[str],
+        type_checking_names: set[str],
+        typing_modules: set[str],
+    ) -> None:
+        type_checking_names.difference_update(names)
+        typing_modules.difference_update(names)
+
+    def scan_statements(
+        statements: list[ast.stmt],
+        type_checking_names: set[str],
+        typing_modules: set[str],
+        *,
+        scope_kind: str,
+        class_function_type_checking_names: set[str] | None = None,
+        class_function_typing_modules: set[str] | None = None,
+        nested_function_unsafe_names: set[str] | None = None,
+    ) -> None:
+        def scan_branch(
+            branch: list[ast.stmt],
+            shadowed_names: set[str] | None = None,
+        ) -> None:
+            branch_type_checking_names = set(type_checking_names)
+            branch_typing_modules = set(typing_modules)
+            if shadowed_names:
+                discard_bindings(
+                    shadowed_names,
+                    branch_type_checking_names,
+                    branch_typing_modules,
+                )
+            scan_statements(
+                branch,
+                branch_type_checking_names,
+                branch_typing_modules,
+                scope_kind=scope_kind,
+                class_function_type_checking_names=(
+                    class_function_type_checking_names
+                ),
+                class_function_typing_modules=class_function_typing_modules,
+                nested_function_unsafe_names=nested_function_unsafe_names,
+            )
+
+        for statement in statements:
+            if isinstance(statement, ast.Import):
+                for imported in statement.names:
+                    local_name = imported.asname or imported.name.split(".", 1)[0]
+                    discard_bindings(
+                        {local_name}, type_checking_names, typing_modules
+                    )
+                    if imported.name in _PROTOCOL_MODULES:
+                        typing_modules.add(local_name)
+                continue
+
+            if isinstance(statement, ast.ImportFrom):
+                for imported in statement.names:
+                    local_name = imported.asname or imported.name
+                    discard_bindings(
+                        {local_name}, type_checking_names, typing_modules
+                    )
+                    if (
+                        statement.module in _PROTOCOL_MODULES
+                        and imported.name == "TYPE_CHECKING"
+                    ):
+                        type_checking_names.add(local_name)
+                continue
+
+            if isinstance(statement, ast.If):
+                is_type_checking = _is_type_checking_guard(
+                    statement.test,
+                    type_checking_names,
+                    typing_modules,
+                )
+                if is_type_checking:
+                    for child_statement in statement.body:
+                        function_ids.update(
+                            id(child)
+                            for child in ast.walk(child_statement)
+                            if isinstance(
+                                child, (ast.FunctionDef, ast.AsyncFunctionDef)
+                            )
+                        )
+                else:
+                    scan_branch(statement.body, bound_names(statement.test))
+
+                scan_branch(statement.orelse, bound_names(statement.test))
+                discard_bindings(
+                    bound_names(statement),
+                    type_checking_names,
+                    typing_modules,
+                )
+                continue
+
+            if isinstance(statement, (ast.For, ast.AsyncFor)):
+                loop_bindings = bound_names(statement.target) | bound_names(
+                    statement.iter
+                )
+                scan_branch(statement.body, loop_bindings)
+                scan_branch(statement.orelse, loop_bindings)
+                discard_bindings(
+                    bound_names(statement),
+                    type_checking_names,
+                    typing_modules,
+                )
+                continue
+
+            if isinstance(statement, ast.While):
+                test_bindings = bound_names(statement.test)
+                scan_branch(statement.body, test_bindings)
+                scan_branch(statement.orelse, test_bindings)
+                discard_bindings(
+                    bound_names(statement),
+                    type_checking_names,
+                    typing_modules,
+                )
+                continue
+
+            if isinstance(statement, (ast.With, ast.AsyncWith)):
+                with_bindings: set[str] = set()
+                for item in statement.items:
+                    with_bindings.update(bound_names(item.context_expr))
+                    if item.optional_vars is not None:
+                        with_bindings.update(bound_names(item.optional_vars))
+                scan_branch(statement.body, with_bindings)
+                discard_bindings(
+                    bound_names(statement),
+                    type_checking_names,
+                    typing_modules,
+                )
+                continue
+
+            if isinstance(statement, ast.Try):
+                scan_branch(statement.body)
+                body_bindings = set().union(
+                    *(bound_names(child) for child in statement.body)
+                )
+                handler_body_bindings: set[str] = set()
+                for handler in statement.handlers:
+                    handler_bindings = (
+                        {handler.name} if handler.name is not None else set()
+                    )
+                    scan_branch(
+                        handler.body,
+                        body_bindings | handler_bindings,
+                    )
+                    handler_body_bindings.update(handler_bindings)
+                    handler_body_bindings.update(
+                        *(bound_names(child) for child in handler.body)
+                    )
+                scan_branch(statement.orelse, body_bindings)
+                else_bindings = set().union(
+                    *(bound_names(child) for child in statement.orelse)
+                )
+                scan_branch(
+                    statement.finalbody,
+                    body_bindings | handler_body_bindings | else_bindings,
+                )
+                discard_bindings(
+                    bound_names(statement),
+                    type_checking_names,
+                    typing_modules,
+                )
+                continue
+
+            if isinstance(statement, ast.Match):
+                subject_bindings = bound_names(statement.subject)
+                for case in statement.cases:
+                    case_bindings = subject_bindings | bound_names(case.pattern)
+                    if case.guard is not None:
+                        case_bindings.update(bound_names(case.guard))
+                    scan_branch(case.body, case_bindings)
+                discard_bindings(
+                    bound_names(statement),
+                    type_checking_names,
+                    typing_modules,
+                )
+                continue
+
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if scope_kind == "class":
+                    function_type_checking_names = set(
+                        class_function_type_checking_names or set()
+                    )
+                    function_typing_modules = set(
+                        class_function_typing_modules or set()
+                    )
+                else:
+                    function_type_checking_names = set(type_checking_names)
+                    function_typing_modules = set(typing_modules)
+                    discard_bindings(
+                        nested_function_unsafe_names or set(),
+                        function_type_checking_names,
+                        function_typing_modules,
+                    )
+                discard_bindings(
+                    function_local_names(statement) | {statement.name},
+                    function_type_checking_names,
+                    function_typing_modules,
+                )
+                scan_statements(
+                    statement.body,
+                    function_type_checking_names,
+                    function_typing_modules,
+                    scope_kind="function",
+                    nested_function_unsafe_names=closure_unsafe_names(
+                        statement.body,
+                        {
+                            argument.arg
+                            for argument in (
+                                *statement.args.posonlyargs,
+                                *statement.args.args,
+                                *statement.args.kwonlyargs,
+                            )
+                        }
+                        | (
+                            {statement.args.vararg.arg}
+                            if statement.args.vararg is not None
+                            else set()
+                        )
+                        | (
+                            {statement.args.kwarg.arg}
+                            if statement.args.kwarg is not None
+                            else set()
+                        ),
+                    ),
+                )
+
+            if isinstance(statement, ast.ClassDef):
+                if scope_kind == "class":
+                    nested_class_type_checking_names = set(
+                        class_function_type_checking_names or set()
+                    )
+                    nested_class_typing_modules = set(
+                        class_function_typing_modules or set()
+                    )
+                    nested_class_function_type_checking_names = set(
+                        class_function_type_checking_names or set()
+                    )
+                    nested_class_function_typing_modules = set(
+                        class_function_typing_modules or set()
+                    )
+                else:
+                    nested_class_type_checking_names = set(type_checking_names)
+                    nested_class_typing_modules = set(typing_modules)
+                    nested_class_function_type_checking_names = set(
+                        type_checking_names
+                    )
+                    nested_class_function_typing_modules = set(typing_modules)
+                    discard_bindings(
+                        nested_function_unsafe_names or set(),
+                        nested_class_function_type_checking_names,
+                        nested_class_function_typing_modules,
+                    )
+                scan_statements(
+                    statement.body,
+                    nested_class_type_checking_names,
+                    nested_class_typing_modules,
+                    scope_kind="class",
+                    class_function_type_checking_names=(
+                        nested_class_function_type_checking_names
+                    ),
+                    class_function_typing_modules=(
+                        nested_class_function_typing_modules
+                    ),
+                )
+
+            discard_bindings(
+                bound_names(statement),
+                type_checking_names,
+                typing_modules,
+            )
+
+    scan_statements(
+        module.body,
+        set(),
+        set(),
+        scope_kind="module",
+        nested_function_unsafe_names=closure_unsafe_names(module.body),
+    )
     return function_ids

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -199,6 +199,113 @@ def _is_intentional_discard_name(name: str) -> bool:
     return False
 
 
+def _is_not_implemented_error(expr: ast.expr | None) -> bool:
+    if isinstance(expr, ast.Call):
+        expr = expr.func
+    if isinstance(expr, ast.Name):
+        return expr.id == "NotImplementedError"
+    return isinstance(expr, ast.Attribute) and expr.attr == "NotImplementedError"
+
+
+def _has_signature_stub_body(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    """Return whether a function only declares an interface contract."""
+    body = list(node.body)
+    has_docstring = bool(
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    )
+    if has_docstring:
+        body = body[1:]
+
+    if not body:
+        return has_docstring
+
+    if len(body) != 1:
+        return False
+
+    stmt = body[0]
+    if isinstance(stmt, ast.Pass):
+        return has_docstring
+    return (
+        isinstance(stmt, ast.Expr)
+        and isinstance(stmt.value, ast.Constant)
+        and stmt.value.value is Ellipsis
+    ) or (
+        isinstance(stmt, ast.Raise) and _is_not_implemented_error(stmt.exc)
+    )
+
+
+def _module_binds_name(module: ast.Module, target_name: str) -> bool:
+    class BindingProbe(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.found = False
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if node.id == target_name and isinstance(node.ctx, (ast.Store, ast.Del)):
+                self.found = True
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            if node.name == target_name:
+                self.found = True
+            self._visit_function_header(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            if node.name == target_name:
+                self.found = True
+            self._visit_function_header(node)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            if node.name == target_name:
+                self.found = True
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for base in node.bases:
+                self.visit(base)
+            for keyword in node.keywords:
+                self.visit(keyword.value)
+
+        def _visit_function_header(
+            self,
+            node: ast.FunctionDef | ast.AsyncFunctionDef,
+        ) -> None:
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for default in node.args.defaults:
+                self.visit(default)
+            for default in node.args.kw_defaults:
+                if default is not None:
+                    self.visit(default)
+
+        def visit_Import(self, node: ast.Import) -> None:
+            self.found = self.found or any(
+                (imported.asname or imported.name.split(".", 1)[0])
+                == target_name
+                for imported in node.names
+            )
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            self.found = self.found or any(
+                (imported.asname or imported.name) == target_name
+                for imported in node.names
+            )
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            for default in node.args.defaults:
+                self.visit(default)
+            for default in node.args.kw_defaults:
+                if default is not None:
+                    self.visit(default)
+
+    probe = BindingProbe()
+    for statement in module.body:
+        probe.visit(statement)
+    return probe.found
+
+
 def _exception_type_leaf_names(exc_type: ast.expr | None) -> set[str]:
     if exc_type is None:
         return set()
@@ -248,6 +355,7 @@ class Definition:
         "suppression_code",
         "folder_role",
         "suppression_lines",
+        "module_shadows_getattr",
     )
 
     def __init__(
@@ -290,6 +398,7 @@ class Definition:
         self.suppression_code = None
         self.folder_role = None
         self.suppression_lines = {line}
+        self.module_shadows_getattr = False
 
     def to_dict(self) -> dict[str, Any]:
         if self.type == "method" and "." in self.name:
@@ -355,6 +464,7 @@ class Visitor(ast.NodeVisitor):
         self.refs = []
         self.cls = None
         self.alias = {}
+        self._alias_binding_lines: dict[str, int] = {}
         self.dyn = set()
         self.exports = set()
         self.current_function_scope = []
@@ -414,6 +524,8 @@ class Visitor(ast.NodeVisitor):
         self._used_attr_names_with_context = set()
         self._conditional_import_targets = set()
         self.local_registration_decorators = set()
+        self._type_checking_function_ids: set[int] = set()
+        self._module_shadows_getattr = False
 
     def add_def(
         self, name: str, t: str, line: int, node: Optional[ast.AST] = None, **extra: Any
@@ -456,9 +568,13 @@ class Visitor(ast.NodeVisitor):
             self.reverse_call_graph[name].add(self._current_function_qname)
 
     def visit_Module(self, node: ast.Module) -> None:
+        from skylos.rules.quality._protocols import type_checking_function_ids
+
         self.local_registration_decorators.update(
             collect_local_registration_decorators(node)
         )
+        self._type_checking_function_ids = type_checking_function_ids(node)
+        self._module_shadows_getattr = _module_binds_name(node, "getattr")
         for stmt in node.body:
             self.visit(stmt)
 
@@ -520,6 +636,7 @@ class Visitor(ast.NodeVisitor):
 
             line = getattr(a, "lineno", node.lineno)
             self.alias[alias_name] = target
+            self._alias_binding_lines[alias_name] = line
             self.add_def(
                 target,
                 "import",
@@ -576,6 +693,7 @@ class Visitor(ast.NodeVisitor):
 
             line = getattr(a, "lineno", node.lineno)
             self.alias[alias_name] = full
+            self._alias_binding_lines[alias_name] = line
             self.add_def(
                 full,
                 "import",
@@ -770,6 +888,35 @@ class Visitor(ast.NodeVisitor):
         if target:
             return f"{target}.{rest}"
         return name
+
+    def _alias_binding_is_active(
+        self,
+        name: str,
+        current_definition: str | None = None,
+    ) -> bool:
+        alias_line = self._alias_binding_lines.get(name)
+        if alias_line is None:
+            return False
+
+        if self.current_function_scope and self.local_var_maps:
+            if any(name in scope_map for scope_map in self.local_var_maps):
+                return False
+
+        candidates = []
+        if self.cls:
+            candidates.append(".".join(filter(None, [self.mod, self.cls, name])))
+        candidates.append(f"{self.mod}.{name}" if self.mod else name)
+        latest_local_line = max(
+            (
+                max(getattr(definition, "suppression_lines", {definition.line}))
+                for definition in self.defs
+                if definition.name in candidates
+                and definition.name != current_definition
+                and definition.type != "import"
+            ),
+            default=-1,
+        )
+        return alias_line > latest_local_line
 
     def _is_numba_overload_decorator(
         self, name: str, current_definition: str | None = None
@@ -990,6 +1137,8 @@ class Visitor(ast.NodeVisitor):
             self._in_protocol_class
             or getattr(self, "_in_abstract_or_overload", False)
             or is_explicit_override
+            or id(node) in self._type_checking_function_ids
+            or _has_signature_stub_body(node)
         )
 
         for arg in all_args:
@@ -1208,13 +1357,23 @@ class Visitor(ast.NodeVisitor):
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         cname = f"{self.mod}.{node.name}"
-        self.add_def(cname, "class", node.lineno, node=node)
+        self.add_def(
+            cname,
+            "class",
+            node.lineno,
+            node=node,
+            module_shadows_getattr=self._module_shadows_getattr,
+        )
 
         is_protocol = False
         for base in node.bases:
-            if isinstance(base, ast.Name) and base.id == "Protocol":
+            base_expr = base.value if isinstance(base, ast.Subscript) else base
+            if isinstance(base_expr, ast.Name) and base_expr.id == "Protocol":
                 is_protocol = True
-            elif isinstance(base, ast.Attribute) and base.attr == "Protocol":
+            elif (
+                isinstance(base_expr, ast.Attribute)
+                and base_expr.attr == "Protocol"
+            ):
                 is_protocol = True
 
         if is_protocol:
@@ -1223,13 +1382,22 @@ class Visitor(ast.NodeVisitor):
         base_qnames = []
 
         for base in node.bases:
+            base_expr = base.value if isinstance(base, ast.Subscript) else base
             base_name = None
-            if isinstance(base, ast.Name):
-                base_name = base.id
-                base_qnames.append(self.alias.get(base_name, self.qual(base_name)))
-            elif isinstance(base, ast.Attribute):
-                base_name = base.attr
-                base_qnames.append(self._get_attr_chain(base))
+            if isinstance(base_expr, ast.Name):
+                base_name = base_expr.id
+                if self._alias_binding_is_active(base_name, cname):
+                    base_qnames.append(self.alias[base_name])
+                elif not self.current_function_scope or not any(
+                    base_name in scope_map for scope_map in self.local_var_maps
+                ):
+                    base_qnames.append(self.qual(base_name))
+            elif isinstance(base_expr, ast.Attribute):
+                base_name = base_expr.attr
+                raw_qname = self._get_attr_chain(base_expr)
+                head, separator, tail = raw_qname.partition(".")
+                if separator and self._alias_binding_is_active(head, cname):
+                    base_qnames.append(f"{self.alias[head]}.{tail}")
 
             if not base_name:
                 continue

--- a/test/test_signature_contract_parameters.py
+++ b/test/test_signature_contract_parameters.py
@@ -1,0 +1,800 @@
+import json
+
+from skylos.analyzer import analyze
+
+
+def _analyze_sources(tmp_path, sources):
+    for filename, source in sources.items():
+        (tmp_path / filename).write_text(source, encoding="utf-8")
+
+    return json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+
+
+def _unused_parameters(tmp_path, sources):
+    result = _analyze_sources(tmp_path, sources)
+    return {finding["full_name"] for finding in result["unused_parameters"]}
+
+
+def test_issue_723_signature_contract_shapes_keep_only_controls(tmp_path):
+    unused = _unused_parameters(
+        tmp_path,
+        {
+            "contracts.py": '''
+from abc import ABC, abstractmethod
+import typing
+
+
+def pytest_addhooks(pluginmanager):
+    """Called to register additional hook specifications."""
+
+
+class ParamType:
+    def get_metavar(self, param, ctx):
+        """Return the metavar for this parameter."""
+
+
+class ChoiceType(ParamType):
+    def get_metavar(self, param, ctx):
+        return f"{param}:{ctx}"
+
+
+class BaseType(ABC):
+    @abstractmethod
+    def completion(self, manager, prefix):
+        """Return completion candidates."""
+
+
+class BoolType(BaseType):
+    def completion(self, manager, prefix):
+        return ["false", "true"]
+
+
+class MarkdownElement:
+    @classmethod
+    def create(cls, markdown, token):
+        return cls()
+
+
+class Heading(MarkdownElement):
+    @classmethod
+    def create(cls, markdown, token):
+        return cls(markdown, token)
+
+
+class RootVisitor:
+    def visit(self, node, **kwargs):
+        getattr(self, f"visit_{type(node).__name__}")(node, **kwargs)
+
+    def visit_AssignBlock(self, node, **kwargs):
+        for child in node.body:
+            self.visit(child)
+
+    def visit_CallBlock(self, node, **kwargs):
+        for child in node.body:
+            self.visit(child, depth=kwargs.get("depth", 0) + 1)
+
+
+class BaseModel:
+    def model_dump(self, **kwargs):
+        return dict(kwargs)
+
+
+class RootModel(BaseModel):
+    if typing.TYPE_CHECKING:
+        def model_dump(self, *, mode="python", include=None):
+            """Sharpen the inherited return type for static type checkers."""
+
+
+def render(text, unused_width):
+    return text.upper()
+
+
+class Formatter:
+    def format_value(self, value, unused_precision):
+        return value.strip()
+''',
+        },
+    )
+
+    assert unused == {
+        "contracts.render.unused_width",
+        "contracts.Formatter.format_value.unused_precision",
+    }
+
+
+def test_signature_stub_detection_is_narrow(tmp_path):
+    result = _analyze_sources(
+        tmp_path,
+        {
+            "stubs.py": '''
+def docstring_only(contract_arg):
+    """Interface declaration."""
+
+
+def bare_pass(contract_arg):
+    pass
+
+
+def docstring_and_pass(contract_arg):
+    """Interface declaration."""
+    pass
+
+
+def docstring_and_ellipsis(contract_arg):
+    """Interface declaration."""
+    ...
+
+
+def bare_ellipsis(contract_arg):
+    ...
+
+
+def bare_not_implemented(contract_arg):
+    raise NotImplementedError
+
+
+def raises_not_implemented(contract_arg):
+    """Interface declaration."""
+    raise NotImplementedError("implemented by adapters")
+
+
+def raises_qualified_not_implemented(contract_arg):
+    """Interface declaration."""
+    raise errors.NotImplementedError
+
+
+def concrete_return(real_unused):
+    """A concrete body still gets normal parameter analysis."""
+    return None
+
+
+def different_raise(real_unused):
+    raise ValueError("not an interface placeholder")
+
+
+def multiple_placeholders(real_unused):
+    pass
+    ...
+''',
+        },
+    )
+    unused = {
+        finding["full_name"] for finding in result["unused_parameters"]
+    }
+    unused_functions = {
+        finding["full_name"] for finding in result["unused_functions"]
+    }
+
+    assert unused == {
+        "stubs.bare_pass.contract_arg",
+        "stubs.concrete_return.real_unused",
+        "stubs.different_raise.real_unused",
+        "stubs.multiple_placeholders.real_unused",
+    }
+    assert "stubs.bare_pass" in unused_functions
+
+
+def test_type_checking_contract_scope_and_shadowing(tmp_path):
+    unused = _unused_parameters(
+        tmp_path,
+        {
+            "type_contracts.py": '''
+from typing import TYPE_CHECKING, TYPE_CHECKING as TC
+import typing as t
+
+runtime_flag = True
+
+if TC:
+    def alias_type_only(unused):
+        return None
+else:
+    def runtime_else(unused):
+        return None
+
+if t.TYPE_CHECKING:
+    def module_type_only(unused):
+        return None
+
+if not TC:
+    def runtime_not_guard(unused):
+        return None
+
+TYPE_CHECKING = runtime_flag
+if TYPE_CHECKING:
+    def shadowed_guard(unused):
+        return None
+
+def runtime_sibling(unused):
+    return None
+
+
+def outer():
+    if TC:
+        def nested_type_only(unused):
+            return None
+
+
+def locally_shadowed():
+    if TC:
+        def nested_runtime(unused):
+            return None
+    TC = runtime_flag
+
+
+def local_import():
+    from typing import TYPE_CHECKING as LOCAL_TC
+    if LOCAL_TC:
+        def nested_local_type_only(unused):
+            return None
+
+
+CLASS_TC = runtime_flag
+
+
+class ClassLocalAlias:
+    from typing import TYPE_CHECKING as CLASS_TC
+
+    def method(self):
+        if CLASS_TC:
+            def nested_runtime(unused):
+                return None
+
+
+NESTED_TC = runtime_flag
+
+
+class OuterClassLocalAlias:
+    from typing import TYPE_CHECKING as NESTED_TC
+
+    class Inner:
+        if NESTED_TC:
+            def nested_runtime(unused):
+                return None
+
+
+def guarded_in_compounds(items, manager, value):
+    try:
+        if TC:
+            def nested_try_type_only(unused):
+                return None
+    finally:
+        pass
+
+    for item in items:
+        if TC:
+            def nested_for_type_only(unused):
+                return None
+
+    while value:
+        if TC:
+            def nested_while_type_only(unused):
+                return None
+        break
+
+    with manager:
+        if TC:
+            def nested_with_type_only(unused):
+                return None
+
+    match value:
+        case _:
+            if TC:
+                def nested_match_type_only(unused):
+                    return None
+
+
+def comprehension_target_does_not_shadow(items):
+    [item for TC in items]
+    if TC:
+        def nested_type_only(unused):
+            return None
+
+
+from typing import TYPE_CHECKING as CONDITIONAL_TC
+
+if runtime_flag:
+    import runtime_config as CONDITIONAL_TC
+
+if CONDITIONAL_TC:
+    def conditionally_shadowed(unused):
+        return None
+
+
+from typing import TYPE_CHECKING as TRY_TC
+
+try:
+    import runtime_config as TRY_TC
+    raise RuntimeError
+except RuntimeError:
+    if TRY_TC:
+        def try_shadowed(unused):
+            return None
+
+
+from typing import TYPE_CHECKING as LATE_TC
+
+
+def module_late_rebind():
+    if LATE_TC:
+        def nested_runtime(unused):
+            return None
+
+
+LATE_TC = runtime_flag
+
+
+def local_late_rebind():
+    from typing import TYPE_CHECKING as LOCAL_LATE_TC
+
+    def inner():
+        if LOCAL_LATE_TC:
+            def nested_runtime(unused):
+                return None
+
+    LOCAL_LATE_TC = runtime_flag
+''',
+        },
+    )
+
+    assert "type_contracts.alias_type_only.unused" not in unused
+    assert "type_contracts.module_type_only.unused" not in unused
+    assert "type_contracts.runtime_else.unused" in unused
+    assert "type_contracts.runtime_not_guard.unused" in unused
+    assert "type_contracts.shadowed_guard.unused" in unused
+    assert "type_contracts.runtime_sibling.unused" in unused
+    assert (
+        "type_contracts.outer.nested_type_only.unused" not in unused
+    )
+    assert (
+        "type_contracts.locally_shadowed.nested_runtime.unused" in unused
+    )
+    assert (
+        "type_contracts.local_import.nested_local_type_only.unused" not in unused
+    )
+    assert (
+        "type_contracts.ClassLocalAlias.method.nested_runtime.unused" in unused
+    )
+    assert "type_contracts.Inner.nested_runtime.unused" in unused
+    for nested_name in (
+        "nested_try_type_only",
+        "nested_for_type_only",
+        "nested_while_type_only",
+        "nested_with_type_only",
+        "nested_match_type_only",
+    ):
+        assert (
+            f"type_contracts.guarded_in_compounds.{nested_name}.unused"
+            not in unused
+        )
+    assert (
+        "type_contracts.comprehension_target_does_not_shadow."
+        "nested_type_only.unused"
+        not in unused
+    )
+    assert "type_contracts.conditionally_shadowed.unused" in unused
+    assert "type_contracts.try_shadowed.unused" in unused
+    assert (
+        "type_contracts.module_late_rebind.nested_runtime.unused" in unused
+    )
+    assert (
+        "type_contracts.local_late_rebind.inner.nested_runtime.unused" in unused
+    )
+
+
+def test_only_shared_parameters_of_resolved_overrides_are_contracts(tmp_path):
+    unused = _unused_parameters(
+        tmp_path,
+        {
+            "base.py": '''
+class Parent:
+    def render(self, value, shared_option=None):
+        return value
+
+    def variadic(self, *items, **options):
+        return None
+
+    @staticmethod
+    def convert(value, shared_option=None):
+        return value
+''',
+            "mid.py": '''
+from base import Parent
+
+
+class Mid(Parent):
+    pass
+''',
+            "children.py": '''
+from base import Parent
+from mid import Mid
+
+
+class Child(Mid):
+    def render(self, value, shared_option=None, child_only=None):
+        return value
+
+    def variadic(self, *args, **kwargs):
+        return None
+
+    def convert(self, value, shared_option=None):
+        return value
+
+
+class RenamedChild(Parent):
+    def render(self, value, renamed_option=None):
+        return value
+
+
+class Unrelated:
+    def render(self, value, shared_option=None):
+        return value
+
+
+class PrivateBase:
+    def __secret(self, private_unused=None):
+        return None
+
+
+class PrivateChild(PrivateBase):
+    def __secret(self, private_unused=None):
+        return None
+
+
+def replacement(*args, **kwargs):
+    return None
+
+
+class ShadowedOverride(Parent):
+    def render(self, value, shared_option=None):
+        return value
+
+    render = replacement
+''',
+            "generic_child.py": '''
+from base import Parent
+
+
+class GenericChild(Parent[int]):
+    def render(self, value, shared_option=None):
+        return value
+''',
+            "alias_child.py": '''
+import base as b
+
+
+class AliasChild(b.Parent):
+    def render(self, value, shared_option=None):
+        return value
+''',
+            "external_parent.py": '''
+class Parent:
+    def render(self, value, shared_option=None):
+        return value
+''',
+            "shadowed_parent.py": '''
+from external_parent import Parent
+
+
+class Parent:
+    def render(self, value, local_option=None):
+        return value
+
+
+class Child(Parent):
+    def render(self, value, shared_option=None):
+        return value
+''',
+            "external_attr.py": '''
+class Parent:
+    def render(self, value, shared_option=None):
+        return value
+''',
+            "shadowed_attr.py": '''
+import external_attr as namespace
+
+namespace = object()
+
+
+class Child(namespace.Parent):
+    def render(self, value, shared_option=None):
+        return value
+''',
+            "reverse_external.py": '''
+class Parent:
+    def render(self, value, shared_option=None):
+        return value
+''',
+            "reverse_binding.py": '''
+class Parent:
+    def render(self, value, local_option=None):
+        return value
+
+
+from reverse_external import Parent
+
+
+class Child(Parent):
+    def render(self, value, shared_option=None):
+        return value
+''',
+        },
+    )
+
+    assert "base.Parent.render.shared_option" not in unused
+    assert "children.Child.render.shared_option" not in unused
+    assert "children.Child.render.child_only" in unused
+    assert "base.Parent.variadic.items" not in unused
+    assert "base.Parent.variadic.options" not in unused
+    assert "children.Child.variadic.args" not in unused
+    assert "children.Child.variadic.kwargs" not in unused
+    assert "base.Parent.convert.shared_option" in unused
+    assert "children.Child.convert.shared_option" in unused
+    assert "children.RenamedChild.render.renamed_option" in unused
+    assert "children.Unrelated.render.shared_option" in unused
+    assert "generic_child.GenericChild.render.shared_option" not in unused
+    assert "alias_child.AliasChild.render.shared_option" not in unused
+    assert "children.PrivateChild.__secret.private_unused" in unused
+    assert "children.ShadowedOverride.render.shared_option" in unused
+    assert "external_parent.Parent.render.shared_option" in unused
+    assert "shadowed_parent.Parent.render.local_option" in unused
+    assert "shadowed_parent.Child.render.shared_option" in unused
+    assert "external_attr.Parent.render.shared_option" in unused
+    assert "shadowed_attr.Child.render.shared_option" in unused
+    assert "reverse_external.Parent.render.shared_option" not in unused
+    assert "reverse_binding.Parent.render.local_option" in unused
+    assert "reverse_binding.Child.render.shared_option" not in unused
+
+
+def test_dynamic_dispatch_only_exempts_forwarded_handler_kwargs(tmp_path):
+    unused = _unused_parameters(
+        tmp_path,
+        {
+            "visitors.py": '''
+class DynamicVisitor:
+    def visit(self, node, **kwargs):
+        getattr(self, f"visit_{type(node).__name__}")(node, **kwargs)
+
+    def visit_Item(self, node, extra=None, **kwargs):
+        return node
+
+
+class DifferentlyNamedKwargs:
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class SuffixedDispatcher:
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__}_impl")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+    def visit_Item_impl(self, node, **kwargs):
+        return node
+
+
+class NoDispatcher:
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class NoForwarding:
+    def visit(self, node, **kwargs):
+        getattr(self, f"visit_{type(node).__name__}")(node)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class LiteralLookup:
+    def visit(self, node, **kwargs):
+        getattr(self, "visit_Item")(node, **kwargs)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class ConstantFormattedLookup:
+    def visit(self, node, **kwargs):
+        getattr(self, f"visit_{'Item'}")(node, **kwargs)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+    def visit_Other(self, node, **kwargs):
+        return node
+
+
+class ConvertedLookup:
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__!r}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class ShadowedGetattr:
+    def visit(self, node, **options):
+        def getattr(obj, name):
+            return lambda *args, **kwargs: None
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class ComprehensionTarget:
+    def visit(self, node, **options):
+        [item for getattr in ()]
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class WrongReceiver:
+    def visit(self, node, **options):
+        getattr(registry, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class StaticReceiver:
+    @staticmethod
+    def visit(node, **options):
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class BaseDispatcher:
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+
+class InheritedHandler(BaseDispatcher):
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class BaseHandler:
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class InheritedDispatcher(BaseHandler):
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+
+class OverridesDispatcher(BaseDispatcher):
+    def visit(self, node, **options):
+        return node
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+def runtime_dispatch(node, **options):
+    return node
+
+
+class AttributeOverride(BaseDispatcher):
+    visit = runtime_dispatch
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class HeaderShadow(BaseDispatcher):
+    def helper(self, option=(visit := runtime_dispatch)):
+        return option
+
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class PlainDispatcher:
+    def visit(self, node, **options):
+        return node
+
+
+class StaticFirst(PlainDispatcher, BaseDispatcher):
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class DynamicFirst(BaseDispatcher, PlainDispatcher):
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+def make_base():
+    return PlainDispatcher
+
+
+class UnknownFirst(make_base(), BaseDispatcher):
+    def visit_Item(self, node, **kwargs):
+        return node
+
+
+class NestedDispatcherOnly:
+    def helper(self):
+        def nested(node, **options):
+            getattr(self, f"visit_{type(node).__name__}")(node, **options)
+        return nested
+
+    def visit_Item(self, node, **kwargs):
+        return node
+''',
+            "shadowed_builtin.py": '''
+def getattr(obj, name):
+    return lambda *args, **kwargs: None
+
+
+class ShadowedBuiltin:
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+''',
+            "imported_getattr.py": '''
+from helpers import getattr
+
+
+class ImportedGetattr:
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+''',
+            "aliased_getattr.py": '''
+import helpers as getattr
+
+
+class AliasedGetattr:
+    def visit(self, node, **options):
+        getattr(self, f"visit_{type(node).__name__}")(node, **options)
+
+    def visit_Item(self, node, **kwargs):
+        return node
+''',
+        },
+    )
+
+    assert "visitors.DynamicVisitor.visit_Item.kwargs" not in unused
+    assert "visitors.DynamicVisitor.visit_Item.extra" in unused
+    assert "visitors.DifferentlyNamedKwargs.visit_Item.kwargs" not in unused
+    assert "visitors.SuffixedDispatcher.visit_Item.kwargs" in unused
+    assert "visitors.SuffixedDispatcher.visit_Item_impl.kwargs" not in unused
+    assert "visitors.NoDispatcher.visit_Item.kwargs" in unused
+    assert "visitors.NoForwarding.visit.kwargs" in unused
+    assert "visitors.NoForwarding.visit_Item.kwargs" in unused
+    assert "visitors.LiteralLookup.visit_Item.kwargs" in unused
+    assert "visitors.ConstantFormattedLookup.visit_Item.kwargs" in unused
+    assert "visitors.ConstantFormattedLookup.visit_Other.kwargs" in unused
+    assert "visitors.ConvertedLookup.visit_Item.kwargs" in unused
+    assert "visitors.ShadowedGetattr.visit_Item.kwargs" in unused
+    assert "visitors.ComprehensionTarget.visit_Item.kwargs" not in unused
+    assert "visitors.WrongReceiver.visit_Item.kwargs" in unused
+    assert "visitors.StaticReceiver.visit_Item.kwargs" in unused
+    assert "visitors.InheritedHandler.visit_Item.kwargs" not in unused
+    assert "visitors.BaseHandler.visit_Item.kwargs" not in unused
+    assert "visitors.OverridesDispatcher.visit_Item.kwargs" in unused
+    assert "visitors.AttributeOverride.visit_Item.kwargs" in unused
+    assert "visitors.HeaderShadow.visit_Item.kwargs" in unused
+    assert "visitors.StaticFirst.visit_Item.kwargs" in unused
+    assert "visitors.DynamicFirst.visit_Item.kwargs" not in unused
+    assert "visitors.UnknownFirst.visit_Item.kwargs" in unused
+    assert "visitors.NestedDispatcherOnly.visit_Item.kwargs" in unused
+    assert "shadowed_builtin.ShadowedBuiltin.visit_Item.kwargs" in unused
+    assert "imported_getattr.ImportedGetattr.visit_Item.kwargs" in unused
+    assert "aliased_getattr.AliasedGetattr.visit_Item.kwargs" in unused

--- a/test/test_signature_contract_parameters.py
+++ b/test/test_signature_contract_parameters.py
@@ -5,7 +5,10 @@ from skylos.analyzer import analyze
 
 def _analyze_sources(tmp_path, sources):
     for filename, source in sources.items():
-        (tmp_path / filename).write_text(source, encoding="utf-8")
+        (tmp_path / filename).write_text(  # skylos: ignore[SKY-D324] pytest tmp_path with literal filenames
+            source,
+            encoding="utf-8",
+        )
 
     return json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
 


### PR DESCRIPTION
## Summary

Fixes #723.

PR #658 tightened grep verification for unused parameters, which exposed several signature contract FPs. This adds AST handling instead of loosening grep verification.

This fixes the six cases from the issue:

  - hook and base method stubs
  - abstract method implementations
  - overridden class and factory methods
  - methods declared only for type checking
  - visitor methods that receive forwarded keyword arguments

##Tests

  - All six false positives from the supplied reproducer are gone.
