### PR TITLE
fix(ai-defect): resolve imported JS barrel exports

### DIFF
--- a/skylos/core/js_api_surface.py
+++ b/skylos/core/js_api_surface.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 from typing import Any
@@ -9,21 +8,22 @@ from skylos.core.api_symbol_truth import (
     SURFACE_KIND_JS_MODULE,
     cache_api_symbol_surface,
 )
-from skylos.core.js_api_surface_exports import collect_js_exports_from_file
-from skylos.core.js_api_surface_members import _add_export_member
+from skylos.core.js_api_surface_exports import (
+    _add_commonjs_default_facade,
+    collect_js_exports_from_file,
+)
 from skylos.core.js_api_surface_utils import (
     EXCLUDED_JS_API_DIRS,
     MAX_JS_API_ENTRYPOINTS_PER_PACKAGE,
-    MAX_JS_API_PACKAGE_JSON_BYTES,
     MAX_JS_API_PACKAGES,
     path_has_excluded_part as _path_has_excluded_part,
+    read_package_json as _read_package_json,
     relative_posix as _relative_posix,
     resolve_entrypoint_target as _resolve_entrypoint_target,
     _safe_source_file,
     safe_name as _safe_name,
     utc_timestamp as _utc_timestamp,
 )
-from skylos.core.safe_cache_io import read_text_no_symlink
 
 
 def build_js_api_surfaces(project_root: str | Path) -> list[dict[str, Any]]:
