### PR TITLE
fix(analyzer): track m3u8 client callbacks from live callers

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2074,6 +2074,20 @@ class Skylos:
             if os.getenv("SKYLOS_DEBUG"):
                 logger.error(traceback.format_exc())
 
+    def _apply_external_protocol_liveness(self, files):
+        report = getattr(self, "_dead_code_liveness_report", None)
+        if report is None:
+            return
+        try:
+            from skylos.deadcode.liveness import apply_external_protocol_liveness
+
+            apply_external_protocol_liveness(
+                self.defs, self._project_root, files, report
+            )
+        except Exception:
+            if os.getenv("SKYLOS_DEBUG"):
+                logger.error(traceback.format_exc())
+
     def _mark_refs(self, progress_callback=None):
         total_refs = len(self.refs)
         if progress_callback:
@@ -4728,6 +4742,9 @@ class Skylos:
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: transitive dead code"))
         self._propagate_transitive_dead()
+        # Resolve library callbacks from surviving callers, so speculative
+        # callback cycles cannot become roots or consume ordinary references.
+        self._apply_external_protocol_liveness(files)
         self._suppress_standalone_orm_models()
 
         grep_verify_report = {

--- a/skylos/deadcode/external_protocols.py
+++ b/skylos/deadcode/external_protocols.py
@@ -1,0 +1,625 @@
+"""Caller-owned callback edges for small, documented external protocols.
+
+m3u8.load's fifth argument / http_client keyword uses download:
+https://github.com/globocom/m3u8/blob/master/m3u8/__init__.py
+
+This is not general escape analysis. Ambiguous control flow, dynamic arguments,
+definition headers, and re-exports are left unresolved. Explicit class imports
+use unique stable declarations in already-parsed files, never runtime imports.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from skylos.deadcode.python_ast import ParsedPythonFile
+
+
+_FUNCTIONS = (ast.FunctionDef, ast.AsyncFunctionDef)
+_DEFERRED = (*_FUNCTIONS, ast.ClassDef, ast.Lambda)
+_COMPREHENSIONS = (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
+_SOURCE_ROOTS = {"src", "lib", "python"}
+_OBJECT_BASE = object()
+_LOAD_PARAMETERS = (
+    "uri",
+    "timeout",
+    "headers",
+    "custom_tags_parser",
+    "http_client",
+    "verify_ssl",
+)
+
+
+def _root_name(node):
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+class _BoundNames(ast.NodeVisitor):
+    """Lexical bindings, including unreachable binders but excluding child scopes."""
+
+    def __init__(self):
+        self.names = set()
+        self.mutated = set()
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.names.add(node.id)
+
+    def visit_Import(self, node):
+        self.names.update(
+            alias.asname or alias.name.split(".")[0] for alias in node.names
+        )
+
+    def visit_ImportFrom(self, node):
+        self.names.update(alias.asname or alias.name for alias in node.names)
+
+    def visit_FunctionDef(self, node):
+        self.names.add(node.name)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+    visit_ClassDef = visit_FunctionDef
+
+    def visit_Lambda(self, node):
+        pass
+
+    def visit_Global(self, node):
+        self.names.update(node.names)
+
+    visit_Nonlocal = visit_Global
+
+    def visit_ExceptHandler(self, node):
+        if node.name:
+            self.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node):
+        if node.name:
+            self.names.add(node.name)
+        self.generic_visit(node)
+
+    visit_MatchStar = visit_MatchAs
+
+    def visit_MatchMapping(self, node):
+        if node.rest:
+            self.names.add(node.rest)
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node):
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.mutated.add(_root_name(node))
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Name) and node.func.id in {"setattr", "delattr"}:
+            if node.args:
+                self.mutated.add(_root_name(node.args[0]))
+        self.generic_visit(node)
+
+
+def _bindings_in(nodes):
+    collector = _BoundNames()
+    for node in nodes:
+        collector.visit(node)
+    return collector
+
+
+def _class_value(value):
+    if isinstance(value, ast.ClassDef):
+        return value
+    if isinstance(value, tuple) and len(value) == 2 and value[0] == "instance":
+        return value[1]
+    return None
+
+
+def _instance_masks_download(cls):
+    if "__getattribute__" in _bindings_in(cls.body).names:
+        return True
+    for method in cls.body:
+        if not isinstance(method, _FUNCTIONS) or method.name != "__init__":
+            continue
+        arguments = [*method.args.posonlyargs, *method.args.args]
+        if not arguments:
+            continue
+        receiver = arguments[0].arg
+        if any(
+            isinstance(node, ast.Attribute)
+            and isinstance(node.ctx, (ast.Store, ast.Del))
+            and node.attr == "download"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == receiver
+            for node in ast.walk(method)
+        ):
+            return True
+        if any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"setattr", "delattr"}
+            and len(node.args) >= 2
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == receiver
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "download"
+            for node in ast.walk(method)
+        ):
+            return True
+    return False
+
+
+class _ClassImports:
+    def __init__(self):
+        self.exports = {}
+        self.modules = set()
+        self.owners = {}
+        self.invalid_classes = set()
+        self.mro_cache = {}
+
+
+def _module_identities(definitions, tree):
+    variables = {
+        (node.lineno, target.id)
+        for node in tree.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        for target in (node.targets if isinstance(node, ast.Assign) else [node.target])
+        if isinstance(target, ast.Name)
+    }
+    names = {
+        definition.name.rpartition(".")[0]
+        for definition in definitions
+        if (
+            isinstance(getattr(definition, "node", None), (*_FUNCTIONS, ast.ClassDef))
+            and definition.node.col_offset == 0
+        )
+        or (
+            definition.type == "variable"
+            and (definition.line, definition.simple_name) in variables
+        )
+    }
+    return names
+
+
+class _Collector:
+    def __init__(self, definitions, imports, tree, is_package=False):
+        self.locations = defaultdict(list)
+        self.found = {}
+        self.class_contexts = {}
+        self.imports = imports
+        self.module_names = _module_identities(definitions, tree)
+        self.module_name = (
+            next(iter(self.module_names)) if len(self.module_names) == 1 else None
+        )
+        self.is_package = is_package
+        self.mro_cache = imports.mro_cache
+        self.invalid_classes = imports.invalid_classes
+        for definition in definitions:
+            node = getattr(definition, "node", None)
+            nodes = getattr(definition, "nodes", None)
+            if isinstance(nodes, (list, tuple)) and len(nodes) > 1:
+                continue
+            if isinstance(node, (*_FUNCTIONS, ast.ClassDef)):
+                self.locations[node.lineno].append(definition)
+
+    def _definition(self, node):
+        candidates = self.locations.get(node.lineno, ())
+        return candidates[0] if len(candidates) == 1 else None
+
+    def _value(self, node, bindings):
+        if isinstance(node, ast.Name):
+            return bindings.get(node.id)
+        if isinstance(node, ast.Attribute):
+            base = self._value(node.value, bindings)
+            if isinstance(base, str):
+                name = f"{base}.{node.attr}"
+                return self.imports.exports.get(name, name)
+        if isinstance(node, ast.Call):
+            cls = self._value(node.func, bindings)
+            if isinstance(cls, ast.ClassDef):
+                return ("instance", cls)
+        return None
+
+    def _import_value(self, node, alias):
+        if isinstance(node, ast.Import):
+            return alias.name if alias.asname else alias.name.split(".")[0]
+        module = node.module or ""
+        if node.level:
+            package = (
+                self.module_name
+                if self.is_package
+                else (self.module_name or "").rpartition(".")[0]
+            )
+            parts = package.split(".") if package else []
+            if node.level > len(parts):
+                return None
+            module = ".".join(
+                [*parts[: len(parts) - node.level + 1], *([module] if module else [])]
+            )
+        name = f"{module}.{alias.name}" if module else alias.name
+        if name == "m3u8.load" or name in self.imports.modules:
+            return name
+        return self.imports.exports.get(name)
+
+    @staticmethod
+    def _bind(name, value, bindings, observed):
+        bindings[name] = value
+        if name in observed and observed[name] != value:
+            observed[name] = None
+        else:
+            observed[name] = value
+
+    def _invalidate(self, nodes, bindings, observed):
+        collected = _bindings_in(nodes)
+        for name in collected.mutated:
+            value = bindings.get(name)
+            cls = _class_value(value)
+            if cls is not None:
+                self.invalid_classes.add(cls)
+                self.mro_cache.clear()
+            elif isinstance(value, str):
+                self.invalid_classes.update(
+                    exported
+                    for name, exported in self.imports.exports.items()
+                    if name.startswith(value + ".")
+                )
+                self.mro_cache.clear()
+            for alias, other in list(bindings.items()):
+                same_module = isinstance(value, str) and isinstance(other, str)
+                if alias == name or (cls is not None and _class_value(other) is cls):
+                    self._bind(alias, None, bindings, observed)
+                elif same_module and value.split(".")[0] == other.split(".")[0]:
+                    self._bind(alias, None, bindings, observed)
+        for name in collected.names:
+            self._bind(name, None, bindings, observed)
+
+    def _mro(self, cls, active=()):
+        if cls is _OBJECT_BASE:
+            return [_OBJECT_BASE]
+        owner = self.imports.owners.get(cls)
+        if owner is not None and owner is not self:
+            return owner._mro(cls, active)
+        if cls in self.mro_cache:
+            return self.mro_cache[cls]
+        if (
+            cls in active
+            or len(active) >= 64
+            or cls in self.invalid_classes
+            or cls.decorator_list
+            or cls.keywords
+            or cls not in self.class_contexts
+        ):
+            return None
+        context = self.class_contexts[cls]
+        bases = []
+        for expression in cls.bases:
+            if (
+                isinstance(expression, ast.Name)
+                and expression.id == "object"
+                and "object" not in context
+            ):
+                base = _OBJECT_BASE
+            else:
+                base = self._value(expression, context)
+            if base is not _OBJECT_BASE and not isinstance(base, ast.ClassDef):
+                return None
+            bases.append(base)
+        if not bases:
+            bases = [_OBJECT_BASE]
+        sequences = []
+        for base in bases:
+            order = self._mro(base, (*active, cls))
+            if order is None:
+                return None
+            sequences.append(list(order))
+        sequences.append(list(bases))
+        result = [cls]
+        while any(sequences):
+            sequences = [sequence for sequence in sequences if sequence]
+            candidate = next(
+                (
+                    sequence[0]
+                    for sequence in sequences
+                    if all(sequence[0] not in other[1:] for other in sequences)
+                ),
+                None,
+            )
+            if candidate is None or len(result) >= 128:
+                return None
+            result.append(candidate)
+            for sequence in sequences:
+                if sequence[0] is candidate:
+                    sequence.pop(0)
+        self.mro_cache[cls] = result
+        return result
+
+    def _download_method(self, client, bindings):
+        cls = _class_value(client)
+        order = self._mro(cls) if cls is not None else None
+        if order is None:
+            return None
+        if not isinstance(client, ast.ClassDef) and any(
+            _instance_masks_download(owner)
+            for owner in order
+            if owner is not _OBJECT_BASE
+        ):
+            return None
+        for owner in order:
+            if owner is _OBJECT_BASE:
+                continue
+            methods = [
+                item
+                for item in owner.body
+                if isinstance(item, _FUNCTIONS) and item.name == "download"
+            ]
+            other = _bindings_in(item for item in owner.body if item not in methods)
+            if "download" in other.names:
+                return None  # A non-method binding masks later MRO entries.
+            if not methods:
+                continue
+            if len(methods) != 1:
+                return None
+            method = methods[0]
+            provider = self.imports.owners[owner]
+            if any(
+                not isinstance(dec, ast.Name)
+                or dec.id not in {"staticmethod", "classmethod"}
+                or dec.id in other.names
+                or dec.id in provider.class_contexts[owner]
+                for dec in method.decorator_list
+            ):
+                return None
+            if isinstance(client, ast.ClassDef) and not method.decorator_list:
+                return None  # An ordinary method needs its instance binding.
+            return provider._definition(method)
+        return None
+
+    def _callback(self, node, bindings, caller):
+        if self._value(node.func, bindings) != "m3u8.load":
+            return
+        if any(isinstance(arg, ast.Starred) for arg in node.args):
+            return
+        if any(keyword.arg is None for keyword in node.keywords):
+            return
+        keywords = [keyword.arg for keyword in node.keywords]
+        if (
+            len(node.args) > len(_LOAD_PARAMETERS)
+            or len(set(keywords)) != len(keywords)
+            or any(name not in _LOAD_PARAMETERS for name in keywords)
+            or set(keywords).intersection(_LOAD_PARAMETERS[: len(node.args)])
+            or not node.args
+            and "uri" not in keywords
+        ):
+            return
+        uri = (
+            node.args[0]
+            if node.args
+            else next(
+                keyword.value for keyword in node.keywords if keyword.arg == "uri"
+            )
+        )
+        if isinstance(uri, ast.Constant):
+            if not isinstance(uri.value, (str, bytes)):
+                return
+            try:
+                parts = urlsplit(uri.value)
+            except ValueError:
+                return
+            # m3u8 uses its file loader when either URL component is absent.
+            if not parts.scheme or not parts.netloc:
+                return
+        clients = [kw.value for kw in node.keywords if kw.arg == "http_client"]
+        if len(node.args) > 4:
+            clients.append(node.args[4])
+        if len(clients) != 1:
+            return
+        definition = self._download_method(self._value(clients[0], bindings), bindings)
+        if definition is not None:
+            client = _class_value(self._value(clients[0], bindings))
+            self.found[(id(definition), id(caller))] = (definition, caller, client)
+
+    def _expression(self, node, bindings, caller, observed, report):
+        if node is None or isinstance(node, (*_DEFERRED, *_COMPREHENSIONS)):
+            return
+        # Do not invent an evaluation path through short-circuit expressions or
+        # let an embedded assignment/mutation retain stale import identity.
+        mutations = _bindings_in((node,))
+        if mutations.names or mutations.mutated:
+            self._invalidate((node,), bindings, observed)
+            return
+        if isinstance(node, (ast.BoolOp, ast.IfExp)):
+            return
+        for child in ast.iter_child_nodes(node):
+            self._expression(child, bindings, caller, observed, report)
+        if report and isinstance(node, ast.Call):
+            self._callback(node, bindings, caller)
+
+    def _suite(self, statements, bindings, caller, observed, stable, report):
+        for node in statements:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    if alias.name == "*":
+                        for bound_name in list(bindings):
+                            self._bind(bound_name, None, bindings, observed)
+                        continue
+                    name = alias.asname or alias.name.split(".")[0]
+                    value = self._import_value(node, alias)
+                    self._bind(name, value, bindings, observed)
+            elif isinstance(node, _FUNCTIONS):
+                self._bind(node.name, None, bindings, observed)
+                if report:
+                    self._function(node, stable)
+            elif isinstance(node, ast.ClassDef):
+                self.imports.owners[node] = self
+                if self.class_contexts.get(node) != bindings:
+                    self.class_contexts[node] = dict(bindings)
+                    self.mro_cache.clear()
+                self._bind(node.name, node, bindings, observed)
+                if report:
+                    # Methods close over the containing function/module, not
+                    # their class namespace. Class-body execution is unsupported.
+                    for item in node.body:
+                        if isinstance(item, _FUNCTIONS):
+                            self._function(item, stable)
+            elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+                self._expression(node.value, bindings, caller, observed, report)
+                value = self._value(node.value, bindings)
+                targets = (
+                    node.targets if isinstance(node, ast.Assign) else [node.target]
+                )
+                for target in targets:
+                    if isinstance(target, ast.Name):
+                        self._bind(target.id, value, bindings, observed)
+                    else:
+                        self._invalidate((target,), bindings, observed)
+            elif isinstance(node, ast.If) and isinstance(node.test, ast.Constant):
+                selected = node.body if bool(node.test.value) else node.orelse
+                if not self._suite(
+                    selected, bindings, caller, observed, stable, report
+                ):
+                    return False
+            elif isinstance(node, (ast.Return, ast.Raise)):
+                for value in ast.iter_child_nodes(node):
+                    self._expression(value, bindings, caller, observed, report)
+                return False
+            elif isinstance(node, ast.Expr):
+                self._expression(node.value, bindings, caller, observed, report)
+            else:
+                self._invalidate((node,), bindings, observed)
+        return True
+
+    def _scope(self, statements, incoming, caller, local_names=()):
+        bindings = dict(incoming)
+        bindings.update((name, None) for name in local_names)
+        observed = {}
+        self._suite(statements, dict(bindings), caller, observed, {}, False)
+        stable = dict(bindings)
+        stable.update(observed)
+        self._suite(statements, bindings, caller, {}, stable, True)
+
+    def _function(self, node, incoming):
+        caller = self._definition(node)
+        if caller is None:
+            return
+        local_names = _bindings_in(node.body).names
+        local_names.update(
+            arg.arg
+            for arg in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
+        )
+        for arg in (node.args.vararg, node.args.kwarg):
+            if arg is not None:
+                local_names.add(arg.arg)
+        self._scope(node.body, incoming, caller, local_names)
+
+
+def find_external_protocol_callbacks(
+    definitions, parsed_files: Iterable[ParsedPythonFile], root
+):
+    """Return (method, caller) edges; None means actual module-level execution."""
+    root = Path(root).resolve()
+    if root.is_file():
+        root = root.parent
+    parsed = list(parsed_files)
+    modules = []
+    for module in parsed:
+        try:
+            parts = module.path.resolve().relative_to(root).parts
+        except (OSError, ValueError):
+            continue
+        if not parts:
+            continue
+        if root.name == "m3u8" and parts[0] == "__init__.py":
+            return []
+        first = parts[1] if parts[0] in _SOURCE_ROOTS and len(parts) > 1 else parts[0]
+        if first in {"m3u8", "m3u8.py", "m3u8.pyi"}:
+            return []
+        modules.append(module)
+    active = [
+        module
+        for module in modules
+        if any(
+            isinstance(node, ast.Import)
+            and any(alias.name == "m3u8" for alias in node.names)
+            or isinstance(node, ast.ImportFrom)
+            and node.level == 0
+            and node.module == "m3u8"
+            for node in ast.walk(module.tree)
+        )
+    ]
+    if not active:
+        return []
+    by_file = defaultdict(list)
+    for definition in definitions.values():
+        by_file[Path(definition.filename).resolve()].append(definition)
+    imports = _ClassImports()
+    collectors = {}
+    packages = defaultdict(set)
+    providers = defaultdict(list)
+    for module in modules:
+        path = module.path.resolve()
+        collector = _Collector(
+            by_file[path], imports, module.tree, path.name == "__init__.py"
+        )
+        collectors[path] = collector
+        if collector.module_name:
+            package, _, stem = collector.module_name.rpartition(".")
+            if collector.is_package:
+                packages[path.parent].add(collector.module_name)
+            elif stem == path.stem:
+                packages[path.parent].add(package)
+    # An imports-only sibling has no own Definition. Reuse only an unambiguous
+    # namespace established by definitions in that exact directory.
+    for module in modules:
+        path = module.path.resolve()
+        collector = collectors[path]
+        anchors = packages[path.parent]
+        if not collector.module_names and len(anchors) == 1:
+            package = next(iter(anchors))
+            collector.module_name = (
+                package
+                if collector.is_package
+                else ".".join(filter(None, (package, path.stem)))
+            )
+        if collector.module_name:
+            providers[collector.module_name].append((module, collector))
+    if any(name == "m3u8" or name.startswith("m3u8.") for name in providers):
+        return []
+    imports.modules.update(
+        name for name, candidates in providers.items() if len(candidates) == 1
+    )
+    exports = {}
+    prepared = []
+    for name, candidates in providers.items():
+        if len(candidates) != 1:
+            continue
+        module, collector = candidates[0]
+        prepared.append((module, collector))
+        stable = {}
+        collector._suite(module.tree.body, {}, None, stable, {}, False)
+        declarations = {
+            node for node in module.tree.body if isinstance(node, ast.ClassDef)
+        }
+        for local, value in stable.items():
+            if (
+                isinstance(value, ast.ClassDef)
+                and value in declarations
+                and value.name == local
+                and collector._definition(value) is not None
+            ):
+                exports[f"{name}.{local}"] = value
+    imports.exports.update(exports)
+    # Refresh owner contexts with the complete direct-export registry before
+    # consumer analysis. No exports are discovered recursively in this pass.
+    for module, collector in prepared:
+        collector._suite(module.tree.body, {}, None, {}, {}, False)
+    for module in active:
+        collector = collectors[module.path.resolve()]
+        collector._scope(module.tree.body, {}, None)
+    found = {}
+    for collector in collectors.values():
+        for key, (method, caller, client) in collector.found.items():
+            if collector._mro(client) is not None:
+                found[key] = (method, caller)
+    return list(found.values())

--- a/skylos/deadcode/liveness.py
+++ b/skylos/deadcode/liveness.py
@@ -10,7 +10,9 @@ from typing import Any, Iterable
 
 from skylos.deadcode.plugin_registry import find_literal_plugin_registry_targets
 from skylos.deadcode.framework_liveness import find_framework_entrypoint_targets
+from skylos.deadcode.external_protocols import find_external_protocol_callbacks
 from skylos.analysis.ast_cache import releases_python_ast_cache
+from skylos.constants import AUTO_CALLED
 from skylos.deadcode.python_ast import ParsedPythonFile, parse_python_files
 
 
@@ -139,6 +141,157 @@ def apply_dead_code_liveness(
     _rescue_documented_public_methods(classes, class_methods, docs_text, report)
     _rescue_unique_external_attr_calls(classes, class_methods, attr_calls, report)
     return report
+
+
+@releases_python_ast_cache
+def apply_external_protocol_liveness(definitions, project_root, files, report) -> None:
+    """Activate external callbacks only after ordinary deadness has settled."""
+    if os.getenv("SKYLOS_DEAD_CODE_LIVENESS", "1").lower() in _DISABLE_VALUES:
+        return
+    root = Path(project_root).resolve()
+    parsed = parse_python_files(_python_files(root, files))
+    callbacks = find_external_protocol_callbacks(definitions, parsed, root)
+    if not callbacks:
+        return
+    nodes = {
+        id(defn): defn
+        for defn in definitions.values()
+        if getattr(defn, "type", None) in {"function", "method", "class", "type"}
+    }
+    dead_classes = {
+        (defn.name, str(defn.filename))
+        for defn in nodes.values()
+        if defn.type in {"class", "type"}
+        and defn.references <= 0
+        and not defn.is_exported
+    }
+    survivors = {
+        key
+        for key, defn in nodes.items()
+        if (defn.references > 0 or defn.is_exported)
+        and not (
+            defn.type == "method"
+            and (defn.name.rpartition(".")[0], str(defn.filename)) in dead_classes
+        )
+    }
+    strong_markers = {
+        "framework_root",
+        "package_entrypoint",
+        "test_entrypoint",
+        "top_level_execution",
+        "coverage_hit",
+        "trace_hit",
+        "reachable_from_root",
+    }
+    strong = {
+        key
+        for key, defn in nodes.items()
+        if strong_markers.intersection(getattr(defn, "heuristic_refs", {}))
+    }
+    seeds = {
+        id(target)
+        for target, caller in callbacks
+        if caller is None or id(caller) in survivors
+    }
+    if not seeds:
+        return
+    proven = {
+        id(target)
+        for target, caller in callbacks
+        if caller is None or id(caller) in survivors & strong
+    }
+    by_name = defaultdict(list)
+    for key, defn in nodes.items():
+        by_name[defn.name].append(key)
+
+    def resolve(name, context):
+        candidates = by_name.get(name, ())
+        if len(candidates) == 1:
+            return candidates[0]
+        local = [key for key in candidates if nodes[key].filename == context.filename]
+        return local[0] if len(local) == 1 else None
+
+    graph = defaultdict(set)
+    for key, defn in nodes.items():
+        for name in getattr(defn, "calls", ()):
+            if (target := resolve(name, defn)) is not None:
+                graph[key].add(target)
+        # Local parameter-method inference currently records reverse links only.
+        for name in getattr(defn, "called_by", ()):
+            if (caller := resolve(name, defn)) is not None:
+                graph[caller].add(key)
+        # The ordinary analyzer already retains implicit protocol methods for
+        # referenced classes. Their bodies must become reachable too when a
+        # callback revives the owning class; do not promote arbitrary methods.
+        if (
+            defn.type == "method"
+            and defn.simple_name in AUTO_CALLED
+            and defn.references > 0
+        ):
+            owner = resolve(defn.name.rpartition(".")[0], defn)
+            if owner is not None and nodes[owner].type in {"class", "type"}:
+                graph[owner].add(key)
+    for target, caller in callbacks:
+        if caller is not None:
+            graph[id(caller)].add(id(target))
+
+    known_plugins = {
+        id(target)
+        for target in find_literal_plugin_registry_targets(definitions, parsed)
+    }
+    reached = set()
+    marked_strong = set()
+    while seeds:
+        stack = [(key, key in proven) for key in seeds]
+        while stack:
+            key, is_strong = stack.pop()
+            if key in reached and (not is_strong or key in marked_strong):
+                continue
+            reached.add(key)
+            target = nodes[key]
+            target.references = max(target.references, 1)
+            if is_strong:
+                marked_strong.add(key)
+                target.heuristic_refs["reachable_from_root"] = 1.0
+            for child in graph[key]:
+                target.calls.add(nodes[child].name)
+                nodes[child].called_by.add(target.name)
+                stack.append((child, is_strong))
+        for target, caller in callbacks:
+            if caller is None:
+                target.heuristic_refs["top_level_execution"] = 1.0
+            elif id(caller) in survivors | reached:
+                caller.calls.add(target.name)
+                target.called_by.add(caller.name)
+        # Preserve the plugin finder's own root policy. Only newly proven
+        # registry targets seed another pass; unrelated ordinary roots do not.
+        new_plugins = [
+            target
+            for target in find_literal_plugin_registry_targets(definitions, parsed)
+            if id(target) not in known_plugins and id(target) in nodes
+        ]
+        seeds = {id(target) for target in new_plugins}
+        known_plugins.update(seeds)
+        proven.update(seeds)
+        for target in new_plugins:
+            _mark(target, "literal_plugin_registry", report)
+    for target, caller in callbacks:
+        if id(target) in reached and (
+            caller is None or id(caller) in survivors | reached
+        ):
+            target.heuristic_refs["dead_code_liveness:external_protocol"] = 1.0
+            if not any(
+                item.name == target.name and item.reason == "external_protocol"
+                for item in report.rescued
+            ):
+                report.rescued.append(
+                    LivenessRescue(
+                        target.name,
+                        "external_protocol",
+                        str(target.filename),
+                        target.line,
+                    )
+                )
 
 
 def _mark(defn: Any, reason: str, report: LivenessReport) -> None:

--- a/test/test_duck_typed_callback_liveness.py
+++ b/test/test_duck_typed_callback_liveness.py
@@ -1,0 +1,414 @@
+"""Static-only regressions for clients consumed by external libraries."""
+
+import json
+import textwrap
+
+import pytest
+
+from skylos.analyzer import Skylos
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+CLIENT = """
+def decode_playlist(uri):
+    return uri, ""
+
+class Boto3Client:
+    @staticmethod
+    def download(uri, *_):
+        return decode_playlist(uri)
+
+    def unused_operation(self):
+        return None
+"""
+
+
+def _scan(tmp_path, source, grep_verify):
+    assert write_text_no_symlink(
+        tmp_path / "playlist.py", textwrap.dedent(source).lstrip()
+    )
+    analyzer = Skylos()
+    result = json.loads(
+        analyzer.analyze(
+            str(tmp_path),
+            thr=0,
+            grep_verify=grep_verify,
+            grep_cache=False,
+            trace_file=False,
+            enable_dependency_hallucinations=False,
+        )
+    )
+    unused = {item["full_name"] for item in result.get("unused_functions", [])}
+    return analyzer, unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "import_line,call",
+    [
+        (
+            "from m3u8 import load as m3u8_load",
+            "m3u8_load(uri, http_client=Boto3Client())",
+        ),
+        ("import m3u8", "m3u8.load(uri, http_client=Boto3Client())"),
+        ("import m3u8 as parser", "parser.load(uri, None, {}, None, Boto3Client())"),
+    ],
+)
+def test_live_external_client_keeps_only_callback_alive(
+    tmp_path, grep_verify, import_line, call
+):
+    source = CLIENT + (
+        f"\ndef load_m3u8_from_s3(uri):\n"
+        f"    {import_line}\n"
+        f"    return {call}\n"
+        '\nload_m3u8_from_s3("s3://example/playlist.m3u8")\n'
+    )
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.Boto3Client.download" not in unused
+    assert "playlist.load_m3u8_from_s3" not in unused
+    assert "playlist.decode_playlist" not in unused
+    assert "playlist.Boto3Client.unused_operation" in unused
+    callback = analyzer.defs["playlist.Boto3Client.download"]
+    assert "playlist.load_m3u8_from_s3" in callback.called_by
+    assert (
+        "playlist.Boto3Client.download"
+        in analyzer.defs["playlist.load_m3u8_from_s3"].calls
+    )
+    assert "reachable_from_root" in callback.heuristic_refs
+    assert (
+        "reachable_from_root"
+        in analyzer.defs["playlist.decode_playlist"].heuristic_refs
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("call_count", [1, 2])
+def test_uncalled_wrapper_does_not_keep_external_callback_alive(
+    tmp_path, grep_verify, call_count
+):
+    source = CLIENT + (
+        "\ndef load_m3u8_from_s3(uri):\n"
+        "    from m3u8 import load\n"
+        + "    load(uri, http_client=Boto3Client())\n"
+        * call_count
+    )
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.load_m3u8_from_s3" in unused
+    # An unused class can cover its methods in the rendered findings. Check
+    # actual liveness too, so that grouping cannot hide a spurious rescue.
+    assert analyzer.defs["playlist.Boto3Client.download"].references == 0
+    assert analyzer.defs["playlist.Boto3Client.unused_operation"].references == 0
+    assert (
+        "reachable_from_root"
+        not in analyzer.defs["playlist.Boto3Client.download"].heuristic_refs
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_module_level_external_callback_is_an_execution_root(tmp_path, grep_verify):
+    source = CLIENT + (
+        "\nfrom m3u8 import load\n"
+        'load("s3://example/playlist.m3u8", http_client=Boto3Client())\n'
+    )
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.Boto3Client.download" not in unused
+    assert "playlist.decode_playlist" not in unused
+    assert "playlist.Boto3Client.unused_operation" in unused
+    assert (
+        "top_level_execution"
+        in analyzer.defs["playlist.Boto3Client.download"].heuristic_refs
+    )
+    assert (
+        "reachable_from_root"
+        in analyzer.defs["playlist.decode_playlist"].heuristic_refs
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_local_m3u8_module_does_not_get_external_protocol(tmp_path, grep_verify):
+    (tmp_path / "m3u8.py").write_text(
+        "def load(uri, http_client):\n    return uri\n", encoding="utf-8"
+    )
+    _, unused = _scan(
+        tmp_path,
+        CLIENT + '\nfrom m3u8 import load\nload("uri", http_client=Boto3Client())\n',
+        grep_verify,
+    )
+
+    assert "playlist.Boto3Client.download" in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_parameter_shadowing_does_not_get_external_protocol(tmp_path, grep_verify):
+    source = (
+        CLIENT
+        + """
+from m3u8 import load
+
+def forward(load, uri):
+    return load(uri, http_client=Boto3Client())
+
+forward(lambda *args, **kwargs: None, "uri")
+"""
+    )
+    _, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.Boto3Client.download" in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_local_library_body_already_keeps_callback_alive(tmp_path, grep_verify):
+    (tmp_path / "external_m3u8.py").write_text(
+        "def load(uri, http_client):\n    return http_client.download(uri)\n",
+        encoding="utf-8",
+    )
+    source = (
+        CLIENT
+        + """
+def load_m3u8_from_s3(uri):
+    from external_m3u8 import load
+    return load(uri, http_client=Boto3Client())
+
+load_m3u8_from_s3("s3://example/playlist.m3u8")
+"""
+    )
+    _, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.Boto3Client.download" not in unused
+    assert "playlist.load_m3u8_from_s3" not in unused
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_external_callback_reaches_literal_plugin_registry(tmp_path, live):
+    (tmp_path / "plugins.py").write_text(
+        "def decode_playlist(uri):\n    return uri\n", encoding="utf-8"
+    )
+    source = """
+import importlib
+from m3u8 import load
+
+HANDLER_PATHS = {"playlist": "plugins:decode_playlist"}
+
+class Client:
+    @staticmethod
+    def download(uri, *_):
+        handler_path = HANDLER_PATHS["playlist"]
+        module_name, func_name = handler_path.split(":")
+        handler = getattr(importlib.import_module(module_name), func_name)
+        return handler(uri), ""
+
+def load_wrapper(uri):
+    return load(uri, http_client=Client())
+"""
+    if live:
+        source += '\nload_wrapper("s3://example/playlist.m3u8")\n'
+    analyzer, unused = _scan(tmp_path, source, grep_verify=False)
+
+    assert ("plugins.decode_playlist" not in unused) is live
+    assert (analyzer.defs["plugins.decode_playlist"].references > 0) is live
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("mutual", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+def test_callback_cycle_needs_a_live_caller(tmp_path, grep_verify, mutual, live):
+    other = "SecondClient" if mutual else "FirstClient"
+    source = (
+        "from m3u8 import load\n\n"
+        "class FirstClient:\n"
+        "    @staticmethod\n"
+        "    def download(uri, *_):\n"
+        f"        return load(uri, http_client={other}())\n"
+    )
+    if mutual:
+        source += (
+            "\nclass SecondClient:\n"
+            "    @staticmethod\n"
+            "    def download(uri, *_):\n"
+            "        return load(uri, http_client=FirstClient())\n"
+        )
+    if live:
+        source += '\nload("s3://example/playlist.m3u8", http_client=FirstClient())\n'
+    analyzer, _ = _scan(tmp_path, source, grep_verify)
+
+    # These fixtures are only scanned, never executed. Even a recursive
+    # callback must not become a liveness root just because it references itself.
+    for client in {"FirstClient", other}:
+        assert (analyzer.defs[f"playlist.{client}.download"].references > 0) is live
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "ordinary_use",
+    [
+        'Boto3Client.download("uri")',
+        "from eventlib import register\nregister(Boto3Client.download)",
+    ],
+)
+def test_unused_external_wrapper_preserves_ordinary_method_use(
+    tmp_path, grep_verify, ordinary_use
+):
+    source = (
+        CLIENT
+        + ordinary_use
+        + """
+
+def unused_wrapper(uri):
+    from m3u8 import load
+    return load(uri, http_client=Boto3Client())
+"""
+    )
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.unused_wrapper" in unused
+    assert "playlist.Boto3Client.download" not in unused
+    assert analyzer.defs["playlist.Boto3Client.download"].references > 0
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_dead_ordinary_caller_does_not_root_an_external_cycle(tmp_path, grep_verify):
+    source = """
+from m3u8 import load
+
+class FirstClient:
+    @staticmethod
+    def download(uri, *_):
+        return load(uri, http_client=SecondClient())
+
+class SecondClient:
+    @staticmethod
+    def download(uri, *_):
+        return load(uri, http_client=FirstClient())
+
+def unused_wrapper(uri):
+    return FirstClient.download(uri)
+"""
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.unused_wrapper" in unused
+    # Grep can already match both methods by name from the dead wrapper's
+    # textual use. Neither method may gain a new external callback edge.
+    second = analyzer.defs["playlist.SecondClient.download"]
+    assert "playlist.FirstClient.download" not in second.called_by
+    assert "dead_code_liveness:external_protocol" not in second.heuristic_refs
+    if not grep_verify:
+        assert second.references == 0
+        assert analyzer.defs["playlist.FirstClient.download"].references == 0
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_external_callback_preserves_constructor_and_local_protocol_dependencies(
+    tmp_path, grep_verify
+):
+    source = """
+from m3u8 import load
+
+class Decoder:
+    def decode(self):
+        return "playlist", ""
+
+def invoke(decoder):
+    return decoder.decode()
+
+class Client:
+    @staticmethod
+    def download(uri, *_):
+        return invoke(Decoder())
+
+def load_wrapper(uri):
+    return load(uri, http_client=Client())
+
+load_wrapper("s3://example/playlist.m3u8")
+"""
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    for name in ("playlist.Decoder", "playlist.Decoder.decode", "playlist.invoke"):
+        assert analyzer.defs[name].references > 0
+        assert name not in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_unused_class_constructor_is_not_an_external_callback_root(
+    tmp_path, grep_verify
+):
+    source = (
+        CLIENT
+        + """
+from m3u8 import load
+
+class UnusedService:
+    def __init__(self):
+        load("s3://example/playlist.m3u8", http_client=Boto3Client())
+
+def unused_wrapper():
+    return UnusedService()
+"""
+    )
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    assert "playlist.unused_wrapper" in unused
+    assert analyzer.defs["playlist.Boto3Client.download"].references == 0
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+@pytest.mark.parametrize("nested_callback", [False, True])
+def test_callback_constructor_keeps_its_dependencies(
+    tmp_path, grep_verify, live, nested_callback
+):
+    prepare = (
+        'load("s3://example/second.m3u8", http_client=SecondClient())'
+        if nested_callback
+        else "prepare()"
+    )
+    source = """
+from m3u8 import load
+
+def prepare():
+    return "playlist", ""
+
+class SecondClient:
+    @staticmethod
+    def download(uri, *_):
+        return prepare()
+
+class Decoder:
+    def __init__(self):
+        self.contents = PREPARE
+
+    def decode(self):
+        return self.contents
+
+    def unused_operation(self):
+        return None
+
+class Client:
+    @staticmethod
+    def download(uri, *_):
+        return Decoder().decode()
+
+def load_wrapper(uri):
+    return load(uri, http_client=Client())
+""".replace("PREPARE", prepare)
+    if live:
+        source += '\nload_wrapper("s3://example/playlist.m3u8")\n'
+    analyzer, unused = _scan(tmp_path, source, grep_verify)
+
+    assert analyzer.defs["playlist.Decoder.unused_operation"].references == 0
+    if live:
+        for name in (
+            "playlist.Decoder",
+            "playlist.Decoder.__init__",
+            "playlist.prepare",
+        ):
+            assert analyzer.defs[name].references > 0
+            assert name not in unused
+        if nested_callback:
+            assert analyzer.defs["playlist.SecondClient.download"].references > 0
+    else:
+        assert "playlist.load_wrapper" in unused
+        assert analyzer.defs["playlist.Client.download"].references == 0
+        assert analyzer.defs["playlist.SecondClient.download"].references == 0

--- a/test/test_external_protocol_imports.py
+++ b/test/test_external_protocol_imports.py
@@ -1,0 +1,187 @@
+"""Imported client fixtures are static data; their modules never execute."""
+
+import json
+import textwrap
+
+import pytest
+
+from skylos.analyzer import Skylos
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+CLIENT = """
+class Client:
+    @staticmethod
+    def download(uri, *_):
+        return uri, ""
+
+    def unrelated(self):
+        return None
+"""
+
+
+def _scan(tmp_path, files, grep_verify):
+    for relative_path, source in files.items():
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        assert write_text_no_symlink(path, textwrap.dedent(source).lstrip())
+    analyzer = Skylos()
+    result = json.loads(
+        analyzer.analyze(
+            str(tmp_path),
+            thr=0,
+            grep_verify=grep_verify,
+            grep_cache=False,
+            trace_file=False,
+            enable_dependency_hallucinations=False,
+        )
+    )
+    return analyzer, {item["full_name"] for item in result.get("unused_functions", [])}
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "import_line,client,provider,caller_path",
+    [
+        ("from clients import Client", "Client", "clients", "playlist.py"),
+        ("from clients import Client as Adapter", "Adapter", "clients", "playlist.py"),
+        ("import clients", "clients.Client", "clients", "playlist.py"),
+        ("import clients as adapters", "adapters.Client", "clients", "playlist.py"),
+        ("from pkg.clients import Client", "Client", "pkg.clients", "playlist.py"),
+        ("from .clients import Client", "Client", "pkg.clients", "pkg/playlist.py"),
+    ],
+)
+def test_live_imported_client_uses_the_defining_file(
+    tmp_path, grep_verify, import_line, client, provider, caller_path
+):
+    caller = (
+        f"{import_line}\nfrom m3u8 import load\n\n"
+        "def fetch(uri):\n"
+        f"    return load(uri, http_client={client}())\n"
+        '\nfetch("s3://example/playlist.m3u8")\n'
+    )
+    analyzer, unused = _scan(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            f"{provider.replace('.', '/')}.py": CLIENT,
+            caller_path: caller,
+            "other.py": CLIENT,
+        },
+        grep_verify,
+    )
+
+    callback = analyzer.defs[f"{provider}.Client.download"]
+    assert callback.references > 0
+    assert "dead_code_liveness:external_protocol" in callback.heuristic_refs
+    assert callback.name not in unused
+    assert analyzer.defs[f"{provider}.Client.unrelated"].references == 0
+    assert analyzer.defs["other.Client.download"].references == 0
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_uncalled_wrapper_does_not_activate_an_imported_client(tmp_path, grep_verify):
+    analyzer, unused = _scan(
+        tmp_path,
+        {
+            "clients.py": CLIENT,
+            "playlist.py": """
+                from clients import Client
+                from m3u8 import load
+                def unused_wrapper(uri):
+                    return load(uri, http_client=Client())
+            """,
+        },
+        grep_verify,
+    )
+    assert "playlist.unused_wrapper" in unused
+    assert analyzer.defs["clients.Client.download"].references == 0
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "provider",
+    [
+        CLIENT + "\nClient = object()\n",
+        CLIENT + "\nClient.download = replacement\n",
+        "from custom import staticmethod\n" + CLIENT,
+    ],
+)
+def test_rebound_provider_does_not_prove_an_imported_callback(
+    tmp_path, grep_verify, provider
+):
+    analyzer, _ = _scan(
+        tmp_path,
+        {
+            "clients.py": provider,
+            "playlist.py": """
+                from clients import Client
+                from m3u8 import load
+                load("s3://example/playlist.m3u8", http_client=Client())
+            """,
+        },
+        grep_verify,
+    )
+    assert analyzer.defs["clients.Client.download"].references == 0
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_parameter_shadowing_does_not_activate_an_imported_client(
+    tmp_path, grep_verify
+):
+    analyzer, _ = _scan(
+        tmp_path,
+        {
+            "clients.py": CLIENT,
+            "playlist.py": """
+                from clients import Client
+                from m3u8 import load
+                def fetch(Client):
+                    return load("s3://example/playlist.m3u8", http_client=Client())
+                fetch(replacement)
+            """,
+        },
+        grep_verify,
+    )
+    assert analyzer.defs["clients.Client.download"].references == 0
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_imported_inherited_method_uses_provider_scope(tmp_path, grep_verify):
+    provider = CLIENT + "\nclass Derived(Client):\n    pass\n"
+    analyzer, unused = _scan(
+        tmp_path,
+        {
+            "clients.py": provider,
+            "playlist.py": """
+                from clients import Derived
+                from m3u8 import load
+                staticmethod = replacement
+                load("s3://example/playlist.m3u8", http_client=Derived())
+            """,
+        },
+        grep_verify,
+    )
+    assert analyzer.defs["clients.Client.download"].references > 0
+    assert "clients.Client.download" not in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_relative_import_with_only_module_level_callback(tmp_path, grep_verify):
+    analyzer, unused = _scan(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/clients.py": CLIENT,
+            "pkg/playlist.py": """
+                from .clients import Client
+                from m3u8 import load
+                load("s3://example/playlist.m3u8", http_client=Client())
+            """,
+        },
+        grep_verify,
+    )
+    callback = analyzer.defs["pkg.clients.Client.download"]
+    assert callback.references > 0
+    assert "dead_code_liveness:external_protocol" in callback.heuristic_refs
+    assert callback.name not in unused

--- a/test/test_external_protocols.py
+++ b/test/test_external_protocols.py
@@ -1,0 +1,340 @@
+"""Contract fixtures are parsed only; no target imports or callbacks execute."""
+
+import ast
+import textwrap
+
+import pytest
+
+from skylos.deadcode.external_protocols import find_external_protocol_callbacks
+from skylos.deadcode.python_ast import ParsedPythonFile
+from skylos.visitors.base import Visitor
+
+
+_CLIENT = """\
+class Client:
+    @staticmethod
+    def download(uri, *args): return uri, ''
+    def unrelated(self): return 1
+    def _private(self): return 2
+"""
+
+
+def _collect(tmp_path, source, extra_paths=()):
+    path = tmp_path / "app.py"
+    tree = ast.parse(textwrap.dedent(source))
+    visitor = Visitor("app", path)
+    visitor.visit(tree)
+    visitor.finalize()
+    definitions = {definition.name: definition for definition in visitor.defs}
+    parsed = [ParsedPythonFile(path, tree)]
+    parsed.extend(
+        ParsedPythonFile(tmp_path / name, ast.parse("")) for name in extra_paths
+    )
+    edges = find_external_protocol_callbacks(definitions, parsed, tmp_path)
+    assert all(definition.references == 0 for definition, _ in edges)
+    return [
+        (method.name, caller.name if caller is not None else None)
+        for method, caller in edges
+    ]
+
+
+@pytest.mark.parametrize(
+    "import_line,callee",
+    [
+        ("import m3u8", "m3u8.load"),
+        ("import m3u8 as playlist", "playlist.load"),
+        ("from m3u8 import load", "load"),
+        ("from m3u8 import load as read", "read"),
+    ],
+)
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        "uri, http_client=Client()",
+        "uri, None, {}, None, Client()",
+    ],
+)
+def test_proven_imports_return_only_caller_owned_download(
+    tmp_path, import_line, callee, arguments
+):
+    source = (
+        _CLIENT
+        + f"def wrapper(uri):\n    {import_line}\n    return {callee}({arguments})\n"
+    )
+    assert _collect(tmp_path, source) == [("app.Client.download", "app.wrapper")]
+
+
+def test_module_execution_has_no_deferred_owner(tmp_path):
+    source = (
+        _CLIENT
+        + "import m3u8\nm3u8.load('s3://example.invalid/list', http_client=Client())\n"
+    )
+    assert _collect(tmp_path, source) == [("app.Client.download", None)]
+
+
+def test_assigned_instance_alias_and_duplicate_calls(tmp_path):
+    source = (
+        _CLIENT
+        + """\
+from m3u8 import load
+def wrapper(uri):
+    client = Client()
+    alias = client
+    load(uri, http_client=alias)
+    return load(uri, http_client=client)
+"""
+    )
+    assert _collect(tmp_path, source) == [("app.Client.download", "app.wrapper")]
+
+
+def test_nested_function_keeps_its_own_caller(tmp_path):
+    source = (
+        _CLIENT
+        + """\
+import m3u8
+def outer(uri):
+    def inner():
+        return m3u8.load(uri, http_client=Client())
+    return inner
+"""
+    )
+    assert _collect(tmp_path, source) == [("app.Client.download", "app.outer.inner")]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "def wrapper(m3u8, uri): return m3u8.load(uri, http_client=Client())",
+        "def wrapper(uri):\n    m3u8 = local\n    return m3u8.load(uri, http_client=Client())",
+        "def wrapper(uri):\n    m3u8.load(uri, http_client=Client())\n    m3u8 = local",
+        "def wrapper(uri):\n    Client = local\n    return m3u8.load(uri, http_client=Client())",
+        "def wrapper(uri):\n    client = Client()\n    client = object()\n    return m3u8.load(uri, http_client=client)",
+        "m3u8.load = local\ndef wrapper(uri): return m3u8.load(uri, http_client=Client())",
+        "Client.download = local\ndef wrapper(uri): return m3u8.load(uri, http_client=Client())",
+        "from other import *\ndef wrapper(uri): return m3u8.load(uri, http_client=Client())",
+        "def wrapper(uri): return m3u8.load(uri, http_client=Client())\nm3u8 = local",
+        "def wrapper(uri): return m3u8.load(uri, http_client=Client())\nClient = local",
+        "def wrapper(uri):\n    return uri\n    m3u8.load(uri, http_client=Client())",
+        "def wrapper(uri):\n    if True:\n        return uri\n    m3u8.load(uri, http_client=Client())",
+    ],
+)
+def test_shadowed_mutated_or_unreachable_calls_do_not_prove_use(tmp_path, body):
+    assert _collect(tmp_path, _CLIENT + "import m3u8\n" + body + "\n") == []
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        "m3u8.loads(uri, http_client=Client())",
+        "m3u8.load(uri, client=Client())",
+        "m3u8.load(uri, http_client=unknown)",
+        "m3u8.load(*args, http_client=Client())",
+        "m3u8.load(uri, http_client=Client(), **options)",
+        "m3u8.load(http_client=Client())",
+        "m3u8.load(uri, uri=uri, http_client=Client())",
+        "m3u8.load(uri, http_client=Client(), unexpected=True)",
+        "m3u8.load(uri, None, {}, None, Client(), True, None)",
+    ],
+)
+def test_wrong_contract_or_visibly_invalid_call_is_not_an_edge(tmp_path, call):
+    source = _CLIENT + f"import m3u8\ndef wrapper(uri): return {call}\n"
+    assert _collect(tmp_path, source) == []
+
+
+@pytest.mark.parametrize(
+    "path", ["m3u8.py", "m3u8/__init__.py", "src/m3u8.py", "lib/m3u8/client.py"]
+)
+def test_local_modules_disable_external_contract(tmp_path, path):
+    source = (
+        _CLIENT
+        + "import m3u8\ndef wrapper(uri): return m3u8.load(uri, http_client=Client())\n"
+    )
+    assert _collect(tmp_path, source, (path,)) == []
+
+
+def test_import_in_an_unrelated_function_does_not_leak(tmp_path):
+    source = (
+        _CLIENT
+        + """\
+def imports_only():
+    import m3u8
+def wrapper(uri):
+    return m3u8.load(uri, http_client=Client())
+"""
+    )
+    assert _collect(tmp_path, source) == []
+
+
+def test_unknown_flow_is_not_promoted(tmp_path):
+    source = (
+        _CLIENT
+        + """\
+def wrapper(uri):
+    if condition:
+        import m3u8
+    return m3u8.load(uri, http_client=Client())
+"""
+    )
+    assert _collect(tmp_path, source) == []
+
+
+@pytest.mark.parametrize(
+    "uri", ["playlist.m3u8", "./playlist.m3u8", "file:///tmp/list.m3u8"]
+)
+def test_literal_local_uri_does_not_invoke_the_client(tmp_path, uri):
+    source = _CLIENT + f"import m3u8\nm3u8.load({uri!r}, http_client=Client())\n"
+    assert _collect(tmp_path, source) == []
+
+
+@pytest.mark.parametrize("decorator", ["staticmethod", "classmethod"])
+@pytest.mark.parametrize(
+    "binding",
+    [
+        "def {name}(function): return other\n",
+        "from other import replacement as {name}\n",
+    ],
+)
+def test_shadowed_method_decorators_do_not_prove_callback_identity(
+    tmp_path, decorator, binding
+):
+    source = (
+        binding.format(name=decorator)
+        + _CLIENT.replace("staticmethod", decorator)
+        + "import m3u8\ndef wrapper(uri): return m3u8.load(uri, http_client=Client())\n"
+    )
+    assert _collect(tmp_path, source) == []
+
+
+@pytest.mark.parametrize("decorator", ["staticmethod", "classmethod"])
+def test_class_local_method_decorator_is_not_a_builtin(tmp_path, decorator):
+    client = _CLIENT.replace("staticmethod", decorator).replace(
+        "class Client:\n", f"class Client:\n    {decorator} = replacement\n"
+    )
+    source = (
+        client
+        + "import m3u8\ndef wrapper(uri): return m3u8.load(uri, http_client=Client())\n"
+    )
+    assert _collect(tmp_path, source) == []
+
+
+_PARENT = """\
+class Parent:
+    @staticmethod
+    def download(uri, *args): return uri, ''
+"""
+
+
+def _inherited(tmp_path, source, client="Client()"):
+    return _collect(
+        tmp_path,
+        source
+        + f"\nfrom m3u8 import load\ndef wrapper(uri): return load(uri, http_client={client})\n",
+    )
+
+
+@pytest.mark.parametrize("client", ["Client()", "Client"])
+@pytest.mark.parametrize("decorator", ["staticmethod", "classmethod"])
+def test_inherited_static_and_class_methods(tmp_path, client, decorator):
+    source = _PARENT.replace("staticmethod", decorator) + "class Client(Parent): pass\n"
+    assert _inherited(tmp_path, source, client) == [
+        ("app.Parent.download", "app.wrapper")
+    ]
+
+
+def test_inherited_instance_method_requires_an_instance(tmp_path):
+    source = "class Parent:\n    def download(self, uri, *args): return uri, ''\nclass Client(Parent): pass\n"
+    assert _inherited(tmp_path, source) == [("app.Parent.download", "app.wrapper")]
+    assert _inherited(tmp_path, source, "Client") == []
+
+
+def test_direct_instance_method_is_not_a_class_callback(tmp_path):
+    source = "class Client:\n    def download(self, uri, timeout, headers, verify_ssl): return uri, ''\n"
+    assert _inherited(tmp_path, source, "Client") == []
+    assert _inherited(tmp_path, source) == [("app.Client.download", "app.wrapper")]
+
+
+@pytest.mark.parametrize(
+    "bases,expected", [("Left, Right", "Left"), ("Right, Left", "Right")]
+)
+def test_multiple_inheritance_preserves_base_order(tmp_path, bases, expected):
+    source = _PARENT.replace("Parent", "Left") + _PARENT.replace("Parent", "Right")
+    source += f"class Client({bases}): pass\n"
+    assert _inherited(tmp_path, source) == [(f"app.{expected}.download", "app.wrapper")]
+
+
+def test_diamond_uses_c3_not_depth_first_lookup(tmp_path):
+    source = _PARENT + "class Left(Parent): pass\n"
+    source += _PARENT.replace("class Parent:", "class Right(Parent):")
+    source += "class Client(Left, Right): pass\n"
+    assert _inherited(tmp_path, source) == [("app.Right.download", "app.wrapper")]
+
+
+def test_subclass_override_does_not_promote_parent_method(tmp_path):
+    source = _PARENT + _PARENT.replace("class Parent:", "class Client(Parent):")
+    assert _inherited(tmp_path, source) == [("app.Client.download", "app.wrapper")]
+
+
+def test_base_alias_is_captured_when_class_is_defined(tmp_path):
+    source = (
+        _PARENT + "Alias = Parent\nclass Client(Alias): pass\nAlias = replacement\n"
+    )
+    assert _inherited(tmp_path, source) == [("app.Parent.download", "app.wrapper")]
+
+
+def test_explicit_object_base_is_supported(tmp_path):
+    source = (
+        _PARENT.replace("class Parent:", "class Parent(object):")
+        + "class Client(Parent): pass\n"
+    )
+    assert _inherited(tmp_path, source) == [("app.Parent.download", "app.wrapper")]
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "class Client(Parent):\n    download = None\n",
+        "class Client(Parent):\n    @custom\n    def download(self, uri, *args): return uri, ''\n",
+        "class Client(unknown): pass\n",
+        "class Client(Parent, unknown): pass\n",
+        "class Client(factory()): pass\n",
+        "Alias = replacement\nclass Client(Alias): pass\n",
+        "class Client(Parent): pass\nParent.download = replacement\n",
+        "class Client(Parent): pass\nClient.download = replacement\n",
+        "class Client(Parent): pass\nsetattr(Parent, 'download', replacement)\n",
+        "class Client(Parent, Parent): pass\n",
+        "class A: pass\nclass B: pass\nclass Left(A, B): pass\nclass Right(B, A): pass\nclass Client(Left, Right, Parent): pass\n",
+    ],
+)
+def test_unproven_or_masked_inherited_callbacks_are_not_promoted(tmp_path, suffix):
+    assert _inherited(tmp_path, _PARENT + suffix) == []
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "def staticmethod(function): return replacement\n",
+        "from helpers import replacement as staticmethod\n",
+    ],
+)
+def test_inherited_decorator_identity_must_be_proven(tmp_path, prefix):
+    source = prefix + _PARENT + "class Client(Parent): pass\n"
+    assert _inherited(tmp_path, source) == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "def __init__(self):\n        self.download = replacement",
+        "def __init__(self):\n        setattr(self, 'download', replacement)",
+        "def __init__(self):\n        delattr(self, 'download')",
+        "def __getattribute__(self, name):\n        return replacement",
+    ],
+)
+def test_instance_shadow_does_not_promote_inherited_download(tmp_path, body):
+    source = _PARENT + f"class Client(Parent):\n    {body}\n"
+    assert _inherited(tmp_path, source) == []
+    # Neither instance initialization nor instance attribute lookup changes the
+    # inherited static method when the library receives the class itself.
+    assert _inherited(tmp_path, source, "Client") == [
+        ("app.Parent.download", "app.wrapper")
+    ]


### PR DESCRIPTION
## Summary

  - Fix download being reported as unused when a live caller passes a client to m3u8.load.
  - Handle inherited and imported clients, aliases, method overrides and constructor dependencies.

  ## Tests

  - pytest test/test_external_protocols.py test/test_external_protocol_imports.py test/
    test_duck_typed_callback_liveness.py

  Refs #777. This fixes the reproduced callback gap .. 