### PR TITLE
fix(analyzer): deterministic module name for multi source-root paths

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1260,14 +1260,23 @@ class Skylos:
     def _module(self, root, f):
         p = list(f.relative_to(root).parts)
 
-        for source_root_name in _PYTHON_SOURCE_ROOT_NAMES:
-            if source_root_name not in p:
+        # Strip the rightmost source-root directory (src/lib/python) so the
+        # resulting module name is deterministic regardless of PYTHONHASHSEED.
+        # Scanning right-to-left guarantees a path like
+        # mcp-servers/python/data_analysis_server/src/.../plots.py always
+        # resolves to data_analysis_server... instead of randomly keeping the
+        # first "python" or "src" segment depending on set iteration order.
+        source_root_idx = None
+        for idx in range(len(p) - 1, -1, -1):
+            if p[idx] not in _PYTHON_SOURCE_ROOT_NAMES:
                 continue
-            source_root_idx = p.index(source_root_name)
-            source_root_path = root / "/".join(p[: source_root_idx + 1])
+            source_root_path = root / "/".join(p[: idx + 1])
             if not (source_root_path / "__init__.py").exists():
-                p = p[source_root_idx + 1 :]
+                source_root_idx = idx
                 break
+
+        if source_root_idx is not None:
+            p = p[source_root_idx + 1 :]
 
         for suffix in PYTHON_SIGNATURE_SUFFIXES:
             if p[-1].endswith(suffix):

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -217,6 +217,35 @@ class TestSkylos:
         result = skylos._module(root, file_path)
         assert result == "main"
 
+    def test_module_name_generation_strips_rightmost_source_root(self, skylos, tmp_path):
+        # Path contains BOTH "python" and "src" source-root names. The old
+        # implementation iterated a set and stripped whichever name came first,
+        # producing module names that depended on PYTHONHASHSEED. The result
+        # must be deterministic and resolve to the rightmost source root.
+        root = tmp_path
+        for rel in (
+            "mcp-servers/python/data_analysis_server/src/data_analysis_server/visualization/plots.py",
+        ):
+            file_path = root / rel
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text("def plot(): ...\n", encoding="utf-8")
+
+        result = skylos._module(root, file_path)
+        assert result == "data_analysis_server.visualization.plots"
+
+    def test_module_name_generation_repeated_src_strips_last(self, skylos, tmp_path):
+        # Same source-root name appearing twice (reporter's hypothetical from
+        # #773) must strip the LAST occurrence deterministically.
+        root = tmp_path
+        file_path = (
+            root / "mcp-servers/src/data_analysis_server/src/data_analysis_server/visualization/plots.py"
+        )
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text("x = 1\n", encoding="utf-8")
+
+        result = skylos._module(root, file_path)
+        assert result == "data_analysis_server.visualization.plots"
+
     def test_should_exclude_file(self, skylos):
         """
         should exclude pycache, build, egg-info and whatever is in exclude_folders


### PR DESCRIPTION
## Bug Description

Fixes #773

`_module()` in `analyzer.py` iterates `_PYTHON_SOURCE_ROOT_NAMES` (`{"src", "lib", "python"}`) as a **set**. Set iteration order depends on `PYTHONHASHSEED`, so when a file path contains more than one of these source-root names, the segment that gets stripped is chosen at random per process.

Example from the issue (IBM/mcp-context-forge):

```
mcp-servers/python/data_analysis_server/src/data_analysis_server/visualization/plots.py
```

resolves its symbol randomly to either:

```
data_analysis_server.src.data_analysis_server.visualization.plots...
```

or

```
data_analysis_server.visualization.plots...
```

The same problem occurs when one of the three names appears more than once in a path - only the first occurrence was ever stripped.

## Root Cause

`skylos/analyzer.py` `_module()`:

```python
for source_root_name in _PYTHON_SOURCE_ROOT_NAMES:  # set iteration = hash order
    if source_root_name not in p:
        continue
    source_root_idx = p.index(source_root_name)     # first occurrence only
    ...
```

Non-deterministic output means findings can't be reliably compared across runs (CI vs local, repeated scans), and module-scoped symbol identity is unstable.

## Fix

Scan the path parts right-to-left and strip the **last** non-package source-root directory. This is deterministic regardless of `PYTHONHASHSEED` and matches the expected behavior in the issue (strip to the last occurrence).

## How to Verify

1. `python -m pytest test/test_analyzer.py -k module_name -q` - new regression tests cover both multi-name and repeated-name paths
2. Run `PYTHONHASHSEED=<n> python -c "..."` invoking `_module()` on the repro path with several seeds - result is identical every time

## Test Plan

- [x] Added regression tests: `test_module_name_generation_strips_rightmost_source_root`, `test_module_name_generation_repeated_src_strips_last`
- [x] Existing `test_module_name_generation` still passes
- [x] Full test suite passes

## Risk Assessment

Low - the change only affects how the module name is derived from a path when multiple source-root names are present. Single-source-root layouts (`src/...`, `lib/...`, plain paths) behave identically to before.
