### PR TITLE
fix(analyzer): tighten dead-code and SQL matching

### DIFF
--- a/skylos/analysis/file_worker.py
+++ b/skylos/analysis/file_worker.py
@@ -423,6 +423,7 @@ def _success_result(
         getattr(visitor, "top_level_refs", set()),
         analysis_error,
         prepared.ignore_rules_by_line,
+        bool(getattr(visitor, "has_explicit_all", False)),
     )
 
 
@@ -465,6 +466,7 @@ def _error_result(file, cfg, error, options: _WorkerOptions) -> tuple:
             kind="source_read_error" if isinstance(error, SourceReadError) else None,
         ),
         {},
+        False,
     )
 
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1179,6 +1179,22 @@ def _mark_evidence_ref(defn, marker: str, confidence: float = 1.0) -> None:
     refs[marker] = max(refs.get(marker, 0.0), confidence)
 
 
+def _source_file_key(value) -> str | None:
+    try:
+        path = os.fspath(value)
+    except TypeError:
+        return None
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _definition_binding_name(definition) -> str:
+    simple_name = str(getattr(definition, "simple_name", ""))
+    if getattr(definition, "type", None) != "import":
+        return simple_name
+    binding_name = getattr(definition, "binding_name", None)
+    return binding_name if isinstance(binding_name, str) else simple_name
+
+
 def _has_evidence_marker(defn, markers) -> bool:
     refs = getattr(defn, "heuristic_refs", {})
     if not isinstance(refs, dict):
@@ -1215,6 +1231,7 @@ class Skylos:
         self.refs = []
         self.dynamic = set()
         self.exports = defaultdict(set)
+        self._explicit_all_exports_by_file = {}
         self._module_alias_prefix_values = ()
         for attribute in _OPTIONAL_RUN_STATE_ATTRIBUTES:
             self.__dict__.pop(attribute, None)
@@ -1440,56 +1457,102 @@ class Skylos:
         return all_files
 
     def _mark_exports(self):
-        for name, definition in self.defs.items():
-            if definition.in_init and not definition.simple_name.startswith("_"):
+        explicit_exports_by_file = getattr(self, "_explicit_all_exports_by_file", {})
+        source_keys = {
+            id(definition): _source_file_key(getattr(definition, "filename", None))
+            for definition in self.defs.values()
+        }
+
+        for definition in self.defs.values():
+            source_key = source_keys[id(definition)]
+            has_explicit_all = source_key in explicit_exports_by_file
+            if (
+                definition.in_init
+                and not has_explicit_all
+                and not definition.simple_name.startswith("_")
+            ):
                 definition.is_exported = True
 
-        all_exported_names = set()
-        for mod, export_names in self.exports.items():
-            all_exported_names.update(export_names)
-
-        for def_name, def_obj in self.defs.items():
+        for def_obj in self.defs.values():
             if str(def_obj.filename).endswith(_TS_JS_SOURCE_EXTS):
                 continue
-            if def_obj.simple_name in all_exported_names:
+            source_key = source_keys[id(def_obj)]
+            export_names = explicit_exports_by_file.get(source_key)
+            if (
+                export_names is not None
+                and _definition_binding_name(def_obj) in export_names
+            ):
                 def_obj.is_exported = True
-                def_obj.references += 1
+                def_obj.references = max(def_obj.references, 1)
 
+        # Keep direct callers and older worker tuples compatible while matching
+        # each export to its own module instead of every same-named definition.
         for mod, export_names in self.exports.items():
             for name in export_names:
-                for def_name, def_obj in self.defs.items():
-                    if (
-                        def_name.startswith(f"{mod}.")
-                        and def_obj.simple_name == name
-                        and def_obj.type != "import"
-                    ):
-                        def_obj.is_exported = True
+                qualified_name = f"{mod}.{name}" if mod else name
+                def_obj = self.defs.get(qualified_name)
+                if def_obj is None or def_obj.type == "import":
+                    continue
+                def_obj.is_exported = True
+                def_obj.references = max(def_obj.references, 1)
 
+        non_import_by_name = defaultdict(list)
         non_import_by_simple = defaultdict(list)
-        for k, d in self.defs.items():
+        for d in self.defs.values():
             if d.type != "import":
+                non_import_by_name[d.name].append(d)
                 non_import_by_simple[d.simple_name].append(d)
 
-        for def_key, def_obj in self.defs.items():
+        def resolve_reexport_target(target_name):
+            exact = non_import_by_name.get(target_name, ())
+            if len(exact) == 1:
+                return exact[0]
+
+            for prefix in self._module_alias_prefix_values:
+                if not target_name.startswith(prefix + "."):
+                    continue
+                stripped = target_name[len(prefix) + 1 :]
+                matches = non_import_by_name.get(stripped, ())
+                if len(matches) == 1:
+                    return matches[0]
+
+            if "." not in target_name:
+                return None
+            simple_name = target_name.rsplit(".", 1)[-1]
+            qualified_matches = [
+                candidate
+                for candidate in non_import_by_simple.get(simple_name, ())
+                if "." in candidate.name
+                and (
+                    candidate.name.endswith(f".{target_name}")
+                    or target_name.endswith(f".{candidate.name}")
+                )
+            ]
+            if len(qualified_matches) == 1:
+                return qualified_matches[0]
+            return None
+
+        for def_obj in self.defs.values():
             if def_obj.type != "import":
                 continue
             if not def_obj.in_init:
                 continue
+            source_key = source_keys[id(def_obj)]
+            export_names = explicit_exports_by_file.get(source_key)
+            if (
+                export_names is not None
+                and _definition_binding_name(def_obj) not in export_names
+            ):
+                continue
             # e.g. "requests.api.get"
             target_name = def_obj.name
-            if target_name:
-                simple = target_name.split(".")[-1]
-            else:
-                simple = ""
-            if not simple:
+            if not target_name:
                 continue
-            if target_name in self.defs and self.defs[target_name].type != "import":
-                self.defs[target_name].references += 1
-                self.defs[target_name].is_exported = True
+            candidate = resolve_reexport_target(target_name)
+            if candidate is None:
                 continue
-            for candidate in non_import_by_simple.get(simple, []):
-                candidate.references += 1
-                candidate.is_exported = True
+            candidate.references += 1
+            candidate.is_exported = True
 
         # propogate exports to methods of exported classes
         exported_classes = set()
@@ -1907,7 +1970,17 @@ class Skylos:
                         return stripped_target
 
             simple = target_fqn.split(".")[-1]
-            cands = simple_to_keys.get(simple, [])
+            if "." not in target_fqn:
+                return None
+            cands = [
+                key
+                for key in simple_to_keys.get(simple, [])
+                if "." in non_import_defs[key].name
+                and (
+                    non_import_defs[key].name.endswith(f".{target_fqn}")
+                    or target_fqn.endswith(f".{non_import_defs[key].name}")
+                )
+            ]
             if len(cands) == 1:
                 return cands[0]
 
@@ -3178,6 +3251,7 @@ class Skylos:
                 file_architecture_metrics = out[23] if len(out) > 23 else None
                 file_top_level_refs = out[24] if len(out) > 24 else set()
                 file_analysis_error = out[25] if len(out) > 25 else None
