### PR TITLE
perf(analyzer): batch engine-sensitive space patterns

### DIFF
--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -1395,6 +1395,33 @@ def _run_ripgrep_pattern_file(
     return _parse_ripgrep_json_matches(result.stdout, deadline=deadline)
 
 
+def _grep_stdin_chunks(
+    contents: Sequence[str],
+    limit: int,
+) -> Iterator[tuple[int, list[str]]]:
+    """Yield ``(offset, lines)`` groups whose encoded stdin fits in ``limit``.
+
+    A single line wider than the cap cannot be sent at all, so it keeps the
+    fail-closed behavior rather than being silently dropped from adjudication.
+    """
+    chunk: list[str] = []
+    chunk_bytes = 0
+    offset = 0
+    for index, content in enumerate(contents):
+        line_bytes = len(content.encode("utf-8")) + 1
+        if line_bytes > limit:
+            raise _GrepInputLimitExceeded("grep adjudication line is too large")
+        if chunk and chunk_bytes + line_bytes > limit:
+            yield offset, chunk
+            chunk = []
+            chunk_bytes = 0
+            offset = index
+        chunk.append(content)
+        chunk_bytes += line_bytes
+    if chunk:
+        yield offset, chunk
+
+
 def _ripgrep_stdin_match_positions(
     pattern: str,
     contents: Sequence[str],
@@ -1402,32 +1429,42 @@ def _ripgrep_stdin_match_positions(
     *,
     deadline: float | None = None,
 ) -> set[int]:
-    """Return the 0-based positions of the given lines that ripgrep matches."""
-    stdin = "\n".join(contents) + "\n"
-    result = _run_bounded_subprocess(
-        [
-            rg,
-            "--no-config",
-            "-n",
-            "--no-heading",
-            "--color",
-            "never",
-            "--",
-            pattern,
-            "-",
-        ],
-        input_text=stdin,
-        timeout=_remaining_timeout(deadline, _GREP_REQUEST_TIMEOUT_SECONDS),
-        input_limit=_GREP_UNICODE_MAX_INPUT_BYTES,
-    )
-    if result.returncode not in (0, 1):
-        msg = result.stderr.strip() or f"exit status {result.returncode}"
-        raise RuntimeError(msg)
+    """Return the 0-based positions of the given lines that ripgrep matches.
+
+    The candidate lines are adjudicated in stdin-sized chunks. A repository
+    can hold more divergent lines than one bounded stdin write allows, and a
+    direct per-pattern search would have resolved all of them, so refusing the
+    whole request there would drop real evidence.
+    """
     positions: set[int] = set()
-    for line in result.stdout.split("\n"):
-        prefix = line.split(":", 1)[0]
-        if prefix.isdigit():
-            positions.add(int(prefix) - 1)
+    for offset, chunk in _grep_stdin_chunks(
+        contents, _GREP_UNICODE_MAX_INPUT_BYTES
+    ):
+        if _deadline_expired(deadline):
+            raise _GrepDeadlineExceeded("deadline exceeded while adjudicating grep")
+        result = _run_bounded_subprocess(
+            [
+                rg,
+                "--no-config",
+                "-n",
+                "--no-heading",
+                "--color",
+                "never",
+                "--",
+                pattern,
+                "-",
+            ],
+            input_text="\n".join(chunk) + "\n",
+            timeout=_remaining_timeout(deadline, _GREP_REQUEST_TIMEOUT_SECONDS),
+            input_limit=_GREP_UNICODE_MAX_INPUT_BYTES,
+        )
+        if result.returncode not in (0, 1):
+            msg = result.stderr.strip() or f"exit status {result.returncode}"
+            raise RuntimeError(msg)
+        for line in result.stdout.split("\n"):
+            prefix = line.split(":", 1)[0]
+            if prefix.isdigit():
+                positions.add(offset + int(prefix) - 1)
     return positions
 
 

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -1034,6 +1034,10 @@ def _streamed_match_can_improve(
     )
 
 
+def _contains_engine_divergent_space(content: str) -> bool:
+    return any(char in content for char in _ENGINE_DIVERGENT_SPACE_CHARS)
+
+
 def _streamed_request_matches(
     request: GrepRequest,
     match: _GrepMatch,
@@ -1047,6 +1051,12 @@ def _streamed_request_matches(
     regex = state.regexes[request]
     assert regex is not None
     python_matches = regex.search(match.content) is not None
+    if (
+        _ENGINE_SENSITIVE_SPACE_PATTERN.search(request.pattern)
+        and _contains_engine_divergent_space(match.content)
+    ):
+        state.requests_requiring_exact_search.add(request)
+        return False
     if not match.content.isascii():
         needs_adjudication = bool(
             _UNICODE_CASE_INSENSITIVE_PATTERN.search(request.pattern)
@@ -1517,7 +1527,7 @@ def _space_divergent_lines(
     return [
         (index, match.content)
         for index, match in enumerate(grep_matches)
-        if any(char in match.content for char in _ENGINE_DIVERGENT_SPACE_CHARS)
+        if _contains_engine_divergent_space(match.content)
     ]
 
 
@@ -1656,7 +1666,14 @@ def _run_ripgrep_batch(
     word_divergent_lines = _word_divergent_lines(
         non_ascii_lines, deadline=deadline
     )
-    space_divergent_lines = _space_divergent_lines(grep_matches)
+    has_space_pattern = any(
+        not request.fixed_string
+        and _ENGINE_SENSITIVE_SPACE_PATTERN.search(request.pattern)
+        for request in batched
+    )
+    space_divergent_lines = (
+        _space_divergent_lines(grep_matches) if has_space_pattern else []
+    )
     unicode_adjudications = 0
     for request in batched:
         if _deadline_expired(deadline):
@@ -1690,7 +1707,7 @@ def _run_ripgrep_batch(
                     if _deadline_expired(deadline):
                         break
                     logger.debug(
-                        "Treating unresolved non-ASCII matches as non-matches "
+                        "Treating unresolved engine-sensitive matches as non-matches "
                         "for %r: %s",
                         request.pattern,
                         exc,

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -126,6 +126,9 @@ _UNICODE_WORD_PATTERN = re.compile(r"\\[bBwW]")
 _UNICODE_CASE_INSENSITIVE_PATTERN = re.compile(r"\(\?[a-z-]*i")
 _ENGINE_SENSITIVE_SPACE_PATTERN = re.compile(r"\\[sS]")
 _UNESCAPED_ALTERNATION_PATTERN = re.compile(r"(?<!\\)(?:\\\\)*\|")
+# Python's re \s matches U+001C-U+001F; ripgrep's Unicode White_Space \s does
+# not. Those four characters are the complete divergence in both directions.
+_ENGINE_DIVERGENT_SPACE_CHARS = ("\x1c", "\x1d", "\x1e", "\x1f")
 _MAX_GREP_LINE_NUMBER = 999_999_999
 _MAX_GREP_LINE_CANDIDATES = 256
 _GREP_LINE_NUMBER = re.compile(r":([1-9][0-9]{0,8}):")
@@ -1358,10 +1361,6 @@ def _requires_direct_grep(request: GrepRequest) -> bool:
         return True
     if not request.pattern.isascii():
         return True
-    if not request.fixed_string and _ENGINE_SENSITIVE_SPACE_PATTERN.search(
-        request.pattern
-    ):
-        return True
     return not request.fixed_string and _python_regex(request.pattern) is None
 
 
@@ -1475,18 +1474,33 @@ def _word_divergent_lines(
     return divergent
 
 
+def _space_divergent_lines(
+    grep_matches: Sequence[_GrepMatch],
+) -> list[tuple[int, str]]:
+    return [
+        (index, match.content)
+        for index, match in enumerate(grep_matches)
+        if any(char in match.content for char in _ENGINE_DIVERGENT_SPACE_CHARS)
+    ]
+
+
 def _unicode_sensitive_lines(
     request: GrepRequest,
     non_ascii_lines: Sequence[tuple[int, str]],
     word_divergent_lines: Sequence[tuple[int, str]],
+    space_divergent_lines: Sequence[tuple[int, str]] = (),
 ) -> list[tuple[int, str]]:
-    if request.fixed_string or not non_ascii_lines:
+    if request.fixed_string:
         return []
-    if _UNICODE_CASE_INSENSITIVE_PATTERN.search(request.pattern):
-        return list(non_ascii_lines)
-    if not _UNICODE_WORD_PATTERN.search(request.pattern):
-        return []
-    return list(word_divergent_lines)
+    sensitive: dict[int, str] = {}
+    if _ENGINE_SENSITIVE_SPACE_PATTERN.search(request.pattern):
+        sensitive.update(space_divergent_lines)
+    if non_ascii_lines:
+        if _UNICODE_CASE_INSENSITIVE_PATTERN.search(request.pattern):
+            sensitive.update(non_ascii_lines)
+        elif _UNICODE_WORD_PATTERN.search(request.pattern):
+            sensitive.update(word_divergent_lines)
+    return sorted(sensitive.items())
 
 
 def _non_ascii_line_overrides(
@@ -1495,16 +1509,18 @@ def _non_ascii_line_overrides(
     word_divergent_lines: Sequence[tuple[int, str]],
     rg: str,
     *,
+    space_divergent_lines: Sequence[tuple[int, str]] = (),
     deadline: float | None = None,
 ) -> dict[int, bool] | None:
-    # After POSIX-class translation the only engine-sensitive construct left
-    # in classifier patterns is \b: ripgrep's UTS#18 word class includes
-    # combining marks, join controls, and non-decimal numerics that Python's
-    # re does not (and vice versa). Let ripgrep itself adjudicate non-ASCII
-    # lines so batched attribution matches what a per-pattern search returns.
-    # Fixed strings are byte-exact substring checks and never diverge.
+    # After POSIX-class translation two engine-sensitive constructs remain in
+    # classifier patterns. \b: ripgrep's UTS#18 word class includes combining
+    # marks, join controls, and non-decimal numerics that Python's re does not
+    # (and vice versa). \s: Python's re matches U+001C-U+001F, which ripgrep's
+    # Unicode White_Space class excludes. Let ripgrep itself adjudicate the
+    # affected lines so batched attribution matches what a per-pattern search
+    # returns. Fixed strings are byte-exact substring checks and never diverge.
     sensitive_lines = _unicode_sensitive_lines(
-        request, non_ascii_lines, word_divergent_lines
+        request, non_ascii_lines, word_divergent_lines, space_divergent_lines
     )
     if not sensitive_lines:
         return None
@@ -1603,12 +1619,13 @@ def _run_ripgrep_batch(
     word_divergent_lines = _word_divergent_lines(
         non_ascii_lines, deadline=deadline
     )
+    space_divergent_lines = _space_divergent_lines(grep_matches)
     unicode_adjudications = 0
     for request in batched:
         if _deadline_expired(deadline):
             break
         sensitive_lines = _unicode_sensitive_lines(
-            request, non_ascii_lines, word_divergent_lines
+            request, non_ascii_lines, word_divergent_lines, space_divergent_lines
         )
         overrides: dict[int, bool] | None = None
         request_incomplete = False
@@ -1622,6 +1639,7 @@ def _run_ripgrep_batch(
                         non_ascii_lines,
                         word_divergent_lines,
                         rg,
+                        space_divergent_lines=space_divergent_lines,
                         deadline=deadline,
                     )
                 except (

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1000,6 +1000,93 @@ class TestBatchedGrepVerify:
         assert results[bar_request] == (line,)
         assert results[literal_request] == ("/repo/other.py:2:pkg.literalé()",)
 
+    def test_engine_sensitive_space_patterns_are_batched(self):
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        space_request = GrepRequest(pattern=r"alpha\somega", **common)
+        negated_request = GrepRequest(pattern=r"alpha\Somega", **common)
+        process_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(("/repo/a.py", 1, "alpha omega\n")),
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=process_result,
+            ) as mock_run,
+            patch(
+                "skylos.core.grep_verify_common._run_grep_request",
+                side_effect=AssertionError("space patterns must stay batched"),
+            ),
+        ):
+            results = execute_grep_batch([space_request, negated_request])
+
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.kwargs["input_text"] == (
+            "alpha\\somega\nalpha\\Somega\n"
+        )
+        assert results[space_request] == ("/repo/a.py:1:alpha omega",)
+        assert results[negated_request] == ()
+
+    def test_ascii_separator_content_uses_ripgrep_space_semantics(self):
+        # U+001C-U+001F are the complete divergence between Python re \s and
+        # ripgrep's Unicode White_Space \s: Python matches them, ripgrep does
+        # not. They are ASCII, so the non-ASCII sensitivity check never sees
+        # them and unadjudicated replay would credit a line ripgrep never
+        # matched for that pattern.
+        content = "alpha\x1comega = 1"
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        space_request = GrepRequest(pattern=r"alpha\somega", **common)
+        companion_request = GrepRequest(pattern=r"alpha", **common)
+
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(("/repo/code.py", 1, f"{content}\n")),
+            stderr="",
+        )
+
+        def fake_run(cmd, **kwargs):
+            if "--json" in cmd:
+                return batch_result
+            assert cmd[-2] == space_request.pattern
+            return Mock(returncode=1, stdout="", stderr="")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                side_effect=fake_run,
+            ) as mock_run,
+        ):
+            results = execute_grep_batch([space_request, companion_request])
+
+        adjudication_calls = [
+            call for call in mock_run.call_args_list if "--json" not in call.args[0]
+        ]
+        assert len(adjudication_calls) == 1
+        assert results[space_request] == ()
+        assert results[companion_request] == (f"/repo/code.py:1:{content}",)
+
     def test_batched_and_legacy_verdicts_match_on_non_ascii_content(self, tmp_path):
         package = tmp_path / "pkg.py"
         package.write_text(

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -1040,12 +1040,19 @@ class TestBatchedGrepVerify:
         assert results[space_request] == ("/repo/a.py:1:alpha omega",)
         assert results[negated_request] == ()
 
-    def test_ascii_separator_content_uses_ripgrep_space_semantics(self):
+    @pytest.mark.parametrize(
+        ("pattern", "adjudication_matches"),
+        [(r"alpha\somega", False), (r"alpha\Somega", True)],
+    )
+    def test_ascii_separator_content_uses_ripgrep_space_semantics(
+        self,
+        pattern,
+        adjudication_matches,
+    ):
         # U+001C-U+001F are the complete divergence between Python re \s and
-        # ripgrep's Unicode White_Space \s: Python matches them, ripgrep does
-        # not. They are ASCII, so the non-ASCII sensitivity check never sees
-        # them and unadjudicated replay would credit a line ripgrep never
-        # matched for that pattern.
+        # ripgrep's Unicode White_Space \s. The inverse difference applies to
+        # \S. They are ASCII, so the non-ASCII sensitivity check never sees
+        # them and unadjudicated replay would produce the wrong verdict.
         content = "alpha\x1comega = 1"
         common = {
             "project_root": "/repo",
@@ -1054,7 +1061,7 @@ class TestBatchedGrepVerify:
             "fixed_string": False,
             "max_results": 5,
         }
-        space_request = GrepRequest(pattern=r"alpha\somega", **common)
+        space_request = GrepRequest(pattern=pattern, **common)
         companion_request = GrepRequest(pattern=r"alpha", **common)
 
         batch_result = Mock(
@@ -1067,7 +1074,11 @@ class TestBatchedGrepVerify:
             if "--json" in cmd:
                 return batch_result
             assert cmd[-2] == space_request.pattern
-            return Mock(returncode=1, stdout="", stderr="")
+            return Mock(
+                returncode=0 if adjudication_matches else 1,
+                stdout=f"1:{content}\n" if adjudication_matches else "",
+                stderr="",
+            )
 
         with (
             patch(
@@ -1085,7 +1096,8 @@ class TestBatchedGrepVerify:
             call for call in mock_run.call_args_list if "--json" not in call.args[0]
         ]
         assert len(adjudication_calls) == 1
-        assert results[space_request] == ()
+        expected = (f"/repo/code.py:1:{content}",) if adjudication_matches else ()
+        assert results[space_request] == expected
         assert results[companion_request] == (f"/repo/code.py:1:{content}",)
 
     def test_large_space_adjudication_payload_is_chunked(self):
@@ -1170,6 +1182,107 @@ class TestBatchedGrepVerify:
             f"/repo/code{index:02d}.py:1:{content}"
             for index, content in enumerate(contents)
             if index % 2 == 0
+        )
+
+    def test_grep_stdin_chunks_use_exact_utf8_byte_limit(self):
+        assert list(grep_verify_common_module._grep_stdin_chunks(["é", "x"], 3)) == [
+            (0, ["é"]),
+            (1, ["x"]),
+        ]
+
+        with pytest.raises(_GrepInputLimitExceeded):
+            list(grep_verify_common_module._grep_stdin_chunks(["éé"], 4))
+
+    def test_single_oversized_space_adjudication_is_incomplete(self):
+        content = "alpha\x1comega"
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        sensitive = GrepRequest(pattern=r"alpha\somega", **common)
+        companion = GrepRequest(pattern="alpha", **common)
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(("/repo/code.py", 1, f"{content}\n")),
+            stderr="",
+        )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_UNICODE_MAX_INPUT_BYTES",
+                4,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                return_value=batch_result,
+            ) as mock_run,
+        ):
+            results = execute_grep_batch([sensitive, companion])
+
+        assert results[sensitive] == ()
+        assert sensitive in results.incomplete_requests
+        assert results[companion] == (f"/repo/code.py:1:{content}",)
+        mock_run.assert_called_once()
+
+    def test_later_space_adjudication_chunk_failure_discards_partial_matches(self):
+        content = "alpha\x1comega"
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 5,
+        }
+        sensitive = GrepRequest(pattern=r"alpha\Somega", **common)
+        companion = GrepRequest(pattern="alpha", **common)
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(
+                ("/repo/a.py", 1, f"{content}\n"),
+                ("/repo/b.py", 1, f"{content}\n"),
+            ),
+            stderr="",
+        )
+        adjudication_calls = 0
+
+        def fake_run(cmd, **kwargs):
+            nonlocal adjudication_calls
+            if "--json" in cmd:
+                return batch_result
+            adjudication_calls += 1
+            if adjudication_calls == 1:
+                return Mock(returncode=0, stdout=f"1:{content}\n", stderr="")
+            raise _GrepDeadlineExceeded("forced later-chunk deadline")
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_UNICODE_MAX_INPUT_BYTES",
+                len(content.encode("utf-8")) + 1,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                side_effect=fake_run,
+            ),
+        ):
+            results = execute_grep_batch([sensitive, companion])
+
+        assert adjudication_calls == 2
+        assert results[sensitive] == ()
+        assert sensitive in results.incomplete_requests
+        assert results[companion] == (
+            f"/repo/a.py:1:{content}",
+            f"/repo/b.py:1:{content}",
         )
 
     def test_batched_and_legacy_verdicts_match_on_non_ascii_content(self, tmp_path):
@@ -1757,6 +1870,75 @@ class TestBatchedGrepVerify:
         )
         assert results.incomplete_requests == set()
         assert open_process.call_count == 2
+
+    @pytest.mark.parametrize(
+        ("pattern", "exact_output", "expected"),
+        [
+            (r"alpha\somega", "", ()),
+            (
+                r"alpha\Somega",
+                _rg_json_output(("/repo/source.py", 1, "alpha\x1comega\n")),
+                ("/repo/source.py:1:alpha\x1comega",),
+            ),
+        ],
+    )
+    def test_streamed_retry_uses_ripgrep_space_semantics(
+        self,
+        pattern,
+        exact_output,
+        expected,
+    ):
+        sensitive = _regex_grep_request(pattern)
+        companion = _regex_grep_request("alpha")
+        union_output = _rg_json_output(("/repo/source.py", 1, "alpha\x1comega\n"))
+        process_outputs = iter((union_output, exact_output))
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=lambda _cmd: _stdout_process(next(process_outputs)),
+            ) as open_process,
+        ):
+            results = execute_grep_batch([sensitive, companion])
+
+        assert results[sensitive] == expected
+        assert results[companion] == ("/repo/source.py:1:alpha\x1comega",)
+        assert results.incomplete_requests == set()
+        assert open_process.call_count == 2
+
+    def test_streamed_space_exact_search_failure_is_incomplete(self):
+        sensitive = _regex_grep_request(r"alpha\somega")
+        companion = _regex_grep_request("alpha")
+        union_output = _rg_json_output(("/repo/source.py", 1, "alpha\x1comega\n"))
+        process_outputs = iter((union_output, "not-json\n"))
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_ripgrep_batch",
+                side_effect=_GrepOutputLimitExceeded("forced output cap"),
+            ),
+            patch(
+                "skylos.core.grep_verify_common._open_grep_process",
+                side_effect=lambda _cmd: _stdout_process(next(process_outputs)),
+            ),
+        ):
+            results = execute_grep_batch([sensitive, companion])
+
+        assert results[sensitive] == ()
+        assert sensitive in results.incomplete_requests
+        assert companion not in results.incomplete_requests
 
     def test_streamed_retry_marks_failed_exact_search_incomplete(self):
         ambiguous = _regex_grep_request(r"\bfoo\b")

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -38,6 +38,7 @@ from skylos.core.grep_verify_common import (
     _GrepDeadlineExceeded,
     _GrepEvidence,
     _GrepExecutionIncomplete,
+    _GrepInputLimitExceeded,
     _GrepOutputLimitExceeded,
     _is_python_source_reference,
     _python_regex,
@@ -1086,6 +1087,90 @@ class TestBatchedGrepVerify:
         assert len(adjudication_calls) == 1
         assert results[space_request] == ()
         assert results[companion_request] == (f"/repo/code.py:1:{content}",)
+
+    def test_large_space_adjudication_payload_is_chunked(self):
+        # Adjudication stdin is capped. A repository with more divergent
+        # candidate lines than that cap must still be adjudicated, because a
+        # direct per-pattern search would have completed. Alternating lines
+        # match under ripgrep semantics and do not, so a chunked adjudication
+        # that mismapped positions would surface here as wrong evidence.
+        padding = "p" * 190
+        contents = [
+            f"alpha omega\x1c{padding}"
+            if index % 2 == 0
+            else f"alpha\x1comega{padding}"
+            for index in range(40)
+        ]
+        common = {
+            "project_root": "/repo",
+            "use_regex": True,
+            "include_globs": ("*.py",),
+            "fixed_string": False,
+            "max_results": 100,
+        }
+        space_request = GrepRequest(pattern=r"alpha\somega", **common)
+
+        batch_result = Mock(
+            returncode=0,
+            stdout=_rg_json_output(
+                *(
+                    (f"/repo/code{index:02d}.py", 1, f"{content}\n")
+                    for index, content in enumerate(contents)
+                )
+            ),
+            stderr="",
+        )
+
+        def fake_run(cmd, **kwargs):
+            if "--json" in cmd:
+                return batch_result
+            payload = kwargs["input_text"]
+            if len(payload.encode("utf-8")) > kwargs["input_limit"]:
+                raise _GrepInputLimitExceeded("grep subprocess input is too large")
+            # Ripgrep's \s excludes U+001C, so only the space lines match.
+            matched = [
+                f"{position}:{line}"
+                for position, line in enumerate(payload.split("\n")[:-1], start=1)
+                if "alpha omega" in line
+            ]
+            return Mock(
+                returncode=0 if matched else 1,
+                stdout="".join(f"{line}\n" for line in matched),
+                stderr="",
+            )
+
+        with (
+            patch(
+                "skylos.core.grep_verify_common.shutil.which",
+                return_value="/usr/bin/rg",
+            ),
+            patch(
+                "skylos.core.grep_verify_common._GREP_UNICODE_MAX_INPUT_BYTES",
+                4096,
+            ),
+            patch(
+                "skylos.core.grep_verify_common._run_bounded_subprocess",
+                side_effect=fake_run,
+            ) as mock_run,
+        ):
+            results = execute_grep_batch([space_request])
+
+        adjudication_calls = [
+            call for call in mock_run.call_args_list if "--json" not in call.args[0]
+        ]
+        assert len(adjudication_calls) > 1
+        for call in adjudication_calls:
+            assert (
+                len(call.kwargs["input_text"].encode("utf-8"))
+                <= call.kwargs["input_limit"]
+            )
+        # Sorted by path, so the fixture names are zero-padded to keep
+        # lexicographic and numeric order the same.
+        assert results[space_request] == tuple(
+            f"/repo/code{index:02d}.py:1:{content}"
+            for index, content in enumerate(contents)
+            if index % 2 == 0
+        )
 
     def test_batched_and_legacy_verdicts_match_on_non_ascii_content(self, tmp_path):
         package = tmp_path / "pkg.py"


### PR DESCRIPTION
 ## Summary

  This updates #730 for the current `main` branch.

  - Batch grep patterns containing `\s` or `\S` instead of running a separate full repo search for each pattern.
  - Recheck the four characters where Python and ripgrep disagree.
  - Preserve correct `\s` and `\S` results during streamed overflow retries.

  The original two commits still retain @mcdigman as the author.

  ## Tests

  - `pytest test/test_grep_verify.py` 

  Supersedes #730.
