### PR TITLE
fix(quality): break SKY-C401 clone-type ties deterministically

### DIFF
--- a/skylos/rules/quality/clones.py
+++ b/skylos/rules/quality/clones.py
@@ -4,6 +4,7 @@ import ast
 import hashlib
 import io
 import tokenize
+from collections import Counter
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from enum import Enum
@@ -437,6 +438,14 @@ def _pair_key(a: Fragment, b: Fragment) -> Tuple[str, int, str, int]:
     )
 
 
+def _select_group_clone_type(types: List[CloneType]) -> CloneType:
+    if not types:
+        return CloneType.TYPE3
+
+    counts = Counter(types)
+    return min(counts, key=lambda clone_type: (-counts[clone_type], clone_type.value))
+
+
 def group_pairs(pairs: List[ClonePair], cfg: CloneConfig) -> List[CloneGroup]:
     if not pairs:
         return []
@@ -501,7 +510,7 @@ def _group_connected(
                     types.append(p.clone_type)
 
         avg_sim = sum(sims) / len(sims) if sims else cfg.grouping_threshold
-        clone_type = max(set(types), key=types.count) if types else CloneType.TYPE3
+        clone_type = _select_group_clone_type(types)
 
         groups.append(
             CloneGroup(

--- a/test/test_quality_rules.py
+++ b/test/test_quality_rules.py
@@ -51,6 +51,72 @@ def test_clone_similarity_threshold_keeps_possible_matches(monkeypatch):
     assert clones_mod._similarity(a, b, threshold=0.9) >= 0.9
 
 
+def test_clone_group_type_tie_uses_canonical_order():
+    select_type = clones_mod._select_group_clone_type
+
+    assert select_type([clones_mod.CloneType.TYPE2, clones_mod.CloneType.TYPE1]) == (
+        clones_mod.CloneType.TYPE1
+    )
+    assert select_type([clones_mod.CloneType.TYPE3, clones_mod.CloneType.TYPE2]) == (
+        clones_mod.CloneType.TYPE2
+    )
+
+
+def test_clone_group_type_prefers_most_common_type():
+    assert (
+        clones_mod._select_group_clone_type(
+            [
+                clones_mod.CloneType.TYPE3,
+                clones_mod.CloneType.TYPE1,
+                clones_mod.CloneType.TYPE3,
+            ]
+        )
+        == clones_mod.CloneType.TYPE3
+    )
+
+
+def test_clone_group_type_empty_defaults_to_type3():
+    assert clones_mod._select_group_clone_type([]) == clones_mod.CloneType.TYPE3
+
+
+def test_group_pairs_uses_canonical_type_for_tied_edges():
+    def fragment(name, line):
+        return clones_mod.Fragment(
+            file_path="sample.py",
+            start_line=line,
+            end_line=line + 10,
+            name=name,
+            kind="function",
+            node_count=10,
+            text_norm=name,
+            ast_norm_type2=name,
+            ast_norm_type3=name,
+        )
+
+    first = fragment("first", 1)
+    second = fragment("second", 20)
+    third = fragment("third", 40)
+    pairs = [
+        clones_mod.ClonePair(
+            a=first,
+            b=second,
+            similarity=0.99,
+            clone_type=clones_mod.CloneType.TYPE3,
+        ),
+        clones_mod.ClonePair(
+            a=second,
+            b=third,
+            similarity=0.99,
+            clone_type=clones_mod.CloneType.TYPE2,
+        ),
+    ]
+
+    for ordered_pairs in (pairs, list(reversed(pairs))):
+        groups = clones_mod.group_pairs(ordered_pairs, clones_mod.CloneConfig())
+        assert len(groups) == 1
+        assert groups[0].clone_type == clones_mod.CloneType.TYPE2
+
+
 # --- SKY-L004: Try Block Patterns ---
 
 


### PR DESCRIPTION
Fixes #733

## Summary

  - Make `SKY-C401` choose the same clone type on every run.
  - Count each clone type before choosing the winner.
  - When counts are tied, prefer `type1`, then `type2`, `type3`, and `type4`.


  ## Tests

  - `pytest test/test_quality_rules.py`