### PR TITLE
perf(analyzer): index qualified reference lookups

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import ast
 from bisect import bisect_left
+from operator import attrgetter
 import sys
 import json
 import logging
@@ -1206,6 +1207,24 @@ def _annotate_dead_code_evidence_sources(defs, test_flags, framework_flags) -> N
             _mark_evidence_ref(defn, "test_entrypoint")
 
 
+_definition_name = attrgetter("name")
+
+
+def _qualified_candidates(definitions: list, qualifier: str) -> list:
+    """Definitions whose dotted name lives under ``qualifier.``, capped at two.
+
+    ``definitions`` must be sorted by ``name``. Callers only distinguish
+    zero / one / more-than-one, so the slice stops at two matches.
+    """
+    lower = f"{qualifier}."
+    # '/' is the code point right after '.', so it bounds every dotted
+    # descendant without scanning the bucket.
+    upper = f"{qualifier}/"
+    start = bisect_left(definitions, lower, key=_definition_name)
+    stop = bisect_left(definitions, upper, start, key=_definition_name)
+    return definitions[start : min(stop, start + 2)]
+
+
 class Skylos:
     def __init__(self):
         self._has_analyzed = False
@@ -1934,18 +1953,9 @@ class Skylos:
                 ].append(definition)
 
         for definitions in non_import_by_simple.values():
-            definitions.sort(key=lambda definition: definition.name)
+            definitions.sort(key=_definition_name)
         for definitions in non_import_by_file_and_simple.values():
-            definitions.sort(key=lambda definition: definition.name)
-
-        qualified_names_by_simple = {
-            simple_name: tuple(definition.name for definition in definitions)
-            for simple_name, definitions in non_import_by_simple.items()
-        }
-        qualified_names_by_file_and_simple = {
-            file_and_simple: tuple(definition.name for definition in definitions)
-            for file_and_simple, definitions in non_import_by_file_and_simple.items()
-        }
+            definitions.sort(key=_definition_name)
 
         _methods_by_file_and_name = defaultdict(list)
         for d in self.defs.values():
@@ -1971,13 +1981,6 @@ class Skylos:
                 if str(member_def.filename) == str(ref_file)
             ]
             return same_file or matches
-
-        def _qualified_range(names: tuple[str, ...], qualifier: str) -> tuple[int, int]:
-            lower = f"{qualifier}."
-            # '/' is the lexicographic successor to '.', so this upper bound
-            # includes every dotted descendant without scanning the bucket.
-            upper = f"{qualifier}/"
-            return bisect_left(names, lower), bisect_left(names, upper)
 
         total_refs = len(self.refs)
         tick_every = int(os.getenv("SKYLOS_MARKREFS_TICK", str(MARKREFS_TICK_DEFAULT)))
@@ -2032,10 +2035,9 @@ class Skylos:
                         continue
 
                 else:
-                    candidates = non_import_by_simple.get(simple, [])
-                    candidate_names = qualified_names_by_simple.get(simple, ())
-                    start, stop = _qualified_range(candidate_names, ref_mod)
-                    candidates = candidates[start : min(stop, start + 2)]
+                    candidates = _qualified_candidates(
+                        non_import_by_simple.get(simple, []), ref_mod
+                    )
             else:
                 candidates = non_import_by_simple.get(simple, [])
 
@@ -2045,18 +2047,13 @@ class Skylos:
                         d for d in candidates if str(d.filename) == str(ref_file)
                     ]
                 else:
-                    file_and_simple = (str(ref_file), simple)
                     same_file_candidates = non_import_by_file_and_simple.get(
-                        file_and_simple, []
+                        (str(ref_file), simple), []
                     )
