### PR TITLE
fix(analyzer): reduce Django and Celery false positives

### DIFF
--- a/skylos/analysis/circular_deps.py
+++ b/skylos/analysis/circular_deps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import ast
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Dict, List, Set, Tuple, Any
 from collections import defaultdict
 
@@ -53,6 +54,54 @@ def _resolve_from_import_targets(
     return dict(targets)
 
 
+def _import_targets(
+    import_module: str, import_type: str, names: List[str], known_modules: Set[str]
+) -> Dict[str, List[str]]:
+    if import_type == "from_import":
+        return _resolve_from_import_targets(import_module, names, known_modules)
+    target = _resolve_known_module(import_module, known_modules)
+    return {target: names} if target else {}
+
+
+def _circular_import_targets(
+    from_module: str,
+    import_module: str,
+    names: List[str],
+    targets: Dict[str, List[str]],
+) -> Dict[str, List[str]]:
+    """Preserve same-package identities without changing cross-package reports.
+
+    Collapsing ``pkg -> pkg.child`` to ``pkg -> pkg`` invents a self-cycle,
+    while discarding that edge would hide a real child-to-package cycle.
+    Keep the exact resolved graph within a package; unresolved symbols still
+    fall back to their known containing module.
+    """
+    if not targets:
+        return {}
+    root = _module_root(import_module)
+    if _module_root(from_module) == root:
+        return targets
+    return {root: names}
+
+
+def _absolute_from_module(
+    node: ast.ImportFrom, module_name: str, file_path: str
+) -> str | None:
+    if node.level == 0:
+        return node.module
+    # Match the package context used by collect_python_raw_imports so the AST
+    # and worker-tuple paths resolve ordinary relative imports identically.
+    package = module_name
+    if Path(file_path).name != "__init__.py" and "." in module_name:
+        package = module_name.rsplit(".", 1)[0]
+    parts = package.split(".") if package else []
+    up = node.level - 1
+    if up > len(parts):
+        return None
+    base = ".".join(parts[: len(parts) - up])
+    return f"{base}.{node.module}" if node.module and base else node.module or base
+
+
 @dataclass
 class ModuleDependency:
     from_module: str
@@ -95,55 +144,35 @@ class DependencyGraphBuilder(ast.NodeVisitor):
 
     def visit_Import(self, node: ast.Import):
         for alias in node.names:
-            module = _resolve_known_module(alias.name, self.known_modules)
-            if module:
-                self.dependencies.append(
-                    ModuleDependency(
-                        from_module=self.module_name,
-                        to_module=_module_root(alias.name),
-                        import_line=node.lineno,
-                        import_type="import",
-                        imported_names=[alias.asname or alias.name],
-                    )
-                )
-                self.architecture_dependencies.append(
-                    ModuleDependency(
-                        from_module=self.module_name,
-                        to_module=module,
-                        import_line=node.lineno,
-                        import_type="import",
-                        imported_names=[alias.asname or alias.name],
-                    )
-                )
+            self._record_import(
+                alias.name, node.lineno, "import", [alias.asname or alias.name]
+            )
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
-        if node.module and node.level == 0:
+        module = _absolute_from_module(node, self.module_name, self.file_path)
+        if module:
             names = [a.name for a in node.names if a.name != "*"]
-            targets = _resolve_from_import_targets(
-                node.module, names, self.known_modules
-            )
-            if targets:
-                self.dependencies.append(
+            self._record_import(module, node.lineno, "from_import", names)
+
+    def _record_import(self, module, line, import_type, names):
+        targets = _import_targets(module, import_type, names, self.known_modules)
+        circular_targets = _circular_import_targets(
+            self.module_name, module, names, targets
+        )
+        for graph, graph_targets in (
+            (self.dependencies, circular_targets),
+            (self.architecture_dependencies, targets),
+        ):
+            for target, target_names in graph_targets.items():
+                graph.append(
                     ModuleDependency(
                         from_module=self.module_name,
-                        to_module=_module_root(node.module),
-                        import_line=node.lineno,
-                        import_type="from_import",
-                        imported_names=names,
+                        to_module=target,
+                        import_line=line,
+                        import_type=import_type,
+                        imported_names=target_names,
                     )
                 )
-                for target, target_names in targets.items():
-                    self.architecture_dependencies.append(
-                        ModuleDependency(
-                            from_module=self.module_name,
-                            to_module=target,
-                            import_line=node.lineno,
-                            import_type="from_import",
-                            imported_names=target_names,
-                        )
-                    )
-        elif node.level > 0:
-            pass
 
     def _is_internal_module(self, module: str) -> bool:
         return _resolve_known_module(module, self.known_modules) is not None
@@ -166,32 +195,23 @@ class CircularDependencyAnalyzer:
             self.known_modules.update(_known_module_names(module_name))
 
         for module_name, raw_imports in raw_imports_by_module.items():
-            file_path = self.modules.get(module_name, "")
             for import_module, line, import_type, names in raw_imports:
-                root = _module_root(import_module)
-                if root in self.known_modules:
+                architecture_targets = _import_targets(
+                    import_module, import_type, names, self.known_modules
+                )
+                circular_targets = _circular_import_targets(
+                    module_name, import_module, names, architecture_targets
+                )
+                for target, target_names in circular_targets.items():
                     dep = ModuleDependency(
                         from_module=module_name,
-                        to_module=root,
+                        to_module=target,
                         import_line=line,
                         import_type=import_type,
-                        imported_names=names,
+                        imported_names=target_names,
                     )
                     self.dependencies[dep.from_module].add(dep.to_module)
                     self.all_deps.append(dep)
-
-                if import_type == "from_import":
-                    architecture_targets = _resolve_from_import_targets(
-                        import_module, names, self.known_modules
-                    )
-                else:
-                    architecture_target = _resolve_known_module(
-                        import_module, self.known_modules
-                    )
-                    architecture_targets = (
-                        {architecture_target: names} if architecture_target else {}
-                    )
-
                 for target in architecture_targets:
                     self.architecture_dependencies[module_name].add(target)
 

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -128,6 +128,7 @@ _OPTIONAL_RUN_STATE_ATTRIBUTES = (
     "_ts_wildcard_edges",
     "_ts_importers_of",
     "_ts_demoted_exports",
+    "_browser_script_entry_files",
 )
 
 
@@ -1144,6 +1145,56 @@ def _changed_definition_keys(
     )
 
 
+def _suppress_django_admin_stubs(empty_files, file_contexts, project_root) -> None:
+    """Keep conventional empty app admin modules in Django projects."""
+    if _scan_has_top_level_python_module(project_root, file_contexts, "django"):
+        return
+    uses_django = any(
+        definition.type == "import"
+        and (definition.name == "django" or definition.name.startswith("django."))
+        for definitions, _tests, _frameworks, _file, _mod, _cfg in file_contexts
+        for definition in definitions
+    )
+    if not uses_django:
+        return
+    scanned_files = {
+        Path(file).resolve()
+        for _defs, _tests, _frameworks, file, _mod, _cfg in file_contexts
+    }
+    empty_files[:] = [
+        finding
+        for finding in empty_files
+        if not (
+            finding.get("rule_id") == "SKY-E002"
+            and Path(str(finding.get("file", ""))).name == "admin.py"
+            and Path(str(finding.get("file", ""))).resolve().parent / "__init__.py"
+            in scanned_files
+        )
+    ]
+
+
+def _scan_has_top_level_python_module(project_root, file_contexts, module_name) -> bool:
+    root = Path(project_root).resolve()
+    for _defs, _tests, _frameworks, file, _mod, _cfg in file_contexts:
+        try:
+            parts = Path(file).resolve().relative_to(root).parts
+        except (OSError, ValueError):
+            continue
+        if not parts:
+            continue
+        if root.name == module_name and parts[0] == "__init__.py":
+            return True
+        if parts[0] in {module_name, f"{module_name}.py"}:
+            return True
+        if (
+            parts[0] in _PYTHON_SOURCE_ROOT_NAMES
+            and len(parts) > 1
+            and parts[1] in {module_name, f"{module_name}.py"}
+        ):
+            return True
+    return False
+
+
 def _collect_grep_verify_candidates(
     definitions: dict,
     candidate_keys: frozenset | None = None,
@@ -1719,6 +1770,7 @@ class Skylos:
             getattr(self, "_ts_wildcard_edges", {}),
             project_root=str(self._project_root),
             workspace_inventory=workspace_inventory,
+            browser_entry_points=getattr(self, "_browser_script_entry_files", ()),
         )
 
     def _find_unused_ts_exports(self, files, exclude_folders, workspace_inventory=None):
@@ -3680,6 +3732,8 @@ class Skylos:
 
         self.pattern_trackers = pattern_trackers
 
+        _suppress_django_admin_stubs(empty_files, file_contexts, root)
+
         self._global_abc_classes = set()
         self._global_protocol_classes = set()
         self._global_abstract_methods = {}
@@ -4539,6 +4593,17 @@ class Skylos:
         except Exception:
             if os.getenv("SKYLOS_DEBUG"):
                 logger.error("Java FXML liveness scan failed", exc_info=True)
+
+        self._browser_script_entry_files = set()
+        try:
+            from skylos.deadcode.browser_refs import collect_browser_script_entry_files
+
+            self._browser_script_entry_files = collect_browser_script_entry_files(
+                Path(root), files, exclude_folders=exclude_folders
+            )
+        except Exception:
+            if os.getenv("SKYLOS_DEBUG"):
+                logger.error("Browser script entry scan failed", exc_info=True)
 
         try:
             from skylos.deadcode.browser_refs import (

--- a/skylos/deadcode/browser_refs.py
+++ b/skylos/deadcode/browser_refs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from skylos.core.file_discovery import discover_source_files
 from skylos.core.safe_cache_io import read_text_no_symlink
@@ -63,14 +63,40 @@ _MARKDOWN_CODE_BLOCK_RE = re.compile(
 )
 _MARKDOWN_INLINE_CODE_RE = re.compile(r"""`[^`\n]*`""")
 _SCRIPT_TAG_RE = re.compile(r"""<script\b(?P<attrs>[^>]*)>""", re.IGNORECASE)
-_SRC_ATTR_RE = re.compile(
-    r"""\bsrc\s*=\s*(?P<quote>["'])(?P<value>.*?)(?P=quote)""",
-    re.IGNORECASE | re.DOTALL,
+_SCRIPT_ATTR_RE = re.compile(
+    r"""(?P<name>[^\s=/>]+)(?:\s*=\s*(?:"(?P<double>[^"]*)"|'(?P<single>[^']*)'|(?P<bare>[^\s>]+)))?""",
+    re.DOTALL,
 )
-_TYPE_ATTR_RE = re.compile(
-    r"""\btype\s*=\s*(?P<quote>["'])(?P<value>.*?)(?P=quote)""",
-    re.IGNORECASE | re.DOTALL,
+_DJANGO_STATIC_TAG_RE = re.compile(
+    r"""^\s*{%\s*static\s+(?P<quote>["'])(?P<path>[^"']+)(?P=quote)\s*%}\s*$""",
+    re.DOTALL,
 )
+_HTML_COMMENT_RE = re.compile(r"""<!--[\s\S]*?-->""")
+_DJANGO_SHORT_COMMENT_RE = re.compile(r"""{#[\s\S]*?#}""")
+_DJANGO_COMMENT_BLOCK_RE = re.compile(
+    r"""{%\s*comment(?:\s+[^%]*?)?\s*%}[\s\S]*?{%\s*endcomment\s*%}""",
+    re.IGNORECASE,
+)
+_CLASSIC_SCRIPT_TYPES = {
+    "",
+    # https://mimesniff.spec.whatwg.org/#javascript-mime-type
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/javascript1.0",
+    "text/javascript1.1",
+    "text/javascript1.2",
+    "text/javascript1.3",
+    "text/javascript1.4",
+    "text/javascript1.5",
+    "text/jscript",
+    "text/livescript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+}
 _JS_CONTROL_WORDS = {
     "catch",
     "do",
@@ -191,7 +217,11 @@ def collect_browser_event_handler_refs(
     seen_names: set[str] = set()
     source_cache: dict[Path, str] = {}
     template_files: list[Path] = []
+    template_names: dict[Path, set[str]] = {}
     monorepo_resolver = _build_ts_monorepo_resolver(root)
+    source_files = list(source_files)
+    scanned_scripts = _scanned_js_files(root, source_files)
+    static_asset_index = _build_static_asset_index(root, scanned_scripts)
 
     reference_files = list(
         _iter_browser_reference_files(root, source_files, exclude_folders)
@@ -203,6 +233,7 @@ def collect_browser_event_handler_refs(
 
         if file_path.suffix.lower() in _HTML_TEMPLATE_SUFFIXES:
             template_files.append(file_path)
+            source = _strip_template_comments(source)
 
         if file_path.suffix.lower() in _MDX_SUFFIXES:
             for name, target_file in extract_mdx_component_refs(
@@ -213,20 +244,67 @@ def collect_browser_event_handler_refs(
             ):
                 _append_ref(refs, seen_refs, name, target_file)
 
-        for name in extract_browser_event_handler_names(source):
-            seen_names.add(name)
+        handler_names = extract_browser_event_handler_names(source)
+        if file_path.suffix.lower() in _HTML_TEMPLATE_SUFFIXES:
+            template_names[file_path] = handler_names
+        else:
+            seen_names.update(handler_names)
+        for name in handler_names:
             _append_ref(refs, seen_refs, name, file_path)
 
-    global_scripts = _collect_non_module_script_files(root, template_files, source_cache)
-    for script_file in global_scripts:
+    script_names: dict[Path, set[str]] = {}
+    for template_file in template_files:
+        global_scripts = _collect_template_script_files(
+            root,
+            [template_file],
+            source_cache,
+            include_modules=False,
+            static_asset_index=static_asset_index,
+            allowed_files=scanned_scripts,
+        )
+        for script_file in global_scripts:
+            script_names.setdefault(script_file, set()).update(
+                template_names.get(template_file, set())
+            )
+    for script_file, names in script_names.items():
         source = _read_text(root, script_file, source_cache)
         if source is None:
             continue
-        for name in seen_names:
+        for name in names | seen_names:
             if _source_defines_top_level_browser_name(source, name):
                 _append_ref(refs, seen_refs, name, script_file)
 
     return refs
+
+
+def collect_browser_script_entry_files(
+    project_root: Path,
+    source_files,
+    *,
+    exclude_folders=None,
+) -> set[Path]:
+    """Find loaded script files, without treating their exports as consumed.
+
+    Literal Django static paths must map to one scanned asset. Finder ordering
+    and custom STATICFILES_DIRS require configuration not inferred here.
+    """
+    root = Path(project_root).resolve()
+    scanned_scripts = _scanned_js_files(root, source_files)
+    if not scanned_scripts:
+        return set()
+    template_files = discover_source_files(
+        root,
+        _HTML_TEMPLATE_SUFFIXES,
+        exclude_folders=exclude_folders,
+    )
+    return _collect_template_script_files(
+        root,
+        list(template_files),
+        {},
+        include_modules=True,
+        static_asset_index=_build_static_asset_index(root, scanned_scripts),
+        allowed_files=scanned_scripts,
+    )
 
 
 def _strip_markdown_code(source: str) -> str:
@@ -448,10 +526,14 @@ def _resolve_readable_project_file(root: Path, file_path: Path) -> Path | None:
     return resolved
 
 
-def _collect_non_module_script_files(
+def _collect_template_script_files(
     root: Path,
     template_files: list[Path],
     source_cache: dict[Path, str],
+    *,
+    include_modules: bool,
+    static_asset_index: dict[str, set[Path]],
+    allowed_files: set[Path],
 ) -> set[Path]:
     script_files: set[Path] = set()
 
@@ -460,35 +542,55 @@ def _collect_non_module_script_files(
         if source is None:
             continue
 
-        for match in _SCRIPT_TAG_RE.finditer(source):
+        for match in _SCRIPT_TAG_RE.finditer(_strip_template_comments(source)):
             attrs = match.group("attrs")
-            if _script_attrs_are_module(attrs):
+            script_type = (_script_attribute(attrs, "type") or "").strip().lower()
+            if script_type not in _CLASSIC_SCRIPT_TYPES and not (
+                include_modules and script_type == "module"
+            ):
                 continue
-            src = _script_src(attrs)
+            src = _script_attribute(attrs, "src")
             if not src:
                 continue
-            script_file = _resolve_script_src(root, template_file.parent, src)
-            if script_file is not None:
+            script_file = _resolve_script_src(
+                root, template_file.parent, src, static_asset_index=static_asset_index
+            )
+            if script_file in allowed_files:
                 script_files.add(script_file)
 
     return script_files
 
 
-def _script_attrs_are_module(attrs: str) -> bool:
-    match = _TYPE_ATTR_RE.search(attrs)
-    if not match:
-        return False
-    return match.group("value").strip().lower() == "module"
+def _strip_template_comments(source: str) -> str:
+    without_blocks = _DJANGO_COMMENT_BLOCK_RE.sub("", source)
+    without_short_comments = _DJANGO_SHORT_COMMENT_RE.sub("", without_blocks)
+    return _HTML_COMMENT_RE.sub("", without_short_comments)
 
 
-def _script_src(attrs: str) -> str | None:
-    match = _SRC_ATTR_RE.search(attrs)
-    if not match:
-        return None
-    return match.group("value").strip()
+def _script_attribute(attrs: str, name: str) -> str | None:
+    for match in _SCRIPT_ATTR_RE.finditer(attrs):
+        if match.group("name").lower() == name:
+            return (
+                match.group("double")
+                or match.group("single")
+                or match.group("bare")
+                or ""
+            )
+    return None
 
 
-def _resolve_script_src(root: Path, template_dir: Path, src: str) -> Path | None:
+def _resolve_script_src(
+    root: Path,
+    template_dir: Path,
+    src: str,
+    *,
+    static_asset_index: dict[str, set[Path]],
+) -> Path | None:
+    static_asset_path = _django_static_asset_path(src)
+    if static_asset_path is not None:
+        matches = static_asset_index.get(static_asset_path, set())
+        return next(iter(matches)) if len(matches) == 1 else None
+
     clean_src = src.split("#", 1)[0].split("?", 1)[0].strip()
     if not clean_src:
         return None
@@ -505,22 +607,63 @@ def _resolve_script_src(root: Path, template_dir: Path, src: str) -> Path | None
     if candidate.suffix.lower() not in _JS_SOURCE_SUFFIXES:
         return None
 
-    try:
-        resolved = candidate.resolve(strict=True)
-        resolved.relative_to(root)
-    except (OSError, ValueError):
-        return None
+    return _resolve_readable_project_file(root, candidate)
 
-    if not resolved.is_file():
+
+def _django_static_asset_path(src: str) -> str | None:
+    match = _DJANGO_STATIC_TAG_RE.fullmatch(src)
+    if match is None:
         return None
-    return resolved
+    raw_path = match.group("path").strip()
+    if not raw_path or raw_path.startswith("/"):
+        return None
+    if any(
+        character in raw_path for character in ("\\", "\x00", ":", "{", "}", "?", "#")
+    ):
+        return None
+    parts = raw_path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    normalized = PurePosixPath(*parts)
+    return (
+        normalized.as_posix()
+        if normalized.suffix.lower() in _JS_SOURCE_SUFFIXES
+        else None
+    )
+
+
+def _scanned_js_files(root: Path, source_files) -> set[Path]:
+    scripts: set[Path] = set()
+    for raw_file in source_files:
+        file_path = Path(raw_file)
+        if file_path.suffix.lower() not in _JS_SOURCE_SUFFIXES:
+            continue
+        resolved = _resolve_readable_project_file(root, file_path)
+        if resolved is not None:
+            scripts.add(resolved)
+    return scripts
+
+
+def _build_static_asset_index(
+    root: Path, script_files: set[Path]
+) -> dict[str, set[Path]]:
+    index: dict[str, set[Path]] = {}
+    for script_file in script_files:
+        parts = script_file.relative_to(root).parts
+        if root.name == "static":
+            index.setdefault(PurePosixPath(*parts).as_posix(), set()).add(script_file)
+        for position, part in enumerate(parts[:-1]):
+            if part == "static":
+                key = PurePosixPath(*parts[position + 1 :]).as_posix()
+                index.setdefault(key, set()).add(script_file)
+    return index
 
 
 def _source_defines_top_level_browser_name(source: str, name: str) -> bool:
     escaped = re.escape(name)
     patterns = (
-        rf"^(?:export\s+)?(?:async\s+)?function\s+{escaped}\b",
-        rf"^(?:export\s+)?(?:const|let|var)\s+{escaped}\s*=",
+        rf"^(?:async\s+)?function\s+{escaped}\b",
+        rf"^(?:const|let|var)\s+{escaped}\s*=",
     )
     for pattern in patterns:
         if re.search(pattern, source, re.MULTILINE):

--- a/skylos/deadcode/framework_liveness.py
+++ b/skylos/deadcode/framework_liveness.py
@@ -1,0 +1,427 @@
+"""Small, evidence-based contracts for statically registered framework callbacks."""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+from skylos.deadcode.python_ast import ParsedPythonFile
+
+
+_FUNCTIONS = (ast.FunctionDef, ast.AsyncFunctionDef)
+_SCOPES = (*_FUNCTIONS, ast.ClassDef, ast.Lambda)
+_SOURCE_ROOTS = {"src", "lib", "python"}
+_RUNPYTHON = {
+    "django.db.migrations.RunPython",
+    "django.db.migrations.operations.RunPython",
+}
+
+
+def find_framework_entrypoint_targets(
+    definitions: dict[str, Any],
+    parsed_files: Iterable[ParsedPythonFile],
+    root: Path,
+) -> list[tuple[Any, str]]:
+    """Return definitions used by proven imports, without executing target code."""
+    parsed = []
+    root = root.resolve()
+    if root.is_file():
+        root = root.parent
+    for module in parsed_files:
+        try:
+            module.path.resolve().relative_to(root)
+        except (OSError, ValueError):
+            continue
+        parsed.append(module)
+    index = _DefinitionIndex(definitions, parsed, root)
+    found: dict[tuple[int, str], tuple[Any, str]] = {}
+    for module in parsed:
+        scanner = _FrameworkScanner(module, index)
+        for definition, reason in scanner.collect():
+            found[(id(definition), reason)] = (definition, reason)
+    return list(found.values())
+
+
+def _bound_names(node: ast.AST) -> set[str]:
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return {alias.asname or alias.name.split(".", 1)[0] for alias in node.names}
+    if isinstance(node, (*_FUNCTIONS, ast.ClassDef)):
+        return {node.name}
+    names = set()
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.Name) and isinstance(child.ctx, (ast.Store, ast.Del)):
+            names.add(child.id)
+        elif not isinstance(child, ast.Lambda):
+            names.update(_bound_names(child))
+    return names
+
+
+def _eager_nodes(node: ast.AST):
+    if isinstance(node, _SCOPES):
+        return
+    yield node
+    for child in ast.iter_child_nodes(node):
+        yield from _eager_nodes(child)
+
+
+def _qualified(node: ast.AST | None, bindings: dict[str, str | None]) -> str | None:
+    if isinstance(node, ast.Name):
+        return bindings.get(node.id)
+    if isinstance(node, ast.Attribute):
+        base = _qualified(node.value, bindings)
+        return f"{base}.{node.attr}" if base else None
+    if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant):
+        base = _qualified(node.value, bindings)
+        if base and isinstance(node.slice.value, str):
+            return f"{base}.{node.slice.value}"
+    return None
+
+
+def _module_name(path: Path, root: Path) -> str:
+    parts = list(path.relative_to(root).with_suffix("").parts)
+    if parts and parts[0] in _SOURCE_ROOTS:
+        parts.pop(0)
+    if parts and parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+class _DefinitionIndex:
+    def __init__(self, definitions, parsed, root):
+        self.by_location = {}
+        self.by_name = defaultdict(list)
+        self.imports = defaultdict(list)
+        self.parameters = defaultdict(dict)
+        self.modules = {}
+        self.shadowed = set()
+        for module in parsed:
+            path = module.path.resolve()
+            self.modules[path] = _module_name(path, root)
+            relative = path.relative_to(root).parts
+            first = (
+                relative[1]
+                if relative[0] in _SOURCE_ROOTS and len(relative) > 1
+                else relative[0]
+            )
+            for framework in ("django", "celery"):
+                if first in {framework, f"{framework}.py"} or (
+                    root.name == framework and relative[0] == "__init__.py"
+                ):
+                    self.shadowed.add(framework)
+        for definition in definitions.values():
+            kind = getattr(definition, "type", "")
+            path = Path(definition.filename).resolve()
+            if path not in self.modules:
+                continue
+            if kind == "parameter":
+                owner, _, name = definition.name.rpartition(".")
+                self.parameters[owner][name] = definition
+            elif kind == "import":
+                self.imports[(path, definition.name)].append(definition)
+            elif kind in {"function", "class"}:
+                node = getattr(definition, "node", None)
+                if node is not None and getattr(node, "col_offset", -1) == 0:
+                    self.by_location[(path, node.lineno)] = definition
+                    self.by_name[definition.name].append(definition)
+                    self.modules[path] = definition.name.rsplit(".", 1)[0]
+        # A dotted setting names the module's final binding, not a stale function.
+        for module in parsed:
+            active = {}
+            for statement in module.tree.body:
+                for name in _bound_names(statement):
+                    active.pop(name, None)
+                if isinstance(statement, _FUNCTIONS):
+                    definition = self.by_location.get(
+                        (module.path.resolve(), statement.lineno)
+                    )
+                    if definition is not None:
+                        active[statement.name] = definition
+            active_ids = {id(item) for item in active.values()}
+            for statement in module.tree.body:
+                if not isinstance(statement, _FUNCTIONS):
+                    continue
+                definition = self.by_location.get(
+                    (module.path.resolve(), statement.lineno)
+                )
+                if definition is not None and id(definition) not in active_ids:
+                    self.by_name[definition.name] = [
+                        item
+                        for item in self.by_name[definition.name]
+                        if item is not definition
+                    ]
+
+    def callable(self, name):
+        candidates = self.by_name.get(name, ())
+        if len(candidates) == 1 and getattr(candidates[0], "type", "") == "function":
+            return candidates[0]
+        return None
+
+
+class _FrameworkScanner:
+    def __init__(self, parsed: ParsedPythonFile, index: _DefinitionIndex):
+        self.parsed = parsed
+        self.path = parsed.path.resolve()
+        self.index = index
+        self.targets = []
+        self.routes: dict[str, tuple[ast.AST, dict[str, str | None]]] = {}
+        self.bindings: dict[str, str | None] = {}
+
+    def collect(self):
+        self._suite(self.parsed.tree.body, self.bindings)
+        for app, (value, bindings) in self.routes.items():
+            if app not in self.bindings.values():
+                continue
+            for candidate in _router_candidates(value):
+                name = (
+                    candidate.value
+                    if isinstance(candidate, ast.Constant)
+                    else _qualified(candidate, bindings)
+                )
+                definition = self.index.callable(name)
+                if definition is not None:
+                    self.targets.append((definition, "celery_task_router"))
+                    self._parameters(definition, 4, "celery_task_router", celery=True)
+        return self.targets
+
+    def _suite(self, statements, bindings, *, class_body=False):
+        for statement in statements:
+            if isinstance(statement, (ast.Return, ast.Raise)):
+                break
+            if isinstance(statement, ast.If) and isinstance(
+                statement.test, ast.Constant
+            ):
+                body = statement.body if statement.test.value else statement.orelse
+                self._suite(body, bindings, class_body=class_body)
+                continue
+            if isinstance(statement, (ast.Import, ast.ImportFrom)):
+                self._imports(statement, bindings)
+                continue
+            if isinstance(statement, _FUNCTIONS):
+                definition = self.index.by_location.get((self.path, statement.lineno))
+                bindings[statement.name] = (
+                    definition.name if definition and not class_body else None
+                )
+                continue
+            if isinstance(statement, ast.ClassDef):
+                if "django" not in self.index.shadowed and any(
+                    _qualified(base, bindings) == "django.apps.AppConfig"
+                    for base in statement.bases
+                ):
+                    ready = None
+                    for method in statement.body:
+                        if "ready" in _bound_names(method):
+                            ready = (
+                                method if isinstance(method, ast.FunctionDef) else None
+                            )
+                    if ready is not None:
+                        self._ready_imports(ready.body)
+                self._suite(statement.body, bindings.copy(), class_body=True)
+                bindings[statement.name] = None
+                continue
+            if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+                value = statement.value
+                if value is not None:
+                    self._calls(value, bindings)
+                targets = (
+                    statement.targets
+                    if isinstance(statement, ast.Assign)
+                    else [statement.target]
+                )
+                for target in targets:
+                    self._assignment(target, value, bindings, class_body)
+                continue
+            if isinstance(statement, ast.Expr):
+                self._calls(statement.value, bindings)
+                if not class_body and isinstance(statement.value, ast.Call):
+                    self._conf_update(statement.value, bindings)
+                continue
+            # Unknown control flow must not establish framework provenance.
+            for name in _bound_names(statement):
+                self._invalidate(name, bindings)
+            for child in () if class_body else _eager_nodes(statement):
+                if isinstance(child, (ast.Attribute, ast.Name)):
+                    qualified = _qualified(child, bindings)
+                    if qualified and qualified.startswith("@celery:"):
+                        self.routes.pop(qualified.split(".", 1)[0], None)
+
+    def _imports(self, node, bindings):
+        for alias in node.names:
+            if isinstance(node, ast.Import):
+                local = alias.asname or alias.name.split(".", 1)[0]
+                target = alias.name if alias.asname else alias.name.split(".", 1)[0]
+            else:
+                local = alias.asname or alias.name
+                module = node.module or ""
+                if node.level:
+                    package = self.index.modules.get(self.path, "").split(".")
+                    if self.path.name != "__init__.py":
+                        package = package[:-1]
+                    package = package[: len(package) - node.level + 1]
+                    module = ".".join([*package, *([module] if module else [])])
+                target = f"{module}.{alias.name}" if module else alias.name
+            self._invalidate(local, bindings)
+            bindings[local] = target
+
+    def _invalidate(self, name, bindings):
+        previous = bindings.get(name)
+        bindings[name] = None
+        if (
+            bindings is self.bindings
+            and previous
+            and previous.startswith("@celery:")
+            and previous not in bindings.values()
+        ):
+            self.routes.pop(previous, None)
+
+    def _assignment(self, target, value, bindings, class_body):
+        qualified = _qualified(target, bindings)
+        if qualified is None and isinstance(target, ast.Subscript) and not class_body:
+            container = _qualified(target.value, bindings)
+            if (
+                container
+                and container.startswith("@celery:")
+                and container.endswith(".conf")
+            ):
+                self.routes.pop(container.split(".", 1)[0], None)
+        if qualified and qualified.startswith("@celery:") and not class_body:
+            app, _, attribute = qualified.partition(".")
+            if attribute == "conf.task_routes":
+                self.routes[app] = (value, bindings.copy())
+            elif attribute == "conf":
+                self.routes.pop(app, None)
+                for name, binding in list(bindings.items()):
+                    if binding == app:
+                        bindings[name] = None
+        if not isinstance(target, ast.Name):
+            for name in _bound_names(target):
+                self._invalidate(name, bindings)
+            return
+        resolved = _qualified(value, bindings)
+        is_celery = (
+            not class_body
+            and "celery" not in self.index.shadowed
+            and isinstance(value, ast.Call)
+            and _qualified(value.func, bindings) == "celery.Celery"
+        )
+        self._invalidate(target.id, bindings)
+        if is_celery:
+            resolved = f"@celery:{value.lineno}:{value.col_offset}"
+            for keyword in value.keywords:
+                if keyword.arg == "task_routes":
+                    self.routes[resolved] = (keyword.value, bindings.copy())
+        bindings[target.id] = resolved
+
+    def _conf_update(self, call, bindings):
+        qualified = _qualified(call.func, bindings)
+        if not qualified or not qualified.startswith("@celery:"):
+            return
+        app, _, attribute = qualified.partition(".")
+        if attribute != "conf.update":
+            if attribute.startswith("config_from_"):
+                self.routes.pop(app, None)
+            return
+        for argument in call.args:
+            if not isinstance(argument, ast.Dict):
+                self.routes.pop(app, None)
+                continue
+            for key, value in zip(argument.keys, argument.values):
+                if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+                    self.routes.pop(app, None)
+                elif key.value == "task_routes":
+                    self.routes[app] = (value, bindings.copy())
+        for keyword in call.keywords:
+            if keyword.arg is None:
+                self.routes.pop(app, None)
+            elif keyword.arg == "task_routes":
+                self.routes[app] = (keyword.value, bindings.copy())
+
+    def _calls(self, expression, bindings):
+        if "django" in self.index.shadowed:
+            return
+        for call in _eager_nodes(expression):
+            if (
+                not isinstance(call, ast.Call)
+                or _qualified(call.func, bindings) not in _RUNPYTHON
+            ):
+                continue
+            callbacks = list(call.args[:2]) + [
+                keyword.value
+                for keyword in call.keywords
+                if keyword.arg in {"code", "reverse_code"}
+            ]
+            for callback in callbacks:
+                definition = self.index.callable(_qualified(callback, bindings))
+                if definition is not None:
+                    self._parameters(definition, 2, "django_migration_callback")
+
+    def _parameters(self, definition, count, reason, *, celery=False):
+        node = getattr(definition, "node", None)
+        if not isinstance(node, ast.FunctionDef):
+            return
+        positional = [*node.args.posonlyargs, *node.args.args]
+        supplied = positional[:count]
+        if len(positional) < count and node.args.vararg is not None:
+            supplied.append(node.args.vararg)
+        if celery:
+            supplied.extend(
+                arg
+                for arg in [*node.args.args, *node.args.kwonlyargs]
+                if arg.arg == "task"
+            )
+            if node.args.kwarg is not None:
+                supplied.append(node.args.kwarg)
+        parameters = self.index.parameters.get(definition.name, {})
+        for argument in supplied:
+            if argument.arg in parameters:
+                self.targets.append((parameters[argument.arg], reason))
+
+    def _ready_imports(self, statements) -> bool:
+        """Collect reachable imports; return whether this suite can continue."""
+        for statement in statements:
+            if isinstance(statement, (ast.Return, ast.Raise)):
+                return False
+            if isinstance(statement, ast.If) and isinstance(
+                statement.test, ast.Constant
+            ):
+                if not self._ready_imports(
+                    statement.body if statement.test.value else statement.orelse
+                ):
+                    return False
+                continue
+            for node in _eager_nodes(statement):
+                if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                    continue
+                for alias in node.names:
+                    if alias.name.rsplit(".", 1)[-1] != "signals":
+                        continue
+                    names = {}
+                    self._imports(node, names)
+                    local = alias.asname or (
+                        alias.name.split(".", 1)[0]
+                        if isinstance(node, ast.Import)
+                        else alias.name
+                    )
+                    module = (
+                        alias.name if isinstance(node, ast.Import) else names.get(local)
+                    )
+                    for definition in self.index.imports.get((self.path, module), ()):
+                        # Import definitions aggregate aliases/lines for one symbol.
+                        if definition.name in self.index.modules.values():
+                            self.targets.append(
+                                (definition, "django_appconfig_signal_import")
+                            )
+        return True
+
+
+def _router_candidates(value):
+    if isinstance(value, (ast.Name, ast.Attribute)):
+        yield value
+    elif isinstance(value, ast.Constant) and isinstance(value.value, str):
+        yield value
+    elif isinstance(value, (ast.Tuple, ast.List)):
+        for candidate in value.elts:
+            # A mapping (including ordered pattern/route pairs) is not a callback.
+            if isinstance(candidate, (ast.Name, ast.Attribute, ast.Constant)):
+                yield from _router_candidates(candidate)

--- a/skylos/deadcode/liveness.py
+++ b/skylos/deadcode/liveness.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from skylos.deadcode.plugin_registry import find_literal_plugin_registry_targets
+from skylos.deadcode.framework_liveness import find_framework_entrypoint_targets
 from skylos.analysis.ast_cache import releases_python_ast_cache
 from skylos.deadcode.python_ast import ParsedPythonFile, parse_python_files
 
@@ -129,6 +130,10 @@ def apply_dead_code_liveness(
     _rescue_optional_import_fallbacks(definitions, refs, report)
     _rescue_protocol_overrides(classes, class_methods, report)
     _rescue_registration_methods(classes, class_methods, report)
+    for target, reason in find_framework_entrypoint_targets(
+        definitions, parsed_files, root
+    ):
+        _mark(target, reason, report)
     for target in find_literal_plugin_registry_targets(definitions, parsed_files):
         _mark(target, "literal_plugin_registry", report)
     _rescue_documented_public_methods(classes, class_methods, docs_text, report)

--- a/skylos/visitors/languages/typescript/analysis.py
+++ b/skylos/visitors/languages/typescript/analysis.py
@@ -1383,6 +1383,7 @@ def find_dead_ts_files(
     wildcard_edges,
     project_root: str | None = None,
     workspace_inventory=None,
+    browser_entry_points=None,
 ):
     exclude_root = _resolve_exclude_root(files, project_root)
     ts_files = set()
@@ -1410,6 +1411,9 @@ def find_dead_ts_files(
         project_root=project_root,
         workspace_inventory=workspace_inventory,
         exclude_folders=exclude_folders,
+    )
+    entry_points.update(
+        os.path.realpath(str(path)) for path in browser_entry_points or ()
     )
 
     dead_set = set()

--- a/test/test_circular_deps.py
+++ b/test/test_circular_deps.py
@@ -1,12 +1,177 @@
 import ast
 import pytest
+from skylos.analysis import circular_deps
 from skylos.analysis.architecture import get_architecture_findings
+from skylos.analysis.file_processing import collect_python_raw_imports
 from skylos.analysis.circular_deps import (
     CircularDependencyAnalyzer,
     CircularDependencyRule,
     DependencyGraphBuilder,
     analyze_circular_dependencies,
 )
+
+
+def _rule_for_sources(sources, mode):
+    rule = CircularDependencyRule()
+    for module, (filename, source) in sources.items():
+        tree = ast.parse(source, filename=filename)
+        if mode == "raw":
+            rule.add_file_imports(
+                filename, module, collect_python_raw_imports(tree, filename, module)
+            )
+        else:
+            rule.add_file(tree, filename, module)
+    return rule
+
+
+@pytest.mark.parametrize("mode", ["ast", "raw"])
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import package.child",
+        "from package import child",
+        "from package.child import value",
+        "from . import child",
+        "from .child import value",
+    ],
+)
+def test_package_child_import_keeps_exact_identity_without_self_cycle(mode, source):
+    rule = _rule_for_sources(
+        {
+            "package": ("/project/package/__init__.py", source),
+            "package.child": ("/project/package/child.py", "value = 'label'"),
+        },
+        mode,
+    )
+
+    assert rule.analyze() == []
+    assert dict(rule._analyzer.dependencies) == {"package": {"package.child"}}
+    assert dict(rule._analyzer.architecture_dependencies) == {
+        "package": {"package.child"}
+    }
+    assert [
+        (dep.from_module, dep.to_module, dep.import_line)
+        for dep in rule._analyzer.all_deps
+    ] == [("package", "package.child", 1)]
+
+
+@pytest.mark.parametrize("mode", ["ast", "raw"])
+@pytest.mark.parametrize(
+    ("sources", "cycle", "edges"),
+    [
+        pytest.param(
+            {
+                "package": (
+                    "/project/package/__init__.py",
+                    "from . import child",
+                ),
+                "package.child": (
+                    "/project/package/child.py",
+                    "from package import value",
+                ),
+            },
+            {"package", "package.child"},
+            {"package": {"package.child"}, "package.child": {"package"}},
+            id="child-imports-package-back",
+        ),
+        pytest.param(
+            {
+                "package.a": ("/project/package/a.py", "from .b import value"),
+                "package.b": ("/project/package/b.py", "from .a import value"),
+            },
+            {"package.a", "package.b"},
+            {"package.a": {"package.b"}, "package.b": {"package.a"}},
+            id="relative-sibling-cycle",
+        ),
+        pytest.param(
+            {
+                "package.nested": (
+                    "/project/package/nested/__init__.py",
+                    "from .. import child",
+                ),
+                "package.child": (
+                    "/project/package/child.py",
+                    "import package.nested",
+                ),
+            },
+            {"package.nested", "package.child"},
+            {
+                "package.nested": {"package.child"},
+                "package.child": {"package.nested"},
+            },
+            id="nested-package-parent-relative-cycle",
+        ),
+    ],
+)
+def test_real_same_package_cycles_remain_visible(mode, sources, cycle, edges):
+    rule = _rule_for_sources(sources, mode)
+
+    findings = rule.analyze()
+
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "SKY-CIRC"
+    assert set(findings[0]["cycle"]) == cycle
+    assert dict(rule._analyzer.dependencies) == edges
+    assert dict(rule._analyzer.architecture_dependencies) == edges
+
+
+@pytest.mark.parametrize("mode", ["ast", "raw"])
+@pytest.mark.parametrize(
+    ("source", "targets"),
+    [
+        ("import package.missing", {"package"}),
+        ("from package import missing", {"package"}),
+        ("from package import child, missing", {"package", "package.child"}),
+    ],
+)
+def test_unresolved_package_children_and_symbols_remain_conservative(
+    mode, source, targets
+):
+    rule = _rule_for_sources(
+        {
+            "package": ("/project/package/__init__.py", source),
+            "package.child": ("/project/package/child.py", "value = 'label'"),
+        },
+        mode,
+    )
+
+    findings = rule.analyze()
+
+    assert len(findings) == 1
+    assert findings[0]["cycle"] == ["package"]
+    assert rule._analyzer.dependencies["package"] == targets
+    assert rule._analyzer.architecture_dependencies["package"] == targets
+
+
+@pytest.mark.parametrize("mode", ["ast", "raw"])
+def test_direct_module_self_import_is_not_suppressed(mode):
+    rule = _rule_for_sources({"module": ("/project/module.py", "import module")}, mode)
+
+    findings = rule.analyze()
+
+    assert len(findings) == 1
+    assert findings[0]["cycle"] == ["module"]
+
+
+@pytest.mark.parametrize("child_source", ["value = 'label'", "import package"])
+def test_same_package_graph_has_python_native_cycle_parity(child_source):
+    if circular_deps._fast_find_cycles is None:
+        pytest.skip("optional native cycle detector is unavailable")
+    rule = _rule_for_sources(
+        {
+            "package": ("/project/package/__init__.py", "from package import child"),
+            "package.child": ("/project/package/child.py", child_source),
+        },
+        "raw",
+    )
+    rule.analyze()
+
+    def normalize(cycles):
+        return {tuple(sorted(cycle)) for cycle in cycles}
+
+    assert normalize(rule._analyzer._find_cycles_py()) == normalize(
+        rule._analyzer._find_cycles_fast()
+    )
 
 
 class TestDependencyGraphBuilder:

--- a/test/test_django_admin_stubs.py
+++ b/test/test_django_admin_stubs.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from skylos.analyzer import analyze
+
+
+def _sources(root: Path, sources: dict[str, str]):
+    for name, source in sources.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("x", encoding="utf-8") as stream:
+            stream.write(source)
+
+
+@pytest.mark.parametrize(
+    ("extra_sources", "package", "reported"),
+    [
+        pytest.param(
+            {"settings.py": "from django.apps import AppConfig\n"},
+            True,
+            False,
+            id="django-package-admin-stub",
+        ),
+        pytest.param({}, True, True, id="non-django-package"),
+        pytest.param(
+            {"settings.py": "from django.apps import AppConfig\n"},
+            False,
+            True,
+            id="standalone-admin-file",
+        ),
+        pytest.param(
+            {
+                "shop/django.py": "value = 1\n",
+                "shop/config.py": "from .django import value\n",
+            },
+            True,
+            True,
+            id="relative-local-django-is-not-the-framework",
+        ),
+        pytest.param(
+            {
+                "django.py": "value = 1\n",
+                "settings.py": "from django.apps import AppConfig\n",
+            },
+            True,
+            True,
+            id="top-level-django-shadow",
+        ),
+        pytest.param(
+            {
+                "src/django/__init__.py": "",
+                "settings.py": "from django.apps import AppConfig\n",
+            },
+            True,
+            True,
+            id="source-root-django-shadow",
+        ),
+    ],
+)
+def test_admin_stub_requires_django_package_context(
+    tmp_path, extra_sources, package, reported
+):
+    sources = {
+        **extra_sources,
+        "shop/admin.py": "# Register your models here.\n",
+        "shop/placeholder.py": "# An ordinary empty file.\n",
+    }
+    if package:
+        sources["shop/__init__.py"] = ""
+    _sources(tmp_path, sources)
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    empty_files = {
+        finding["file"]
+        for finding in result.get("unused_files", [])
+        if finding.get("rule_id") == "SKY-E002"
+    }
+
+    assert (str(tmp_path / "shop/admin.py") in empty_files) is reported
+    assert str(tmp_path / "shop/placeholder.py") in empty_files
+
+
+def test_admin_filename_does_not_rescue_unused_functions(tmp_path):
+    _sources(
+        tmp_path,
+        {
+            "settings.py": "from django.apps import AppConfig\n",
+            "shop/__init__.py": "",
+            "shop/admin.py": "def unused_helper():\n    return 1\n",
+        },
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+
+    assert any(
+        finding["name"] == "unused_helper"
+        for finding in result.get("unused_functions", [])
+    )

--- a/test/test_django_celery_entrypoints.py
+++ b/test/test_django_celery_entrypoints.py
@@ -1,0 +1,318 @@
+"""Framework fixtures are parsed by Skylos, never imported or executed."""
+
+import json
+import textwrap
+
+import pytest
+
+from skylos.analyzer import analyze
+
+
+def _scan(tmp_path, sources):
+    for name, source in sources.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("x", encoding="utf-8") as stream:
+            stream.write(textwrap.dedent(source).lstrip())
+    return json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+
+
+def _names(result, bucket):
+    return {item["full_name"] for item in result.get(bucket, [])}
+
+
+@pytest.mark.parametrize(
+    "registration",
+    [
+        "from django.db import migrations as ops\noperation = ops.RunPython(forwards)",
+        "from django.db.migrations import RunPython as Operation\n"
+        "operation = Operation(code=forwards)",
+        "import django.db.migrations\nimport django.db.models\n"
+        "operation = django.db.migrations.RunPython(forwards)",
+    ],
+)
+def test_runpython_rescues_only_framework_argument_slots(tmp_path, registration):
+    result = _scan(
+        tmp_path,
+        {
+            "shop/__init__.py": "",
+            "shop/migrations/__init__.py": "",
+            "shop/migrations/0001_data.py": (
+                "def forwards(apps, schema_editor, extra=None): pass\n"
+                "def unrelated(apps, schema_editor): pass\n" + registration
+            ),
+        },
+    )
+    unused = _names(result, "unused_parameters")
+    assert not any(name.endswith(".forwards.apps") for name in unused)
+    assert not any(name.endswith(".forwards.schema_editor") for name in unused)
+    assert any(name.endswith(".forwards.extra") for name in unused)
+    assert any(name.endswith(".unrelated.apps") for name in unused)
+    assert any(name.endswith(".unrelated.schema_editor") for name in unused)
+
+
+def test_runpython_imported_and_reverse_callbacks(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "callbacks.py": "def forwards(apps, editor, extra=None): pass\n",
+            "shop/__init__.py": "",
+            "shop/migrations/__init__.py": "",
+            "shop/migrations/0001_data.py": """
+                from django.db import migrations
+                from callbacks import forwards as apply_data
+                def backwards(*runtime, extra=None): pass
+                class Migration(migrations.Migration):
+                    operations = [migrations.RunPython(apply_data, backwards)]
+            """,
+        },
+    )
+    unused = _names(result, "unused_parameters")
+    assert "callbacks.forwards.apps" not in unused
+    assert "callbacks.forwards.editor" not in unused
+    assert "callbacks.forwards.extra" in unused
+    assert not any(name.endswith(".backwards.runtime") for name in unused)
+    assert any(name.endswith(".backwards.extra") for name in unused)
+
+
+@pytest.mark.parametrize(
+    "registration",
+    [
+        "class RunPython: pass\noperation = RunPython(forwards)",
+        "from django.db import migrations\nimport local_ops as migrations\n"
+        "operation = migrations.RunPython(forwards)",
+        "from django.db import migrations\n"
+        "def helper(migrations): return migrations.RunPython(forwards)",
+        "from django.db import migrations\nclass Holder:\n"
+        "    migrations = object()\n    operation = migrations.RunPython(forwards)",
+        "from django.db import migrations\nforwards = replacement\n"
+        "operation = migrations.RunPython(forwards)",
+    ],
+)
+def test_runpython_lookalikes_and_shadowing_do_not_rescue(tmp_path, registration):
+    result = _scan(
+        tmp_path,
+        {
+            "shop/__init__.py": "",
+            "shop/migrations/__init__.py": "",
+            "shop/migrations/0001_data.py": (
+                "def forwards(apps, schema_editor): pass\n" + registration
+            ),
+        },
+    )
+    unused = _names(result, "unused_parameters")
+    assert any(name.endswith(".forwards.apps") for name in unused)
+    assert any(name.endswith(".forwards.schema_editor") for name in unused)
+
+
+@pytest.mark.parametrize(
+    "configuration",
+    [
+        'app = Factory("shop", task_routes=("routers.route_task",))',
+        'app = Factory("shop")\napp.conf.task_routes = ("routers.route_task",)',
+        'app = Factory("shop")\napp.conf.update(task_routes=("routers.route_task",))',
+        'app = Factory("shop")\napp.conf.update({"task_routes": ("routers.route_task",)})',
+        'from routers import route_task as router\napp = Factory("shop")\n'
+        "app.conf.task_routes = (router,)",
+    ],
+)
+def test_actual_celery_router_and_signature_are_live(tmp_path, configuration):
+    result = _scan(
+        tmp_path,
+        {
+            "routers.py": """
+                def route_task(name, args, kwargs, options, task=None, extra=None, **kw):
+                    return None
+                def unrelated(name, args, kwargs, options, task=None): return None
+            """,
+            "app.py": "from celery import Celery as Factory\n" + configuration,
+        },
+    )
+    assert "routers.route_task" not in _names(result, "unused_functions")
+    unused = _names(result, "unused_parameters")
+    for argument in ("name", "args", "kwargs", "options", "task", "kw"):
+        assert f"routers.route_task.{argument}" not in unused
+    assert "routers.route_task.extra" in unused
+    assert "routers.unrelated.args" in unused
+
+
+@pytest.mark.parametrize(
+    "configuration",
+    [
+        "class Celery:\n    def __init__(self):\n"
+        '        self.task_routes = ("routers.route_task",)\napp = Celery()',
+        'task_routes = ("routers.route_task",)',
+        "from celery import Celery\nCelery = factory\n"
+        'app = Celery("shop", task_routes=("routers.route_task",))',
+        'from celery import Celery\napp = Celery("shop")\napp = object()\n'
+        'app.conf.task_routes = ("routers.route_task",)',
+        'from celery import Celery\napp = Celery("shop")\n'
+        'app.conf.task_routes = ("routers.route_task",)\napp.conf.task_routes = {}',
+        'from celery import Celery\napp = Celery("shop")\n'
+        'app.conf.task_routes = ("routers.route_task",)\napp.conf.update(settings)',
+        'from celery import Celery\napp = Celery("shop")\n'
+        'app.conf.task_routes = {"routers.route_task": {"queue": "labels"}}',
+    ],
+)
+def test_celery_fake_private_and_stale_configuration_does_not_rescue(
+    tmp_path, configuration
+):
+    result = _scan(
+        tmp_path,
+        {
+            "routers.py": "def route_task(name, args, kwargs, options): return None\n",
+            "app.py": configuration,
+        },
+    )
+    assert "routers.route_task" in _names(result, "unused_functions")
+    assert "routers.route_task.args" in _names(result, "unused_parameters")
+
+
+def test_appconfig_ready_signal_import_only(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "shop/__init__.py": "",
+            "shop/signals.py": "",
+            "shop/helpers.py": "",
+            "shop/apps.py": """
+                from django.apps import AppConfig as BaseConfig
+                class ShopConfig(BaseConfig):
+                    def ready(self):
+                        from . import helpers, signals as hooks
+                    def unrelated(self):
+                        from . import signals as unrelated_signals
+            """,
+        },
+    )
+    imports = result.get("unused_imports", [])
+    assert not any(
+        item["line"] == 4 and item["simple_name"] == "signals" for item in imports
+    )
+    assert any(item["simple_name"] == "helpers" for item in imports)
+
+
+@pytest.mark.parametrize(
+    "prefix", ["class AppConfig: pass", "from local_apps import AppConfig"]
+)
+def test_fake_appconfig_ready_import_stays_unused(tmp_path, prefix):
+    result = _scan(
+        tmp_path,
+        {
+            "shop/__init__.py": "",
+            "shop/signals.py": "",
+            "shop/apps.py": prefix + "\nclass ShopConfig(AppConfig):\n"
+            "    def ready(self):\n        from . import signals\n",
+        },
+    )
+    assert "shop.signals" in _names(result, "unused_imports")
+
+
+@pytest.mark.parametrize(
+    "replacement", ["def ready(self): pass", "ready = replacement"]
+)
+def test_overwritten_ready_method_does_not_rescue_stale_import(tmp_path, replacement):
+    result = _scan(
+        tmp_path,
+        {
+            "shop/__init__.py": "",
+            "shop/signals.py": "",
+            "shop/apps.py": "from django.apps import AppConfig\n"
+            "class ShopConfig(AppConfig):\n"
+            "    def ready(self):\n        from . import signals\n"
+            f"    {replacement}\n",
+        },
+    )
+    assert "shop.signals" in _names(result, "unused_imports")
+
+
+@pytest.mark.parametrize(
+    "exit_statement", ["return", "raise RuntimeError('not ready')"]
+)
+def test_ready_literal_branch_exit_prevents_signal_import(tmp_path, exit_statement):
+    result = _scan(
+        tmp_path,
+        {
+            "shop/__init__.py": "",
+            "shop/signals.py": "",
+            "shop/apps.py": "from django.apps import AppConfig\n"
+            "class ShopConfig(AppConfig):\n"
+            "    def ready(self):\n"
+            "        if True:\n"
+            "            if False:\n"
+            "                pass\n"
+            "            else:\n"
+            f"                {exit_statement}\n"
+            "        from . import signals\n",
+        },
+    )
+    assert "shop.signals" in _names(result, "unused_imports")
+
+
+def test_ready_false_exit_branch_keeps_signal_import_live(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "shop/__init__.py": "",
+            "shop/signals.py": "",
+            "shop/apps.py": "from django.apps import AppConfig\n"
+            "class ShopConfig(AppConfig):\n"
+            "    def ready(self):\n"
+            "        if False:\n"
+            "            return\n"
+            "        from . import signals\n",
+        },
+    )
+    assert "shop.signals" not in _names(result, "unused_imports")
+
+
+def test_class_local_app_shadow_does_not_erase_module_configuration(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "routers.py": "def route_task(name, args, kwargs, options): return None\n",
+            "app.py": 'from celery import Celery\napp = Celery("shop")\n'
+            'app.conf.task_routes = ("routers.route_task",)\n'
+            "class Other:\n    app = object()\n",
+        },
+    )
+    assert "routers.route_task.args" not in _names(result, "unused_parameters")
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        'app.conf["task_routes"] = {}',
+        "app.conf = object()\napp.conf.task_routes = ('routers.route_task',)",
+        "app.conf[key] = value",
+    ],
+)
+def test_replaced_celery_configuration_does_not_rescue_router(tmp_path, replacement):
+    result = _scan(
+        tmp_path,
+        {
+            "routers.py": "def route_task(name, args, kwargs, options): return None\n",
+            "app.py": 'from celery import Celery\napp = Celery("shop")\n'
+            'app.conf.task_routes = ("routers.route_task",)\n' + replacement,
+        },
+    )
+    assert "routers.route_task.args" in _names(result, "unused_parameters")
+
+
+@pytest.mark.parametrize("framework", ["django", "celery"])
+def test_local_framework_package_is_not_trusted(tmp_path, framework):
+    sources = {
+        f"{framework}/__init__.py": "",
+        "routers.py": "def route_task(name, args, kwargs, options): return None\n",
+        "app.py": 'from celery import Celery\napp = Celery("shop", task_routes=("routers.route_task",))',
+        "shop/__init__.py": "",
+        "shop/migrations/__init__.py": "",
+        "shop/migrations/0001_data.py": "from django.db import migrations\n"
+        "def forwards(apps, editor): pass\noperation = migrations.RunPython(forwards)",
+    }
+    result = _scan(tmp_path, sources)
+    unused = _names(result, "unused_parameters")
+    if framework == "django":
+        assert any(name.endswith(".forwards.apps") for name in unused)
+    else:
+        assert "routers.route_task.args" in unused

--- a/test/test_django_static_entrypoints.py
+++ b/test/test_django_static_entrypoints.py
@@ -1,0 +1,295 @@
+"""Template loading proves file reachability, not consumption of every export."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from skylos.deadcode import browser_refs
+from skylos.visitors.base import Definition
+from skylos.visitors.languages.typescript.analysis import (
+    demote_unconsumed_ts_exports,
+    find_dead_ts_files,
+)
+
+
+def _sources(root: Path, sources: dict[str, str]) -> list[Path]:
+    files = []
+    for name, source in sources.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("x", encoding="utf-8") as stream:
+            stream.write(source)
+        if path.suffix in {".js", ".mjs"}:
+            files.append(path)
+    return files
+
+
+def _entries(root: Path, files: list[Path], **kwargs) -> set[Path]:
+    return browser_refs.collect_browser_script_entry_files(root, files, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "asset", ["static/widget.js", "app/static/widget.js", "app/static/app/widget.js"]
+)
+@pytest.mark.parametrize("script_type", ["", ' type="module"'])
+def test_literal_static_script_is_a_file_entrypoint(tmp_path, asset, script_type):
+    static_path = asset.split("static/", 1)[1]
+    files = _sources(
+        tmp_path,
+        {
+            asset: "export function greet() { return 'ok'; }\n",
+            "templates/page.html": f"<script{script_type} src=\"{{% static '{static_path}' %}}\"></script>",
+            "unloaded.js": "function unused() {}\n",
+        },
+    )
+
+    entries = _entries(tmp_path, files)
+
+    assert entries == {tmp_path / asset}
+    findings = find_dead_ts_files(
+        files, [], {}, {}, project_root=str(tmp_path), browser_entry_points=entries
+    )
+    assert {Path(item["file"]).name for item in findings} == {"unloaded.js"}
+
+
+@pytest.mark.parametrize("script_type", ["", ' type="module"'])
+def test_loading_script_does_not_consume_unused_export(tmp_path, script_type):
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "export function greet() { return 'ok'; }\n",
+            "templates/page.html": f"<script{script_type} src=\"{{% static 'widget.js' %}}\"></script>",
+        },
+    )
+    definition = Definition("greet", "function", files[0], 1)
+    definition.is_exported = True
+
+    assert _entries(tmp_path, files) == {files[0]}
+    demoted = demote_unconsumed_ts_exports({"greet": definition}, {})
+
+    assert demoted == [definition]
+    assert definition.references == 0
+    assert definition.is_exported is False
+    assert browser_refs.collect_browser_event_handler_refs(tmp_path, files) == []
+
+
+def test_named_handler_reaches_only_called_function_in_loaded_classic_script(tmp_path):
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "function greet() { return 'ok'; }\nfunction unused() {}\n",
+            "other/widget.js": "function greet() { return 'other'; }\n",
+            "templates/page.html": '<script src="{% static \'widget.js\' %}"></script><button onclick="greet()">Go</button>',
+        },
+    )
+
+    refs = browser_refs.collect_browser_event_handler_refs(tmp_path, files)
+
+    assert ("greet", str(tmp_path / "static/widget.js")) in refs
+    assert ("greet", str(tmp_path / "other/widget.js")) not in refs
+    assert not any(name == "unused" for name, _ in refs)
+
+
+@pytest.mark.parametrize("script_type", [' type="module"', " type=module"])
+def test_module_exports_are_not_global_inline_handlers(tmp_path, script_type):
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "export function greet() {}\n",
+            "templates/page.html": f'<script{script_type} src="{{% static \'widget.js\' %}}"></script><button onclick="greet()">Go</button>',
+        },
+    )
+
+    refs = browser_refs.collect_browser_event_handler_refs(tmp_path, files)
+
+    assert ("greet", str(files[0])) not in refs
+
+
+def test_export_declaration_is_not_a_classic_script_global(tmp_path):
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "export function greet() {}\n",
+            "templates/page.html": '<script src="{% static \'widget.js\' %}"></script><button onclick="greet()">Go</button>',
+        },
+    )
+
+    refs = browser_refs.collect_browser_event_handler_refs(tmp_path, files)
+
+    assert ("greet", str(files[0])) not in refs
+
+
+def test_template_handler_is_not_assigned_to_another_pages_script(tmp_path):
+    files = _sources(
+        tmp_path,
+        {
+            "first/static/first.js": "function greet() {}\n",
+            "second/static/second.js": "function greet() {}\n",
+            "templates/first.html": '<script src="{% static \'first.js\' %}"></script><button onclick="greet()">Go</button>',
+            "templates/second.html": "<script src=\"{% static 'second.js' %}\"></script>",
+        },
+    )
+
+    refs = browser_refs.collect_browser_event_handler_refs(tmp_path, files)
+
+    assert ("greet", str(files[0])) in refs
+    assert ("greet", str(files[1])) not in refs
+
+
+def test_commented_handler_does_not_consume_a_loaded_scripts_function(tmp_path):
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "function greet() {}\n",
+            "templates/page.html": '<script src="{% static \'widget.js\' %}"></script><!-- <button onclick="greet()">Go</button> -->',
+        },
+    )
+
+    assert browser_refs.collect_browser_event_handler_refs(tmp_path, files) == []
+
+
+def test_static_directory_can_itself_be_the_scan_root(tmp_path):
+    root = tmp_path / "static"
+    root.mkdir()
+    files = _sources(
+        root,
+        {
+            "widget.js": "function greet() {}\n",
+            "page.html": "<script src=\"{% static 'widget.js' %}\"></script>",
+        },
+    )
+
+    assert _entries(root, files) == {files[0]}
+
+
+@pytest.mark.parametrize(
+    "markup",
+    [
+        "<script data-src=\"{% static 'widget.js' %}\"></script>",
+        '<script src="{% static asset_name %}"></script>',
+        "<script src=\"{% static 'missing.js' %}\"></script>",
+        '<script type="application/json" src="{% static \'widget.js\' %}"></script>',
+        "<!-- <script src=\"{% static 'widget.js' %}\"></script> -->",
+        "{# <script src=\"{% static 'widget.js' %}\"></script> #}",
+        "{% comment %}<script src=\"{% static 'widget.js' %}\"></script>{% endcomment %}",
+    ],
+)
+def test_nonloading_template_lookalikes_do_not_create_entrypoints(tmp_path, markup):
+    files = _sources(
+        tmp_path,
+        {"static/widget.js": "function greet() {}\n", "templates/page.html": markup},
+    )
+
+    assert _entries(tmp_path, files) == set()
+
+
+def test_ambiguous_static_asset_is_not_guessed(tmp_path):
+    files = _sources(
+        tmp_path,
+        {
+            "first/static/widget.js": "function greet() {}\n",
+            "second/static/widget.js": "function greet() {}\n",
+            "templates/page.html": '<script src="{% static \'widget.js\' %}"></script><button onclick="greet()">Go</button>',
+        },
+    )
+
+    assert _entries(tmp_path, files) == set()
+    refs = browser_refs.collect_browser_event_handler_refs(tmp_path, files)
+    assert not any(Path(filename).suffix == ".js" for _, filename in refs)
+
+
+def test_only_scanned_assets_and_included_templates_create_entrypoints(tmp_path):
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "function greet() {}\n",
+            "templates/page.html": "<script src=\"{% static 'widget.js' %}\"></script>",
+        },
+    )
+
+    assert _entries(tmp_path, []) == set()
+    assert _entries(tmp_path, files, exclude_folders=["templates"]) == set()
+
+
+@pytest.mark.parametrize(
+    "script_type", ["", ' type="text/javascript"', ' type="application/x-javascript"']
+)
+def test_regular_browser_script_url_remains_supported(tmp_path, script_type):
+    files = _sources(
+        tmp_path,
+        {
+            "widget.js": "function greet() {}\n",
+            "templates/page.html": f'<script{script_type} src="/widget.js?v=1#loaded"></script><button onclick="greet()">Go</button>',
+        },
+    )
+
+    assert _entries(tmp_path, files) == {files[0]}
+    assert ("greet", str(files[0])) in browser_refs.collect_browser_event_handler_refs(
+        tmp_path, files
+    )
+
+
+def test_loaded_module_keeps_its_imported_dependency_file_reachable(tmp_path):
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "import { greet } from './helpers.js';\ngreet();\n",
+            "static/helpers.js": "export function greet() {}\n",
+            "templates/page.html": '<script type="module" src="{% static \'widget.js\' %}"></script>',
+        },
+    )
+    entries = _entries(tmp_path, files)
+    importers = {str(files[1]): {str(files[0])}}
+
+    assert (
+        find_dead_ts_files(
+            files,
+            [],
+            importers,
+            {},
+            project_root=str(tmp_path),
+            browser_entry_points=entries,
+        )
+        == []
+    )
+
+
+def test_analyzer_preserves_called_handler_and_reports_unused_helper(tmp_path):
+    from skylos.analyzer import analyze
+
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "function greet() { return 'ok'; }\nfunction unusedHelper() { return 'unused'; }\n",
+            "templates/page.html": '<script src="{% static \'widget.js\' %}"></script><button onclick="greet()">Go</button>',
+        },
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    unused = {item["name"] for item in result.get("unused_functions", [])}
+    unused_files = {Path(item["file"]) for item in result.get("unused_files", [])}
+
+    assert "greet" not in unused
+    assert "unusedHelper" in unused
+    assert files[0] not in unused_files
+
+
+@pytest.mark.parametrize("script_type", ["", ' type="module"'])
+def test_analyzer_keeps_uncalled_export_unused_in_loaded_file(tmp_path, script_type):
+    from skylos.analyzer import analyze
+
+    files = _sources(
+        tmp_path,
+        {
+            "static/widget.js": "export function greet() { return 'ok'; }\n",
+            "templates/page.html": f"<script{script_type} src=\"{{% static 'widget.js' %}}\"></script>",
+        },
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    unused = {item["name"] for item in result.get("unused_functions", [])}
+    unused_files = {Path(item["file"]) for item in result.get("unused_files", [])}
+
+    assert "greet" in unused
+    assert files[0] not in unused_files


### PR DESCRIPTION
Fix #776

## Summary

  - Fixed unused param warnings on Django migration callbacks
  - Recognize signal imports in AppConfig.ready() and conventional empty admin.py files.
  - Recognize registered Celery routers and their callback parameters.
  - Resolve Django references and template event handlers.
  - Fixed false package self-cycles without hiding real circular imports.

## Tests

pytest test/test_django_admin_stubs.py test/test_django_celery_entrypoints.py test/test_django_static_entrypoints.py \
    test/test_circular_deps.py test/test_dead_code_liveness.py test/test_ts_exports.py test/test_typescript_expanded.py \
    test/test_architecture.py test/test_fast_parity.py