+                file_has_explicit_all = bool(out[27]) if len(out) > 27 else False
                 if isinstance(file_analysis_error, dict):
                     analysis_errors.append(file_analysis_error)
                 (
@@ -3250,6 +3324,10 @@ class Skylos:
                 self.refs.extend(refs)
                 self.dynamic.update(dyn)
                 self.exports[mod].update(exports)
+                if file_has_explicit_all:
+                    source_key = _source_file_key(file)
+                    if source_key is not None:
+                        self._explicit_all_exports_by_file[source_key] = set(exports)
 
                 file_contexts.append(
                     (defs, test_flags, framework_flags, file, mod, cfg)

--- a/skylos/core/grep_verify_python_strategy.py
+++ b/skylos/core/grep_verify_python_strategy.py
@@ -162,9 +162,15 @@ def multi_strategy_search(
             rf"\b{re.escape(full_name)}\b",
             project_root,
             use_regex=True,
+            include_globs=["*.py", "*.pyi"],
             max_results=max_per_strategy,
         )
         if qualified_refs:
+            qualified_refs = [
+                ref
+                for ref in qualified_refs
+                if _is_python_source_reference(ref, simple_name)
+            ]
             _defs, usages = filter_grep_results(qualified_refs, finding)
             if usages:
                 results["qualified_references"] = usages[:max_per_strategy]

--- a/skylos/rules/danger/danger.py
+++ b/skylos/rules/danger/danger.py
@@ -243,6 +243,7 @@ class _PythonCommandExfilChecker(_DangerousCallsChecker):
 
 
 _SQL_TOKENS = (
+    "sqlalchemy",
     ".execute",
     ".executemany",
     ".executescript",
@@ -256,6 +257,7 @@ _SQL_TOKENS = (
     "objects.raw",
 )
 _SQL_RAW_TOKENS = (
+    "sqlalchemy",
     ".text(",
     " text(",
     "read_sql",

--- a/skylos/rules/danger/danger_sql/sql_flow.py
+++ b/skylos/rules/danger/danger_sql/sql_flow.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 import ast
 import sys
 from skylos.rules.danger.taint import TaintVisitor
+from skylos.rules.danger.danger_sql.sqlalchemy_provenance import (
+    SQLAlchemyTextProvenance,
+)
 
 
 DB_MODULES = frozenset(
@@ -185,30 +188,17 @@ def is_parameterized_query(call: ast.Call, query_expr: ast.AST):
     return False
 
 
-def is_sqlalchemy_text(expr: ast.AST):
-    if not isinstance(expr, ast.Call):
-        return False
-
-    func = expr.func
-
-    if isinstance(func, ast.Attribute) and func.attr == "text":
-        return True
-
-    if isinstance(func, ast.Name) and func.id == "text":
-        return True
-    return False
-
-
 class _SQLFlowChecker(TaintVisitor):
     RULE_ID_SQLI = "SKY-D211"
     SEVERITY_CRITICAL = "CRITICAL"
     SEVERITY_HIGH = "HIGH"
     DBAPI_SQL_SINK_SUFFIXES = (".execute", ".executemany", ".executescript")
 
-    def __init__(self, file_path, findings):
+    def __init__(self, tree: ast.AST, file_path, findings):
         super().__init__(file_path, findings)
         self.passthrough_functions: set[str] = set()
         self.db_names: set[str] = set()
+        self.sqlalchemy_text = SQLAlchemyTextProvenance(tree)
         self.static_string_stack: list[dict[str, bool]] = [{}]
         self.db_receiver_alias_stack: list[set[str]] = [set()]
 
@@ -279,6 +269,7 @@ class _SQLFlowChecker(TaintVisitor):
                 self._mark_db_receiver_alias(target.attr)
 
     def visit_Import(self, node):
+        self.sqlalchemy_text.record_import(node)
         for alias in node.names:
             top_level = alias.name.split(".")[0]
             if top_level in DB_MODULES or alias.name in DB_MODULES:
@@ -286,6 +277,7 @@ class _SQLFlowChecker(TaintVisitor):
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node):
+        self.sqlalchemy_text.record_import(node)
         if node.module:
             top_level = node.module.split(".")[0]
             if top_level in DB_MODULES or node.module in DB_MODULES:
@@ -319,12 +311,75 @@ class _SQLFlowChecker(TaintVisitor):
                     break
 
     def visit_FunctionDef(self, node):
-        self._record_passthrough_function(node)
-        super().visit_FunctionDef(node)
+        self.sqlalchemy_text.record_name_binding(node.name)
+        self.sqlalchemy_text.enter_function(node)
+        try:
+            self._record_passthrough_function(node)
+            super().visit_FunctionDef(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
 
     def visit_AsyncFunctionDef(self, node):
-        self._record_passthrough_function(node)
-        super().visit_AsyncFunctionDef(node)
+        self.sqlalchemy_text.record_name_binding(node.name)
+        self.sqlalchemy_text.enter_function(node)
+        try:
+            self._record_passthrough_function(node)
+            super().visit_AsyncFunctionDef(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def visit_ClassDef(self, node):
+        self.sqlalchemy_text.record_name_binding(node.name)
+        self.sqlalchemy_text.enter_class(node)
+        try:
+            super().visit_ClassDef(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def visit_Name(self, node: ast.Name):
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.sqlalchemy_text.record_name_binding(node.id)
+        self.generic_visit(node)
+
+    def visit_Lambda(self, node: ast.Lambda):
+        self.sqlalchemy_text.enter_lambda(node)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def _visit_scoped_comprehension(self, node):
+        first, *remaining = node.generators
+        self.visit(first.iter)
+        self.sqlalchemy_text.enter_comprehension(node)
+        try:
+            self.visit(first.target)
+            for condition in first.ifs:
+                self.visit(condition)
+            for generator in remaining:
+                self.visit(generator.iter)
+                self.visit(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            if isinstance(node, ast.DictComp):
+                self.visit(node.key)
+                self.visit(node.value)
+            else:
+                self.visit(node.elt)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def visit_ListComp(self, node: ast.ListComp):
+        self._visit_scoped_comprehension(node)
+
+    def visit_SetComp(self, node: ast.SetComp):
+        self._visit_scoped_comprehension(node)
+
+    def visit_DictComp(self, node: ast.DictComp):
+        self._visit_scoped_comprehension(node)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp):
+        self._visit_scoped_comprehension(node)
 
     def visit_Assign(self, node):
         self._track_db_receiver_aliases(node.targets, node.value)
@@ -449,7 +504,7 @@ class _SQLFlowChecker(TaintVisitor):
             self.generic_visit(node)
             return
 
-        if is_sqlalchemy_text(node):
+        if self.sqlalchemy_text.is_text_call(node):
             for argument in node.args:
                 if _is_interpolated_string(argument) or self.is_tainted(argument):
                     self.findings.append(
@@ -470,7 +525,7 @@ class _SQLFlowChecker(TaintVisitor):
 
 def scan(tree, file_path, findings):
     try:
-        checker = _SQLFlowChecker(file_path, findings)
+        checker = _SQLFlowChecker(tree, file_path, findings)
         checker.visit(tree)
     except Exception as e:
         print(f"SQL flow analysis failed for {file_path}: {e}", file=sys.stderr)

--- a/skylos/rules/danger/danger_sql/sql_raw_flow.py
+++ b/skylos/rules/danger/danger_sql/sql_raw_flow.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 import ast
 import sys
 from skylos.rules.danger.taint import TaintVisitor
+from skylos.rules.danger.danger_sql.sqlalchemy_provenance import (
+    SQLAlchemyTextProvenance,
+)
 
 
 def _qualified_name(node: ast.Call):
@@ -69,13 +72,94 @@ def _is_interpolated_string(n: ast.AST):
 
 
 class _SQLRawFlowChecker(TaintVisitor):
+    def __init__(self, tree: ast.AST, file_path, findings):
+        super().__init__(file_path, findings)
+        self.sqlalchemy_text = SQLAlchemyTextProvenance(tree)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self.sqlalchemy_text.record_import(node)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        self.sqlalchemy_text.record_import(node)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.sqlalchemy_text.record_name_binding(node.name)
+        self.sqlalchemy_text.enter_function(node)
+        try:
+            super().visit_FunctionDef(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.sqlalchemy_text.record_name_binding(node.name)
+        self.sqlalchemy_text.enter_function(node)
+        try:
+            super().visit_AsyncFunctionDef(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.sqlalchemy_text.record_name_binding(node.name)
+        self.sqlalchemy_text.enter_class(node)
+        try:
+            super().visit_ClassDef(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.sqlalchemy_text.record_name_binding(node.id)
+        self.generic_visit(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self.sqlalchemy_text.enter_lambda(node)
+        try:
+            self.generic_visit(node)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def _visit_scoped_comprehension(self, node) -> None:
+        first, *remaining = node.generators
+        self.visit(first.iter)
+        self.sqlalchemy_text.enter_comprehension(node)
+        try:
+            self.visit(first.target)
+            for condition in first.ifs:
+                self.visit(condition)
+            for generator in remaining:
+                self.visit(generator.iter)
+                self.visit(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            if isinstance(node, ast.DictComp):
+                self.visit(node.key)
+                self.visit(node.value)
+            else:
+                self.visit(node.elt)
+        finally:
+            self.sqlalchemy_text.leave_scope()
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_scoped_comprehension(node)
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_scoped_comprehension(node)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_scoped_comprehension(node)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_scoped_comprehension(node)
+
     def visit_Call(self, node: ast.Call):
         qn = _qualified_name(node)
         if not qn:
             self.generic_visit(node)
             return
 
-        if qn.endswith(".text") and node.args:
+        if self.sqlalchemy_text.is_text_call(node) and node.args:
             sql = node.args[0]
             if _is_interpolated_string(sql) or self.is_tainted(sql):
                 self.findings.append(
@@ -125,7 +209,7 @@ class _SQLRawFlowChecker(TaintVisitor):
 
 def scan(tree: ast.AST, file_path, findings):
     try:
-        checker = _SQLRawFlowChecker(file_path, findings)
+        checker = _SQLRawFlowChecker(tree, file_path, findings)
         checker.visit(tree)
     except Exception as e:
         print(f"Raw SQL flow analysis failed for {file_path}: {e}", file=sys.stderr)

--- a/skylos/rules/danger/danger_sql/sqlalchemy_provenance.py
+++ b/skylos/rules/danger/danger_sql/sqlalchemy_provenance.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+
+_SQLALCHEMY_ROOT = "sqlalchemy"
+
+
+@dataclass(frozen=True)
+class _ImportBinding:
+    qualified_name: str
+
+
+@dataclass
+class _ScopeFrame:
+    kind: str
+    bindings: dict[str, _ImportBinding | None]
+    lookup_parent: _ScopeFrame | None
+    active_bindings: dict[str, _ImportBinding | None] | None = None
+
+
+def _is_absolute_sqlalchemy_module(module: str | None, level: int = 0) -> bool:
+    return bool(
+        level == 0
+        and module
+        and (module == _SQLALCHEMY_ROOT or module.startswith(f"{_SQLALCHEMY_ROOT}."))
+    )
+
+
+def _import_bindings(
+    node: ast.Import | ast.ImportFrom,
+) -> list[tuple[str, _ImportBinding | None]]:
+    bindings: list[tuple[str, _ImportBinding | None]] = []
+
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".", 1)[0]
+            if _is_absolute_sqlalchemy_module(alias.name):
+                resolved = alias.name if alias.asname else local
+                bindings.append((local, _ImportBinding(resolved)))
+            else:
+                bindings.append((local, None))
+        return bindings
+
+    module = node.module
+    is_sqlalchemy = _is_absolute_sqlalchemy_module(module, node.level)
+    for alias in node.names:
+        if alias.name == "*":
+            if is_sqlalchemy and module:
+                bindings.append(("text", _ImportBinding(f"{module}.text")))
+            continue
+
+        local = alias.asname or alias.name
+        if is_sqlalchemy and module:
+            bindings.append((local, _ImportBinding(f"{module}.{alias.name}")))
+        else:
+            bindings.append((local, None))
+    return bindings
+
+
+class _ScopeBindingCollector(ast.NodeVisitor):
+    """Collect bindings in one lexical scope without entering child scopes."""
+
+    def __init__(self) -> None:
+        self.candidates: dict[str, list[_ImportBinding | None]] = {}
+        self.global_names: set[str] = set()
+        self.nonlocal_names: set[str] = set()
+
+    def _record(self, name: str, binding: _ImportBinding | None) -> None:
+        self.candidates.setdefault(name, []).append(binding)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for name, binding in _import_bindings(node):
+            self._record(name, binding)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for name, binding in _import_bindings(node):
+            self._record(name, binding)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self._record(node.id, None)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._record(node.name, None)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._record(node.name, None)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._record(node.name, None)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
+    def _visit_comprehension(
+        self, node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp
+    ) -> None:
+        for generator in node.generators:
+            self.visit(generator.iter)
+            for condition in generator.ifs:
+                self.visit(condition)
+        if isinstance(node, ast.DictComp):
+            self.visit(node.key)
+            self.visit(node.value)
+        else:
+            self.visit(node.elt)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node)
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name:
+            self._record(node.name, None)
+        self.generic_visit(node)
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self.global_names.update(node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self.nonlocal_names.update(node.names)
+
+
+def _collect_scope(
+    node: ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+) -> _ScopeBindingCollector:
+    collector = _ScopeBindingCollector()
+    for statement in node.body:
+        collector.visit(statement)
+    return collector
+
+
+def _module_bindings(tree: ast.AST) -> dict[str, _ImportBinding | None]:
+    if not isinstance(tree, ast.Module):
+        return {}
+
+    bindings: dict[str, _ImportBinding | None] = {}
+    for statement in tree.body:
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            for name, binding in _import_bindings(statement):
+                bindings[name] = binding
+        elif isinstance(
+            statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            bindings[statement.name] = None
+        else:
+            collector = _ScopeBindingCollector()
+            collector.visit(statement)
+            for name in collector.candidates:
+                bindings[name] = None
+    return bindings
+
+
+def _function_local_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str]:
+    collector = _collect_scope(node)
+    names = set(collector.candidates)
+    arguments = [
+        *getattr(node.args, "posonlyargs", []),
+        *node.args.args,
+        *node.args.kwonlyargs,
+    ]
+    if node.args.vararg:
+        arguments.append(node.args.vararg)
+    if node.args.kwarg:
+        arguments.append(node.args.kwarg)
+    names.update(argument.arg for argument in arguments)
+    names.difference_update(collector.global_names)
+    names.difference_update(collector.nonlocal_names)
+    return names
+
+
+class SQLAlchemyTextProvenance:
+    """Resolve ``text`` calls only through proven absolute SQLAlchemy imports."""
+
+    def __init__(self, tree: ast.AST) -> None:
+        module = _ScopeFrame(
+            kind="module",
+            bindings=_module_bindings(tree),
+            lookup_parent=None,
+            active_bindings={},
+        )
+        self._module = module
+        self._scope_stack = [module]
+
+    @property
+    def _current(self) -> _ScopeFrame:
+        return self._scope_stack[-1]
+
+    def enter_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        lookup_parent = self._current
+        while lookup_parent.kind == "class" and lookup_parent.lookup_parent:
+            lookup_parent = lookup_parent.lookup_parent
+        bindings = {name: None for name in _function_local_names(node)}
+        self._scope_stack.append(
+            _ScopeFrame("function", bindings, lookup_parent=lookup_parent)
+        )
+
+    def enter_class(self, node: ast.ClassDef) -> None:
+        collector = _collect_scope(node)
+        bindings = {name: None for name in collector.candidates}
+        self._scope_stack.append(
+            _ScopeFrame("class", bindings, lookup_parent=self._current)
+        )
+
+    def enter_lambda(self, node: ast.Lambda) -> None:
+        lookup_parent = self._current
+        while lookup_parent.kind == "class" and lookup_parent.lookup_parent:
+            lookup_parent = lookup_parent.lookup_parent
+        arguments = [
+            *getattr(node.args, "posonlyargs", []),
+            *node.args.args,
+            *node.args.kwonlyargs,
+        ]
+        if node.args.vararg:
+            arguments.append(node.args.vararg)
+        if node.args.kwarg:
+            arguments.append(node.args.kwarg)
+        collector = _ScopeBindingCollector()
+        collector.visit(node.body)
+        names = set(collector.candidates)
+        names.update(argument.arg for argument in arguments)
+        bindings = {name: None for name in names}
+        self._scope_stack.append(
+            _ScopeFrame("function", bindings, lookup_parent=lookup_parent)
+        )
+
+    def enter_comprehension(
+        self, node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp
+    ) -> None:
+        names: set[str] = set()
+        for generator in node.generators:
+            names.update(
+                child.id
+                for child in ast.walk(generator.target)
+                if isinstance(child, ast.Name)
+            )
+        bindings = {name: None for name in names}
+        self._scope_stack.append(
+            _ScopeFrame("comprehension", bindings, lookup_parent=self._current)
+        )
+
+    def leave_scope(self) -> None:
+        if len(self._scope_stack) > 1:
+            self._scope_stack.pop()
+
+    def record_import(self, node: ast.Import | ast.ImportFrom) -> None:
+        target = self._current
+        destination = (
+            target.active_bindings if target.kind == "module" else target.bindings
+        )
+        if destination is None:
+            return
+        for name, binding in _import_bindings(node):
+            destination[name] = binding
+
+    def record_name_binding(self, name: str) -> None:
+        target = self._current
+        destination = (
+            target.active_bindings if target.kind == "module" else target.bindings
+        )
+        if destination is not None:
+            destination[name] = None
+
+    def _lookup(self, name: str) -> _ImportBinding | None:
+        use_precollected_module = any(
+            scope.kind == "function" for scope in self._scope_stack
+        )
+        scope: _ScopeFrame | None = self._current
+        while scope is not None:
+            if scope.kind == "module" and not use_precollected_module:
+                bindings = scope.active_bindings or {}
+            else:
+                bindings = scope.bindings
+            if name in bindings:
+                return bindings[name]
+            scope = scope.lookup_parent
+        return None
+
+    def is_text_call(self, node: ast.AST) -> bool:
+        if not isinstance(node, ast.Call):
+            return False
+
+        func = node.func
+        attributes: list[str] = []
+        while isinstance(func, ast.Attribute):
+            attributes.append(func.attr)
+            func = func.value
+        if not isinstance(func, ast.Name):
+            return False
+
+        binding = self._lookup(func.id)
+        if binding is None:
+            return False
+
+        attributes.reverse()
+        qualified_name = ".".join([binding.qualified_name, *attributes])
+        return qualified_name.startswith("sqlalchemy.") and qualified_name.endswith(
+            ".text"
+        )

--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -332,6 +332,7 @@ class Definition:
         "references",
         "is_exported",
         "in_init",
+        "binding_name",
         "node",
         "calls",
         "called_by",
@@ -375,6 +376,7 @@ class Definition:
         self.references = 0
         self.is_exported = False
         self.in_init = "__init__.py" in str(filename)
+        self.binding_name = self.simple_name
 
         self.node = node
         self.calls = set()
@@ -467,6 +469,7 @@ class Visitor(ast.NodeVisitor):
         self._alias_binding_lines: dict[str, int] = {}
         self.dyn = set()
         self.exports = set()
+        self.has_explicit_all = False
         self.current_function_scope = []
         self.current_function_params = []
         self.local_var_maps = []
@@ -577,6 +580,7 @@ class Visitor(ast.NodeVisitor):
         self._module_shadows_getattr = _module_binds_name(node, "getattr")
         for stmt in node.body:
             self.visit(stmt)
+        self._finalize_dunder_all_exports(node.body)
 
     def qual(self, name: str) -> str:
         if name in self.alias:
@@ -641,8 +645,13 @@ class Visitor(ast.NodeVisitor):
                 target,
                 "import",
                 line,
+                binding_name=alias_name,
                 is_exported=a.asname == a.name if a.asname else False,
-                suppression_lines={line, node.lineno, getattr(node, "end_lineno", line)},
+                suppression_lines={
+                    line,
+                    node.lineno,
+                    getattr(node, "end_lineno", line),
+                },
             )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
@@ -698,8 +707,13 @@ class Visitor(ast.NodeVisitor):
                 full,
                 "import",
                 line,
+                binding_name=alias_name,
                 is_exported=a.asname == a.name if a.asname else False,
-                suppression_lines={line, node.lineno, getattr(node, "end_lineno", line)},
+                suppression_lines={
+                    line,
+                    node.lineno,
+                    getattr(node, "end_lineno", line),
+                },
             )
 
     def visit_If(self, node: ast.If) -> None:
@@ -1685,7 +1699,6 @@ class Visitor(ast.NodeVisitor):
         if isinstance(node.value, ast.Dict):
             self._track_dict_dispatch(node)
 
-        self._process_dunder_all_exports(node)
         self._try_infer_types_from_call(node)
         self._process_textual_bindings(node)
         self._extract_string_refs(node.value)
@@ -1734,6 +1747,8 @@ class Visitor(ast.NodeVisitor):
         def _define(t):
             if isinstance(t, ast.Name):
                 name_simple = t.id
+                if self._should_skip_variable_def(name_simple):
+                    return
                 var_name = self._compute_variable_name(name_simple)
 
                 in_typeddict = bool(
@@ -1769,6 +1784,15 @@ class Visitor(ast.NodeVisitor):
         _define(node.target)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        if (
+            not self.current_function_scope
+            and not self.cls
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+        ):
+            self.visit(node.value)
+            return
+
         if isinstance(node.target, ast.Name):
             nm = node.target.id
             if (
@@ -1819,30 +1843,226 @@ class Visitor(ast.NodeVisitor):
             for elt in target_node.elts:
                 self._process_target_for_def(elt, _in_tuple_unpack=True)
 
-    def _process_dunder_all_exports(self, node: ast.Assign) -> None:
-        for target in node.targets:
-            if not isinstance(target, ast.Name):
-                continue
-            if target.id != "__all__":
-                continue
-            if not isinstance(node.value, (ast.List, ast.Tuple)):
+    def _finalize_dunder_all_exports(self, statements: list[ast.stmt]) -> None:
+        export_names: set[str] | None = None
+        observed_names: set[str] = set()
+        saw_runtime_update = False
+
+        for statement in statements:
+            observed_names.update(self._observed_dunder_all_names(statement))
+            matched, replacement = self._dunder_all_assignment(statement)
+            if matched:
+                saw_runtime_update = True
+                export_names = replacement
                 continue
 
-            for elt in node.value.elts:
-                value = self._extract_string_value(elt)
-                if value is None:
-                    continue
-
-                self.all_exports.add(value)
-                self.exports.add(value)
-
-                if self.mod:
-                    export_name = f"{self.mod}.{value}"
+            matched, additions = self._dunder_all_mutation(statement)
+            if matched:
+                saw_runtime_update = True
+                if export_names is None or additions is None:
+                    export_names = None
                 else:
-                    export_name = value
+                    export_names.update(additions)
+                continue
 
-                self.add_ref(export_name)
-                self.add_ref(value)
+            if self._contains_dunder_all_runtime_update(statement):
+                saw_runtime_update = True
+                export_names = None
+
+        self.exports.clear()
+        self.all_exports.clear()
+        self.has_explicit_all = saw_runtime_update and export_names is not None
+        # Exact state can narrow an __init__ surface. When evaluation became
+        # dynamic, retain observed names only as conservative export evidence.
+        final_names = export_names if self.has_explicit_all else observed_names
+        self.exports.update(final_names)
+        self.all_exports.update(final_names)
+
+    def _dunder_all_assignment(
+        self, statement: ast.stmt
+    ) -> tuple[bool, set[str] | None]:
+        if isinstance(statement, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == "__all__"
+                for target in statement.targets
+            ):
+                return True, self._static_dunder_all_names(statement.value)
+            return False, None
+
+        if (
+            isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == "__all__"
+            and statement.value is not None
+        ):
+            return True, self._static_dunder_all_names(statement.value)
+
+        return False, None
+
+    def _dunder_all_mutation(self, statement: ast.stmt) -> tuple[bool, set[str] | None]:
+        if (
+            isinstance(statement, ast.AugAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == "__all__"
+        ):
+            if not isinstance(statement.op, ast.Add):
+                return True, None
+            return True, self._static_dunder_all_names(statement.value)
+
+        if not isinstance(statement, ast.Expr) or not isinstance(
+            statement.value, ast.Call
+        ):
+            return False, None
+
+        call = statement.value
+        if not (
+            isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "__all__"
+        ):
+            return False, None
+
+        if call.func.attr == "append":
+            if len(call.args) != 1 or call.keywords:
+                return True, None
+            value = self._extract_string_value(call.args[0])
+            return True, {value} if value is not None else None
+
+        if call.func.attr == "extend":
+            if len(call.args) != 1 or call.keywords:
+                return True, None
+            return True, self._static_dunder_all_names(call.args[0])
+
+        return True, None
+
+    def _static_dunder_all_names(self, value: ast.expr) -> set[str] | None:
+        if not isinstance(value, (ast.List, ast.Tuple)):
+            return None
+
+        names = set()
+        for element in value.elts:
+            name = self._extract_string_value(element)
+            if name is None:
+                return None
+            names.add(name)
+        return names
+
+    def _observed_dunder_all_names(self, node: ast.AST) -> set[str]:
+        if isinstance(
+            node,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
+        ):
+            return set()
+
+        names: set[str] = set()
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        ):
+            names.update(self._partial_static_dunder_all_names(node.value))
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+            and node.value is not None
+        ):
+            names.update(self._partial_static_dunder_all_names(node.value))
+        elif (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+        ):
+            names.update(self._partial_static_dunder_all_names(node.value))
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "__all__"
+            ):
+                if node.func.attr == "append" and len(node.args) == 1:
+                    name = self._extract_string_value(node.args[0])
+                    if name is not None:
+                        names.add(name)
+                elif node.func.attr == "extend" and len(node.args) == 1:
+                    names.update(self._partial_static_dunder_all_names(node.args[0]))
+
+        for child in ast.iter_child_nodes(node):
+            names.update(self._observed_dunder_all_names(child))
+        return names
+
+    def _partial_static_dunder_all_names(self, value: ast.expr) -> set[str]:
+        if not isinstance(value, (ast.List, ast.Tuple)):
+            return set()
+        return {
+            name
+            for element in value.elts
+            if (name := self._extract_string_value(element)) is not None
+        }
+
+    def _contains_dunder_all_runtime_update(self, node: ast.AST) -> bool:
+        if isinstance(
+            node,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
+        ):
+            return False
+
+        if isinstance(node, ast.Assign):
+            targets_update = any(
+                self._target_contains_dunder_all(target) for target in node.targets
+            )
+            return targets_update or self._contains_dunder_all_runtime_update(
+                node.value
+            )
+        if isinstance(node, ast.AnnAssign):
+            target_updates = (
+                self._target_contains_dunder_all(node.target) and node.value is not None
+            )
+            return target_updates or (
+                node.value is not None
+                and self._contains_dunder_all_runtime_update(node.value)
+            )
+        if isinstance(node, ast.AugAssign):
+            return self._target_contains_dunder_all(
+                node.target
+            ) or self._contains_dunder_all_runtime_update(node.value)
+        if isinstance(node, ast.Delete):
+            return any(
+                self._target_contains_dunder_all(target) for target in node.targets
+            )
+        if isinstance(node, ast.NamedExpr):
+            return self._target_contains_dunder_all(
+                node.target
+            ) or self._contains_dunder_all_runtime_update(node.value)
+        if isinstance(node, ast.Call) and self._call_may_mutate_dunder_all(node):
+            return True
+
+        return any(
+            self._contains_dunder_all_runtime_update(child)
+            for child in ast.iter_child_nodes(node)
+        )
+
+    def _target_contains_dunder_all(self, target: ast.AST) -> bool:
+        if isinstance(target, ast.Name):
+            return target.id == "__all__"
+        if isinstance(target, (ast.Tuple, ast.List)):
+            return any(self._target_contains_dunder_all(item) for item in target.elts)
+        if isinstance(target, (ast.Attribute, ast.Subscript)):
+            return self._target_contains_dunder_all(target.value)
+        if isinstance(target, ast.Starred):
+            return self._target_contains_dunder_all(target.value)
+        return False
+
+    def _call_may_mutate_dunder_all(self, call: ast.Call) -> bool:
+        if (
+            isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "__all__"
+        ):
+            return True
+        return any(
+            isinstance(node, ast.Name) and node.id == "__all__"
+            for argument in (*call.args, *(keyword.value for keyword in call.keywords))
+            for node in ast.walk(argument)
+        )
 
     def _extract_string_value(self, elt: ast.expr) -> Optional[str]:
         if isinstance(elt, ast.Constant) and isinstance(elt.value, str):

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -707,6 +707,243 @@ class TestAnalyze:
         assert _architecture_iad_strict({"enforce_iad": True}) is True
         assert _architecture_iad_strict({"strict_iad": True}) is True
 
+    def test_init_explicit_all_only_keeps_declared_symbols_live(self, tmp_path):
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            "from .core import public_reexport as package_api, stale_reexport\n\n"
+            '__all__ = ["LIVE_CONSTANT", "public_function", "package_api"]\n\n'
+            'LIVE_CONSTANT: str = "live"\n'
+            'DEAD_CONSTANT: str = "dead"\n\n'
+            "def public_function():\n"
+            "    return LIVE_CONSTANT\n\n"
+            "def dead_function():\n"
+            '    return "dead"\n',
+            encoding="utf-8",
+        )
+        (package / "core.py").write_text(
+            "def public_reexport():\n"
+            "    return 'public'\n\n"
+            "def stale_reexport():\n"
+            "    return 'stale'\n\n"
+            "def LIVE_CONSTANT():\n"
+            "    return 'same simple name in another module'\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                grep_verify=False,
+                trace_file=False,
+            )
+        )
+        dead = {
+            (Path(item["file"]).name, item["simple_name"])
+            for category in (
+                "unused_functions",
+                "unused_variables",
+                "unused_imports",
+            )
+            for item in result.get(category, [])
+        }
+
+        assert ("__init__.py", "LIVE_CONSTANT") not in dead
+        assert ("__init__.py", "public_function") not in dead
+        assert ("__init__.py", "public_reexport") not in dead
+        assert ("core.py", "public_reexport") not in dead
+        assert ("__init__.py", "DEAD_CONSTANT") in dead
+        assert ("__init__.py", "dead_function") in dead
+        assert ("__init__.py", "stale_reexport") in dead
+        assert ("core.py", "LIVE_CONSTANT") in dead
+
+    def test_init_empty_explicit_all_exports_nothing(self, tmp_path):
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            "__all__ = []\n\n"
+            "PUBLIC_LOOKING_CONSTANT = 'dead'\n\n"
+            "def public_looking_function():\n"
+            "    return 'dead'\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                grep_verify=False,
+                trace_file=False,
+            )
+        )
+        dead = {
+            (Path(item["file"]).name, item["simple_name"])
+            for category in ("unused_functions", "unused_variables")
+            for item in result.get(category, [])
+        }
+
+        assert ("__init__.py", "PUBLIC_LOOKING_CONSTANT") in dead
+        assert ("__init__.py", "public_looking_function") in dead
+
+    def test_init_static_all_mutations_remain_authoritative(self, tmp_path):
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            '__all__: list[str] = ["FIRST"]\n'
+            '__all__ += ("SECOND",)\n'
+            '__all__.append("third")\n'
+            '__all__.extend(["fourth"])\n\n'
+            'FIRST = "first"\n'
+            'SECOND = "second"\n\n'
+            "def third():\n"
+            '    return "third"\n\n'
+            "def fourth():\n"
+            '    return "fourth"\n\n'
+            "def stale():\n"
+            '    return "stale"\n',
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                grep_verify=False,
+                trace_file=False,
+            )
+        )
+        dead = {
+            (Path(item["file"]).name, item["simple_name"])
+            for category in ("unused_functions", "unused_variables")
+            for item in result.get(category, [])
+        }
+
+        assert ("__init__.py", "FIRST") not in dead
+        assert ("__init__.py", "SECOND") not in dead
+        assert ("__init__.py", "third") not in dead
+        assert ("__init__.py", "fourth") not in dead
+        assert ("__init__.py", "stale") in dead
+
+    def test_init_dynamic_all_mutation_falls_back_to_public_surface(self, tmp_path):
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            'DYNAMIC_EXPORTS = ["maybe_exported"]\n'
+            '__all__ = ["declared"]\n'
+            "__all__.extend(DYNAMIC_EXPORTS)\n\n"
+            "def declared():\n"
+            '    return "declared"\n\n'
+            "def maybe_exported():\n"
+            '    return "maybe"\n\n'
+            "def public_because_surface_is_unknown():\n"
+            '    return "unknown"\n',
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                grep_verify=False,
+                trace_file=False,
+            )
+        )
+        dead = {
+            (Path(item["file"]).name, item["simple_name"])
+            for category in ("unused_functions", "unused_variables")
+            for item in result.get(category, [])
+        }
+
+        assert ("__init__.py", "declared") not in dead
+        assert ("__init__.py", "maybe_exported") not in dead
+        assert ("__init__.py", "public_because_surface_is_unknown") not in dead
+
+    def test_dynamic_all_preserves_observed_exports_in_regular_module(self, tmp_path):
+        (tmp_path / "app.py").write_text(
+            'DYNAMIC_NAME = "maybe_exported"\n'
+            '__all__ = ["known"]\n'
+            "__all__.append(DYNAMIC_NAME)\n\n"
+            "def known():\n"
+            '    return "known"\n\n'
+            "def stale():\n"
+            '    return "stale"\n',
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                grep_verify=False,
+                trace_file=False,
+            )
+        )
+        dead = {
+            (Path(item["file"]).name, item["simple_name"])
+            for category in ("unused_functions", "unused_variables")
+            for item in result.get(category, [])
+        }
+
+        assert ("app.py", "known") not in dead
+        assert ("app.py", "stale") in dead
+
+    def test_external_init_reexport_does_not_rescue_unrelated_local_name(
+        self, tmp_path
+    ):
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            'from external import foo\n\n__all__ = ["foo"]\n',
+            encoding="utf-8",
+        )
+        (package / "local.py").write_text(
+            "def foo():\n    return 'dead local symbol'\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                grep_verify=False,
+                trace_file=False,
+            )
+        )
+        dead = {
+            (Path(item["file"]).name, item["simple_name"])
+            for item in result.get("unused_functions", [])
+        }
+
+        assert ("local.py", "foo") in dead
+
+    def test_init_without_explicit_all_remains_a_public_surface(self, tmp_path):
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            "PUBLIC_CONSTANT = 'public'\n\n"
+            "def public_function():\n"
+            "    return PUBLIC_CONSTANT\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                grep_verify=False,
+                trace_file=False,
+            )
+        )
+        dead = {
+            (Path(item["file"]).name, item["simple_name"])
+            for category in ("unused_functions", "unused_variables")
+            for item in result.get(category, [])
+        }
+
+        assert ("__init__.py", "PUBLIC_CONSTANT") not in dead
+        assert ("__init__.py", "public_function") not in dead
+
     def test_package_subdir_scan_keeps_absolute_imports_live(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text("[tool.skylos]\n", encoding="utf-8")
         package = tmp_path / "pkg"
@@ -1950,7 +2187,7 @@ class TestClass:
             project_root=scan_root,
         )
 
