### PR TITLE
fix(ai-defect): report CI permission signals reliably

### DIFF
--- a/skylos/rules/ai_defect/ci_permission_expansion.py
+++ b/skylos/rules/ai_defect/ci_permission_expansion.py
@@ -46,22 +46,22 @@ def detect_ci_permission_expansion(diff_text: str, file_path: str) -> list[dict]
         return []
 
     removed, added = _parse_changed_lines(diff_text)
-    removed_normalized: set[str] = set()
+    removed_signals: set[tuple[str, str]] = set()
     for line in removed:
         normalized_removed = _normalize_yaml_line(line.text)
-        if normalized_removed:
-            removed_normalized.add(normalized_removed)
+        for signal in _signals_for_added_line(normalized_removed):
+            removed_signals.add((signal["expansion_type"], signal["value"]))
 
     findings: list[dict] = []
     seen: set[tuple[str, str]] = set()
     for line in added:
         normalized = _normalize_yaml_line(line.text)
-        if not normalized or normalized in removed_normalized:
+        if not normalized:
             continue
 
         for signal in _signals_for_added_line(normalized):
             key = (signal["expansion_type"], signal["value"])
-            if key in seen:
+            if key in removed_signals or key in seen:
                 continue
             seen.add(key)
             findings.append(

--- a/skylos/rules/ai_defect/ci_permission_expansion.py
+++ b/skylos/rules/ai_defect/ci_permission_expansion.py
@@ -59,23 +59,20 @@ def detect_ci_permission_expansion(diff_text: str, file_path: str) -> list[dict]
         if not normalized or normalized in removed_normalized:
             continue
 
-        signal = _signal_for_added_line(normalized)
-        if signal is None:
-            continue
-
-        key = (signal["expansion_type"], signal["value"])
-        if key in seen:
-            continue
-        seen.add(key)
-        findings.append(
-            _make_finding(
-                file_path,
-                line.line_no,
-                expansion_type=signal["expansion_type"],
-                value=signal["value"],
-                severity=signal["severity"],
+        for signal in _signals_for_added_line(normalized):
+            key = (signal["expansion_type"], signal["value"])
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                _make_finding(
+                    file_path,
+                    line.line_no,
+                    expansion_type=signal["expansion_type"],
+                    value=signal["value"],
+                    severity=signal["severity"],
+                )
             )
-        )
 
     return findings
 
@@ -129,21 +126,34 @@ def _normalize_yaml_line(line: str) -> str:
     return stripped.strip("'\"")
 
 
-def _signal_for_added_line(line: str) -> dict | None:
-    for trigger in _PRIVILEGED_TRIGGERS:
+def _signals_for_added_line(line: str) -> list[dict]:
+    """Return every CI-permission signal an added line introduces.
+
+    Collects ALL matching privileged triggers (sorted, so the result is
+    deterministic regardless of PYTHONHASHSEED) instead of early-returning on
+    the first match. A line like ``on: [pull_request_target, workflow_run]``
+    therefore reports both triggers, not one random pick.
+    """
+    signals: list[dict] = []
+
+    for trigger in sorted(_PRIVILEGED_TRIGGERS):
         if _line_adds_trigger(line, trigger):
-            return {
-                "expansion_type": "privileged_trigger",
-                "value": trigger,
-                "severity": "HIGH",
-            }
+            signals.append(
+                {
+                    "expansion_type": "privileged_trigger",
+                    "value": trigger,
+                    "severity": "HIGH",
+                }
+            )
 
     if re.match(r"^permissions\s*:\s*['\"]?write-all['\"]?\s*(?:#.*)?$", line):
-        return {
-            "expansion_type": "write_all_permissions",
-            "value": "permissions: write-all",
-            "severity": "HIGH",
-        }
+        signals.append(
+            {
+                "expansion_type": "write_all_permissions",
+                "value": "permissions: write-all",
+                "severity": "HIGH",
+            }
+        )
 
     if line.startswith("permissions:") and "{" in line:
         inline_writes: list[str] = []
@@ -151,23 +161,27 @@ def _signal_for_added_line(line: str) -> dict | None:
             if permission in _WRITE_PERMISSIONS:
                 inline_writes.append(permission)
 
-        if inline_writes:
-            return {
-                "expansion_type": "write_permission",
-                "value": f"{inline_writes[0]}: write",
-                "severity": "HIGH",
-            }
+        for permission in sorted(inline_writes):
+            signals.append(
+                {
+                    "expansion_type": "write_permission",
+                    "value": f"{permission}: write",
+                    "severity": "HIGH",
+                }
+            )
 
     match = _PERMISSION_WRITE_RE.match(line)
     if match and match.group("permission") in _WRITE_PERMISSIONS:
         permission = match.group("permission")
-        return {
-            "expansion_type": "write_permission",
-            "value": f"{permission}: write",
-            "severity": "HIGH",
-        }
+        signals.append(
+            {
+                "expansion_type": "write_permission",
+                "value": f"{permission}: write",
+                "severity": "HIGH",
+            }
+        )
 
-    return None
+    return signals
 
 
 def _line_adds_trigger(line: str, trigger: str) -> bool:

--- a/skylos/rules/ai_defect/ci_permission_expansion.py
+++ b/skylos/rules/ai_defect/ci_permission_expansion.py
@@ -3,18 +3,41 @@
 from __future__ import annotations
 
 import re
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
+from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
 
 RULE_ID = "SKY-A103"
 
 _HUNK_RE = re.compile(r"@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 _PERMISSION_WRITE_RE = re.compile(
-    r"^(?P<permission>[A-Za-z0-9_-]+)\s*:\s*['\"]?write['\"]?\s*(?:#.*)?$"
+    r"^['\"]?(?P<permission>[A-Za-z0-9_-]+)['\"]?\s*:\s*"
+    r"['\"]?write['\"]?\s*,?\s*$"
 )
-_INLINE_PERMISSIONS_RE = re.compile(r"\b([A-Za-z0-9_-]+)\s*:\s*write\b")
+_INLINE_PERMISSIONS_RE = re.compile(
+    r"(?:^|[{,])\s*['\"]?([A-Za-z0-9_-]+)['\"]?\s*:\s*"
+    r"['\"]?write['\"]?(?=\s*(?:[,}]|$))"
+)
+_ON_LINE_RE = re.compile(r"^['\"]?on['\"]?\s*:\s*(?P<value>.*)$")
+_PERMISSIONS_LINE_RE = re.compile(r"^['\"]?permissions['\"]?\s*:\s*(?P<value>.*)$")
 _PRIVILEGED_TRIGGERS = {"pull_request_target", "workflow_run"}
 _GITHUB_ACTIONS_WORKFLOW_SUFFIXES = {".yml", ".yaml"}
+_ROOT_COMPARABLE_SLOTS = {"on:0", "permissions:0"}
+_YAML_MAPPING_TAG = "tag:yaml.org,2002:map"
+_YAML_SEQUENCE_TAG = "tag:yaml.org,2002:seq"
+_YAML_NULL_TAG = "tag:yaml.org,2002:null"
+_YAML_SAFE_SCALAR_TAGS = {
+    "tag:yaml.org,2002:str",
+    _YAML_NULL_TAG,
+    "tag:yaml.org,2002:bool",
+}
+_YAML_NULL_VALUES = {"", "~", "null", "Null", "NULL"}
+_YAML_TRUE_VALUES = {"y", "yes", "true", "on"}
+_YAML_FALSE_VALUES = {"n", "no", "false", "off"}
+_MAX_COMPARABLE_YAML_NODES = 1_000
 _WRITE_PERMISSIONS = {
     "actions",
     "attestations",
@@ -38,6 +61,7 @@ _WRITE_PERMISSIONS = {
 class _DiffLine:
     line_no: int
     text: str
+    change_id: int
 
 
 def detect_ci_permission_expansion(diff_text: str, file_path: str) -> list[dict]:
@@ -46,24 +70,67 @@ def detect_ci_permission_expansion(diff_text: str, file_path: str) -> list[dict]
         return []
 
     removed, added = _parse_changed_lines(diff_text)
-    removed_signals: set[tuple[str, str]] = set()
+    removed_lines_by_change = _lines_by_change(
+        [line for line in removed if _normalize_yaml_line(line.text)]
+    )
+    added_lines_by_change = _lines_by_change(
+        [line for line in added if _normalize_yaml_line(line.text)]
+    )
+    # Without a full YAML document, only a one-line replacement is safe to
+    # compare for indented/job-level containers. Root `on` and `permissions`
+    # are unique slots and are handled separately below.
+    comparable_changes = {
+        change_id
+        for change_id, removed_lines in removed_lines_by_change.items()
+        if len(removed_lines) == 1
+        and len(added_lines_by_change.get(change_id, ())) == 1
+    }
+    same_code_changes = {
+        change_id
+        for change_id in comparable_changes
+        if _strip_yaml_comment(removed_lines_by_change[change_id][0].text).rstrip()
+        == _strip_yaml_comment(added_lines_by_change[change_id][0].text).rstrip()
+    }
+
+    removed_root_signals: Counter[tuple[str, str, str]] = Counter()
+    removed_by_change: dict[int, Counter[tuple[str, str, str]]] = {}
     for line in removed:
-        normalized_removed = _normalize_yaml_line(line.text)
-        for signal in _signals_for_added_line(normalized_removed):
-            removed_signals.add((signal["expansion_type"], signal["value"]))
+        if not _is_safe_removal_evidence(line.text):
+            continue
+        for slot, signal in _signal_entries_for_line(line.text):
+            removal_key = (slot, signal["expansion_type"], signal["value"])
+            if slot in _ROOT_COMPARABLE_SLOTS:
+                # These slots have file-wide scope, so harmless moves or
+                # adjacent root-key edits can be compared across change blocks.
+                removed_root_signals[removal_key] += 1
+                continue
+            if line.change_id not in comparable_changes:
+                continue
+            if (
+                not _is_comparable_slot(slot)
+                and line.change_id not in same_code_changes
+            ):
+                continue
+            counter = removed_by_change.setdefault(line.change_id, Counter())
+            counter[removal_key] += 1
 
     findings: list[dict] = []
-    seen: set[tuple[str, str]] = set()
     for line in added:
-        normalized = _normalize_yaml_line(line.text)
-        if not normalized:
-            continue
-
-        for signal in _signals_for_added_line(normalized):
-            key = (signal["expansion_type"], signal["value"])
-            if key in removed_signals or key in seen:
+        removed_signals = removed_by_change.get(line.change_id)
+        seen_on_line: set[tuple[str, str]] = set()
+        for slot, signal in _signal_entries_for_line(line.text):
+            removal_key = (slot, signal["expansion_type"], signal["value"])
+            if slot in _ROOT_COMPARABLE_SLOTS and removed_root_signals[removal_key] > 0:
+                removed_root_signals[removal_key] -= 1
                 continue
-            seen.add(key)
+            if removed_signals and removed_signals[removal_key] > 0:
+                removed_signals[removal_key] -= 1
+                continue
+
+            finding_key = (signal["expansion_type"], signal["value"])
+            if finding_key in seen_on_line:
+                continue
+            seen_on_line.add(finding_key)
             findings.append(
                 _make_finding(
                     file_path,
@@ -75,6 +142,17 @@ def detect_ci_permission_expansion(diff_text: str, file_path: str) -> list[dict]
             )
 
     return findings
+
+
+def _lines_by_change(lines: list[_DiffLine]) -> dict[int, list[_DiffLine]]:
+    grouped: dict[int, list[_DiffLine]] = {}
+    for line in lines:
+        grouped.setdefault(line.change_id, []).append(line)
+    return grouped
+
+
+def _is_comparable_slot(slot: str) -> bool:
+    return slot.startswith(("on:", "permissions:"))
 
 
 def _is_github_actions_workflow(file_path: str) -> bool:
@@ -95,35 +173,254 @@ def _parse_changed_lines(diff_text: str) -> tuple[list[_DiffLine], list[_DiffLin
     added: list[_DiffLine] = []
     old_line = 0
     new_line = 0
+    change_id = 0
+    in_change = False
+    in_hunk = False
 
     for raw_line in diff_text.splitlines():
         hunk_match = _HUNK_RE.match(raw_line)
         if hunk_match:
             old_line = int(hunk_match.group(1))
             new_line = int(hunk_match.group(2))
+            in_change = False
+            in_hunk = True
             continue
 
-        if raw_line.startswith("-") and not raw_line.startswith("---"):
-            removed.append(_DiffLine(old_line, raw_line[1:]))
+        if not in_hunk:
+            continue
+
+        if raw_line.startswith("\\ No newline at end of file"):
+            continue
+
+        if raw_line.startswith("-"):
+            if not in_change:
+                change_id += 1
+                in_change = True
+            removed.append(_DiffLine(old_line, raw_line[1:], change_id))
             old_line += 1
             continue
 
-        if raw_line.startswith("+") and not raw_line.startswith("+++"):
-            added.append(_DiffLine(new_line, raw_line[1:]))
+        if raw_line.startswith("+"):
+            if not in_change:
+                change_id += 1
+                in_change = True
+            added.append(_DiffLine(new_line, raw_line[1:], change_id))
             new_line += 1
             continue
 
-        old_line += 1
-        new_line += 1
+        in_change = False
+        if raw_line.startswith(" "):
+            old_line += 1
+            new_line += 1
 
     return removed, added
 
 
 def _normalize_yaml_line(line: str) -> str:
-    stripped = line.strip()
-    if not stripped or stripped.startswith("#"):
-        return ""
-    return stripped.strip("'\"")
+    return _strip_yaml_comment(line).strip()
+
+
+def _strip_yaml_comment(line: str) -> str:
+    """Strip a YAML comment without treating quoted ``#`` characters as comments."""
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    index = 0
+
+    while index < len(line):
+        char = line[index]
+
+        if in_double_quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_double_quote = False
+            index += 1
+            continue
+
+        if in_single_quote:
+            if char == "'":
+                if index + 1 < len(line) and line[index + 1] == "'":
+                    index += 2
+                    continue
+                in_single_quote = False
+            index += 1
+            continue
+
+        if char == '"':
+            in_double_quote = True
+        elif char == "'":
+            in_single_quote = True
+        elif char == "#" and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+        index += 1
+
+    return line
+
+
+def _is_safe_removal_evidence(line: str) -> bool:
+    """Require unambiguous YAML before an old signal may suppress a new one."""
+    normalized = _normalize_yaml_line(line)
+    if not normalized:
+        return False
+
+    try:
+        # Composed nodes do not retain whether a tag was explicit. Reject all
+        # explicit tags so ``!!bool on`` cannot masquerade as the ordinary
+        # GitHub Actions key that PyYAML implicitly resolves as a boolean.
+        if any(
+            getattr(event, "tag", None) is not None
+            for event in yaml.parse(normalized, Loader=yaml.SafeLoader)
+        ):
+            return False
+        root = yaml.compose(normalized, Loader=yaml.SafeLoader)
+    except Exception:
+        return False
+    if root is None:
+        return False
+
+    pending: list[tuple[Node, bool]] = [(root, False)]
+    active: set[int] = set()
+    visited: set[int] = set()
+    while pending:
+        node, leaving = pending.pop()
+        node_id = id(node)
+        if leaving:
+            active.discard(node_id)
+            visited.add(node_id)
+            continue
+        if node_id in active:
+            return False
+        if node_id in visited:
+            continue
+        if len(visited) + len(active) >= _MAX_COMPARABLE_YAML_NODES:
+            return False
+        if not _has_safe_yaml_tag(node):
+            return False
+
+        active.add(node_id)
+        pending.append((node, True))
+
+        if isinstance(node, MappingNode):
+            raw_keys: set[str] = set()
+            resolved_keys: set[tuple[str, object]] = set()
+            for key_node, value_node in node.value:
+                key = _scalar_node_value(key_node)
+                resolved_key = _yaml_scalar_identity(key_node)
+                if (
+                    key is None
+                    or resolved_key is None
+                    or key in raw_keys
+                    or resolved_key in resolved_keys
+                ):
+                    return False
+                raw_keys.add(key)
+                resolved_keys.add(resolved_key)
+                pending.extend(((value_node, False), (key_node, False)))
+        elif isinstance(node, SequenceNode):
+            pending.extend((child, False) for child in node.value)
+
+    # ``compose`` preserves useful lexical values (notably the key ``on``),
+    # but it does not validate that explicit tags can actually be constructed.
+    # A second SafeLoader pass rejects malformed core tags and unsupported tags
+    # before the removed line is trusted as suppression evidence.
+    try:
+        yaml.safe_load(normalized)
+    except Exception:
+        return False
+
+    return True
+
+
+def _has_safe_yaml_tag(node: Node) -> bool:
+    if isinstance(node, MappingNode):
+        return node.tag == _YAML_MAPPING_TAG
+    if isinstance(node, SequenceNode):
+        return node.tag == _YAML_SEQUENCE_TAG
+    if not isinstance(node, ScalarNode) or node.tag not in _YAML_SAFE_SCALAR_TAGS:
+        return False
+    if node.tag == _YAML_NULL_TAG:
+        # PyYAML's explicit ``!!null`` constructor accepts arbitrary text.
+        # Only trust the spellings that are actually YAML null values.
+        return node.value in _YAML_NULL_VALUES
+    return True
+
+
+def _yaml_scalar_identity(node: Node) -> tuple[str, object] | None:
+    """Return a key identity matching SafeLoader's implicit scalar resolution."""
+    if not isinstance(node, ScalarNode) or not _has_safe_yaml_tag(node):
+        return None
+    if node.tag == "tag:yaml.org,2002:str":
+        return ("str", node.value)
+    if node.tag == _YAML_NULL_TAG:
+        return ("null", None)
+    if node.tag == "tag:yaml.org,2002:bool":
+        normalized = node.value.casefold()
+        if normalized in _YAML_TRUE_VALUES:
+            return ("bool", True)
+        if normalized in _YAML_FALSE_VALUES:
+            return ("bool", False)
+    return None
+
+
+def _signal_entries_for_line(line: str) -> list[tuple[str, dict]]:
+    normalized = _normalize_yaml_line(line)
+    if not normalized:
+        return []
+
+    indent = len(line) - len(line.lstrip(" \t"))
+    try:
+        parsed = yaml.compose(normalized, Loader=yaml.SafeLoader)
+    except Exception:
+        return _fallback_signal_entries(normalized, indent)
+
+    entries: list[tuple[str, dict]] = []
+    if isinstance(parsed, MappingNode):
+        has_container = False
+        for key_node, value_node in parsed.value:
+            key = _scalar_node_value(key_node)
+            if key == "on":
+                has_container = True
+                entries.extend(
+                    (f"on:{indent}", signal) for signal in _trigger_signals(value_node)
+                )
+            elif key == "permissions":
+                has_container = True
+                entries.extend(
+                    (f"permissions:{indent}", signal)
+                    for signal in _permission_signals(value_node)
+                )
+
+        if has_container:
+            return entries
+
+        trigger_keys = [
+            key
+            for key_node, _ in parsed.value
+            if (key := _scalar_node_value(key_node)) in _PRIVILEGED_TRIGGERS
+        ]
+        for trigger in sorted(set(trigger_keys)):
+            entries.append((f"trigger-entry:{indent}", _trigger_signal(trigger)))
+
+        entries.extend(
+            (f"permission-entry:{indent}", signal)
+            for signal in _permission_signals(parsed)
+        )
+        return entries
+
+    if isinstance(parsed, SequenceNode):
+        entries.extend(
+            (f"trigger-entry:{indent}", signal) for signal in _trigger_signals(parsed)
+        )
+        return entries
+
+    parsed_value = _plain_scalar_token(parsed)
+    if parsed_value in _PRIVILEGED_TRIGGERS:
+        return [(f"trigger-entry:{indent}", _trigger_signal(parsed_value))]
+
+    return []
 
 
 def _signals_for_added_line(line: str) -> list[dict]:
@@ -134,65 +431,154 @@ def _signals_for_added_line(line: str) -> list[dict]:
     the first match. A line like ``on: [pull_request_target, workflow_run]``
     therefore reports both triggers, not one random pick.
     """
-    signals: list[dict] = []
+    return [signal for _, signal in _signal_entries_for_line(line)]
 
-    for trigger in sorted(_PRIVILEGED_TRIGGERS):
-        if _line_adds_trigger(line, trigger):
-            signals.append(
-                {
-                    "expansion_type": "privileged_trigger",
-                    "value": trigger,
-                    "severity": "HIGH",
-                }
-            )
 
-    if re.match(r"^permissions\s*:\s*['\"]?write-all['\"]?\s*(?:#.*)?$", line):
-        signals.append(
+def _scalar_node_value(node: Node | None) -> str | None:
+    return node.value if isinstance(node, ScalarNode) else None
+
+
+def _plain_scalar_token(node: Node | None) -> str | None:
+    value = _scalar_node_value(node)
+    if value is None or not isinstance(node, ScalarNode) or node.style is not None:
+        return value
+    return value.removesuffix(",").rstrip()
+
+
+def _trigger_signals(value: Node | None) -> list[dict]:
+    triggers: set[str] = set()
+    scalar_value = _scalar_node_value(value)
+    if scalar_value in _PRIVILEGED_TRIGGERS:
+        triggers.add(scalar_value)
+    elif isinstance(value, SequenceNode):
+        triggers.update(
+            item_value
+            for item in value.value
+            if (item_value := _scalar_node_value(item)) in _PRIVILEGED_TRIGGERS
+        )
+    elif isinstance(value, MappingNode):
+        triggers.update(
+            key_value
+            for key, _ in value.value
+            if (key_value := _scalar_node_value(key)) in _PRIVILEGED_TRIGGERS
+        )
+
+    return [_trigger_signal(trigger) for trigger in sorted(triggers)]
+
+
+def _trigger_signal(trigger: str) -> dict:
+    return {
+        "expansion_type": "privileged_trigger",
+        "value": trigger,
+        "severity": "HIGH",
+    }
+
+
+def _permission_signals(value: Node | None) -> list[dict]:
+    if _scalar_node_value(value) == "write-all":
+        return [
             {
                 "expansion_type": "write_all_permissions",
                 "value": "permissions: write-all",
                 "severity": "HIGH",
             }
+        ]
+
+    if not isinstance(value, MappingNode):
+        return []
+
+    permissions = sorted(
+        permission_value
+        for permission, access in value.value
+        if (permission_value := _scalar_node_value(permission)) in _WRITE_PERMISSIONS
+        and _plain_scalar_token(access) == "write"
+    )
+    return [
+        {
+            "expansion_type": "write_permission",
+            "value": f"{permission}: write",
+            "severity": "HIGH",
+        }
+        for permission in permissions
+    ]
+
+
+def _fallback_signal_entries(line: str, indent: int) -> list[tuple[str, dict]]:
+    entries: list[tuple[str, dict]] = []
+
+    for trigger in sorted(_PRIVILEGED_TRIGGERS):
+        if _line_adds_trigger(line, trigger):
+            slot = "on" if _ON_LINE_RE.match(line) else "trigger-entry"
+            entries.append((f"{slot}:{indent}", _trigger_signal(trigger)))
+
+    permissions_match = _PERMISSIONS_LINE_RE.match(line)
+    if permissions_match and re.fullmatch(
+        r"['\"]?write-all['\"]?", permissions_match.group("value").strip()
+    ):
+        entries.append(
+            (
+                f"permissions:{indent}",
+                {
+                    "expansion_type": "write_all_permissions",
+                    "value": "permissions: write-all",
+                    "severity": "HIGH",
+                },
+            )
         )
 
-    if line.startswith("permissions:") and "{" in line:
-        inline_writes: list[str] = []
+    if permissions_match and "{" in permissions_match.group("value"):
+        inline_writes: set[str] = set()
         for permission in _INLINE_PERMISSIONS_RE.findall(line):
             if permission in _WRITE_PERMISSIONS:
-                inline_writes.append(permission)
+                inline_writes.add(permission)
 
         for permission in sorted(inline_writes):
-            signals.append(
-                {
-                    "expansion_type": "write_permission",
-                    "value": f"{permission}: write",
-                    "severity": "HIGH",
-                }
+            entries.append(
+                (
+                    f"permissions:{indent}",
+                    {
+                        "expansion_type": "write_permission",
+                        "value": f"{permission}: write",
+                        "severity": "HIGH",
+                    },
+                )
             )
 
     match = _PERMISSION_WRITE_RE.match(line)
     if match and match.group("permission") in _WRITE_PERMISSIONS:
         permission = match.group("permission")
-        signals.append(
-            {
-                "expansion_type": "write_permission",
-                "value": f"{permission}: write",
-                "severity": "HIGH",
-            }
+        entries.append(
+            (
+                f"permission-entry:{indent}",
+                {
+                    "expansion_type": "write_permission",
+                    "value": f"{permission}: write",
+                    "severity": "HIGH",
+                },
+            )
         )
 
-    return signals
+    return entries
 
 
 def _line_adds_trigger(line: str, trigger: str) -> bool:
+    line = _normalize_yaml_line(line)
     if trigger not in line:
         return False
 
-    trigger_pattern = (
-        rf"(?:^|[\s\[,{{:-]){re.escape(trigger)}(?:\s*:|[\s\],}}]|$)"
+    on_match = _ON_LINE_RE.match(line)
+    if on_match:
+        trigger_pattern = (
+            rf"(?<![A-Za-z0-9_-])['\"]?{re.escape(trigger)}['\"]?"
+            rf"(?![A-Za-z0-9_-])"
+        )
+        return re.search(trigger_pattern, on_match.group("value")) is not None
+
+    trigger_entry_pattern = (
+        rf"^(?:-\s*)?['\"]?{re.escape(trigger)}['\"]?"
+        rf"\s*(?::.*|,?)$"
     )
-    match = re.search(trigger_pattern, line)
-    return match is not None
+    return re.match(trigger_entry_pattern, line) is not None
 
 
 def _make_finding(

--- a/test/test_ai_pr_diff_rules.py
+++ b/test/test_ai_pr_diff_rules.py
@@ -85,6 +85,364 @@ def test_reports_only_new_inline_write_permission_on_changed_line():
     assert [f["metadata"]["added_value"] for f in findings] == ["issues: write"]
 
 
+@pytest.mark.parametrize(
+    ("removed", "added"),
+    [
+        (
+            "on: [workflow_run, pull_request_target]",
+            "on: [pull_request_target, workflow_run]",
+        ),
+        (
+            "permissions: {issues: write, contents: write}",
+            "permissions: {contents: write, issues: write}",
+        ),
+    ],
+)
+def test_ci_permission_expansion_ignores_reordering(removed, added):
+    findings = detect_ci_permission_expansion(
+        _make_diff([removed], [added]),
+        ".github/workflows/ci.yml",
+    )
+
+    assert findings == []
+
+
+def test_adjacent_root_replacements_report_only_new_signals():
+    diff = _make_diff(
+        [
+            "on: [pull_request_target]",
+            "permissions: {contents: write}",
+        ],
+        [
+            "on: [pull_request_target, workflow_run]",
+            "permissions: {contents: write, issues: write}",
+        ],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == [
+        "workflow_run",
+        "issues: write",
+    ]
+
+
+def test_moving_root_permission_does_not_repeat_finding():
+    diff = "\n".join(
+        [
+            "--- a/file",
+            "+++ b/file",
+            "@@ -1,3 +1,3 @@",
+            "-permissions: write-all",
+            " name: CI",
+            "+permissions: write-all",
+            " on: push",
+        ]
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert findings == []
+
+
+@pytest.mark.parametrize(
+    ("removed", "added", "expected"),
+    [
+        (
+            "permissions: {contents: write, contents: read}",
+            "permissions: {contents: write}",
+            ["contents: write"],
+        ),
+        (
+            "{on: workflow_run, on: push}",
+            "on: workflow_run",
+            ["workflow_run"],
+        ),
+        (
+            "{on: workflow_run, true: push}",
+            "on: workflow_run",
+            ["workflow_run"],
+        ),
+        (
+            "permissions: !unsupported write-all",
+            "permissions: write-all",
+            ["permissions: write-all"],
+        ),
+        (
+            "on: !!bool workflow_run",
+            "on: workflow_run",
+            ["workflow_run"],
+        ),
+        (
+            "!!bool on: workflow_run",
+            "on: workflow_run",
+            ["workflow_run"],
+        ),
+        (
+            "permissions: {contents: !!bool write}",
+            "permissions: {contents: write}",
+            ["contents: write"],
+        ),
+        (
+            "permissions: !!python/object:os.system write-all",
+            "permissions: write-all",
+            ["permissions: write-all"],
+        ),
+        (
+            "on: !!null workflow_run",
+            "on: workflow_run",
+            ["workflow_run"],
+        ),
+        (
+            "permissions: {contents: !!null write}",
+            "permissions: {contents: write}",
+            ["contents: write"],
+        ),
+        (
+            "permissions: {!!binary contents: write}",
+            "permissions: {contents: write}",
+            ["contents: write"],
+        ),
+        (
+            "on: !!set {workflow_run: null}",
+            "on: workflow_run",
+            ["workflow_run"],
+        ),
+        (
+            "on: &recursive [workflow_run, *recursive]",
+            "on: workflow_run",
+            ["workflow_run"],
+        ),
+    ],
+)
+def test_ambiguous_removed_yaml_cannot_suppress_finding(removed, added, expected):
+    findings = detect_ci_permission_expansion(
+        _make_diff([removed], [added]),
+        ".github/workflows/ci.yml",
+    )
+
+    assert [f["metadata"]["added_value"] for f in findings] == expected
+
+
+@pytest.mark.parametrize(
+    ("added", "expected"),
+    [
+        (
+            "on: workflow_run # pull_request_target is disabled",
+            ["workflow_run"],
+        ),
+        (
+            "permissions: {issues: write} # contents: write is disabled",
+            ["issues: write"],
+        ),
+    ],
+)
+def test_ci_permission_expansion_ignores_signals_in_comments(added, expected):
+    findings = detect_ci_permission_expansion(
+        _make_diff([], [added]),
+        ".github/workflows/ci.yml",
+    )
+
+    assert [f["metadata"]["added_value"] for f in findings] == expected
+
+
+def test_added_comment_does_not_break_replacement_matching():
+    diff = _make_diff(
+        ["on: [pull_request_target]"],
+        [
+            "on: [pull_request_target, workflow_run]",
+            "# workflow_run requires review",
+        ],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == ["workflow_run"]
+
+
+def test_comment_only_change_does_not_repeat_permission_finding():
+    diff = _make_diff(
+        ["  contents: write # old explanation"],
+        ["  contents: write # clearer explanation"],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert findings == []
+
+
+def test_unrelated_removed_text_does_not_cancel_real_trigger():
+    diff = _make_diff(
+        ["name: workflow_run migration"],
+        ["on: workflow_run"],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == ["workflow_run"]
+
+
+def test_permission_removed_from_one_job_does_not_cancel_addition_to_another():
+    diff = "\n".join(
+        [
+            "--- a/file",
+            "+++ b/file",
+            "@@ -1,5 +1,5 @@",
+            " jobs:",
+            "   build:",
+            "-    permissions: {contents: write}",
+            "+    permissions: {contents: read}",
+            "   release:",
+            "-    permissions: {contents: read}",
+            "+    permissions: {contents: write}",
+        ]
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [(f["line"], f["metadata"]["added_value"]) for f in findings] == [
+        (5, "contents: write")
+    ]
+
+
+def test_ci_permission_expansion_supports_quoted_flow_values():
+    diff = _make_diff(
+        [],
+        [
+            'on: ["workflow_run", "pull_request_target"]',
+            'permissions: {"issues": "write", "contents": "write"}',
+        ],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == [
+        "pull_request_target",
+        "workflow_run",
+        "contents: write",
+        "issues: write",
+    ]
+
+
+def test_ci_permission_expansion_supports_multiline_flow_values():
+    diff = _make_diff(
+        [],
+        [
+            "on: [",
+            "  pull_request_target,",
+            "  workflow_run",
+            "]",
+            "permissions: {",
+            "  contents: write,",
+            "  issues: write",
+            "}",
+        ],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [(f["line"], f["metadata"]["added_value"]) for f in findings] == [
+        (2, "pull_request_target"),
+        (3, "workflow_run"),
+        (6, "contents: write"),
+        (7, "issues: write"),
+    ]
+
+
+def test_ci_permission_expansion_handles_split_single_permission_flow_map():
+    diff = _make_diff(
+        [],
+        [
+            "permissions: {contents: write",
+            "}",
+        ],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == ["contents: write"]
+
+
+@pytest.mark.parametrize(
+    "added",
+    [
+        "name: workflow_run migration",
+        "run: echo pull_request_target",
+        "true: workflow_run",
+        "yes: pull_request_target",
+        "1: workflow_run",
+        "ON: pull_request_target",
+    ],
+)
+def test_ci_permission_expansion_ignores_triggers_outside_on(added):
+    findings = detect_ci_permission_expansion(
+        _make_diff([], [added]),
+        ".github/workflows/ci.yml",
+    )
+
+    assert findings == []
+
+
+def test_line_number_shift_does_not_break_one_line_replacement_matching():
+    diff = "\n".join(
+        [
+            "--- a/file",
+            "+++ b/file",
+            "@@ -1,2 +1,3 @@",
+            "+name: CI",
+            " jobs: {}",
+            "-on: [pull_request_target]",
+            "+on: [pull_request_target, workflow_run]",
+        ]
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == ["workflow_run"]
+
+
+def test_no_newline_marker_does_not_shift_finding_line():
+    diff = "\n".join(
+        [
+            "--- a/file",
+            "+++ b/file",
+            "@@ -1 +1 @@",
+            "-on: pull_request",
+            "\\ No newline at end of file",
+            "+on: [pull_request, workflow_run]",
+            "\\ No newline at end of file",
+        ]
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [(f["line"], f["metadata"]["added_value"]) for f in findings] == [
+        (1, "workflow_run")
+    ]
+
+
+def test_same_permission_added_to_two_jobs_reports_both_locations():
+    diff = _make_diff(
+        [],
+        [
+            "jobs:",
+            "  build:",
+            "    permissions:",
+            "      contents: write",
+            "  release:",
+            "    permissions:",
+            "      contents: write",
+        ],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [(f["line"], f["metadata"]["added_value"]) for f in findings] == [
+        (4, "contents: write"),
+        (7, "contents: write"),
+    ]
+
+
 def test_ci_permission_expansion_ignores_line_moves():
     diff = _make_diff(["permissions: write-all"], ["permissions: write-all"])
 
@@ -160,7 +518,9 @@ def test_analyzer_reports_diff_backed_ai_pr_rules(tmp_path):
     )
 
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
     subprocess.run(["git", "add", "."], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-qm", "initial"], cwd=repo, check=True)
@@ -196,10 +556,7 @@ def test_analyzer_reports_diff_backed_ai_pr_rules(tmp_path):
             changed_files={str(workflow), str(cli_file)},
         )
     )
-    rule_ids = {
-        finding.get("rule_id")
-        for finding in result.get("ai_defects", [])
-    }
+    rule_ids = {finding.get("rule_id") for finding in result.get("ai_defects", [])}
 
     assert "SKY-A103" in rule_ids
     assert "SKY-A104" in rule_ids

--- a/test/test_ai_pr_diff_rules.py
+++ b/test/test_ai_pr_diff_rules.py
@@ -46,11 +46,10 @@ def test_detects_all_privileged_triggers_on_same_line():
 
     findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
 
-    assert len(findings) == 2
-    assert {f["metadata"]["added_value"] for f in findings} == {
+    assert [f["metadata"]["added_value"] for f in findings] == [
         "pull_request_target",
         "workflow_run",
-    }
+    ]
 
 
 def test_reports_all_inline_write_permissions():
@@ -58,11 +57,32 @@ def test_reports_all_inline_write_permissions():
 
     findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
 
-    assert len(findings) == 2
-    assert {f["metadata"]["added_value"] for f in findings} == {
+    assert [f["metadata"]["added_value"] for f in findings] == [
         "contents: write",
         "issues: write",
-    }
+    ]
+
+
+def test_reports_only_new_privileged_trigger_on_changed_line():
+    diff = _make_diff(
+        ["on: [pull_request_target]"],
+        ["on: [pull_request_target, workflow_run]"],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == ["workflow_run"]
+
+
+def test_reports_only_new_inline_write_permission_on_changed_line():
+    diff = _make_diff(
+        ["permissions: {contents: write}"],
+        ["permissions: {contents: write, issues: write}"],
+    )
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert [f["metadata"]["added_value"] for f in findings] == ["issues: write"]
 
 
 def test_ci_permission_expansion_ignores_line_moves():

--- a/test/test_ai_pr_diff_rules.py
+++ b/test/test_ai_pr_diff_rules.py
@@ -40,6 +40,31 @@ def test_detects_github_actions_privileged_trigger_added():
     assert findings[0]["metadata"]["added_value"] == "pull_request_target"
 
 
+def test_detects_all_privileged_triggers_on_same_line():
+    # #774: both triggers on one line must BOTH be reported, deterministically.
+    diff = _make_diff([], ["on: [pull_request_target, workflow_run]"])
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert len(findings) == 2
+    assert {f["metadata"]["added_value"] for f in findings} == {
+        "pull_request_target",
+        "workflow_run",
+    }
+
+
+def test_reports_all_inline_write_permissions():
+    diff = _make_diff([], ["permissions: {contents: write, issues: write}"])
+
+    findings = detect_ci_permission_expansion(diff, ".github/workflows/ci.yml")
+
+    assert len(findings) == 2
+    assert {f["metadata"]["added_value"] for f in findings} == {
+        "contents: write",
+        "issues: write",
+    }
+
+
 def test_ci_permission_expansion_ignores_line_moves():
     diff = _make_diff(["permissions: write-all"], ["permissions: write-all"])
 


### PR DESCRIPTION
Fix #774.

# Summary 

This includes the core fix from #781 and adds coverage for the edge cases found during review.

  - reports every privileged trigger and write permission on a line
  - reports only genuinely new privileges on modified lines
  - prevents removals in another job from hiding new privileges
  - handles comments, quoting, multiline YAML, duplicate keys, unusual YAML tags, and cyclic aliases safely

  Tests:

pytest test/test_ai_pr_diff_rules.py test/test_verify_change.py test/test_evidence_contract.py test/test_cli.py