### PR TITLE
perf(analysis): share parsed ASTs across rule passes

### DIFF
--- a/skylos/analysis/ast_cache.py
+++ b/skylos/analysis/ast_cache.py
@@ -1,0 +1,212 @@
+"""Run-scoped cache of parsed Python module ASTs.
+
+Repo-wide rule passes (phantom refs, API hallucination coverage, API
+signature checks, dead-code liveness) each need the same files parsed.
+This cache lets them share one tree per file while preserving each call
+site's read semantics: sources are cached per (path, read mode), and a
+tree is parsed once per distinct source text, so call sites with
+different read modes still share a tree whenever the decoded source is
+identical (the common case of a regular, valid-UTF-8 file).
+
+Equal sources are pooled per path, so a file read under several modes
+costs one string rather than one per mode.
+
+Lifetime is a session. Every entry point that populates the cache -- the
+analyzer run and each public rule scanner -- runs inside one, and the
+outermost session clears on the way out, so nothing outlives the call the
+caller made. Sessions nest, so a scanner called from the analyzer still
+shares the run's cache instead of dropping it early. Within a session,
+entries are dropped when a file's identity changes. Derived per-tree
+caches can register a clear callback so their id(tree)-keyed entries
+never outlive the trees stored here.
+
+Not thread-safe: the caches and the session depth are plain module
+globals, so sessions must not overlap across threads -- two entry points
+running concurrently would clear each other's live entries. Skylos'
+own file-level parallelism is process-based, and every caller of these
+entry points is single-threaded.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from skylos.core.safe_cache_io import read_text_no_symlink
+
+# Read modes. Each mirrors the exact read semantics of the call sites it
+# replaces; adding a mode must not change an existing one.
+MODE_REPLACE = "replace"  # read_text(encoding="utf-8", errors="replace")
+MODE_STRICT = "strict"  # read_text(encoding="utf-8")
+MODE_SAFE_REPLACE_2MB = "safe_replace_2mb"  # no-symlink read, 2 MiB cap
+MODE_SAFE_IGNORE_1MB = "safe_ignore_1mb"  # no-symlink read, 1 MiB cap
+MODE_IGNORE = "ignore"  # read_text(encoding="utf-8", errors="ignore")
+
+_SAFE_MODE_ARGS = {
+    MODE_SAFE_REPLACE_2MB: {"max_bytes": 2 * 1024 * 1024, "errors": "replace"},
+    MODE_SAFE_IGNORE_1MB: {"max_bytes": 1_000_000, "errors": "ignore"},
+}
+
+_MISSING = object()
+
+_sources: dict[tuple[str, str], str | None] = {}
+_trees: dict[str, dict[str, ast.Module | None]] = {}
+_source_pool: dict[str, dict[str, str]] = {}
+_path_tokens: dict[str, tuple | None] = {}
+_dependent_clears: list[Callable[[], None]] = []
+_session_depth = 0
+
+
+def mode_max_bytes(mode: str) -> int | None:
+    """Byte cap enforced by ``mode``, or None when the mode reads uncapped."""
+    safe_args = _SAFE_MODE_ARGS.get(mode)
+    return None if safe_args is None else safe_args["max_bytes"]
+
+
+def _read_source(path: Path, mode: str) -> str | None:
+    if mode == MODE_REPLACE:
+        try:
+            return path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+    if mode == MODE_IGNORE:
+        try:
+            return path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return None
+    if mode == MODE_STRICT:
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+    safe_args = _SAFE_MODE_ARGS[mode]
+    return read_text_no_symlink(path, encoding="utf-8", **safe_args)
+
+
+def _path_token(path: Path) -> tuple | None:
+    """Identity of the file at ``path``, or None when it cannot be stat-ed.
+
+    Includes st_ctime_ns so that a rewrite whose size and mtime are then
+    restored -- what ``cp -p``, ``rsync -t`` and a test calling os.utime
+    all do -- is still seen as a change.
+    """
+    try:
+        stat_result = path.stat()
+    except OSError:
+        return None
+    return (
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+        stat_result.st_size,
+        stat_result.st_ino,
+        stat_result.st_dev,
+    )
+
+
+def _drop_path(key: str) -> None:
+    """Forget everything cached for ``key`` after the file changed."""
+    for callback in _dependent_clears:
+        callback()
+    for cached_key in [entry for entry in _sources if entry[0] == key]:
+        del _sources[cached_key]
+    _trees.pop(key, None)
+    _source_pool.pop(key, None)
+
+
+def load_python_source(path: Path, mode: str) -> str | None:
+    """Return the decoded source for ``path`` under ``mode``, or None."""
+    path = Path(path)
+    key = str(path)
+
+    token = _path_token(path)
+    cached_token = _path_tokens.get(key, _MISSING)
+    if cached_token is _MISSING:
+        _path_tokens[key] = token
+    elif cached_token != token:
+        _drop_path(key)
+        _path_tokens[key] = token
+
+    source = _sources.get((key, mode), _MISSING)
+    if source is _MISSING:
+        source = _read_source(path, mode)
+        if source is not None:
+            # Modes differ only in read policy, so they usually decode to
+            # equal text; keep one string object per file rather than one
+            # per mode.
+            source = _source_pool.setdefault(key, {}).setdefault(source, source)
+        _sources[(key, mode)] = source
+    return source
+
+
+def load_python_module(path: Path, mode: str) -> tuple[str | None, ast.Module | None]:
+    """Return ``(source, tree)`` for ``path`` under read mode ``mode``.
+
+    ``source`` is None when the file cannot be read under that mode;
+    ``tree`` is None when the file cannot be read or does not parse.
+    """
+    source = load_python_source(path, mode)
+    if source is None:
+        return None, None
+    per_path = _trees.setdefault(str(path), {})
+    tree = per_path.get(source, _MISSING)
+    if tree is _MISSING:
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            tree = None
+        per_path[source] = tree
+    return source, tree
+
+
+def register_dependent_clear(callback: Callable[[], None]) -> None:
+    """Register a callback run whenever this cache is cleared.
+
+    Used by caches keyed on id(tree) for trees held here, so their
+    entries are dropped before the trees can be garbage collected.
+    """
+    if callback not in _dependent_clears:
+        _dependent_clears.append(callback)
+
+
+@contextmanager
+def python_ast_cache_session() -> Iterator[None]:
+    """Scope the cache to this block.
+
+    Sessions nest and only the outermost one clears -- on the way in as
+    well as on the way out -- so a rule pass entered directly starts clean
+    and releases everything it cached, while the same pass nested inside an
+    analyzer run neither inherits stale entries nor drops the run's.
+    """
+    global _session_depth
+    if _session_depth == 0:
+        clear_python_ast_cache()
+    _session_depth += 1
+    try:
+        yield
+    finally:
+        _session_depth -= 1
+        if _session_depth == 0:
+            clear_python_ast_cache()
+
+
+def releases_python_ast_cache(func):
+    """Run ``func`` inside a cache session, preserving its signature."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with python_ast_cache_session():
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+def clear_python_ast_cache() -> None:
+    for callback in _dependent_clears:
+        callback()
+    _sources.clear()
+    _trees.clear()
+    _source_pool.clear()
+    _path_tokens.clear()

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -41,6 +41,11 @@ from skylos.visitors.languages.typescript.analysis import (
     find_dead_ts_files,
     find_unused_ts_exports,
 )
