### PR TITLE
fix(cwe): correct 10 misaligned CWE mappings

### DIFF
--- a/skylos/rules/quality/standards.py
+++ b/skylos/rules/quality/standards.py
@@ -4,8 +4,8 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     # Logic rules
     "SKY-L001": [
         {
-            "id": "CWE-1321",
-            "name": "Improperly Controlled Modification of Object Prototype Attributes",
+            "id": "CWE-665",
+            "name": "Improper Initialization",
         }
     ],
     "SKY-L002": [
@@ -16,7 +16,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     ],
     "SKY-L004": [{"id": "CWE-705", "name": "Incorrect Control Flow Scoping"}],
     "SKY-L005": [{"id": "CWE-563", "name": "Assignment to Variable without Use"}],
-    "SKY-L006": [{"id": "CWE-394", "name": "Unexpected Status Code or Return Value"}],
+    "SKY-L006": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-L007": [{"id": "CWE-391", "name": "Unchecked Error Condition"}],
     "SKY-L008": [
         {
@@ -53,22 +53,22 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     ],
     "SKY-L023": [{"id": "CWE-476", "name": "NULL Pointer Dereference"}],
     "SKY-L024": [
-        {"id": "CWE-1127", "name": "Compilation with Insufficient Warnings or Errors"}
+        {"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}
     ],
     "SKY-L026": [{"id": "CWE-1164", "name": "Irrelevant Code"}],
     "SKY-L027": [
-        {"id": "CWE-1095", "name": "Loop Condition Value Update within the Loop"}
+        {"id": "CWE-1041", "name": "Use of Redundant Code"}
     ],  # maintainability: duplicated literals
     "SKY-L028": [
         {
-            "id": "CWE-1075",
-            "name": "Unconditional Control Flow Transfer in Finally Block",
+            "id": "CWE-1121",
+            "name": "Excessive McCabe Cyclomatic Complexity",
         }
     ],  # complex control flow
     "SKY-L029": [
         {
-            "id": "CWE-1064",
-            "name": "Invokable Control Element with Signature Containing an Excessive Number of Parameters",
+            "id": "CWE-710",
+            "name": "Improper Adherence to Coding Standards",
         }
     ],
     "SKY-L030": [
@@ -107,7 +107,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
         {"id": "CWE-693", "name": "Protection Mechanism Failure"},
         {"id": "CWE-862", "name": "Missing Authorization"},
     ],
-    "SKY-Q401": [{"id": "CWE-667", "name": "Improper Locking"}],
+    "SKY-Q401": [{"id": "CWE-400", "name": "Uncontrolled Resource Consumption"}],
     "SKY-Q501": [{"id": "CWE-1093", "name": "Excessively Complex Data Representation"}],
     "SKY-Q502": [
         {
@@ -115,12 +115,12 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
             "name": "Source Code File with Excessive Number of Lines of Code",
         }
     ],
-    "SKY-Q701": [{"id": "CWE-1047", "name": "Modules with Circular Dependencies"}],
+    "SKY-Q701": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-Q702": [{"id": "CWE-1093", "name": "Excessively Complex Data Representation"}],
     "SKY-Q801": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-Q802": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-Q803": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
-    "SKY-Q804": [{"id": "CWE-704", "name": "Incorrect Type Conversion or Cast"}],
+    "SKY-Q804": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-Q806": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-C303": [
         {
@@ -148,7 +148,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     "SKY-Q406": [{"id": "CWE-252", "name": "Unchecked Return Value"}],
     "SKY-Q407": [{"id": "CWE-252", "name": "Unchecked Return Value"}],
     "SKY-U005": [
-        {"id": "CWE-1104", "name": "Use of Unmaintained Third Party Components"}
+        {"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}
     ],
     # Unreachable
     "SKY-UC001": [{"id": "CWE-561", "name": "Dead Code"}],

--- a/skylos/rules/quality/standards.py
+++ b/skylos/rules/quality/standards.py
@@ -52,17 +52,15 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
         }
     ],
     "SKY-L023": [{"id": "CWE-476", "name": "NULL Pointer Dereference"}],
-    "SKY-L024": [
-        {"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}
-    ],
+    "SKY-L024": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-L026": [{"id": "CWE-1164", "name": "Irrelevant Code"}],
     "SKY-L027": [
-        {"id": "CWE-1041", "name": "Use of Redundant Code"}
+        {"id": "CWE-1106", "name": "Insufficient Use of Symbolic Constants"}
     ],  # maintainability: duplicated literals
     "SKY-L028": [
         {
-            "id": "CWE-1121",
-            "name": "Excessive McCabe Cyclomatic Complexity",
+            "id": "CWE-1119",
+            "name": "Excessive Use of Unconditional Branching",
         }
     ],  # complex control flow
     "SKY-L029": [
@@ -107,7 +105,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
         {"id": "CWE-693", "name": "Protection Mechanism Failure"},
         {"id": "CWE-862", "name": "Missing Authorization"},
     ],
-    "SKY-Q401": [{"id": "CWE-400", "name": "Uncontrolled Resource Consumption"}],
+    "SKY-Q401": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     "SKY-Q501": [{"id": "CWE-1093", "name": "Excessively Complex Data Representation"}],
     "SKY-Q502": [
         {
@@ -147,9 +145,7 @@ CWE_MAP: dict[str, list[dict[str, str]]] = {
     ],
     "SKY-Q406": [{"id": "CWE-252", "name": "Unchecked Return Value"}],
     "SKY-Q407": [{"id": "CWE-252", "name": "Unchecked Return Value"}],
-    "SKY-U005": [
-        {"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}
-    ],
+    "SKY-U005": [{"id": "CWE-710", "name": "Improper Adherence to Coding Standards"}],
     # Unreachable
     "SKY-UC001": [{"id": "CWE-561", "name": "Dead Code"}],
     "SKY-UC002": [{"id": "CWE-561", "name": "Dead Code"}],

--- a/test/test_quality_standards.py
+++ b/test/test_quality_standards.py
@@ -61,28 +61,22 @@ class TestCWEMapping:
         assert "ESLint no-async-promise-executor" in STANDARD_REFS["SKY-Q405"]
 
     def test_corrected_cwe_mappings_match_rule_behavior(self):
-        """Regression: these 10 CWE mappings were wrong and have been
-        corrected to match each rule's actual behavior."""
-        # L001: mutable default args = improper initialization, not JS prototype pollution
-        assert CWE_MAP["SKY-L001"][0]["id"] == "CWE-665"
-        # L006: inconsistent return = coding standards, not unexpected status code
-        assert CWE_MAP["SKY-L006"][0]["id"] == "CWE-710"
-        # L024: stale mock = coding standards, not compilation warnings
-        assert CWE_MAP["SKY-L024"][0]["id"] == "CWE-710"
-        # L027: duplicate string literal = redundant code, not loop condition update
-        assert CWE_MAP["SKY-L027"][0]["id"] == "CWE-1041"
-        # L028: too many returns = complexity, not finally-block transfer
-        assert CWE_MAP["SKY-L028"][0]["id"] == "CWE-1121"
-        # L029: boolean trap = coding standards, not excessive params
-        assert CWE_MAP["SKY-L029"][0]["id"] == "CWE-710"
-        # Q401: async blocking = resource consumption, not improper locking
-        assert CWE_MAP["SKY-Q401"][0]["id"] == "CWE-400"
-        # Q701: coupling = coding standards, not circular dependencies
-        assert CWE_MAP["SKY-Q701"][0]["id"] == "CWE-710"
-        # Q804: DIP = coding standards, not type conversion
-        assert CWE_MAP["SKY-Q804"][0]["id"] == "CWE-710"
-        # U005: unused dep = coding standards, not unmaintained components
-        assert CWE_MAP["SKY-U005"][0]["id"] == "CWE-710"
+        """Regression: lock the reviewed CWE IDs and official names."""
+        expected = {
+            "SKY-L001": ("CWE-665", "Improper Initialization"),
+            "SKY-L006": ("CWE-710", "Improper Adherence to Coding Standards"),
+            "SKY-L024": ("CWE-710", "Improper Adherence to Coding Standards"),
+            "SKY-L027": ("CWE-1106", "Insufficient Use of Symbolic Constants"),
+            "SKY-L028": ("CWE-1119", "Excessive Use of Unconditional Branching"),
+            "SKY-L029": ("CWE-710", "Improper Adherence to Coding Standards"),
+            "SKY-Q401": ("CWE-710", "Improper Adherence to Coding Standards"),
+            "SKY-Q701": ("CWE-710", "Improper Adherence to Coding Standards"),
+            "SKY-Q804": ("CWE-710", "Improper Adherence to Coding Standards"),
+            "SKY-U005": ("CWE-710", "Improper Adherence to Coding Standards"),
+        }
+
+        for rule_id, (cwe_id, cwe_name) in expected.items():
+            assert CWE_MAP[rule_id] == [{"id": cwe_id, "name": cwe_name}]
 
 
 class TestEnrichFinding:
@@ -525,7 +519,7 @@ class TestSarifCWE:
                 "file": "x.py",
                 "line": 1,
                 "col": 0,
-                "cwe": [{"id": "CWE-1321", "name": "test"}],
+                "cwe": [{"id": "CWE-665", "name": "Improper Initialization"}],
             },
         ]
         sarif = SarifExporter(findings).generate()

--- a/test/test_quality_standards.py
+++ b/test/test_quality_standards.py
@@ -60,6 +60,30 @@ class TestCWEMapping:
         assert "Python sequence repetition semantics" in STANDARD_REFS["SKY-L034"]
         assert "ESLint no-async-promise-executor" in STANDARD_REFS["SKY-Q405"]
 
+    def test_corrected_cwe_mappings_match_rule_behavior(self):
+        """Regression: these 10 CWE mappings were wrong and have been
+        corrected to match each rule's actual behavior."""
+        # L001: mutable default args = improper initialization, not JS prototype pollution
+        assert CWE_MAP["SKY-L001"][0]["id"] == "CWE-665"
+        # L006: inconsistent return = coding standards, not unexpected status code
+        assert CWE_MAP["SKY-L006"][0]["id"] == "CWE-710"
+        # L024: stale mock = coding standards, not compilation warnings
+        assert CWE_MAP["SKY-L024"][0]["id"] == "CWE-710"
+        # L027: duplicate string literal = redundant code, not loop condition update
+        assert CWE_MAP["SKY-L027"][0]["id"] == "CWE-1041"
+        # L028: too many returns = complexity, not finally-block transfer
+        assert CWE_MAP["SKY-L028"][0]["id"] == "CWE-1121"
+        # L029: boolean trap = coding standards, not excessive params
+        assert CWE_MAP["SKY-L029"][0]["id"] == "CWE-710"
+        # Q401: async blocking = resource consumption, not improper locking
+        assert CWE_MAP["SKY-Q401"][0]["id"] == "CWE-400"
+        # Q701: coupling = coding standards, not circular dependencies
+        assert CWE_MAP["SKY-Q701"][0]["id"] == "CWE-710"
+        # Q804: DIP = coding standards, not type conversion
+        assert CWE_MAP["SKY-Q804"][0]["id"] == "CWE-710"
+        # U005: unused dep = coding standards, not unmaintained components
+        assert CWE_MAP["SKY-U005"][0]["id"] == "CWE-710"
+
 
 class TestEnrichFinding:
     def test_enriches_known_rule(self):


### PR DESCRIPTION
10 CWE mappings in standards.py pointed at unrelated CWEs. L001 was mapped to CWE-1321 (JS prototype pollution) for a Python mutable-default-args rule; L027 to CWE-1095 (loop condition) for duplicate string literals; L028 to CWE-1075 (finally-block) for too-many-returns; Q401 to CWE-667 (improper locking) for async blocking. Corrected those and 6 others to CWEs that match each rule's actual behavior.