### PR TITLE
fix(cicd): correct workflow rule locations and runner checks

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -255,6 +255,16 @@ Finding types:
 | D335 | MEDIUM | Edge service missing sandboxing | systemd |
 | D336 | HIGH | Broad edge service privilege | systemd |
 
+For GitHub Actions, D290 and D295 point to the relevant trigger or job's
+`runs-on` declaration. Their inline ignores apply to that line or an immediately
+preceding standalone YAML comment, not to other declarations or text inside
+quoted values and script blocks.
+
+D295 reports at HIGH severity. Runner-label order does not affect the check.
+Simple literal matrices are exempt only when every possible runner value can be
+proved to be a known GitHub-hosted label. Runner groups, unknown expressions and
+matrix combinations that cannot be resolved conservatively still produce a warning.
+
 ## Kubernetes Deployment Exposure (SKY-DEP)
 
 Skylos correlates resources in one rendered multi-document Kubernetes file.

--- a/skylos/rules/config/cicd/github_actions.py
+++ b/skylos/rules/config/cicd/github_actions.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 
 from skylos.core.safe_cache_io import read_text_no_symlink
+from skylos.rules.config.cicd.runner_labels import runner_may_be_self_hosted
+from skylos.rules.config.cicd.yaml_source import YamlSource, load_yaml_with_locations
 from skylos.rules.config.findings import config_finding
 from skylos.security.command_guard import scan_shell_command
 
@@ -257,21 +259,34 @@ def _discover_action_files(
     return sorted(candidates)
 
 
-def _load_yaml(path: Path) -> dict[str, Any] | None:
+class _WorkflowLines(list[str]):
+    """Raw lines paired with the source map from the same safe YAML parse."""
+
+    def __init__(self, text: str, source: YamlSource):
+        super().__init__(text.splitlines())
+        self.source = source
+
+
+def _load_yaml(path: Path) -> tuple[dict[str, Any], _WorkflowLines] | None:
     if yaml is None:
         return None
     try:
         text = read_text_no_symlink(path, max_bytes=MAX_YAML_BYTES, encoding="utf-8")
         if text is None:
             return None
-        raw = yaml.safe_load(text)
+        loaded = load_yaml_with_locations(
+            text, max_depth=MAX_YAML_GRAPH_DEPTH, max_nodes=MAX_YAML_GRAPH_NODES
+        )
+        if loaded is None:
+            return None
+        raw, source = loaded
     except Exception:
         return None
     if not isinstance(raw, dict):
         return None
     if not _yaml_graph_is_safe(raw):
         return None
-    return raw
+    return raw, _WorkflowLines(text, source)
 
 
 def _yaml_graph_is_safe(value: Any) -> bool:
@@ -358,10 +373,67 @@ def _line_for_template(lines: list[str], run_body: str) -> int:
     return _line_for_key(lines, "run")
 
 
-def _is_inline_ignored(lines: list[str], line: int, rule_id: str) -> bool:
+def _source_for_lines(lines: list[str]) -> YamlSource | None:
+    if isinstance(lines, _WorkflowLines):
+        return lines.source
+    loaded = load_yaml_with_locations(
+        "\n".join(lines),
+        max_depth=MAX_YAML_GRAPH_DEPTH,
+        max_nodes=MAX_YAML_GRAPH_NODES,
+    )
+    return loaded[1] if loaded is not None else None
+
+
+def _line_for_trigger(data: dict[str, Any], lines: list[str], name: str) -> int:
+    source = _source_for_lines(lines)
+    if source is None:
+        return 1
+    on_key = "on" if "on" in data else True
+    trigger = _on_value(data)
+    if isinstance(trigger, dict):
+        path = (on_key, name)
+    elif isinstance(trigger, list):
+        path = (on_key, trigger.index(name))
+    else:
+        return source.line_for_path((on_key,), key=False) or 1
+    return source.line_for_path(path) or source.line_for_path((on_key,)) or 1
+
+
+def _line_for_job_field(lines: list[str], job_id: Any, field: str) -> int:
+    source = _source_for_lines(lines)
+    if source is None:
+        return 1
+    return (
+        source.line_for_path(("jobs", job_id, field))
+        or source.line_for_path(("jobs", job_id))
+        or 1
+    )
+
+
+def _is_inline_ignored(
+    lines: list[str], line: int, rule_id: str, *, yaml_only: bool = True
+) -> bool:
+    if not 1 <= line <= len(lines):
+        return False
     needle = f"skylos: ignore[{rule_id}]"
+    if not any(needle in lines[idx] for idx in (line - 2, line - 1) if idx >= 0):
+        return False
+    if not yaml_only:
+        # Existing script findings can be anchored inside run block scalars.
+        # Preserve their script-comment behavior; they need a separate parser.
+        return True
+    source = _source_for_lines(lines)
+    if source is None:
+        return False
     for idx in (line - 2, line - 1):
-        if 0 <= idx < len(lines) and needle in lines[idx]:
+        if idx < 0:
+            continue
+        # A trailing ignore belongs only to its own line. Only a standalone
+        # comment may apply to the next line, never quoted or block-scalar text.
+        if idx == line - 2 and not lines[idx].lstrip().startswith("#"):
+            continue
+        comment = source.comment_on_line(idx + 1)
+        if comment is not None and needle in comment:
             return True
     return False
 
@@ -381,8 +453,15 @@ def _add_finding(
     findings: list[dict[str, Any]],
     lines: list[str],
     finding: dict[str, Any],
+    *,
+    yaml_only: bool = False,
 ):
-    if _is_inline_ignored(lines, int(finding.get("line", 1)), str(finding["rule_id"])):
+    if _is_inline_ignored(
+        lines,
+        int(finding.get("line", 1)),
+        str(finding["rule_id"]),
+        yaml_only=yaml_only,
+    ):
         return
     identity = _finding_identity(finding)
     if any(_finding_identity(existing) == identity for existing in findings):
@@ -407,13 +486,15 @@ def _on_value(data: dict[str, Any]) -> Any:
     return data.get(True)
 
 
-def _jobs(data: dict[str, Any]) -> Iterator[tuple[str, dict[str, Any]]]:
+def _jobs(data: dict[str, Any]) -> Iterator[tuple[Any, dict[str, Any]]]:
     jobs = data.get("jobs")
     if not isinstance(jobs, dict):
         return
     for job_id, job in jobs.items():
         if isinstance(job, dict):
-            yield str(job_id), job
+            # Keep the parsed key for source lookup (YAML 1.1 resolves names
+            # such as on/yes to booleans). Message formatting still uses str.
+            yield job_id, job
 
 
 def _is_reusable_job(job: dict[str, Any]) -> bool:
@@ -651,10 +732,11 @@ def _scan_triggers(
                     "content with a privileged token."
                 ),
                 file=path,
-                line=_line_for_contains(lines, "pull_request_target"),
+                line=_line_for_trigger(data, lines, "pull_request_target"),
                 severity="HIGH",
                 value="pull_request_target",
             ),
