### PR TITLE
fix(ai-defect): report all CI permission triggers on one line

### DIFF
--- a/skylos/rules/ai_defect/ci_permission_expansion.py
+++ b/skylos/rules/ai_defect/ci_permission_expansion.py
@@ -59,23 +59,20 @@ def detect_ci_permission_expansion(diff_text: str, file_path: str) -> list[dict]
         if not normalized or normalized in removed_normalized:
             continue
 
-        signal = _signal_for_added_line(normalized)
-        if signal is None:
-            continue
-
-        key = (signal["expansion_type"], signal["value"])
-        if key in seen:
-            continue
-        seen.add(key)
-        findings.append(
-            _make_finding(
-                file_path,
-                line.line_no,
-                expansion_type=signal["expansion_type"],
-                value=signal["value"],
-                severity=signal["severity"],
+        for signal in _signals_for_added_line(normalized):
+            key = (signal["expansion_type"], signal["value"])
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                _make_finding(
+                    file_path,
+                    line.line_no,
+                    expansion_type=signal["expansion_type"],
+                    value=signal["value"],
+                    severity=signal["severity"],
+                )
             )
-        )
 
     return findings
 
@@ -129,21 +126,34 @@ def _normalize_yaml_line(line: str) -> str:
     return stripped.strip("'\"")
 
 
-def _signal_for_added_line(line: str) -> dict | None:
-    for trigger in _PRIVILEGED_TRIGGERS:
+def _signals_for_added_line(line: str) -> list[dict]:
+    """Return every CI-permission signal an added line introduces.
+
+    Collects ALL matching privileged triggers (sorted, so the result is
+    deterministic regardless of PYTHONHASHSEED) instead of early-returning on
+    the first match. A line like ``on: [pull_request_target, workflow_run]``
+    therefore reports both triggers, not one random pick.
+    """
+    signals: list[dict] = []
+
+    for trigger in sorted(_PRIVILEGED_TRIGGERS):
         if _line_adds_trigger(line, trigger):
-            return {
-                "expansion_type": "privileged_trigger",
-                "value": trigger,
-                "severity": "HIGH",
-            }
+            signals.append(
+                {
+                    "expansion_type": "privileged_trigger",
+                    "value": trigger,
+                    "severity": "HIGH",
+                }
+            )
 
     if re.match(r"^permissions\s*:\s*['\"]?write-all['\"]?\s*(?:#.*)?$", line):
-        return {
-            "expansion_type": "write_all_permissions",
-            "value": "permissions: write-all",
-            "severity": "HIGH",
-        }
+        signals.append(
+            {
+                "expansion_type": "write_all_permissions",
+                "value": "permissions: write-all",
+                "severity": "HIGH",
+            }
+        )
 
     if line.startswith("permissions:") and "{" in line:
         inline_writes: list[str] = []
@@ -151,23 +161,27 @@ def _signal_for_added_line(line: str) -> dict | None:
             if permission in _WRITE_PERMISSIONS:
                 inline_writes.append(permission)
 
-        if inline_writes:
-            return {
-                "expansion_type": "write_permission",
-                "value": f"{inline_writes[0]}: write",
-                "severity": "HIGH",
-            }
+        for permission in sorted(inline_writes):
+            signals.append(
+                {
+                    "expansion_type": "write_permission",
+                    "value": f"{permission}: write",
+                    "severity": "HIGH",
+                }
+            )
 
     match = _PERMISSION_WRITE_RE.match(line)
     if match and match.group("permission") in _WRITE_PERMISSIONS:
         permission = match.group("permission")
-        return {
-            "expansion_type": "write_permission",
-            "value": f"{permission}: write",
-            "severity": "HIGH",
-        }
+        signals.append(
+            {
+                "expansion_type": "write_permission",
+                "value": f"{permission}: write",
+                "severity": "HIGH",
+            }
+        )
 
-    return None
+    return signals
 
 
 def _line_adds_trigger(line: str, trigger: str) -> bool:

--- a/test/test_ai_pr_diff_rules.py
+++ b/test/test_ai_pr_diff_rules.py
@@ -40,6 +40,31 @@ def test_detects_github_actions_privileged_trigger_added():
     assert findings[0]["metadata"]["added_value"] == "pull_request_target"
 
 
+def test_detects_all_privileged_triggers_on_same_line():
+    # #774: both triggers on one line must BOTH be reported, deterministically.
+    diff = _make_diff([], ["on: [pull_request_target, workflow_run]"])
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert len(findings) == 2
+    assert {f["metadata"]["added_value"] for f in findings} == {
+        "pull_request_target",
+        "workflow_run",
+    }
+
+
+def test_reports_all_inline_write_permissions():
+    diff = _make_diff([], ["permissions: {contents: write, issues: write}"])
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert len(findings) == 2
+    assert {f["metadata"]["added_value"] for f in findings} == {
+        "contents: write",
+        "issues: write",
+    }
+
+
 def test_ci_permission_expansion_ignores_line_moves():
     diff = _make_diff(["permissions: write-all"], ["permissions: write-all"])
 


### PR DESCRIPTION
## Bug Description

Fixes #774

`_signal_for_added_line()` in `rules/ai_defect/ci_permission_expansion.py` early-returns on the first matching privileged trigger, so a single added line can never report more than one finding. Because `_PRIVILEGED_TRIGGERS = {"pull_request_target", "workflow_run"}` is a **set**, *which* trigger gets reported is also random (hash order, same class of bug as #773).

Repro:

```
_signal_for_added_line('on: [pull_request_target, workflow_run]')
```

returns exactly one finding, and the choice is non-deterministic across runs. A user triaging `pull_request_target` at a different severity level than `workflow_run` would never see the second one.

The same "drops to one" behavior exists for inline permissions (`permissions: {contents: write, issues: write}` only reported `contents`).

## Root Cause

`skylos/rules/ai_defect/ci_permission_expansion.py`:

```python
def _signal_for_added_line(line: str) -> dict | None:
    for trigger in _PRIVILEGED_TRIGGERS:   # set iteration = hash order
        if _line_adds_trigger(line, trigger):
            return {...}                    # early return, single finding
```

and `inline_writes[0]` only ever emitted the first inline write permission.

## Fix

Rename to `_signals_for_added_line()` returning a **list** of all signals for the line:

- every matching privileged trigger, iterated in sorted order (deterministic)
- `permissions: write-all`
- every inline `X: write` permission in a `permissions: {...}` block (sorted)
- a standalone `permission: write` line

The caller in `detect_ci_permission_expansion()` loops over the returned signals and emits one finding each (the existing `seen` set still deduplicates across lines).

## How to Verify

1. `python -m pytest test/test_ai_pr_diff_rules.py -q` - new tests cover multi-trigger lines and multi-inline-permission lines
2. Call `_signals_for_added_line('on: [pull_request_target, workflow_run]')` repeatedly (and with different `PYTHONHASHSEED` values) - always returns both triggers, in the same order

## Test Plan

- [x] Added regression tests: `test_detects_all_privileged_triggers_on_same_line`, `test_reports_all_inline_write_permissions`
- [x] Existing tests (`test_detects_github_actions_privileged_trigger_added`, line-move ignore, etc.) still pass
- [x] Full test suite passes

## Risk Assessment

Low - single-trigger and single-permission lines produce the same findings as before. The only behavior change is that multi-trigger / multi-inline lines now report one finding per trigger instead of one random pick.
