### PR TITLE
fix(ai-defect): avoid oversized registry responses

### DIFF
--- a/skylos/rules/ai_defect/manifest_dependency_hallucination.py
+++ b/skylos/rules/ai_defect/manifest_dependency_hallucination.py
@@ -52,7 +52,6 @@ STATUS_UNKNOWN = "unknown"
 VERSION_CACHE_SCHEMA_VERSION = 1
 VERSION_CACHE_PATH = Path(".skylos") / "cache" / "dependency_versions.json"
 MAX_VERSION_CACHE_BYTES = 5_000_000
-MAX_REGISTRY_RESPONSE_BYTES = 1_000_000
 MAX_INSTALL_SURFACE_BYTES = 1_000_000
 NPM_REGISTRY_ORIGIN = "https://registry.npmjs.org"
 GO_PROXY_ORIGIN = "https://proxy.golang.org"
@@ -1963,25 +1962,12 @@ def _check_pypi_version(name: str, version: str) -> str:
 
     safe_version = quote(version.strip(), safe="")
     version_url = f"{PYPI_JSON_ORIGIN}/{package_path}/{safe_version}/json"
-    try:
-        _fetch_json(version_url, user_agent="skylos-pypi-dep-scanner/1.0")
-        return STATUS_PRESENT
-    except urllib.error.HTTPError as exc:
-        if exc.code != 404:
-            return STATUS_UNKNOWN
-    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
-        return STATUS_UNKNOWN
-
     package_url = f"{PYPI_JSON_ORIGIN}/{package_path}/json"
-    try:
-        _fetch_json(package_url, user_agent="skylos-pypi-dep-scanner/1.0")
-        return STATUS_MISSING_VERSION
-    except urllib.error.HTTPError as exc:
-        if exc.code == 404:
-            return STATUS_MISSING_PACKAGE
-        return STATUS_UNKNOWN
-    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
-        return STATUS_UNKNOWN
+    return _check_registry_version_urls(
+        version_url,
+        package_url,
+        user_agent="skylos-pypi-dep-scanner/1.0",
+    )
 
 
 def _check_npm_version(name: str, version: str) -> str:
@@ -1989,22 +1975,14 @@ def _check_npm_version(name: str, version: str) -> str:
     if package_path is None:
         return STATUS_UNKNOWN
 
-    url = f"{NPM_REGISTRY_ORIGIN}/{package_path}"
-    try:
-        data = _fetch_json(url, user_agent="skylos-npm-dep-scanner/1.0")
-    except urllib.error.HTTPError as exc:
-        if exc.code == 404:
-            return STATUS_MISSING_PACKAGE
-        return STATUS_UNKNOWN
-    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
-        return STATUS_UNKNOWN
-
-    versions = data.get("versions")
-    if not isinstance(versions, dict):
-        return STATUS_UNKNOWN
-    if version in versions:
-        return STATUS_PRESENT
-    return STATUS_MISSING_VERSION
+    safe_version = quote(version.strip(), safe="")
+    package_url = f"{NPM_REGISTRY_ORIGIN}/{package_path}"
+    version_url = f"{package_url}/{safe_version}"
+    return _check_registry_version_urls(
+        version_url,
+        package_url,
+        user_agent="skylos-npm-dep-scanner/1.0",
+    )
 
 
 def _check_go_version(name: str, version: str) -> str:
@@ -2015,25 +1993,30 @@ def _check_go_version(name: str, version: str) -> str:
     go_version = _go_version(version)
     safe_go_version = quote(go_version, safe="")
     info_url = f"{GO_PROXY_ORIGIN}/{module_path}/@v/{safe_go_version}.info"
-    try:
-        _fetch_text(info_url, user_agent="skylos-go-dep-scanner/1.0")
+    list_url = f"{GO_PROXY_ORIGIN}/{module_path}/@v/list"
+    return _check_registry_version_urls(
+        info_url,
+        list_url,
+        user_agent="skylos-go-dep-scanner/1.0",
+    )
+
+
+def _check_registry_version_urls(
+    version_url: str,
+    package_url: str,
+    *,
+    user_agent: str,
+) -> str:
+    version_status = _registry_http_status(version_url, user_agent=user_agent)
+    if version_status == 200:
         return STATUS_PRESENT
-    except urllib.error.HTTPError as exc:
-        if exc.code != 404:
-            return STATUS_UNKNOWN
-    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+    if version_status != 404:
         return STATUS_UNKNOWN
 
