### PR TITLE
fix(analyzer): preserve scan context in Git hooks

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -58,6 +58,7 @@ from skylos.core.file_discovery import (
     find_git_root,
     should_exclude_path,
 )
+from skylos.core.git_context import GitContext
 from skylos.core.safe_cache_io import read_project_text_no_symlink
 from skylos.core.linter import LinterVisitor
 from skylos.deadcode.signature_contracts import mark_signature_contract_parameters
@@ -283,6 +284,25 @@ def _relative_changed_file(root, changed_file):
         return str(changed_path.resolve().relative_to(root))
     except ValueError:
         return str(changed_path)
+
+
+def _scoped_changed_paths(root, scan_paths, changed_files):
+    """Keep changed paths inside the requested files/directories, even if deleted."""
+    targets = scan_paths if isinstance(scan_paths, (list, tuple)) else [scan_paths]
+    targets = [Path(target).resolve() for target in targets]
+    selected = set()
+    for changed_file in changed_files or ():
+        candidate = Path(changed_file)
+        candidate = (
+            candidate if candidate.is_absolute() else Path(root) / candidate
+        ).resolve()
+        for target in targets:
+            if candidate == target or (
+                target.is_dir() and candidate.is_relative_to(target)
+            ):
+                selected.add(candidate)
+                break
+    return selected
 
 
 def _diff_result_has_text(diff_result):
@@ -1108,8 +1128,7 @@ def _changed_definition_keys(
 
     root = Path(project_root)
     changed_paths = {
-        _canonical_analysis_path(changed_file, root)
-        for changed_file in changed_files
+        _canonical_analysis_path(changed_file, root) for changed_file in changed_files
     }
     return frozenset(
         key
@@ -3533,95 +3552,106 @@ class Skylos:
                     }
                 )
 
+        git_context = GitContext.from_path(root)
         if changed_files is None and (
             enable_quality or enable_danger or enable_ai_defects
         ):
             try:
-                import subprocess
-
-                diff_result = subprocess.run(
-                    ["git", "diff", "--name-only", "HEAD"],
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                    cwd=str(root),
-                )
-                if diff_result.returncode == 0 and diff_result.stdout.strip():
-                    changed_files = set()
-                    for line in diff_result.stdout.strip().splitlines():
-                        full_path = str((root / line).resolve())
-                        changed_files.add(full_path)
-                staged_result = subprocess.run(
-                    ["git", "diff", "--name-only", "--cached"],
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                    cwd=str(root),
-                )
-                if staged_result.returncode == 0 and staged_result.stdout.strip():
-                    if changed_files is None:
-                        changed_files = set()
-                    for line in staged_result.stdout.strip().splitlines():
-                        full_path = str((root / line).resolve())
-                        changed_files.add(full_path)
+                detected_changes = set()
+                for revision in ("HEAD", "--cached"):
+                    diff_result = git_context.run(
+                        "diff", "--name-only", "--no-relative", "-z", revision
+                    )
+                    if diff_result.returncode == 0:
+                        detected_changes.update(
+                            str((git_context.root / name).resolve())
+                            for name in diff_result.stdout.split("\0")
+                            if name
+                        )
+                if detected_changes:
+                    changed_files = {
+                        str(candidate)
+                        for candidate in _scoped_changed_paths(
+                            root, path, detected_changes
+                        )
+                    }
             except Exception:
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error("Auto-detect git changes failed", exc_info=True)
 
-        if changed_files and enable_quality and "SKY-L021" not in project_ignore:
+        # CLI callers already resolved config/default excludes and --include.
+        # Direct API callers without an effective list still need config excludes.
+        regression_excludes = (
+            exclude_folders
+            if exclude_folders is not None
+            else (project_cfg.get("exclude") or [])
+        )
+        scoped_changes = {
+            candidate
+            for candidate in _scoped_changed_paths(root, path, changed_files)
+            if not should_exclude_path(candidate, project_root, regression_excludes)
+        }
+        # Generic control-removal heuristics only apply to surviving source
+        # files. Explicit contracts can also describe deleted source files.
+        source_regression_files = (
+            scoped_changes.intersection(Path(file).resolve() for file in files)
+            if enable_quality and scoped_changes
+            else set()
+        )
+        if (
+            source_regression_files
+            and enable_quality
+            and "SKY-L021" not in project_ignore
+        ):
             from skylos.rules.quality.regression import detect_security_regressions
             from skylos.security.contracts import resolve_diff_base_ref
 
             try:
-                import subprocess
-
                 diff_base = resolve_diff_base_ref(root)
 
-                for cf in changed_files:
-                    rel_cf = (
-                        str(Path(cf).resolve().relative_to(root))
-                        if Path(cf).is_absolute()
-                        else str(cf)
-                    )
+                for cf in sorted(source_regression_files):
+                    rel_cf = git_context.relative_path(cf)
+                    if rel_cf is None:
+                        continue
                     diff_cmd = (
-                        ["git", "diff", f"{diff_base}...HEAD", "--", rel_cf]
+                        ["diff", f"{diff_base}...HEAD"]
                         if diff_base
-                        else ["git", "diff", "HEAD", "--", rel_cf]
+                        else ["diff", "HEAD"]
                     )
-                    diff_result = subprocess.run(
-                        diff_cmd,
-                        capture_output=True,
-                        text=True,
-                        timeout=10,
-                        cwd=str(root),
-                    )
+                    diff_options = [
+                        "--no-relative",
+                        "--no-ext-diff",
+                        "--no-textconv",
+                        "--",
+                        f":(literal){rel_cf}",
+                    ]
+                    diff_result = git_context.run(*diff_cmd, *diff_options)
                     if diff_result.returncode != 0 and diff_base:
-                        diff_result = subprocess.run(
-                            ["git", "diff", "HEAD", "--", rel_cf],
-                            capture_output=True,
-                            text=True,
-                            timeout=10,
-                            cwd=str(root),
-                        )
+                        diff_result = git_context.run("diff", "HEAD", *diff_options)
                     if diff_result.returncode == 0 and diff_result.stdout.strip():
                         reg_findings = detect_security_regressions(
                             diff_result.stdout,
-                            cf,
+                            str(cf),
                         )
                         all_quality.extend(reg_findings)
             except Exception:
                 if os.getenv("SKYLOS_DEBUG"):
                     logger.error("Security regression scan failed", exc_info=True)
 
-        if changed_files and enable_danger and "SKY-SC001" not in project_ignore:
+        contract_regression_files = {str(candidate) for candidate in scoped_changes}
+        if (
+            contract_regression_files
+            and enable_danger
+            and "SKY-SC001" not in project_ignore
+        ):
             from skylos.security.contracts import detect_security_contract_regressions
 
             try:
                 all_dangers.extend(
                     detect_security_contract_regressions(
-                        root,
+                        project_root,
                         project_cfg,
-                        changed_files=changed_files,
+                        changed_files=contract_regression_files,
                     )
                 )
             except Exception:

--- a/skylos/core/git_context.py
+++ b/skylos/core/git_context.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from skylos.core.file_discovery import find_git_root
+
+
+_REPOSITORY_ENV = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_INTERNAL_SUPER_PREFIX",
+)
+
+
+def _absolute_env_path(value: str, cwd: Path) -> Path:
+    path = Path(value)
+    return (path if path.is_absolute() else cwd / path).resolve()
+
+
+def _git_paths(root: Path, env: dict[str, str]) -> tuple[Path, Path] | None:
+    """Ask Git how this invocation resolves its repository and index."""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "rev-parse",
+                "--path-format=absolute",
+                "--absolute-git-dir",
+                "--git-path",
+                "index",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(root),
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    lines = result.stdout.splitlines()
+    if result.returncode != 0 or len(lines) != 2:
+        return None
+    return tuple(_absolute_env_path(line, root) for line in lines)
+
+
+@dataclass(frozen=True)
+class GitContext:
+    """Git reads anchored to the requested worktree, including inside hooks."""
+
+    root: Path
+    env: dict[str, str]
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> GitContext:
+        original_cwd = Path.cwd()
+        inherited = dict(os.environ)
+        target = Path(path).resolve()
+        start = target.parent if target.is_file() else target
+        root = find_git_root(start)
+        explicit_git_dir = None
+
+        # Separate Git directories normally have a .git file. Also support an
+        # explicitly declared worktree with no marker, but never guess its root
+        # from GIT_DIR alone: in a hook Git can mistake a subdirectory for it.
+        if root is None and inherited.get("GIT_WORK_TREE") and inherited.get("GIT_DIR"):
+            worktree = _absolute_env_path(inherited["GIT_WORK_TREE"], original_cwd)
+            if worktree.is_dir() and start.is_relative_to(worktree):
+                root = worktree
+                explicit_git_dir = _absolute_env_path(
+                    inherited["GIT_DIR"], original_cwd
+                )
+
+        env = dict(inherited)
+        for key in (*_REPOSITORY_ENV, "GIT_INDEX_FILE"):
+            env.pop(key, None)
+        if root is not None:
+            env["GIT_WORK_TREE"] = str(root)
+        if explicit_git_dir is not None:
+            env["GIT_DIR"] = str(explicit_git_dir)
+            if inherited.get("GIT_COMMON_DIR"):
+                env["GIT_COMMON_DIR"] = str(
+                    _absolute_env_path(inherited["GIT_COMMON_DIR"], original_cwd)
+                )
+
+        root = root or start
+        if inherited.get("GIT_INDEX_FILE"):
+            original_paths = _git_paths(original_cwd, inherited)
+            target_paths = _git_paths(root, env)
+            if original_paths and target_paths and original_paths[0] == target_paths[0]:
+                # Relative index paths follow Git's setup semantics, which
+                # differ between repository discovery and an explicit GIT_DIR.
+                env["GIT_INDEX_FILE"] = str(original_paths[1])
+        return cls(root=root, env=env)
+
+    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(self.root),
+            env=self.env,
+        )
+
+    def relative_path(self, path: str | Path) -> str | None:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self.root / candidate
+        try:
+            return candidate.resolve().relative_to(self.root).as_posix()
+        except (OSError, ValueError):
+            return None

