### PR TITLE
perf(analyzer): index abstract override lookups

### DIFF
--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -881,6 +881,37 @@ def _check_pydantic_methods(def_obj, framework):
     return None
 
 
+def _get_abstract_override_indexes(analyzer, all_defs):
+    cached = getattr(analyzer, "_abstract_override_indexes", None)
+    if cached and cached[0] is all_defs:
+        return cached
+
+    classes_by_file_and_name = {}
+    classes_by_name = {}
+    class_names = set()
+    methods_by_owner_and_name = {}
+    for dobj in all_defs.values():
+        if dobj.type == "class":
+            class_names.add(dobj.simple_name)
+            classes_by_file_and_name.setdefault((dobj.filename, dobj.simple_name), dobj)
+            classes_by_name.setdefault(dobj.simple_name, dobj)
+        elif dobj.type == "method" and "." in dobj.name:
+            owner_name = dobj.name.rsplit(".", 2)[-2]
+            methods_by_owner_and_name.setdefault(
+                (owner_name, dobj.simple_name), []
+            ).append(dobj)
+
+    indexes = (
+        all_defs,
+        classes_by_file_and_name,
+        classes_by_name,
+        class_names,
+        methods_by_owner_and_name,
+    )
+    analyzer._abstract_override_indexes = indexes
+    return indexes
+
+
 def _check_abstract_overrides(def_obj, analyzer, framework):
     if def_obj.type != "method" or "." not in def_obj.name:
         return None
@@ -908,20 +939,16 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
     all_defs = getattr(analyzer, "defs", {})
     class_name = parts[-2] if len(parts) >= 2 else None
     if class_name:
-        class_def = None
-        for dobj in all_defs.values():
-            if (
-                dobj.type == "class"
-                and dobj.simple_name == class_name
-                and dobj.filename == def_obj.filename
-            ):
-                class_def = dobj
-                break
+        (
+            _,
+            classes_by_file_and_name,
+            classes_by_name,
+            class_names,
+            methods_by_owner_and_name,
+        ) = _get_abstract_override_indexes(analyzer, all_defs)
+        class_def = classes_by_file_and_name.get((def_obj.filename, class_name))
         if class_def is None:
-            for dname, dobj in all_defs.items():
-                if dobj.type == "class" and dobj.simple_name == class_name:
-                    class_def = dobj
-                    break
+            class_def = classes_by_name.get(class_name)
         if class_def and getattr(class_def, "base_classes", None):
             has_external_base = False
             protocol_classes = set(getattr(analyzer, "_global_protocol_classes", set()))
@@ -930,24 +957,16 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
                 base_simple = base_name.split(".")[-1]
                 if base_simple in protocol_classes:
                     continue
-                for dname, dobj in all_defs.items():
-                    if (
-                        dobj.type == "method"
-                        and dobj.simple_name == method_name
-                        and dobj is not def_obj
-                        and "." in dobj.name
-                        and dobj.name.split(".")[-2] == base_simple
-                    ):
+                for dobj in methods_by_owner_and_name.get(
+                    (base_simple, method_name), ()
+                ):
+                    if dobj is not def_obj:
                         return _suppress(
                             def_obj,
                             f"overrides {base_simple}.{method_name}",
                             code="parent_override",
                         )
-                base_in_project = any(
-                    dobj.type == "class" and dobj.simple_name == base_simple
-                    for dobj in all_defs.values()
-                )
-                if not base_in_project and "." in base_name:
+                if base_simple not in class_names and "." in base_name:
                     has_external_base = True
             if has_external_base and not method_name.startswith("__"):
                 return -40

--- a/skylos/analysis/penalties.py
+++ b/skylos/analysis/penalties.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Any, Optional
+from typing import Any, Optional, NamedTuple
 from skylos.constants import PENALTIES, get_non_library_dir_kind, is_test_path
 from skylos.config import is_whitelisted
 from skylos.deadcode.config_entrypoints import configured_entrypoint_reason
@@ -881,18 +881,23 @@ def _check_pydantic_methods(def_obj, framework):
     return None
 
 
-def _get_abstract_override_indexes(analyzer, all_defs):
+class _AbstractOverrideIndexes(NamedTuple):
+    all_defs: dict
+    classes_by_file_and_name: dict
+    classes_by_name: dict
+    methods_by_owner_and_name: dict
+
+
+def _get_abstract_override_indexes(analyzer, all_defs) -> _AbstractOverrideIndexes:
     cached = getattr(analyzer, "_abstract_override_indexes", None)
     if cached and cached[0] is all_defs:
         return cached
 
     classes_by_file_and_name = {}
     classes_by_name = {}
-    class_names = set()
     methods_by_owner_and_name = {}
     for dobj in all_defs.values():
         if dobj.type == "class":
-            class_names.add(dobj.simple_name)
             classes_by_file_and_name.setdefault((dobj.filename, dobj.simple_name), dobj)
             classes_by_name.setdefault(dobj.simple_name, dobj)
         elif dobj.type == "method" and "." in dobj.name:
@@ -901,11 +906,10 @@ def _get_abstract_override_indexes(analyzer, all_defs):
                 (owner_name, dobj.simple_name), []
             ).append(dobj)
 
