### PR TITLE
fix(analyzer): recognize declaration-only Python stubs

### DIFF
--- a/skylos/visitors/base.py
+++ b/skylos/visitors/base.py
@@ -239,6 +239,78 @@ def _has_signature_stub_body(
     )
 
 
+def _is_stub_value(node: ast.AST | None) -> bool:
+    """Recognize declaration values, not expressions that run an implementation."""
+    if node is None or isinstance(node, ast.Constant):
+        return True
+    return (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, (ast.UAdd, ast.USub))
+        and isinstance(node.operand, ast.Constant)
+        and isinstance(node.operand.value, (int, float, complex))
+    )
+
+
+def _is_stub_declaration(node: ast.AST) -> bool:
+    """Recognize non-concrete declarations in a Python type stub."""
+    if isinstance(node, ast.AnnAssign):
+        return isinstance(node.target, ast.Name) and _is_stub_value(node.value)
+    if isinstance(node, ast.Assign):
+        return (
+            all(isinstance(target, ast.Name) for target in node.targets)
+            and isinstance(node.value, ast.Constant)
+            and node.value.value is Ellipsis
+        )
+    if isinstance(node, ast.If):
+        # Stubs may select declarations by version/platform or TYPE_CHECKING.
+        # Calls, comprehensions and assignment expressions are not such guards.
+        condition_nodes = (
+            ast.Name,
+            ast.Attribute,
+            ast.Subscript,
+            ast.Slice,
+            ast.Tuple,
+            ast.List,
+            ast.Constant,
+            ast.Compare,
+            ast.BoolOp,
+            ast.UnaryOp,
+            ast.Load,
+            ast.cmpop,
+            ast.And,
+            ast.Or,
+            ast.Not,
+            ast.UAdd,
+            ast.USub,
+        )
+        return all(
+            isinstance(part, condition_nodes) for part in ast.walk(node.test)
+        ) and all(
+            _is_stub_declaration(statement) for statement in [*node.body, *node.orelse]
+        )
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        body = node.body
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            body = body[1:]
+        if isinstance(node, ast.ClassDef):
+            return all(_is_stub_declaration(statement) for statement in body)
+        return (
+            len(body) == 1
+            and isinstance(body[0], ast.Expr)
+            and _is_stub_declaration(body[0])
+        )
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and node.value.value is Ellipsis
+    )
+
+
 def _module_binds_name(module: ast.Module, target_name: str) -> bool:
     class BindingProbe(ast.NodeVisitor):
         def __init__(self) -> None:
@@ -462,6 +534,8 @@ class Visitor(ast.NodeVisitor):
     def __init__(self, mod: str, file: Union[Path, str]) -> None:
         self.mod = mod
         self.file = file
+        self._is_type_stub = Path(file).suffix.lower() == ".pyi"
+        self._stub_binding_lines: dict[str, int] = {}
         self.defs = []
         self.refs = []
         self.cls = None
@@ -533,6 +607,17 @@ class Visitor(ast.NodeVisitor):
     def add_def(
         self, name: str, t: str, line: int, node: Optional[ast.AST] = None, **extra: Any
     ) -> None:
+        # Omit declaration candidates rather than adding synthetic references:
+        # .py and .pyi siblings share qualified names in the merged symbol map.
+        if (
+            self._is_type_stub
+            and not self.current_function_scope
+            and t in {"class", "function", "method"}
+            and node is not None
+            and _is_stub_declaration(node)
+        ):
+            self._stub_binding_lines[name] = line
+            return
         found = False
         for d in self.defs:
             if d.name == name:
@@ -584,13 +669,11 @@ class Visitor(ast.NodeVisitor):
 
     def qual(self, name: str) -> str:
         if name in self.alias:
-            if self.mod:
-                local_name = f"{self.mod}.{name}"
-                if any(d.name == local_name for d in self.defs):
-                    return local_name
-            else:
-                if any(d.name == name for d in self.defs):
-                    return name
+            local_name = f"{self.mod}.{name}" if self.mod else name
+            if local_name in self._stub_binding_lines or any(
+                d.name == local_name for d in self.defs
+            ):
+                return local_name
             return self.alias[name]
 
         if name in PYTHON_BUILTINS:
@@ -880,6 +963,11 @@ class Visitor(ast.NodeVisitor):
             candidates.append(".".join(filter(None, [self.mod, self.cls, name])))
         candidates.append(f"{self.mod}.{name}" if self.mod else name)
 
+        if any(
+            candidate in self._stub_binding_lines and candidate != current_definition
+            for candidate in candidates
+        ):
+            return True
         return any(
             d.name in candidates
             and d.name != current_definition
@@ -929,6 +1017,17 @@ class Visitor(ast.NodeVisitor):
                 and definition.type != "import"
             ),
             default=-1,
+        )
+        latest_local_line = max(
+            latest_local_line,
+            max(
+                (
+                    self._stub_binding_lines.get(candidate, -1)
+                    for candidate in candidates
+                    if candidate != current_definition
+                ),
+                default=-1,
+            ),
         )
         return alias_line > latest_local_line
 
@@ -1693,8 +1792,13 @@ class Visitor(ast.NodeVisitor):
                     if isinstance(t, ast.Name):
                         self.pattern_tracker.f_string_patterns[t.id] = pattern
 
+        declaration_only = (
+            self._is_type_stub
+            and not self.current_function_scope
+            and _is_stub_declaration(node)
+        )
         for target in node.targets:
-            self._process_target_for_def(target)
+            self._process_target_for_def(target, declaration_only=declaration_only)
 
         if isinstance(node.value, ast.Dict):
             self._track_dict_dispatch(node)
@@ -1760,7 +1864,14 @@ class Visitor(ast.NodeVisitor):
                 if in_typeddict and is_class_body and is_annotation_only:
                     return
 