--- a/skylos/security/contracts.py
+++ b/skylos/security/contracts.py
@@ -6,6 +6,8 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from skylos.core.git_context import GitContext
+
 RULE_ID = "SKY-SC001"
 _VALID_SEVERITIES = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
 _FASTAPI_ROUTE_DECORATORS = {
@@ -130,7 +132,7 @@ def detect_security_contract_regressions(
     findings: list[dict] = []
 
     for contract in contracts:
-        if changed_relpaths and contract.file_path not in changed_relpaths:
+        if changed_files is not None and contract.file_path not in changed_relpaths:
             continue
 
         before_source = _read_file_at_ref(root, diff_base or "HEAD", contract.file_path)
@@ -214,11 +216,17 @@ def _read_file_at_ref(
 ) -> str | None:
     if not ref:
         return None
+    context = GitContext.from_path(project_root)
+    repo_path = context.relative_path(Path(project_root).resolve() / relpath)
+    if repo_path is None:
+        return None
     result = subprocess.run(
-        ["git", "show", f"{ref}:{relpath}"],
+        ["git", "show", f"{ref}:{repo_path}"],
         capture_output=True,
         text=True,
-        cwd=str(project_root),
+        cwd=str(context.root),
+        env=context.env,
+        timeout=10,
     )
     if result.returncode == 0:
         return result.stdout
@@ -226,11 +234,14 @@ def _read_file_at_ref(
 
 
 def _git_ref_exists(project_root: str | os.PathLike[str], ref: str) -> bool:
+    context = GitContext.from_path(project_root)
     result = subprocess.run(
         ["git", "rev-parse", "--verify", ref],
         capture_output=True,
         text=True,
-        cwd=str(project_root),
+        cwd=str(context.root),
+        env=context.env,
+        timeout=10,
     )
     return result.returncode == 0
 

--- a/test/test_git_context.py
+++ b/test/test_git_context.py
@@ -1,0 +1,169 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from skylos.core.git_context import GitContext
+
+
+_CONTEXT_ENV = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_INTERNAL_SUPER_PREFIX",
+    "GIT_INDEX_FILE",
+)
+
+
+def _git(root, *args):
+    env = dict(os.environ)
+    for key in _CONTEXT_ENV:
+        env.pop(key, None)
+    return subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", *args],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    for key in _CONTEXT_ENV:
+        monkeypatch.delenv(key, raising=False)
+    root = tmp_path / "working repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    package = root / "package"
+    package.mkdir()
+    (package / "tracked.py").write_text("value = 1\n", encoding="utf-8")
+    _git(root, "add", "package/tracked.py")
+    _git(
+        root,
+        "-c",
+        "user.name=Skylos Test",
+        "-c",
+        "user.email=skylos-test@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-qm",
+        "fixture",
+    )
+    monkeypatch.chdir(root)
+    return root
+
+
+@pytest.mark.parametrize("relative_selector", [False, True])
+@pytest.mark.parametrize("single_file", [False, True])
+def test_hook_context_keeps_worktree_root(
+    repo, monkeypatch, relative_selector, single_file
+):
+    selector = ".git" if relative_selector else str(repo / ".git")
+    monkeypatch.setenv("GIT_DIR", selector)
+    target = repo / "package"
+    if single_file:
+        target /= "tracked.py"
+
+    context = GitContext.from_path(target)
+
+    assert context.root == repo
+    assert context.run("rev-parse", "--show-toplevel").stdout.strip() == str(repo)
+    assert context.run("diff", "--name-only", "HEAD").stdout == ""
+    assert os.environ["GIT_DIR"] == selector
+
+
+def test_real_modification_survives_hook_context(repo, monkeypatch):
+    monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
+    source = repo / "package" / "tracked.py"
+    source.write_text("value = 2\n", encoding="utf-8")
+
+    result = GitContext.from_path(source).run("diff", "--name-only", "-z", "HEAD")
+
+    assert result.returncode == 0
+    assert result.stdout == "package/tracked.py\0"
+
+
+def test_relative_alternate_index_follows_original_git_context(repo, monkeypatch):
+    alternate = repo / ".git" / "alternate index"
+    alternate.write_bytes((repo / ".git" / "index").read_bytes())
+    monkeypatch.chdir(repo / "package")
+    monkeypatch.setenv("GIT_INDEX_FILE", ".git/alternate index")
+
+    context = GitContext.from_path(repo / "package")
+
+    assert context.env["GIT_INDEX_FILE"] == str(alternate)
+    assert context.run("ls-files", "-z").stdout == "package/tracked.py\0"
+
+
+def test_relative_alternate_index_with_explicit_git_dir(repo, monkeypatch):
+    alternate = repo / ".git" / "alternate index"
+    alternate.write_bytes((repo / ".git" / "index").read_bytes())
+    monkeypatch.chdir(repo / "package")
+    monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
+    monkeypatch.setenv("GIT_INDEX_FILE", "../.git/alternate index")
+
+    context = GitContext.from_path(repo / "package")
+
+    assert context.env["GIT_INDEX_FILE"] == str(alternate)
+    assert context.run("ls-files", "-z").stdout == "package/tracked.py\0"
+
+
+def test_linked_worktree_does_not_inherit_other_worktrees_index(repo, monkeypatch):
+    linked = repo.parent / "linked worktree"
+    _git(repo, "worktree", "add", "--detach", str(linked), "HEAD")
+    monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(repo))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(repo / ".git" / "index"))
+
+    context = GitContext.from_path(linked / "package")
+
+    assert (linked / ".git").is_file()
+    assert context.root == linked
+    assert "GIT_INDEX_FILE" not in context.env
+    assert context.run("rev-parse", "--show-toplevel").stdout.strip() == str(linked)
+    assert context.run("diff", "--name-only", "HEAD").stdout == ""
+
+
+def test_markerless_explicit_worktree_with_external_git_dir(repo, monkeypatch):
+    worktree = repo.parent / "external working tree"
+    git_dir = repo.parent / "external metadata"
+    worktree.mkdir()
+    git_dir.mkdir()
+    _git(
+        worktree, "--git-dir", str(git_dir), "--work-tree", str(worktree), "init", "-q"
+    )
+    monkeypatch.setenv("GIT_DIR", str(git_dir))
+    monkeypatch.setenv("GIT_WORK_TREE", str(worktree))
+
+    context = GitContext.from_path(worktree)
+
+    assert not (worktree / ".git").exists()
+    assert context.root == worktree
+    assert context.run("rev-parse", "--show-toplevel").stdout.strip() == str(worktree)
+
+
+def test_nonrepo_fallback_does_not_use_unrelated_git_dir(repo, monkeypatch):
+    target = repo.parent / "not a repo"
+    target.mkdir()
+    monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
+
+    context = GitContext.from_path(target)
+
+    assert context.root == target
+    assert context.run("rev-parse", "--show-toplevel").returncode != 0
+
+
+def test_relative_paths_preserve_names_and_reject_outside_files(repo):
+    context = GitContext.from_path(repo / "package")
+
+    assert context.relative_path(repo / "package" / 'a "quoted" name.py') == (
+        'package/a "quoted" name.py'
+    )
+    assert context.relative_path(repo.parent / "outside.py") is None
+    assert context.relative_path(Path("package") / "tracked.py") == "package/tracked.py"