-    indexes = (
-        all_defs,
+    indexes = _AbstractOverrideIndexes(
+        all_defs,  # the cache key
         classes_by_file_and_name,
         classes_by_name,
-        class_names,
         methods_by_owner_and_name,
     )
     analyzer._abstract_override_indexes = indexes
@@ -939,16 +943,10 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
     all_defs = getattr(analyzer, "defs", {})
     class_name = parts[-2] if len(parts) >= 2 else None
     if class_name:
-        (
-            _,
-            classes_by_file_and_name,
-            classes_by_name,
-            class_names,
-            methods_by_owner_and_name,
-        ) = _get_abstract_override_indexes(analyzer, all_defs)
-        class_def = classes_by_file_and_name.get((def_obj.filename, class_name))
+        indexes = _get_abstract_override_indexes(analyzer, all_defs)
+        class_def = indexes.classes_by_file_and_name.get((def_obj.filename, class_name))
         if class_def is None:
-            class_def = classes_by_name.get(class_name)
+            class_def = indexes.classes_by_name.get(class_name)
         if class_def and getattr(class_def, "base_classes", None):
             has_external_base = False
             protocol_classes = set(getattr(analyzer, "_global_protocol_classes", set()))
@@ -957,7 +955,7 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
                 base_simple = base_name.split(".")[-1]
                 if base_simple in protocol_classes:
                     continue
-                for dobj in methods_by_owner_and_name.get(
+                for dobj in indexes.methods_by_owner_and_name.get(
                     (base_simple, method_name), ()
                 ):
                     if dobj is not def_obj:
@@ -966,7 +964,7 @@ def _check_abstract_overrides(def_obj, analyzer, framework):
                             f"overrides {base_simple}.{method_name}",
                             code="parent_override",
                         )
-                if base_simple not in class_names and "." in base_name:
+                if base_simple not in indexes.classes_by_name and "." in base_name:
                     has_external_base = True
             if has_external_base and not method_name.startswith("__"):
                 return -40

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -102,6 +102,7 @@ _OPTIONAL_RUN_STATE_ATTRIBUTES = (
     "_global_protocol_implementers",
     "_global_protocol_method_names",
     "_global_django_path_converter_classes",
+    "_abstract_override_indexes",
     "_duck_typed_implementers",
     "_dotted_variable_simple_name_counts",
     "_global_type_map",

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 from collections import defaultdict
 from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
-from skylos.analysis.penalties import apply_penalties
+from skylos.analysis.penalties import _check_abstract_overrides, apply_penalties
 from skylos.deadcode.config_entrypoints import configured_entrypoint_reason
 from skylos.engines.go_runner import GoEngineError
 
@@ -2204,6 +2204,79 @@ class TestClass:
 
 
 class TestApplyPenalties:
+    def test_abstract_override_lookup_indexes_definitions_once(self, mock_definition):
+        class CountingDefinitions(dict):
+            def __init__(self, definitions):
+                super().__init__(definitions)
+                self.items_calls = 0
+                self.values_calls = 0
+
+            def items(self):
+                self.items_calls += 1
+                return super().items()
+
+            def values(self):
+                self.values_calls += 1
+                return super().values()
+
+        base_class = mock_definition(
+            name="models.Base", simple_name="Base", type="class"
+        )
+        base_method = mock_definition(
+            name="models.Base.render_report_segment",
+            simple_name="render_report_segment",
+            type="method",
+        )
+        child_class = mock_definition(
+            name="models.Child", simple_name="Child", type="class"
+        )
+        child_class.base_classes = ["models.Base"]
+        child_method = mock_definition(
+            name="models.Child.render_report_segment",
+            simple_name="render_report_segment",
+            type="method",
+        )
+        external_class = mock_definition(
+            name="models.ExternalChild", simple_name="ExternalChild", type="class"
+        )
+        external_class.base_classes = ["framework.ExternalBase"]
+        external_methods = [
+            mock_definition(
+                name=f"models.ExternalChild.external_hook_{index}",
+                simple_name=f"external_hook_{index}",
+                type="method",
+            )
+            for index in range(2)
+        ]
+        definitions = CountingDefinitions(
+            {
+                definition.name: definition
+                for definition in (
+                    base_class,
+                    base_method,
+                    child_class,
+                    child_method,
+                    external_class,
+                    *external_methods,
+                )
+            }
+        )
+        analyzer = Skylos()
+        analyzer.defs = definitions
+        analyzer._global_abstract_methods = {}
+        analyzer._global_protocol_classes = set()
+        framework = Mock()
+        framework.abstract_methods = {}
+        framework.protocol_classes = set()
+
+        assert _check_abstract_overrides(child_method, analyzer, framework) is True
+        assert child_method.suppression_code == "parent_override"
+        for method in external_methods:
+            assert _check_abstract_overrides(method, analyzer, framework) == -40
+
+        assert definitions.values_calls == 1
+        assert definitions.items_calls == 0
+
     @pytest.mark.parametrize(
         ("filename", "def_type", "expected_reason"),
         [


### PR DESCRIPTION
Closes #766 

## Summary

- build class and method indexes once for abstract-override checks and cache them

The resulting code is also somewhat more readable IMO

## Measured Performance improvement
Total time in just _check_abstract_overrides:
- scipy/scipy: 65.3 s -> 0.05s
- homeassistant/core/homeassistant: 2058s -> 0.34s


## Validation

- 7,865 passed, 7 skipped, 2 unchanged baseline failures deselected
- 19/19 sandbox-blocked socket tests passed outside the sandbox
- staged Skylos gate passed

**AI Use Disclosure**
Diagnosed with cProfile; codex drafted the initial commit I did the cleanup by hand. Reviewed per repository instructions by Claude Opus 5.0 and GPT-5.6 Sol.