-                if ref_mod and ref_mod not in ("cls", "self"):
-                    same_file_names = qualified_names_by_file_and_simple.get(
-                        file_and_simple, ()
-                    )
-                    start, stop = _qualified_range(same_file_names, ref_mod)
-                    same_file_candidates = same_file_candidates[
-                        start : min(stop, start + 2)
-                    ]
+                    if ref_mod:
+                        same_file_candidates = _qualified_candidates(
+                            same_file_candidates, ref_mod
+                        )
                 if len(same_file_candidates) == 1:
                     candidates = same_file_candidates
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import ast
+from bisect import bisect_left
 import sys
 import json
 import logging
@@ -1922,8 +1923,29 @@ class Skylos:
                 self.defs[resolved].references += 1
 
         simple_name_lookup = defaultdict(list)
+        non_import_by_simple = defaultdict(list)
+        non_import_by_file_and_simple = defaultdict(list)
         for definition in self.defs.values():
             simple_name_lookup[definition.simple_name].append(definition)
+            if definition.type != "import":
+                non_import_by_simple[definition.simple_name].append(definition)
+                non_import_by_file_and_simple[
+                    (str(definition.filename), definition.simple_name)
+                ].append(definition)
+
+        for definitions in non_import_by_simple.values():
+            definitions.sort(key=lambda definition: definition.name)
+        for definitions in non_import_by_file_and_simple.values():
+            definitions.sort(key=lambda definition: definition.name)
+
+        qualified_names_by_simple = {
+            simple_name: tuple(definition.name for definition in definitions)
+            for simple_name, definitions in non_import_by_simple.items()
+        }
+        qualified_names_by_file_and_simple = {
+            file_and_simple: tuple(definition.name for definition in definitions)
+            for file_and_simple, definitions in non_import_by_file_and_simple.items()
+        }
 
         _methods_by_file_and_name = defaultdict(list)
         for d in self.defs.values():
@@ -1949,6 +1971,13 @@ class Skylos:
                 if str(member_def.filename) == str(ref_file)
             ]
             return same_file or matches
+
+        def _qualified_range(names: tuple[str, ...], qualifier: str) -> tuple[int, int]:
+            lower = f"{qualifier}."
+            # '/' is the lexicographic successor to '.', so this upper bound
+            # includes every dotted descendant without scanning the bucket.
+            upper = f"{qualifier}/"
+            return bisect_left(names, lower), bisect_left(names, upper)
 
         total_refs = len(self.refs)
         tick_every = int(os.getenv("SKYLOS_MARKREFS_TICK", str(MARKREFS_TICK_DEFAULT)))
@@ -1988,6 +2017,7 @@ class Skylos:
             else:
                 ref_mod, simple = "", ref
             candidates = simple_name_lookup.get(simple, [])
+            same_file_candidates = []
 
             if ref_mod:
                 if ref_mod in ("cls", "self"):
@@ -2002,25 +2032,33 @@ class Skylos:
                         continue
 
                 else:
-                    filtered = []
-                    for d in candidates:
-                        if d.name.startswith(ref_mod + ".") and d.type != "import":
-                            filtered.append(d)
-                    candidates = filtered
+                    candidates = non_import_by_simple.get(simple, [])
+                    candidate_names = qualified_names_by_simple.get(simple, ())
+                    start, stop = _qualified_range(candidate_names, ref_mod)
+                    candidates = candidates[start : min(stop, start + 2)]
             else:
-                filtered = []
-                for d in candidates:
-                    if d.type != "import":
-                        filtered.append(d)
-                candidates = filtered
+                candidates = non_import_by_simple.get(simple, [])
 
             if len(candidates) > 1:
-                same_file = []
-                for d in candidates:
-                    if str(d.filename) == str(ref_file):
-                        same_file.append(d)
-                if len(same_file) == 1:
-                    candidates = same_file
+                if ref_mod in ("cls", "self"):
+                    same_file_candidates = [
+                        d for d in candidates if str(d.filename) == str(ref_file)
+                    ]
+                else:
+                    file_and_simple = (str(ref_file), simple)
+                    same_file_candidates = non_import_by_file_and_simple.get(
+                        file_and_simple, []
+                    )
+                if ref_mod and ref_mod not in ("cls", "self"):
+                    same_file_names = qualified_names_by_file_and_simple.get(
+                        file_and_simple, ()
+                    )
+                    start, stop = _qualified_range(same_file_names, ref_mod)
+                    same_file_candidates = same_file_candidates[
+                        start : min(stop, start + 2)
+                    ]
+                if len(same_file_candidates) == 1:
+                    candidates = same_file_candidates
 
             if len(candidates) == 1:
                 candidates[0].references += 1
@@ -2028,11 +2066,8 @@ class Skylos:
 
             if len(candidates) > 1:
                 if ref_mod in ("self", "cls"):
-                    same_file_cands = [
-                        d for d in candidates if str(d.filename) == str(ref_file)
-                    ]
-                    if same_file_cands:
-                        for d in same_file_cands:
+                    if same_file_candidates:
+                        for d in same_file_candidates:
                             d.references += 1
                     continue
                 if not ref_mod:
@@ -2056,10 +2091,7 @@ class Skylos:
                             member_def.references += 1
                         continue
 
-            non_import_defs_fallback = []
-            for d in simple_name_lookup.get(simple, []):
-                if d.type != "import":
-                    non_import_defs_fallback.append(d)
+            non_import_defs_fallback = non_import_by_simple.get(simple, [])
 
             if len(non_import_defs_fallback) == 1:
                 non_import_defs_fallback[0].references += 1

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -525,6 +525,84 @@ class TestSkylos:
         assert local.references == 1
         assert remote.references == 0
 
+    def test_mark_refs_qualified_prefix_excludes_sibling_name_prefix(
+        self, skylos, mock_definition
+    ):
+        """`package.Parent` must not reach `package.Parents`.
+
+        The qualified lookup bounds its search at ``qualifier + "/"``, the code
+        point right after ``.``. A sibling whose name merely starts with the
+        same characters is not a dotted descendant and must stay unmatched.
+        """
+        sibling = mock_definition(
+            name="package.Parents.target",
+            simple_name="target",
+            type="function",
+        )
+        nested = mock_definition(
+            name="package.Parent.Nested.target",
+            simple_name="target",
+            type="function",
+        )
+        skylos.defs = {
+            sibling.name: sibling,
+            nested.name: nested,
+        }
+        skylos.refs = [("package.Parent.target", Path("caller.py"))]
+        skylos._global_type_map = {}
+
+        skylos._mark_refs()
+
+        assert nested.references == 1
+        assert sibling.references == 0
+
+    def test_mark_refs_qualified_prefix_leaves_three_way_ambiguity_unresolved(
+        self, skylos, mock_definition
+    ):
+        """More than two prefix matches stays ambiguous.
+
+        The qualified lookup stops collecting at two matches because callers
+        only distinguish zero / one / more-than-one. Truncation must not make
+        an unresolvable reference look resolvable.
+        """
+        definitions = []
+        for suffix, filename in (("A", "a.py"), ("B", "a.py"), ("C", "b.py")):
+            definition = mock_definition(
+                name=f"pkg.P.{suffix}.target",
+                simple_name="target",
+                type="function",
+            )
+            definition.filename = Path(filename)
+            definitions.append(definition)
+        skylos.defs = {d.name: d for d in definitions}
+        skylos.refs = [("pkg.P.target", Path("a.py"))]
+        skylos._global_type_map = {}
+
+        skylos._mark_refs()
+
+        assert [d.references for d in definitions] == [0, 0, 0]
+
+    def test_mark_refs_qualified_prefix_narrows_three_matches_by_file(
+        self, skylos, mock_definition
+    ):
+        """A unique same-file match wins even past the two-match cutoff."""
+        definitions = []
+        for suffix, filename in (("A", "a.py"), ("B", "b.py"), ("C", "c.py")):
+            definition = mock_definition(
+                name=f"pkg.P.{suffix}.target",
+                simple_name="target",
+                type="function",
+            )
+            definition.filename = Path(filename)
+            definitions.append(definition)
+        skylos.defs = {d.name: d for d in definitions}
+        skylos.refs = [("pkg.P.target", Path("b.py"))]
+        skylos._global_type_map = {}
+
+        skylos._mark_refs()
+
+        assert [d.references for d in definitions] == [0, 1, 0]
+
 
 class TestHeuristics:
     @pytest.fixture

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -473,6 +473,58 @@ class TestSkylos:
         assert mock_import.references == 1
         assert mock_original.references == 2
 