-    list_url = f"{GO_PROXY_ORIGIN}/{module_path}/@v/list"
-    try:
-        _fetch_text(list_url, user_agent="skylos-go-dep-scanner/1.0")
-    except urllib.error.HTTPError as exc:
-        if exc.code == 404:
-            return STATUS_MISSING_PACKAGE
-        return STATUS_UNKNOWN
-    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
-        return STATUS_UNKNOWN
-    return STATUS_MISSING_VERSION
+    package_status = _registry_http_status(package_url, user_agent=user_agent)
+    if package_status == 200:
+        return STATUS_MISSING_VERSION
+    return STATUS_MISSING_PACKAGE if package_status == 404 else STATUS_UNKNOWN
 
 
 def _go_version(version: str) -> str:
@@ -2132,30 +2115,22 @@ def _safe_go_path_part(value: str) -> bool:
     return True
 
 
-def _fetch_json(url: str, *, user_agent: str) -> dict[str, Any]:
-    text = _fetch_text(url, user_agent=user_agent)
-    data = json.loads(text)
-    if isinstance(data, dict):
-        return data
-    return {}
-
-
-def _fetch_text(url: str, *, user_agent: str) -> str:
-    if not _allowed_registry_url(url):
-        raise ValueError("Registry URL host is not allowed")
-
-    request = urllib.request.Request(url, method="GET")
-    request.add_header("User-Agent", user_agent)
-    with (
-        urllib.request.urlopen(  # skylos: ignore[SKY-D216] URL is validated against fixed registry hosts above.
+def _registry_http_status(url: str, *, user_agent: str) -> int | None:
+    try:
+        if not _allowed_registry_url(url):
+            raise ValueError("Registry URL host is not allowed")
+        request = urllib.request.Request(url, method="HEAD")
+        request.add_header("User-Agent", user_agent)
+        with urllib.request.urlopen(  # skylos: ignore[SKY-D216] fixed registry host
             request,
             timeout=5,
-        ) as response
-    ):
-        raw = response.read(MAX_REGISTRY_RESPONSE_BYTES + 1)
-    if len(raw) > MAX_REGISTRY_RESPONSE_BYTES:
-        raise ValueError("Registry response exceeds size limit")
-    return raw.decode("utf-8", errors="replace")
+        ):
+            pass
+    except urllib.error.HTTPError as exc:
+        return exc.code
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return None
+    return 200
 
 
 def _allowed_registry_url(url: str) -> bool:

