### PR TITLE
fix(ai-defect): recognize control-flow module exports

### DIFF
--- a/skylos/rules/ai_defect/phantom_refs.py
+++ b/skylos/rules/ai_defect/phantom_refs.py
@@ -8,6 +8,10 @@ from difflib import SequenceMatcher
 from pathlib import Path
 
 from skylos.analysis.control_flow import _parse_requires_python
+from skylos.rules.quality._protocols import (
+    type_checking_context,
+    type_checking_guard_branches,
+)
 from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
 
@@ -58,6 +62,33 @@ class _ScopeInfo:
     imported_module_paths: dict[str, list[tuple[int, str]]]
 
 
+@dataclass
+class _ModuleFactState:
+    members: set[str]
+    exported_modules: dict[str, str]
+    has_dynamic_getattr: bool = False
+    has_wildcard_reexport: bool = False
+
+    def copy(self) -> _ModuleFactState:
+        return _ModuleFactState(
+            members=set(self.members),
+            exported_modules=dict(self.exported_modules),
+            has_dynamic_getattr=self.has_dynamic_getattr,
+            has_wildcard_reexport=self.has_wildcard_reexport,
+        )
+
+
+@dataclass
+class _ModuleFacts:
+    members: set[str]
+    type_checking_members: set[str]
+    exported_modules: dict[str, str]
+    type_checking_exported_modules: dict[str, str]
+    has_dynamic_getattr: bool
+    has_type_checking_dynamic_getattr: bool
+    type_checking_node_ids: set[int]
+
+
 def scan_repo_phantom_security_references(
     project_root, py_files, target_files=None, vibe_dictionary=None
 ):
