### PR TITLE
fix(ai-defect): support PEP 735 dependency groups

### DIFF
--- a/skylos/rules/ai_defect/dependency_hallucination.py
+++ b/skylos/rules/ai_defect/dependency_hallucination.py
@@ -5,8 +5,8 @@ import os
 import re
 import site
 import sys
-import urllib.request
 import urllib.error
+import urllib.request
 from pathlib import Path
 
 try:
@@ -16,6 +16,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
 
 from skylos.core.safe_cache_io import (
     load_project_json_cache,
+    read_project_text_no_symlink,
     read_text_no_symlink,
     save_project_json_cache,
 )
@@ -31,6 +32,8 @@ from skylos.core.safe_cache_io import (
 _IMPORT_TO_DIST_MAPPING: dict[str, str] | None = None
 _MAPPING_FILENAME = "pipreqs_import_mapping.txt"
 MAX_DEPENDENCY_MANIFEST_BYTES = 5_000_000
+MAX_DEPENDENCY_SCOPE_COMPONENTS = 256
+MAX_DEPENDENCY_SCOPE_PATH_CHARS = 4096
 logger = logging.getLogger(__name__)
 
 
@@ -411,6 +414,20 @@ def _project_dependency_metadata(data):
     return deps, project_name
 
 
+def _dependency_group_names(data):
+    groups = data.get("dependency-groups")
+    if not isinstance(groups, dict):
+        return set()
+
+    deps = set()
+    for specs in groups.values():
+        # PEP 735 also permits {include-group = "..."} entries. Every group
+        # is considered declared here, so collecting the string entries from
+        # all groups already includes the referenced group's dependencies.
+        deps.update(_dependency_names(specs))
+    return deps
+
+
 def _poetry_dependency_names(poetry):
     deps = set()
     poetry_dependencies = poetry.get("dependencies")
@@ -441,28 +458,40 @@ def _poetry_dependency_metadata(data):
     return _poetry_dependency_names(poetry), project_name
 
 
-def _parse_pyproject_toml(path):
-    txt = read_text_no_symlink(
-        path,
-        max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
-        encoding="utf-8",
-    )
+def _pyproject_dependency_metadata(data):
+    deps, project_name = _project_dependency_metadata(data)
+    deps.update(_dependency_group_names(data))
+    poetry_deps, poetry_name = _poetry_dependency_metadata(data)
+    deps.update(poetry_deps)
+    if project_name is None:
+        project_name = poetry_name
+    return deps, project_name
+
+
+def _parse_pyproject_toml(path, *, project_root=None):
+    if project_root is None:
+        txt = read_text_no_symlink(
+            path,
+            max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
+            encoding="utf-8",
+        )
+    else:
+        txt = read_project_text_no_symlink(
+            project_root,
+            path,
+            max_bytes=MAX_DEPENDENCY_MANIFEST_BYTES,
+            encoding="utf-8",
+        )
     if txt is None:
         return set(), None
 
     try:
         data = tomllib.loads(txt)
-    except tomllib.TOMLDecodeError as exc:
+    except (tomllib.TOMLDecodeError, RecursionError, ValueError) as exc:
         logger.debug("Failed to parse dependency metadata from %s: %s", path, exc)
         return set(), None
 
-    deps, project_name = _project_dependency_metadata(data)
-    poetry_deps, poetry_name = _poetry_dependency_metadata(data)
-    deps.update(poetry_deps)
-    if project_name is None:
-        project_name = poetry_name
-
-    return deps, project_name
+    return _pyproject_dependency_metadata(data)
 
 
 def _parse_setup_py(path):
@@ -585,6 +614,119 @@ def _collect_declared_deps(repo_root):
         deps.add(_normalize_name(project_name))
 
     return deps
+
+
+def _nested_pyproject_metadata(repo_root, directory):
+    pyproject = directory / "pyproject.toml"
+    try:
+        if not pyproject.exists():
+            return frozenset(), False
+    except OSError:
+        return frozenset(), False
+
+    deps, project_name = _parse_pyproject_toml(
+        pyproject,
+        project_root=repo_root,
+    )
+    if project_name:
+        deps.add(_normalize_name(project_name))
+    return frozenset(deps), True
+
+
+def _dependency_scope_for_file(
+    repo_root,
+    file_path,
+    scope_cache,
+    extra_deps_by_directory=None,
+):
+    root = Path(os.path.abspath(repo_root))
+    try:
+        raw_path = os.fspath(file_path)
+    except TypeError:
+        return scope_cache[root]
+    if (
+        not isinstance(raw_path, str)
+        or len(raw_path) > MAX_DEPENDENCY_SCOPE_PATH_CHARS
+    ):
+        return scope_cache[root]
+
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = root / path
+    directory = Path(os.path.abspath(path)).parent
+
+    try:
+        relative_directory = directory.relative_to(root)
+    except ValueError:
+        return scope_cache[root]
+    if len(relative_directory.parts) > MAX_DEPENDENCY_SCOPE_COMPONENTS:
+        return scope_cache[root]
+
+    pending = []
+    current = directory
+    while current not in scope_cache:
+        pending.append(current)
+        parent = current.parent
+        if parent == current:
+            return scope_cache[root]
+        current = parent
+
+    declared_deps, manifest_context = scope_cache[current]
+    for nested_directory in reversed(pending):
+        nested_deps, has_pyproject = _nested_pyproject_metadata(
+            root, nested_directory
+        )
+        extra_deps = (
+            extra_deps_by_directory.get(nested_directory, frozenset())
+            if extra_deps_by_directory
+            else frozenset()
+        )
+        if nested_deps or extra_deps:
+            declared_deps = declared_deps.union(nested_deps, extra_deps)
+        manifest_context = manifest_context or has_pyproject or bool(extra_deps)
+        scope_cache[nested_directory] = declared_deps, manifest_context
+
+    return scope_cache[directory]
+
+
+def _normalized_dependency_names(dependencies):
+    if isinstance(dependencies, str):
+        dependencies = (dependencies,)
+
+    normalized = set()
+    for dependency in dependencies or ():
+        name = _normalize_name(dependency)
+        if name:
+            normalized.add(name)
+    return frozenset(normalized)
+
+
+def _split_extra_dependency_scopes(repo_root, extra_declared_deps):
+    """Separate root-wide diff declarations from nested manifest scopes."""
+    if not extra_declared_deps:
+        return frozenset(), {}
+
+    by_directory = getattr(extra_declared_deps, "by_directory", None)
+    if not isinstance(by_directory, dict):
+        return _normalized_dependency_names(extra_declared_deps), {}
+
+    root = Path(os.path.abspath(repo_root))
+    scopes = {}
+    for directory_label, dependencies in by_directory.items():
+        relative = Path(str(directory_label))
+        if relative.is_absolute() or ".." in relative.parts:
+            continue
+        directory = Path(os.path.abspath(root / relative))
+        try:
+            directory.relative_to(root)
+        except ValueError:
+            continue
+
+        names = _normalized_dependency_names(dependencies)
+        if names:
+            scopes[directory] = scopes.get(directory, frozenset()).union(names)
+
+    return scopes.pop(root, frozenset()), scopes
 
 
 def _find_import_line(src, mod):
@@ -848,9 +990,18 @@ def scan_python_dependency_hallucinations(repo_root, py_files):
     if repo_root is None:
         return findings
 
-    ctx = _build_dependency_context(repo_root)
+    root = Path(os.path.abspath(repo_root))
+    ctx = _build_dependency_context(root)
+    scope_cache = {
+        root: (frozenset(ctx["declared_deps"]), ctx["manifest_context"])
+    }
 
     for file_path in py_files:
+        declared_deps, manifest_context = _dependency_scope_for_file(
+            root, file_path, scope_cache
+        )
+        ctx["declared_deps"] = declared_deps
+        ctx["manifest_context"] = manifest_context
         try:
             src = file_path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
@@ -890,15 +1041,23 @@ def scan_diff_added_imports(
     if repo_root is None:
         return findings, False
 
-    root = Path(repo_root)
+    root = Path(os.path.abspath(repo_root))
     ctx = _build_dependency_context(root)
     if extra_local_modules:
         ctx["local_modules"] = set(ctx["local_modules"]) | set(extra_local_modules)
-    if extra_declared_deps:
-        ctx["declared_deps"] = set(ctx["declared_deps"]) | {
-            _normalize_name(dep) for dep in extra_declared_deps if _normalize_name(dep)
-        }
+    root_extra_deps, scoped_extra_deps = _split_extra_dependency_scopes(
+        root, extra_declared_deps
+    )
+    if root_extra_deps:
+        ctx["declared_deps"] = set(ctx["declared_deps"]) | set(root_extra_deps)
         ctx["manifest_context"] = True
+
+    scope_cache = {
+        root: (
+            frozenset(ctx["declared_deps"]),
+            ctx["manifest_context"],
+        )
+    }
 
     seen = set()
     for file_label, line_no, module_name in added_imports:
@@ -906,6 +1065,15 @@ def scan_diff_added_imports(
         if (file_label, mod) in seen:
             continue
         seen.add((file_label, mod))
+
+        declared_deps, manifest_context = _dependency_scope_for_file(
+            root,
+            file_label,
+            scope_cache,
+            scoped_extra_deps,
+        )
+        ctx["declared_deps"] = declared_deps
+        ctx["manifest_context"] = manifest_context
 
         template = _classify_import(mod, ctx)
         if template is None:

--- a/skylos/rules/ai_defect/diff_dependencies.py
+++ b/skylos/rules/ai_defect/diff_dependencies.py
@@ -6,15 +6,21 @@ from json.decoder import scanstring
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from skylos.core.safe_cache_io import read_project_text_no_symlink
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
 
+from skylos.core.safe_cache_io import read_project_text_no_symlink
 from skylos.rules.ai_defect.dependency_hallucination import (
     FROM_RE,
     IMPORT_RE,
+    MAX_DEPENDENCY_MANIFEST_BYTES,
     RULE_ID_HALLUCINATION,
     RULE_ID_UNDECLARED,
     _is_confident_hallucination_candidate,
     _normalize_name,
+    _pyproject_dependency_metadata,
     scan_diff_added_imports,
 )
 from skylos.rules.ai_defect.manifest_dependency_hallucination import (
@@ -26,11 +32,11 @@ from skylos.rules.ai_defect.manifest_dependency_hallucination import (
     check_dependency_version_status,
 )
 from skylos.rules.sca.vulnerability_scanner import (
+    _PACKAGE_JSON_DEPENDENCY_SECTIONS,
     ECOSYSTEM_GO,
     ECOSYSTEM_NPM,
     ECOSYSTEM_PYPI,
     MAX_MANIFEST_BYTES,
-    _PACKAGE_JSON_DEPENDENCY_SECTIONS,
     _classify_npm_registry_spec,
     _parse_package_json_text,
 )
@@ -56,6 +62,9 @@ _EXACT_PY_VERSION_RE = re.compile(r"^\d[\w.!+]*$")
 _PYPROJECT_KEY_BLOCKLIST = frozenset(
     {"version", "python", "requires-python", "target-version"}
 )
+_MAX_DIFF_PATH_CHARS = 4096
+_MAX_DIFF_PATH_COMPONENTS = 256
+_NEW_FILE_HUNK_RE = re.compile(r"^@@ -0,0 \+1(?:,(\d+))? @@(?: .*)?$")
 
 _PACKAGE_JSON_DEP_RE = re.compile(
     r"^\s*\"(@?[a-z0-9][a-z0-9._/-]*)\"\s*:\s*\"([^\"]*)\""
@@ -75,6 +84,19 @@ _REGISTRY_LABELS = {
     ECOSYSTEM_NPM: "the npm registry",
     ECOSYSTEM_GO: "the Go module proxy",
 }
+
+
+class _ScopedDependencyNames(set[str]):
+    """Dependency names plus their project-relative manifest directories."""
+
+    def __init__(self, by_directory: dict[str, set[str]]) -> None:
+        self.by_directory = {
+            directory: frozenset(names)
+            for directory, names in by_directory.items()
+        }
+        super().__init__(
+            name for names in self.by_directory.values() for name in names
+        )
 
 
 def scan_diff_dependency_hallucinations(
@@ -120,7 +142,10 @@ def scan_diff_dependency_hallucinations(
             repo_root,
             added_imports,
             extra_local_modules=local_roots,
-            extra_declared_deps=_added_pypi_dependency_names(manifest_specs),
+            extra_declared_deps=_added_pypi_dependency_names(
+                manifest_specs,
+                diff_text=diff_text,
+            ),
         )
         for finding in import_findings:
             finding["kind"] = _IMPORT_KINDS.get(finding.get("rule_id"), "dependency")
@@ -145,7 +170,7 @@ def _parse_added_lines(diff_text) -> list[tuple[str, list[tuple[int, str]]]]:
         file_match = _DIFF_FILE_RE.match(raw_line)
         if file_match:
             current_added = []
-            files.append((file_match.group(1).strip(), current_added))
+            files.append((file_match.group(1), current_added))
             line_no = 0
             continue
         if current_added is None:
@@ -280,6 +305,84 @@ def _pyproject_specs(
     return specs
 
 
+def _added_pyproject_dependency_names(
+    diff_text: str,
+) -> dict[str, set[str]]:
+    names_by_directory: dict[str, set[str]] = {}
+    for file_path, text in _complete_new_file_postimages(diff_text):
+        if PurePosixPath(file_path).name != "pyproject.toml":
+            continue
+        scope = _pypi_manifest_scope(file_path)
+        if scope is None:
+            continue
+        try:
+            if len(text.encode("utf-8")) > MAX_DEPENDENCY_MANIFEST_BYTES:
+                continue
+            data = tomllib.loads(text)
+        except (UnicodeError, tomllib.TOMLDecodeError, RecursionError, ValueError):
+            continue
+        names, _project_name = _pyproject_dependency_metadata(data)
+        if names:
+            names_by_directory.setdefault(scope, set()).update(names)
+    return names_by_directory
+
+
+def _complete_new_file_postimages(diff_text: str) -> list[tuple[str, str]]:
+    lines = str(diff_text or "").splitlines()
+    postimages = []
+    index = 0
+
+    while index < len(lines):
+        if lines[index] != "--- /dev/null":
+            index += 1
+            continue
+        if index + 2 >= len(lines):
+            break
+
+        file_match = _DIFF_FILE_RE.match(lines[index + 1])
+        hunk_match = _NEW_FILE_HUNK_RE.match(lines[index + 2])
+        if file_match is None or hunk_match is None:
+            index += 1
+            continue
+
+        count_text = hunk_match.group(1) or "1"
+        if len(count_text) > 7:
+            index += 3
+            continue
+        expected_lines = int(count_text)
+        added_lines = []
+        valid = True
+        index += 3
+
+        while index < len(lines):
+            raw_line = lines[index]
+            if raw_line.startswith("diff --git "):
+                break
+            if raw_line.startswith("--- "):
+                if (
+                    index + 1 < len(lines)
+                    and lines[index + 1].startswith("+++ ")
+                ):
+                    break
+                valid = False
+                index += 1
+                continue
+            if raw_line.startswith("+"):
+                added_lines.append(raw_line[1:])
+            elif raw_line.startswith("\\ No newline at end of file"):
+                pass
+            else:
+                valid = False
+            index += 1
+
+        if valid and len(added_lines) == expected_lines:
+            postimages.append(
+                (file_match.group(1), "\n".join(added_lines))
+            )
+
+    return postimages
+
+
 def _parse_new_file_lines(diff_text) -> list[tuple[str, list[tuple[str, int, str]]]]:
     files: list[tuple[str, list[tuple[str, int, str]]]] = []
     current_lines: list[tuple[str, int, str]] | None = None
@@ -290,7 +393,7 @@ def _parse_new_file_lines(diff_text) -> list[tuple[str, list[tuple[str, int, str
         file_match = _DIFF_FILE_RE.match(raw_line)
         if file_match:
             current_lines = []
-            files.append((file_match.group(1).strip(), current_lines))
+            files.append((file_match.group(1), current_lines))
             line_no = 0
             in_hunk = False
             continue
@@ -393,8 +496,23 @@ def _matching_package_json_postimage(
 
 
 def _safe_diff_relative_path(file_path: str) -> PurePosixPath | None:
-    relative = PurePosixPath(file_path)
-    if relative.is_absolute() or ".." in relative.parts:
+    raw_path = str(file_path or "")
+    if (
+        not raw_path
+        or raw_path != raw_path.strip()
+        or len(raw_path) > _MAX_DIFF_PATH_CHARS
+        or "\\" in raw_path
+        or re.match(r"^[A-Za-z]:", raw_path)
+    ):
+        return None
+    relative = PurePosixPath(raw_path)
+    if (
+        not relative.parts
+        or relative.as_posix() != raw_path
+        or len(relative.parts) > _MAX_DIFF_PATH_COMPONENTS
+        or relative.is_absolute()
+        or ".." in relative.parts
+    ):
         return None
     return relative
 
@@ -602,15 +720,35 @@ def _package_json_dependency_section(stack: list[str | None]) -> str | None:
     return section if section in _PACKAGE_JSON_DEPENDENCY_SECTIONS else None
 
 
-def _added_pypi_dependency_names(specs: list[dict[str, Any]]) -> set[str]:
-    names = set()
+def _added_pypi_dependency_names(
+    specs: list[dict[str, Any]],
+    *,
+    diff_text: str = "",
+) -> _ScopedDependencyNames:
+    names_by_directory: dict[str, set[str]] = {}
     for spec in specs:
         if spec.get("ecosystem") != ECOSYSTEM_PYPI:
             continue
+        relative = _safe_diff_relative_path(spec.get("file"))
+        if relative is None or relative.name.lower() == "pyproject.toml":
+            continue
         normalized = _normalize_name(spec.get("name"))
-        if normalized:
-            names.add(normalized)
-    return names
+        scope = _pypi_manifest_scope(relative.as_posix())
+        if normalized and scope is not None:
+            names_by_directory.setdefault(scope, set()).add(normalized)
+    for directory, names in _added_pyproject_dependency_names(diff_text).items():
+        names_by_directory.setdefault(directory, set()).update(names)
+    return _ScopedDependencyNames(names_by_directory)
+
+
+def _pypi_manifest_scope(file_path) -> str | None:
+    relative = _safe_diff_relative_path(file_path)
+    if relative is None:
+        return None
+    parent = relative.parent
+    if parent.name.lower() == "requirements":
+        parent = parent.parent
+    return parent.as_posix()
 
 
 def _go_mod_specs(

--- a/test/test_diff_dependencies.py
+++ b/test/test_diff_dependencies.py
@@ -34,6 +34,15 @@ def _new_file_diff(filename, text):
     )
 
 
+def _diff_with_new_file(filename, lines, *file_blocks):
+    return "\n".join(
+        [
+            _diff(*file_blocks),
+            _new_file_diff(filename, "\n".join(lines)),
+        ]
+    )
+
+
 def _noop_import_scanner(
     _repo_root,
     _added_imports,
@@ -114,6 +123,34 @@ class TestScanDiffAddedImports:
         )
         assert findings == []
 
+    def test_nested_pyproject_dependency_only_applies_to_nested_diff_imports(
+        self, tmp_path, monkeypatch
+    ):
+        repo = self._repo(tmp_path)
+        nested = repo / "child"
+        nested.mkdir()
+        (nested / "pyproject.toml").write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+            '[project]\nname = "child"\ndependencies = ["maturin"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"maturin": {"maturin"}},
+        )
+
+        findings, _ = scan_diff_added_imports(
+            repo,
+            [
+                ("child/build.py", 1, "maturin"),
+                ("sibling.py", 1, "maturin"),
+            ],
+        )
+
+        assert [(finding["file"], finding["symbol"]) for finding in findings] == [
+            ("sibling.py", "maturin")
+        ]
+
     def test_unreachable_registry_is_reported(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
             dep_mod, "_check_pypi_status", lambda _name, _cache: "unknown"
@@ -139,6 +176,347 @@ class TestScanDiffAddedImports:
         )
 
         assert result["findings"] == []
+
+    def test_nested_dependency_added_by_diff_does_not_satisfy_sibling_import(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"maturin": {"maturin"}},
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff_with_new_file(
+                "child/pyproject.toml",
+                [
+                    "[dependency-groups]",
+                    "dev = [",
+                    '    "maturin",',
+                    "]",
+                ],
+                ("child/build.py", ["import maturin"]),
+                ("sibling.py", ["import maturin"]),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        undeclared = [
+            finding
+            for finding in result["findings"]
+            if finding["rule_id"] == "SKY-D223"
+        ]
+        assert [(finding["file"], finding["symbol"]) for finding in undeclared] == [
+            ("sibling.py", "maturin")
+        ]
+
+    def test_diff_pep735_include_group_name_is_not_a_dependency(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"sharedgroup": {"sharedgroup"}},
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff_with_new_file(
+                "child/pyproject.toml",
+                [
+                    "[dependency-groups]",
+                    'dev = [{include-group = "sharedgroup"}]',
+                ],
+                ("child/app.py", ["import sharedgroup"]),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [("SKY-D223", "child/app.py", "sharedgroup")]
+
+    def test_diff_pep735_ignores_nested_arrays_and_later_tables(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {
+                "evildep": {"evildep"},
+                "laterdep": {"laterdep"},
+                "quotedsectiondep": {"quotedsectiondep"},
+                "versioneddep": {"versioneddep"},
+            },
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff_with_new_file(
+                "child/pyproject.toml",
+                [
+                    "[dependency-groups]",
+                    'dev = [["evildep"]]',
+                    "[[tool.entries]]",
+                    'names = ["laterdep"]',
+                    'constraints = ["versioneddep>=1"]',
+                    '["project.optional-dependencies"]',
+                    'dev = ["quotedsectiondep"]',
+                ],
+                (
+                    "child/app.py",
+                    [
+                        "import evildep",
+                        "import laterdep",
+                        "import quotedsectiondep",
+                        "import versioneddep",
+                    ],
+                ),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [
+            ("SKY-D223", "child/app.py", "evildep"),
+            ("SKY-D223", "child/app.py", "laterdep"),
+            ("SKY-D223", "child/app.py", "quotedsectiondep"),
+            ("SKY-D223", "child/app.py", "versioneddep"),
+        ]
+
+    def test_diff_dependency_groups_array_table_does_not_declare_dependencies(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"arraytabledep": {"arraytabledep"}},
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff_with_new_file(
+                "child/pyproject.toml",
+                [
+                    "[[dependency-groups]]",
+                    'dev = ["arraytabledep"]',
+                ],
+                ("child/app.py", ["import arraytabledep"]),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [("SKY-D223", "child/app.py", "arraytabledep")]
+
+    def test_diff_pyproject_dependency_string_escapes_are_decoded(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {
+                "evil": {"evil"},
+                "evil_dist": {"evil-dist"},
+            },
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff_with_new_file(
+                "child/pyproject.toml",
+                [
+                    "[dependency-groups]",
+                    'dev = ["evil\\u002Ddist"]',
+                ],
+                ("child/app.py", ["import evil", "import evil_dist"]),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [("SKY-D223", "child/app.py", "evil")]
+
+    @pytest.mark.parametrize("quote", ['"""', "'''"])
+    def test_diff_pyproject_multiline_strings_do_not_supply_inner_names(
+        self, tmp_path, monkeypatch, quote
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"evil": {"evil"}},
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff_with_new_file(
+                "child/pyproject.toml",
+                [
+                    "[tool.example]",
+                    f"config = {quote}",
+                    "[dependency-groups]",
+                    'dev = ["evil"]',
+                    quote,
+                ],
+                ("child/app.py", ["import evil"]),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [("SKY-D223", "child/app.py", "evil")]
+
+    @pytest.mark.parametrize(
+        "manifest_diff",
+        [
+            "--- a/child/pyproject.toml\n"
+            "+++ b/child/pyproject.toml\n"
+            "@@ -10,2 +10,3 @@\n"
+            " [dependency-groups]\n"
+            '+dev = ["evil>=1"]\n'
+            ' """',
+            _new_file_diff(
+                "child/pyproject.toml",
+                '[dependency-groups]\ndev = ["evil>=1"]\n[broken',
+            ),
+            _new_file_diff(
+                "child/pyproject.toml",
+                '[dependency-groups]\ndev = ["evil>=1"]',
+            )
+            + "\n--- stray hunk content",
+        ],
+        ids=["partial-hunk", "malformed-new-file", "invalid-trailing-line"],
+    )
+    def test_untrusted_pyproject_fragments_do_not_supply_dependencies(
+        self, tmp_path, monkeypatch, manifest_diff
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"evil": {"evil"}},
+        )
+        diff_text = "\n".join(
+            [
+                _diff(("child/app.py", ["import evil"])),
+                manifest_diff,
+            ]
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            diff_text,
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [("SKY-D223", "child/app.py", "evil")]
+
+    @pytest.mark.parametrize(
+        "manifest_path",
+        [
+            " child/pyproject.toml ",
+            "child//pyproject.toml",
+            "child/./pyproject.toml",
+            "child/PYPROJECT.TOML",
+        ],
+    )
+    def test_aliased_new_manifest_path_is_not_trusted(
+        self, tmp_path, monkeypatch, manifest_path
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"maturin": {"maturin"}},
+        )
+        diff_text = "\n".join(
+            [
+                _diff(("child/app.py", ["import maturin"])),
+                _new_file_diff(
+                    manifest_path,
+                    '[dependency-groups]\ndev = ["maturin"]',
+                ),
+            ]
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            diff_text,
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [("SKY-D223", "child/app.py", "maturin")]
+
+    @pytest.mark.parametrize(
+        "manifest_lines",
+        [
+            ["[project]", 'dependencies = ["maturin>=1"]'],
+            ["[project.optional-dependencies]", 'test = ["maturin"]'],
+            ["[tool.poetry.dependencies]", 'maturin = "1.0"'],
+            ["[tool.poetry.extras]", 'build = ["maturin"]'],
+        ],
+    )
+    def test_diff_pyproject_declaration_sections_satisfy_import(
+        self, tmp_path, monkeypatch, manifest_lines
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"maturin": {"maturin"}},
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff_with_new_file(
+                "child/pyproject.toml",
+                manifest_lines,
+                ("child/app.py", ["import maturin"]),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert result["findings"] == []
+
+    @pytest.mark.parametrize(
+        "unsafe_path",
+        [r"..\outside\requirements.txt", "C:foo/requirements.txt"],
+    )
+    def test_unsafe_diff_manifest_path_cannot_satisfy_import(
+        self, tmp_path, monkeypatch, unsafe_path
+    ):
+        monkeypatch.setattr(
+            dep_mod,
+            "_build_installed_module_mapping",
+            lambda: {"maturin": {"maturin"}},
+        )
+
+        result = scan_diff_dependency_hallucinations(
+            _diff(
+                ("app.py", ["import maturin"]),
+                (unsafe_path, ["maturin==1.0"]),
+            ),
+            self._repo(tmp_path),
+            status_checker=lambda *_args: "present",
+        )
+
+        assert [
+            (finding["rule_id"], finding["file"], finding["symbol"])
+            for finding in result["findings"]
+        ] == [("SKY-D223", "app.py", "maturin")]
 
 
 class TestManifestDiffChecks:

--- a/test/test_hallucination_dependency.py
+++ b/test/test_hallucination_dependency.py
@@ -89,6 +89,204 @@ dependencies = [
     assert "google-genai" in deps
 
 
+def test_parse_pyproject_toml_pep735_dependency_groups(tmp_path):
+    py = _write_py(
+        tmp_path / "pyproject.toml",
+        """
+[dependency-groups]
+test = ["pytest>=8", "coverage[toml]; python_version >= '3.11'"]
+lint = ["ruff", {include-group = "test"}]
+""".strip(),
+    )
+
+    deps, project_name = dep._parse_pyproject_toml(py)
+
+    assert deps == {"coverage", "pytest", "ruff"}
+    assert project_name is None
+
+
+def test_pep735_malformed_objects_do_not_create_dependencies(tmp_path):
+    py = _write_py(
+        tmp_path / "pyproject.toml",
+        """
+[dependency-groups]
+valid = ["requests", {include-group = "cycle"}]
+cycle = [{include-group = "cycle"}]
+not-a-list = {include-group = "valid"}
+future = [{new-object = "fabricated-package"}]
+""".strip(),
+    )
+
+    deps, _ = dep._parse_pyproject_toml(py)
+
+    assert deps == {"requests"}
+
+
+def test_pep735_dependency_group_prevents_d223(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_py(
+        repo / "pyproject.toml",
+        """
+[project]
+name = "pep735-reproducer"
+version = "0.0.0"
+dependencies = []
+
+[dependency-groups]
+dev = ["pytest"]
+""".strip(),
+    )
+    source = _write_py(repo / "reproduce.py", "import pytest\n")
+
+    monkeypatch.setattr(dep, "_get_stdlib_modules", lambda: set())
+    monkeypatch.setattr(dep, "_collect_local_modules", lambda root: set())
+    monkeypatch.setattr(dep, "_load_private_allowlist", lambda: set())
+    monkeypatch.setattr(
+        dep,
+        "_build_installed_module_mapping",
+        lambda: {"pytest": {"pytest"}},
+    )
+
+    findings = dep.scan_python_dependency_hallucinations(repo, [source])
+
+    assert _extract_single(findings, dep.RULE_ID_UNDECLARED) == []
+
+
+def test_nested_pyproject_dependencies_do_not_leak_to_siblings(
+    monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_py(
+        repo / "pyproject.toml",
+        '[project]\nname = "parent"\ndependencies = []\n\n'
+        '[dependency-groups]\ndev = ["pytest"]\n',
+    )
+    nested = repo / "pydantic-core"
+    nested.mkdir()
+    _write_py(
+        nested / "pyproject.toml",
+        '[project]\nname = "pydantic-core"\ndependencies = []\n\n'
+        '[dependency-groups]\nbuild = ["maturin"]\n',
+    )
+    nested_source = _write_py(
+        nested / "build.py", "import maturin\nimport pytest\n"
+    )
+    sibling_source = _write_py(repo / "tools" / "build.py", "import maturin\n")
+
+    monkeypatch.setattr(dep, "_get_stdlib_modules", lambda: set())
+    monkeypatch.setattr(dep, "_collect_local_modules", lambda root: set())
+    monkeypatch.setattr(dep, "_load_private_allowlist", lambda: set())
+    monkeypatch.setattr(
+        dep,
+        "_build_installed_module_mapping",
+        lambda: {"maturin": {"maturin"}, "pytest": {"pytest"}},
+    )
+
+    findings = dep.scan_python_dependency_hallucinations(
+        repo, [nested_source, sibling_source]
+    )
+
+    undeclared = _extract_single(findings, dep.RULE_ID_UNDECLARED)
+    assert [(finding["file"], finding["symbol"]) for finding in undeclared] == [
+        (str(sibling_source), "maturin")
+    ]
+
+
+def test_nested_pyproject_scope_rejects_symlinked_directory(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _write_py(
+        outside / "pyproject.toml",
+        '[project]\ndependencies = ["outside-dependency"]\n',
+    )
+    nested_link = repo / "child"
+    try:
+        nested_link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        return
+
+    scope_cache = {repo: (frozenset({"root-dependency"}), True)}
+    declared, manifest_context = dep._dependency_scope_for_file(
+        repo,
+        nested_link / "module.py",
+        scope_cache,
+    )
+
+    assert declared == {"root-dependency"}
+    assert manifest_context is True
+
+
+def test_dependency_scope_rejects_excessive_path_depth(monkeypatch, tmp_path):
+    root_scope = (frozenset({"root-dependency"}), True)
+    scope_cache = {tmp_path: root_scope}
+    calls = []
+    monkeypatch.setattr(
+        dep,
+        "_nested_pyproject_metadata",
+        lambda *args: calls.append(args),
+    )
+    deep_file = "/".join(
+        ["child"] * (dep.MAX_DEPENDENCY_SCOPE_COMPONENTS + 1)
+        + ["module.py"]
+    )
+
+    scope = dep._dependency_scope_for_file(tmp_path, deep_file, scope_cache)
+
+    assert scope == root_scope
+    assert scope_cache == {tmp_path: root_scope}
+    assert calls == []
+
+
+def test_hostile_nested_pyproject_does_not_abort_sibling_scan(
+    monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_py(repo / "requirements.txt", "click\n")
+    nested = repo / "child"
+    nested.mkdir()
+    _write_py(nested / "pyproject.toml", "hostile = true\n")
+    nested_source = _write_py(nested / "app.py", "import maturin\n")
+    sibling_source = _write_py(repo / "sibling.py", "import maturin\n")
+
+    def raise_recursion_error(_text):
+        raise RecursionError
+
+    monkeypatch.setattr(dep.tomllib, "loads", raise_recursion_error)
+    monkeypatch.setattr(dep, "_get_stdlib_modules", lambda: set())
+    monkeypatch.setattr(dep, "_collect_local_modules", lambda root: set())
+    monkeypatch.setattr(dep, "_load_private_allowlist", lambda: set())
+    monkeypatch.setattr(
+        dep,
+        "_build_installed_module_mapping",
+        lambda: {"maturin": {"maturin"}},
+    )
+
+    findings = dep.scan_python_dependency_hallucinations(
+        repo, [nested_source, sibling_source]
+    )
+
+    assert [
+        (finding["file"], finding["symbol"])
+        for finding in _extract_single(findings, dep.RULE_ID_UNDECLARED)
+    ] == [(str(nested_source), "maturin"), (str(sibling_source), "maturin")]
+
+
+def test_pyproject_parser_value_error_is_ignored(monkeypatch, tmp_path):
+    pyproject = _write_py(tmp_path / "pyproject.toml", "hostile = true\n")
+
+    def raise_value_error(_text):
+        raise ValueError
+
+    monkeypatch.setattr(dep.tomllib, "loads", raise_value_error)
+
+    assert dep._parse_pyproject_toml(pyproject) == (set(), None)
+
+
 def test_pyproject_comment_apostrophe_does_not_hide_declared_dependency(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
Closes #740

## Summary

  - Support PEP 735 `[dependency-groups]` in `pyproject.toml`.
  - Support dependencies declared in nested `pyproject.toml` files.
  - Root dependencies are available to child projects.
  - Nested dependencies only apply to their own folder and do not leak into siblings.
  - Ignore malformed TOML, partial diffs, unsafe paths, and symlinked manifests.

  ## Tests

  - pytest test/test_hallucination_dependency.py test/test_diff_dependencies.py