@@ -183,45 +183,6 @@ def inspect_js_package_api_surface(
         return None, "unresolved_package_condition", True
 
     return None, None, False
-
-
-def _add_commonjs_default_facade(
-    root: Path,
-    entrypoint: Path,
-    members: dict[str, dict[str, Any]],
-) -> None:
-    suffix = entrypoint.suffix.lower()
-    commonjs_by_extension = suffix in {".cjs", ".cts"}
-    commonjs_by_package = suffix == ".js" and _nearest_package_type(
-        root, entrypoint
-    ) == "commonjs"
-    if not commonjs_by_extension and not commonjs_by_package:
-        return
-    _add_export_member(
-        root,
-        members,
-        "default",
-        "commonjs",
-        entrypoint,
-        1,
-        source="commonjs_default_facade",
-    )
-
-
-def _nearest_package_type(root: Path, entrypoint: Path) -> str | None:
-    current = entrypoint.parent
-    while True:
-        package_json = current / "package.json"
-        if package_json.is_file() and not package_json.is_symlink():
-            package_type = _read_package_json(package_json).get("type")
-            return package_type if isinstance(package_type, str) else None
-        if current == root or current.parent == current:
-            return None
-        try:
-            current.relative_to(root)
-        except ValueError:
-            return None
-        current = current.parent
 
 
 def _package_source_subpath(package_name: str, module_source: str) -> str | None:
@@ -389,19 +350,6 @@ def _discover_package_json_files(root: Path) -> list[Path]:
         if len(package_files) >= MAX_JS_API_PACKAGES:
             break
     return package_files
-def _read_package_json(path: Path) -> dict[str, Any]:
-    text = read_text_no_symlink(
-        path,
-        max_bytes=MAX_JS_API_PACKAGE_JSON_BYTES,
-        encoding="utf-8",
-    )
-    if text is None:
-        return {}
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError:
-        return {}
-    return data if isinstance(data, dict) else {}
 def _package_entrypoints(
     root: Path,
     package_dir: Path,

--- a/skylos/core/js_api_surface_exports.py
+++ b/skylos/core/js_api_surface_exports.py
@@ -13,8 +13,10 @@ from skylos.core.js_api_surface_members import (
     _exported_direct_member_pairs,
     _exported_function_signature_names,
     _exported_namespace_names,
+    _locally_exported_names,
     _member_chain,
     _module_scope_exportable_bindings,
+    _module_scope_import_bindings,
     _named_export_clause_pairs,
     _namespace_export_name,
     _node_line,
@@ -25,6 +27,7 @@ from skylos.core.js_api_surface_members import (
 from skylos.core.js_api_surface_utils import (
     MAX_JS_API_REEXPORT_DEPTH,
     MAX_JS_API_SURFACE_SOURCE_BYTES,
+    nearest_package_type as _nearest_package_type,
     resolve_entrypoint_target as _resolve_entrypoint_target,
     safe_name as _safe_name,
 )
@@ -46,6 +49,7 @@ def collect_js_exports_from_file(
         _add_diagnostic(diagnostics, "reexport_depth_limit")
         return
     if file_path in visited:
+        _add_diagnostic(diagnostics, "cyclic_reexport")
         return
     visited.add(file_path)
 
@@ -69,6 +73,13 @@ def collect_js_exports_from_file(
         _add_diagnostic(diagnostics, "parse_error")
         return
     local_bindings = _module_scope_exportable_bindings(source, core.root_node)
+    imported_bindings = _imported_export_bindings(
+        root, file_path, source, core.root_node, visited, depth, diagnostics
+    )
+    for name, kind in imported_bindings.items():
+        # TypeScript permits a type import and a local value to share a name.
+        if kind != "type" or name not in local_bindings:
+            local_bindings[name] = kind
     if _has_conditional_commonjs_export(core, source):
         _add_diagnostic(diagnostics, "conditional_commonjs_export")
 
@@ -102,6 +113,75 @@ def collect_js_exports_from_file(
             )
         elif _expression_may_mutate_commonjs_exports(source, node):
             _add_diagnostic(diagnostics, "dynamic_commonjs_export")
+
+
+def _imported_export_bindings(
+    root: Path,
+    file_path: Path,
+    source: bytes,
+    root_node: Any,
+    visited: set[Path],
+    depth: int,
+    diagnostics: set[str] | None,
+) -> dict[str, str]:
+    # Imports are private unless a local export clause actually names them.
+    exported_locals = _locally_exported_names(source, root_node)
+    if not exported_locals:
+        return {}
+    bindings: dict[str, str] = {}
+    source_members: dict[str, dict[str, dict[str, Any]]] = {}
+    for local_name, (source_literal, imported_name, type_only) in (
+        _module_scope_import_bindings(source, root_node).items()
+    ):
+        if local_name not in exported_locals:
+            continue
+        if source_literal not in source_members:
+            resolved = _resolved_reexport_source(root, file_path, source_literal)
+            if resolved is None:
+                _add_diagnostic(
+                    diagnostics,
+                    "unresolved_local_reexport"
+                    if source_literal.startswith(".")
+                    else "external_reexport",
+                )
+                continue
+            # Resolve a source once, even when a barrel exports many of its bindings.
+            source_members[source_literal] = _reexport_members(
+                root, resolved, visited, depth, diagnostics
+            )
+            _add_commonjs_default_facade(root, resolved, source_members[source_literal])
+        if imported_name == "*":
+            bindings[local_name] = "type" if type_only else "namespace"
+            continue
+        member = source_members[source_literal].get(imported_name)
+        if member is not None:
+            bindings[local_name] = "type" if type_only else member["kind"]
+    return bindings
+
+
+def _add_commonjs_default_facade(
+    root: Path,
+    entrypoint: Path,
+    members: dict[str, dict[str, Any]],
+) -> None:
+    suffix = entrypoint.suffix.lower()
+    commonjs_by_extension = suffix in {".cjs", ".cts"}
+    commonjs_by_package = suffix == ".js" and _nearest_package_type(
+        root, entrypoint
+    ) == "commonjs"
+    if not commonjs_by_extension and not commonjs_by_package:
+        return
+    _add_export_member(
+        root,
+        members,
+        "default",
+        "commonjs",
+        entrypoint,
+        1,
+        source="commonjs_default_facade",
+    )
+
+
 def _collect_export_statement(
     root: Path,
     file_path: Path,

--- a/skylos/core/js_api_surface_members.py
+++ b/skylos/core/js_api_surface_members.py
@@ -245,6 +245,84 @@ def _module_scope_exportable_bindings(source: bytes, root_node: Any | None) -> d
     for child in root_node.named_children:
         _collect_module_scope_bindings(source, child, bindings)
     return bindings
+
+
+def _module_scope_import_bindings(
+    source: bytes, root_node: Any
+) -> dict[str, tuple[str, str, bool]]:
+    """Map local import names to their source, imported name and type-only flag."""
+    bindings: dict[str, tuple[str, str, bool]] = {}
+    for node in root_node.named_children:
+        if node.type != "import_statement":
+            continue
+        source_node = node.child_by_field_name("source")
+        source_literal = (
+            _string_literal_value(source, source_node) if source_node else None
+        )
+        clause = next(
+            (child for child in node.named_children if child.type == "import_clause"),
+            None,
+        )
+        if source_literal is None or clause is None:
+            continue
+        type_only = any(child.type == "type" for child in node.children)
+        for local_name, imported_name, specifier_type_only in _import_clause_bindings(
+            source, clause
+        ):
+            bindings[local_name] = (
+                source_literal,
+                imported_name,
+                type_only or specifier_type_only,
+            )
+    return bindings
+
+
+def _locally_exported_names(source: bytes, root_node: Any) -> set[str]:
+    return {
+        original_name
+        for node in root_node.named_children
+        if node.type == "export_statement"
+        and _export_source_literal(source, node) is None
+        for original_name, _, _ in _named_export_clause_pairs(source, node)
+    }
+
+
+def _import_clause_bindings(source: bytes, clause: Any):
+    for child in clause.named_children:
+        if child.type == "named_imports":
+            yield from _named_import_bindings(source, child)
+            continue
+        if child.type == "identifier":
+            name_node = child
+        elif child.type == "namespace_import":
+            name_node = next(
+                (node for node in child.named_children if node.type == "identifier"),
+                None,
+            )
+        else:
+            continue
+        name = _safe_name(_node_text(source, name_node))
+        if name is not None:
+            yield name, "default" if child.type == "identifier" else "*", False
+
+
+def _named_import_bindings(source: bytes, clause: Any):
+    for specifier in clause.named_children:
+        if specifier.type != "import_specifier":
+            continue
+        name_node = specifier.child_by_field_name("name")
+        alias_node = specifier.child_by_field_name("alias")
+        imported_name = _safe_name(
+            _string_literal_value(source, name_node)
+            if name_node is not None and name_node.type == "string"
+            else _node_text(source, name_node)
+        )
+        local_name = _safe_name(_node_text(source, alias_node or name_node))
+        if imported_name is not None and local_name is not None:
+            type_only = any(child.type == "type" for child in specifier.children)
+            yield local_name, imported_name, type_only
+
+
 def _collect_module_scope_bindings(
     source: bytes,
     node: Any,

--- a/skylos/core/js_api_surface_utils.py
+++ b/skylos/core/js_api_surface_utils.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import Any
 
+from skylos.core.safe_cache_io import read_text_no_symlink
 
 MAX_JS_API_PACKAGE_JSON_BYTES = 1_000_000
 MAX_JS_API_SURFACE_SOURCE_BYTES = 1_000_000
@@ -39,6 +41,37 @@ EXCLUDED_JS_API_DIRS = {
     "vendor",
     "__pycache__",
 }
+
+
+def read_package_json(path: Path) -> dict[str, Any]:
+    text = read_text_no_symlink(
+        path,
+        max_bytes=MAX_JS_API_PACKAGE_JSON_BYTES,
+        encoding="utf-8",
+    )
+    if text is None:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def nearest_package_type(root: Path, entrypoint: Path) -> str | None:
+    current = entrypoint.parent
+    while True:
+        package_json = current / "package.json"
+        if package_json.is_file() and not package_json.is_symlink():
+            package_type = read_package_json(package_json).get("type")
+            return package_type if isinstance(package_type, str) else None
+        if current == root or current.parent == current:
+            return None
+        try:
+            current.relative_to(root)
+        except ValueError:
+            return None
+        current = current.parent
 
 
 def resolve_entrypoint_target(root: Path, package_dir: Path, target: str) -> Path | None:

--- a/test/test_js_barrel_exports.py
+++ b/test/test_js_barrel_exports.py
@@ -1,0 +1,539 @@
+"""Static regression coverage for imports re-exported by local clauses."""
+
+from pathlib import Path
+
+import pytest
+
+from skylos.core import js_api_surface_exports
+from skylos.core.js_api_surface import inspect_js_file_api_surface
+from skylos.rules.ai_defect.js_api_hallucination import (
+    JS_SOURCE_SUFFIXES,
+    scan_js_local_api_hallucinations,
+)
+from skylos.visitors.languages.typescript.core import TypeScriptCore
+from skylos.visitors.languages.typescript.resolve import MonorepoResolver
+
+
+def _create_sources(repo: Path, sources: dict[str, str]):
+    for filename, source in sources.items():
+        path = repo / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("x", encoding="utf-8") as stream:
+            stream.write(source)
+
+
+def _scan(repo: Path):
+    files = sorted(
+        path for path in repo.rglob("*") if path.suffix in JS_SOURCE_SUFFIXES
+    )
+    raw_imports = {}
+    for path in files:
+        core = TypeScriptCore(str(path), path.read_bytes())
+        core.scan()
+        if core.raw_imports:
+            raw_imports[path] = core.raw_imports
+    return scan_js_local_api_hallucinations(
+        repo,
+        files,
+        raw_imports,
+        monorepo_resolver=MonorepoResolver(str(repo)),
+    )
+
+
+@pytest.mark.parametrize("suffix", [".ts", ".js"])
+def test_import_then_local_export_has_complete_surface(tmp_path, suffix):
+    _create_sources(
+        tmp_path,
+        {
+            f"mod{suffix}": "export function foo() { return 'label'; }\n",
+            f"index{suffix}": 'import { foo } from "./mod";\nexport { foo };\n',
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, f"index{suffix}")
+
+    assert surface is not None
+    assert surface["metadata"]["complete"] is True
+    assert surface["exports"] == ["foo"]
+    assert surface["members"]["foo"]["kind"] == "function"
+
+
+@pytest.mark.parametrize("suffix", [".ts", ".js"])
+def test_downstream_import_from_local_barrel_is_not_phantom(tmp_path, suffix):
+    _create_sources(
+        tmp_path,
+        {
+            f"mod{suffix}": "export function foo() { return 'label'; }\n",
+            f"index{suffix}": 'import { foo } from "./mod";\nexport { foo };\n',
+            f"app{suffix}": 'import { foo } from "./index";\nfoo();\n',
+        },
+    )
+
+    findings, coverage = _scan(tmp_path)
+
+    assert findings == []
+    assert coverage["status"] == "completed"
+    assert coverage["outcome"] == "pass"
+    assert coverage["finding_count"] == 0
+    assert coverage["verified_references"] == 2
+    assert coverage["skipped_references"] == 0
+
+
+@pytest.mark.parametrize(
+    ("suffix", "barrel", "kinds"),
+    [
+        pytest.param(
+            ".ts",
+            'import {\n  foo as first,\n  foo as second,\n} from "./mod";\n'
+            "export {\n  first as published,\n  second as alternate,\n};\n",
+            {"alternate": "function", "published": "function"},
+            id="ts-multiline-import-and-export-aliases",
+        ),
+        pytest.param(
+            ".js",
+            'import {\n  foo as first,\n  foo as second,\n} from "./mod";\n'
+            "export {\n  first as published,\n  second as alternate,\n};\n",
+            {"alternate": "function", "published": "function"},
+            id="js-multiline-import-and-export-aliases",
+        ),
+        pytest.param(
+            ".ts",
+            'export { foo };\nimport { foo } from "./mod";\n',
+            {"foo": "function"},
+            id="export-before-import",
+        ),
+        pytest.param(
+            ".ts",
+            'import { "foo" as local } from "./mod";\nexport { local as foo };\n',
+            {"foo": "function"},
+            id="quoted-imported-name",
+        ),
+        pytest.param(
+            ".ts",
+            'import makeLabel from "./mod";\nexport { makeLabel as labelFactory };\n',
+            {"labelFactory": "function"},
+            id="default-import-renamed-named-export",
+        ),
+        pytest.param(
+            ".ts",
+            'import { default as makeLabel } from "./mod";\n'
+            "export { makeLabel as default };\n",
+            {"default": "function"},
+            id="named-default-import-exported-as-default",
+        ),
+        pytest.param(
+            ".js",
+            'import * as localLabels from "./mod";\n'
+            "export { localLabels as labels };\n",
+            {"labels": "namespace"},
+            id="namespace-import-not-flattened",
+        ),
+        pytest.param(
+            ".ts",
+            'import type { Widget } from "./mod";\n'
+            'import { Label } from "./mod";\n'
+            "export { Widget, Label };\n",
+            {"Label": "type", "Widget": "type"},
+            id="type-only-import-and-upstream-interface",
+        ),
+        pytest.param(
+            ".ts",
+            'import { type Widget, foo } from "./mod";\nexport { Widget, foo };\n',
+            {"Widget": "type", "foo": "function"},
+            id="inline-type-import-does-not-affect-runtime-sibling",
+        ),
+        pytest.param(
+            ".ts",
+            'import { Widget, foo } from "./mod";\n'
+            "export type { Widget };\nexport { type foo as FactoryType };\n",
+            {"FactoryType": "type", "Widget": "type"},
+            id="statement-and-specifier-type-only-exports",
+        ),
+        pytest.param(
+            ".ts",
+            'import type { Label } from "./mod";\n'
+            "const Label = 'label';\nexport { Label };\n",
+            {"Label": "variable"},
+            id="imported-type-does-not-overwrite-local-runtime-value",
+        ),
+        pytest.param(
+            ".ts",
+            'import { Widget } from "./mod";\n'
+            "type Widget = string;\nexport { Widget };\n",
+            {"Widget": "class"},
+            id="imported-runtime-value-supersedes-local-type-alias",
+        ),
+    ],
+)
+def test_imported_export_surface_preserves_names_and_kinds(
+    tmp_path, suffix, barrel, kinds
+):
+    module = (
+        "export function foo() { return 'label'; }\n"
+        "export default function makeLabel() { return 'label'; }\n"
+        "export class Widget {}\n"
+    )
+    if suffix == ".ts":
+        module += "export interface Label { text: string }\n"
+    _create_sources(tmp_path, {f"mod{suffix}": module, f"index{suffix}": barrel})
+
+    surface = inspect_js_file_api_surface(tmp_path, f"index{suffix}")
+
+    assert surface is not None
+    assert surface["exports"] == sorted(kinds)
+    assert {
+        name: member["kind"] for name, member in surface["members"].items()
+    } == kinds
+    assert surface["metadata"]["complete"] is True
+    assert surface["metadata"]["incomplete_reasons"] == []
+
+
+def test_unexported_imports_stay_private_without_degrading_surface(tmp_path):
+    _create_sources(
+        tmp_path,
+        {
+            "mod.ts": "export function foo() { return 'label'; }\n",
+            "index.ts": 'import { unused } from "optional-labels";\n'
+            'import { foo } from "./mod";\nexport const published = "label";\n',
+            "app.ts": 'import { foo } from "./index";\nfoo();\n',
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+    findings, coverage = _scan(tmp_path)
+
+    assert surface is not None
+    assert surface["exports"] == ["published"]
+    assert surface["metadata"]["complete"] is True
+    assert [
+        (finding["rule_id"], finding["file"], finding["line"], finding["simple_name"])
+        for finding in findings
+    ] == [("SKY-L012", str(tmp_path / "app.ts"), 1, "foo")]
+    assert coverage["finding_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "barrel",
+    [
+        pytest.param(
+            'import { missing as absent } from "./mod";\nexport { absent };\n',
+            id="imported-symbol-not-present-in-source",
+        ),
+        pytest.param("export { absent };\n", id="unknown-local-binding"),
+    ],
+)
+def test_barrel_does_not_invent_nonexistent_bindings(tmp_path, barrel):
+    _create_sources(
+        tmp_path,
+        {
+            "mod.ts": "export function foo() { return 'label'; }\n",
+            "index.ts": barrel,
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+
+    assert surface is not None
+    assert surface["exports"] == []
+    assert surface["members"] == {}
+
+
+@pytest.mark.parametrize("source", ["optional-labels", "./missing"])
+def test_unresolved_exported_import_makes_surface_incomplete(tmp_path, source):
+    _create_sources(
+        tmp_path,
+        {
+            "index.ts": f'import {{ foo }} from "{source}";\nexport {{ foo }};\n',
+            "app.ts": 'import { foo } from "./index";\nfoo();\n',
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+    findings, coverage = _scan(tmp_path)
+
+    assert surface is not None
+    assert surface["exports"] == []
+    assert surface["metadata"]["complete"] is False
+    assert surface["metadata"]["incomplete_reasons"]
+    assert findings == []
+    assert coverage["finding_count"] == 0
+    assert coverage["outcome"] == "incomplete"
+
+
+def test_chained_import_then_export_barrels_remain_resolvable(tmp_path):
+    _create_sources(
+        tmp_path,
+        {
+            "mod.ts": "export function foo() { return 'label'; }\n",
+            "middle.ts": 'import { foo as local } from "./mod";\n'
+            "export { local as shared };\n",
+            "index.ts": 'import { shared as local } from "./middle";\n'
+            "export { local as foo };\n",
+            "app.ts": 'import { foo } from "./index";\nfoo();\n',
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+    findings, coverage = _scan(tmp_path)
+
+    assert surface is not None
+    assert surface["exports"] == ["foo"]
+    assert surface["members"]["foo"]["kind"] == "function"
+    assert surface["metadata"]["complete"] is True
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 3
+    assert coverage["skipped_references"] == 0
+
+
+def test_cyclic_imported_barrels_do_not_claim_complete_absence(tmp_path):
+    _create_sources(
+        tmp_path,
+        {
+            "index.ts": 'import { foo } from "./other";\nexport { foo };\n',
+            "other.ts": 'import { foo } from "./index";\nexport { foo };\n',
+            "app.ts": 'import { foo } from "./index";\nfoo();\n',
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+    findings, coverage = _scan(tmp_path)
+
+    assert surface is not None
+    assert surface["exports"] == []
+    assert surface["metadata"]["complete"] is False
+    assert surface["metadata"]["incomplete_reasons"]
+    assert findings == []
+    assert coverage["finding_count"] == 0
+    assert coverage["outcome"] == "incomplete"
+
+
+@pytest.mark.parametrize(
+    ("barrel", "kinds"),
+    [
+        pytest.param(
+            'import { type as local } from "./mod";\nexport { local };\n',
+            {"local": "variable"},
+            id="exported-value-named-type-is-not-a-modifier",
+        ),
+        pytest.param(
+            'import /* label types */ type\n{ Widget } from "./mod";\n'
+            "export { Widget };\n",
+            {"Widget": "type"},
+            id="statement-type-modifier-with-comment-and-newline",
+        ),
+        pytest.param(
+            'import { type/* label type */\n Widget } from "./mod";\n'
+            "export { Widget };\n",
+            {"Widget": "type"},
+            id="specifier-type-modifier-with-comment-and-newline",
+        ),
+        pytest.param(
+            'import Label, { foo as local } from "./mod";\n'
+            "export { Label as PublishedLabel, local as published };\n",
+            {"PublishedLabel": "class", "published": "function"},
+            id="mixed-default-and-named-import-clause",
+        ),
+        pytest.param(
+            'import type * as Labels from "./mod";\nexport { Labels };\n',
+            {"Labels": "type"},
+            id="type-only-namespace-import",
+        ),
+        pytest.param(
+            'import type Label from "./mod";\nexport { Label };\n',
+            {"Label": "type"},
+            id="type-only-default-import",
+        ),
+    ],
+)
+def test_barrel_type_modifiers_follow_syntax_not_identifier_text(
+    tmp_path, barrel, kinds
+):
+    _create_sources(
+        tmp_path,
+        {
+            "mod.ts": "export const type = 'label';\n"
+            "export function foo() { return 'label'; }\n"
+            "export class Widget {}\nexport default class Label {}\n",
+            "index.ts": barrel,
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+
+    assert surface is not None
+    assert surface["exports"] == sorted(kinds)
+    assert {
+        name: member["kind"] for name, member in surface["members"].items()
+    } == kinds
+    assert surface["metadata"]["complete"] is True
+    assert surface["metadata"]["incomplete_reasons"] == []
+
+
+def test_many_local_exports_read_their_shared_source_only_once(tmp_path, monkeypatch):
+    names = [f"label{index}" for index in range(30)]
+    clause = ", ".join(names)
+    _create_sources(
+        tmp_path,
+        {
+            "mod.ts": "".join(
+                f"export function {name}() {{ return 'label'; }}\n" for name in names
+            ),
+            "index.ts": f'import {{ {clause} }} from "./mod";\n'
+            f"export {{ {clause} }};\n",
+        },
+    )
+    original_read = js_api_surface_exports.read_text_no_symlink
+    source_path = (tmp_path / "mod.ts").resolve()
+    source_reads = 0
+
+    def counted_read(path, *args, **kwargs):
+        nonlocal source_reads
+        if Path(path) == source_path:
+            source_reads += 1
+        return original_read(path, *args, **kwargs)
+
+    monkeypatch.setattr(js_api_surface_exports, "read_text_no_symlink", counted_read)
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+
+    assert surface is not None
+    assert surface["exports"] == sorted(names)
+    assert all(member["kind"] == "function" for member in surface["members"].values())
+    assert surface["metadata"]["complete"] is True
+    assert source_reads == 1
+
+
+def test_unsupported_local_export_named_type_does_not_prove_absence(tmp_path):
+    # The current parser produces an ERROR for this contextual-keyword export.
+    # Keep its surface incomplete instead of inventing a complete empty API.
+    _create_sources(
+        tmp_path,
+        {
+            "mod.ts": "export function foo() { return 'label'; }\n",
+            "index.ts": 'import { foo as type } from "./mod";\nexport { type };\n',
+            "app.ts": 'import { type as readLabel } from "./index";\nreadLabel();\n',
+        },
+    )
+
+    surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+    findings, coverage = _scan(tmp_path)
+
+    assert surface is not None
+    assert surface["exports"] == []
+    assert surface["metadata"]["complete"] is False
+    assert "parse_error" in surface["metadata"]["incomplete_reasons"]
+    assert findings == []
+    assert coverage["finding_count"] == 0
+    assert coverage["outcome"] == "incomplete"
+
+
+@pytest.mark.parametrize(
+    ("module_path", "package_files"),
+    [
+        pytest.param("mod.cjs", {}, id="cjs-extension"),
+        pytest.param("mod.cts", {}, id="cts-extension"),
+        pytest.param(
+            "mod.js",
+            {"package.json": '{"type":"commonjs"}\n'},
+            id="root-commonjs-package",
+        ),
+        pytest.param(
+            "nested/mod.js",
+            {
+                "package.json": '{"type":"module"}\n',
+                "nested/package.json": '{"type":"commonjs"}\n',
+            },
+            id="nested-commonjs-package-overrides-root",
+        ),
+    ],
+)
+def test_commonjs_implicit_default_survives_local_barrel_export(
+    tmp_path, module_path, package_files
+):
+    _create_sources(
+        tmp_path,
+        {
+            **package_files,
+            module_path: "const label = 1;\n",
+            "index.ts": f'import labels from "./{module_path}";\nexport {{ labels }};\n',
+            "app.ts": 'import { labels } from "./index";\n',
+        },
+    )
+
+    source_surface = inspect_js_file_api_surface(tmp_path, module_path)
+    barrel_surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+    findings, coverage = _scan(tmp_path)
+
+    assert source_surface is not None
+    assert source_surface["exports"] == ["default"]
+    assert source_surface["members"]["default"]["kind"] == "commonjs"
+    assert source_surface["metadata"]["complete"] is True
+    assert barrel_surface is not None
+    assert barrel_surface["exports"] == ["labels"]
+    assert barrel_surface["members"]["labels"]["kind"] == "commonjs"
+    assert barrel_surface["metadata"]["complete"] is True
+    assert findings == []
+    assert coverage["outcome"] == "pass"
+    assert coverage["verified_references"] == 2
+    assert coverage["skipped_references"] == 0
+
+
+@pytest.mark.parametrize(
+    ("module_path", "package_type"),
+    [
+        pytest.param("mod.mjs", "commonjs", id="mjs-overrides-commonjs-package"),
+        pytest.param("mod.js", "module", id="js-in-module-package"),
+    ],
+)
+def test_esm_source_does_not_invent_implicit_default(
+    tmp_path, module_path, package_type
+):
+    _create_sources(
+        tmp_path,
+        {
+            "package.json": f'{{"type":"{package_type}"}}\n',
+            module_path: "const label = 1;\n",
+            "index.ts": f'import labels from "./{module_path}";\nexport {{ labels }};\n',
+        },
+    )
+
+    source_surface = inspect_js_file_api_surface(tmp_path, module_path)
+    barrel_surface = inspect_js_file_api_surface(tmp_path, "index.ts")
+
+    assert source_surface is not None
+    assert source_surface["exports"] == []
+    assert source_surface["metadata"]["complete"] is True
+    assert barrel_surface is not None
+    assert barrel_surface["exports"] == []
+    assert barrel_surface["members"] == {}
+
+
+def test_many_barrel_consumers_keep_only_genuine_missing_name_finding(tmp_path):
+    names = [f"label{index}" for index in range(30)]
+    clause = ", ".join(names)
+    sources = {
+        "mod.ts": "".join(
+            f"export function {name}() {{ return 'label'; }}\n" for name in names
+        ),
+        "index.ts": f'import {{ {clause} }} from "./mod";\nexport {{ {clause} }};\n',
+    }
+    for index in range(4):
+        imported_names = clause if index < 3 else f"{clause}, missingLabel"
+        sources[f"consumer{index}.ts"] = (
+            f'import {{ {imported_names} }} from "./index";\n'
+        )
+    _create_sources(tmp_path, sources)
+
+    findings, coverage = _scan(tmp_path)
+
+    assert [
+        (finding["rule_id"], finding["file"], finding["line"], finding["simple_name"])
+        for finding in findings
+    ] == [("SKY-L012", str(tmp_path / "consumer3.ts"), 1, "missingLabel")]
+    assert coverage["status"] == "completed"
+    assert coverage["outcome"] == "fail"
+    assert coverage["finding_count"] == 1
+    assert coverage["references"] == 151
+    assert coverage["verified_references"] == 150
+    assert coverage["skipped_references"] == 0


### PR DESCRIPTION
Fix #798.

## Summary

  - Fix false SKY-L012 reports when TS/JS barrels import symbols
  - Sort out aliases, type only imports, namespaces and CommonJS defaults.

## Tests

pytest test/test_js_api_surface.py test/test_js_api_hallucination.py test/test_js_barrel_exports.py
