### PR TITLE
fix(deps): use published dependency minimums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "inquirer>=3.0.3",
+    "inquirer>=3.1.0",
     "libcst>=1.8.2",
     "rich>=14.0.0",
     "textual>=1.0.0",
@@ -88,7 +88,7 @@ dependencies = [
     "pyyaml",
     "networkx",
     "pyperclip",
-    "ca9>=0.1.0",
+    "ca9>=0.1.1",
     "mcp>=1.0.0,<2"
 ]
 

--- a/test/test_dependency_metadata.py
+++ b/test/test_dependency_metadata.py
@@ -36,3 +36,37 @@ def test_runtime_dependency_compatibility_bands(package, supported, next_breakin
 
     assert Version(supported) in requirement.specifier
     assert Version(next_breaking) not in requirement.specifier
+
+
+@pytest.mark.parametrize(
+    ("package", "published_minimum", "missing_version"),
+    [
+        ("inquirer", "3.1.0", "3.0.3"),
+        ("ca9", "0.1.1", "0.1.0"),
+    ],
+)
+def test_runtime_dependency_minimums_use_published_releases(
+    package, published_minimum, missing_version
+):
+    # First published releases satisfying the old ranges, verified on PyPI:
+    # https://pypi.org/project/inquirer/#history
+    # https://pypi.org/project/ca9/#history
+    requirement = _runtime_requirements()[package]
+
+    assert str(requirement.specifier) == f">={published_minimum}"
+    assert Version(published_minimum) in requirement.specifier
+    assert Version(missing_version) not in requirement.specifier
+
+
+@pytest.mark.parametrize("package", ["inquirer", "ca9"])
+def test_corrected_dependency_minimums_match_lock_metadata(package):
+    requirement = _runtime_requirements()[package]
+    lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+    project = next(item for item in lock["package"] if item["name"] == "skylos")
+    locked_requirement = next(
+        item for item in project["metadata"]["requires-dist"] if item["name"] == package
+    )
+    locked_package = next(item for item in lock["package"] if item["name"] == package)
+
+    assert locked_requirement["specifier"] == str(requirement.specifier)
+    assert Version(locked_package["version"]) in requirement.specifier

--- a/uv.lock
+++ b/uv.lock
@@ -2439,8 +2439,8 @@ test = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'all'", specifier = ">=3.14.0" },
     { name = "aiohttp", marker = "extra == 'llm'", specifier = ">=3.14.0" },
-    { name = "ca9", specifier = ">=0.1.0" },
-    { name = "inquirer", specifier = ">=3.0.3" },
+    { name = "ca9", specifier = ">=0.1.1" },
+    { name = "inquirer", specifier = ">=3.1.0" },
     { name = "keyring", specifier = "!=3.4.2,>=25.6.0" },
     { name = "libcst", specifier = ">=1.8.2" },
     { name = "litellm", marker = "extra == 'all'", specifier = ">=1.84.0,<1.85.0" },


### PR DESCRIPTION
Fix #790 
 
## Summary

  - Change inquirer>=3.0.3 to inquirer>=3.1.0 and ca9>=0.1.0 to ca9>=0.1.1, using versions that exists on PyPI.
  - Update matching entries in uv.lock without changing locked package versions or hashes.

  ## Tests

  - pytest test/test_dependency_metadata.py