@@ -76,8 +107,12 @@ def scan_repo_phantom_security_references(
     module_to_file = {}
     file_to_module = {}
     module_members = {}
+    module_type_checking_members = {}
     module_alias_exports = {}
+    module_type_checking_alias_exports = {}
     dynamic_modules = set()
+    type_checking_dynamic_modules = set()
+    module_type_checking_node_ids = {}
     parse_failures = set()
 
     for file_path in files:
@@ -102,18 +137,39 @@ def scan_repo_phantom_security_references(
 
     builtin_names = set(dir(builtins))
 
-    def _store_module_facts(module_name, tree):
-        members, has_dynamic_getattr, exported_modules = _collect_module_facts(
-            tree, module_name, local_modules
+    def _store_module_facts(
+        module_name,
+        tree,
+        *,
+        source_has_type_checking=None,
+        include_reference_context=False,
+    ):
+        facts = _collect_module_facts(
+            tree,
+            module_name,
+            local_modules,
+            source_has_type_checking=source_has_type_checking,
+            include_reference_context=include_reference_context,
         )
-        module_members[module_name] = members
+        module_members[module_name] = facts.members
+        module_type_checking_members[module_name] = facts.type_checking_members
         module_alias_exports[module_name] = {
             alias: target
-            for alias, target in exported_modules.items()
+            for alias, target in facts.exported_modules.items()
             if target in local_modules
         }
-        if has_dynamic_getattr:
+        module_type_checking_alias_exports[module_name] = {
+            alias: target
+            for alias, target in facts.type_checking_exported_modules.items()
+            if target in local_modules
+        }
+        module_type_checking_node_ids[module_name] = facts.type_checking_node_ids
+        dynamic_modules.discard(module_name)
+        type_checking_dynamic_modules.discard(module_name)
+        if facts.has_dynamic_getattr:
             dynamic_modules.add(module_name)
+        if facts.has_type_checking_dynamic_getattr:
+            type_checking_dynamic_modules.add(module_name)
 
     def _ensure_module_loaded(module_name):
         if module_name in module_members:
@@ -127,12 +183,17 @@ def scan_repo_phantom_security_references(
             return False
 
         try:
-            tree = ast.parse(file_path.read_text(encoding="utf-8", errors="replace"))
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+            tree = ast.parse(source)
         except (OSError, SyntaxError):
             parse_failures.add(module_name)
             return False
 
-        _store_module_facts(module_name, tree)
+        _store_module_facts(
+            module_name,
+            tree,
+            source_has_type_checking="TYPE_CHECKING" in source,
+        )
         return True
 
     findings = []
@@ -146,13 +207,35 @@ def scan_repo_phantom_security_references(
         if target_paths and file_path not in target_paths:
             continue
         try:
-            tree = ast.parse(file_path.read_text(encoding="utf-8", errors="replace"))
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+            tree = ast.parse(source)
         except (OSError, SyntaxError):
             continue
 
-        _store_module_facts(current_module, tree)
+        _store_module_facts(
+            current_module,
+            tree,
+            source_has_type_checking="TYPE_CHECKING" in source,
+            include_reference_context=True,
+        )
         parent_map = _build_parent_map(tree)
         scope_infos = _build_scope_infos(tree, current_module, local_modules)
+        type_checking_node_ids = module_type_checking_node_ids.get(
+            current_module, set()
+        )
+
+        def _active_module_surface(
+            node,
+            current_type_checking_node_ids=type_checking_node_ids,
+        ):
+            if id(node) in current_type_checking_node_ids:
+                return (
+                    module_type_checking_members,
+                    module_type_checking_alias_exports,
+                    type_checking_dynamic_modules,
+                )
+            return module_members, module_alias_exports, dynamic_modules
+
         findings.extend(
             _direct_local_import_findings(
                 file_path,
@@ -160,7 +243,10 @@ def scan_repo_phantom_security_references(
                 tree,
                 local_modules,
                 module_members,
+                module_type_checking_members,
                 dynamic_modules,
+                type_checking_dynamic_modules,
+                type_checking_node_ids,
                 package_modules,
                 _ensure_module_loaded,
                 module_dunder_attributes,
@@ -175,13 +261,16 @@ def scan_repo_phantom_security_references(
                     continue
                 if _attribute_is_nested_prefix(node, parent_map):
                     continue
+                active_members, active_aliases, active_dynamic = _active_module_surface(
+                    node
+                )
                 resolved = _resolve_local_module_member(
                     expr=node,
                     node=node,
                     tree=tree,
                     parent_map=parent_map,
                     scope_infos=scope_infos,
-                    module_alias_exports=module_alias_exports,
+                    module_alias_exports=active_aliases,
                     local_modules=local_modules,
                     ensure_module_loaded=_ensure_module_loaded,
                 )
@@ -190,12 +279,12 @@ def scan_repo_phantom_security_references(
                 target_module, member_name, expr_text = resolved
                 if not _ensure_module_loaded(target_module):
                     continue
-                if target_module in dynamic_modules:
+                if target_module in active_dynamic:
                     continue
                 if _module_has_member(
                     target_module,
                     member_name,
-                    module_members,
+                    active_members,
                     package_modules,
                     module_dunder_attributes,
                 ):
@@ -227,13 +316,16 @@ def scan_repo_phantom_security_references(
                         findings.append(bare_finding)
                     continue
 
+                active_members, active_aliases, active_dynamic = _active_module_surface(
+                    node
+                )
                 resolved = _resolve_local_module_member(
                     expr=node.func,
                     node=node,
                     tree=tree,
                     parent_map=parent_map,
                     scope_infos=scope_infos,
-                    module_alias_exports=module_alias_exports,
+                    module_alias_exports=active_aliases,
                     local_modules=local_modules,
                     ensure_module_loaded=_ensure_module_loaded,
                 )
@@ -243,12 +335,12 @@ def scan_repo_phantom_security_references(
                 target_module, member_name, expr_text = resolved
                 if not _ensure_module_loaded(target_module):
                     continue
-                if target_module in dynamic_modules:
+                if target_module in active_dynamic:
                     continue
                 if _module_has_member(
                     target_module,
                     member_name,
-                    module_members,
+                    active_members,
                     package_modules,
                     module_dunder_attributes,
                 ):
@@ -272,13 +364,16 @@ def scan_repo_phantom_security_references(
 
             for deco in node.decorator_list:
                 deco_target = _decorator_target(deco)
+                active_members, active_aliases, active_dynamic = _active_module_surface(
+                    deco_target
+                )
                 resolved = _resolve_local_module_member(
                     expr=deco_target,
                     node=deco_target,
                     tree=tree,
                     parent_map=parent_map,
                     scope_infos=scope_infos,
-                    module_alias_exports=module_alias_exports,
+                    module_alias_exports=active_aliases,
                     local_modules=local_modules,
                     ensure_module_loaded=_ensure_module_loaded,
                 )
@@ -288,12 +383,12 @@ def scan_repo_phantom_security_references(
                 target_module, member_name, expr_text = resolved
                 if not _ensure_module_loaded(target_module):
                     continue
-                if target_module in dynamic_modules:
+                if target_module in active_dynamic:
                     continue
                 if _module_has_member(
                     target_module,
                     member_name,
-                    module_members,
+                    active_members,
                     package_modules,
                     module_dunder_attributes,
                 ):
@@ -318,7 +413,10 @@ def _direct_local_import_findings(
     tree,
     local_modules,
     module_members,
+    module_type_checking_members,
     dynamic_modules,
+    type_checking_dynamic_modules,
+    type_checking_node_ids,
     package_modules,
     ensure_module_loaded,
     module_dunder_attributes: frozenset[str] = _STANDARD_MODULE_ATTRIBUTES,
@@ -330,7 +428,13 @@ def _direct_local_import_findings(
         base = _resolve_import_from_base(current_module, node)
         if base not in local_modules:
             continue
-        if not ensure_module_loaded(base) or base in dynamic_modules:
+        if id(node) in type_checking_node_ids:
+            active_members = module_type_checking_members
+            active_dynamic = type_checking_dynamic_modules
+        else:
+            active_members = module_members
+            active_dynamic = dynamic_modules
+        if not ensure_module_loaded(base) or base in active_dynamic:
             continue
         for alias in node.names:
             if alias.name == "*":
@@ -341,7 +445,7 @@ def _direct_local_import_findings(
             if _module_has_member(
                 base,
                 alias.name,
-                module_members,
+                active_members,
                 package_modules,
                 module_dunder_attributes,
             ):
@@ -465,56 +569,636 @@ def _module_name(root: Path, file_path: Path) -> str:
     return ".".join(parts)
 
 
-def _collect_module_facts(tree, current_module, local_modules):
-    members = set()
-    exported_modules = {}
-    has_dynamic_getattr = False
-
+def _collect_module_facts(
+    tree,
+    current_module,
+    local_modules,
+    *,
+    source_has_type_checking=None,
+    include_reference_context=False,
+):
     if not isinstance(tree, ast.Module):
-        return members, has_dynamic_getattr, exported_modules
+        return _ModuleFacts(
+            members=set(),
+            type_checking_members=set(),
+            exported_modules={},
+            type_checking_exported_modules={},
+            has_dynamic_getattr=False,
+            has_type_checking_dynamic_getattr=False,
+            type_checking_node_ids=set(),
+        )
 
-    type_alias_node = getattr(ast, "TypeAlias", None)
-    for stmt in tree.body:
+    if source_has_type_checking is False:
+        type_checking_guards = {}
+        type_checking_node_ids = set()
+    elif include_reference_context:
+        type_checking_guards, type_checking_node_ids = type_checking_context(tree)
+    else:
+        type_checking_guards = type_checking_guard_branches(tree)
+        type_checking_node_ids = set()
+    if include_reference_context:
+        type_checking_node_ids.update(_postponed_annotation_node_ids(tree))
+    runtime = _collect_module_fact_state(
+        tree.body,
+        current_module,
+        local_modules,
+        type_checking_guards,
+        type_checking_mode=False,
+    )
+    if type_checking_guards:
+        type_checking = _collect_module_fact_state(
+            tree.body,
+            current_module,
+            local_modules,
+            type_checking_guards,
+            type_checking_mode=True,
+        )
+    else:
+        type_checking = runtime.copy()
+    return _ModuleFacts(
+        members=runtime.members,
+        type_checking_members=type_checking.members,
+        exported_modules=runtime.exported_modules,
+        type_checking_exported_modules=type_checking.exported_modules,
+        has_dynamic_getattr=(
+            runtime.has_dynamic_getattr or runtime.has_wildcard_reexport
+        ),
+        has_type_checking_dynamic_getattr=(
+            type_checking.has_dynamic_getattr or type_checking.has_wildcard_reexport
+        ),
+        type_checking_node_ids=type_checking_node_ids,
+    )
+
+
+def _collect_module_fact_state(
+    statements,
+    current_module,
+    local_modules,
+    type_checking_guards,
+    *,
+    type_checking_mode,
+    initial=None,
+):
+    state = initial.copy() if initial is not None else _ModuleFactState(set(), {})
+
+    for stmt in statements:
         if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            members.add(stmt.name)
+            _invalidate_interruptible_module_facts(state, [stmt])
+            _bind_plain_module_names(state, {stmt.name})
             if stmt.name == "__getattr__":
-                has_dynamic_getattr = True
+                state.has_dynamic_getattr = True
         elif isinstance(stmt, ast.ClassDef):
-            members.add(stmt.name)
+            _invalidate_interruptible_module_facts(state, [stmt])
+            _bind_plain_module_names(state, {stmt.name})
         elif isinstance(stmt, ast.Assign):
+            _apply_expression_rebindings(state, stmt.value)
+            names = set()
             for target in stmt.targets:
-                members.update(_extract_target_names(target))
+                names.update(_extract_target_names(target))
+            _bind_plain_module_names(state, names)
         elif isinstance(stmt, ast.AnnAssign):
-            members.update(_extract_target_names(stmt.target))
-        elif type_alias_node is not None and isinstance(stmt, type_alias_node):
-            members.update(_extract_target_names(stmt.name))
+            names = _extract_target_names(stmt.target)
+            state.members.update(names)
+            if stmt.value is not None:
+                _apply_expression_rebindings(state, stmt.value)
+                _clear_module_aliases(state, names)
+        elif isinstance(stmt, ast.AugAssign):
+            _apply_expression_rebindings(state, stmt.value)
+            _bind_plain_module_names(state, _extract_target_names(stmt.target))
+        elif _is_type_alias_statement(stmt):
+            _bind_plain_module_names(state, _extract_target_names(stmt.name))
         elif isinstance(stmt, ast.Import):
             for alias in stmt.names:
                 bound_name = alias.asname or alias.name.split(".", 1)[0]
-                members.add(bound_name)
+                _bind_plain_module_names(state, {bound_name})
                 if alias.asname and alias.name in local_modules:
-                    exported_modules[bound_name] = alias.name
+                    state.exported_modules[bound_name] = alias.name
                 elif not alias.asname:
                     head = alias.name.split(".", 1)[0]
                     if head in local_modules:
-                        exported_modules[head] = head
+                        state.exported_modules[head] = head
         elif isinstance(stmt, ast.ImportFrom):
             base = _resolve_import_from_base(current_module, stmt)
             for alias in stmt.names:
                 if alias.name == "*":
                     if base in local_modules:
-                        has_dynamic_getattr = True
+                        state.has_wildcard_reexport = True
                     continue
                 bound_name = alias.asname or alias.name
-                members.add(bound_name)
+                _bind_plain_module_names(state, {bound_name})
                 if base:
                     full_name = f"{base}.{alias.name}"
                 else:
                     full_name = alias.name
                 if full_name in local_modules:
-                    exported_modules[bound_name] = full_name
+                    state.exported_modules[bound_name] = full_name
+        elif isinstance(stmt, ast.Delete):
+            names = set()
+            for target in stmt.targets:
+                names.update(_extract_target_names(target))
+            _delete_module_names(state, names)
+        elif isinstance(stmt, ast.If):
+            _apply_expression_rebindings(state, stmt.test)
+            type_checking_branch = type_checking_guards.get(id(stmt))
+            if type_checking_branch is not None:
+                select_body = (
+                    type_checking_branch
+                    if type_checking_mode
+                    else not type_checking_branch
+                )
+                selected = stmt.body if select_body else stmt.orelse
+                state = _collect_module_fact_state(
+                    selected,
+                    current_module,
+                    local_modules,
+                    type_checking_guards,
+                    type_checking_mode=type_checking_mode,
+                    initial=state,
+                )
+                continue
 
-    return members, has_dynamic_getattr, exported_modules
+            condition = _static_truth_value(stmt.test)
+            if condition is not None:
+                selected = stmt.body if condition else stmt.orelse
+                state = _collect_module_fact_state(
+                    selected,
+                    current_module,
+                    local_modules,
+                    type_checking_guards,
+                    type_checking_mode=type_checking_mode,
+                    initial=state,
+                )
+                continue
+
+            body_state = _collect_module_fact_state(
+                stmt.body,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=state,
+            )
+            else_state = _collect_module_fact_state(
+                stmt.orelse,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=state,
+            )
+            state = _intersect_module_fact_states([body_state, else_state])
+        elif _is_try_statement(stmt):
+            handler_entry_state = state.copy()
+            _invalidate_interruptible_module_facts(
+                handler_entry_state,
+                stmt.body,
+            )
+            _invalidate_interruptible_module_facts(
+                handler_entry_state,
+                [handler.type for handler in stmt.handlers if handler.type],
+            )
+            normal_state = _collect_module_fact_state(
+                stmt.body,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=state,
+            )
+            normal_state = _collect_module_fact_state(
+                stmt.orelse,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=normal_state,
+            )
+            paths = [normal_state]
+            for handler in stmt.handlers:
+                handler_state = handler_entry_state.copy()
+                if handler.name:
+                    _bind_plain_module_names(handler_state, {handler.name})
+                handler_state = _collect_module_fact_state(
+                    handler.body,
+                    current_module,
+                    local_modules,
+                    type_checking_guards,
+                    type_checking_mode=type_checking_mode,
+                    initial=handler_state,
+                )
+                if handler.name:
+                    _delete_module_names(handler_state, {handler.name})
+                paths.append(handler_state)
+            state = _intersect_module_fact_states(paths)
+            state = _collect_module_fact_state(
+                stmt.finalbody,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=state,
+            )
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            entry_state = state.copy()
+            early_exit_states = []
+            if stmt.items:
+                first_item = stmt.items[0]
+                _apply_expression_rebindings(
+                    entry_state,
+                    first_item.context_expr,
+                )
+                if first_item.optional_vars is not None:
+                    if not isinstance(first_item.optional_vars, ast.Name):
+                        suppressed_target_state = entry_state.copy()
+                        _invalidate_interruptible_module_facts(
+                            suppressed_target_state,
+                            [first_item.optional_vars],
+                        )
+                        early_exit_states.append(suppressed_target_state)
+                    _bind_plain_module_names(
+                        entry_state,
+                        _extract_target_names(first_item.optional_vars),
+                    )
+
+            body_entry_state = entry_state.copy()
+            for item in stmt.items[1:]:
+                _apply_expression_rebindings(
+                    body_entry_state,
+                    item.context_expr,
+                )
+                if item.optional_vars is not None:
+                    _bind_plain_module_names(
+                        body_entry_state,
+                        _extract_target_names(item.optional_vars),
+                    )
+
+            interrupted_state = entry_state.copy()
+            interruptible_nodes = []
+            for item in stmt.items[1:]:
+                interruptible_nodes.append(item.context_expr)
+                if item.optional_vars is not None:
+                    interruptible_nodes.append(item.optional_vars)
+            interruptible_nodes.extend(stmt.body)
+            _invalidate_interruptible_module_facts(
+                interrupted_state,
+                interruptible_nodes,
+            )
+            body_state = _collect_module_fact_state(
+                stmt.body,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=body_entry_state,
+            )
+            state = _intersect_module_fact_states(
+                [*early_exit_states, interrupted_state, body_state]
+            )
+        elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+            _apply_expression_rebindings(state, stmt.iter)
+            if _is_statically_empty_iterable(stmt.iter):
+                state = _collect_module_fact_state(
+                    stmt.orelse,
+                    current_module,
+                    local_modules,
+                    type_checking_guards,
+                    type_checking_mode=type_checking_mode,
+                    initial=state,
+                )
+                continue
+            body_start = state.copy()
+            _bind_plain_module_names(
+                body_start,
+                _extract_target_names(stmt.target),
+            )
+            body_state = _collect_module_fact_state(
+                stmt.body,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=body_start,
+            )
+            loop_state = _intersect_module_fact_states([state, body_state])
+            else_state = _collect_module_fact_state(
+                stmt.orelse,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=loop_state,
+            )
+            state = _intersect_module_fact_states([loop_state, else_state])
+        elif isinstance(stmt, ast.While):
+            _apply_expression_rebindings(state, stmt.test)
+            if _static_truth_value(stmt.test) is False:
+                state = _collect_module_fact_state(
+                    stmt.orelse,
+                    current_module,
+                    local_modules,
+                    type_checking_guards,
+                    type_checking_mode=type_checking_mode,
+                    initial=state,
+                )
+                continue
+            body_state = _collect_module_fact_state(
+                stmt.body,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=state,
+            )
+            loop_state = _intersect_module_fact_states([state, body_state])
+            else_state = _collect_module_fact_state(
+                stmt.orelse,
+                current_module,
+                local_modules,
+                type_checking_guards,
+                type_checking_mode=type_checking_mode,
+                initial=loop_state,
+            )
+            state = _intersect_module_fact_states([loop_state, else_state])
+        elif isinstance(stmt, ast.Match):
+            _apply_expression_rebindings(state, stmt.subject)
+            _invalidate_interruptible_module_facts(
+                state,
+                [case.guard for case in stmt.cases if case.guard],
+            )
+            exhaustive = bool(stmt.cases) and _is_irrefutable_match_case(stmt.cases[-1])
+            paths = [] if exhaustive else [state.copy()]
+            for case in stmt.cases:
+                case_state = state.copy()
+                _bind_plain_module_names(
+                    case_state,
+                    _extract_match_pattern_names(case.pattern),
+                )
+                case_state = _collect_module_fact_state(
+                    case.body,
+                    current_module,
+                    local_modules,
+                    type_checking_guards,
+                    type_checking_mode=type_checking_mode,
+                    initial=case_state,
+                )
+                paths.append(case_state)
+            state = _intersect_module_fact_states(paths)
+        elif isinstance(stmt, ast.Expr):
+            _apply_expression_rebindings(state, stmt.value)
+        elif isinstance(stmt, ast.Assert):
+            _invalidate_interruptible_module_facts(
+                state,
+                [expression for expression in (stmt.test, stmt.msg) if expression],
+            )
+
+    return state
+
+
+def _invalidate_interruptible_module_facts(state, statements):
+    class MutationCollector(ast.NodeVisitor):
+        def __init__(self):
+            self.rebound_names = set()
+            self.deleted_names = set()
+            self.clears_dynamic_getattr = False
+
+        def _record_names(self, names, *, deleted=False):
+            self.rebound_names.update(names)
+            if deleted:
+                self.deleted_names.update(names)
+            if "__getattr__" in names:
+                self.clears_dynamic_getattr = True
+
+        def visit_Name(self, node):
+            if isinstance(node.ctx, ast.Store):
+                self._record_names({node.id})
+            elif isinstance(node.ctx, ast.Del):
+                self._record_names({node.id}, deleted=True)
+
+        def visit_Import(self, node):
+            self._record_names(
+                {
+                    imported.asname or imported.name.split(".", 1)[0]
+                    for imported in node.names
+                }
+            )
+
+        def visit_ImportFrom(self, node):
+            self._record_names(
+                {
+                    imported.asname or imported.name
+                    for imported in node.names
+                    if imported.name != "*"
+                }
+            )
+
+        def visit_FunctionDef(self, node):
+            self.rebound_names.add(node.name)
+            self._visit_function_header(node)
+
+        def visit_AsyncFunctionDef(self, node):
+            self.rebound_names.add(node.name)
+            self._visit_function_header(node)
+
+        def _visit_function_header(self, node):
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for default in node.args.defaults:
+                self.visit(default)
+            for default in node.args.kw_defaults:
+                if default is not None:
+                    self.visit(default)
+            for argument in (
+                *node.args.posonlyargs,
+                *node.args.args,
+                *node.args.kwonlyargs,
+            ):
+                if argument.annotation is not None:
+                    self.visit(argument.annotation)
+            for argument in (node.args.vararg, node.args.kwarg):
+                if argument is not None and argument.annotation is not None:
+                    self.visit(argument.annotation)
+            if node.returns is not None:
+                self.visit(node.returns)
+            for type_parameter in getattr(node, "type_params", []):
+                self.visit(type_parameter)
+
+        def visit_ClassDef(self, node):
+            self._record_names({node.name})
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for base in node.bases:
+                self.visit(base)
+            for keyword in node.keywords:
+                self.visit(keyword.value)
+            for type_parameter in getattr(node, "type_params", []):
+                self.visit(type_parameter)
+
+        def visit_Lambda(self, node):
+            for default in node.args.defaults:
+                self.visit(default)
+            for default in node.args.kw_defaults:
+                if default is not None:
+                    self.visit(default)
+
+        def visit_ExceptHandler(self, node):
+            if node.type is not None:
+                self.visit(node.type)
+            if node.name:
+                self._record_names({node.name}, deleted=True)
+            for child in node.body:
+                self.visit(child)
+
+        def visit_MatchAs(self, node):
+            if node.name:
+                self._record_names({node.name})
+            if node.pattern is not None:
+                self.visit(node.pattern)
+
+        def visit_MatchStar(self, node):
+            if node.name:
+                self._record_names({node.name})
+
+        def visit_MatchMapping(self, node):
+            if node.rest:
+                self._record_names({node.rest})
+            self.generic_visit(node)
+
+    collector = MutationCollector()
+    for stmt in statements:
+        collector.visit(stmt)
+
+    state.members.difference_update(collector.deleted_names)
+    for name in collector.rebound_names:
+        state.exported_modules.pop(name, None)
+    if collector.clears_dynamic_getattr:
+        state.has_dynamic_getattr = False
+
+
+def _bind_plain_module_names(state, names):
+    state.members.update(names)
+    _clear_module_aliases(state, names)
+
+
+def _clear_module_aliases(state, names):
+    for name in names:
+        state.exported_modules.pop(name, None)
+        if name == "__getattr__":
+            state.has_dynamic_getattr = False
+
+
+def _delete_module_names(state, names):
+    state.members.difference_update(names)
+    _clear_module_aliases(state, names)
+
+
+def _apply_expression_rebindings(state, expression):
+    possible_names = {
+        name
+        for node in ast.walk(expression)
+        if isinstance(node, ast.NamedExpr)
+        for name in _extract_target_names(node.target)
+    }
+    _clear_module_aliases(state, possible_names)
+
+    current = expression
+    while isinstance(current, ast.NamedExpr):
+        state.members.update(_extract_target_names(current.target))
+        current = current.value
+
+
+def _intersect_module_fact_states(states):
+    if not states:
+        return _ModuleFactState(set(), {})
+
+    members = set(states[0].members)
+    for state in states[1:]:
+        members.intersection_update(state.members)
+
+    exported_modules = {
+        name: target
+        for name, target in states[0].exported_modules.items()
+        if name in members
+        and all(state.exported_modules.get(name) == target for state in states[1:])
+    }
+    return _ModuleFactState(
+        members=members,
+        exported_modules=exported_modules,
+        has_dynamic_getattr=all(state.has_dynamic_getattr for state in states),
+        has_wildcard_reexport=all(state.has_wildcard_reexport for state in states),
+    )
+
+
+def _static_truth_value(test):
+    if isinstance(test, ast.NamedExpr):
+        return _static_truth_value(test.value)
+    if isinstance(test, ast.Constant):
+        return bool(test.value)
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+        value = _static_truth_value(test.operand)
+        return None if value is None else not value
+    return None
+
+
+def _is_try_statement(stmt):
+    return isinstance(stmt, ast.Try) or type(stmt).__name__ == "TryStar"
+
+
+def _is_type_alias_statement(stmt):
+    type_alias_node = getattr(ast, "TypeAlias", None)
+    return type_alias_node is not None and isinstance(stmt, type_alias_node)
+
+
+def _extract_match_pattern_names(pattern):
+    names = set()
+    for node in ast.walk(pattern):
+        if isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name:
+            names.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest:
+            names.add(node.rest)
+    return names
+
+
+def _is_statically_empty_iterable(expression):
+    return (
+        isinstance(expression, (ast.List, ast.Set, ast.Tuple)) and not expression.elts
+    )
+
+
+def _is_irrefutable_match_case(case):
+    pattern = case.pattern
+    return (
+        case.guard is None
+        and isinstance(pattern, ast.MatchAs)
+        and pattern.pattern is None
+    )
+
+
+def _postponed_annotation_node_ids(tree):
+    if not _uses_future_annotations(tree):
+        return set()
+
+    annotation_roots = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.arg) and node.annotation is not None:
+            annotation_roots.append(node.annotation)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.returns is not None:
+                annotation_roots.append(node.returns)
+        elif isinstance(node, ast.AnnAssign):
+            annotation_roots.append(node.annotation)
+
+    return {
+        id(node) for annotation in annotation_roots for node in ast.walk(annotation)
+    }
+
+
+def _uses_future_annotations(tree):
+    return any(
+        isinstance(stmt, ast.ImportFrom)
+        and stmt.module == "__future__"
+        and any(imported.name == "annotations" for imported in stmt.names)
+        for stmt in tree.body
+    )
 
 
 def _build_parent_map(tree):

--- a/skylos/rules/ai_defect/python_api_hallucination.py
+++ b/skylos/rules/ai_defect/python_api_hallucination.py
@@ -101,11 +101,23 @@ def _inspect_python_coverage(
         for module_name, file_path in modules.items()
         if file_path.name in {"__init__.py", "__init__.pyi", "__init__.pyw"}
     }
-    trees, members, aliases, dynamic, load_reasons = _load_module_facts(
-        modules, local_modules
+    target_modules = {_module_name(root, path): path for path in targets}
+    (
+        trees,
+        members,
+        type_checking_members,
+        aliases,
+        type_checking_aliases,
+        dynamic,
+        type_checking_dynamic,
+        type_checking_node_ids,
+        load_reasons,
+    ) = _load_module_facts(
+        modules,
+        local_modules,
+        reference_modules=set(target_modules),
     )
     state = _PythonCoverageState(reasons=Counter())
-    target_modules = {_module_name(root, path): path for path in targets}
     module_dunder_attributes = _module_dunder_attributes(root)
 
     for module_name, target_path in target_modules.items():
@@ -122,8 +134,12 @@ def _inspect_python_coverage(
             local_modules,
             trees,
             members,
+            type_checking_members,
             aliases,
+            type_checking_aliases,
             dynamic,
+            type_checking_dynamic,
+            type_checking_node_ids.get(module_name, set()),
             package_modules,
             state,
             module_dunder_attributes,
@@ -149,8 +165,12 @@ def _inspect_target_references(
     local_modules: set[str],
     trees: dict[str, ast.AST],
     members: dict[str, set[str]],
+    type_checking_members: dict[str, set[str]],
     aliases: dict[str, dict[str, str]],
+    type_checking_aliases: dict[str, dict[str, str]],
     dynamic: set[str],
+    type_checking_dynamic: set[str],
+    type_checking_node_ids: set[int],
     package_modules: set[str],
     state: _PythonCoverageState,
     module_dunder_attributes: frozenset[str],
@@ -168,20 +188,34 @@ def _inspect_target_references(
         local_modules,
         trees,
         members,
+        type_checking_members,
         dynamic,
+        type_checking_dynamic,
+        type_checking_node_ids,
         package_modules,
         state,
         module_dunder_attributes,
     )
 
     for expression, owner in _reference_expressions(tree, parent_map):
+        if (
+            id(expression) in type_checking_node_ids
+            or id(owner) in type_checking_node_ids
+        ):
+            active_members = type_checking_members
+            active_aliases = type_checking_aliases
+            active_dynamic = type_checking_dynamic
+        else:
+            active_members = members
+            active_aliases = aliases
+            active_dynamic = dynamic
         resolved = _resolve_local_module_member(
             expr=expression,
             node=owner,
             tree=tree,
             parent_map=parent_map,
             scope_infos=scope_infos,
-            module_alias_exports=aliases,
+            module_alias_exports=active_aliases,
             local_modules=local_modules,
             ensure_module_loaded=ensure_module_loaded,
         )
@@ -189,14 +223,14 @@ def _inspect_target_references(
             continue
         target_module, member_name, _ = resolved
         state.references += 1
-        if target_module in dynamic:
+        if target_module in active_dynamic:
             state.skip("dynamic_module_surface")
         elif target_module not in trees:
             state.skip("target_surface_unavailable")
         elif _module_has_member(
             target_module,
             member_name,
-            members,
+            active_members,
             package_modules,
             module_dunder_attributes,
         ):
@@ -224,7 +258,10 @@ def _inspect_import_references(
     local_modules: set[str],
     trees: dict[str, ast.AST],
     members: dict[str, set[str]],
+    type_checking_members: dict[str, set[str]],
     dynamic: set[str],
+    type_checking_dynamic: set[str],
+    type_checking_node_ids: set[int],
     package_modules: set[str],
     state: _PythonCoverageState,
     module_dunder_attributes: frozenset[str],
@@ -238,7 +275,10 @@ def _inspect_import_references(
                 local_modules,
                 trees,
                 members,
+                type_checking_members,
                 dynamic,
+                type_checking_dynamic,
+                type_checking_node_ids,
                 package_modules,
                 state,
                 module_dunder_attributes,
@@ -254,12 +294,21 @@ def _inspect_from_import(
     local_modules: set[str],
     trees: dict[str, ast.AST],
     members: dict[str, set[str]],
+    type_checking_members: dict[str, set[str]],
     dynamic: set[str],
+    type_checking_dynamic: set[str],
+    type_checking_node_ids: set[int],
     package_modules: set[str],
     state: _PythonCoverageState,
     module_dunder_attributes: frozenset[str],
 ) -> None:
     base = _resolve_import_from_base(current_module, node)
+    if id(node) in type_checking_node_ids:
+        active_members = type_checking_members
+        active_dynamic = type_checking_dynamic
+    else:
+        active_members = members
+        active_dynamic = dynamic
     if base not in local_modules:
         if _local_module_exists(root, base):
             state.references += 1
@@ -273,7 +322,7 @@ def _inspect_from_import(
         if alias.name == "*":
             state.skip("wildcard_import")
             continue
-        if base in dynamic:
+        if base in active_dynamic:
             state.skip("dynamic_module_surface")
             continue
         if base not in trees:
@@ -283,7 +332,7 @@ def _inspect_from_import(
         if full_module in local_modules or _module_has_member(
             base,
             alias.name,
-            members,
+            active_members,
             package_modules,
             module_dunder_attributes,
         ):
@@ -362,39 +411,72 @@ def _enrich_python_findings(findings: list[dict[str, Any]]) -> None:
 def _load_module_facts(
     modules: dict[str, Path],
     local_modules: set[str],
+    *,
+    reference_modules: set[str],
 ) -> tuple[
     dict[str, ast.AST],
     dict[str, set[str]],
+    dict[str, set[str]],
+    dict[str, dict[str, str]],
     dict[str, dict[str, str]],
     set[str],
+    set[str],
+    dict[str, set[int]],
     dict[str, str],
 ]:
     trees: dict[str, ast.AST] = {}
     members: dict[str, set[str]] = {}
+    type_checking_members: dict[str, set[str]] = {}
     aliases: dict[str, dict[str, str]] = {}
+    type_checking_aliases: dict[str, dict[str, str]] = {}
     dynamic: set[str] = set()
+    type_checking_dynamic: set[str] = set()
+    type_checking_node_ids: dict[str, set[int]] = {}
     reasons: dict[str, str] = {}
     for module_name, file_path in modules.items():
-        tree, reason = _parse_python_file(file_path)
+        tree, reason, source_has_type_checking = _parse_python_file(file_path)
         if tree is None:
             reasons[module_name] = reason or "target_surface_unavailable"
             continue
         trees[module_name] = tree
-        module_members, has_dynamic_getattr, exported_modules = _collect_module_facts(
-            tree, module_name, local_modules
+        facts = _collect_module_facts(
+            tree,
+            module_name,
+            local_modules,
+            source_has_type_checking=source_has_type_checking,
+            include_reference_context=module_name in reference_modules,
         )
-        members[module_name] = module_members
+        members[module_name] = facts.members
+        type_checking_members[module_name] = facts.type_checking_members
         aliases[module_name] = {
             alias: target
-            for alias, target in exported_modules.items()
+            for alias, target in facts.exported_modules.items()
             if target in local_modules
         }
-        if has_dynamic_getattr:
+        type_checking_aliases[module_name] = {
+            alias: target
+            for alias, target in facts.type_checking_exported_modules.items()
+            if target in local_modules
+        }
+        type_checking_node_ids[module_name] = facts.type_checking_node_ids
+        if facts.has_dynamic_getattr:
             dynamic.add(module_name)
-    return trees, members, aliases, dynamic, reasons
+        if facts.has_type_checking_dynamic_getattr:
+            type_checking_dynamic.add(module_name)
+    return (
+        trees,
+        members,
+        type_checking_members,
+        aliases,
+        type_checking_aliases,
+        dynamic,
+        type_checking_dynamic,
+        type_checking_node_ids,
+        reasons,
+    )
 
 
-def _parse_python_file(path: Path) -> tuple[ast.AST | None, str | None]:
+def _parse_python_file(path: Path) -> tuple[ast.AST | None, str | None, bool]:
     source = read_text_no_symlink(
         path,
         max_bytes=_MAX_PYTHON_SOURCE_BYTES,
@@ -402,11 +484,11 @@ def _parse_python_file(path: Path) -> tuple[ast.AST | None, str | None]:
         errors="replace",
     )
     if source is None:
-        return None, "source_unreadable"
+        return None, "source_unreadable", False
     try:
-        return ast.parse(source), None
+        return ast.parse(source), None, "TYPE_CHECKING" in source
     except SyntaxError:
-        return None, "parse_error"
+        return None, "parse_error", "TYPE_CHECKING" in source
 
 
 def _safe_root(project_root: str | Path) -> Path | None:

--- a/skylos/rules/quality/_protocols.py
+++ b/skylos/rules/quality/_protocols.py
@@ -1,4 +1,5 @@
 import ast
+from typing import cast
 
 _PROTOCOL_MODULES = frozenset({"typing", "typing_extensions"})
 
@@ -66,23 +67,84 @@ def protocol_method_ids(module: ast.Module) -> set[int]:
     }
 
 
-def _is_type_checking_guard(
+def _type_checking_guard_branch(
     test: ast.expr,
     type_checking_names: set[str],
     typing_modules: set[str],
-) -> bool:
+) -> bool | None:
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+        branch = _type_checking_guard_branch(
+            test.operand,
+            type_checking_names,
+            typing_modules,
+        )
+        return None if branch is None else not branch
     if isinstance(test, ast.Name):
-        return test.id in type_checking_names
-    return (
+        return True if test.id in type_checking_names else None
+    if (
         isinstance(test, ast.Attribute)
         and test.attr == "TYPE_CHECKING"
         and isinstance(test.value, ast.Name)
         and test.value.id in typing_modules
-    )
+    ):
+        return True
+    return None
 
 
 def type_checking_function_ids(module: ast.Module) -> set[int]:
-    function_ids: set[int] = set()
+    _, function_ids = _collect_type_checking_context(
+        module,
+        functions_only=True,
+    )
+    return function_ids
+
+
+def type_checking_context(module: ast.Module) -> tuple[dict[int, bool], set[int]]:
+    return _collect_type_checking_context(module, functions_only=False)
+
+
+def type_checking_guard_branches(module: ast.Module) -> dict[int, bool]:
+    guard_branches, _ = _collect_type_checking_context(
+        module,
+        functions_only=None,
+    )
+    return guard_branches
+
+
+def _collect_type_checking_context(
+    module: ast.Module,
+    *,
+    functions_only: bool | None,
+) -> tuple[dict[int, bool], set[int]]:
+    has_candidate_import = any(
+        (
+            isinstance(node, ast.ImportFrom)
+            and node.module in _PROTOCOL_MODULES
+            and any(imported.name == "TYPE_CHECKING" for imported in node.names)
+        )
+        or (
+            isinstance(node, ast.Import)
+            and any(imported.name in _PROTOCOL_MODULES for imported in node.names)
+        )
+        for node in ast.walk(module)
+    )
+    if not has_candidate_import:
+        return {}, set()
+
+    guard_branches: dict[int, bool] = {}
+    context_ids: set[int] = set()
+
+    def mutated_type_checking_module(node: ast.Call) -> str | None:
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in {"setattr", "delattr"}
+            and len(node.args) >= 2
+            and isinstance(node.args[0], ast.Name)
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "TYPE_CHECKING"
+        ):
+            return node.args[0].id
+        return None
 
     class BindingCollector(ast.NodeVisitor):
         def __init__(self) -> None:
@@ -91,6 +153,27 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
         def visit_Name(self, node: ast.Name) -> None:
             if isinstance(node.ctx, (ast.Store, ast.Del)):
                 self.names.add(node.id)
+
+        def visit_Attribute(self, node: ast.Attribute) -> None:
+            if (
+                node.attr == "TYPE_CHECKING"
+                and isinstance(node.ctx, (ast.Store, ast.Del))
+                and isinstance(node.value, ast.Name)
+            ):
+                self.names.add(node.value.id)
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call) -> None:
+            mutated_module = mutated_type_checking_module(node)
+            if mutated_module is not None:
+                self.names.add(mutated_module)
+            self.generic_visit(node)
+
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+            if node.value is not None:
+                self.visit(node.target)
+                self.visit(node.value)
+            self.visit(node.annotation)
 
         def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
             self.names.add(node.name)
@@ -185,10 +268,22 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
     class FunctionBindingCollector(BindingCollector):
         def __init__(self) -> None:
             super().__init__()
+            self.global_names: set[str] = set()
             self.nonlocal_names: set[str] = set()
 
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+            # A bare annotation makes a simple name local for the whole
+            # function, even though it does not bind a value at runtime.
+            if isinstance(node.target, ast.Name):
+                self.names.add(node.target.id)
+            elif node.value is not None:
+                self.visit(node.target)
+            self.visit(node.annotation)
+            if node.value is not None:
+                self.visit(node.value)
+
         def visit_Global(self, node: ast.Global) -> None:
-            self.nonlocal_names.update(node.names)
+            self.global_names.update(node.names)
 
         def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
             self.nonlocal_names.update(node.names)
@@ -220,14 +315,27 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                 else:
                     self.names.add(local_name)
 
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            super().visit_ClassDef(node)
+            self.names.update(class_external_names(node))
+
     def bound_names(node: ast.AST) -> set[str]:
         collector = BindingCollector()
         collector.visit(node)
         return collector.names
 
-    def function_local_names(
-        function: ast.FunctionDef | ast.AsyncFunctionDef,
+    def type_parameter_names(
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
     ) -> set[str]:
+        return {
+            type_parameter.name
+            for type_parameter in getattr(node, "type_params", [])
+            if isinstance(getattr(type_parameter, "name", None), str)
+        }
+
+    def function_scope_bindings(
+        function: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> tuple[set[str], set[str]]:
         collector = FunctionBindingCollector()
         collector.names.update(
             argument.arg
@@ -241,9 +349,54 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
             collector.names.add(function.args.vararg.arg)
         if function.args.kwarg is not None:
             collector.names.add(function.args.kwarg.arg)
+        collector.names.update(type_parameter_names(function))
         for child_statement in function.body:
             collector.visit(child_statement)
-        return collector.names - collector.nonlocal_names
+        local_names = collector.names - (
+            collector.global_names | collector.nonlocal_names
+        )
+        external_names = collector.global_names | collector.nonlocal_names
+        return local_names, external_names
+
+    def class_external_names(class_node: ast.ClassDef) -> set[str]:
+        class ExternalCollector(ast.NodeVisitor):
+            def __init__(self) -> None:
+                self.names: set[str] = set()
+
+            def visit_Global(self, node: ast.Global) -> None:
+                self.names.update(node.names)
+
+            def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+                self.names.update(node.names)
+
+            def visit_Attribute(self, node: ast.Attribute) -> None:
+                if (
+                    node.attr == "TYPE_CHECKING"
+                    and isinstance(node.ctx, (ast.Store, ast.Del))
+                    and isinstance(node.value, ast.Name)
+                ):
+                    self.names.add(node.value.id)
+                self.generic_visit(node)
+
+            def visit_Call(self, node: ast.Call) -> None:
+                mutated_module = mutated_type_checking_module(node)
+                if mutated_module is not None:
+                    self.names.add(mutated_module)
+                self.generic_visit(node)
+
+            def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+                return
+
+            def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+                return
+
+            def visit_Lambda(self, node: ast.Lambda) -> None:
+                return
+
+        collector = ExternalCollector()
+        for child_statement in class_node.body:
+            collector.visit(child_statement)
+        return collector.names
 
     def closure_unsafe_names(
         statements: list[ast.stmt],
@@ -328,24 +481,35 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                 continue
 
             if isinstance(statement, ast.If):
-                is_type_checking = _is_type_checking_guard(
+                type_checking_branch = _type_checking_guard_branch(
                     statement.test,
                     type_checking_names,
                     typing_modules,
                 )
-                if is_type_checking:
-                    for child_statement in statement.body:
-                        function_ids.update(
-                            id(child)
-                            for child in ast.walk(child_statement)
-                            if isinstance(
-                                child, (ast.FunctionDef, ast.AsyncFunctionDef)
+                if type_checking_branch is not None:
+                    guard_branches[id(statement)] = type_checking_branch
+                    guarded_branch = (
+                        statement.body if type_checking_branch else statement.orelse
+                    )
+                    runtime_branch = (
+                        statement.orelse if type_checking_branch else statement.body
+                    )
+                    if functions_only is not None:
+                        for child_statement in guarded_branch:
+                            context_ids.update(
+                                id(child)
+                                for child in ast.walk(child_statement)
+                                if not functions_only
+                                or isinstance(
+                                    child,
+                                    (ast.FunctionDef, ast.AsyncFunctionDef),
+                                )
                             )
-                        )
+                    scan_branch(guarded_branch, bound_names(statement.test))
+                    scan_branch(runtime_branch, bound_names(statement.test))
                 else:
                     scan_branch(statement.body, bound_names(statement.test))
-
-                scan_branch(statement.orelse, bound_names(statement.test))
+                    scan_branch(statement.orelse, bound_names(statement.test))
                 discard_bindings(
                     bound_names(statement),
                     type_checking_names,
@@ -354,8 +518,13 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                 continue
 
             if isinstance(statement, (ast.For, ast.AsyncFor)):
-                loop_bindings = bound_names(statement.target) | bound_names(
-                    statement.iter
+                body_bindings = set().union(
+                    *(bound_names(child) for child in statement.body)
+                )
+                loop_bindings = (
+                    bound_names(statement.target)
+                    | bound_names(statement.iter)
+                    | body_bindings
                 )
                 scan_branch(statement.body, loop_bindings)
                 scan_branch(statement.orelse, loop_bindings)
@@ -367,9 +536,11 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                 continue
 
             if isinstance(statement, ast.While):
-                test_bindings = bound_names(statement.test)
-                scan_branch(statement.body, test_bindings)
-                scan_branch(statement.orelse, test_bindings)
+                loop_bindings = bound_names(statement.test) | set().union(
+                    *(bound_names(child) for child in statement.body)
+                )
+                scan_branch(statement.body, loop_bindings)
+                scan_branch(statement.orelse, loop_bindings)
                 discard_bindings(
                     bound_names(statement),
                     type_checking_names,
@@ -391,30 +562,48 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                 )
                 continue
 
-            if isinstance(statement, ast.Try):
-                scan_branch(statement.body)
+            if isinstance(statement, ast.Try) or type(statement).__name__ == "TryStar":
+                try_statement = cast(ast.Try, statement)
+                is_try_star = type(statement).__name__ == "TryStar"
+                scan_branch(try_statement.body)
                 body_bindings = set().union(
-                    *(bound_names(child) for child in statement.body)
+                    *(bound_names(child) for child in try_statement.body)
                 )
                 handler_body_bindings: set[str] = set()
-                for handler in statement.handlers:
+                prior_handler_type_bindings: set[str] = set()
+                prior_star_handler_bindings: set[str] = set()
+                for handler in try_statement.handlers:
                     handler_bindings = (
                         {handler.name} if handler.name is not None else set()
                     )
+                    handler_type_bindings: set[str] = set()
+                    if handler.type is not None:
+                        handler_type_bindings = bound_names(handler.type)
+                        handler_bindings.update(handler_type_bindings)
                     scan_branch(
                         handler.body,
-                        body_bindings | handler_bindings,
+                        body_bindings
+                        | prior_handler_type_bindings
+                        | prior_star_handler_bindings
+                        | handler_bindings,
                     )
-                    handler_body_bindings.update(handler_bindings)
-                    handler_body_bindings.update(
+                    handler_effect_bindings = set().union(
                         *(bound_names(child) for child in handler.body)
                     )
-                scan_branch(statement.orelse, body_bindings)
+                    handler_body_bindings.update(handler_bindings)
+                    handler_body_bindings.update(handler_effect_bindings)
+                    prior_handler_type_bindings.update(handler_type_bindings)
+                    if is_try_star:
+                        prior_star_handler_bindings.update(handler_bindings)
+                        prior_star_handler_bindings.update(
+                            handler_effect_bindings
+                        )
+                scan_branch(try_statement.orelse, body_bindings)
                 else_bindings = set().union(
-                    *(bound_names(child) for child in statement.orelse)
+                    *(bound_names(child) for child in try_statement.orelse)
                 )
                 scan_branch(
-                    statement.finalbody,
+                    try_statement.finalbody,
                     body_bindings | handler_body_bindings | else_bindings,
                 )
                 discard_bindings(
@@ -426,11 +615,15 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
 
             if isinstance(statement, ast.Match):
                 subject_bindings = bound_names(statement.subject)
+                prior_case_bindings = set(subject_bindings)
                 for case in statement.cases:
-                    case_bindings = subject_bindings | bound_names(case.pattern)
+                    case_bindings = prior_case_bindings | bound_names(case.pattern)
                     if case.guard is not None:
                         case_bindings.update(bound_names(case.guard))
                     scan_branch(case.body, case_bindings)
+                    prior_case_bindings.update(bound_names(case.pattern))
+                    if case.guard is not None:
+                        prior_case_bindings.update(bound_names(case.guard))
                 discard_bindings(
                     bound_names(statement),
                     type_checking_names,
@@ -439,6 +632,9 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                 continue
 
             if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                function_local_names, function_external_names = (
+                    function_scope_bindings(statement)
+                )
                 if scope_kind == "class":
                     function_type_checking_names = set(
                         class_function_type_checking_names or set()
@@ -455,7 +651,9 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                         function_typing_modules,
                     )
                 discard_bindings(
-                    function_local_names(statement) | {statement.name},
+                    function_local_names
+                    | function_external_names
+                    | {statement.name},
                     function_type_checking_names,
                     function_typing_modules,
                 )
@@ -513,6 +711,17 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                         nested_class_function_type_checking_names,
                         nested_class_function_typing_modules,
                     )
+                class_type_parameter_names = type_parameter_names(statement)
+                discard_bindings(
+                    class_type_parameter_names,
+                    nested_class_type_checking_names,
+                    nested_class_typing_modules,
+                )
+                discard_bindings(
+                    class_type_parameter_names,
+                    nested_class_function_type_checking_names,
+                    nested_class_function_typing_modules,
+                )
                 scan_statements(
                     statement.body,
                     nested_class_type_checking_names,
@@ -526,8 +735,11 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
                     ),
                 )
 
+            statement_bindings = bound_names(statement)
+            if isinstance(statement, ast.ClassDef):
+                statement_bindings.update(class_external_names(statement))
             discard_bindings(
-                bound_names(statement),
+                statement_bindings,
                 type_checking_names,
                 typing_modules,
             )
@@ -539,4 +751,4 @@ def type_checking_function_ids(module: ast.Module) -> set[int]:
         scope_kind="module",
         nested_function_unsafe_names=closure_unsafe_names(module.body),
     )
-    return function_ids
+    return guard_branches, context_ids

--- a/test/test_python_api_hallucination.py
+++ b/test/test_python_api_hallucination.py
@@ -108,6 +108,621 @@ def test_python_local_api_check_passes_existing_direct_import(tmp_path):
     assert check["verified_references"] == 1
 
 
+def test_python_local_api_check_accepts_module_control_flow_members(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "control_flow_package/__init__.py": "",
+            "control_flow_package/provider.py": (
+                "from typing import TYPE_CHECKING, TypeAlias\n\n"
+                "DIRECT_VALUE = 0\n\n"
+                "if TYPE_CHECKING:\n"
+                "    TypeOnlyValue: TypeAlias = int\n\n"
+                "if True:\n"
+                "    IF_VALUE = 1\n"
+                "else:\n"
+                "    IF_VALUE = 3\n\n"
+                "try:\n"
+                "    TRY_VALUE = 2\n"
+                "except RuntimeError:\n"
+                "    TRY_VALUE = -1\n"
+            ),
+            "reproduce.py": (
+                "from __future__ import annotations\n"
+                "from typing import TYPE_CHECKING\n\n"
+                "from control_flow_package.provider import (\n"
+                "    DIRECT_VALUE,\n"
+                "    IF_VALUE,\n"
+                "    TRY_VALUE,\n"
+                ")\n\n"
+                "if TYPE_CHECKING:\n"
+                "    from control_flow_package.provider import TypeOnlyValue\n\n"
+                "def identity(value: TypeOnlyValue) -> TypeOnlyValue:\n"
+                "    return value\n"
+            ),
+        },
+        targets=["reproduce.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["references"] == 4
+    assert check["verified_references"] == 4
+
+
+def test_python_local_api_check_accepts_mixed_control_flow_bindings(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "package/__init__.py": "",
+            "package/backend_a.py": "class SelectedBackend:\n    pass\n",
+            "package/backend_b.py": "class SelectedBackend:\n    pass\n",
+            "package/provider.py": (
+                "import sys\n\n"
+                "if sys.version_info < (3, 9):\n"
+                "    get_all_type_hints = len\n"
+                "else:\n"
+                "    def get_all_type_hints(value):\n"
+                "        return value\n\n"
+                "try:\n"
+                "    from package.backend_a import SelectedBackend\n"
+                "except ImportError:\n"
+                "    from package.backend_b import SelectedBackend\n"
+            ),
+            "app.py": (
+                "from package.provider import (\n"
+                "    SelectedBackend,\n"
+                "    get_all_type_hints,\n"
+                ")\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 2
+
+
+def test_python_local_api_check_keeps_one_sided_and_runtime_names_flagged(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "if runtime_flag:\n"
+                "    ONE_SIDED = 1\n\n"
+                "try:\n"
+                "    TRY_ONLY = 2\n"
+                "except RuntimeError:\n"
+                "    pass\n\n"
+                "if TYPE_CHECKING:\n"
+                "    TYPE_ONLY = int\n\n"
+                "if False:\n"
+                "    NEVER_DEFINED = 3\n"
+            ),
+            "app.py": (
+                "from provider import (\n"
+                "    MISSING,\n"
+                "    NEVER_DEFINED,\n"
+                "    ONE_SIDED,\n"
+                "    TRY_ONLY,\n"
+                "    TYPE_ONLY,\n"
+                ")\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert {finding["simple_name"] for finding in findings} == {
+        "MISSING",
+        "NEVER_DEFINED",
+        "ONE_SIDED",
+        "TRY_ONLY",
+        "TYPE_ONLY",
+    }
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 5
+
+
+def test_python_local_api_check_does_not_export_nested_scope_members(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "if True:\n"
+                "    def public_factory():\n"
+                "        function_local = 1\n"
+                "        return function_local\n\n"
+                "    class PublicNamespace:\n"
+                "        class_local = 2\n"
+            ),
+            "app.py": (
+                "from provider import (\n"
+                "    PublicNamespace,\n"
+                "    class_local,\n"
+                "    function_local,\n"
+                "    public_factory,\n"
+                ")\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert {finding["simple_name"] for finding in findings} == {
+        "class_local",
+        "function_local",
+    }
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 2
+
+
+def test_python_local_api_check_ignores_type_only_dynamic_getattr_at_runtime(
+    tmp_path,
+):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "if TYPE_CHECKING:\n"
+                "    def __getattr__(name):\n"
+                "        return name\n"
+            ),
+            "app.py": "import provider\nprint(provider.missing)\n",
+        },
+        targets=["app.py"],
+    )
+
+    assert [finding["simple_name"] for finding in findings] == ["missing"]
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 1
+
+
+def test_python_local_api_check_handles_type_checking_contexts(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "if TYPE_CHECKING:\n"
+                "    TypeOnly = int\n"
+                "else:\n"
+                "    RuntimeOnly = int\n"
+            ),
+            "app.py": (
+                "from __future__ import annotations\n"
+                "from typing import TYPE_CHECKING\n"
+                "import typing as t\n\n"
+                "TYPE_CHECKING: bool\n\n"
+                "if not TYPE_CHECKING:\n"
+                "    from provider import RuntimeOnly\n"
+                "else:\n"
+                "    from provider import TypeOnly\n\n"
+                "def nested():\n"
+                "    if t.TYPE_CHECKING:\n"
+                "        from provider import TypeOnly\n\n"
+                "class Namespace:\n"
+                "    if t.TYPE_CHECKING:\n"
+                "        from provider import TypeOnly\n\n"
+                "if TYPE_CHECKING:\n"
+                "    import provider\n\n"
+                "def identity(value: provider.TypeOnly) -> provider.TypeOnly:\n"
+                "    return value\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+
+
+def test_python_local_api_check_keeps_dynamic_surfaces_conservative(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "source.py": "EXPORTED = 1\n",
+            "wildcard_provider.py": ("from source import *\n\n__getattr__ = None\n"),
+            "with_provider.py": (
+                "from contextlib import nullcontext\n\n"
+                "EXPORTED = 1\n\n"
+                "def __getattr__(name):\n"
+                "    return name\n\n"
+                "with nullcontext(), nullcontext(None) as __getattr__:\n"
+                "    del EXPORTED\n"
+            ),
+            "unpack_provider.py": (
+                "class SuppressingContext:\n"
+                "    def __enter__(self):\n"
+                "        return []\n\n"
+                "    def __exit__(self, *args):\n"
+                "        return True\n\n"
+                "with SuppressingContext() as (UNPACKED,):\n"
+                "    pass\n"
+            ),
+            "try_provider.py": (
+                "def __getattr__(name):\n"
+                "    return name\n\n"
+                "try:\n"
+                "    __getattr__ = None\n"
+                "    risky_operation()\n"
+                "    def __getattr__(name):\n"
+                "        return name\n"
+                "except RuntimeError:\n"
+                "    pass\n"
+            ),
+            "match_provider.py": (
+                "if True:\n"
+                "    def __getattr__(name):\n"
+                "        return name\n\n"
+                "    match 1:\n"
+                "        case _ if (__getattr__ := 1):\n"
+                "            pass\n"
+            ),
+            "assert_provider.py": (
+                "if True:\n"
+                "    def __getattr__(name):\n"
+                "        return name\n\n"
+                "    assert (__getattr__ := 1)\n"
+            ),
+            "header_provider.py": (
+                "if True:\n"
+                "    def __getattr__(name):\n"
+                "        return name\n\n"
+                "    def helper(value=(__getattr__ := 1)):\n"
+                "        return value\n"
+            ),
+            "handler_type_provider.py": (
+                "if True:\n"
+                "    def __getattr__(name):\n"
+                "        return name\n\n"
+                "    try:\n"
+                "        raise RuntimeError\n"
+                "    except (__getattr__ := (RuntimeError,)):\n"
+                "        pass\n"
+            ),
+            "app.py": (
+                "import assert_provider\n"
+                "import handler_type_provider\n"
+                "import header_provider\n"
+                "import match_provider\n"
+                "import try_provider\n"
+                "import wildcard_provider\n"
+                "import with_provider\n\n"
+                "from unpack_provider import UNPACKED\n"
+                "from with_provider import EXPORTED\n\n"
+                "print(assert_provider.unknown)\n"
+                "print(handler_type_provider.unknown)\n"
+                "print(header_provider.unknown)\n"
+                "print(match_provider.unknown)\n"
+                "print(try_provider.unknown)\n"
+                "print(wildcard_provider.unknown)\n"
+                "print(with_provider.unknown)\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert {finding["name"] for finding in findings} == {
+        "EXPORTED",
+        "UNPACKED",
+        "assert_provider.unknown",
+        "handler_type_provider.unknown",
+        "header_provider.unknown",
+        "match_provider.unknown",
+        "try_provider.unknown",
+        "with_provider.unknown",
+    }
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 8
+
+
+def test_python_local_api_check_rejects_transient_try_mutations(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "EXPORTED = 1\n\n"
+                "def __getattr__(name):\n"
+                "    return name\n\n"
+                "try:\n"
+                "    if runtime_flag:\n"
+                "        del EXPORTED\n"
+                "        __getattr__ = None\n"
+                "        risky_operation()\n"
+                "        EXPORTED = 2\n"
+                "        def __getattr__(name):\n"
+                "            return name\n"
+                "except RuntimeError:\n"
+                "    pass\n"
+            ),
+            "app.py": (
+                "from provider import EXPORTED\n"
+                "import provider\n\n"
+                "print(provider.unknown)\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert {finding["name"] for finding in findings} == {
+        "EXPORTED",
+        "provider.unknown",
+    }
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 2
+
+
+def test_python_local_api_check_handles_definite_compound_bindings(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "PRESERVED = 1\n\n"
+                "while False:\n"
+                "    del PRESERVED\n"
+                "else:\n"
+                "    WHILE_ELSE = 2\n\n"
+                "for item in []:\n"
+                "    del PRESERVED\n"
+                "else:\n"
+                "    FOR_ELSE = 3\n\n"
+                "match 1:\n"
+                "    case 1:\n"
+                "        MATCHED = 4\n"
+                "    case _:\n"
+                "        MATCHED = 5\n\n"
+                "if (WALRUS := 1):\n"
+                "    pass\n"
+            ),
+            "app.py": (
+                "from provider import (\n"
+                "    FOR_ELSE,\n"
+                "    MATCHED,\n"
+                "    PRESERVED,\n"
+                "    WALRUS,\n"
+                "    WHILE_ELSE,\n"
+                ")\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert findings == []
+    assert check["outcome"] == "pass"
+    assert check["verified_references"] == 5
+
+
+def test_python_local_api_check_rejects_mutated_type_checking_sentinel(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "import typing as t\n\n"
+                "t.TYPE_CHECKING = runtime_flag\n"
+                "if t.TYPE_CHECKING:\n"
+                "    TRUE_BRANCH = 1\n"
+                "else:\n"
+                "    FALSE_BRANCH = 2\n"
+            ),
+            "app.py": ("from provider import FALSE_BRANCH, TRUE_BRANCH\n"),
+        },
+        targets=["app.py"],
+    )
+
+    assert {finding["simple_name"] for finding in findings} == {
+        "FALSE_BRANCH",
+        "TRUE_BRANCH",
+    }
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 2
+
+
+def test_python_local_api_check_rejects_function_local_type_checking_annotation(
+    tmp_path,
+):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "if TYPE_CHECKING:\n"
+                "    MissingType = int\n"
+            ),
+            "app.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "def load_type():\n"
+                "    TYPE_CHECKING: bool\n"
+                "    if TYPE_CHECKING:\n"
+                "        from provider import MissingType\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert [finding["name"] for finding in findings] == ["MissingType"]
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 1
+
+
+def test_python_local_api_check_rejects_shadowed_type_checking_guards(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "if TYPE_CHECKING:\n"
+                "    ClassAttributeOnly = int\n"
+                "    ClassOnly = int\n"
+                "    ClassNonlocalOnly = int\n"
+                "    ExceptOnly = int\n"
+                "    FunctionAfterClassAttributeOnly = int\n"
+                "    GlobalOnly = int\n"
+                "    HandlerTypeOnly = int\n"
+                "    LoopOnly = int\n"
+                "    MatchOnly = int\n"
+                "    NonlocalOnly = int\n"
+                "    SetattrOnly = int\n"
+            ),
+            "app.py": (
+                "from typing import TYPE_CHECKING as CLASS_FLAG\n"
+                "import typing as typing_module\n\n"
+                "RUNTIME_FLAG = True\n\n"
+                "def before_class_attribute_mutation():\n"
+                "    if typing_module.TYPE_CHECKING:\n"
+                "        from provider import FunctionAfterClassAttributeOnly\n\n"
+                "def outer():\n"
+                "    from typing import TYPE_CHECKING as GLOBAL_FLAG\n\n"
+                "    def inner():\n"
+                "        global GLOBAL_FLAG\n"
+                "        if GLOBAL_FLAG:\n"
+                "            from provider import GlobalOnly\n\n"
+                "def loop():\n"
+                "    from typing import TYPE_CHECKING as LOOP_FLAG\n"
+                "    while keep_going():\n"
+                "        if LOOP_FLAG:\n"
+                "            from provider import LoopOnly\n"
+                "        LOOP_FLAG = RUNTIME_FLAG\n\n"
+                "def nonlocal_outer():\n"
+                "    from typing import TYPE_CHECKING as NONLOCAL_FLAG\n\n"
+                "    def inner():\n"
+                "        nonlocal NONLOCAL_FLAG\n"
+                "        if NONLOCAL_FLAG:\n"
+                "            from provider import NonlocalOnly\n"
+                "        NONLOCAL_FLAG = RUNTIME_FLAG\n\n"
+                "def class_nonlocal():\n"
+                "    from typing import TYPE_CHECKING as CLASS_NONLOCAL_FLAG\n\n"
+                "    class Mutator:\n"
+                "        nonlocal CLASS_NONLOCAL_FLAG\n"
+                "        CLASS_NONLOCAL_FLAG = RUNTIME_FLAG\n\n"
+                "    if CLASS_NONLOCAL_FLAG:\n"
+                "        from provider import ClassNonlocalOnly\n\n"
+                "class Mutator:\n"
+                "    global CLASS_FLAG\n"
+                "    CLASS_FLAG = RUNTIME_FLAG\n\n"
+                "if CLASS_FLAG:\n"
+                "    from provider import ClassOnly\n\n"
+                "class AttributeMutator:\n"
+                "    typing_module.TYPE_CHECKING = RUNTIME_FLAG\n\n"
+                "if typing_module.TYPE_CHECKING:\n"
+                "    from provider import ClassAttributeOnly\n\n"
+                "import typing as setattr_module\n\n"
+                "setattr(setattr_module, 'TYPE_CHECKING', RUNTIME_FLAG)\n"
+                "if setattr_module.TYPE_CHECKING:\n"
+                "    from provider import SetattrOnly\n\n"
+                "from typing import TYPE_CHECKING as HANDLER_FLAG\n\n"
+                "try:\n"
+                "    raise ValueError\n"
+                "except (HANDLER_FLAG := TypeError):\n"
+                "    pass\n"
+                "except ValueError:\n"
+                "    if HANDLER_FLAG:\n"
+                "        from provider import HandlerTypeOnly\n\n"
+                "from typing import TYPE_CHECKING as MATCH_FLAG\n\n"
+                "match 1:\n"
+                "    case _ if not (MATCH_FLAG := RUNTIME_FLAG):\n"
+                "        pass\n"
+                "    case _:\n"
+                "        if MATCH_FLAG:\n"
+                "            from provider import MatchOnly\n\n"
+                "try:\n"
+                "    raise RuntimeError\n"
+                "except (EXCEPT_FLAG := RuntimeError):\n"
+                "    if EXCEPT_FLAG:\n"
+                "        from provider import ExceptOnly\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    assert {finding["name"] for finding in findings} == {
+        "ClassAttributeOnly",
+        "ClassOnly",
+        "ClassNonlocalOnly",
+        "ExceptOnly",
+        "FunctionAfterClassAttributeOnly",
+        "GlobalOnly",
+        "HandlerTypeOnly",
+        "LoopOnly",
+        "MatchOnly",
+        "NonlocalOnly",
+        "SetattrOnly",
+    }
+    assert check["outcome"] == "fail"
+    assert check["finding_count"] == 11
+
+
+def test_python_local_api_check_rejects_try_star_handler_rebinding(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "if TYPE_CHECKING:\n"
+                "    LaterHandlerOnly = int\n"
+            ),
+            "app.py": (
+                "from typing import TYPE_CHECKING as HANDLER_FLAG\n\n"
+                "RUNTIME_FLAG = True\n\n"
+                "try:\n"
+                "    raise ExceptionGroup(\n"
+                "        'boom', [ValueError(), TypeError()]\n"
+                "    )\n"
+                "except* ValueError:\n"
+                "    HANDLER_FLAG = RUNTIME_FLAG\n"
+                "except* TypeError:\n"
+                "    if HANDLER_FLAG:\n"
+                "        from provider import LaterHandlerOnly\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    if hasattr(ast, "TryStar"):
+        assert [finding["name"] for finding in findings] == ["LaterHandlerOnly"]
+        assert check["outcome"] == "fail"
+        assert check["finding_count"] == 1
+    else:
+        assert findings == []
+        assert check["outcome"] == "incomplete"
+
+
+def test_python_local_api_check_rejects_type_parameter_shadowing(tmp_path):
+    findings, check = _scan(
+        tmp_path,
+        {
+            "provider.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "if TYPE_CHECKING:\n"
+                "    ClassTypeOnly = int\n"
+                "    FunctionTypeOnly = int\n"
+            ),
+            "app.py": (
+                "from typing import TYPE_CHECKING\n\n"
+                "def generic[TYPE_CHECKING]():\n"
+                "    if TYPE_CHECKING:\n"
+                "        from provider import FunctionTypeOnly\n\n"
+                "class Generic[TYPE_CHECKING]:\n"
+                "    if TYPE_CHECKING:\n"
+                "        from provider import ClassTypeOnly\n"
+            ),
+        },
+        targets=["app.py"],
+    )
+
+    if hasattr(ast, "TypeVar"):
+        assert {finding["name"] for finding in findings} == {
+            "ClassTypeOnly",
+            "FunctionTypeOnly",
+        }
+        assert check["outcome"] == "fail"
+        assert check["finding_count"] == 2
+    else:
+        assert findings == []
+        assert check["outcome"] == "incomplete"
+
+
 def test_python_local_api_check_passes_explicit_dotted_submodule_import(tmp_path):
     findings, check = _scan(
         tmp_path,


### PR DESCRIPTION
Fixes #741.

## Summary

Now recognizes module names defined through:

  - both sides of an `if/else`
  - `try/except` paths
  - `TYPE_CHECKING` code

  It still reports names that are only defined on some paths or when the result is uncertain.