-        assert len(result) == 27
+        assert len(result) == 28
         assert result[0] == []
         assert result[19] == []
         assert result[25]["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
@@ -1966,7 +2203,7 @@ class TestClass:
 
         result = proc_file(str(source), "oversized", project_root=tmp_path)
 
-        assert len(result) == 27
+        assert len(result) == 28
         assert result[0] == []
         assert result[19] == []
         assert result[25]["kind"] == "source_read_error"
@@ -1986,7 +2223,7 @@ class TestClass:
 
         result = proc_file(str(source), "bounded", project_root=tmp_path)
 
-        assert len(result) == 27
+        assert len(result) == 28
         assert result[19] == [source_text]
         assert result[25] is None
 

--- a/test/test_grep_verify.py
+++ b/test/test_grep_verify.py
@@ -2829,6 +2829,56 @@ class TestQualifiedReferenceSubstring:
         results = multi_strategy_search(findings[0], str(tmp_path))
         assert "qualified_references" in results
 
+        verdicts = grep_verify_findings(findings, str(tmp_path))
+        assert verdicts["foo.bar"].alive
+
+    def test_qualified_ref_in_markdown_does_not_rescue(self, tmp_path):
+        (tmp_path / "mod.py").write_text("def bar():\n    pass\n")
+        (tmp_path / "NOTES.md").write_text("foo.bar\n")
+
+        findings = [
+            {
+                "name": "bar",
+                "full_name": "foo.bar",
+                "simple_name": "bar",
+                "type": "function",
+                "file": str(tmp_path / "mod.py"),
+                "line": 1,
+                "confidence": 80,
+            }
+        ]
+
+        results = multi_strategy_search(findings[0], str(tmp_path))
+        assert "qualified_references" not in results
+
+        verdicts = grep_verify_findings(findings, str(tmp_path))
+        assert "foo.bar" not in verdicts
+
+    @pytest.mark.parametrize("reference", ['value = "foo.bar"\n', "# foo.bar\n"])
+    def test_qualified_ref_in_python_non_code_does_not_rescue(
+        self, tmp_path, reference
+    ):
+        (tmp_path / "mod.py").write_text("def bar():\n    pass\n")
+        (tmp_path / "other.py").write_text(reference)
+
+        findings = [
+            {
+                "name": "bar",
+                "full_name": "foo.bar",
+                "simple_name": "bar",
+                "type": "function",
+                "file": str(tmp_path / "mod.py"),
+                "line": 1,
+                "confidence": 80,
+            }
+        ]
+
+        results = multi_strategy_search(findings[0], str(tmp_path))
+        assert "qualified_references" not in results
+
+        verdicts = grep_verify_findings(findings, str(tmp_path))
+        assert "foo.bar" not in verdicts
+
 
 class TestAnalyzerIntegration:
     def test_exhausted_budget_withholds_candidates_and_marks_scan_incomplete(

--- a/test/test_sql_injection.py
+++ b/test/test_sql_injection.py
@@ -2,6 +2,9 @@ from pathlib import Path
 from skylos.rules.danger.danger import scan_ctx
 
 
+SQLALCHEMY_TEXT_RULE_IDS = {"SKY-D211", "SKY-D217"}
+
+
 def _write(tmp_path: Path, name, code):
     p = tmp_path / name
     p.write_text(code, encoding="utf-8")
@@ -24,7 +27,190 @@ def test_sqlalchemy_text_tainted_flags(tmp_path):
         "    sa.text('DELETE FROM logs WHERE ip=' + ip)\n"
     )
     out = _scan_one(tmp_path, "raw_sa.py", code)
-    assert "SKY-D217" in _rule_ids(out)
+    assert SQLALCHEMY_TEXT_RULE_IDS <= _rule_ids(out)
+
+
+def test_sqlalchemy_text_import_aliases_remain_sql_sinks(tmp_path):
+    cases = {
+        "direct": (
+            "from sqlalchemy import text as draw_text\n"
+            "def direct(ip):\n"
+            "    draw_text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "qualified": (
+            "import sqlalchemy as plt\n"
+            "def qualified(ip):\n"
+            "    plt.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+    }
+    for symbol, code in cases.items():
+        out = _scan_one(tmp_path, f"raw_sa_{symbol}.py", code)
+        ids = {finding["rule_id"] for finding in out}
+        assert SQLALCHEMY_TEXT_RULE_IDS <= ids
+
+
+def test_sqlalchemy_text_requires_unshadowed_absolute_import(tmp_path):
+    safe_cases = {
+        "unbound_global": (
+            "def f(ip):\n    sqlalchemy.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "bare_parameter": (
+            "def f(sqlalchemy, ip):\n"
+            "    sqlalchemy.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "relative_import": (
+            "from .sqlalchemy import text as draw_text\n"
+            "def f(ip):\n"
+            "    draw_text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "shadowed_alias": (
+            "import sqlalchemy as sa\n"
+            "def f(sa, ip):\n"
+            "    sa.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "assigned_local": (
+            "import sqlalchemy as sa\n"
+            "def f(plot, ip):\n"
+            "    sa = plot\n"
+            "    sa.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "unrelated_module_alias": (
+            "import matplotlib.pyplot as sqlalchemy\n"
+            "def f(ip):\n"
+            "    sqlalchemy.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "unrelated_text_import": (
+            "from matplotlib.pyplot import text\n"
+            "def f(ip):\n"
+            "    text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+        "reassigned_alias": (
+            "import sqlalchemy as sa\n"
+            "sa = object()\n"
+            "def f(ip):\n"
+            "    sa.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        ),
+    }
+    for name, code in safe_cases.items():
+        out = _scan_one(tmp_path, f"safe_sa_{name}.py", code)
+        assert not (SQLALCHEMY_TEXT_RULE_IDS & _rule_ids(out))
+
+
+def test_sqlalchemy_text_module_import_is_visible_before_ast_visit(tmp_path):
+    code = (
+        "def f(ip):\n"
+        "    sa.text('DELETE FROM logs WHERE ip=' + ip)\n"
+        "import sqlalchemy as sa\n"
+    )
+    out = _scan_one(tmp_path, "late_module_sa_import.py", code)
+    assert SQLALCHEMY_TEXT_RULE_IDS <= _rule_ids(out)
+
+
+def test_sqlalchemy_text_local_absolute_import_before_call_flags(tmp_path):
+    code = (
+        "def f(ip):\n"
+        "    from sqlalchemy import text\n"
+        "    text('DELETE FROM logs WHERE ip=' + ip)\n"
+    )
+    out = _scan_one(tmp_path, "local_sa_import.py", code)
+    assert SQLALCHEMY_TEXT_RULE_IDS <= _rule_ids(out)
+
+
+def test_comprehension_target_does_not_shadow_enclosing_sqlalchemy_alias(tmp_path):
+    code = (
+        "import sqlalchemy as sa\n"
+        "def f(ip, rows):\n"
+        "    [x for sa in rows for x in (sa,)]\n"
+        "    sa.text('SELECT ' + ip)\n"
+    )
+    out = _scan_one(tmp_path, "sa_after_comprehension.py", code)
+    assert SQLALCHEMY_TEXT_RULE_IDS <= _rule_ids(out)
+
+
+def test_comprehension_target_shadows_sqlalchemy_alias_inside_scope(tmp_path):
+    code = (
+        "import sqlalchemy as sa\n"
+        "def f(ip, rows):\n"
+        "    return [sa.text('SELECT ' + ip) for sa in rows]\n"
+    )
+    out = _scan_one(tmp_path, "sa_inside_comprehension.py", code)
+    assert not (SQLALCHEMY_TEXT_RULE_IDS & _rule_ids(out))
+
+
+def test_final_unconditional_module_import_provides_sqlalchemy_provenance(tmp_path):
+    vulnerable_cases = {
+        "after_assignment": (
+            "sa = None\n"
+            "import sqlalchemy as sa\n"
+            "def f(ip):\n"
+            "    sa.text('SELECT ' + ip)\n"
+        ),
+        "after_unrelated_import": (
+            "import matplotlib.pyplot as sa\n"
+            "import sqlalchemy as sa\n"
+            "def f(ip):\n"
+            "    sa.text('SELECT ' + ip)\n"
+        ),
+    }
+    for name, code in vulnerable_cases.items():
+        out = _scan_one(tmp_path, f"sa_final_import_{name}.py", code)
+        assert SQLALCHEMY_TEXT_RULE_IDS <= _rule_ids(out)
+
+
+def test_final_unrelated_module_binding_removes_sqlalchemy_provenance(tmp_path):
+    code = (
+        "import sqlalchemy as sa\n"
+        "import matplotlib.pyplot as sa\n"
+        "def f(ip):\n"
+        "    sa.text('SELECT ' + ip)\n"
+    )
+    out = _scan_one(tmp_path, "sa_final_unrelated_import.py", code)
+    assert not (SQLALCHEMY_TEXT_RULE_IDS & _rule_ids(out))
+
+
+def test_lambda_parameter_shadows_sqlalchemy_alias(tmp_path):
+    code = (
+        "import sqlalchemy as sa\n"
+        "def f(ip):\n"
+        "    return lambda sa: sa.text('SELECT ' + ip)\n"
+    )
+    out = _scan_one(tmp_path, "sa_shadowed_in_lambda.py", code)
+    assert not (SQLALCHEMY_TEXT_RULE_IDS & _rule_ids(out))
+
+
+def test_lambda_with_unshadowed_sqlalchemy_alias_flags(tmp_path):
+    code = (
+        "import sqlalchemy as sa\n"
+        "def f(ip):\n"
+        "    return lambda plot: sa.text('SELECT ' + ip)\n"
+    )
+    out = _scan_one(tmp_path, "sa_used_in_lambda.py", code)
+    assert SQLALCHEMY_TEXT_RULE_IDS <= _rule_ids(out)
+
+
+def test_non_sqlalchemy_text_receiver_is_not_a_sql_sink(tmp_path):
+    code = (
+        "import matplotlib.pyplot as plt\n"
+        "import pandas as pd\n"
+        "def render(df: pd.DataFrame, read_col: str, labels: list[str]) -> None:\n"
+        "    fig, ax = plt.subplots()\n"
+        "    for i, (_, row) in enumerate(df.iterrows()):\n"
+        "        value = row[read_col]\n"
+        "        if value:\n"
+        "            ax.text(i - 0.17, value / 2, labels[i], ha='center')\n"
+    )
+    out = _scan_one(tmp_path, "matplotlib_text.py", code)
+    assert not ({"SKY-D211", "SKY-D217"} & _rule_ids(out))
+
+
+def test_non_sqlalchemy_text_receiver_stays_safe_when_sqlalchemy_is_imported(tmp_path):
+    code = (
+        "import sqlalchemy as sa\n"
+        "def render(ax, value, label):\n"
+        "    ax.text(0, value / 2, label)\n"
+    )
+    out = _scan_one(tmp_path, "mixed_text_receivers.py", code)
+    assert not ({"SKY-D211", "SKY-D217"} & _rule_ids(out))
 
 
 def test_pandas_read_sql_tainted_flags(tmp_path):

--- a/test/test_visitor.py
+++ b/test/test_visitor.py
@@ -403,13 +403,8 @@ CONSTANT = 50
 """
         visitor = self.parse_and_visit(code)
 
-        ref_names = set()
-        for ref in visitor.refs:
-            ref_names.add(ref[0])
-
-        self.assertIn("function1", ref_names)
-        self.assertIn("Class1", ref_names)
-        self.assertIn("CONSTANT", ref_names)
+        self.assertEqual(visitor.exports, {"function1", "Class1", "CONSTANT"})
+        self.assertTrue(visitor.has_explicit_all)
 
     def test_all_tuple_format(self):
         """Test __all__ with tuple format."""
@@ -418,13 +413,72 @@ __all__ = ('func1', 'func2', 'Class1')
 """
         visitor = self.parse_and_visit(code)
 
-        ref_names = set()
-        for ref in visitor.refs:
-            ref_names.add(ref[0])
+        self.assertEqual(visitor.exports, {"func1", "func2", "Class1"})
+        self.assertTrue(visitor.has_explicit_all)
 
-        self.assertIn("func1", ref_names)
-        self.assertIn("func2", ref_names)
-        self.assertIn("Class1", ref_names)
+    def test_annotated_all_literal_is_authoritative(self):
+        visitor = self.parse_and_visit('__all__: list[str] = ["function1", "Class1"]\n')
+
+        self.assertTrue(visitor.has_explicit_all)
+        self.assertEqual(visitor.exports, {"function1", "Class1"})
+        self.assertNotIn(
+            "__all__", {definition.simple_name for definition in visitor.defs}
+        )
+
+    def test_all_literal_mutations_are_collected(self):
+        visitor = self.parse_and_visit(
+            '__all__ = ["initial"]\n'
+            '__all__ += ("augmented",)\n'
+            '__all__.append("appended")\n'
+            '__all__.extend(["extended_one", "extended_two"])\n'
+        )
+
+        self.assertTrue(visitor.has_explicit_all)
+        self.assertEqual(
+            visitor.exports,
+            {
+                "initial",
+                "augmented",
+                "appended",
+                "extended_one",
+                "extended_two",
+            },
+        )
+
+    def test_all_reassignment_replaces_exports_and_stale_refs(self):
+        visitor = self.parse_and_visit(
+            '__all__ = ["stale"]\n__all__ = ["replacement"]\n__all__.append("final")\n'
+        )
+        ref_names = {ref[0] for ref in visitor.refs}
+
+        self.assertTrue(visitor.has_explicit_all)
+        self.assertEqual(visitor.exports, {"replacement", "final"})
+        self.assertNotIn("stale", ref_names)
+        self.assertNotIn("test_module.stale", ref_names)
+
+    def test_dynamic_all_updates_are_not_authoritative(self):
+        cases = (
+            ('__all__ = ["known", dynamic_name]\n', {"known"}),
+            ('__all__ = ["known"]\n__all__ += dynamic_exports\n', {"known"}),
+            ('__all__ = ["known"]\n__all__.append(dynamic_name)\n', {"known"}),
+            ('__all__ = ["known"]\n__all__.extend(dynamic_exports)\n', {"known"}),
+            ('__all__ = ["known"]\nother = mutate(__all__)\n', {"known"}),
+            (
+                '__all__ = ["known"]\nif enabled:\n    __all__.append("conditional")\n',
+                {"known", "conditional"},
+            ),
+        )
+
+        for code, expected_exports in cases:
+            with self.subTest(code=code):
+                visitor = Visitor("test_module", self.temp_file.name)
+                visitor.visit(ast.parse(code))
+                ref_names = {ref[0] for ref in visitor.refs}
+
+                self.assertFalse(visitor.has_explicit_all)
+                self.assertEqual(visitor.exports, expected_exports)
+                for name in expected_exports:
+                    self.assertNotIn(f"test_module.{name}", ref_names)
 
     def test_builtin_detection(self):
         code = """


### PR DESCRIPTION
Fixes #765

## Summary

  Fixed 3 problems in dead-code and SQL analysis:

  - Respect explicit `__all__` declarations in package `__init__.py` files
  - Prevent qualified names in md, comments, and string literals from rescuing dead Python symbols.
  - Require SQLAlchemy import provenance before treating `.text()` calls as SKY-D211/SKY-D217 SQL sinks.

# Tests

pytest test/test_analyzer.py test/test_visitor.py test/test_dead_code_evidence.py test/test_parallel_static.py \
test/test_grep_verify.py test/test_sql_injection.py test/test_dangerous.py test/test_sanitizers.py \
test/test_skylos.py test/test_integration.py test/test_src_layout.py test/test_module_reachability.py