### PR TITLE
perf(analyzer): index export lookups

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -11,6 +11,8 @@ import subprocess
 import traceback
 from pathlib import Path
 from collections import Counter, defaultdict
+from collections.abc import Callable
+from typing import TypeVar
 
 try:
     from skylos_fast import discover_files as _fast_discover
@@ -1225,21 +1227,34 @@ def _annotate_dead_code_evidence_sources(defs, test_flags, framework_flags) -> N
 
 
 _definition_name = attrgetter("name")
+_QualifiedCandidate = TypeVar("_QualifiedCandidate")
 
 
-def _qualified_candidates(definitions: list, qualifier: str) -> list:
-    """Definitions whose dotted name lives under ``qualifier.``, capped at two.
+def _qualified_candidates(
+    definitions: list[_QualifiedCandidate],
+    qualifier: str,
+    *,
+    key: Callable[[_QualifiedCandidate], str] = _definition_name,
+    limit: int | None = 2,
+) -> list[_QualifiedCandidate]:
+    """Return the values whose dotted ``key`` lives under ``qualifier``.
 
-    ``definitions`` must be sorted by ``name``. Callers only distinguish
-    zero / one / more-than-one, so the slice stops at two matches.
+    ``definitions`` must already be sorted by ``key``; the lookup is a
+    bisect, so an unsorted input silently returns the wrong slice.
+
+    ``limit`` caps the number of matches returned. The default of two
+    serves _mark_refs, which only distinguishes zero / one / more-than-one;
+    pass ``None`` when every match matters.
     """
     lower = f"{qualifier}."
     # '/' is the code point right after '.', so it bounds every dotted
     # descendant without scanning the bucket.
     upper = f"{qualifier}/"
-    start = bisect_left(definitions, lower, key=_definition_name)
-    stop = bisect_left(definitions, upper, start, key=_definition_name)
-    return definitions[start : min(stop, start + 2)]
+    start = bisect_left(definitions, lower, key=key)
+    stop = bisect_left(definitions, upper, start, key=key)
+    if limit is not None:
+        stop = min(stop, start + limit)
+    return definitions[start:stop]
 
 
 class Skylos:
@@ -1479,13 +1494,13 @@ class Skylos:
 
     def _mark_exports(self):
         explicit_exports_by_file = getattr(self, "_explicit_all_exports_by_file", {})
-        source_keys = {
-            id(definition): _source_file_key(getattr(definition, "filename", None))
-            for definition in self.defs.values()
-        }
+        source_keys = {}
+        non_import_by_name = defaultdict(list)
+        non_import_by_simple = defaultdict(list)
 
         for definition in self.defs.values():
-            source_key = source_keys[id(definition)]
+            source_key = _source_file_key(getattr(definition, "filename", None))
+            source_keys[id(definition)] = source_key
             has_explicit_all = source_key in explicit_exports_by_file
             if (
                 definition.in_init
@@ -1493,18 +1508,17 @@ class Skylos:
                 and not definition.simple_name.startswith("_")
             ):
                 definition.is_exported = True
-
-        for def_obj in self.defs.values():
-            if str(def_obj.filename).endswith(_TS_JS_SOURCE_EXTS):
-                continue
-            source_key = source_keys[id(def_obj)]
-            export_names = explicit_exports_by_file.get(source_key)
-            if (
-                export_names is not None
-                and _definition_binding_name(def_obj) in export_names
-            ):
-                def_obj.is_exported = True
-                def_obj.references = max(def_obj.references, 1)
+            if not str(definition.filename).endswith(_TS_JS_SOURCE_EXTS):
+                export_names = explicit_exports_by_file.get(source_key)
+                if (
+                    export_names is not None
+                    and _definition_binding_name(definition) in export_names
+                ):
+                    definition.is_exported = True
+                    definition.references = max(definition.references, 1)
+            if definition.type != "import":
+                non_import_by_name[definition.name].append(definition)
+                non_import_by_simple[definition.simple_name].append(definition)
 
         # Keep direct callers and older worker tuples compatible while matching
         # each export to its own module instead of every same-named definition.
@@ -1516,13 +1530,6 @@ class Skylos:
                     continue
                 def_obj.is_exported = True
                 def_obj.references = max(def_obj.references, 1)
-
-        non_import_by_name = defaultdict(list)
-        non_import_by_simple = defaultdict(list)
-        for d in self.defs.values():
-            if d.type != "import":
-                non_import_by_name[d.name].append(d)
-                non_import_by_simple[d.simple_name].append(d)
 
         def resolve_reexport_target(target_name):
             exact = non_import_by_name.get(target_name, ())
@@ -1577,66 +1584,73 @@ class Skylos:
 
         # propogate exports to methods of exported classes
         exported_classes = set()
-        for def_name, def_obj in self.defs.items():
+        for def_obj in self.defs.values():
             if def_obj.type == "class" and def_obj.is_exported:
                 exported_classes.add(def_obj.name)
 
-        if exported_classes:
-            for def_name, def_obj in self.defs.items():
-                if def_obj.type not in ("function", "method"):
+        if not exported_classes:
+            return
+
+        for def_obj in self.defs.values():
+            if def_obj.type not in ("function", "method"):
+                continue
+            if str(def_obj.filename).endswith(
+                (".java",) + _CSHARP_SOURCE_EXTS + _KOTLIN_SOURCE_EXTS
+            ):
+                continue
+            if "." not in def_obj.name:
+                continue
+            parent = def_obj.name.rsplit(".", 1)[0]
+            if parent in exported_classes and not def_obj.simple_name.startswith("_"):
+                def_obj.is_exported = True
+                def_obj.references = max(def_obj.references, 1)
+
+        if not hasattr(self, "_global_type_map"):
+            return
+
+        # reverse lookup: simple class name -> set of qualified def names
+        class_by_simple: dict[str, set[str]] = defaultdict(set)
+        for def_obj in self.defs.values():
+            if def_obj.type == "class":
+                class_by_simple[def_obj.simple_name].add(def_obj.name)
+
+        queue = list(exported_classes)
+        visited = set(exported_classes)
+        transitive_classes: set[str] = set()
+        global_type_keys = sorted(self._global_type_map)
+
+        while queue:
+            cls_name = queue.pop()
+            for attr_key in _qualified_candidates(
+                global_type_keys,
+                cls_name,
+                key=str,
+                limit=None,
+            ):
+                type_name = self._global_type_map[attr_key]
+                for candidate in class_by_simple.get(type_name, set()):
+                    if candidate not in visited:
+                        visited.add(candidate)
+                        transitive_classes.add(candidate)
+                        queue.append(candidate)
+
+        if not transitive_classes:
+            return
+
+        for def_obj in self.defs.values():
+            target_name = def_obj.name
+            if def_obj.type == "class" and target_name in transitive_classes:
+                def_obj.is_exported = True
+                def_obj.references = max(def_obj.references, 1)
+            elif def_obj.type in ("function", "method") and "." in target_name:
+                if str(def_obj.filename).endswith(".java"):
                     continue
-                if str(def_obj.filename).endswith(
-                    (".java",) + _CSHARP_SOURCE_EXTS + _KOTLIN_SOURCE_EXTS
-                ):
-                    continue
-                if "." not in def_obj.name:
-                    continue
-                parent = def_obj.name.rsplit(".", 1)[0]
-                if parent in exported_classes and not def_obj.simple_name.startswith(
+                parent = target_name.rsplit(".", 1)[0]
+                if parent in transitive_classes and not def_obj.simple_name.startswith(
                     "_"
                 ):
                     def_obj.is_exported = True
                     def_obj.references = max(def_obj.references, 1)
-
-        if exported_classes and hasattr(self, "_global_type_map"):
-            # reverse lookup: simple class name -> set of qualified def names
-            class_by_simple: dict[str, set[str]] = defaultdict(set)
-            for def_name, def_obj in self.defs.items():
-                if def_obj.type == "class":
-                    class_by_simple[def_obj.simple_name].add(def_obj.name)
-
-            queue = list(exported_classes)
-            visited = set(exported_classes)
-            transitive_classes: set[str] = set()
-
-            while queue:
-                cls_name = queue.pop()
-                prefix = cls_name + "."
-                for attr_key, type_name in self._global_type_map.items():
-                    if not attr_key.startswith(prefix):
-                        continue
-                    candidates = class_by_simple.get(type_name, set())
-                    for candidate in candidates:
-                        if candidate not in visited:
-                            visited.add(candidate)
-                            transitive_classes.add(candidate)
-                            queue.append(candidate)
-
-            if transitive_classes:
-                for def_name, def_obj in self.defs.items():
-                    if def_obj.type == "class" and def_obj.name in transitive_classes:
-                        def_obj.is_exported = True
-                        def_obj.references = max(def_obj.references, 1)
-                    elif def_obj.type in ("function", "method") and "." in def_obj.name:
-                        if str(def_obj.filename).endswith(".java"):
-                            continue
-                        parent = def_obj.name.rsplit(".", 1)[0]
-                        if (
-                            parent in transitive_classes
-                            and not def_obj.simple_name.startswith("_")
-                        ):
-                            def_obj.is_exported = True
-                            def_obj.references = max(def_obj.references, 1)
 
     def _build_ts_import_graph(self, ts_raw_imports: dict, monorepo_resolver=None):
         (

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -436,6 +436,75 @@ class TestSkylos:
 
         assert mock_def.is_exported
 
+    def test_mark_exports_explicit_exports_stay_module_scoped(
+        self, skylos, mock_definition
+    ):
+        exported = mock_definition("package.published", "published", "function")
+        nested = mock_definition("package.branch.published", "published", "function")
+        skylos.defs = {
+            exported.name: exported,
+            nested.name: nested,
+        }
+        skylos.exports = {"package": {"published"}}
+
+        skylos._mark_exports()
+
+        assert exported.is_exported
+        assert exported.references == 1
+        assert not nested.is_exported
+        assert nested.references == 0
+
+    def test_mark_exports_init_import_leaves_ambiguous_targets_unresolved(
+        self, skylos, mock_definition
+    ):
+        import_definition = mock_definition(
+            "missing.published", "published", "import", in_init=True
+        )
+        candidates = [
+            mock_definition(
+                f"branch_{index}.missing.published", "published", "function"
+            )
+            for index in range(2)
+        ]
+        skylos.defs = {
+            "package/__init__.py:missing.published": import_definition,
+            **{candidate.name: candidate for candidate in candidates},
+        }
+
+        skylos._mark_exports()
+
+        assert all(not candidate.is_exported for candidate in candidates)
+        assert all(candidate.references == 0 for candidate in candidates)
+
+    def test_mark_exports_indexes_all_transitive_type_prefixes(
+        self, skylos, mock_definition
+    ):
+        root = mock_definition("package.Root", "Root", "class", is_exported=True)
+        children = [
+            mock_definition(f"package.Child{index}", f"Child{index}", "class")
+            for index in range(3)
+        ]
+        leaf = mock_definition("package.Leaf", "Leaf", "class")
+        sibling = mock_definition("package.Sibling", "Sibling", "class")
+        definitions = [root, *children, leaf, sibling]
+        skylos.defs = {definition.name: definition for definition in definitions}
+        skylos._global_type_map = {
+            "package.RootExtra.sibling": "Sibling",
+            "package.Root.third": "Child2",
+            "package.Child2.leaf": "Leaf",
+            "package.Root.first": "Child0",
+            "package.Root.second": "Child1",
+        }
+
+        skylos._mark_exports()
+
+        assert all(child.is_exported for child in children)
+        assert all(child.references == 1 for child in children)
+        assert leaf.is_exported
+        assert leaf.references == 1
+        assert not sibling.is_exported
+        assert sibling.references == 0
+
     def test_mark_refs_direct_reference(self, skylos):
         mock_def = Mock()
         mock_def.type = "function"

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -546,6 +546,58 @@ class TestSkylos:
         assert all(definition.is_exported for definition in reachable)
         assert type_map.key_visits == len(type_map)
 
+    def test_mark_exports_uses_logarithmic_type_prefix_lookups(
+        self, skylos, mock_definition
+    ):
+        class ProbeKeys(list[str]):
+            def __init__(self, values: list[str]) -> None:
+                super().__init__(values)
+                self.index_probes = 0
+                self.iterated_items = 0
+
+            def __getitem__(self, index):
+                if isinstance(index, int):
+                    self.index_probes += 1
+                return super().__getitem__(index)
+
+            def __iter__(self):
+                for value in super().__iter__():
+                    self.iterated_items += 1
+                    yield value
+
+        root = mock_definition("package.Root", "Root", "class", is_exported=True)
+        reachable = [
+            mock_definition(f"package.Node{index}", f"Node{index}", "class")
+            for index in range(4)
+        ]
+        skylos.defs = {definition.name: definition for definition in [root, *reachable]}
+
+        type_map = {
+            "package.Root.child": "Node0",
+            "package.Node0.child": "Node1",
+            "package.Node1.child": "Node2",
+            "package.Node2.child": "Node3",
+            **{
+                f"package.Unrelated{index:04d}.child": "Missing"
+                for index in range(4092)
+            },
+        }
+        skylos._global_type_map = type_map
+        probe_keys = ProbeKeys(sorted(type_map))
+
+        with patch(
+            "skylos.analyzer.sorted", return_value=probe_keys, create=True
+        ) as sorted_mock:
+            skylos._mark_exports()
+
+        sorted_mock.assert_called_once_with(type_map)
+        assert all(definition.is_exported for definition in reachable)
+        assert probe_keys.iterated_items == 0
+
+        lookup_count = 1 + len(reachable)
+        logarithmic_bound = 2 * lookup_count * len(probe_keys).bit_length()
+        assert 0 < probe_keys.index_probes <= logarithmic_bound
+
     def test_mark_refs_direct_reference(self, skylos):
         mock_def = Mock()
         mock_def.type = "function"

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 from collections import defaultdict
+from collections.abc import Iterator, Mapping
 from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.analysis.penalties import _check_abstract_overrides, apply_penalties
@@ -504,6 +505,46 @@ class TestSkylos:
         assert leaf.references == 1
         assert not sibling.is_exported
         assert sibling.references == 0
+
+    def test_mark_exports_indexes_global_type_map_once(self, skylos, mock_definition):
+        class ScanCountingMap(Mapping[str, str]):
+            def __init__(self, values: dict[str, str]) -> None:
+                self._values = values
+                self.key_visits = 0
+
+            def __getitem__(self, key: str) -> str:
+                return self._values[key]
+
+            def __iter__(self) -> Iterator[str]:
+                for key in self._values:
+                    self.key_visits += 1
+                    yield key
+
+            def __len__(self) -> int:
+                return len(self._values)
+
+        root = mock_definition("package.Root", "Root", "class", is_exported=True)
+        reachable = [
+            mock_definition(f"package.Node{index}", f"Node{index}", "class")
+            for index in range(4)
+        ]
+        skylos.defs = {definition.name: definition for definition in [root, *reachable]}
+
+        type_map = ScanCountingMap(
+            {
+                "package.Root.child": "Node0",
+                "package.Node0.child": "Node1",
+                "package.Node1.child": "Node2",
+                "package.Node2.child": "Node3",
+                **{f"package.Unrelated{index}.child": "Missing" for index in range(8)},
+            }
+        )
+        skylos._global_type_map = type_map
+
+        skylos._mark_exports()
+
+        assert all(definition.is_exported for definition in reachable)
+        assert type_map.key_visits == len(type_map)
 
     def test_mark_refs_direct_reference(self, skylos):
         mock_def = Mock()


### PR DESCRIPTION
Follow-up to #769  applying analogous fixes to `_mark_exports`. 

I started drafting this before I noticed the new PR #770 had merged, which already absorbs the vast majority of the perf win this was going to have. I decided to still PR it anyway, because it squashes the last O(n^2) bit of the method and so is still a meaningful speedup on very large repositories like homeassistant/core.

I also preserved some light refactor changes I was doing that reduce the measured cyclomatic and cognitive complexity a bit more, by doing early returns and fusing loops to make the crucial control flow ordering clear and avoid differently named variables that do exactly the same thing.

**Bottom line**
Before this raft of O(n^2) squashing performance optimizations, my first run of `homeassistant/core` took ~5 *hours* (which is why I was only running `homeassistant/core/homeassistant` as a baseline). Now, with the full it takes just over 6 minutes, taking running skylos on the full repo from unfeasible to merely a quick coffee break. This sequence of O(n^2) fixes therefore represents a categorical improvement in the kinds of repos that could feasibly use skylos. 

## Summary

- index transitive exported-class type lookups with sorted dotted-prefix ranges
- fuse redundant definition scans and simplify control flow with early returns

## Complexity

A lot of the line diff in the PR is just unindenting due to early returns; it meaningfully reduces the complexity metrics skylos uses to score the function, although they are still high.

_mark_exports metric | Current main | This PR | Change
-- | -- | -- | --
Cyclomatic (SKY-Q301) | 52 | 47 | −5
Cognitive (SKY-Q306) | 114 | 88 | −26

## Behavior preservation

- explicit `__all__` remains authoritative per source file
- direct exports remain scoped to their exact module
- ambiguous re-export targets remain unresolved
- TypeScript/Java/Kotlin/C# export handling remains unchanged
- `liveness_primer` checked on expanded corpus, 0 diffs vs current main

## Performance

An isolated 5,000-class transitive-export benchmark improved from 0.541s to 0.049s.

Corpus | Current main `_mark_exports` | This PR `_mark_exports` | Saved | Speedup 
-- | --: | --: | --: | --: |
Home Assistant (`homeassistant/core/homeassistant`) | 13.4s | 0.65s | 12.7s  | 20.6x 
SciPy | 0.22s | 0.20s | 0.025s | 1.1x 
Pydantic | 0.03s | 0.013s | 0.017s | 2.3x 

For a full-root `homeassistant/core` scan with no cProfile isolation of `_mark_exports`, the speedup is 461.91s -> 384.77s, saving 77.14s. 


## Validation

- 5 focused `_mark_exports` tests passed
- 198 analyzer tests passed
- all 15 integration tests passed
- 85 dead-code and framework-aware tests passed
- 5,000 randomized current-main/replacement cases matched
- no Ruff findings on changed lines
- Pyright produced the same 17 baseline findings on both versions
- syntax compilation and `git diff --check` passed

## AI Use Disclosure

The quadratic paths were identified from cProfile data. I did most of the original refactoring by hand in analogy to the previous `_mark_refs` speedup, with guidance from Codex. Codex integrated the optimization with the newer export semantics and ran behavior-preservation validation; the resulting diff was reviewed by Codex and Opus 5.0 agents.