--- a/test/test_manifest_dependency_registry.py
+++ b/test/test_manifest_dependency_registry.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+from unittest.mock import MagicMock
+
+import pytest
+
+from skylos.rules.ai_defect import manifest_dependency_hallucination as manifest_rule
+from skylos.rules.ai_defect.manifest_dependency_hallucination import (
+    RULE_ID_VERSION_HALLUCINATION,
+    STATUS_MISSING_PACKAGE,
+    STATUS_MISSING_VERSION,
+    STATUS_PRESENT,
+    STATUS_UNKNOWN,
+    VERSION_CACHE_PATH,
+    check_dependency_version_status,
+    scan_manifest_dependency_hallucinations,
+)
+from skylos.rules.sca.vulnerability_scanner import (
+    ECOSYSTEM_GO,
+    ECOSYSTEM_NPM,
+    ECOSYSTEM_PYPI,
+)
+
+NPM_VERSION_URL = "https://registry.npmjs.org/react/999999.0.0"
+NPM_PACKAGE_URL = "https://registry.npmjs.org/react"
+
+
+def _oversized_registry_response():
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    response.read.return_value = b"x" * 1_000_001
+    return response
+
+
+def _not_found(url):
+    return urllib.error.HTTPError(url, 404, "not found", {}, None)
+
+
+def test_large_npm_response_flags_missing_version_and_caches(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"dependencies": {"react": "999999.0.0"}}),
+        encoding="utf-8",
+    )
+    response = _oversized_registry_response()
+    seen_requests = []
+
+    def fake_urlopen(request, *, timeout):
+        seen_requests.append((request.full_url, request.get_method(), timeout))
+        if request.full_url == NPM_VERSION_URL:
+            raise _not_found(NPM_VERSION_URL)
+        if request.full_url == NPM_PACKAGE_URL:
+            return response
+        raise AssertionError(f"unexpected registry URL: {request.full_url}")
+
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", fake_urlopen)
+    findings = scan_manifest_dependency_hallucinations(repo)
+
+    assert [finding["rule_id"] for finding in findings] == [
+        RULE_ID_VERSION_HALLUCINATION
+    ]
+    assert findings[0]["metadata"]["package_name"] == "react"
+    assert findings[0]["metadata"]["dependency_truth_state"] == (STATUS_MISSING_VERSION)
+    assert seen_requests == [
+        (NPM_VERSION_URL, "HEAD", 5),
+        (NPM_PACKAGE_URL, "HEAD", 5),
+    ]
+    response.read.assert_not_called()
+    cache = json.loads((repo / VERSION_CACHE_PATH).read_text(encoding="utf-8"))
+    assert cache["statuses"] == {
+        "npm:react:999999.0.0": STATUS_MISSING_VERSION,
+    }
+
+    monkeypatch.setattr(
+        manifest_rule.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("cached status performed a lookup"),
+    )
+    assert scan_manifest_dependency_hallucinations(repo) == findings
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        (
+            ECOSYSTEM_NPM,
+            "@scope/widget",
+            "999999.0.0",
+            "https://registry.npmjs.org/@scope%2Fwidget/999999.0.0",
+            "https://registry.npmjs.org/@scope%2Fwidget",
+        ),
+        (
+            ECOSYSTEM_PYPI,
+            "numpy",
+            "999999.0.0",
+            "https://pypi.org/pypi/numpy/999999.0.0/json",
+            "https://pypi.org/pypi/numpy/json",
+        ),
+        (
+            ECOSYSTEM_GO,
+            "github.com/stretchr/testify",
+            "999999.0.0",
+            "https://proxy.golang.org/github.com/stretchr/testify/@v/v999999.0.0.info",
+            "https://proxy.golang.org/github.com/stretchr/testify/@v/list",
+        ),
+    ],
+    ids=["npm", "pypi", "go"],
+)
+def test_registry_checks_use_head_without_reading_response_bodies(
+    monkeypatch,
+    case,
+):
+    ecosystem, name, version, version_url, package_url = case
+    response = _oversized_registry_response()
+    seen_requests = []
+    mode = "present"
+
+    def fake_urlopen(request, *, timeout):
+        seen_requests.append((request.full_url, request.get_method(), timeout))
+        if request.full_url == version_url:
+            if mode != "present":
+                raise _not_found(version_url)
+            return response
+        if request.full_url == package_url:
+            if mode == "missing_package":
+                raise _not_found(package_url)
+            return response
+        raise AssertionError(f"unexpected registry URL: {request.full_url}")
+
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", fake_urlopen)
+    cases = [
+        ("present", STATUS_PRESENT, [version_url]),
+        ("missing_version", STATUS_MISSING_VERSION, [version_url, package_url]),
+        ("missing_package", STATUS_MISSING_PACKAGE, [version_url, package_url]),
+    ]
+
+    for mode, expected_status, expected_urls in cases:
+        seen_requests.clear()
+        status = check_dependency_version_status(ecosystem, name, version, {})
+        assert status == expected_status
+        assert seen_requests == [(url, "HEAD", 5) for url in expected_urls]
+
+    response.read.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("failure_point", "expected_urls"),
+    [
+        ("version", [NPM_VERSION_URL]),
+        ("package", [NPM_VERSION_URL, NPM_PACKAGE_URL]),
+    ],
+)
+def test_registry_checks_keep_non_404_failures_unknown(
+    monkeypatch,
+    failure_point,
+    expected_urls,
+):
+    seen_requests = []
+
+    def fake_urlopen(request, *, timeout):
+        seen_requests.append((request.full_url, request.get_method(), timeout))
+        if request.full_url == NPM_VERSION_URL:
+            if failure_point == "version":
+                raise urllib.error.HTTPError(
+                    NPM_VERSION_URL,
+                    500,
+                    "registry failure",
+                    {},
+                    None,
+                )
+            raise _not_found(NPM_VERSION_URL)
+        if request.full_url == NPM_PACKAGE_URL:
+            raise TimeoutError("registry timeout")
+        raise AssertionError(f"unexpected registry URL: {request.full_url}")
+
+    monkeypatch.setattr(manifest_rule.urllib.request, "urlopen", fake_urlopen)
+    status = check_dependency_version_status(
+        ECOSYSTEM_NPM,
+        "react",
+        "999999.0.0",
+        {},
+    )
+
+    assert status == STATUS_UNKNOWN
+    assert seen_requests == [(url, "HEAD", 5) for url in expected_urls]


### PR DESCRIPTION
## Summary

Fixes #735.

  Responses for popular packages such as React and NumPy can exceed the 1 MB limit, which will cause the lookup to return `unknown`. This dropped SKY-D225 findings and prevented the result from being cached. Now we will 

  1. check the exact version using a `HEAD` request
  2. check package existence after a 404 to distinguish a missing version from a missing package
  3. apply to npm, PyPI, and Go
  4. keeps timeouts and unexpected registry errors as `unknown`