+    def test_mark_refs_qualified_prefix_includes_descendant_definitions(
+        self, skylos, mock_definition
+    ):
+        nested = mock_definition(
+            name="package.Parent.Nested.target",
+            simple_name="target",
+            type="function",
+        )
+        other = mock_definition(
+            name="package.Other.target",
+            simple_name="target",
+            type="function",
+        )
+        skylos.defs = {
+            nested.name: nested,
+            other.name: other,
+        }
+        skylos.refs = [("package.Parent.target", Path("caller.py"))]
+        skylos._global_type_map = {}
+
+        skylos._mark_refs()
+
+        assert nested.references == 1
+        assert other.references == 0
+
+    def test_mark_refs_qualified_prefix_prefers_unique_same_file_definition(
+        self, skylos, mock_definition
+    ):
+        local = mock_definition(
+            name="package.Parent.Local.target",
+            simple_name="target",
+            type="function",
+        )
+        local.filename = Path("local.py")
+        remote = mock_definition(
+            name="package.Parent.Remote.target",
+            simple_name="target",
+            type="function",
+        )
+        remote.filename = Path("remote.py")
+        skylos.defs = {
+            local.name: local,
+            remote.name: remote,
+        }
+        skylos.refs = [("package.Parent.target", Path("local.py"))]
+        skylos._global_type_map = {}
+
+        skylos._mark_refs()
+
+        assert local.references == 1
+        assert remote.references == 0
+
 
 class TestHeuristics:
     @pytest.fixture


### PR DESCRIPTION
Closes #768 

## Summary

- index non-import definitions by simple name and source file
- resolve qualified references with logarithmic binary searches instead of repeated candidate scans

Knocks down the empirical O(n^2)  scaling.

## Measured Performance Improvement

- homeassistant/core/homeassistant: `_mark_refs` cumulative time: 1213.7 s -> 84.5s
   - direct `str.startswith` calls from `_mark_refs`: 2.661 billion -> 1.965 million
- scipy: 23.1s -> 14.3s in `_mark_refs` (scipy specifically is not as badly hit by this particular quadratic scaling relative to its size as a repo)
- Not much change in timing (maybe ~5% improvement within ~inter-run noise) on skylos's current SHA pinned liveness_primer corpus (small to medium sized repositories not as affected by quadratic scaling)

Note: I doubt this completely maxes out possible perf wins in `_mark_refs`; I thought the maintainer might find a smaller footprint/relatively straightforward code change from me that specifically targets the O(n^2) scaling with indexing more palatable than a larger refactor, given how cognitively complex and important this function is. 

## Validation

- Home Assistant findings were byte-for-byte identical across both 2,218-line outputs
- 188 analyzer tests passed
- 85 dead-code and framework-aware tests passed
- targeted Ruff undefined-name, unbound-name, and closure-binding checks passed
- liveness_primer shows 0 diffs on corpus

**AI Use Disclosure**
Profiled targeted and and potential O(n^2) identified by hand using cProfile. Codex implemented an indexing scheme and the sorting/bisection. Reviewed according to skylos repository review guidelines using GPT-5.6 Sol and Opus 5.0. Second commit was partly based on my own by-hand simplification findings.