--- a/test/test_git_context.py
+++ b/test/test_git_context.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from skylos.core.git_context import GitContext
+from skylos.core.safe_cache_io import write_text_no_symlink
 
 
 _CONTEXT_ENV = (
@@ -18,10 +19,12 @@ _CONTEXT_ENV = (
 )
 
 
-def _git(root, *args):
+def _git(root, *args, index_file=None):
     env = dict(os.environ)
     for key in _CONTEXT_ENV:
         env.pop(key, None)
+    if index_file is not None:
+        env["GIT_INDEX_FILE"] = str(index_file)
     return subprocess.run(
         ["git", "-c", "core.hooksPath=/dev/null", *args],
         cwd=root,
@@ -41,7 +44,7 @@ def repo(tmp_path, monkeypatch):
     _git(root, "init", "-q")
     package = root / "package"
     package.mkdir()
-    (package / "tracked.py").write_text("value = 1\n", encoding="utf-8")
+    assert write_text_no_symlink(package / "tracked.py", "value = 1\n")
     _git(root, "add", "package/tracked.py")
     _git(
         root,
@@ -81,7 +84,7 @@ def test_hook_context_keeps_worktree_root(
 def test_real_modification_survives_hook_context(repo, monkeypatch):
     monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
     source = repo / "package" / "tracked.py"
-    source.write_text("value = 2\n", encoding="utf-8")
+    assert write_text_no_symlink(source, "value = 2\n")
 
     result = GitContext.from_path(source).run("diff", "--name-only", "-z", "HEAD")
 
@@ -91,7 +94,7 @@ def test_real_modification_survives_hook_context(repo, monkeypatch):
 
 def test_relative_alternate_index_follows_original_git_context(repo, monkeypatch):
     alternate = repo / ".git" / "alternate index"
-    alternate.write_bytes((repo / ".git" / "index").read_bytes())
+    _git(repo, "read-tree", "HEAD", index_file=alternate)
     monkeypatch.chdir(repo / "package")
     monkeypatch.setenv("GIT_INDEX_FILE", ".git/alternate index")
 
@@ -103,7 +106,7 @@ def test_relative_alternate_index_follows_original_git_context(repo, monkeypatch
 
 def test_relative_alternate_index_with_explicit_git_dir(repo, monkeypatch):
     alternate = repo / ".git" / "alternate index"
-    alternate.write_bytes((repo / ".git" / "index").read_bytes())
+    _git(repo, "read-tree", "HEAD", index_file=alternate)
     monkeypatch.chdir(repo / "package")
     monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
     monkeypatch.setenv("GIT_INDEX_FILE", "../.git/alternate index")

--- a/test/test_git_hook_regressions.py
+++ b/test/test_git_hook_regressions.py
@@ -9,6 +9,7 @@ import pytest
 
 from skylos.analyzer import analyze
 from skylos.constants import parse_exclude_folders
+from skylos.core.safe_cache_io import write_text_no_symlink
 
 
 _ORIGINAL = (
@@ -72,7 +73,7 @@ def _git(repo, *args):
 
 def _write(path, content):
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
+    assert write_text_no_symlink(path, content)
 
 
 def _commit(repo, *paths):

--- a/test/test_git_hook_regressions.py
+++ b/test/test_git_hook_regressions.py
@@ -1,0 +1,349 @@
+"""Git-hook scan context must preserve the analyzer's selected source files."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.constants import parse_exclude_folders
+
+
+_ORIGINAL = (
+    "import html\n\n"
+    "def format_label(value: str) -> str:\n"
+    "    return html.escape(value)\n"
+)
+_EDITED = "def format_label(value: str) -> str:\n    return value.upper()\n"
+_CONFIG = (
+    '[tool.skylos]\nexclude = ["output", "skip_*.py"]\n\n'
+    "[tool.skylos.gate]\nmax_quality = 0\n"
+)
+_CONTRACT_CONFIG = (
+    "\n[[tool.skylos.security_contracts]]\n"
+    'id = "label-dependency"\n'
+    'framework = "fastapi"\n'
+    'file = "routes.py"\n'
+    'handler = "show_label"\n'
+    'guards = ["normalize_label"]\n'
+)
+_CONTRACT_ORIGINAL = (
+    "from fastapi import APIRouter, Depends\n\n"
+    "router = APIRouter()\n\n"
+    "def normalize_label():\n"
+    "    return 'example'\n\n"
+    "@router.get('/label')\n"
+    "def show_label(label=Depends(normalize_label)):\n"
+    "    return {'label': label}\n"
+)
+_CONTRACT_EDITED = (
+    "from fastapi import APIRouter\n\n"
+    "router = APIRouter()\n\n"
+    "@router.get('/label')\n"
+    "def show_label():\n"
+    "    return {'label': 'example'}\n"
+)
+
+
+def _git(repo, *args):
+    git_env = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+    result = subprocess.run(
+        [
+            "git",
+            "-c",
+            f"core.hooksPath={repo / '.disabled-hooks'}",
+            "-c",
+            "commit.gpgsign=false",
+            "-C",
+            str(repo),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=git_env,
+    )
+    return result.stdout.strip()
+
+
+def _write(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _commit(repo, *paths):
+    _git(repo, "add", "--", *paths)
+    _git(repo, "commit", "-qm", "fixture baseline")
+
+
+@pytest.fixture(params=["ordinary", "linked"])
+def git_checkout(tmp_path, request):
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.name", "Skylos Tests")
+    _git(repo, "config", "user.email", "skylos-tests@example.invalid")
+    _write(repo / "pyproject.toml", _CONFIG)
+    _write(repo / "pkg" / "pyproject.toml", _CONFIG)
+    _write(repo / "pkg" / "app.py", _ORIGINAL)
+    _commit(repo, "pyproject.toml", "pkg/pyproject.toml", "pkg/app.py")
+    if request.param == "linked":
+        checkout = tmp_path / "linked"
+        _git(repo, "worktree", "add", "-q", "-b", "scan-checkout", str(checkout))
+        return checkout
+    return repo
+
+
+def _hook_environment(repo, monkeypatch):
+    git_dir = _git(repo, "rev-parse", "--absolute-git-dir")
+    monkeypatch.setenv("GIT_DIR", git_dir)
+    monkeypatch.delenv("GIT_WORK_TREE", raising=False)
+    monkeypatch.setenv("GIT_PREFIX", "")
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    monkeypatch.chdir(repo / "pkg")
+
+
+def _regressions(target, **kwargs):
+    payload = json.loads(
+        analyze(target, enable_quality=True, grep_verify=False, **kwargs)
+    )
+    assert "error" not in payload, payload
+    return [
+        finding
+        for finding in payload.get("quality", [])
+        if finding.get("rule_id") == "SKY-L021"
+    ]
+
+
+def test_clean_subdirectory_scan_in_git_hook_has_no_regressions(
+    git_checkout, monkeypatch
+):
+    repo = git_checkout
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    assert _git(repo, "status", "--porcelain") == ""
+    assert _regressions(str(repo / "pkg")) == []
+
+    _hook_environment(repo, monkeypatch)
+
+    assert _regressions(".") == []
+
+
+@pytest.mark.parametrize("staged", [False, True], ids=["unstaged", "staged"])
+@pytest.mark.parametrize("explicit", [False, True], ids=["automatic", "explicit"])
+def test_git_hook_reports_real_edit_at_its_existing_source_path(
+    git_checkout, monkeypatch, staged, explicit
+):
+    repo = git_checkout
+    app = repo / "pkg" / "app.py"
+    _write(app, _EDITED)
+    if staged:
+        _git(repo, "add", "--", "pkg/app.py")
+    _hook_environment(repo, monkeypatch)
+    options = {"changed_files": {str(app)}} if explicit else {}
+
+    findings = _regressions(".", **options)
+
+    assert findings, "The real tracked edit must still be checked in a hook"
+    assert {Path(finding["file"]).resolve() for finding in findings} == {app.resolve()}
+    assert all(Path(finding["file"]).is_file() for finding in findings)
+    assert any("anitization" in finding["message"] for finding in findings)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["output/format.py", "skip_formatter.py", "debug.log", "README.md"],
+)
+@pytest.mark.parametrize("explicit", [False, True], ids=["automatic", "explicit"])
+def test_git_hook_skips_excluded_and_non_source_changes(
+    git_checkout, monkeypatch, relative_path, explicit
+):
+    repo = git_checkout
+    changed = repo / "pkg" / relative_path
+    _write(changed, _ORIGINAL)
+    _commit(repo, f"pkg/{relative_path}")
+    _write(changed, _EDITED)
+    _hook_environment(repo, monkeypatch)
+    options = {"changed_files": {str(changed)}} if explicit else {}
+
+    assert _regressions(".", **options) == []
+
+
+def test_git_hook_explicit_include_restores_config_excluded_source(
+    git_checkout, monkeypatch
+):
+    repo = git_checkout
+    included = repo / "pkg" / "output" / "format.py"
+    still_excluded = repo / "pkg" / "skip_formatter.py"
+    for path in (included, still_excluded):
+        _write(path, _ORIGINAL)
+    _commit(repo, "pkg/output/format.py", "pkg/skip_formatter.py")
+    for path in (included, still_excluded):
+        _write(path, _EDITED)
+    _hook_environment(repo, monkeypatch)
+    excludes = parse_exclude_folders(
+        include_folders=["output"],
+        config_exclude_folders=["output", "skip_*.py"],
+    )
+
+    findings = _regressions(".", exclude_folders=sorted(excludes))
+
+    assert findings, "An explicit include must restore the real edited source"
+    assert {Path(finding["file"]).resolve() for finding in findings} == {
+        included.resolve()
+    }
+
+
+@pytest.mark.parametrize("scope", ["repo", "directory", "file", "file-list"])
+def test_git_hook_regressions_stay_inside_selected_scan_targets(
+    git_checkout, monkeypatch, scope
+):
+    repo = git_checkout
+    app = repo / "pkg" / "app.py"
+    neighbor = repo / "pkg" / "neighbor.py"
+    outside = repo / "sibling.py"
+    _write(neighbor, _ORIGINAL)
+    _write(outside, _ORIGINAL)
+    _commit(repo, "pkg/neighbor.py", "sibling.py")
+    for path in (app, neighbor, outside):
+        _write(path, _EDITED)
+    _hook_environment(repo, monkeypatch)
+    targets = {
+        "repo": (str(repo), {app, neighbor, outside}),
+        "directory": (str(repo / "pkg"), {app, neighbor}),
+        "file": (str(app), {app}),
+        "file-list": ([str(app), str(outside)], {app, outside}),
+    }
+    target, expected = targets[scope]
+
+    findings = _regressions(target)
+
+    assert {Path(finding["file"]).resolve() for finding in findings} == {
+        path.resolve() for path in expected
+    }
+
+
+@pytest.mark.parametrize("explicit", [False, True], ids=["automatic", "explicit"])
+def test_deleted_source_is_not_a_surviving_control_regression(
+    git_checkout, monkeypatch, explicit
+):
+    repo = git_checkout
+    removed = repo / "pkg" / "app.py"
+    removed.unlink()
+    _write(repo / "pkg" / "remaining.py", "label = 'still here'\n")
+    _hook_environment(repo, monkeypatch)
+    options = {"changed_files": {str(removed)}} if explicit else {}
+
+    assert _regressions(".", **options) == []
+
+
+def _prepare_contract(repo, relative_path="routes.py"):
+    contract_config = _CONTRACT_CONFIG.replace(
+        'file = "routes.py"', f'file = "{relative_path}"'
+    )
+    _write(repo / "pkg" / "pyproject.toml", _CONFIG + contract_config)
+    route = repo / "pkg" / relative_path
+    _write(route, _CONTRACT_ORIGINAL)
+    # A same-named root file must not replace the subproject's committed source.
+    _write(repo / "routes.py", _CONTRACT_EDITED)
+    _commit(repo, "pkg/pyproject.toml", f"pkg/{relative_path}", "routes.py")
+    return route
+
+
+def _contract_regressions(target, **kwargs):
+    payload = json.loads(
+        analyze(target, enable_danger=True, grep_verify=False, **kwargs)
+    )
+    assert "error" not in payload, payload
+    return [
+        finding
+        for finding in payload.get("danger", [])
+        if finding.get("rule_id") == "SKY-SC001"
+    ]
+
+
+@pytest.mark.parametrize("keep_dependency", [True, False], ids=["kept", "removed"])
+def test_git_hook_contract_reads_subproject_base_blob(
+    git_checkout, monkeypatch, keep_dependency
+):
+    repo = git_checkout
+    route = _prepare_contract(repo)
+    current = (
+        _CONTRACT_ORIGINAL.replace("'example'", "'updated'")
+        if keep_dependency
+        else _CONTRACT_EDITED
+    )
+    _write(route, current)
+    _hook_environment(repo, monkeypatch)
+
+    findings = _contract_regressions(".")
+
+    if keep_dependency:
+        assert findings == []
+    else:
+        assert len(findings) == 1
+        assert Path(findings[0]["file"]).resolve() == route.resolve()
+        assert "normalize_label" in findings[0]["message"]
+
+
+def test_git_hook_deleted_contracted_source_still_reports(git_checkout, monkeypatch):
+    repo = git_checkout
+    route = _prepare_contract(repo)
+    route.unlink()
+    _hook_environment(repo, monkeypatch)
+
+    findings = _contract_regressions(".")
+
+    assert len(findings) == 1
+    assert Path(findings[0]["file"]).resolve() == route.resolve()
+    assert "normalize_label" in findings[0]["message"]
+
+
+def test_git_hook_explicit_include_restores_config_excluded_contract(
+    git_checkout, monkeypatch
+):
+    repo = git_checkout
+    route = _prepare_contract(repo, "output/routes.py")
+    _write(route, _CONTRACT_EDITED)
+    _hook_environment(repo, monkeypatch)
+    excludes = parse_exclude_folders(
+        include_folders=["output"],
+        config_exclude_folders=["output", "skip_*.py"],
+    )
+
+    findings = _contract_regressions(".", exclude_folders=sorted(excludes))
+
+    assert len(findings) == 1
+    assert Path(findings[0]["file"]).resolve() == route.resolve()
+    assert "normalize_label" in findings[0]["message"]
+
+
+def test_git_hook_file_target_does_not_evaluate_sibling_contract(
+    git_checkout, monkeypatch
+):
+    repo = git_checkout
+    route = _prepare_contract(repo)
+    _write(route, _CONTRACT_EDITED)
+    _hook_environment(repo, monkeypatch)
+
+    assert _contract_regressions(str(repo / "pkg" / "app.py")) == []
+
+
+def test_contract_empty_changed_selection_does_not_evaluate_all_files(
+    git_checkout, monkeypatch
+):
+    from skylos.config import load_config
+    from skylos.security.contracts import detect_security_contract_regressions
+
+    repo = git_checkout
+    route = _prepare_contract(repo)
+    _write(route, _CONTRACT_EDITED)
+    _hook_environment(repo, monkeypatch)
+    project = repo / "pkg"
+    config = load_config(project)
+    config["security_contracts"][0]["file"] = "pkg/routes.py"
+
+    assert detect_security_contract_regressions(repo, config, changed_files=set()) == []

--- a/test/test_security_contracts.py
+++ b/test/test_security_contracts.py
@@ -1,5 +1,4 @@
 import ast
-from pathlib import Path
 
 from skylos.config import load_config
 from skylos.rules.quality.logic import HardcodedCredentialRule
@@ -136,7 +135,7 @@ exclude = ["app/**"]
         encoding="utf-8",
     )
 
-    def fake_run(cmd, capture_output, text, cwd):
+    def fake_run(cmd, capture_output, text, cwd, **kwargs):
         class Result:
             returncode = 0
             stdout = before_source
@@ -240,7 +239,7 @@ def list_users():
         ]
     }
 
-    def fake_run(cmd, capture_output, text, cwd):
+    def fake_run(cmd, capture_output, text, cwd, **kwargs):
         class Result:
             returncode = 0
             stdout = before_source
@@ -310,7 +309,7 @@ def get_audit_log():
         ]
     }
 
-    def fake_run(cmd, capture_output, text, cwd):
+    def fake_run(cmd, capture_output, text, cwd, **kwargs):
         class Result:
             returncode = 0
             stdout = before_source
@@ -359,7 +358,7 @@ def list_users():
         ]
     }
 
-    def fake_run(cmd, capture_output, text, cwd):
+    def fake_run(cmd, capture_output, text, cwd, **kwargs):
         class Result:
             returncode = 0
             stdout = before_source


### PR DESCRIPTION
Fixes #794

## Summary 

Running Skylos from a package subdir inside a git hook could flag unchanged code as having removed security controls.  Git commands now use the correct worktree root