+from skylos.analysis.ast_cache import (
+    MODE_IGNORE,
+    load_python_module,
+    releases_python_ast_cache,
+)
 from skylos.visitors.languages.go import clear_go_cache
 
 from skylos.rules.secrets import (
@@ -2761,6 +2766,7 @@ class Skylos:
             analysis_errors=analysis_errors,
         )
 
+    @releases_python_ast_cache
     def analyze(
         self,
         path,
@@ -4086,11 +4092,12 @@ class Skylos:
                             PhantomDecoratorRule(vibe_dictionary=vibe_dictionary)
                         )
                     for py_file in _ai_py_files:
-                        source = Path(py_file).read_text(
-                            encoding="utf-8",
-                            errors="ignore",
+                        source, tree = load_python_module(
+                            Path(py_file),
+                            MODE_IGNORE,
                         )
-                        tree = ast.parse(source)
+                        if tree is None:
+                            continue
                         linter = LinterVisitor(fallback_rules, str(py_file))
                         linter.context["source"] = source
                         linter.visit(tree)

--- a/skylos/deadcode/liveness.py
+++ b/skylos/deadcode/liveness.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from skylos.deadcode.plugin_registry import find_literal_plugin_registry_targets
+from skylos.analysis.ast_cache import releases_python_ast_cache
 from skylos.deadcode.python_ast import ParsedPythonFile, parse_python_files
 
 
@@ -97,6 +98,7 @@ class _AttrCall:
     line: int
 
 
+@releases_python_ast_cache
 def apply_dead_code_liveness(
     definitions: dict[str, Any],
     refs: Iterable[tuple[str, Any]],

--- a/skylos/deadcode/python_ast.py
+++ b/skylos/deadcode/python_ast.py
@@ -5,6 +5,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from skylos.analysis.ast_cache import (
+    MODE_STRICT,
+    load_python_module,
+    releases_python_ast_cache,
+)
+
 
 @dataclass(frozen=True)
 class ParsedPythonFile:
@@ -12,12 +18,18 @@ class ParsedPythonFile:
     tree: ast.Module
 
 
+@releases_python_ast_cache
 def parse_python_files(files: Iterable[Path]) -> list[ParsedPythonFile]:
+    """Parse ``files``, skipping any that cannot be read or parsed.
+
+    The returned entries own their trees, so the session drops the cache's
+    duplicate references on the way out. Nested in an analyzer run the
+    session is a no-op and the trees stay shared with the other passes.
+    """
     parsed: list[ParsedPythonFile] = []
     for path in files:
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        except (OSError, SyntaxError, UnicodeDecodeError):
+        _, tree = load_python_module(path, MODE_STRICT)
+        if tree is None:
             continue
         parsed.append(ParsedPythonFile(path=path, tree=tree))
     return parsed

--- a/skylos/reporting/architecture_result.py
+++ b/skylos/reporting/architecture_result.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import os
 import traceback
 from pathlib import Path
@@ -10,6 +9,7 @@ from skylos.analysis.architecture_support import (
     expand_reexported_entrypoint_modules,
     find_package_boundary_modules,
 )
+from skylos.analysis.ast_cache import MODE_IGNORE, load_python_module
 from skylos.analysis.circular_deps import CircularDependencyRule
 
 _MAX_ARCHITECTURE_SOURCE_BYTES = 2_000_000
@@ -222,14 +222,12 @@ def _add_module_tree(mod_trees, mod, file, source_root):
         return
     if stat.st_size > _MAX_ARCHITECTURE_SOURCE_BYTES:
         return
-    try:
-        src = source_path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
+    # Inside an analyzer run the other Python passes have usually parsed
+    # this file already, so this is typically a cache hit.
+    _, tree = load_python_module(source_path, MODE_IGNORE)
+    if tree is None:
         return
-    try:
-        mod_trees[mod] = ast.parse(src)
-    except SyntaxError:
-        return
+    mod_trees[mod] = tree
 
 
 def _attach_architecture_findings(result, project_cfg, all_quality, arch_findings):

--- a/skylos/rules/ai_defect/api_signature_hallucination.py
+++ b/skylos/rules/ai_defect/api_signature_hallucination.py
@@ -7,15 +7,22 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from skylos.analysis.ast_cache import (
+    MODE_SAFE_IGNORE_1MB,
+    load_python_module,
+    load_python_source,
+    mode_max_bytes,
+    releases_python_ast_cache,
+)
 from skylos.core.python_api_surface import PythonApiSurfaceCacheSession
-from skylos.core.safe_cache_io import read_text_no_symlink
 
 RULE_ID_API_SIGNATURE = "SKY-D224"
 SEV_HIGH = "HIGH"
 DEFAULT_API_SIGNATURE_ALLOWLIST = ("requests", "pandas", "boto3", "openai")
 VIBE_CATEGORY = "api_signature_hallucination"
 AI_LIKELIHOOD = "high"
-MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES = 1_000_000
+# Source-size cap enforced by ast_cache's MODE_SAFE_IGNORE_1MB read mode.
+MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES = mode_max_bytes(MODE_SAFE_IGNORE_1MB)
 _MAX_API_SIGNATURE_PREFILTER_ROOTS = 64
 
 SurfaceLoader = Callable[[str | Path, str], dict[str, Any] | None]
@@ -327,6 +334,7 @@ class _ApiSignatureChecker(ast.NodeVisitor):
         self.findings.append(_finding(self.file_path, node, target.label, message))
 
 
+@releases_python_ast_cache
 def scan_python_api_signature_hallucinations(
     repo_root: str | Path | None,
     py_files: list[Path],
@@ -411,12 +419,7 @@ def _parse_python_file(
     if not resolved.is_file():
         return None
 
-    source = read_text_no_symlink(
-        resolved,
-        max_bytes=MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES,
-        encoding="utf-8",
-        errors="ignore",
-    )
+    source = load_python_source(resolved, MODE_SAFE_IGNORE_1MB)
     if source is None:
         return None
     if (
@@ -425,10 +428,11 @@ def _parse_python_file(
     ):
         return None
 
-    try:
-        return ast.parse(source)
-    except SyntaxError:
-        return None
+    # Deliberately a second call rather than one load_python_module above:
+    # the prefilter rejects most files, and asking for the module up front
+    # would parse every one of them to save a cached-source lookup.
+    _, tree = load_python_module(resolved, MODE_SAFE_IGNORE_1MB)
+    return tree
 
 
 def _source_mentions_allowed_root(source: str, allowed_roots: set[str]) -> bool:

--- a/skylos/rules/ai_defect/phantom_refs.py
+++ b/skylos/rules/ai_defect/phantom_refs.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import ast
 import builtins
-from collections import defaultdict
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from skylos.analysis.ast_cache import (
+    MODE_REPLACE,
+    load_python_module,
+    register_dependent_clear,
+    releases_python_ast_cache,
+)
 from skylos.analysis.control_flow import _parse_requires_python
 from skylos.rules.quality._protocols import (
     type_checking_context,
@@ -89,6 +95,7 @@ class _ModuleFacts:
     type_checking_node_ids: set[int]
 
 
+@releases_python_ast_cache
 def scan_repo_phantom_security_references(
     project_root, py_files, target_files=None, vibe_dictionary=None
 ):
@@ -182,10 +189,8 @@ def scan_repo_phantom_security_references(
             parse_failures.add(module_name)
             return False
 
-        try:
-            source = file_path.read_text(encoding="utf-8", errors="replace")
-            tree = ast.parse(source)
-        except (OSError, SyntaxError):
+        source, tree = load_python_module(file_path, MODE_REPLACE)
+        if tree is None:
             parse_failures.add(module_name)
             return False
 
@@ -206,10 +211,8 @@ def scan_repo_phantom_security_references(
     for file_path, current_module in file_to_module.items():
         if target_paths and file_path not in target_paths:
             continue
-        try:
-            source = file_path.read_text(encoding="utf-8", errors="replace")
-            tree = ast.parse(source)
-        except (OSError, SyntaxError):
+        source, tree = load_python_module(file_path, MODE_REPLACE)
+        if tree is None:
             continue
 
         _store_module_facts(
@@ -218,8 +221,9 @@ def scan_repo_phantom_security_references(
             source_has_type_checking="TYPE_CHECKING" in source,
             include_reference_context=True,
         )
-        parent_map = _build_parent_map(tree)
-        scope_infos = _build_scope_infos(tree, current_module, local_modules)
+        ast_index = _ast_index_for(tree)
+        parent_map = ast_index.parent_map
+        scope_infos = _scope_infos_for(tree, current_module, local_modules)
         type_checking_node_ids = module_type_checking_node_ids.get(
             current_module, set()
         )
@@ -250,10 +254,11 @@ def scan_repo_phantom_security_references(
                 package_modules,
                 _ensure_module_loaded,
                 module_dunder_attributes,
+                ast_index,
             )
         )
 
-        for node in ast.walk(tree):
+        for node in ast_index.scan_nodes:
             if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
                 if _attribute_is_call_target(node, parent_map):
                     continue
@@ -268,7 +273,7 @@ def scan_repo_phantom_security_references(
                     expr=node,
                     node=node,
                     tree=tree,
-                    parent_map=parent_map,
+                    ast_index=ast_index,
                     scope_infos=scope_infos,
                     module_alias_exports=active_aliases,
                     local_modules=local_modules,
@@ -306,7 +311,7 @@ def scan_repo_phantom_security_references(
                         file_path=file_path,
                         node=node.func,
                         tree=tree,
-                        parent_map=parent_map,
+                        ast_index=ast_index,
                         scope_infos=scope_infos,
                         repo_member_names=repo_member_names,
                         builtin_names=builtin_names,
@@ -323,7 +328,7 @@ def scan_repo_phantom_security_references(
                     expr=node.func,
                     node=node,
                     tree=tree,
-                    parent_map=parent_map,
+                    ast_index=ast_index,
                     scope_infos=scope_infos,
                     module_alias_exports=active_aliases,
                     local_modules=local_modules,
@@ -371,7 +376,7 @@ def scan_repo_phantom_security_references(
                     expr=deco_target,
                     node=deco_target,
                     tree=tree,
-                    parent_map=parent_map,
+                    ast_index=ast_index,
                     scope_infos=scope_infos,
                     module_alias_exports=active_aliases,
                     local_modules=local_modules,
@@ -420,9 +425,15 @@ def _direct_local_import_findings(
     package_modules,
     ensure_module_loaded,
     module_dunder_attributes: frozenset[str] = _STANDARD_MODULE_ATTRIBUTES,
+    ast_index=None,
 ):
     findings = []
-    for node in ast.walk(tree):
+    if ast_index is None:
+        # Built, not memoized: a caller reaching this fallback may hand us a
+        # tree the run-scoped cache does not hold, and an id(tree)-keyed
+        # entry for it could outlive the tree.
+        ast_index = _build_ast_index(tree)
+    for node in ast_index.import_nodes:
         if not isinstance(node, ast.ImportFrom):
             continue
         base = _resolve_import_from_base(current_module, node)
@@ -492,7 +503,7 @@ def _bare_call_finding(
     file_path,
     node,
     tree,
-    parent_map,
+    ast_index,
     scope_infos,
     repo_member_names,
     builtin_names,
@@ -503,15 +514,15 @@ def _bare_call_finding(
         return None
     if name in phantom_security_names:
         return None
-    if _bare_name_is_bound(name, node, tree, parent_map, scope_infos):
+    if _bare_name_is_bound(name, node, tree, ast_index, scope_infos):
         return None
     if not _resembles_local_symbol(name, repo_member_names):
         return None
     return _build_bare_call_finding(file_path, node, name)
 
 
-def _bare_name_is_bound(name, node, tree, parent_map, scope_infos):
-    for scope in _enclosing_scopes(node, tree, parent_map):
+def _bare_name_is_bound(name, node, tree, ast_index, scope_infos):
+    for scope in _enclosing_scopes(node, tree, ast_index):
         info = scope_infos.get(scope)
         if not info:
             continue
@@ -520,26 +531,62 @@ def _bare_name_is_bound(name, node, tree, parent_map, scope_infos):
     return False
 
 
+_RESEMBLANCE_THRESHOLD = 0.82
+_RESEMBLANCE_INDEX_CACHE: dict[int, tuple[set, dict[str, int], dict[int, list]]] = {}
+
+
+def _resemblance_index(repo_member_names):
+    """(trailing-token counts, candidates by length) for the member names.
+
+    Both views are derived once per member-name set: the token counts answer
+    the shared-trailing-token half of the test without touching every
+    candidate, and the length buckets let the similarity half skip whole
+    buckets that cannot reach the threshold.
+    """
+    entry = _RESEMBLANCE_INDEX_CACHE.get(id(repo_member_names))
+    if entry is None or entry[0] is not repo_member_names:
+        token_counts: dict[str, int] = {}
+        by_length: dict[int, list] = {}
+        for candidate in repo_member_names:
+            if "_" in candidate:
+                tail = candidate.rsplit("_", 1)[1]
+                token_counts[tail] = token_counts.get(tail, 0) + 1
+            by_length.setdefault(len(candidate), []).append(candidate)
+        entry = (repo_member_names, token_counts, by_length)
+        _RESEMBLANCE_INDEX_CACHE[id(repo_member_names)] = entry
+    return entry[1], entry[2]
+
+
+register_dependent_clear(_RESEMBLANCE_INDEX_CACHE.clear)
+
+
 def _resembles_local_symbol(name, repo_member_names):
-    for candidate in repo_member_names:
-        if candidate == name:
+    token_counts, by_length = _resemblance_index(repo_member_names)
+
+    if "_" in name:
+        tail = name.rsplit("_", 1)[1]
+        sharing = token_counts.get(tail, 0)
+        if name in repo_member_names:
+            sharing -= 1
+        if sharing > 0:
+            return True
+
+    length = len(name)
+    for candidate_length, candidates in by_length.items():
+        # SequenceMatcher.ratio() can never exceed real_quick_ratio(), which
+        # is 2 * min(la, lb) / (la + lb), so whole length buckets are out of
+        # reach of the threshold without comparing a single character.
+        if 2 * min(length, candidate_length) < _RESEMBLANCE_THRESHOLD * (
+            length + candidate_length
+        ):
             continue
-        if _shared_suffix_token(name, candidate):
-            return True
-        similarity = SequenceMatcher(None, name, candidate).ratio()
-        if similarity >= 0.82:
-            return True
+        for candidate in candidates:
+            if candidate == name:
+                continue
+            similarity = SequenceMatcher(None, name, candidate).ratio()
+            if similarity >= _RESEMBLANCE_THRESHOLD:
+                return True
     return False
-
-
-def _shared_suffix_token(left, right):
-    left_parts = left.split("_")
-    right_parts = right.split("_")
-    if len(left_parts) < 2:
-        return False
-    if len(right_parts) < 2:
-        return False
-    return left_parts[-1] == right_parts[-1]
 
 
 def _decorator_target(decorator):
@@ -569,7 +616,56 @@ def _module_name(root: Path, file_path: Path) -> str:
     return ".".join(parts)
 
 
+_MODULE_FACTS_CACHE: dict[tuple, tuple[frozenset, "_ModuleFacts"]] = {}
+
+
 def _collect_module_facts(
+    tree,
+    current_module,
+    local_modules,
+    *,
+    source_has_type_checking=None,
+    include_reference_context=False,
+):
+    """Memoized ``_build_module_facts``, shared across rule passes.
+
+    The phantom-ref scan and the API hallucination coverage pass collect
+    identical facts for the same tree and module. Keyed by id(tree) (trees
+    are held by the run-scoped AST cache, which clears this); the returned
+    facts are only ever read by callers, never mutated.
+
+    Only the reference-context result is memoized: that is the one both
+    passes ask for. The plain result is built once per module -- the
+    phantom scan's _ensure_module_loaded guards it -- so caching it would
+    hold a second full set of module facts that nothing ever reads again.
+    """
+    if not include_reference_context:
+        return _build_module_facts(
+            tree,
+            current_module,
+            local_modules,
+            source_has_type_checking=source_has_type_checking,
+        )
+
+    key = (id(tree), current_module, source_has_type_checking)
+    cached = _MODULE_FACTS_CACHE.get(key)
+    if cached is not None and cached[0] == local_modules:
+        return cached[1]
+    facts = _build_module_facts(
+        tree,
+        current_module,
+        local_modules,
+        source_has_type_checking=source_has_type_checking,
+        include_reference_context=True,
+    )
+    _MODULE_FACTS_CACHE[key] = (frozenset(local_modules), facts)
+    return facts
+
+
+register_dependent_clear(_MODULE_FACTS_CACHE.clear)
+
+
+def _build_module_facts(
     tree,
     current_module,
     local_modules,
@@ -1173,7 +1269,22 @@ def _is_irrefutable_match_case(case):
     )
 
 
+_POSTPONED_ANNOTATION_CACHE: dict[int, set[int]] = {}
+
+
 def _postponed_annotation_node_ids(tree):
+    """Memoized per tree; both rule passes ask for the same tree's ids."""
+    node_ids = _POSTPONED_ANNOTATION_CACHE.get(id(tree))
+    if node_ids is None:
+        node_ids = _build_postponed_annotation_node_ids(tree)
+        _POSTPONED_ANNOTATION_CACHE[id(tree)] = node_ids
+    return node_ids
+
+
+register_dependent_clear(_POSTPONED_ANNOTATION_CACHE.clear)
+
+
+def _build_postponed_annotation_node_ids(tree):
     if not _uses_future_annotations(tree):
         return set()
 
@@ -1201,21 +1312,149 @@ def _uses_future_annotations(tree):
     )
 
 
-def _build_parent_map(tree):
+_SCOPE_NODE_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+_FUNCTION_SCOPE_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+
+@dataclass(frozen=True, slots=True)
+class _ModuleAstIndex:
+    """Per-tree node index built in a single walk.
+
+    ``scope_chains`` stores, for each Name/Attribute/Call node, the tuple
+    of scopes enclosing it ([module, outer, ..., inner]) with the same
+    semantics as a parent-map climb: class scopes are invisible from
+    nested functions, and a function's decorator expressions see the
+    function's own enclosing scopes rather than the function scope.
+    ``parent_map`` only holds parents of Attribute/Call nodes — the only
+    nodes whose parents the scans query directly. The node lists are in
+    ``ast.walk`` (breadth-first) order so consumers that used to walk the
+    whole tree see nodes in the same order.
+    """
+
+    parent_map: dict
+    scope_chains: dict
+    scope_nodes: list
+    import_nodes: list
+    scan_nodes: list
+
+
+_AST_INDEX_CACHE: dict[int, _ModuleAstIndex] = {}
+
+
+def _ast_index_for(tree):
+    """Return the cached ``_ModuleAstIndex`` for ``tree``, building it once.
+
+    Keyed by id(tree); safe because every indexed tree is held alive by
+    the run-scoped AST cache, and this cache is cleared with it.
+    """
+    index = _AST_INDEX_CACHE.get(id(tree))
+    if index is None:
+        index = _build_ast_index(tree)
+        _AST_INDEX_CACHE[id(tree)] = index
+    return index
+
+
+register_dependent_clear(_AST_INDEX_CACHE.clear)
+
+
+def _build_ast_index(tree):
     parent_map = {}
-    for parent in ast.walk(tree):
-        for child in ast.iter_child_nodes(parent):
-            parent_map[child] = parent
-    return parent_map
+    scope_chains = {}
+    scope_nodes = []
+    import_nodes = []
+    scan_nodes = []
+
+    todo = deque([(tree, (tree,))])
+    while todo:
+        node, chain = todo.popleft()
+        if isinstance(node, (ast.Attribute, ast.Call)):
+            scope_chains[node] = chain
+            scan_nodes.append(node)
+        elif isinstance(node, ast.Name):
+            scope_chains[node] = chain
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            import_nodes.append(node)
+        elif isinstance(node, _SCOPE_NODE_TYPES):
+            scope_nodes.append(node)
+            if not isinstance(node, ast.Lambda):
+                scan_nodes.append(node)
+
+        is_function_scope = isinstance(node, _FUNCTION_SCOPE_TYPES)
+        if is_function_scope:
+            child_chain = tuple(
+                scope for scope in chain if not isinstance(scope, ast.ClassDef)
+            ) + (node,)
+        elif isinstance(node, ast.ClassDef):
+            child_chain = chain + (node,)
+        else:
+            child_chain = chain
+
+        decorators = (
+            getattr(node, "decorator_list", None) if is_function_scope else None
+        )
+        # Inlined ast.iter_child_nodes: this runs once per node of every
+        # module in the repo, and the two generator frames it saves are a
+        # measurable share of the index build.
+        for field in node._fields:
+            value = getattr(node, field, None)
+            if isinstance(value, ast.AST):
+                children = (value,)
+            elif type(value) is list:
+                children = value
+            else:
+                continue
+            for child in children:
+                if not isinstance(child, ast.AST):
+                    continue
+                if isinstance(child, (ast.Attribute, ast.Call)):
+                    parent_map[child] = node
+                if decorators and child in decorators:
+                    todo.append((child, chain))
+                else:
+                    todo.append((child, child_chain))
+
+    return _ModuleAstIndex(
+        parent_map=parent_map,
+        scope_chains=scope_chains,
+        scope_nodes=scope_nodes,
+        import_nodes=import_nodes,
+        scan_nodes=scan_nodes,
+    )
+
+
+_SCOPE_INFOS_CACHE: dict[int, tuple[str, set, dict]] = {}
+
+
+def _scope_infos_for(tree, current_module, local_modules):
+    """Memoized ``_build_scope_infos``, shared across rule passes.
+
+    The phantom-ref scan and the API hallucination coverage pass build
+    identical scope infos for the same tree/module; keyed by id(tree)
+    (trees are held by the run-scoped AST cache, which clears this).
+    """
+    cached = _SCOPE_INFOS_CACHE.get(id(tree))
+    if (
+        cached is not None
+        and cached[0] == current_module
+        and cached[1] == local_modules
+    ):
+        return cached[2]
+    scope_infos = _build_scope_infos(tree, current_module, local_modules)
+    _SCOPE_INFOS_CACHE[id(tree)] = (
+        current_module,
+        frozenset(local_modules),
+        scope_infos,
+    )
+    return scope_infos
+
+
+register_dependent_clear(_SCOPE_INFOS_CACHE.clear)
 
 
 def _build_scope_infos(tree, current_module, local_modules):
     scope_infos = {tree: _collect_scope_info(tree, current_module, local_modules)}
-    for node in ast.walk(tree):
-        if isinstance(
-            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
-        ):
-            scope_infos[node] = _collect_scope_info(node, current_module, local_modules)
+    for node in _ast_index_for(tree).scope_nodes:
+        scope_infos[node] = _collect_scope_info(node, current_module, local_modules)
     return scope_infos
 
 
@@ -1365,7 +1604,7 @@ def _resolve_local_module_member(
     expr,
     node,
     tree,
-    parent_map,
+    ast_index,
     scope_infos,
     module_alias_exports,
     local_modules,
@@ -1379,7 +1618,7 @@ def _resolve_local_module_member(
         base_name=chain[0],
         node=node,
         tree=tree,
-        parent_map=parent_map,
+        ast_index=ast_index,
         scope_infos=scope_infos,
     )
     if not base_module:
@@ -1389,7 +1628,7 @@ def _resolve_local_module_member(
         chain=chain,
         node=node,
         tree=tree,
-        parent_map=parent_map,
+        ast_index=ast_index,
         scope_infos=scope_infos,
     ):
         return None
@@ -1413,9 +1652,9 @@ def _resolve_local_module_member(
     return current_module, chain[-1], ".".join(chain)
 
 
-def _resolve_visible_alias(base_name, node, tree, parent_map, scope_infos):
+def _resolve_visible_alias(base_name, node, tree, ast_index, scope_infos):
     visible_module = None
-    for scope in _enclosing_scopes(node, tree, parent_map):
+    for scope in _enclosing_scopes(node, tree, ast_index):
         info = scope_infos.get(scope)
         if not info:
             continue
@@ -1439,13 +1678,13 @@ def _is_explicitly_imported_module_reference(
     chain,
     node,
     tree,
-    parent_map,
+    ast_index,
     scope_infos,
 ):
     expression = ".".join(chain)
     base_name = chain[0]
 
-    for scope in _enclosing_scopes(node, tree, parent_map):
+    for scope in _enclosing_scopes(node, tree, ast_index):
         info = scope_infos.get(scope)
         if not info:
             continue
@@ -1459,34 +1698,8 @@ def _is_explicitly_imported_module_reference(
     return False
 
 
-def _enclosing_scopes(node, tree, parent_map):
-    scopes = [tree]
-    cur = parent_map.get(node)
-    child = node
-    nested_scopes = []
-    function_barrier = False
-
-    while cur is not None:
-        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-            if _is_decorator_expression(child, cur):
-                child = cur
-                cur = parent_map.get(cur)
-                continue
-            nested_scopes.append(cur)
-            function_barrier = True
-        elif isinstance(cur, ast.ClassDef) and not function_barrier:
-            nested_scopes.append(cur)
-
-        child = cur
-        cur = parent_map.get(cur)
-
-    scopes.extend(reversed(nested_scopes))
-    return scopes
-
-
-def _is_decorator_expression(child, parent):
-    decorator_list = getattr(parent, "decorator_list", None)
-    return bool(decorator_list) and child in decorator_list
+def _enclosing_scopes(node, tree, ast_index):
+    return ast_index.scope_chains.get(node) or (tree,)
 
 
 def _attribute_is_call_target(node, parent_map):

--- a/skylos/rules/ai_defect/python_api_hallucination.py
+++ b/skylos/rules/ai_defect/python_api_hallucination.py
@@ -6,10 +6,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-from skylos.core.safe_cache_io import read_text_no_symlink
+from skylos.analysis.ast_cache import (
+    MODE_SAFE_REPLACE_2MB,
+    load_python_module,
+    register_dependent_clear,
+    releases_python_ast_cache,
+)
 from skylos.rules.ai_defect.phantom_refs import (
-    _build_parent_map,
-    _build_scope_infos,
+    _ast_index_for,
+    _scope_infos_for,
     _collect_module_facts,
     _module_dunder_attributes,
     _module_has_member,
@@ -22,7 +27,6 @@ from skylos.rules.vibe_dictionary import DEFAULT_VIBE_DICTIONARY
 
 
 PYTHON_API_CHECK_ID = "python_local_api_reference"
-_MAX_PYTHON_SOURCE_BYTES = 2 * 1024 * 1024
 PYTHON_API_SUFFIXES = (".py", ".pyi", ".pyw")
 
 
@@ -42,6 +46,7 @@ class _PythonCoverageState:
         self.reasons[reason] += 1
 
 
+@releases_python_ast_cache
 def scan_python_local_api_hallucinations(
     project_root: str | Path,
     py_files: Iterable[str | Path],
@@ -175,8 +180,8 @@ def _inspect_target_references(
     state: _PythonCoverageState,
     module_dunder_attributes: frozenset[str],
 ) -> None:
-    parent_map = _build_parent_map(tree)
-    scope_infos = _build_scope_infos(tree, current_module, local_modules)
+    ast_index = _ast_index_for(tree)
+    scope_infos = _scope_infos_for(tree, current_module, local_modules)
 
     def ensure_module_loaded(module_name: str) -> bool:
         return module_name in trees
@@ -184,7 +189,7 @@ def _inspect_target_references(
     _inspect_import_references(
         root,
         current_module,
-        tree,
+        ast_index,
         local_modules,
         trees,
         members,
@@ -197,7 +202,7 @@ def _inspect_target_references(
         module_dunder_attributes,
     )
 
-    for expression, owner in _reference_expressions(tree, parent_map):
+    for expression, owner in _reference_expressions(ast_index):
         if (
             id(expression) in type_checking_node_ids
             or id(owner) in type_checking_node_ids
@@ -213,7 +218,7 @@ def _inspect_target_references(
             expr=expression,
             node=owner,
             tree=tree,
-            parent_map=parent_map,
+            ast_index=ast_index,
             scope_infos=scope_infos,
             module_alias_exports=active_aliases,
             local_modules=local_modules,
@@ -237,14 +242,11 @@ def _inspect_target_references(
             state.verified += 1
 
 
-def _reference_expressions(
-    tree: ast.AST,
-    parent_map: dict[ast.AST, ast.AST],
-) -> Iterable[tuple[ast.AST, ast.AST]]:
-    for node in ast.walk(tree):
+def _reference_expressions(ast_index) -> Iterable[tuple[ast.AST, ast.AST]]:
+    for node in ast_index.scan_nodes:
         if not isinstance(node, ast.Attribute) or not isinstance(node.ctx, ast.Load):
             continue
-        parent = parent_map.get(node)
+        parent = ast_index.parent_map.get(node)
         if isinstance(parent, ast.Attribute) and parent.value is node:
             continue
         owner = parent if isinstance(parent, ast.Call) and parent.func is node else node
@@ -254,7 +256,7 @@ def _reference_expressions(
 def _inspect_import_references(
     root: Path,
     current_module: str,
-    tree: ast.AST,
+    ast_index,
     local_modules: set[str],
     trees: dict[str, ast.AST],
     members: dict[str, set[str]],
@@ -266,7 +268,7 @@ def _inspect_import_references(
     state: _PythonCoverageState,
     module_dunder_attributes: frozenset[str],
 ) -> None:
-    for node in ast.walk(tree):
+    for node in ast_index.import_nodes:
         if isinstance(node, ast.ImportFrom):
             _inspect_from_import(
                 root,
@@ -359,12 +361,36 @@ def _inspect_module_import(
             state.skip("local_import_outside_scan")
 
 
+_LOCAL_PREFIX_CACHE: dict[int, tuple[set[str], set[str]]] = {}
+
+
+def _local_module_prefixes(local_modules: set[str]) -> set[str]:
+    """Every proper dotted prefix of every local module, built once."""
+    entry = _LOCAL_PREFIX_CACHE.get(id(local_modules))
+    if entry is None or entry[0] is not local_modules:
+        prefixes: set[str] = set()
+        for candidate in local_modules:
+            parts = candidate.split(".")
+            for index in range(1, len(parts)):
+                prefixes.add(".".join(parts[:index]))
+        entry = (local_modules, prefixes)
+        _LOCAL_PREFIX_CACHE[id(local_modules)] = entry
+    return entry[1]
+
+
+register_dependent_clear(_LOCAL_PREFIX_CACHE.clear)
+
+
 def _has_local_module_prefix(module_name: str, local_modules: set[str]) -> bool:
-    return any(
-        module_name.startswith(f"{candidate}.")
-        or candidate.startswith(f"{module_name}.")
-        for candidate in local_modules
-    )
+    # "some local module is a package prefix of module_name" is a lookup over
+    # module_name's own dotted prefixes; "module_name is a package prefix of
+    # some local module" is a lookup in the precomputed prefix set. Both
+    # replace a scan of every local module per call.
+    parts = module_name.split(".")
+    for index in range(1, len(parts)):
+        if ".".join(parts[:index]) in local_modules:
+            return True
+    return module_name in _local_module_prefixes(local_modules)
 
 
 def _local_module_exists(root: Path, module_name: str) -> bool:
@@ -477,18 +503,12 @@ def _load_module_facts(
 
 
 def _parse_python_file(path: Path) -> tuple[ast.AST | None, str | None, bool]:
-    source = read_text_no_symlink(
-        path,
-        max_bytes=_MAX_PYTHON_SOURCE_BYTES,
-        encoding="utf-8",
-        errors="replace",
-    )
+    source, tree = load_python_module(path, MODE_SAFE_REPLACE_2MB)
     if source is None:
         return None, "source_unreadable", False
-    try:
-        return ast.parse(source), None, "TYPE_CHECKING" in source
-    except SyntaxError:
+    if tree is None:
         return None, "parse_error", "TYPE_CHECKING" in source
+    return tree, None, "TYPE_CHECKING" in source
 
 
 def _safe_root(project_root: str | Path) -> Path | None:

--- a/test/test_ast_cache.py
+++ b/test/test_ast_cache.py
@@ -1,0 +1,333 @@
+import ast
+import inspect
+import json
+import os
+import pathlib
+
+import pytest
+
+from skylos.analysis import ast_cache
+from skylos.analysis.ast_cache import (
+    MODE_IGNORE,
+    MODE_REPLACE,
+    MODE_SAFE_IGNORE_1MB,
+    MODE_SAFE_REPLACE_2MB,
+    MODE_STRICT,
+    clear_python_ast_cache,
+    load_python_module,
+    load_python_source,
+    mode_max_bytes,
+    python_ast_cache_session,
+    register_dependent_clear,
+)
+from skylos.analyzer import Skylos
+from skylos.deadcode.python_ast import parse_python_files
+from skylos.reporting.architecture_result import _architecture_module_trees
+from skylos.rules.ai_defect import phantom_refs
+from skylos.rules.ai_defect.api_signature_hallucination import (
+    MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES,
+)
+from skylos.rules.ai_defect.python_api_hallucination import (
+    scan_python_local_api_hallucinations,
+)
+
+ALL_MODES = (
+    MODE_REPLACE,
+    MODE_STRICT,
+    MODE_IGNORE,
+    MODE_SAFE_REPLACE_2MB,
+    MODE_SAFE_IGNORE_1MB,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache():
+    clear_python_ast_cache()
+    yield
+    clear_python_ast_cache()
+
+
+def _write(path, source):
+    path.write_text(  # skylos: ignore[SKY-D324] pytest tmp_path fixture
+        source,
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_every_read_mode_shares_one_source_object_and_one_tree(tmp_path):
+    path = _write(tmp_path / "module.py", "x = 1\n")
+
+    results = [load_python_module(path, mode) for mode in ALL_MODES]
+
+    assert len({id(source) for source, _ in results}) == 1
+    assert len({id(tree) for _, tree in results}) == 1
+    assert len(ast_cache._trees[str(path)]) == 1
+
+
+def test_safe_modes_refuse_symlinks_that_plain_modes_follow(tmp_path):
+    target = _write(tmp_path / "real.py", "x = 1\n")
+    link = tmp_path / "link.py"
+    link.symlink_to(target)
+
+    assert load_python_source(link, MODE_REPLACE) == "x = 1\n"
+    assert load_python_source(link, MODE_SAFE_REPLACE_2MB) is None
+
+
+def test_edited_file_is_reread_even_when_the_size_is_unchanged(tmp_path):
+    path = _write(tmp_path / "module.py", "x = 1\n")
+    first_source, first_tree = load_python_module(path, MODE_REPLACE)
+    assert first_source == "x = 1\n"
+
+    _write(path, "x = 9\n")
+    os.utime(path, ns=(0, 0))
+
+    second_source, second_tree = load_python_module(path, MODE_REPLACE)
+    assert second_source == "x = 9\n"
+    assert second_tree is not first_tree
+
+
+def test_editing_a_file_runs_registered_dependent_clears(tmp_path):
+    calls = []
+
+    def _record():
+        calls.append(1)
+
+    register_dependent_clear(_record)
+    try:
+        path = _write(tmp_path / "module.py", "x = 1\n")
+        load_python_module(path, MODE_REPLACE)
+        calls.clear()
+
+        _write(path, "x = 1\ny = 2\n")
+        load_python_module(path, MODE_REPLACE)
+
+        assert calls
+    finally:
+        ast_cache._dependent_clears.remove(_record)
+
+
+def test_unreadable_and_unparsable_files_return_none(tmp_path):
+    unparsable = _write(tmp_path / "broken.py", "def (:\n")
+    source, tree = load_python_module(unparsable, MODE_IGNORE)
+    assert source == "def (:\n"
+    assert tree is None
+
+    assert load_python_module(tmp_path / "absent.py", MODE_REPLACE) == (None, None)
+
+
+def test_clear_drops_every_cache(tmp_path):
+    path = _write(tmp_path / "module.py", "x = 1\n")
+    load_python_module(path, MODE_REPLACE)
+    assert ast_cache._sources
+
+    clear_python_ast_cache()
+
+    assert not ast_cache._sources
+    assert not ast_cache._trees
+    assert not ast_cache._source_pool
+    assert not ast_cache._path_tokens
+
+
+def test_mode_max_bytes_is_the_documented_cap():
+    assert mode_max_bytes(MODE_SAFE_IGNORE_1MB) == 1_000_000
+    assert mode_max_bytes(MODE_SAFE_IGNORE_1MB) == MAX_PYTHON_API_SIGNATURE_SOURCE_BYTES
+    assert mode_max_bytes(MODE_SAFE_REPLACE_2MB) == 2 * 1024 * 1024
+    assert mode_max_bytes(MODE_REPLACE) is None
+
+
+def test_repeated_rule_scans_see_edits_made_between_them(tmp_path):
+    lib = _write(tmp_path / "lib.py", "def real():\n    return 1\n")
+    app = _write(tmp_path / "app.py", "import lib\n\nlib.missing()\n")
+    files = [lib, app]
+
+    findings, _ = scan_python_local_api_hallucinations(
+        tmp_path, files, target_files=files
+    )
+    assert [finding["simple_name"] for finding in findings] == ["missing"]
+
+    _write(lib, "def real():\n    return 1\n\n\ndef missing():\n    return 2\n")
+
+    findings, _ = scan_python_local_api_hallucinations(
+        tmp_path, files, target_files=files
+    )
+    assert findings == []
+
+
+def test_analyze_releases_the_run_scoped_cache(tmp_path):
+    _write(tmp_path / "module.py", "import os\n\n\ndef f():\n    return os.path\n")
+
+    Skylos().analyze(str(tmp_path), enable_ai_defects=True)
+
+    assert not ast_cache._sources
+    assert not ast_cache._trees
+
+
+def test_one_unparsable_file_does_not_suppress_phantom_calls_elsewhere(tmp_path):
+    _write(tmp_path / "a_broken.py", "def (:\n")
+    _write(
+        tmp_path / "b_phantom.py",
+        "def process(data):\n    clean = sanitize_input(data)\n    return clean\n",
+    )
+
+    result = json.loads(Skylos().analyze(str(tmp_path), enable_ai_defects=True))
+
+    rule_ids = {finding.get("rule_id") for finding in result.get("ai_defects", [])}
+    assert "SKY-L012" in rule_ids
+
+
+def test_public_scanner_releases_everything_it_cached(tmp_path):
+    lib = _write(tmp_path / "lib.py", "def real():\n    return 1\n")
+    app = _write(tmp_path / "app.py", "import lib\n\nlib.missing()\n")
+
+    scan_python_local_api_hallucinations(tmp_path, [lib, app], target_files=[lib, app])
+
+    assert not ast_cache._sources
+    assert not ast_cache._trees
+    assert not ast_cache._source_pool
+    assert not ast_cache._path_tokens
+    assert not phantom_refs._AST_INDEX_CACHE
+    assert not phantom_refs._SCOPE_INFOS_CACHE
+    assert not phantom_refs._MODULE_FACTS_CACHE
+    assert not phantom_refs._POSTPONED_ANNOTATION_CACHE
+
+
+def test_nested_sessions_share_until_the_outermost_one_exits(tmp_path):
+    path = _write(tmp_path / "module.py", "x = 1\n")
+
+    with python_ast_cache_session():
+        with python_ast_cache_session():
+            _, inner_tree = load_python_module(path, MODE_REPLACE)
+        assert ast_cache._trees
+        _, outer_tree = load_python_module(path, MODE_REPLACE)
+        assert outer_tree is inner_tree
+
+    assert not ast_cache._trees
+
+
+def test_a_scanner_nested_in_a_session_does_not_drop_it(tmp_path):
+    lib = _write(tmp_path / "lib.py", "def real():\n    return 1\n")
+    app = _write(tmp_path / "app.py", "import lib\n\nlib.real()\n")
+
+    with python_ast_cache_session():
+        _, tree = load_python_module(lib, MODE_REPLACE)
+        scan_python_local_api_hallucinations(
+            tmp_path, [lib, app], target_files=[lib, app]
+        )
+        assert ast_cache._trees
+        assert load_python_module(lib, MODE_REPLACE)[1] is tree
+
+    assert not ast_cache._trees
+
+
+def test_rewrite_that_preserves_size_and_mtime_is_still_seen(tmp_path):
+    path = _write(tmp_path / "module.py", "x = 111\n")
+    before = path.stat()
+    load_python_module(path, MODE_REPLACE)
+
+    _write(path, "x = 222\n")
+    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+    assert path.stat().st_size == before.st_size
+    assert path.stat().st_mtime_ns == before.st_mtime_ns
+
+    source, _ = load_python_module(path, MODE_REPLACE)
+    assert source == "x = 222\n"
+
+
+def test_only_the_reference_context_module_facts_are_memoized():
+    tree = ast.parse("x = 1\n")
+
+    phantom_refs._collect_module_facts(
+        tree, "m", set(), include_reference_context=False
+    )
+    assert not phantom_refs._MODULE_FACTS_CACHE
+
+    phantom_refs._collect_module_facts(tree, "m", set(), include_reference_context=True)
+    assert len(phantom_refs._MODULE_FACTS_CACHE) == 1
+
+
+def test_analyze_keeps_its_explicit_public_signature():
+    parameters = inspect.signature(Skylos.analyze).parameters
+
+    assert "path" in parameters
+    assert parameters["thr"].default == 60
+    assert not any(
+        parameter.kind is parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+    assert Skylos.analyze.__name__ == "analyze"
+
+
+def test_parse_python_files_releases_the_cache_but_keeps_its_result(tmp_path):
+    first = _write(tmp_path / "a.py", "x = 1\n")
+    second = _write(tmp_path / "b.py", "y = 2\n")
+
+    parsed = parse_python_files([first, second])
+
+    assert [entry.path for entry in parsed] == [first, second]
+    assert all(isinstance(entry.tree, ast.Module) for entry in parsed)
+    assert not ast_cache._sources
+    assert not ast_cache._trees
+    assert not ast_cache._source_pool
+
+
+def test_parse_python_files_shares_trees_inside_an_open_session(tmp_path):
+    path = _write(tmp_path / "a.py", "x = 1\n")
+
+    with python_ast_cache_session():
+        _, tree = load_python_module(path, MODE_STRICT)
+        parsed = parse_python_files([path])
+        assert parsed[0].tree is tree
+        assert ast_cache._trees
+
+    assert not ast_cache._trees
+
+
+def test_an_analyze_nested_in_a_session_does_not_wipe_it(tmp_path):
+    path = _write(tmp_path / "module.py", "x = 1\n")
+
+    with python_ast_cache_session():
+        _, tree = load_python_module(path, MODE_REPLACE)
+        Skylos().analyze(str(tmp_path))
+        assert load_python_module(path, MODE_REPLACE)[1] is tree
+
+    assert not ast_cache._trees
+
+
+def test_the_outermost_session_starts_from_a_clean_cache(tmp_path):
+    path = _write(tmp_path / "module.py", "x = 1\n")
+    load_python_module(path, MODE_REPLACE)
+    assert ast_cache._trees
+
+    with python_ast_cache_session():
+        assert not ast_cache._trees
+
+
+def test_the_import_findings_fallback_does_not_memoize_a_foreign_tree():
+    tree = ast.parse("import os\n")
+
+    phantom_refs._direct_local_import_findings(
+        pathlib.Path("x.py"),
+        "m",
+        tree,
+        set(),
+        {},
+        {},
+        set(),
+        set(),
+        set(),
+        set(),
+        lambda name: False,
+    )
+
+    assert not phantom_refs._AST_INDEX_CACHE
+
+
+def test_architecture_module_trees_reuse_the_session_cache(tmp_path):
+    root = tmp_path.resolve()
+    path = _write(root / "module.py", "x = 1\n")
+
+    with python_ast_cache_session():
+        _, tree = load_python_module(path, MODE_IGNORE)
+        assert _architecture_module_trees([path], {path: "m"}, {})["m"] is tree
+
+    assert _architecture_module_trees([path], {path: "m"}, {"m": 0.5}) == {}


### PR DESCRIPTION
Closes #775 
Closes #778

## Summary

- Shares parsed Python ASTs across repo-wide analysis passes
- reuses a per-tree AST index for phantom-reference and Python API-hallucination analysis, and memoizes scope information shared by both rule passes.
- Fixes a bug where analysis silently aborted on an unparseable file, rather than continuing

## Why?

The ai-defects rules contain 2 full parses and 4 full AST walks that are completely duplicative. 

That could be improved in isolation, and indeed accounts for most of the perf improvement of this PR, but this PR proposes to build indices that unify all the AST walks in the same scope. In measured counts of ast.walk calls, with --ai-defects the PR reduces the total full AST walks from ~12 to ~2. 

I can de-scope unifying all the other AST walks if desired.

As implemented, the fix would inevitably create a merge conflict with an isolated fix to #775, so I just incorporated a fix to that into this PR as well; it could be done as a separate PR that then has its code overwritten by this one, or fixed in isolation if the full unification is not desired.

Also, as implemented, the cache is not thread safe if the outer `analyze` was called separately from multiple different threads. That isn't how skylos uses it so I thought that was an acceptable caveat, but it can be fixed or modified if desired by the maintainer; I didn't want to get *too* far ahead without knowing if merging all the other AST.walks outside ai-defects is ok in the first place. 

**AI Use Disclosure**
The duplicate walks were found by analysis of cProfile results, and scoped the way to unify them. Opus 5.0 drafted the changes and they were reviewed according to skylos repository standards by codex GPT-5.6 Sol and claude Fable 5. 

## Performance impact
About a ~10% reduction in overall time for `liveness_primer` scans including `--ai-defects` and `--quality`. In the mcp-context-forge example, the biggest component of the perf impact is shaving ~30s from the ai-defects scan. For mcp-context-forge, cuts ~31 million calls to ast.walk.

## How to test

- python -m pytest -q test/test_analyzer.py test/test_api_signature_hallucination.py test/test_python_api_hallucination.py test/test_dead_code.py test/test_dead_code_liveness.py
- python -m pytest -q test/
- python scripts/corpus_ci.py --manifest corpus/manifest.json

Results on this head:

- Focused analyzer suite: 275 passed.
- Full suite: 7,900 passed and 7 skipped; two agent JSON-nesting error-message failures reproduce unchanged at base 891f407.
- Corpus guard: 47 cases, 0 failures.
- liveness_primer shows no diffs except the *expected* ones on mcp-context-forge due to the #775 fix.