### PR TITLE
fix(security): prevent false SKY-D212 warnings on RegExp.exec()

### DIFF
--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -611,12 +611,20 @@ def _child_process_aliases(root_node, lang: Language, source_bytes: bytes) -> se
     return aliases
 
 
+def _field_matches_node(
+    node: Node | None, field_name: str, expected_node: Node
+) -> bool:
+    if node is None:
+        return False
+    field_node = node.child_by_field_name(field_name)
+    return field_node is not None and field_node.id == expected_node.id
+
+
 def _regexp_use_kind(node: Node, source_bytes: bytes) -> str | None:
     member_node = node.parent
     if member_node is None or member_node.type != "member_expression":
         return None
-    object_node = member_node.child_by_field_name("object")
-    if object_node is None or object_node.id != node.id:
+    if not _field_matches_node(member_node, "object", node):
         return None
 
     property_node = member_node.child_by_field_name("property")
@@ -625,26 +633,17 @@ def _regexp_use_kind(node: Node, source_bytes: bytes) -> str | None:
     property_name = _get_text(source_bytes, property_node)
 
     call_node = member_node.parent
-    function_node = (
-        call_node.child_by_field_name("function") if call_node is not None else None
-    )
-    if property_name in _REGEXP_PROOF_METHODS and (
-        call_node is not None
-        and call_node.type == "call_expression"
-        and function_node is not None
-        and function_node.id == member_node.id
+    if (
+        property_name in _REGEXP_PROOF_METHODS
+        and getattr(call_node, "type", None) == "call_expression"
+        and _field_matches_node(call_node, "function", member_node)
     ):
         return property_name
 
-    parent = member_node.parent
-    left_node = parent.child_by_field_name("left") if parent is not None else None
-    is_write = parent is not None and (
-        (
-            parent.type in {"assignment_expression", "augmented_assignment_expression"}
-            and left_node is not None
-            and left_node.id == member_node.id
-        )
-        or parent.type == "update_expression"
+    parent_type = getattr(call_node, "type", None)
+    is_write = parent_type == "update_expression" or (
+        parent_type in {"assignment_expression", "augmented_assignment_expression"}
+        and _field_matches_node(call_node, "left", member_node)
     )
     if property_name in _REGEXP_PROOF_PROPERTIES and (
         not is_write or property_name == "lastIndex"
@@ -683,6 +682,32 @@ def _is_directly_exported_binding(node: Node) -> bool:
     return export is not None and export.type == "export_statement"
 
 
+def _unique_regexp_bindings(
+    nodes: list[Node], source_bytes: bytes
+) -> dict[tuple[int, str], Node]:
+    declarations: dict[tuple[int, str], list[Node]] = {}
+    for node in nodes:
+        scope = _regexp_binding_scope(node)
+        if scope is not None:
+            key = (scope.id, _get_text(source_bytes, node))
+            declarations.setdefault(key, []).append(node)
+    return {
+        key: bindings[0] for key, bindings in declarations.items() if len(bindings) == 1
+    }
+
+
+def _nearest_regexp_binding_key(
+    node: Node, name: str, candidates: dict[tuple[int, str], Node]
+) -> tuple[int, str] | None:
+    current = node.parent
+    while current is not None:
+        key = (current.id, name)
+        if current.type in _REGEXP_BINDING_SCOPE_TYPES and key in candidates:
+            return key
+        current = current.parent
+    return None
+
+
 def _proven_regexp_exec_receivers(
     root_node: Node, lang: Language, source_bytes: bytes
 ) -> set[int]:
@@ -692,21 +717,10 @@ def _proven_regexp_exec_receivers(
         "danger_regexp_literal_bindings",
         _REGEXP_LITERAL_BINDING_PATTERN,
     )
-    declarations: dict[tuple[int, str], list[Node]] = {}
-    for node in captures.get("regexp_name", []):
-        scope = _regexp_binding_scope(node)
-        if scope is not None:
-            key = (scope.id, _get_text(source_bytes, node))
-            declarations.setdefault(key, []).append(node)
-
-    candidates = {key for key, nodes in declarations.items() if len(nodes) == 1}
-    declaration_ids = {
-        nodes[0].id for key, nodes in declarations.items() if key in candidates
-    }
+    candidates = _unique_regexp_bindings(captures.get("regexp_name", []), source_bytes)
+    declaration_ids = {node.id for node in candidates.values()}
     invalid = {
-        key
-        for key, nodes in declarations.items()
-        if key in candidates and _is_directly_exported_binding(nodes[0])
+        key for key, node in candidates.items() if _is_directly_exported_binding(node)
     }
     exec_receivers: dict[tuple[int, str], set[int]] = {}
     stack = [root_node]
@@ -714,17 +728,7 @@ def _proven_regexp_exec_receivers(
         node = stack.pop()
         if _is_regexp_name_node(node) and node.id not in declaration_ids:
             name = _get_text(source_bytes, node)
-            current = node.parent
-            binding_key: tuple[int, str] | None = None
-            while current is not None:
-                candidate = (current.id, name)
-                if (
-                    current.type in _REGEXP_BINDING_SCOPE_TYPES
-                    and candidate in candidates
-                ):
-                    binding_key = candidate
-                    break
-                current = current.parent
+            binding_key = _nearest_regexp_binding_key(node, name, candidates)
             if binding_key is not None:
                 use_kind = _regexp_use_kind(node, source_bytes)
                 if use_kind == "exec":

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import os
 import re
-from tree_sitter import Language, Query, QueryCursor
+from tree_sitter import Language, Node, Query, QueryCursor
 import tree_sitter_typescript as tsts
 
 from skylos.constants import (
@@ -20,12 +20,7 @@ try:
 except Exception:
     TS_LANG = None
 
-_SAFE_EXEC_OBJECTS: set[str] = {
-    "regex",
-    "re",
-    "regexp",
-    "pattern",
-    "reg",
+_SAFE_DATABASE_EXEC_OBJECTS: set[str] = {
     "db",
     "stmt",
     "query",
@@ -127,6 +122,14 @@ _CHILD_PROCESS_ALIAS_PATTERN = """
   value: (call_expression
     function: (identifier) @require_fn (#eq? @require_fn "require")
     arguments: (arguments (string) @require_module)))
+"""
+
+_REGEXP_LITERAL_BINDING_PATTERN = """
+(lexical_declaration
+  "const"
+  (variable_declarator
+    name: (identifier) @regexp_name
+    value: (regex)))
 """
 
 _INTERNAL_URL_PREFIXES = (
@@ -591,6 +594,62 @@ def _child_process_aliases(root_node, lang: Language, source_bytes: bytes) -> se
     return aliases
 
 
+def _is_regexp_exec_call_receiver(node: Node, source_bytes: bytes) -> bool:
+    member_node = node.parent
+    if member_node is None or member_node.type != "member_expression":
+        return False
+    if member_node.child_by_field_name("object") != node:
+        return False
+
+    property_node = member_node.child_by_field_name("property")
+    if property_node is None or _get_text(source_bytes, property_node) != "exec":
+        return False
+
+    call_node = member_node.parent
+    return (
+        call_node is not None
+        and call_node.type == "call_expression"
+        and call_node.child_by_field_name("function") == member_node
+    )
+
+
+def _proven_regexp_literal_bindings(
+    root_node: Node, lang: Language, source_bytes: bytes
+) -> set[str]:
+    captures = _run_batch(
+        root_node,
+        lang,
+        "danger_regexp_literal_bindings",
+        _REGEXP_LITERAL_BINDING_PATTERN,
+    )
+    declarations: dict[str, list[Node]] = {}
+    for node in captures.get("regexp_name", []):
+        declarations.setdefault(_get_text(source_bytes, node), []).append(node)
+
+    candidates = {name for name, nodes in declarations.items() if len(nodes) == 1}
+    declaration_ranges = {
+        (nodes[0].start_byte, nodes[0].end_byte)
+        for name, nodes in declarations.items()
+        if name in candidates
+    }
+    invalid: set[str] = set()
+    stack = [root_node]
+    while stack:
+        node = stack.pop()
+        if node.type == "identifier":
+            name = _get_text(source_bytes, node)
+            location = (node.start_byte, node.end_byte)
+            if (
+                name in candidates
+                and location not in declaration_ranges
+                and not _is_regexp_exec_call_receiver(node, source_bytes)
+            ):
+                invalid.add(name)
+        stack.extend(reversed(node.children))
+
+    return candidates - invalid
+
+
 def _template_prefix(node, source_bytes: bytes) -> str:
     text = _get_text(source_bytes, node)
     if text.startswith("`"):
@@ -785,6 +844,9 @@ def scan_danger(
     jsx_captures = _run_batch(root_node, lang, "danger_jsx", _JSX_PATTERN)
     complex_captures = _run_batch(root_node, lang, "danger_complex", _COMPLEX_PATTERN)
     child_process_aliases = _child_process_aliases(root_node, lang, source_bytes)
+    regexp_literal_bindings = _proven_regexp_literal_bindings(
+        root_node, lang, source_bytes
+    )
     static_string_bindings = _collect_static_string_bindings(root_node, source_bytes)
 
     for k, v in jsx_captures.items():
@@ -822,8 +884,14 @@ def scan_danger(
         obj_node = member_node.child_by_field_name("object")
         if obj_node is None:
             continue
-        obj_name = _get_text(source_bytes, obj_node).lower()
-        if obj_name in _SAFE_EXEC_OBJECTS and obj_name not in child_process_aliases:
+        raw_obj_name = _get_text(source_bytes, obj_node)
+        obj_name = raw_obj_name.lower()
+        if raw_obj_name in regexp_literal_bindings:
+            continue
+        if (
+            obj_name in _SAFE_DATABASE_EXEC_OBJECTS
+            and obj_name not in child_process_aliases
+        ):
             continue
         call_expr = member_node.parent
         command = _first_static_call_arg(call_expr, source_bytes)

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -129,7 +129,7 @@ _REGEXP_LITERAL_BINDING_PATTERN = """
   "const"
   (variable_declarator
     name: (identifier) @regexp_name
-    value: (regex)))
+    value: (_)))
 """
 
 _REGEXP_BINDING_SCOPE_TYPES = {
@@ -620,6 +620,62 @@ def _field_matches_node(
     return field_node is not None and field_node.id == expected_node.id
 
 
+def _static_member_path(node: Node | None, source_bytes: bytes) -> tuple[str, ...] | None:
+    if node is None:
+        return None
+    node = _unwrap_ts_expression(node)
+    if node.type == "identifier":
+        return (_get_text(source_bytes, node),)
+    object_node = node.child_by_field_name("object")
+    if node.type == "member_expression":
+        property_node = node.child_by_field_name("property")
+        property_name = (
+            _get_text(source_bytes, property_node)
+            if property_node is not None
+            else None
+        )
+    elif node.type == "subscript_expression":
+        property_name = _static_string_value(
+            node.child_by_field_name("index"), source_bytes
+        )
+    else:
+        return None
+    object_path = _static_member_path(object_node, source_bytes)
+    if object_path is None or property_name is None:
+        return None
+    return (*object_path, property_name)
+
+
+def _is_delete_expression(node: Node) -> bool:
+    if not node.children:
+        return False
+    return (node.type, node.children[0].type) == ("unary_expression", "delete")
+
+
+def _invalidates_regexp_exec_proof(node: Node, source_bytes: bytes) -> bool:
+    path = _static_member_path(node, source_bytes)
+    prototype_path = ("RegExp", "prototype")
+    if path == prototype_path:
+        parent_path = _static_member_path(node.parent, source_bytes)
+        return parent_path is None or parent_path[:2] != prototype_path
+    if path != (*prototype_path, "exec"):
+        return False
+    parent = node.parent
+    if parent is None:
+        return False
+    left_node = parent.child_by_field_name("left")
+    is_assignment = (
+        parent.type in {"assignment_expression", "augmented_assignment_expression"}
+        and left_node is not None
+        and left_node.id == node.id
+    )
+    return (
+        is_assignment
+        or _is_delete_expression(parent)
+        or parent.type == "update_expression"
+    )
+
+
 def _regexp_use_kind(node: Node, source_bytes: bytes) -> str | None:
     member_node = node.parent
     if member_node is None or member_node.type != "member_expression":
@@ -687,6 +743,16 @@ def _unique_regexp_bindings(
 ) -> dict[tuple[int, str], Node]:
     declarations: dict[tuple[int, str], list[Node]] = {}
     for node in nodes:
+        value_node = node.parent.child_by_field_name("value")
+        if value_node is None:
+            continue
+        while value_node.type in _TS_EXPRESSION_WRAPPERS:
+            unwrapped = _unwrap_ts_expression(value_node)
+            if unwrapped is value_node:
+                break
+            value_node = unwrapped
+        if value_node.type != "regex":
+            continue
         scope = _regexp_binding_scope(node)
         if scope is not None:
             key = (scope.id, _get_text(source_bytes, node))
@@ -726,6 +792,8 @@ def _proven_regexp_exec_receivers(
     stack = [root_node]
     while stack:
         node = stack.pop()
+        if _invalidates_regexp_exec_proof(node, source_bytes):
+            return set()
         if _is_regexp_name_node(node) and node.id not in declaration_ids:
             name = _get_text(source_bytes, node)
             binding_key = _nearest_regexp_binding_key(node, name, candidates)

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -132,6 +132,23 @@ _REGEXP_LITERAL_BINDING_PATTERN = """
     value: (regex)))
 """
 
+_REGEXP_BINDING_SCOPE_TYPES = {
+    "for_in_statement",
+    "for_statement",
+    "program",
+    "statement_block",
+    "switch_body",
+}
+
+_REGEXP_IDENTIFIER_TYPES = {
+    "identifier",
+    "shorthand_property_identifier",
+    "shorthand_property_identifier_pattern",
+}
+
+_REGEXP_PROOF_METHODS = {"exec", "test"}
+_REGEXP_PROOF_PROPERTIES = {"flags", "lastIndex", "source"}
+
 _INTERNAL_URL_PREFIXES = (
     "http://localhost",
     "http://127.0.0.1",
@@ -594,60 +611,132 @@ def _child_process_aliases(root_node, lang: Language, source_bytes: bytes) -> se
     return aliases
 
 
-def _is_regexp_exec_call_receiver(node: Node, source_bytes: bytes) -> bool:
+def _regexp_use_kind(node: Node, source_bytes: bytes) -> str | None:
     member_node = node.parent
     if member_node is None or member_node.type != "member_expression":
-        return False
-    if member_node.child_by_field_name("object") != node:
-        return False
+        return None
+    object_node = member_node.child_by_field_name("object")
+    if object_node is None or object_node.id != node.id:
+        return None
 
     property_node = member_node.child_by_field_name("property")
-    if property_node is None or _get_text(source_bytes, property_node) != "exec":
-        return False
+    if property_node is None:
+        return None
+    property_name = _get_text(source_bytes, property_node)
 
     call_node = member_node.parent
-    return (
+    function_node = (
+        call_node.child_by_field_name("function") if call_node is not None else None
+    )
+    if property_name in _REGEXP_PROOF_METHODS and (
         call_node is not None
         and call_node.type == "call_expression"
-        and call_node.child_by_field_name("function") == member_node
+        and function_node is not None
+        and function_node.id == member_node.id
+    ):
+        return property_name
+
+    parent = member_node.parent
+    left_node = parent.child_by_field_name("left") if parent is not None else None
+    is_write = parent is not None and (
+        (
+            parent.type in {"assignment_expression", "augmented_assignment_expression"}
+            and left_node is not None
+            and left_node.id == member_node.id
+        )
+        or parent.type == "update_expression"
+    )
+    if property_name in _REGEXP_PROOF_PROPERTIES and not is_write:
+        return "property_read"
+    return None
+
+
+def _regexp_binding_scope(node: Node) -> Node | None:
+    current = node.parent
+    while current is not None:
+        if current.type in _REGEXP_BINDING_SCOPE_TYPES:
+            return current
+        current = current.parent
+    return None
+
+
+def _is_regexp_name_node(node: Node) -> bool:
+    if node.type in _REGEXP_IDENTIFIER_TYPES:
+        return True
+    parent = node.parent
+    name_node = parent.child_by_field_name("name") if parent is not None else None
+    return (
+        node.type == "type_identifier"
+        and parent is not None
+        and parent.type in {"class", "class_declaration"}
+        and name_node is not None
+        and name_node.id == node.id
     )
 
 
-def _proven_regexp_literal_bindings(
+def _is_directly_exported_binding(node: Node) -> bool:
+    declarator = node.parent
+    declaration = declarator.parent if declarator is not None else None
+    export = declaration.parent if declaration is not None else None
+    return export is not None and export.type == "export_statement"
+
+
+def _proven_regexp_exec_receivers(
     root_node: Node, lang: Language, source_bytes: bytes
-) -> set[str]:
+) -> set[int]:
     captures = _run_batch(
         root_node,
         lang,
         "danger_regexp_literal_bindings",
         _REGEXP_LITERAL_BINDING_PATTERN,
     )
-    declarations: dict[str, list[Node]] = {}
+    declarations: dict[tuple[int, str], list[Node]] = {}
     for node in captures.get("regexp_name", []):
-        declarations.setdefault(_get_text(source_bytes, node), []).append(node)
+        scope = _regexp_binding_scope(node)
+        if scope is not None:
+            key = (scope.id, _get_text(source_bytes, node))
+            declarations.setdefault(key, []).append(node)
 
-    candidates = {name for name, nodes in declarations.items() if len(nodes) == 1}
-    declaration_ranges = {
-        (nodes[0].start_byte, nodes[0].end_byte)
-        for name, nodes in declarations.items()
-        if name in candidates
+    candidates = {key for key, nodes in declarations.items() if len(nodes) == 1}
+    declaration_ids = {
+        nodes[0].id for key, nodes in declarations.items() if key in candidates
     }
-    invalid: set[str] = set()
+    invalid = {
+        key
+        for key, nodes in declarations.items()
+        if key in candidates and _is_directly_exported_binding(nodes[0])
+    }
+    exec_receivers: dict[tuple[int, str], set[int]] = {}
     stack = [root_node]
     while stack:
         node = stack.pop()
-        if node.type == "identifier":
+        if _is_regexp_name_node(node) and node.id not in declaration_ids:
             name = _get_text(source_bytes, node)
-            location = (node.start_byte, node.end_byte)
-            if (
-                name in candidates
-                and location not in declaration_ranges
-                and not _is_regexp_exec_call_receiver(node, source_bytes)
-            ):
-                invalid.add(name)
+            current = node.parent
+            binding_key: tuple[int, str] | None = None
+            while current is not None:
+                candidate = (current.id, name)
+                if (
+                    current.type in _REGEXP_BINDING_SCOPE_TYPES
+                    and candidate in candidates
+                ):
+                    binding_key = candidate
+                    break
+                current = current.parent
+            if binding_key is not None:
+                use_kind = _regexp_use_kind(node, source_bytes)
+                if use_kind == "exec":
+                    exec_receivers.setdefault(binding_key, set()).add(node.id)
+                elif use_kind is None:
+                    invalid.add(binding_key)
         stack.extend(reversed(node.children))
 
-    return candidates - invalid
+    return {
+        receiver_id
+        for key, receiver_ids in exec_receivers.items()
+        if key not in invalid
+        for receiver_id in receiver_ids
+    }
 
 
 def _template_prefix(node, source_bytes: bytes) -> str:
@@ -844,8 +933,11 @@ def scan_danger(
     jsx_captures = _run_batch(root_node, lang, "danger_jsx", _JSX_PATTERN)
     complex_captures = _run_batch(root_node, lang, "danger_complex", _COMPLEX_PATTERN)
     child_process_aliases = _child_process_aliases(root_node, lang, source_bytes)
-    regexp_literal_bindings = _proven_regexp_literal_bindings(
-        root_node, lang, source_bytes
+    exec_prop_nodes = complex_captures.get("exec_prop", [])
+    regexp_exec_receivers = (
+        _proven_regexp_exec_receivers(root_node, lang, source_bytes)
+        if exec_prop_nodes
+        else set()
     )
     static_string_bindings = _collect_static_string_bindings(root_node, source_bytes)
 
@@ -877,7 +969,7 @@ def scan_danger(
                 }
             )
 
-    for prop_node in complex_captures.get("exec_prop", []):
+    for prop_node in exec_prop_nodes:
         member_node = prop_node.parent
         if member_node is None:
             continue
@@ -886,7 +978,7 @@ def scan_danger(
             continue
         raw_obj_name = _get_text(source_bytes, obj_node)
         obj_name = raw_obj_name.lower()
-        if raw_obj_name in regexp_literal_bindings:
+        if obj_node.id in regexp_exec_receivers:
             continue
         if (
             obj_name in _SAFE_DATABASE_EXEC_OBJECTS

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -646,7 +646,9 @@ def _regexp_use_kind(node: Node, source_bytes: bytes) -> str | None:
         )
         or parent.type == "update_expression"
     )
-    if property_name in _REGEXP_PROOF_PROPERTIES and not is_write:
+    if property_name in _REGEXP_PROOF_PROPERTIES and (
+        not is_write or property_name == "lastIndex"
+    ):
         return "property_read"
     return None
 

--- a/skylos/visitors/languages/typescript/danger.py
+++ b/skylos/visitors/languages/typescript/danger.py
@@ -596,7 +596,9 @@ def _field_matches_node(
     return field_node is not None and field_node.id == expected_node.id
 
 
-def _static_member_path(node: Node | None, source_bytes: bytes) -> tuple[str, ...] | None:
+def _static_member_path(
+    node: Node | None, source_bytes: bytes
+) -> tuple[str, ...] | None:
     if node is None:
         return None
     node = _unwrap_ts_expression(node)
@@ -684,13 +686,147 @@ def _regexp_use_kind(node: Node, source_bytes: bytes) -> str | None:
     return None
 
 
-def _regexp_binding_scope(node: Node) -> Node | None:
+def _regexp_binding_scope(node: Node, *, function_scoped: bool = False) -> Node | None:
     current = node.parent
     while current is not None:
-        if current.type in _REGEXP_BINDING_SCOPE_TYPES:
+        if function_scoped:
+            if current.type in _TS_FUNCTION_NODE_TYPES or current.type in {
+                "class_static_block",
+                "internal_module",
+            }:
+                # Body bindings are not visible in parameter default expressions.
+                return current.child_by_field_name("body")
+            if current.type == "program":
+                return current
+        elif current.type in _REGEXP_BINDING_SCOPE_TYPES:
             return current
         current = current.parent
     return None
+
+
+def _regexp_binding_identifiers(pattern: Node | None) -> list[Node]:
+    """Extract declaration targets, never type names or default-value reads."""
+    identifiers = []
+    stack = [pattern] if pattern is not None else []
+    while stack:
+        node = stack.pop()
+        if node.type in {
+            "identifier",
+            "type_identifier",  # Class declaration/expression name.
+            "shorthand_property_identifier_pattern",
+        }:
+            identifiers.append(node)
+        elif node.type in {"required_parameter", "optional_parameter"}:
+            child = node.child_by_field_name("pattern")
+            if child is not None:
+                stack.append(child)
+        elif node.type in {"assignment_pattern", "object_assignment_pattern"}:
+            child = node.child_by_field_name("left")
+            if child is not None:
+                stack.append(child)
+        elif node.type == "pair_pattern":
+            child = node.child_by_field_name("value")
+            if child is not None:
+                stack.append(child)
+        elif node.type in {
+            "formal_parameters",
+            "object_pattern",
+            "array_pattern",
+            "rest_pattern",
+        }:
+            stack.extend(reversed(node.named_children))
+    return identifiers
+
+
+def _regexp_shadow_bindings(
+    root_node: Node,
+    source_bytes: bytes,
+    candidates: dict[tuple[int, str], Node],
+) -> tuple[set[tuple[int, str]], set[int]]:
+    """Index other bindings before resolving uses, including hoisted shadows."""
+    candidate_ids = {node.id for node in candidates.values()}
+    names = {name for _, name in candidates}
+    shadows: set[tuple[int, str]] = set()
+    declaration_ids: set[int] = set()
+    for node in _iter_nodes(root_node):
+        declarations: list[tuple[Node | None, Node | None]] = []
+        if (
+            "arguments" in names
+            and node.type in _TS_FUNCTION_NODE_TYPES
+            and node.type != "arrow_function"
+        ):
+            shadows.add((node.id, "arguments"))
+        parameters = node.child_by_field_name("parameters")
+        if parameters is not None and parameters.type == "formal_parameters":
+            declarations.append((parameters, node))
+        if node.type == "arrow_function":
+            declarations.append((node.child_by_field_name("parameter"), node))
+        elif node.type == "catch_clause":
+            declarations.append((node.child_by_field_name("parameter"), node))
+        elif node.type == "variable_declarator":
+            scope = _regexp_binding_scope(
+                node, function_scoped=node.parent.type == "variable_declaration"
+            )
+            declarations.append((node.child_by_field_name("name"), scope))
+        elif node.type == "for_in_statement":
+            kind = node.child_by_field_name("kind")
+            if kind is not None:
+                scope = (
+                    _regexp_binding_scope(node, function_scoped=True)
+                    if kind.type == "var"
+                    else node
+                )
+                declarations.append((node.child_by_field_name("left"), scope))
+        elif node.type in {
+            "function_declaration",
+            "generator_function_declaration",
+            "function_signature",
+            "class_declaration",
+            "enum_declaration",
+            "internal_module",
+        }:
+            declarations.append(
+                (node.child_by_field_name("name"), _regexp_binding_scope(node))
+            )
+        elif node.type in {"function_expression", "generator_function", "class"}:
+            declarations.append((node.child_by_field_name("name"), node))
+        elif node.type == "import_alias":
+            declarations.append((node.named_children[0], _regexp_binding_scope(node)))
+        elif node.type == "import_statement" and not any(
+            child.type == "type" for child in node.children
+        ):
+            scope = _regexp_binding_scope(node)
+            for imported in _iter_nodes(node):
+                if imported.type == "import_specifier" and not any(
+                    child.type == "type" for child in imported.children
+                ):
+                    declarations.append(
+                        (
+                            imported.child_by_field_name("alias")
+                            or imported.child_by_field_name("name"),
+                            scope,
+                        )
+                    )
+                elif imported.type in {
+                    "import_clause",
+                    "namespace_import",
+                    "import_require_clause",
+                }:
+                    declarations.extend(
+                        (child, scope)
+                        for child in imported.named_children
+                        if child.type == "identifier"
+                    )
+
+        for pattern, scope in declarations:
+            for identifier in _regexp_binding_identifiers(pattern):
+                name = _get_text(source_bytes, identifier)
+                if name not in names or identifier.id in candidate_ids:
+                    continue
+                declaration_ids.add(identifier.id)
+                if scope is not None:
+                    shadows.add((scope.id, name))
+    return shadows, declaration_ids
 
 
 def _is_regexp_name_node(node: Node) -> bool:
@@ -739,13 +875,26 @@ def _unique_regexp_bindings(
 
 
 def _nearest_regexp_binding_key(
-    node: Node, name: str, candidates: dict[tuple[int, str], Node]
+    node: Node,
+    name: str,
+    candidates: dict[tuple[int, str], Node],
+    shadows: set[tuple[int, str]],
 ) -> tuple[int, str] | None:
+    child = node
     current = node.parent
     while current is not None:
         key = (current.id, name)
+        if key in shadows:
+            # Computed method names/decorators run in the enclosing scope,
+            # outside the method's parameter and implicit arguments bindings.
+            if current.type != "method_definition" or any(
+                _field_matches_node(current, field, child)
+                for field in ("body", "parameters")
+            ):
+                return None
         if current.type in _REGEXP_BINDING_SCOPE_TYPES and key in candidates:
             return key
+        child = current
         current = current.parent
     return None
 
@@ -760,7 +909,13 @@ def _proven_regexp_exec_receivers(
         _REGEXP_LITERAL_BINDING_PATTERN,
     )
     candidates = _unique_regexp_bindings(captures.get("regexp_name", []), source_bytes)
-    declaration_ids = {node.id for node in candidates.values()}
+    if not candidates:
+        return set()
+    shadows, declaration_ids = _regexp_shadow_bindings(
+        root_node, source_bytes, candidates
+    )
+    declaration_ids.update(node.id for node in candidates.values())
+    names = {name for _, name in candidates}
     invalid = {
         key for key, node in candidates.items() if _is_directly_exported_binding(node)
     }
@@ -768,11 +923,19 @@ def _proven_regexp_exec_receivers(
     stack = [root_node]
     while stack:
         node = stack.pop()
+        if node.type == "import_statement":
+            # Static import linkage names are not value reads. Runtime bindings
+            # were indexed above; import-equals expressions remain traversed.
+            continue
         if _invalidates_regexp_exec_proof(node, source_bytes):
             return set()
         if _is_regexp_name_node(node) and node.id not in declaration_ids:
             name = _get_text(source_bytes, node)
-            binding_key = _nearest_regexp_binding_key(node, name, candidates)
+            binding_key = (
+                _nearest_regexp_binding_key(node, name, candidates, shadows)
+                if name in names
+                else None
+            )
             if binding_key is not None:
                 use_kind = _regexp_use_kind(node, source_bytes)
                 if use_kind == "exec":

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -100,12 +100,54 @@ class TestTSDangerRules:
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D202" not in ids
 
-    def test_regex_exec_not_flagged(self, tmp_path):
-        """regex.exec() is safe — should NOT trigger SKY-D212."""
-        code = 'const regex = /hello/g;\nconst m = regex.exec("hello world");'
+    def test_regexp_literal_exec_not_flagged(self, tmp_path):
+        """An unescaped RegExp literal should not trigger SKY-D212."""
+        code = (
+            "const GITHUB_PATTERN = /github\\.com/;\n"
+            'const match = GITHUB_PATTERN.exec("https://github.com/org/repo");'
+        )
         _, _, _, danger = _scan_ts(tmp_path, code)
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D212" not in ids
+
+    @pytest.mark.parametrize(
+        ("code", "expected_line"),
+        [
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "GITHUB_PATTERN.exec = cp.exec;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                4,
+            ),
+            (
+                (
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "function run(GITHUB_PATTERN) {\n"
+                    "  GITHUB_PATTERN.exec(cmd);\n"
+                    "}\n"
+                ),
+                3,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const pattern = cp;\n"
+                    "pattern.exec(cmd);\n"
+                ),
+                3,
+            ),
+        ],
+        ids=["property-replaced", "binding-shadowed", "safe-looking-alias"],
+    )
+    def test_regex_lookalikes_remain_flagged(self, tmp_path, code, expected_line):
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        d212_findings = [f for f in danger if f["rule_id"] == "SKY-D212"]
+        assert len(d212_findings) == 1
+        assert d212_findings[0]["file"] == str(tmp_path / "test.ts")
+        assert d212_findings[0]["line"] == expected_line
 
     def test_db_exec_not_flagged(self, tmp_path):
         """db.exec() / stmt.exec() should NOT trigger SKY-D212."""

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -138,12 +138,13 @@ class TestTSDangerRules:
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D212" not in ids
 
-    def test_regexp_test_and_property_reads_preserve_proof(self, tmp_path):
+    def test_regexp_safe_uses_preserve_proof(self, tmp_path):
         code = (
             "const pattern = /github\\.com/g;\n"
             "pattern.test(url);\n"
             "console.log(pattern.source, pattern.flags, pattern.lastIndex);\n"
-            "pattern.exec(url);\n"
+            "pattern.lastIndex = 0;\n"
+            "while ((match = pattern.exec(url)) !== null) {}\n"
         )
         _, _, _, danger = _scan_ts(tmp_path, code)
         ids = {f["rule_id"] for f in danger}
@@ -248,6 +249,20 @@ class TestTSDangerRules:
                 ),
                 3,
             ),
+            (
+                (
+                    'const pattern = new RegExp("github.com");\n'
+                    "pattern.exec(url);\n"
+                ),
+                2,
+            ),
+            (
+                (
+                    "let pattern = /github\\.com/;\n"
+                    "pattern.exec(url);\n"
+                ),
+                2,
+            ),
         ],
         ids=[
             "property-replaced",
@@ -260,6 +275,8 @@ class TestTSDangerRules:
             "custom-match-escape",
             "direct-export",
             "re-export",
+            "regexp-constructor",
+            "mutable-regexp-binding",
         ],
     )
     def test_regex_lookalikes_remain_flagged(self, tmp_path, code, expected_line):

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -110,6 +110,45 @@ class TestTSDangerRules:
         ids = {f["rule_id"] for f in danger}
         assert "SKY-D212" not in ids
 
+    def test_same_regexp_name_in_sibling_scopes_not_flagged(self, tmp_path):
+        code = (
+            "{\n"
+            "  const pattern = /github\\.com/;\n"
+            "  pattern.exec(firstUrl);\n"
+            "}\n"
+            "{\n"
+            "  const pattern = /gitlab\\.com/;\n"
+            "  pattern.exec(secondUrl);\n"
+            "}\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D212" not in ids
+
+    def test_nested_regexp_bindings_not_flagged(self, tmp_path):
+        code = (
+            "const pattern = /github\\.com/;\n"
+            "pattern.exec(firstUrl);\n"
+            "function matchGitLab(secondUrl) {\n"
+            "  const pattern = /gitlab\\.com/;\n"
+            "  pattern.exec(secondUrl);\n"
+            "}\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D212" not in ids
+
+    def test_regexp_test_and_property_reads_preserve_proof(self, tmp_path):
+        code = (
+            "const pattern = /github\\.com/g;\n"
+            "pattern.test(url);\n"
+            "console.log(pattern.source, pattern.flags, pattern.lastIndex);\n"
+            "pattern.exec(url);\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D212" not in ids
+
     @pytest.mark.parametrize(
         ("code", "expected_line"),
         [
@@ -139,8 +178,89 @@ class TestTSDangerRules:
                 ),
                 3,
             ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "function run(cmd) {\n"
+                    "  const { GITHUB_PATTERN } = { GITHUB_PATTERN: cp };\n"
+                    "  GITHUB_PATTERN.exec(cmd);\n"
+                    "}\n"
+                ),
+                5,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "function run(cmd) {\n"
+                    "  const [GITHUB_PATTERN] = [cp];\n"
+                    "  GITHUB_PATTERN.exec(cmd);\n"
+                    "}\n"
+                ),
+                5,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "function run(cmd) {\n"
+                    "  class GITHUB_PATTERN { static exec = cp.exec; }\n"
+                    "  GITHUB_PATTERN.exec(cmd);\n"
+                    "}\n"
+                ),
+                5,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "const holder = { GITHUB_PATTERN };\n"
+                    "holder.GITHUB_PATTERN.exec = cp.exec;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                5,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "const carrier = {\n"
+                    "  match(pattern) { pattern.exec = cp.exec; },\n"
+                    "};\n"
+                    "carrier.match(GITHUB_PATTERN);\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                7,
+            ),
+            (
+                (
+                    "export const GITHUB_PATTERN = /github\\.com/;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                2,
+            ),
+            (
+                (
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "export { GITHUB_PATTERN };\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                3,
+            ),
         ],
-        ids=["property-replaced", "binding-shadowed", "safe-looking-alias"],
+        ids=[
+            "property-replaced",
+            "binding-shadowed",
+            "safe-looking-alias",
+            "object-destructuring-shadow",
+            "array-destructuring-shadow",
+            "class-shadow",
+            "shorthand-escape",
+            "custom-match-escape",
+            "direct-export",
+            "re-export",
+        ],
     )
     def test_regex_lookalikes_remain_flagged(self, tmp_path, code, expected_line):
         _, _, _, danger = _scan_ts(tmp_path, code)

--- a/test/test_typescript_expanded.py
+++ b/test/test_typescript_expanded.py
@@ -151,6 +151,32 @@ class TestTSDangerRules:
         assert "SKY-D212" not in ids
 
     @pytest.mark.parametrize(
+        "initializer",
+        [
+            "(/github\\.com/)",
+            "/github\\.com/ as RegExp",
+            "/github\\.com/ satisfies RegExp",
+            "((/github\\.com/) as RegExp) satisfies RegExp",
+        ],
+    )
+    def test_wrapped_regexp_literal_exec_not_flagged(self, tmp_path, initializer):
+        code = f"const pattern = {initializer};\npattern.exec(url);\n"
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D212" not in ids
+
+    def test_read_only_regexp_prototype_use_preserves_proof(self, tmp_path):
+        code = (
+            "Other.prototype.exec = replacement;\n"
+            "const nativeExec = RegExp.prototype.exec;\n"
+            "const pattern = /github\\.com/;\n"
+            "pattern.exec(url);\n"
+        )
+        _, _, _, danger = _scan_ts(tmp_path, code)
+        ids = {f["rule_id"] for f in danger}
+        assert "SKY-D212" not in ids
+
+    @pytest.mark.parametrize(
         ("code", "expected_line"),
         [
             (
@@ -161,6 +187,52 @@ class TestTSDangerRules:
                     "GITHUB_PATTERN.exec(cmd);\n"
                 ),
                 4,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "RegExp.prototype.exec = cp.exec;\n"
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                4,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    'Object.defineProperty(RegExp.prototype, "exec", '
+                    "{ value: cp.exec });\n"
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                4,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    'RegExp["prototype"]["exec"] = cp.exec;\n'
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                4,
+            ),
+            (
+                (
+                    'import cp from "child_process";\n'
+                    "const prototype = RegExp.prototype;\n"
+                    "prototype.exec = cp.exec;\n"
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                5,
+            ),
+            (
+                (
+                    "delete RegExp.prototype.exec;\n"
+                    "const GITHUB_PATTERN = /github\\.com/;\n"
+                    "GITHUB_PATTERN.exec(cmd);\n"
+                ),
+                3,
             ),
             (
                 (
@@ -266,6 +338,11 @@ class TestTSDangerRules:
         ],
         ids=[
             "property-replaced",
+            "regexp-prototype-assignment",
+            "regexp-prototype-define-property",
+            "regexp-prototype-computed-assignment",
+            "regexp-prototype-alias",
+            "regexp-prototype-delete",
             "binding-shadowed",
             "safe-looking-alias",
             "object-destructuring-shadow",

--- a/test/test_typescript_regexp_scopes.py
+++ b/test/test_typescript_regexp_scopes.py
@@ -1,0 +1,338 @@
+"""RegExp scope regressions using inert, in-memory TypeScript sources."""
+
+import pytest
+from tree_sitter import Parser
+
+from skylos.visitors.languages.typescript import danger as danger_module
+
+
+def _scan_exec_findings(source: str, expected_exec_lines: list[int]) -> list[tuple]:
+    source_bytes = source.encode("utf-8")
+    lang = danger_module.TS_LANG
+    assert lang is not None
+    root = Parser(lang).parse(source_bytes).root_node
+    assert not root.has_error
+
+    captures = danger_module._run_batch(
+        root, lang, "danger_complex", danger_module._COMPLEX_PATTERN
+    )
+    assert (
+        sorted(node.start_point[0] + 1 for node in captures.get("exec_prop", []))
+        == expected_exec_lines
+    )
+
+    findings = danger_module.scan_danger(
+        root, "src/labels.ts", lang=lang, source=source_bytes
+    )
+    assert not [
+        finding
+        for finding in findings
+        if finding["rule_id"] == "SKY-ANALYSIS-INCOMPLETE"
+    ]
+    return [
+        (finding["rule_id"], finding["file"], finding["line"])
+        for finding in findings
+        if finding["rule_id"] == "SKY-D212"
+    ]
+
+
+def test_code_block_regex_exec_is_not_command_execution():
+    source = (
+        "const codeBlockRegex = /```([\\s\\S]*?)```/g;\n"
+        'const content = "```label```";\n'
+        "let match;\n"
+        "while ((match = codeBlockRegex.exec(content)) !== null) {\n"
+        "  const block = match[1];\n"
+        "}\n"
+    )
+
+    assert _scan_exec_findings(source, [4]) == []
+
+
+@pytest.mark.parametrize(
+    "inner_scope",
+    [
+        pytest.param(
+            "function describe(codeBlockRegex) {\n  return codeBlockRegex.length;\n}\n",
+            id="function-parameter",
+        ),
+        pytest.param(
+            "function describe<T>(codeBlockRegex: T): T {\n"
+            "  return codeBlockRegex;\n"
+            "}\n",
+            id="typed-generic-parameter",
+        ),
+        pytest.param(
+            "const describe = (codeBlockRegex: string) => codeBlockRegex.length;\n",
+            id="typed-arrow-parameter",
+        ),
+        pytest.param(
+            "function describe() {\n"
+            '  const codeBlockRegex = "label";\n'
+            "  return codeBlockRegex.length;\n"
+            "}\n",
+            id="function-const-local",
+        ),
+        pytest.param(
+            "function describe() {\n"
+            '  var codeBlockRegex = "label";\n'
+            "  return codeBlockRegex.length;\n"
+            "}\n",
+            id="function-var-local",
+        ),
+        pytest.param(
+            "{\n"
+            '  let codeBlockRegex = "label";\n'
+            "  const size = codeBlockRegex.length;\n"
+            "}\n",
+            id="block-let-local",
+        ),
+        pytest.param(
+            "try {\n"
+            '  throw "label";\n'
+            "} catch (codeBlockRegex) {\n"
+            "  const label = codeBlockRegex;\n"
+            "}\n",
+            id="catch-binding",
+        ),
+        pytest.param(
+            "function describe({ codeBlockRegex }: { codeBlockRegex: string }) {\n"
+            "  return codeBlockRegex.length;\n"
+            "}\n",
+            id="typed-destructured-parameter",
+        ),
+        pytest.param(
+            'for (const codeBlockRegex of ["label"]) {\n'
+            "  const size = codeBlockRegex.length;\n"
+            "}\n",
+            id="for-of-lexical-binding",
+        ),
+        pytest.param(
+            "for (let codeBlockRegex = 0; codeBlockRegex < 1; codeBlockRegex++) {\n"
+            "  const index = codeBlockRegex;\n"
+            "}\n",
+            id="for-initializer-lexical-binding",
+        ),
+        pytest.param(
+            "{\n"
+            '  const { codeBlockRegex } = { codeBlockRegex: "label" };\n'
+            "  const size = codeBlockRegex.length;\n"
+            "}\n",
+            id="object-destructured-local",
+        ),
+        pytest.param(
+            "{\n"
+            '  const { label: codeBlockRegex } = { label: "label" };\n'
+            "  const size = codeBlockRegex.length;\n"
+            "}\n",
+            id="renamed-destructured-local",
+        ),
+        pytest.param(
+            "{\n"
+            '  const { codeBlockRegex = "label" } = {};\n'
+            "  const size = codeBlockRegex.length;\n"
+            "}\n",
+            id="object-destructuring-literal-default",
+        ),
+        pytest.param(
+            "{\n"
+            '  const [codeBlockRegex = "label"] = [];\n'
+            "  const size = codeBlockRegex.length;\n"
+            "}\n",
+            id="array-destructuring-literal-default",
+        ),
+        pytest.param(
+            "const describe = function codeBlockRegex() {\n"
+            "  return codeBlockRegex.name;\n"
+            "};\n",
+            id="named-function-expression",
+        ),
+        pytest.param(
+            "const Label = class codeBlockRegex {\n"
+            "  describe() { return codeBlockRegex.name; }\n"
+            "};\n",
+            id="named-class-expression",
+        ),
+        pytest.param(
+            "const labels = {\n"
+            "  describe(codeBlockRegex: string) { return codeBlockRegex.length; }\n"
+            "};\n",
+            id="object-method-parameter",
+        ),
+        pytest.param(
+            "class Label {\n"
+            "  describe(codeBlockRegex: string) { return codeBlockRegex.length; }\n"
+            "}\n",
+            id="class-method-parameter",
+        ),
+    ],
+)
+def test_inner_shadow_does_not_invalidate_outer_regexp(inner_scope):
+    source = (
+        "const codeBlockRegex = /label/g;\n"
+        'codeBlockRegex.exec("label");\n'
+        + inner_scope
+        + 'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [2, len(source.splitlines())]) == []
+
+
+def test_sibling_function_binding_does_not_affect_local_regexp():
+    source = (
+        "function matchLabel() {\n"
+        "  const codeBlockRegex = /label/g;\n"
+        '  return codeBlockRegex.exec("label");\n'
+        "}\n"
+        "function describe(codeBlockRegex: string) {\n"
+        "  return codeBlockRegex.length;\n"
+        "}\n"
+    )
+
+    assert _scan_exec_findings(source, [3]) == []
+
+
+def test_nested_regexp_bindings_keep_their_own_calls():
+    source = (
+        "const codeBlockRegex = /label/g;\n"
+        'codeBlockRegex.exec("label");\n'
+        "function matchOtherLabel() {\n"
+        "  const codeBlockRegex = /other/g;\n"
+        '  return codeBlockRegex.exec("other");\n'
+        "}\n"
+        'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [2, 5, 7]) == []
+
+
+def test_closure_preserves_outer_literal_regexp():
+    source = (
+        "const codeBlockRegex = /label/g;\n"
+        "function matchLabel(text: string) {\n"
+        "  return codeBlockRegex.exec(text);\n"
+        "}\n"
+        'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [3, 5]) == []
+
+
+def test_nested_var_is_body_scoped_without_shadowing_parameter_default():
+    source = (
+        "const codeBlockRegex = /label/g;\n"
+        'function describe(match = codeBlockRegex.exec("label")) {\n'
+        "  if (true) {\n"
+        '    var codeBlockRegex = "label";\n'
+        "  }\n"
+        "  const label = codeBlockRegex;\n"
+        "  return match;\n"
+        "}\n"
+        'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [2, 9]) == []
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    ["const labels = {", "class Label {"],
+    ids=["object-method", "class-method"],
+)
+def test_computed_method_name_uses_outer_regexp_before_parameter_scope(declaration):
+    source = (
+        "const codeBlockRegex = /label/g;\n"
+        f"{declaration}\n"
+        '  [codeBlockRegex.exec("label")![0]](codeBlockRegex: string) {\n'
+        "    return codeBlockRegex.length;\n"
+        "  }\n"
+        "};\n"
+        'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [3, 7]) == []
+
+
+@pytest.mark.parametrize(
+    "import_statement",
+    [
+        pytest.param(
+            'import { codeBlockRegex as label } from "./labels";',
+            id="aliased-remote-spelling",
+        ),
+        pytest.param(
+            'import type { codeBlockRegex } from "./labels";',
+            id="type-only-import",
+        ),
+        pytest.param(
+            'import { type codeBlockRegex } from "./labels";',
+            id="type-only-specifier",
+        ),
+    ],
+)
+def test_static_import_names_do_not_contaminate_runtime_regexp(import_statement):
+    source = (
+        f"{import_statement}\n"
+        "const codeBlockRegex = /label/g;\n"
+        'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [3]) == []
+
+
+@pytest.mark.parametrize(
+    "function_body",
+    [
+        pytest.param("  return arguments.length;\n", id="ordinary-function"),
+        pytest.param(
+            "  const count = () => arguments.length;\n  return count;\n",
+            id="arrow-inherits-function-arguments",
+        ),
+    ],
+)
+def test_implicit_arguments_is_independent_of_outer_regexp(function_body):
+    source = (
+        "const arguments = /label/g;\n"
+        'arguments.exec("label");\n'
+        "function describe() {\n"
+        f"{function_body}"
+        "}\n"
+        'arguments.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [2, len(source.splitlines())]) == []
+
+
+def test_arrow_retains_outer_regexp_named_arguments():
+    source = (
+        "const arguments = /label/g;\n"
+        "const matchLabel = (text: string) => arguments.exec(text);\n"
+        'arguments.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [2, 3]) == []
+
+
+def test_opaque_same_named_parameter_does_not_inherit_outer_regexp_proof():
+    source = (
+        "const codeBlockRegex = /label/g;\n"
+        'codeBlockRegex.exec("label");\n'
+        "function describe(codeBlockRegex: { exec(text: string): string }) {\n"
+        '  return codeBlockRegex.exec("label");\n'
+        "}\n"
+        'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [2, 4, 6]) == [("SKY-D212", "src/labels.ts", 4)]
+
+
+def test_unknown_exec_receiver_is_not_exempted_by_nearby_regexp():
+    source = (
+        "const codeBlockRegex = /label/g;\n"
+        'codeBlockRegex.exec("label");\n'
+        "declare const receiver: { exec(text: string): string };\n"
+        'receiver.exec("label");\n'
+        'codeBlockRegex.exec("label");\n'
+    )
+
+    assert _scan_exec_findings(source, [2, 4, 5]) == [("SKY-D212", "src/labels.ts", 4)]


### PR DESCRIPTION
Fixes #803 
Supersedes #805

## Summary

  - Built on @mcdigman  #805
  - Stopping unrelated params, local variables and imports with the same name from causing false SKY-D212 warnings

  ## Tests

- `pytest test/test_typescript_regexp_scopes.py test/test_typescript_expanded.py test/test_typescript.py \
test/test_typescript_security_proof.py test/test_typescript_security_flow_candidates.py \
test/test_typescript_archive_security.py test/test_typescript_unsafe_export_regressions.py test/test_ts_danger_nextjs.py`