-                self.add_def(var_name, "variable", t.lineno)
+                if (
+                    self._is_type_stub
+                    and not self.current_function_scope
+                    and _is_stub_declaration(node)
+                ):
+                    self._stub_binding_lines[var_name] = t.lineno
+                else:
+                    self.add_def(var_name, "variable", t.lineno)
 
                 if (
                     self._dataclass_stack
@@ -1815,7 +1926,11 @@ class Visitor(ast.NodeVisitor):
         self.visit(node.value)
 
     def _process_target_for_def(
-        self, target_node: ast.expr, _in_tuple_unpack: bool = False
+        self,
+        target_node: ast.expr,
+        _in_tuple_unpack: bool = False,
+        *,
+        declaration_only: bool = False,
     ) -> None:
         if isinstance(target_node, ast.Name):
             name_simple = target_node.id
@@ -1827,7 +1942,10 @@ class Visitor(ast.NodeVisitor):
                 return
 
             var_name = self._compute_variable_name(name_simple)
-            self.add_def(var_name, "variable", target_node.lineno)
+            if declaration_only:
+                self._stub_binding_lines[var_name] = target_node.lineno
+            else:
+                self.add_def(var_name, "variable", target_node.lineno)
 
             if self.current_function_scope and self.local_var_maps:
                 self.local_var_maps[-1][name_simple] = var_name
@@ -1841,7 +1959,9 @@ class Visitor(ast.NodeVisitor):
 
         elif isinstance(target_node, (ast.Tuple, ast.List)):
             for elt in target_node.elts:
-                self._process_target_for_def(elt, _in_tuple_unpack=True)
+                self._process_target_for_def(
+                    elt, _in_tuple_unpack=True, declaration_only=declaration_only
+                )
 
     def _finalize_dunder_all_exports(self, statements: list[ast.stmt]) -> None:
         export_names: set[str] | None = None

--- a/test/test_python_stub_declarations.py
+++ b/test/test_python_stub_declarations.py
@@ -1,0 +1,278 @@
+"""Inert source fixtures for declaration-only Python stub files."""
+
+import json
+import textwrap
+
+import pytest
+
+from skylos.analyzer import Skylos, analyze
+
+
+def _sources(tmp_path, files):
+    for filename, source in files.items():
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("x", encoding="utf-8") as stream:
+            stream.write(textwrap.dedent(source).lstrip())
+
+
+def _scan(tmp_path, files):
+    _sources(tmp_path, files)
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+    assert result.get("analysis_errors", []) == []
+    return result
+
+
+def _names(result, bucket):
+    return {item["full_name"] for item in result.get(bucket, [])}
+
+
+@pytest.fixture(autouse=True)
+def _single_worker(monkeypatch):
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+
+
+@pytest.mark.parametrize("scope", ["module", "class"])
+def test_stub_annotation_and_ellipsis_bindings_are_not_unused(tmp_path, scope):
+    declarations = """\
+_bracket_re = ...
+_annotation: object
+_annotated_ellipsis: object = ...
+_first = _second = ...
+"""
+    source = (
+        declarations
+        if scope == "module"
+        else "class _Shape:\n" + textwrap.indent(declarations, "    ")
+    )
+    result = _scan(tmp_path, {"src/plotly-stubs/basedatatypes.pyi": source})
+
+    assert result.get("unused_variables", []) == []
+
+
+@pytest.mark.parametrize("scope", ["module", "class"])
+def test_stub_annotated_literal_bindings_are_declarations(tmp_path, scope):
+    declarations = "_typed: int = 0\n_negative: int = -1\n"
+    source = (
+        declarations
+        if scope == "module"
+        else "class _Shape:\n" + textwrap.indent(declarations, "    ")
+    )
+    result = _scan(tmp_path, {"contracts.pyi": source})
+
+    assert result.get("unused_variables", []) == []
+    assert result.get("unused_classes", []) == []
+
+
+def test_stub_function_class_and_method_declarations_are_not_unused(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "contracts.pyi": '''
+                def _declared(value: object) -> object: ...
+                async def _async_declared(value: object) -> object: ...
+                def _documented(value: object) -> object:
+                    """Contract only."""
+                    ...
+                class _Empty: ...
+                class _Shape:
+                    _field: object
+                    def _method(self, value: object) -> object: ...
+                    def _documented_method(self, value: object) -> object:
+                        """Contract only."""
+                        ...
+            ''',
+        },
+    )
+
+    assert result.get("unused_functions", []) == []
+    assert result.get("unused_classes", []) == []
+    assert result.get("unused_parameters", []) == []
+
+
+@pytest.mark.parametrize("suffix", [".py", ".pyw"])
+def test_runtime_files_keep_identical_placeholder_warnings(tmp_path, suffix):
+    result = _scan(
+        tmp_path,
+        {
+            "runtime" + suffix: """
+                _bracket_re = ...
+                _annotation: object
+                _first = _second = ...
+                def _declared(value): ...
+                class _Shape:
+                    _field: object
+            """,
+        },
+    )
+
+    assert {
+        "runtime._bracket_re",
+        "runtime._annotation",
+        "runtime._first",
+        "runtime._second",
+    } <= _names(result, "unused_variables")
+    assert "runtime._declared" in _names(result, "unused_functions")
+    assert "runtime._Shape" in _names(result, "unused_classes")
+
+
+def test_stub_concrete_code_and_function_locals_remain_analyzed(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "contracts.pyi": """
+                _concrete = 7
+                _computed: int = int("7")
+                def _implementation(unused):
+                    _local: object
+                    _placeholder = ...
+                    return 1
+                class _Implementation:
+                    _concrete_field = 7
+            """,
+        },
+    )
+
+    assert {
+        "contracts._concrete",
+        "contracts._computed",
+        "contracts._implementation._local",
+        "contracts._implementation._placeholder",
+    } <= _names(result, "unused_variables")
+    assert "contracts._implementation" in _names(result, "unused_functions")
+    assert "contracts._implementation.unused" in _names(result, "unused_parameters")
+    assert "contracts._Implementation" in _names(result, "unused_classes")
+
+
+@pytest.mark.parametrize("body", ["_local: int", "_local = ..."])
+def test_single_local_binding_is_not_a_stub_function_body(tmp_path, body):
+    result = _scan(
+        tmp_path,
+        {"contracts.pyi": "def _implementation(unused):\n    " + body + "\n"},
+    )
+
+    assert "contracts._implementation" in _names(result, "unused_functions")
+    assert "contracts._implementation._local" in _names(result, "unused_variables")
+    assert "contracts._implementation.unused" in _names(result, "unused_parameters")
+
+
+def test_stub_conditional_class_declarations_are_not_unused(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "contracts.pyi": """
+                import sys
+                class _Versioned:
+                    if sys.version_info >= (3, 11):
+                        _field: int
+                        def _read(self) -> int: ...
+                    else:
+                        _field: str
+                        def _read(self) -> str: ...
+            """,
+        },
+    )
+
+    assert result.get("unused_variables", []) == []
+    assert result.get("unused_functions", []) == []
+    assert result.get("unused_classes", []) == []
+    assert "sys" not in _names(result, "unused_imports")
+
+
+@pytest.mark.parametrize(
+    ("condition", "body"),
+    [("predicate()", "_field: int"), ("True", "_field = int('7')")],
+)
+def test_stub_class_with_concrete_conditional_code_stays_reportable(
+    tmp_path, condition, body
+):
+    result = _scan(
+        tmp_path,
+        {"contracts.pyi": f"class _Concrete:\n    if {condition}:\n        {body}\n"},
+    )
+
+    assert "contracts._Concrete" in _names(result, "unused_classes")
+
+
+def test_stub_unused_imports_remain_visible_and_annotation_imports_stay_used(tmp_path):
+    result = _scan(
+        tmp_path,
+        {
+            "contracts.pyi": """
+                import math
+                from decimal import Decimal
+                _amount: Decimal
+            """,
+        },
+    )
+
+    assert "math" in _names(result, "unused_imports")
+    assert "decimal.Decimal" not in _names(result, "unused_imports")
+    assert result.get("unused_variables", []) == []
+
+
+@pytest.mark.parametrize(
+    "binding",
+    ["decorate = ...", "decorate: object", "def decorate(): ...", "class decorate: ..."],
+)
+def test_stub_binding_still_shadows_an_imported_decorator(tmp_path, binding):
+    result = _scan(
+        tmp_path,
+        {
+            "contracts.pyi": (
+                "from numba.extending import overload as decorate\n"
+                + binding
+                + "\n@decorate(float)\ndef _implementation(unused): return 1\n"
+            ),
+        },
+    )
+
+    assert "contracts._implementation" in _names(result, "unused_functions")
+
+
+@pytest.mark.parametrize("stub_first", [True, False])
+def test_stub_sibling_cannot_replace_runtime_candidates(
+    tmp_path, monkeypatch, stub_first
+):
+    _sources(
+        tmp_path,
+        {
+            "api.py": "_value = 7\ndef _function(): return 1\nclass _Class: pass\n",
+            "api.pyi": "_value: int\ndef _function() -> int: ...\nclass _Class: ...\n",
+        },
+    )
+    paths = [tmp_path / "api.pyi", tmp_path / "api.py"]
+    if not stub_first:
+        paths.reverse()
+    monkeypatch.setattr(
+        Skylos, "_discover_files", lambda self, path, excludes: (paths, tmp_path)
+    )
+
+    result = json.loads(analyze(str(tmp_path), conf=0, grep_verify=False))
+
+    assert result.get("analysis_errors", []) == []
+    for bucket, name, line in (
+        ("unused_variables", "api._value", 1),
+        ("unused_functions", "api._function", 2),
+        ("unused_classes", "api._Class", 3),
+    ):
+        findings = [
+            item for item in result.get(bucket, []) if item["full_name"] == name
+        ]
+        assert [(item["file"], item["line"]) for item in findings] == [
+            (str(tmp_path / "api.py"), line)
+        ]
+
+
+@pytest.mark.parametrize("declaration_first", [True, False])
+def test_stub_declarations_do_not_hide_same_name_concrete_bindings(
+    tmp_path, declaration_first
+):
+    declaration = "_value: int\ndef _function() -> int: ...\nclass _Class: ...\n"
+    concrete = "_value = 7\ndef _function(): return 1\nclass _Class:\n    _field = 7\n"
+    source = declaration + concrete if declaration_first else concrete + declaration
+    result = _scan(tmp_path, {"contracts.pyi": source})
+
+    assert "contracts._value" in _names(result, "unused_variables")
+    assert "contracts._function" in _names(result, "unused_functions")
+    assert "contracts._Class" in _names(result, "unused_classes")


### PR DESCRIPTION
## Summary

  - Keep concrete code and unused imports reportable.
  - Prevent stub declarations from overwriting same-named .py definitions.
  - Preserve alias-shadowing checks when declarations replace imported names.

## Tests

pytest test/test_python_stub_declarations.py test/test_visitor.py test/test_pep695_type_params.py \
    test/test_framework_aware.py test/test_signature_contract_parameters.py test/test_python_api_hallucination.py \
    test/test_api_signature_hallucination.py test/test_analyzer.py