### PR TITLE
fix(catalog): swap SKY-F101/F102 rule descriptions

### DIFF
--- a/skylos/rules/catalog.py
+++ b/skylos/rules/catalog.py
@@ -106,8 +106,8 @@ _RULES = (
         "SKY-T105", "Unvalidated JSON type assertion", "quality", "MEDIUM"
     ),
     RuleCatalogEntry("SKY-T106", "Unsafe exported API type", "quality", "MEDIUM"),
-    RuleCatalogEntry("SKY-F101", "Framework route missing auth", "quality"),
-    RuleCatalogEntry("SKY-F102", "Framework handler practice issue", "quality"),
+    RuleCatalogEntry("SKY-F101", "Framework handler practice issue", "quality"),
+    RuleCatalogEntry("SKY-F102", "Framework route missing auth", "quality"),
     RuleCatalogEntry("SKY-R101", "Python type-check policy", "quality", "MEDIUM"),
     RuleCatalogEntry("SKY-R102", "Python lint policy", "quality", "LOW"),
     RuleCatalogEntry("SKY-R103", "Skylos gate policy", "quality", "LOW"),

--- a/test/test_rules_cmd.py
+++ b/test/test_rules_cmd.py
@@ -8,7 +8,15 @@ from rich.console import Console
 
 from skylos import cli
 from skylos.commands import rules_cmd
-from skylos.rules.catalog import get_rule_catalog
+from skylos.rules.catalog import get_rule_catalog, get_rule_name
+
+
+def test_catalog_f101_f102_not_swapped():
+    """Regression: SKY-F101 is about handler practice (response model), not auth.
+    SKY-F102 is about route missing auth, not handler practice.
+    See practices.py: F101=missing_response_contract, F102=missing_auth_guard."""
+    assert get_rule_name("SKY-F101") == "Framework handler practice issue"
+    assert get_rule_name("SKY-F102") == "Framework route missing auth"
 
 
 def test_run_rules_command_returns_validate_failure():


### PR DESCRIPTION
catalog.py listed F101 as 'Framework route missing auth' and F102 as 'Framework handler practice issue', but practices.py emits F101 for missing response contracts and F102 for missing auth guards on mutating routes. Swap the names to match actual behavior.