### PR TITLE
fix(secrets): avoid ordered character set false positives

### DIFF
--- a/skylos/rules/secrets.py
+++ b/skylos/rules/secrets.py
@@ -380,6 +380,8 @@ YARN_DEPENDENCY_RE = re.compile(
 
 IGNORE_DIRECTIVE = "skylos: ignore[SKY-S101]"
 DEFAULT_MIN_ENTROPY = 3.9
+_ORDERED_ASCII_RUN_MIN_LENGTH = 8
+_ORDERED_CHARACTER_SET_PUNCTUATION = frozenset("-._~+/=")
 
 IS_TEST_PATH = re.compile(r"(^|/)(tests?(/|$)|test_[^/]+\.py$)")
 
@@ -403,6 +405,85 @@ def _entropy(s):
         entropy -= probability * log2(probability)
 
     return entropy
+
+
+def _ordered_ascii_domain(character: str) -> str | None:
+    if "0" <= character <= "9":
+        return "digit"
+    if "A" <= character <= "Z":
+        return "upper"
+    if "a" <= character <= "z":
+        return "lower"
+    return None
+
+
+def _without_long_ordered_ascii_runs(value: str) -> tuple[str, int]:
+    """Remove maximal ascending digit/A-Z/a-z runs without reordering input."""
+    kept = []
+    removed = 0
+    start = 0
+    while start < len(value):
+        domain = _ordered_ascii_domain(value[start])
+        end = start + 1
+        while (
+            domain is not None
+            and end < len(value)
+            and _ordered_ascii_domain(value[end]) == domain
+            and ord(value[end]) == ord(value[end - 1]) + 1
+        ):
+            end += 1
+
+        if end - start >= _ORDERED_ASCII_RUN_MIN_LENGTH:
+            removed += end - start
+        else:
+            kept.append(value[start:end])
+        start = end
+
+    return "".join(kept), removed
+
+
+def _looks_like_ordered_character_set(value: str, *, min_entropy: float) -> bool:
+    """Require every alphanumeric character to be part of an ordered run."""
+    residual, removed = _without_long_ordered_ascii_runs(value)
+    if removed < _ORDERED_ASCII_RUN_MIN_LENGTH or any(
+        character not in _ORDERED_CHARACTER_SET_PUNCTUATION
+        for character in residual
+    ):
+        return False
+    return _entropy(residual) < min_entropy
+
+
+def _bare_candidate_is_complete_ordered_character_set(
+    line_content: str,
+    *,
+    start: int,
+    end: int,
+    min_entropy: float,
+) -> bool:
+    """Return whether a bare candidate spans one complete quoted character set."""
+    left = start - 1
+    while (
+        left >= 0
+        and line_content[left] in _ORDERED_CHARACTER_SET_PUNCTUATION
+    ):
+        left -= 1
+    if left < 0 or line_content[left] not in {"'", '"'}:
+        return False
+
+    quote = line_content[left]
+    right = end
+    while (
+        right < len(line_content)
+        and line_content[right] in _ORDERED_CHARACTER_SET_PUNCTUATION
+    ):
+        right += 1
+    if right >= len(line_content) or line_content[right] != quote:
+        return False
+
+    return _looks_like_ordered_character_set(
+        line_content[left + 1 : right],
+        min_entropy=min_entropy,
+    )
 
 
 def _mask(tok):
@@ -3553,20 +3634,29 @@ def scan_ctx(
                 continue
             tok_entropy = _entropy(clean_token)
 
-            if tok_entropy >= min_entropy and len(clean_token) >= 20:
-                generic_finding = {
-                    "rule_id": "SKY-S101",
-                    "severity": "CRITICAL",
-                    "provider": "generic",
-                    "message": f"High-entropy value detected (entropy={tok_entropy:.2f})",
-                    "file": rel_path,
-                    "line": line_number,
-                    "col": max(0, col_pos),
-                    "end_col": max(1, source_end),
-                    "preview": _mask(clean_token),
-                    "entropy": round(tok_entropy, 2),
-                }
-                findings.append(generic_finding)
+            if not (tok_entropy >= min_entropy and len(clean_token) >= 20):
+                continue
+            if is_bare and _bare_candidate_is_complete_ordered_character_set(
+                line_content,
+                start=col_pos,
+                end=source_end,
+                min_entropy=min_entropy,
+            ):
+                continue
+
+            generic_finding = {
+                "rule_id": "SKY-S101",
+                "severity": "CRITICAL",
+                "provider": "generic",
+                "message": f"High-entropy value detected (entropy={tok_entropy:.2f})",
+                "file": rel_path,
+                "line": line_number,
+                "col": max(0, col_pos),
+                "end_col": max(1, source_end),
+                "preview": _mask(clean_token),
+                "entropy": round(tok_entropy, 2),
+            }
+            findings.append(generic_finding)
 
     # A neutral source file can still be a client boundary when its directive
     # prologue exceeded the parse budget. Preserve a blocking result whenever

--- a/test/test_secrets.py
+++ b/test/test_secrets.py
@@ -239,6 +239,91 @@ def test_bare_generic_token_still_detected():
     assert generic[0]["col"] == src.index(token)
 
 
+def test_ordered_character_set_enumeration_is_not_a_secret():
+    src = (
+        "UNRESERVED_CHARACTERS = (\n"
+        '    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"\n'
+        ")\n"
+    )
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src))
+        if finding["provider"] == "generic"
+    ]
+
+    assert generic == []
+
+
+def test_unsorted_character_set_lookalike_remains_detectable():
+    token = "ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW"
+    src = f'candidate = "{token}"\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+    assert generic[0]["col"] == src.index(token)
+
+    static_findings = list(
+        scan_ctx(
+            _ctx_from_source(
+                src,
+                rel="mitmproxy/tools/web/static/vendor.js",
+            )
+        )
+    )
+    assert any(finding["rule_id"] == "SKY-S102" for finding in static_findings)
+
+
+def test_ordered_character_set_under_secret_key_remains_detectable():
+    token = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    src = f'API_TOKEN = "{token}"\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        GENERIC_SECRET + "-01234567",
+        (
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+            + GENERIC_SECRET
+        ),
+        "01234567ABCDEFGHaB3dE5fG7hJ9kL2a",
+        "0123456-ABCDEFG-abcdefg-0123456-",
+        (
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-."
+            "aB3dE5fG7hI9jK2lM4nO6pQ8rS0tU1vW2xY3zZ"
+        ),
+        (
+            "aB3dE5fG7hI9jK2lM4nO6pQ8rS0tU1vW2xY3zZ."
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        ),
+    ],
+)
+def test_ordered_runs_do_not_hide_bare_secret_lookalikes(token):
+    src = f'candidate = "{token}"\n'
+
+    generic = [
+        finding
+        for finding in scan_ctx(_ctx_from_source(src))
+        if finding["provider"] == "generic"
+    ]
+
+    assert len(generic) == 1
+
+
 @pytest.mark.parametrize(
     "relpath,src",
     [


### PR DESCRIPTION
Fixes #739.

## Summary

Fixes SKY-S101 incorrectly reporting ordered character lists as secrets. The check only ignores complete quoted character lists.

  ## Tests

  - `pytest test/test_secrets.py test/test_s102.py test/test_secrets_nonpy.py`