+            yaml_only=True,
         )
     if _trigger_contains(trigger, "workflow_run"):
         _add_finding(
@@ -668,10 +750,11 @@ def _scan_triggers(
                     "execution from potentially attacker-influenced workflows."
                 ),
                 file=path,
-                line=_line_for_contains(lines, "workflow_run"),
+                line=_line_for_trigger(data, lines, "workflow_run"),
                 severity="HIGH",
                 value="workflow_run",
             ),
+            yaml_only=True,
         )
 
 
@@ -998,38 +1081,34 @@ def _scan_self_hosted_runners(
         if _is_reusable_job(job):
             continue
         runs_on = job.get("runs-on")
-        risky = False
-        value = "self-hosted"
+        if not runner_may_be_self_hosted(job):
+            continue
         if isinstance(runs_on, str):
-            risky = runs_on == "self-hosted" or "${{" in runs_on
             value = runs_on
         elif isinstance(runs_on, list):
-            labels = [str(item) for item in runs_on]
-            risky = bool(labels) and (
-                labels[0] == "self-hosted" or any("${{" in label for label in labels)
-            )
-            value = ",".join(labels)
+            value = ",".join(str(label) for label in runs_on)
         elif isinstance(runs_on, dict):
-            risky = "group" in runs_on
-            value = "runner-group"
+            value = "runner-group" if "group" in runs_on else str(runs_on)
+        else:
+            value = str(runs_on)
 
-        if risky:
-            _add_finding(
-                findings,
-                lines,
-                _finding(
-                    rule_id=rule_id,
-                    name="github-actions-self-hosted-runner",
-                    message=(
-                        f"Job {job_id} uses or may expand to a self-hosted runner. "
-                        "Use ephemeral isolated runners for untrusted workflows."
-                    ),
-                    file=path,
-                    line=_line_for_contains(lines, "runs-on"),
-                    severity="MEDIUM",
-                    value=value,
+        _add_finding(
+            findings,
+            lines,
+            _finding(
+                rule_id=rule_id,
+                name="github-actions-self-hosted-runner",
+                message=(
+                    f"Job {job_id} uses or may expand to a self-hosted runner. "
+                    "Use ephemeral isolated runners for untrusted workflows."
                 ),
-            )
+                file=path,
+                line=_line_for_job_field(lines, job_id, "runs-on"),
+                severity="HIGH",
+                value=value,
+            ),
+            yaml_only=True,
+        )
 
 
 def _image_is_pinned(image: str) -> bool:
@@ -1927,12 +2006,10 @@ def scan_github_actions_file(
     file_path = _resolve_github_actions_scan_path(path, root=root_path)
     if file_path is None:
         return []
-    data = _load_yaml(file_path)
-    if data is None:
+    loaded = _load_yaml(file_path)
+    if loaded is None:
         return []
-
-    text = read_text_no_symlink(file_path, max_bytes=MAX_YAML_BYTES, encoding="utf-8")
-    lines = text.splitlines() if text is not None else []
+    data, lines = loaded
 
     ignore = ignore or set()
     findings: list[dict[str, Any]] = []

--- a/skylos/rules/config/cicd/runner_labels.py
+++ b/skylos/rules/config/cicd/runner_labels.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# Keep this exact: custom labels that merely resemble hosted labels are not proof.
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idruns-on
+_HOSTED_LABELS = frozenset(
+    {
+        "ubuntu-latest",
+        "ubuntu-slim",
+        "ubuntu-22.04",
+        "ubuntu-24.04",
+        "ubuntu-26.04",
+        "ubuntu-22.04-arm",
+        "ubuntu-24.04-arm",
+        "ubuntu-26.04-arm",
+        "windows-latest",
+        "windows-2022",
+        "windows-2025",
+        "windows-2025-vs2026",
+        "windows-11-arm",
+        "windows-11-vs2026-arm",
+        "macos-latest",
+        "macos-14",
+        "macos-15",
+        "macos-26",
+        "macos-15-intel",
+        "macos-26-intel",
+        "xcode-27",
+    }
+)
+_MATRIX_PROPERTY_RE = re.compile(
+    r"\$\{\{\s*matrix\."
+    r"(?P<path>[A-Za-z_][A-Za-z0-9_-]*(?:\.[A-Za-z_][A-Za-z0-9_-]*)*)"
+    r"\s*\}\}"
+)
+_MAX_MATRIX_ROWS = 256
+_MAX_LITERAL_NODES = 4096
+_MAX_LITERAL_DEPTH = 16
+
+
+def _is_literal_matrix(matrix: dict[str, Any]) -> bool:
+    pending = [(matrix, 0)]
+    nodes = 0
+    while pending:
+        value, depth = pending.pop()
+        nodes += 1
+        if nodes > _MAX_LITERAL_NODES or depth > _MAX_LITERAL_DEPTH:
+            return False
+        if isinstance(value, str):
+            if "${{" in value:
+                return False
+        elif isinstance(value, dict):
+            if len(value) > _MAX_MATRIX_ROWS or any(
+                not isinstance(key, str) or "${{" in key for key in value
+            ):
+                return False
+            pending.extend((child, depth + 1) for child in value.values())
+        elif isinstance(value, list):
+            if len(value) > _MAX_MATRIX_ROWS:
+                return False
+            pending.extend((child, depth + 1) for child in value)
+        elif value is not None and not isinstance(value, (bool, int, float)):
+            return False
+    return True
+
+
+def _literal_matrix_rows(job: dict[str, Any]) -> list[dict[str, Any]] | None:
+    strategy = job.get("strategy")
+    if not isinstance(strategy, dict):
+        return None
+    matrix = strategy.get("matrix")
+    if not isinstance(matrix, dict) or not _is_literal_matrix(matrix):
+        return None
+    if any(
+        key.lower() in {"include", "exclude"} and key not in {"include", "exclude"}
+        for key in matrix
+    ):
+        return None
+
+    include = matrix.get("include", [])
+    exclude = matrix.get("exclude", [])
+    if not all(
+        isinstance(entries, list) and all(isinstance(row, dict) for row in entries)
+        for entries in (include, exclude)
+    ):
+        return None
+    # Excludes alone only remove possibilities, so checking every base row is
+    # conservative. With includes, they can turn an overlay into a new row; do
+    # not prove safety without modelling that interaction.
+    if include and exclude:
+        return None
+
+    axes = {
+        key: values
+        for key, values in matrix.items()
+        if key not in {"include", "exclude"}
+    }
+    originals: list[dict[str, Any]] = [{}] if axes else []
+    for key, values in axes.items():
+        if not isinstance(values, list) or not values:
+            return None
+        if len(originals) * len(values) > _MAX_MATRIX_ROWS:
+            return None
+        originals = [dict(row, **{key: value}) for row in originals for value in values]
+
+    rows = [dict(row) for row in originals]
+    for addition in include:
+        # Expression properties are case-insensitive. Do not guess when the
+        # spelling used by an include differs from an original axis name.
+        if any(
+            key != axis and key.lower() == axis.lower()
+            for key in addition
+            for axis in axes
+        ):
+            return None
+        # Nested object equality is outside this deliberately small proof.
+        if any(
+            key in axes
+            and (
+                isinstance(value, (dict, list))
+                or any(isinstance(item, (dict, list)) for item in axes[key])
+            )
+            for key, value in addition.items()
+        ):
+            return None
+        matched = False
+        for index, original in enumerate(originals):
+            if all(
+                key not in original
+                or (type(original[key]) is type(value) and original[key] == value)
+                for key, value in addition.items()
+            ):
+                # Includes can overwrite earlier additions, never original axes.
+                rows[index].update(addition)
+                matched = True
+        if not matched:
+            rows.append(dict(addition))
+        if len(rows) > _MAX_MATRIX_ROWS:
+            return None
+    return rows or None
+
+
+def _is_hosted_label_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.lower() in _HOSTED_LABELS
+    if isinstance(value, list) and value:
+        return all(
+            isinstance(label, str) and label.lower() in _HOSTED_LABELS
+            for label in value
+        )
+    return False
+
+
+def _matrix_property_is_hosted(expression: str, job: dict[str, Any]) -> bool:
+    match = _MATRIX_PROPERTY_RE.fullmatch(expression.strip())
+    if match is None:
+        return False
+    rows = _literal_matrix_rows(job)
+    if rows is None:
+        return False
+    path = match.group("path").split(".")
+    for row in rows:
+        value: Any = row
+        for key in path:
+            if not isinstance(value, dict) or key not in value:
+                return False
+            if any(other != key and other.lower() == key.lower() for other in value):
+                return False
+            value = value[key]
+        if not _is_hosted_label_value(value):
+            return False
+    return True
+
+
+def runner_may_be_self_hosted(job: dict[str, Any]) -> bool:
+    """Classify explicit or unresolved runner selection conservatively.
+
+    Fixed custom labels keep their existing behavior: only the explicit
+    self-hosted label establishes risk. Dynamic selections require a bounded
+    literal matrix proof that every possible label is a known hosted label.
+    """
+    if "runs-on" not in job:
+        return False
+    runs_on = job["runs-on"]
+    if isinstance(runs_on, dict):
+        if "group" in runs_on or set(runs_on) != {"labels"}:
+            return True
+        runs_on = runs_on["labels"]
+    labels = runs_on if isinstance(runs_on, list) else [runs_on]
+    if not labels:
+        return True
+    for label in labels:
+        if not isinstance(label, str) or not label.strip():
+            return True
+        if label.strip().lower() == "self-hosted":
+            return True
+        if "${{" in label and not _matrix_property_is_hosted(label, job):
+            return True
+    return False

--- a/skylos/rules/config/cicd/yaml_source.py
+++ b/skylos/rules/config/cicd/yaml_source.py
@@ -1,0 +1,267 @@
+"""Load YAML and retain locations for semantic paths through the document."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import yaml
+    from yaml.events import AliasEvent
+    from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
+except ImportError:  # pragma: no cover - PyYAML is a runtime dependency.
+    yaml = None
+
+
+_MERGE_TAG = "tag:yaml.org,2002:merge"
+
+
+if yaml is not None:
+
+    class _LocationLoader(yaml.SafeLoader):
+        def __init__(self, text: str, max_depth: int, max_nodes: int):
+            super().__init__(text)
+            self.alias_lines: dict[tuple[Node, str, int], int] = {}
+            self.text_lines = text.splitlines()
+            self.max_depth = max_depth
+            self.max_nodes = max_nodes
+            self._depth = -1
+            self._nodes = 0
+
+        def compose_node(self, parent, index):
+            self._depth += 1
+            self._nodes += 1
+            try:
+                if self._depth > self.max_depth or self._nodes > self.max_nodes:
+                    raise ValueError("YAML resource limit exceeded")
+                if parent is not None and self.check_event(AliasEvent):
+                    if isinstance(parent, MappingNode):
+                        edge = (
+                            parent,
+                            "key" if index is None else "value",
+                            len(parent.value),
+                        )
+                    else:
+                        edge = (parent, "item", index)
+                    self.alias_lines[edge] = self.peek_event().start_mark.line + 1
+                return super().compose_node(parent, index)
+            finally:
+                self._depth -= 1
+
+
+@dataclass(frozen=True)
+class _Entry:
+    node: Node
+    key_line: int
+    value_line: int
+    fallback_line: int | None = None
+
+
+class YamlSource:
+    """Source locations using the same resolved keys as the loaded mapping.
+
+    Descendants reached through an alias or a merge use its local reference
+    line. This keeps annotations at the use site when a value is reused.
+    """
+
+    def __init__(self, root: Node, loader: Any):
+        self._root = root
+        self._aliases = loader.alias_lines
+        self._pairs: dict[Node, list[tuple[Node, Node]]] = {}
+        self._items: dict[Node, list[Node]] = {}
+        self._entries: dict[Node, dict[Any, _Entry]] = {}
+        self._expanded_sizes: dict[Node, int] = {}
+        self._expanded_total = 0
+        self._lines = loader.text_lines
+        self._scalar_spans: dict[int, list[tuple[int, int]]] = {}
+        self._comments: dict[int, str | None] = {}
+        self.data: dict[Any, Any] = {}
+        self._snapshot(root, loader.max_depth, loader.max_nodes)
+        for node in self._pairs:
+            self._mapping_entries(node, loader)
+
+    def _snapshot(self, root: Node, max_depth: int, max_nodes: int) -> None:
+        active: set[Node] = set()
+        heights: dict[Node, int] = {}
+        stack = [(root, False)]
+        while stack:
+            node, leaving = stack.pop()
+            if leaving:
+                children = self._children(node)
+                height = 1 + max((heights[child] for child in children), default=-1)
+                if height > max_depth:
+                    raise ValueError("YAML graph is too deep")
+                heights[node] = height
+                active.remove(node)
+                continue
+            if node in active:
+                raise ValueError("Cyclic YAML graph")
+            if node in heights:
+                continue
+            if len(active) > max_depth or len(active) + len(heights) >= max_nodes:
+                raise ValueError("YAML graph resource limit exceeded")
+            if isinstance(node, MappingNode):
+                self._pairs[node] = list(node.value)
+            elif isinstance(node, SequenceNode):
+                self._items[node] = list(node.value)
+            elif isinstance(node, ScalarNode):
+                self._record_scalar_span(node)
+            active.add(node)
+            stack.append((node, True))
+            stack.extend((child, False) for child in reversed(self._children(node)))
+
+    def _children(self, node: Node) -> list[Node]:
+        if node in self._pairs:
+            return [child for pair in self._pairs[node] for child in pair]
+        return self._items.get(node, [])
+
+    def _record_scalar_span(self, node: ScalarNode) -> None:
+        for index in range(node.start_mark.line, node.end_mark.line + 1):
+            if index >= len(self._lines):
+                break
+            if index == node.start_mark.line and node.style in {"|", ">"}:
+                # Comments after a block indicator belong to YAML, not its text.
+                continue
+            start = node.start_mark.column if index == node.start_mark.line else 0
+            end = (
+                node.end_mark.column
+                if index == node.end_mark.line
+                else len(self._lines[index])
+            )
+            if end > start:
+                self._scalar_spans.setdefault(index, []).append((start, end))
+
+    def comment_on_line(self, line: int) -> str | None:
+        """Return the YAML comment (including '#'), excluding scalar text."""
+        index = line - 1
+        if index < 0 or index >= len(self._lines):
+            return None
+        if index in self._comments:
+            return self._comments[index]
+        text = self._lines[index]
+        offset = text.find("#")
+        for start, end in sorted(self._scalar_spans.get(index, [])):
+            if offset < 0 or offset < start:
+                break
+            if offset < end:
+                offset = text.find("#", end)
+        comment = text[offset:] if offset >= 0 else None
+        self._comments[index] = comment
+        return comment
+
+    def _mapping_entries(self, node: Node, loader: Any) -> dict[Any, _Entry]:
+        if node in self._entries:
+            return self._entries[node]
+
+        merged: dict[Any, _Entry] = {}
+        explicit: dict[Any, _Entry] = {}
+        expanded_size = 0
+        for position, (key_node, value_node) in enumerate(self._pairs[node]):
+            if not isinstance(key_node, ScalarNode):
+                # SafeLoader collections cannot be mapping keys. Reject them
+                # before their constructors can flatten nested mappings.
+                raise ValueError("YAML mapping keys must be scalars")
+            key_line = self._aliases.get(
+                (node, "key", position), key_node.start_mark.line + 1
+            )
+            alias_line = self._aliases.get((node, "value", position))
+            if key_node.tag == _MERGE_TAG:
+                merge_line = alias_line or key_line
+                if isinstance(value_node, MappingNode):
+                    sources = [value_node]
+                elif isinstance(value_node, SequenceNode):
+                    sources = list(reversed(self._items[value_node]))
+                else:
+                    raise ValueError("Invalid YAML merge")
+                for source in sources:
+                    if not isinstance(source, MappingNode):
+                        raise ValueError("Invalid YAML merge source")
+                    source_entries = self._mapping_entries(source, loader)
+                    expanded_size += self._expanded_sizes[source]
+                    if expanded_size > loader.max_nodes:
+                        raise ValueError("YAML merge expansion limit exceeded")
+                    merged.update(
+                        (key, _Entry(entry.node, merge_line, merge_line, merge_line))
+                        for key, entry in source_entries.items()
+                    )
+                continue
+
+            # SafeConstructor applies this normalization while flattening maps.
+            if key_node.tag == "tag:yaml.org,2002:value":
+                key_node.tag = "tag:yaml.org,2002:str"
+            key = loader.construct_object(key_node, deep=True)
+            explicit[key] = _Entry(
+                value_node,
+                key_line,
+                alias_line or value_node.start_mark.line + 1,
+                alias_line,
+            )
+            expanded_size += 1
+
+        self._expanded_total += expanded_size
+        if self._expanded_total > loader.max_nodes:
+            raise ValueError("YAML merge expansion limit exceeded")
+        merged.update(explicit)
+        self._entries[node] = merged
+        self._expanded_sizes[node] = expanded_size
+        return merged
+
+    def line_for_path(self, path: tuple[Any, ...], *, key: bool = True) -> int | None:
+        """Return a one-based key/value line, or None when the path is absent."""
+        node = self._root
+        key_line = value_line = node.start_mark.line + 1
+        fallback_line = None
+        for part in path:
+            if isinstance(node, MappingNode):
+                try:
+                    entry = self._entries[node].get(part)
+                except TypeError:
+                    return None
+                if entry is None:
+                    return None
+                key_line = fallback_line or entry.key_line
+                value_line = fallback_line or entry.value_line
+                fallback_line = fallback_line or entry.fallback_line
+                node = entry.node
+            elif isinstance(node, SequenceNode):
+                items = self._items[node]
+                if not isinstance(part, int) or part < 0 or part >= len(items):
+                    return None
+                alias_line = self._aliases.get((node, "item", part))
+                node = items[part]
+                key_line = value_line = (
+                    fallback_line or alias_line or node.start_mark.line + 1
+                )
+                fallback_line = fallback_line or alias_line
+            else:
+                return None
+        return key_line if key else value_line
+
+
+def load_yaml_with_locations(
+    text: str,
+    *,
+    max_depth: int = 100,
+    max_nodes: int = 50_000,
+) -> tuple[dict[Any, Any], YamlSource] | None:
+    """Safely parse a mapping once, with bounded composition and merge graphs."""
+    if yaml is None or max_depth < 0 or max_nodes < 1:
+        return None
+    loader = None
+    try:
+        loader = _LocationLoader(text, max_depth, max_nodes)
+        root = loader.get_single_node()
+        if not isinstance(root, MappingNode):
+            return None
+        source = YamlSource(root, loader)
+        data = loader.construct_document(root)
+        if not isinstance(data, dict):
+            return None
+        source.data = data
+        return data, source
+    except Exception:
+        # Some SafeLoader scalar constructors raise ordinary Python errors.
+        return None
+    finally:
+        if loader is not None:
+            loader.dispose()

--- a/test/test_github_actions_finding_locations.py
+++ b/test/test_github_actions_finding_locations.py
@@ -1,0 +1,175 @@
+"""Location and comment-scope contracts using inert YAML and dummy findings."""
+
+from pathlib import Path
+
+import pytest
+
+from skylos.rules.config.cicd import github_actions
+from skylos.rules.config.cicd.github_actions import _is_inline_ignored
+from skylos.rules.config.cicd.yaml_source import load_yaml_with_locations
+from skylos.rules.catalog import get_rule_catalog
+
+
+@pytest.mark.parametrize(
+    ("text", "line", "expected"),
+    [
+        ("# skylos: ignore[TEST-LABEL]\nlabel: value\n", 2, True),
+        ("label: value # skylos: ignore[TEST-LABEL]\n", 1, True),
+        (
+            "first: value # skylos: ignore[TEST-LABEL]\nsecond: value\n",
+            2,
+            False,
+        ),
+        ('label: "# skylos: ignore[TEST-LABEL]"\n', 1, False),
+        ('label: "# skylos: ignore[TEST-LABEL]"\nnext: value\n', 2, False),
+        ("label: |\n  # skylos: ignore[TEST-LABEL]\nnext: value\n", 3, False),
+        ("# skylos: ignore[TEST-OTHER]\nlabel: value\n", 2, False),
+        ("# skylos: ignore[TEST-LABEL]\n\nlabel: value\n", 3, False),
+        ("# skylos: ignore[TEST-LABEL]\nlabel: value\n", 0, False),
+    ],
+    ids=[
+        "preceding-standalone-comment",
+        "same-line-comment",
+        "previous-inline-comment-does-not-spill",
+        "quoted-text-is-not-comment",
+        "previous-quoted-text-is-not-comment",
+        "block-scalar-text-is-not-comment",
+        "other-rule-is-not-ignored",
+        "blank-line-breaks-scope",
+        "invalid-line-is-not-ignored",
+    ],
+)
+def test_yaml_ignore_comment_scope(text, line, expected):
+    assert _is_inline_ignored(text.splitlines(), line, "TEST-LABEL") is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "name", "line"),
+    [
+        ("# alpha\nname: alpha\non:\n  alpha:\n", "alpha", 4),
+        (
+            "on:\n  beta:\n    branches: [alpha-example]\n  'alpha': {}\n",
+            "alpha",
+            4,
+        ),
+        ("on:\n  - alpha\n  - beta\n", "beta", 3),
+        ('"on": [alpha, beta]\n', "beta", 1),
+        ("on:\n  alpha\n", "alpha", 2),
+        ("base: &events\n  alpha:\non:\n  <<: *events\n", "alpha", 4),
+        ("base: &event alpha\non: *event\n", "alpha", 2),
+        ("on: beta\non:\n  alpha:\n", "alpha", 3),
+    ],
+)
+def test_trigger_location_uses_semantic_path(text, name, line):
+    data, source = load_yaml_with_locations(text)
+    lines = github_actions._WorkflowLines(text, source)
+    assert github_actions._line_for_trigger(data, lines, name) == line
+
+
+def test_job_field_locations_stay_in_their_own_scope():
+    text = (
+        "# label: reference\n"
+        "jobs:\n"
+        "  first:\n"
+        "    label: repeated\n"
+        "  second:\n"
+        "    'label': repeated\n"
+    )
+    _, source = load_yaml_with_locations(text)
+    lines = github_actions._WorkflowLines(text, source)
+    assert github_actions._line_for_job_field(lines, "first", "label") == 4
+    assert github_actions._line_for_job_field(lines, "second", "label") == 6
+
+
+def test_dummy_finding_ignore_applies_only_to_intended_occurrence():
+    text = "# skylos: ignore[TEST-LABEL]\nfirst: value\nsecond: value\n"
+    _, source = load_yaml_with_locations(text)
+    lines = github_actions._WorkflowLines(text, source)
+    findings = []
+    for line in (2, 3):
+        github_actions._add_finding(
+            findings,
+            lines,
+            {"rule_id": "TEST-LABEL", "file": "labels.yml", "line": line},
+            yaml_only=True,
+        )
+    assert findings == [{"rule_id": "TEST-LABEL", "file": "labels.yml", "line": 3}]
+
+
+def test_runner_classifier_wiring_preserves_job_locations_and_catalog_severity(
+    monkeypatch,
+):
+    # Force a diagnostic for benign hosted selections to check the wiring only.
+    text = (
+        "jobs:\n"
+        "  first:\n"
+        "    runs-on: ubuntu-latest\n"
+        "  second:\n"
+        "    runs-on: windows-latest\n"
+    )
+    data, source = load_yaml_with_locations(text)
+    lines = github_actions._WorkflowLines(text, source)
+    visited = []
+
+    def classify(job):
+        visited.append(job)
+        return True
+
+    monkeypatch.setattr(github_actions, "runner_may_be_self_hosted", classify)
+    findings = []
+    github_actions._scan_self_hosted_runners(
+        data, Path("labels.yml"), lines, findings, set()
+    )
+    assert visited == list(data["jobs"].values())
+    assert [finding["line"] for finding in findings] == [3, 5]
+    severity = get_rule_catalog("SKY-D295")[0]["severity"]
+    assert severity == "HIGH"
+    assert all(finding["severity"] == severity for finding in findings)
+
+
+def test_scanner_reads_safe_workflow_once_and_accepts_hosted_matrix(monkeypatch):
+    text = (
+        "name: Preview\n"
+        "on: workflow_dispatch\n"
+        "permissions: {}\n"
+        "jobs:\n"
+        "  preview:\n"
+        "    strategy:\n"
+        "      matrix:\n"
+        "        os: [ubuntu-latest, windows-latest, macos-latest]\n"
+        "    runs-on: ${{ matrix.os }}\n"
+        "    steps: []\n"
+    )
+    path = Path(".github/workflows/preview.yml")
+    reads = []
+
+    def read(candidate, **kwargs):
+        reads.append(candidate)
+        return text
+
+    monkeypatch.setattr(
+        github_actions, "_resolve_github_actions_scan_path", lambda *a, **k: path
+    )
+    monkeypatch.setattr(github_actions, "read_text_no_symlink", read)
+    assert github_actions.scan_github_actions_file(path) == []
+    assert reads == [path]
+
+
+@pytest.mark.parametrize("name", ["on", "off", "yes", "no", "true", "false"])
+def test_job_field_lookup_preserves_yaml_boolean_keys(name):
+    text = f"jobs:\n  {name}:\n    label: value\n"
+    data, source = load_yaml_with_locations(text)
+    lines = github_actions._WorkflowLines(text, source)
+    job_key, _ = next(github_actions._jobs(data))
+    assert github_actions._line_for_job_field(lines, job_key, "label") == 3
+
+
+def test_embedded_script_comments_keep_existing_ignore_behavior():
+    text = "run: |\n  echo hello # skylos: ignore[TEST-SCRIPT]\n"
+    _, source = load_yaml_with_locations(text)
+    lines = github_actions._WorkflowLines(text, source)
+    assert not _is_inline_ignored(lines, 2, "TEST-SCRIPT", yaml_only=True)
+    assert _is_inline_ignored(lines, 2, "TEST-SCRIPT", yaml_only=False)
+    findings = []
+    github_actions._add_finding(findings, lines, {"rule_id": "TEST-SCRIPT", "line": 2})
+    assert findings == []

--- a/test/test_github_actions_runner_labels.py
+++ b/test/test_github_actions_runner_labels.py
@@ -1,0 +1,159 @@
+import pytest
+
+from skylos.rules.config.cicd.runner_labels import runner_may_be_self_hosted
+
+
+@pytest.mark.parametrize(
+    ("selection", "expected"),
+    [
+        ("ubuntu-latest", False),
+        ("custom-runner", False),
+        (["linux", "x64"], False),
+        ({"labels": "ubuntu-latest"}, False),
+        ({"labels": ["ubuntu-latest"]}, False),
+        ("self-hosted", True),
+        ("SELF-HOSTED", True),
+        (["linux", "self-hosted"], True),
+        ({"labels": ["linux", "self-hosted"]}, True),
+        ({"group": "build-runners", "labels": "ubuntu-latest"}, True),
+        ({"group": None}, True),
+        (None, True),
+        (True, True),
+        (42, True),
+        ("", True),
+        ([], True),
+        ({}, True),
+        ({"labels": []}, True),
+        ({"labels": {"labels": "ubuntu-latest"}}, True),
+        (["ubuntu-latest", None], True),
+        (["ubuntu-latest", ["linux"]], True),
+    ],
+)
+def test_fixed_runner_selection(selection, expected):
+    assert runner_may_be_self_hosted({"runs-on": selection}) is expected
+
+
+def test_job_without_runner_selection():
+    assert runner_may_be_self_hosted({}) is False
+
+
+def _matrix_job(matrix, selection="${{ matrix.os }}"):
+    return {"runs-on": selection, "strategy": {"matrix": matrix}}
+
+
+@pytest.mark.parametrize(
+    "selection",
+    [
+        "${{ matrix.os }}",
+        ["${{ matrix.os }}"],
+        {"labels": "${{ matrix.os }}"},
+        {"labels": ["${{ matrix.os }}"]},
+    ],
+)
+def test_literal_hosted_matrix(selection):
+    job = _matrix_job(
+        {"os": ["ubuntu-latest", "windows-latest", "macos-latest"]}, selection
+    )
+    assert runner_may_be_self_hosted(job) is False
+
+
+def test_literal_object_property_and_label_array():
+    job = _matrix_job(
+        {"runner": [{"labels": ["ubuntu-latest"]}, {"labels": "windows-2022"}]},
+        "${{ matrix.runner.labels }}",
+    )
+    assert runner_may_be_self_hosted(job) is False
+
+
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        {"include": [{"os": "ubuntu-latest"}, {"os": "macos-latest"}]},
+        {"os": ["ubuntu-latest"], "include": [{"os": "windows-latest"}]},
+        {"os": ["ubuntu-latest"], "include": [{"toolchain": "stable"}]},
+        {
+            "toolchain": ["stable", "beta"],
+            "include": [{"os": "ubuntu-latest"}, {"os": "windows-latest"}],
+        },
+        {"os": ["ubuntu-latest"], "exclude": [{"os": "ubuntu-latest"}]},
+    ],
+)
+def test_literal_matrix_includes_and_excludes(matrix):
+    assert runner_may_be_self_hosted(_matrix_job(matrix)) is False
+
+
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        None,
+        {},
+        "${{ inputs.matrix }}",
+        {"os": None},
+        {"os": []},
+        {"os": "ubuntu-latest"},
+        {"os": [None]},
+        {"os": ["ubuntu-latest", "custom-runner"]},
+        {"os": ["ubuntu-latest-custom"]},
+        {"os": ["${{ inputs.os }}"]},
+        {"os": ["ubuntu-latest"], "other": "${{ inputs.versions }}"},
+        {"os": ["ubuntu-latest"], "include": [{"os": "custom-runner"}]},
+        {
+            "include": [{"os": "custom-runner"}, {"os": "ubuntu-latest"}],
+        },
+        {
+            "os": ["ubuntu-latest"],
+            "include": [{"os": "custom-runner"}, {"os": "ubuntu-latest"}],
+        },
+        {"os": ["custom-runner"], "include": [{"os": "ubuntu-latest"}]},
+        {"os": ["ubuntu-latest"], "include": [{"OS": "custom-runner"}]},
+        {"os": ["ubuntu-latest"], "OS": ["custom-runner"]},
+        {"os": ["ubuntu-latest"], "Include": [{"os": "custom-runner"}]},
+        {"include": [{"os": "ubuntu-latest"}, {"toolchain": "stable"}]},
+        {
+            "os": ["ubuntu-latest"],
+            "toolchain": ["stable"],
+            "include": [{"toolchain": "nightly"}],
+        },
+        {"os": ["custom-runner"], "exclude": [{"os": "custom-runner"}]},
+        {
+            "os": ["ubuntu-latest"],
+            "include": [{"os": "windows-latest"}],
+            "exclude": [{"os": "ubuntu-latest"}],
+        },
+        {"os": ["ubuntu-latest"], "include": None},
+        {"os": ["ubuntu-latest"], "exclude": "invalid"},
+        {"os": ["ubuntu-latest"], "include": [None]},
+    ],
+)
+def test_unproven_or_malformed_matrix_is_conservative(matrix):
+    assert runner_may_be_self_hosted(_matrix_job(matrix)) is True
+
+
+@pytest.mark.parametrize(
+    "selection",
+    [
+        "${{ inputs.os }}",
+        "${{ matrix.missing }}",
+        "${{ matrix.os.name }}",
+        "${{ matrix.os || inputs.os }}",
+        "prefix-${{ matrix.os }}",
+        "${{ fromJSON(inputs.labels) }}",
+        {"group": "build-runners", "labels": "${{ matrix.os }}"},
+    ],
+)
+def test_unresolved_selection_is_conservative(selection):
+    assert (
+        runner_may_be_self_hosted(_matrix_job({"os": ["ubuntu-latest"]}, selection))
+        is True
+    )
+
+
+def test_matrix_expansion_is_bounded():
+    job = _matrix_job({"os": ["ubuntu-latest"] * 17, "version": list(range(17))})
+    assert runner_may_be_self_hosted(job) is True
+
+
+def test_recursive_matrix_is_bounded():
+    matrix = {"os": ["ubuntu-latest"]}
+    matrix["recursive"] = [matrix]
+    assert runner_may_be_self_hosted(_matrix_job(matrix)) is True

--- a/test/test_github_actions_yaml_source.py
+++ b/test/test_github_actions_yaml_source.py
@@ -1,0 +1,225 @@
+import pytest
+
+from skylos.rules.config.cicd.yaml_source import load_yaml_with_locations
+
+
+def _load(text, **limits):
+    result = load_yaml_with_locations(text, **limits)
+    assert result is not None
+    return result
+
+
+def test_locations_follow_scopes_and_ignore_textual_lookalikes():
+    data, source = _load(
+        "# label: ignored\n"
+        "name: 'label: ignored'\n"
+        "notes: |\n"
+        "  label: ignored\n"
+        "groups:\n"
+        "  first:\n"
+        "    label: repeated\n"
+        "  second:\n"
+        "    'label': repeated\n"
+    )
+    assert data["groups"]["second"]["label"] == "repeated"
+    assert source.line_for_path(("groups", "first", "label")) == 7
+    assert source.line_for_path(("groups", "second", "label")) == 9
+    assert source.line_for_path(("label",)) is None
+
+
+def test_mapping_sequence_and_scalar_values_have_distinct_paths():
+    _, source = _load(
+        '"events":\n'
+        "  - alpha\n"
+        "  - beta\n"
+        "groups:\n"
+        "  sample:\n"
+        "    entries:\n"
+        "      - label:\n"
+        "          text: example\n"
+    )
+    assert source.line_for_path(("events",)) == 1
+    assert source.line_for_path(("events",), key=False) == 2
+    assert source.line_for_path(("events", 1)) == 3
+    assert source.line_for_path(("groups", "sample")) == 5
+    assert source.line_for_path(("groups", "sample"), key=False) == 6
+    assert (
+        source.line_for_path(("groups", "sample", "entries", 0, "label", "text")) == 8
+    )
+
+
+def test_flow_collections_and_quoted_keys():
+    data, source = _load(
+        '"groups": {first: {"label": alpha},\n  second: {label: beta}}\n'
+    )
+    assert data["groups"]["second"]["label"] == "beta"
+    assert source.line_for_path(("groups", "first", "label")) == 1
+    assert source.line_for_path(("groups", "second", "label")) == 2
+
+
+def test_duplicate_keys_follow_safe_loader_last_wins_behavior():
+    data, source = _load("group:\n  label: old\ngroup:\n  label: new\n")
+    assert data == {"group": {"label": "new"}}
+    assert source.line_for_path(("group",)) == 3
+    assert source.line_for_path(("group", "label")) == 4
+
+
+def test_boolean_key_semantics_are_preserved():
+    data, source = _load("on: alpha\ntrue: beta\n'on': gamma\n")
+    assert data == {True: "beta", "on": "gamma"}
+    assert source.line_for_path((True,)) == 2
+    assert source.line_for_path(("on",)) == 3
+
+
+def test_mapping_alias_uses_local_reference_for_descendants():
+    data, source = _load(
+        "base: &base\n  nested:\n    label: example\ngroup:\n  *base\n"
+    )
+    assert data["group"] == data["base"]
+    assert source.line_for_path(("base", "nested", "label")) == 3
+    assert source.line_for_path(("group",)) == 4
+    assert source.line_for_path(("group",), key=False) == 5
+    assert source.line_for_path(("group", "nested", "label")) == 5
+
+
+def test_scalar_and_sequence_aliases_use_local_references():
+    _, source = _load(
+        "label: &label sample\n"
+        "items: &items\n"
+        "  - nested: value\n"
+        "groups:\n"
+        "  - *label\n"
+        "  - *items\n"
+    )
+    assert source.line_for_path(("groups", 0)) == 5
+    assert source.line_for_path(("groups", 1, 0, "nested")) == 6
+
+
+def test_alias_keys_use_local_key_reference():
+    data, source = _load("key: &name label\ngroup:\n  *name: example\n")
+    assert data["group"] == {"label": "example"}
+    assert source.line_for_path(("group", "label")) == 3
+
+
+def test_merges_use_local_merge_lines_but_keep_explicit_overrides():
+    data, source = _load(
+        "base: &base\n"
+        "  nested:\n"
+        "    label: inherited\n"
+        "  title: old\n"
+        "group:\n"
+        "  <<: *base\n"
+        "  title: new\n"
+    )
+    assert data["group"] == {"nested": {"label": "inherited"}, "title": "new"}
+    assert source.line_for_path(("group", "nested")) == 6
+    assert source.line_for_path(("group", "nested", "label")) == 6
+    assert source.line_for_path(("group", "title")) == 7
+
+
+def test_merge_sequence_precedence_matches_constructed_data():
+    data, source = _load(
+        "first: &first {label: first}\n"
+        "second: &second {label: second, title: title}\n"
+        "group:\n"
+        "  <<: [*first, *second]\n"
+    )
+    assert data["group"] == {"label": "first", "title": "title"}
+    assert source.line_for_path(("group", "label")) == 4
+    assert source.line_for_path(("group", "title")) == 4
+
+
+def test_nested_merges_keep_outer_use_site():
+    data, source = _load(
+        "base: &base {label: sample}\n"
+        "middle: &middle\n"
+        "  <<: *base\n"
+        "group:\n"
+        "  <<: *middle\n"
+    )
+    assert data["group"]["label"] == "sample"
+    assert source.line_for_path(("group", "label")) == 5
+
+
+def test_scalar_spans_distinguish_comments_from_text():
+    _, source = _load(
+        "# document comment\n"
+        "plain: word#part # plain comment\n"
+        'quoted: "# quoted text" # quoted comment\n'
+        "block: | # block header comment\n"
+        "  # block text\n"
+        "  more # block text\n"
+        "folded: >\n"
+        "  # folded text\n"
+        "empty: # empty comment\n"
+    )
+    assert source.comment_on_line(1) == "# document comment"
+    assert source.comment_on_line(2) == "# plain comment"
+    assert source.comment_on_line(3) == "# quoted comment"
+    assert source.comment_on_line(4) == "# block header comment"
+    assert source.comment_on_line(5) is None
+    assert source.comment_on_line(6) is None
+    assert source.comment_on_line(8) is None
+    assert source.comment_on_line(9) == "# empty comment"
+    assert source.comment_on_line(0) is None
+    assert source.comment_on_line(10) is None
+
+
+def test_multiline_quoted_scalars_do_not_supply_comments():
+    _, source = _load('text: "first\n  # still quoted\n  last" # actual comment\n')
+    assert source.comment_on_line(2) is None
+    assert source.comment_on_line(3) == "# actual comment"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [("missing",), ("items", -1), ("items", 2), ("items", "0"), ("label", "nested")],
+)
+def test_invalid_paths_return_none(path):
+    _, source = _load("items: [a, b]\nlabel: example\n")
+    assert source.line_for_path(path) is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "- entry\n",
+        "label: [\n",
+        "label: !widget example\n",
+        "label: !!timestamp arbitrary\n",
+        "? [first, second]\n: example\n",
+        "? {label: example}\n: value\n",
+        "label: *missing\n",
+        "label: first\n---\nlabel: second\n",
+    ],
+)
+def test_invalid_or_non_mapping_documents_fail_closed(text):
+    assert load_yaml_with_locations(text) is None
+
+
+def test_cyclic_alias_graphs_fail_closed():
+    assert load_yaml_with_locations("group: &group {child: *group}\n") is None
+
+
+def test_depth_and_node_bounds_apply_before_construction():
+    assert (
+        load_yaml_with_locations("outer: {inner: {label: value}}", max_depth=2) is None
+    )
+    assert load_yaml_with_locations("a: 1\nb: 2\n", max_nodes=4) is None
+    assert load_yaml_with_locations("a: 1\nb: 2\n", max_nodes=5) is not None
+
+
+def test_alias_reuse_still_checks_longest_graph_path():
+    text = "base: &base {label: value}\ngroup: {nested: *base}\n"
+    assert load_yaml_with_locations(text, max_depth=2) is None
+    assert load_yaml_with_locations(text, max_depth=3) is not None
+
+
+def test_repeated_merge_expansion_is_bounded():
+    text = (
+        "base: &base {a: 1, b: 2, c: 3}\n"
+        "group: {<<: [*base, *base, *base, *base, *base, *base, *base, *base]}\n"
+    )
+    assert load_yaml_with_locations(text, max_nodes=25) is None
+    assert load_yaml_with_locations(text, max_nodes=50) is not None


### PR DESCRIPTION
Fix #791

## Summary

- Fix D290 and D295 pointing to comments or the wrong trigger or job.
- Keep ignores tied to the correct declaration. Quoted values and script text no longer count as YAML ignore comments.
- Check runner labels regardless of their order.
- Stop flagging simple matrices that use only runners hosted by GitHub.
- Set D295 severity to HIGH to match the rule catalog.

  ## Tests

- `pytest test/test_github_actions_finding_locations.py test/test_github_actions_yaml_source.py \
    test/test_github_actions_runner_labels.py test/test_github_actions_security.py`