### PR TITLE
feat(verify): compare Python working changes with HEAD

### DIFF
--- a/docs/ai-code-verification.md
+++ b/docs/ai-code-verification.md
@@ -7,12 +7,29 @@ network service for local/workspace API verification.
 
 This command has a narrower purpose than `skylos defend`:
 
-- `skylos verify`: did the edited code contain a proven AI-code defect, and did
-  every applicable deterministic verification check complete?
+- `skylos verify`: did the edited code contain a proven AI-code defect, did its
+  Python behavior change from Git HEAD, and did applicable checks complete?
 - `skylos defend`: does an agent implementation contain expected static
   guardrails before deployment?
 
 Neither command currently proves the runtime behavior of a running agent.
+
+For path targets, Python behavior comparison runs automatically alongside the
+existing checks:
+
+```bash
+skylos verify app.py
+skylos verify .
+```
+
+Skylos uses Git HEAD as the baseline and discovers affected functions. The
+terminal report explains what changed and its possible impact. Pipes, `--stdin`,
+and saved output retain JSON with the same explanations. The
+JSON `behavior` result also records modeled differences and comparisons that could
+not be completed. A difference needs review: Skylos cannot infer whether the
+change was intentional. See [Python behavior comparison](behavior-preservation.md)
+for the supported model and its limits. Stdin verification retains its existing
+checks; it does not compare the provided source with Git.
 
 ## Status and exit codes
 
@@ -20,12 +37,17 @@ Schema-version-2 responses use three statuses:
 
 | Status | Exit | Meaning |
 |:---|:---:|:---|
-| `pass` | `0` | No verified findings and every applicable expected check completed |
+| `pass` | `0` | No verified findings, every applicable expected check completed, and no behavior comparison requires review |
 | `fail` | `1` | At least one verified AI-code finding exists |
-| `incomplete` | `2` | No finding exists, but one or more required proofs were unsupported, skipped, uncertain, or missing |
+| `incomplete` | `2` | No finding exists, but a check was unsupported, skipped, uncertain, or missing, or a modeled behavior change needs review |
 
 Findings take precedence over incomplete coverage. `--no-fail` changes the
 process exit code to `0`, but does not change the JSON status.
+
+Behavior comparison reports `unavailable` when no Git HEAD can be read, and
+`unchanged` when no relevant Python change needs comparison. These do not alter
+the result of the existing checks. Neither status claims behavior was proved
+equivalent.
 
 ## Local API verification support
 

--- a/docs/behavior-integration-plan.md
+++ b/docs/behavior-integration-plan.md
@@ -1,0 +1,217 @@
+# Behavior comparison integration plan
+
+Updated: 2026-09-09.
+
+Progress: step 1 complete; step 2 is next. Steps 2–5 have not been executed.
+
+## Objective
+
+Make useful Python behavior changes visible through existing Skylos workflows,
+without adding CLI flags, running target code, duplicating the static scan, or
+calling every intentional change a defect.
+
+This file is the implementation checklist. Complete and validate one numbered
+step at a time. Record the result here before starting the next step.
+
+## Starting point
+
+- `skylos verify <path>` runs AI-code checks and compares affected Python
+  functions in HEAD with the working tree. Differences and unsupported
+  comparisons make otherwise passing verification incomplete (exit 2).
+- Regular scans, including `-a`, and `suite` do not run behavior comparison.
+- Regular `--diff` selects committed branch changes. Its baseline is different
+  from the current behavior comparator's HEAD-to-working-tree baseline.
+- `skylos <path> --verify` is an existing paid cloud findings-verification
+  option. It is unrelated to local behavior comparison; keep its meaning.
+- The model is experimental: common annotations, branches, classes and async
+  code remain unsupported. A modeled difference requires intent review.
+- Current reports sometimes display zero findings for checks that did not run.
+
+## Decisions
+
+- Initial activation belongs in existing comprehensive/change-review workflows:
+  `skylos <path> -a`, `skylos <path> --diff [ref]`, and `skylos suite <path>`.
+- Keep `skylos verify` as the focused comparison workflow.
+- Plain scans retain their current analysis selection during this rollout.
+- Share source comparison, not the entire `verify_change_path` operation.
+- Behavior differences are review observations. Unsupported comparisons are
+  coverage information. Neither automatically changes ordinary defect gates
+  or code grades.
+- Show the actual baseline, selected scope and coverage. Zero comparisons must
+  never be described as preserved behavior.
+- Activate regular-scan comparison only once steps 2–5 are integrated and their
+  acceptance checks pass. Avoid releasing a terminal-only or JSON-only feature.
+
+## 1. Extract the shared source-comparison service
+
+Status: complete.
+
+Purpose: let any workflow compare prepared source snapshots without invoking
+Git, the static analyzer, a renderer, or a command's exit policy again.
+
+Implementation:
+
+- Add `skylos/verification/comparison.py` with `SourceSnapshot`,
+  `ComparisonScope`, and `compare_source_changes(before, after, scope=...)`.
+- Snapshots own read-only copies of source mappings and original-byte hashes.
+  Scope carries a repository-relative file/directory, optional line range and
+  excluded folders.
+- Move AST indexing, helper/caller impact discovery, comparison selection,
+  budgets and behavior-result aggregation from `changes.py` into that service.
+- Determine Python source changes from source contents, so missing or stale
+  caller-supplied hashes cannot suppress an edit. Preserve original byte hashes
+  for Git evidence and environment-change detection.
+- Keep `compare_working_changes(...)` as the compatible Git adapter: resolve
+  scope/HEAD, load each snapshot once, handle submodule changes, call the shared
+  service once, and attach Git metadata/assumptions.
+- Keep overall verification status mapping in `verify_change.py`. Keep the
+  explicit `verify_refactor(...)` API and its preservation obligation intact.
+
+Acceptance checks:
+
+- Source-only calls work with filesystem, subprocess and analyzer entry points
+  blocked; snapshot inputs cannot be changed through the original mappings.
+- Return-loss explanations and helper extraction still work; an edited helper
+  still affects its unchanged selected caller.
+- Line/exclusion scope, environment changes and deleted functions retain their
+  conservative results. Existing limits remain enforced.
+- Existing Git adapter output, original-byte hashes, verify CLI output and exit
+  codes remain compatible. One verify invocation calls the AI analyzer once.
+- New service tests and the existing behavior/verify regression suites pass.
+
+Completion evidence (2026-09-09):
+
+- Shared service implemented in `skylos/verification/comparison.py`; the existing
+  Git adapter now loads snapshots and delegates to it. Command exit policy stays
+  in `verify_change.py`.
+- Added 14 source-service cases in `test/test_behavior_comparison.py` and one
+  adapter integration case in `test/test_behavior_changes.py`. They cover pure
+  source execution, immutable inputs, helper impact, missing/stale hashes,
+  exclusions, budgets, single snapshot/service calls, and Latin-1 byte evidence.
+- Fixed the excluded-file fast path: selecting an excluded unsupported file now
+  respects the same scope as supported files. The regression failed before the
+  fix and passes after it.
+- Source service, Git discovery and refactor integration: **70 passed**.
+- Engine/soundness/explanations, verify rendering/API/CLI, dependency-bump and
+  ordinary CLI guardrails: **371 passed**. Total: **441 passed**.
+- The real return-loss demo retains its previous behavior JSON and exit code 2.
+- Independent implementation review found no blocking step-1 concerns.
+
+## 2. Make the comparison baseline explicit
+
+Status: pending; depends on step 1.
+
+Implementation:
+
+- Introduce one resolved comparison context: repository root, immutable base
+  commit, current revision/source kind, selected scopes and source snapshots.
+- Local verification and comprehensive local scans compare HEAD to working
+  sources. Branch review resolves the existing diff reference's merge base and
+  compares it to HEAD, matching committed line/file selection.
+- Dirty working files must not be mixed silently with committed branch evidence.
+  Either read committed current sources for that comparison or report the
+  mismatch explicitly; keep the ordinary analyzer's scope separately identified.
+- Resolve from the requested target repository, including invocation from a
+  different current directory. Report missing refs/shallow-history limitations
+  as unavailable/incomplete comparison with an explicit reason.
+- Group multiple scan paths by repository, read each pair of snapshots once,
+  union overlapping selections, and deduplicate function comparisons.
+- Keep `--baseline` finding fingerprints separate from source baselines.
+
+Acceptance checks:
+
+- The return-loss demo is detected both before commit and in a clean committed
+  branch comparison. A clean local tree explicitly has no local changes.
+- Cover diverged branches, dirty files, file/directory/multiple-path scopes,
+  targets outside the current directory, no Git, and missing base history.
+- Base/current commit identities agree with the source bytes in the report.
+
+## 3. Separate behavior review from defect policy
+
+Status: pending; depends on step 2.
+
+Implementation:
+
+- Add a behavior report contract with comparison context, observations,
+  equivalent/different/unsupported counts, reasons and model limitations.
+- Keep differences and unknown coverage outside defect finding lists, grades,
+  automatic fixes, and generic strict/gate issue counting.
+- Keep the focused verify command's explicit incomplete result for differences
+  and unsupported comparisons; retain existing failures from AI-code checks.
+- Represent disabled, unavailable and no applicable changes as distinct report
+  states; do not manufacture successful comparisons for those cases.
+
+Acceptance checks:
+
+- Intentional behavior edits do not silently become ordinary defect failures.
+- Unsupported functions affect reported coverage, not ordinary defect counts.
+- Existing real analysis errors and defect gates still fail as before; verify
+  exit codes remain documented and tested.
+
+## 4. Connect existing workflows and output formats
+
+Status: pending; depends on steps 2 and 3; activate together with step 5.
+
+Implementation:
+
+- In `commands/scan_cmd.py`, call the shared service after the single static
+  analyzer result is decoded. Select it through existing `-a`/`--diff` intent.
+- In `core/suite.py`, reuse the same service after static analysis. Keep
+  `verify_change_path` as a separate consumer, never a nested scan call.
+- Attach behavior independently of generic changed-line/finding-baseline
+  filters, preserving unchanged callers affected by changed helpers.
+- Carry the same evidence into JSON, rich/pretty/tree/TUI, concise output,
+  LLM reports, SARIF and GitHub annotations. Use review/advisory semantics in
+  exports; unsupported coverage belongs in report metadata, not issue spam.
+- Show concrete differences first, a compact coverage summary next, and model
+  limitations. Retain complete recorded detail in machine-readable output.
+
+Acceptance checks:
+
+- A normal comprehensive scan and focused verify describe the same source
+  change, with the same baseline and function identity.
+- Analyzer and snapshot call-count tests prevent duplicate scans/reads.
+- Terminal, redirected output, saved reports and CI exports preserve evidence.
+- A helper edit remains visible through its unchanged caller after filtering.
+- No new CLI flags; existing paid `--verify` behavior remains separate.
+
+## 5. Make summaries describe what was actually checked
+
+Status: pending; ship with step 4.
+
+Implementation:
+
+- Replace zero-for-disabled presentation with explicit checked/skipped states.
+- Label grades with their scanned scope. Do not present a dead-code-only grade
+  as evidence that all analysis families were checked.
+- When behavior review exists, distinguish clean static checks from changes
+  requiring review. Do not follow a behavior warning with an unqualified clean
+  codebase message.
+- Update command help and user docs with baseline, coverage and exit semantics.
+
+Acceptance checks:
+
+- Golden terminal/JSON examples cover disabled checks, fully clean checks,
+  behavior differences, unsupported functions, no changes, and no baseline.
+- The original missing-target case remains an input error before analysis.
+- Run focused CLI/report/gate tests, regenerate the repo map, and check formatting.
+
+## Later decision: enable comparison in plain scans
+
+This is a separate rollout decision, not part of the five steps above. First
+expand useful support for ordinary Python and measure real edit fixtures:
+useful comparison coverage, misleading change reports, incorrect equivalence,
+and added runtime. Record reproducible measurements rather than treating a high
+unit-test count as evidence of broad usefulness. Add a cheap applicability check
+and reuse parsed sources before considering automatic execution on every scan.
+
+## Resume notes
+
+- Current authorized execution: step 1 only.
+- Step 1 is complete. Regular scans and `suite` still retain their existing
+  activation behavior; their comparison integration is step 4.
+- Next work after step 1: explicit comparison context and baseline tests in
+  step 2; do not enable regular-scan comparison before the integration checks.
+- The user authorized splitting this tested checkpoint into focused commits.
+  Preserve the completed behavior-comparison work; step 2 remains pending.
+  No push or PR is requested.

--- a/docs/behavior-preservation.md
+++ b/docs/behavior-preservation.md
@@ -1,0 +1,167 @@
+# Python behavior comparison
+
+Python behavior comparison runs automatically with the normal verification
+command:
+
+```bash
+skylos verify app.py
+skylos verify .
+```
+
+Skylos compares affected Python functions in Git HEAD with the current working
+tree, alongside the existing AI-code checks. The path selects a file or project;
+Skylos selects the functions and baseline. Changed local helpers can affect a
+function even when that function's own source is unchanged.
+
+The selected path must exist. A missing file or project directory is an input
+error (exit code 2), including when using `--file` with `--project-context`.
+
+In a terminal, the command explains each difference with its location, before
+and after behavior, possible impact on callers, and a review prompt. For example:
+
+```text
+app.py:1 — run
+  Callback result discarded
+  Before: Returned the result of callback(value).
+  After: Returns None.
+  Impact: Callers that use the returned value now receive None and may break.
+```
+
+Pipes, redirected output, `--stdin`, and `--output` keep machine-readable JSON.
+The same explanation is included in each difference's `explanation` object.
+No extra formatting flag is needed. This comparison runs through `skylos verify`;
+the ordinary `skylos <path>` scan retains its existing analysis/reporting.
+
+A modeled difference needs review. It may be an intentional feature change or
+a regression; the command cannot infer that intent. Differences are reported as
+incomplete verification rather than being labeled proven product bugs.
+
+The behavior comparison is experimental and bounded. It reads source as data
+without importing the project, executing its functions, checking out the base
+revision, invoking an LLM, or contacting a package registry. Existing AI-code
+checks retain their own behavior, including configured dependency checks.
+
+## What is compared
+
+The Python interpreter model compares ordered outgoing calls and their
+arguments, returned values, propagated exceptions, and cleanup effects. It
+also requires the selected function's declared parameter names and kinds to
+stay the same. It follows supported helper functions in the same file and statically resolvable
+repository imports. A helper extraction can preserve these observations even
+though the source structure changes:
+
+```python
+# Base
+def run(callback, value):
+    return callback(value)
+
+# Working tree
+def apply(transform, item):
+    return transform(item)
+
+def run(callback, value):
+    return apply(callback, value)
+```
+
+Changing the argument to `callback`, dropping its call, dropping its returned
+value, swallowing its exception, or changing cleanup order can produce a
+modeled difference. Changes to a resolved imported helper are included even
+when the selected file itself is unchanged.
+
+Import resolution initially uses repository-root module names. Imports that
+could refer to a local file through an undeclared source root, such as `src/`,
+`lib/`, or `python/`, are incomplete. Package binding conflicts are also
+incomplete.
+
+## Status and evidence
+
+The normal `verify_change` JSON response includes a `behavior` object with the
+baseline, source evidence, and individual function comparisons.
+
+| `behavior.status` | Meaning | Effect on an otherwise passing result |
+| :--- | :--- | :--- |
+| `equivalent` | The affected functions have equal observations within the supported model and its assumptions | Remains `pass` |
+| `different` | At least one function has a modeled difference that needs review | Becomes `incomplete` |
+| `unknown` | The comparison cannot establish equivalence | Becomes `incomplete` |
+| `unchanged` | No statically identified Python change in the selected scope needs comparison | Remains `pass` |
+| `unavailable` | No Git HEAD baseline is available, or the selected file is not Python | Remains `pass`; behavior was not compared |
+
+Existing verified AI-code findings still produce `fail`, including when behavior
+comparison needs review. Overall exit codes remain 0 for `pass`, 1 for `fail`,
+and 2 for `incomplete`. `--no-fail` changes only the exit code.
+
+The behavior evidence records:
+
+- The resolved immutable HEAD commit.
+- SHA-256 hashes of the Python sources and recognized dependency/environment
+  manifests read from the baseline and working tree.
+- Individual function comparisons, including the model version, symbol ranges,
+  differences, reasons for incompleteness, and assumptions.
+- The selected function/helper scope and comparison budgets.
+
+These hashes identify the inputs to the comparison. They do not establish
+semantic correctness independently of the model. Working-tree reads are not an
+atomic filesystem transaction; rerun after further edits. Evidence is from the
+static model, not an executed runtime witness.
+
+## Supported boundary
+
+The initial subset covers synchronous module-level functions, simple local
+assignments, supported literal and parameter values, statically bound helper
+calls, opaque callback/imported calls, and supported `try`/`except`/`finally`
+control flow. Unsupported operations in an affected function produce `unknown`
+even if that function's source text is identical in both versions.
+
+The model assumes that names have their declared source/import bindings after
+successful module initialization, and that these bindings and external
+dependencies remain stable. Import hooks and initialization-time rebinding are
+excluded. Opaque calls are observed through their arguments, order, result,
+active exception context, and exception outcome. This allows arbitrary return
+and exception outcomes; a difference involving a fixed
+external API may need validation against that API's actual contract. The report
+does not contain an executed runtime witness. It cannot establish equivalence
+for callbacks that inspect frames or tracebacks,
+monkey-patching, timing, memory consumption, or arbitrary runtime environments.
+
+Conditionals, loops, recursion, async functions, generators, decorators, defaults,
+annotations, dynamic object operations, and unsupported exception matching are
+outside the initial subset. Ordinary Python arithmetic can invoke user-defined
+methods, so arbitrary arithmetic is not treated as a pure mathematical
+operation. This mode does not certify arbitrary Python programs or whole
+repositories.
+
+The default budgets are 128 affected functions, 64 modeled paths per function,
+and helper depth 8. Exhausting a budget
+produces `incomplete`. Snapshot reads are bounded to 4,096 inputs, 1 MiB per file,
+and 16 MiB total; exceeding a bound, decoding failures, or source symlinks also
+prevent certification. Unchanged Git submodules are treated as external
+dependencies; a changed submodule commit or dirty submodule prevents comparison.
+
+Snapshots include tracked and unignored Python files across the Git repository,
+plus recognized dependency manifests. Newly created unignored helper files are
+included. Ignored dependencies and the external environment are assumed stable.
+A change to a recognized dependency/environment manifest (such as
+`requirements.txt`, `pyproject.toml`, or a Python lockfile) produces `incomplete`.
+
+The command discovers affected functions within the selected path. Comparisons
+cover whole functions and supported helpers. Discovery follows static imports
+and name references; dynamic loading and runtime rebinding are outside this
+initial selection model. Existing file/range selection,
+project context, AI contracts, analyzer confidence, dependency-check settings,
+and folder exclusions remain available for ordinary verification; they do not
+expand the behavior model's supported semantics. Stdin verification runs its
+existing checks without a Git behavior comparison.
+
+## How the verifier is tested
+
+The regression suite checks pairs that should preserve behavior (including
+helper extraction) and deliberately changed pairs (arguments, call order,
+returns, exceptions, and cleanup). Independent tests also check cases that
+must remain incomplete: unsupported syntax, changed bindings, ambiguous
+imports, exhausted budgets, and escaping local callables. Git/CLI integration
+tests exercise actual base revisions, working edits, helper changes, source
+hashes, and exit statuses. Test snippets are source data, not executed targets.
+
+These tests protect the implemented subset. Broader claims require expanded
+semantics, a representative labeled change corpus, and measured false-pass,
+false-failure, and incompleteness rates.

--- a/docs/behavior-preservation.md
+++ b/docs/behavior-preservation.md
@@ -38,6 +38,11 @@ The same explanation is included in each difference's `explanation` object.
 No extra formatting flag is needed. This comparison runs through `skylos verify`;
 the ordinary `skylos <path>` scan retains its existing analysis/reporting.
 
+`--output` creates or replaces a regular file in an existing directory. It
+rejects symlinks in the destination or its parent directories and files with
+multiple hard links. An unsafe or unwritable destination is an error (exit code
+2), including with `--no-fail`.
+
 A modeled difference needs review. It may be an intentional feature change or
 a regression; the command cannot infer that intent. Differences are reported as
 incomplete verification rather than being labeled proven product bugs.

--- a/docs/behavior-preservation.md
+++ b/docs/behavior-preservation.md
@@ -8,6 +8,12 @@ skylos verify app.py
 skylos verify .
 ```
 
+The [integration plan](behavior-integration-plan.md) tracks rollout into existing
+comprehensive scans and branch review. Its first step provides a shared
+`compare_source_changes` service for prepared `SourceSnapshot` inputs and a
+`ComparisonScope`. The current Git adapter calls that service; Git loading,
+terminal rendering and command exit policy remain outside source comparison.
+
 Skylos compares affected Python functions in Git HEAD with the current working
 tree, alongside the existing AI-code checks. The path selects a file or project;
 Skylos selects the functions and baseline. Changed local helpers can affect a

--- a/docs/behavior-preservation.md
+++ b/docs/behavior-preservation.md
@@ -145,7 +145,10 @@ The default budgets are 128 affected functions, 64 modeled paths per function,
 and helper depth 8. Exhausting a budget
 produces `incomplete`. Snapshot reads are bounded to 4,096 inputs, 1 MiB per file,
 and 16 MiB total; exceeding a bound, decoding failures, or source symlinks also
-prevent certification. Unchanged Git submodules are treated as external
+prevent certification. Working-tree reads open each directory and file without
+following symlinks. Platforms without the required safe directory-relative
+file operations return `unknown` rather than certifying the snapshot.
+Unchanged Git submodules are treated as external
 dependencies; a changed submodule commit or dirty submodule prevents comparison.
 
 Snapshots include tracked and unignored Python files across the Git repository,

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1079</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12298</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>1081</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12327</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1945,12 +1945,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/comparison.py skylos/verification/behavior.py skylos/verification/explanations.py skylos/verification/refactor.py skylos/verification/changes.py skylos/verification/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/comparison.py skylos/verification/behavior.py skylos/verification/explanations.py skylos/verification/refactor.py skylos/verification/render.py skylos/verification/changes.py skylos/verification/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification" rel="noopener noreferrer">skylos/verification</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 6</span>
-          <span class="pill"><strong>symbols</strong> 41</span>
+          <span class="pill"><strong>files</strong> 7</span>
+          <span class="pill"><strong>symbols</strong> 49</span>
         </div>
       </div>
       <p>Generated facts are available; this folder still needs a curated summary.</p>
@@ -1968,6 +1968,7 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">skylos/verification/behavior.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">skylos/verification/explanations.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">skylos/verification/refactor.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/render.py" rel="noopener noreferrer">skylos/verification/render.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/changes.py" rel="noopener noreferrer">skylos/verification/changes.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/__init__.py" rel="noopener noreferrer">skylos/verification/__init__.py</a></li></ul>
       </div>
@@ -2047,8 +2048,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 303</span>
-          <span class="pill"><strong>symbols</strong> 5214</span>
+          <span class="pill"><strong>files</strong> 304</span>
+          <span class="pill"><strong>symbols</strong> 5235</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1028</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>11484</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>1067</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12153</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>32</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -600,12 +600,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="scripts repository maintenance, benchmark, parity, and regression scripts. use this for repeatable evidence and local automation that should not live in runtime package code. scripts/security_benchmark.py scripts/quality_benchmark.py scripts/check_rule_docs_parity.py test/test_typescript_safe_glob.py test/test_typescript_security_flow_candidates.py test/test_typescript_security_proof.py scripts/repo_map_renderer.py scripts/build_repo_map.py scripts/regression_delta.py scripts/compare_codex_skylos_quality.py scripts/compare_codex_skylos_agent_review.py scripts/deep_audit_logic_benchmark.py scripts/analyzer_speed_check.py scripts/compare_codex_skylos_demo_deadcode.py">
+    <article class="folder-card searchable" data-search="scripts repository maintenance, benchmark, parity, and regression scripts. use this for repeatable evidence and local automation that should not live in runtime package code. scripts/security_benchmark.py scripts/quality_benchmark.py scripts/check_rule_docs_parity.py test/test_typescript_safe_glob.py test/test_typescript_security_flow_candidates.py test/test_typescript_security_proof.py scripts/repo_map_renderer.py scripts/build_repo_map.py scripts/regression_delta.py scripts/compare_codex_skylos_quality.py scripts/compare_codex_skylos_agent_review.py scripts/analyzer_speed_check.py scripts/deep_audit_logic_benchmark.py scripts/compare_codex_skylos_demo_deadcode.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/scripts" rel="noopener noreferrer">scripts</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 21</span>
-          <span class="pill"><strong>symbols</strong> 137</span>
+          <span class="pill"><strong>symbols</strong> 140</span>
         </div>
       </div>
       <p>Repository maintenance, benchmark, parity, and regression scripts.</p>
@@ -624,8 +624,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/regression_delta.py" rel="noopener noreferrer">scripts/regression_delta.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_quality.py" rel="noopener noreferrer">scripts/compare_codex_skylos_quality.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_agent_review.py" rel="noopener noreferrer">scripts/compare_codex_skylos_agent_review.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/deep_audit_logic_benchmark.py" rel="noopener noreferrer">scripts/deep_audit_logic_benchmark.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">scripts/analyzer_speed_check.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/deep_audit_logic_benchmark.py" rel="noopener noreferrer">scripts/deep_audit_logic_benchmark.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/scripts/compare_codex_skylos_demo_deadcode.py" rel="noopener noreferrer">scripts/compare_codex_skylos_demo_deadcode.py</a></li></ul>
       </div>
       <div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 306</span>
+          <span class="pill"><strong>symbols</strong> 317</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -783,12 +783,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/analysis reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references. change this when multiple scanners need the same code-understanding primitive. skylos/analysis/module_reachability.py skylos/analysis/control_flow.py  skylos/analysis/penalties.py skylos/analysis/file_worker.py skylos/analysis/file_processing.py skylos/analysis/architecture.py skylos/analysis/circular_deps.py skylos/analysis/ast_mask.py skylos/analysis/control_flow.py skylos/analysis/architecture_findings.py">
+    <article class="folder-card searchable" data-search="skylos/analysis reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references. change this when multiple scanners need the same code-understanding primitive. skylos/analysis/module_reachability.py skylos/analysis/control_flow.py  skylos/analysis/penalties.py skylos/analysis/file_worker.py skylos/analysis/file_processing.py skylos/analysis/circular_deps.py skylos/analysis/architecture.py skylos/analysis/ast_cache.py skylos/analysis/ast_mask.py skylos/analysis/control_flow.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis" rel="noopener noreferrer">skylos/analysis</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 17</span>
-          <span class="pill"><strong>symbols</strong> 150</span>
+          <span class="pill"><strong>files</strong> 18</span>
+          <span class="pill"><strong>symbols</strong> 165</span>
         </div>
       </div>
       <p>Reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.</p>
@@ -805,11 +805,11 @@
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/penalties.py" rel="noopener noreferrer">skylos/analysis/penalties.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/file_worker.py" rel="noopener noreferrer">skylos/analysis/file_worker.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/file_processing.py" rel="noopener noreferrer">skylos/analysis/file_processing.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">skylos/analysis/architecture.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/circular_deps.py" rel="noopener noreferrer">skylos/analysis/circular_deps.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture.py" rel="noopener noreferrer">skylos/analysis/architecture.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">skylos/analysis/ast_cache.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">skylos/analysis/ast_mask.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">skylos/analysis/control_flow.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/architecture_findings.py" rel="noopener noreferrer">skylos/analysis/architecture_findings.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/control_flow.py" rel="noopener noreferrer">skylos/analysis/control_flow.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -833,7 +833,7 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/api public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata. keep compatibility in mind here; external users may import from skylos.api. skylos/api/__init__.py skylos/api/_findings.py skylos/api/_payloads.py test/test_api.py test/test_api_signature_hallucination.py test/test_api_symbol_truth.py test/test_go_api_hallucination.py test/test_java_api_hallucination.py test/test_js_api_hallucination.py skylos/api/__init__.py skylos/api/_artifacts.py skylos/api/_payloads.py skylos/api/_findings.py skylos/api/_urls.py skylos/api/_ai_detection.py skylos/api/_snippets.py">
+    <article class="folder-card searchable" data-search="skylos/api public api facade and private helpers for payloads, snippets, findings, urls, and ai-detection metadata. keep compatibility in mind here; external users may import from skylos.api. skylos/api/__init__.py skylos/api/_findings.py skylos/api/_payloads.py test/test_api.py test/test_api_signature_availability.py test/test_api_signature_hallucination.py test/test_api_signature_zero_arguments.py test/test_api_symbol_truth.py test/test_go_api_hallucination.py skylos/api/__init__.py skylos/api/_artifacts.py skylos/api/_payloads.py skylos/api/_findings.py skylos/api/_urls.py skylos/api/_ai_detection.py skylos/api/_snippets.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api" rel="noopener noreferrer">skylos/api</a></h3>
         <div class="stat-row">
@@ -848,7 +848,7 @@
         <div class="mini-label">Entrypoints</div>
         <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/__init__.py" rel="noopener noreferrer">skylos/api/__init__.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_findings.py" rel="noopener noreferrer">skylos/api/_findings.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/skylos/api/_payloads.py" rel="noopener noreferrer">skylos/api/_payloads.py</a></div>
         <div class="mini-label">Nearby tests</div>
-        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_api.py" rel="noopener noreferrer">test/test_api.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_api_signature_hallucination.py" rel="noopener noreferrer">test/test_api_signature_hallucination.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_api_symbol_truth.py" rel="noopener noreferrer">test/test_api_symbol_truth.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_go_api_hallucination.py" rel="noopener noreferrer">test/test_go_api_hallucination.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_api_hallucination.py" rel="noopener noreferrer">test/test_java_api_hallucination.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_js_api_hallucination.py" rel="noopener noreferrer">test/test_js_api_hallucination.py</a></div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_api.py" rel="noopener noreferrer">test/test_api.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_api_signature_availability.py" rel="noopener noreferrer">test/test_api_signature_availability.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_api_signature_hallucination.py" rel="noopener noreferrer">test/test_api_signature_hallucination.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_api_signature_zero_arguments.py" rel="noopener noreferrer">test/test_api_signature_zero_arguments.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_api_symbol_truth.py" rel="noopener noreferrer">test/test_api_symbol_truth.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_go_api_hallucination.py" rel="noopener noreferrer">test/test_go_api_hallucination.py</a></div>
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
@@ -1213,12 +1213,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.  test/test_underscore_discard_bindings.py skylos/core/grep_verify_common.py skylos/core/python_api_surface.py skylos/core/verify_change_schema.py skylos/core/gatekeeper.py skylos/core/js_api_surface_members.py skylos/core/evidence_contract.py skylos/core/go_api_surface.py skylos/core/grep_verify.py">
+    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.  test/test_underscore_discard_bindings.py skylos/core/grep_verify_common.py skylos/core/js_api_surface_members.py skylos/core/python_api_surface.py skylos/core/verify_change_schema.py skylos/core/gatekeeper.py skylos/core/evidence_contract.py skylos/core/go_api_surface.py skylos/core/grep_verify.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 35</span>
-          <span class="pill"><strong>symbols</strong> 627</span>
+          <span class="pill"><strong>files</strong> 36</span>
+          <span class="pill"><strong>symbols</strong> 639</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1233,10 +1233,10 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/js_api_surface_members.py" rel="noopener noreferrer">skylos/core/js_api_surface_members.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">skylos/core/python_api_surface.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/verify_change_schema.py" rel="noopener noreferrer">skylos/core/verify_change_schema.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">skylos/core/gatekeeper.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/js_api_surface_members.py" rel="noopener noreferrer">skylos/core/js_api_surface_members.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/evidence_contract.py" rel="noopener noreferrer">skylos/core/evidence_contract.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/go_api_surface.py" rel="noopener noreferrer">skylos/core/go_api_surface.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a></li></ul>
@@ -1248,27 +1248,27 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">source_globs_for_language</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">record_grep_requests</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">replay_grep_results</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/js_api_surface_members.py" rel="noopener noreferrer">_object_export_members</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/js_api_surface_members.py" rel="noopener noreferrer">_named_export_clause_pairs</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/js_api_surface_members.py" rel="noopener noreferrer">_namespace_export_name</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/js_api_surface_members.py" rel="noopener noreferrer">_exported_function_signature_names</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/js_api_surface_members.py" rel="noopener noreferrer">_exported_direct_member_pairs</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">PythonApiSurfaceCacheSession</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">load_python_api_surface_cache</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">save_python_api_surface_cache</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">cached_python_api_surface</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">cache_python_api_surface</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/verify_change_schema.py" rel="noopener noreferrer">parse_line_range</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/verify_change_schema.py" rel="noopener noreferrer">build_verify_change_response</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/verify_change_schema.py" rel="noopener noreferrer">_iter_ai_findings</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/verify_change_schema.py" rel="noopener noreferrer">_is_ai_finding</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">cached_python_api_surface</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/plugin_registry.py skylos/deadcode/browser_refs.py skylos/deadcode/java_fxml_refs.py skylos/deadcode/config_entrypoints.py skylos/deadcode/signature_contracts.py skylos/deadcode/finding_evidence.py">
+    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/browser_refs.py skylos/deadcode/plugin_registry.py skylos/deadcode/java_fxml_refs.py skylos/deadcode/config_entrypoints.py skylos/deadcode/signature_contracts.py skylos/deadcode/external_protocols.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 11</span>
-          <span class="pill"><strong>symbols</strong> 179</span>
+          <span class="pill"><strong>files</strong> 13</span>
+          <span class="pill"><strong>symbols</strong> 201</span>
         </div>
       </div>
       <p>Dead-code specific analysis, framework liveness, and evidence support.</p>
@@ -1284,12 +1284,12 @@
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/evidence.py" rel="noopener noreferrer">skylos/deadcode/evidence.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">skylos/deadcode/liveness.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">skylos/deadcode/plugin_registry.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/browser_refs.py" rel="noopener noreferrer">skylos/deadcode/browser_refs.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">skylos/deadcode/plugin_registry.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/java_fxml_refs.py" rel="noopener noreferrer">skylos/deadcode/java_fxml_refs.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/config_entrypoints.py" rel="noopener noreferrer">skylos/deadcode/config_entrypoints.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/signature_contracts.py" rel="noopener noreferrer">skylos/deadcode/signature_contracts.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/finding_evidence.py" rel="noopener noreferrer">skylos/deadcode/finding_evidence.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/external_protocols.py" rel="noopener noreferrer">skylos/deadcode/external_protocols.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1301,12 +1301,12 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">LivenessRescue</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">LivenessReport</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">apply_dead_code_liveness</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">apply_external_protocol_liveness</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">_AttrCall</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/liveness.py" rel="noopener noreferrer">_mark</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">find_literal_plugin_registry_targets</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">_ImportContext</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">_definitions_by_file_simple</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">_definitions_by_name</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/browser_refs.py" rel="noopener noreferrer">extract_browser_event_handler_names</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/browser_refs.py" rel="noopener noreferrer">extract_mdx_component_refs</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/browser_refs.py" rel="noopener noreferrer">collect_mdx_ts_imports</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/browser_refs.py" rel="noopener noreferrer">collect_browser_event_handler_refs</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -1761,12 +1761,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/rules rule catalog and concrete rule implementations for quality, security, ai-defect, config, edge, ci/cd, and sca findings. start here when adding rule ids, tuning scanner semantics, config posture checks, or changing rule docs parity. skylos/rules/catalog.py skylos/rules/ai_defect skylos/rules/danger skylos/rules/config skylos/rules/quality test/test_ai_pr_diff_rules.py test/test_community_rules.py test/test_good_practices_rules.py test/test_mcp_rules.py test/test_quality_new_rules.py test/test_quality_rules.py skylos/rules/secrets.py skylos/rules/ai_defect/manifest_dependency_hallucination.py skylos/rules/config/deployment/exposure.py skylos/rules/config/cicd/github_actions.py skylos/rules/config/gpu/compatibility.py skylos/rules/quality/logic_foundation.py skylos/rules/sca/vulnerability_scanner.py skylos/rules/ai_defect/assertion_weakening.py">
+    <article class="folder-card searchable" data-search="skylos/rules rule catalog and concrete rule implementations for quality, security, ai-defect, config, edge, ci/cd, and sca findings. start here when adding rule ids, tuning scanner semantics, config posture checks, or changing rule docs parity. skylos/rules/catalog.py skylos/rules/ai_defect skylos/rules/danger skylos/rules/config skylos/rules/quality test/test_ai_pr_diff_rules.py test/test_community_rules.py test/test_good_practices_rules.py test/test_mcp_rules.py test/test_quality_new_rules.py test/test_quality_rules.py skylos/rules/secrets.py skylos/rules/ai_defect/manifest_dependency_hallucination.py skylos/rules/config/deployment/exposure.py skylos/rules/config/cicd/github_actions.py skylos/rules/config/gpu/compatibility.py skylos/rules/quality/logic_foundation.py skylos/rules/ai_defect/phantom_refs.py skylos/rules/sca/vulnerability_scanner.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules" rel="noopener noreferrer">skylos/rules</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 107</span>
-          <span class="pill"><strong>symbols</strong> 1521</span>
+          <span class="pill"><strong>files</strong> 113</span>
+          <span class="pill"><strong>symbols</strong> 1603</span>
         </div>
       </div>
       <p>Rule catalog and concrete rule implementations for quality, security, AI-defect, config, edge, CI/CD, and SCA findings.</p>
@@ -1786,8 +1786,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/cicd/github_actions.py" rel="noopener noreferrer">skylos/rules/config/cicd/github_actions.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/config/gpu/compatibility.py" rel="noopener noreferrer">skylos/rules/config/gpu/compatibility.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/quality/logic_foundation.py" rel="noopener noreferrer">skylos/rules/quality/logic_foundation.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/sca/vulnerability_scanner.py" rel="noopener noreferrer">skylos/rules/sca/vulnerability_scanner.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/ai_defect/assertion_weakening.py" rel="noopener noreferrer">skylos/rules/ai_defect/assertion_weakening.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/ai_defect/phantom_refs.py" rel="noopener noreferrer">skylos/rules/ai_defect/phantom_refs.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/rules/sca/vulnerability_scanner.py" rel="noopener noreferrer">skylos/rules/sca/vulnerability_scanner.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1945,12 +1945,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/typescript/security_proofs.py skylos/visitors/languages/typescript/quality_signals.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/security_flow.py skylos/visitors/languages/typescript/type_safety.py skylos/visitors/languages/shell/danger.py">
+    <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/typescript/security_proofs.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/typescript/quality_signals.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/security_flow.py skylos/visitors/languages/typescript/type_safety.py skylos/visitors/languages/shell/danger.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 47</span>
-          <span class="pill"><strong>symbols</strong> 652</span>
+          <span class="pill"><strong>symbols</strong> 668</span>
         </div>
       </div>
       <p>AST/tree visitors that collect findings and semantic evidence.</p>
@@ -1965,8 +1965,8 @@
       <div>
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/security_proofs.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/security_proofs.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/quality_signals.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/danger.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/quality_signals.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/analysis.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/analysis.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/java/danger.py" rel="noopener noreferrer">skylos/visitors/languages/java/danger.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/security_flow.py" rel="noopener noreferrer">skylos/visitors/languages/typescript/security_flow.py</a></li>
@@ -1980,27 +1980,27 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/security_proofs.py" rel="noopener noreferrer">check_unverified_webhooks</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/security_proofs.py" rel="noopener noreferrer">_is_http_cookie_sink</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/security_proofs.py" rel="noopener noreferrer">_identifier_may_be_http_response</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">scan_quality_signals</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">_node_text</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">_is_async_candidate</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">_candidate_has_possible_async_callback</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">_index_async_binding_scopes</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">scan_danger</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_shannon_entropy</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_query</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_get_text</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/danger.py" rel="noopener noreferrer">_is_sensitive_name</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">scan_quality_signals</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">_node_text</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">_is_async_candidate</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors/languages/typescript/quality_signals.py" rel="noopener noreferrer">_candidate_has_possible_async_callback</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
     </article>
 
 
-    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_behavior_benchmark.py test/test_agent_behavior_cli.py test/test_agent_behavior_contract.py test/test_agent_behavior_evaluator.py test/test_typescript_security_proof.py test/test_secrets.py test/test_java_security.py test/test_deployment_exposure.py test/test_verify_orchestrator.py test/test_cli.py test/test_gpu_compatibility.py test/test_ts_danger_release_blockers.py">
+    <article class="folder-card searchable" data-search="test unit and regression tests covering cli, analyzer, rules, integrations, and benchmarks. add narrow tests here before trusting analyzer or policy changes. test/ test/__init__.py test/conftest.py test/test_agent_behavior_benchmark.py test/test_agent_behavior_cli.py test/test_agent_behavior_contract.py test/test_agent_behavior_evaluator.py test/test_typescript_security_proof.py test/test_secrets.py test/test_java_security.py test/test_deployment_exposure.py test/test_cli.py test/test_verify_orchestrator.py test/test_gpu_compatibility.py test/test_ts_danger_release_blockers.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 268</span>
-          <span class="pill"><strong>symbols</strong> 4602</span>
+          <span class="pill"><strong>files</strong> 297</span>
+          <span class="pill"><strong>symbols</strong> 5110</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2018,8 +2018,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_secrets.py" rel="noopener noreferrer">test/test_secrets.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_java_security.py" rel="noopener noreferrer">test/test_java_security.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_deployment_exposure.py" rel="noopener noreferrer">test/test_deployment_exposure.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_cli.py" rel="noopener noreferrer">test/test_cli.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_verify_orchestrator.py" rel="noopener noreferrer">test/test_verify_orchestrator.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_gpu_compatibility.py" rel="noopener noreferrer">test/test_gpu_compatibility.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/test/test_ts_danger_release_blockers.py" rel="noopener noreferrer">test/test_ts_danger_release_blockers.py</a></li></ul>
       </div>
@@ -2055,14 +2055,14 @@
         <tbody>
             <tr class="searchable" data-search="skylos/cli.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">skylos/cli.py</a></td>
-              <td>34 / 165</td>
+              <td>34 / 168</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3 / 54</td>
+              <td>3 / 61</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -2111,7 +2111,7 @@
 
             <tr class="searchable" data-search="skylos/core/grep_verify_common.py small shared core types and helpers used across scan paths.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify_common.py" rel="noopener noreferrer">skylos/core/grep_verify_common.py</a></td>
-              <td>13 / 106</td>
+              <td>13 / 109</td>
               <td><span class="warn">many symbols</span></td>
               <td>Small shared core types and helpers used across scan paths.</td>
             </tr>
@@ -5051,6 +5051,13 @@
               <td>scripts/analyzer_speed_check.py</td>
             </tr>
 
+            <tr class="searchable" data-search="run_scale_probe def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">run_scale_probe</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>scripts/analyzer_speed_check.py</td>
+            </tr>
+
             <tr class="searchable" data-search="run_speed_check def scripts/analyzer_speed_check.py repository maintenance, benchmark, parity, and regression scripts.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/scripts/analyzer_speed_check.py" rel="noopener noreferrer">run_speed_check</a></td>
               <td>def</td>
@@ -6458,6 +6465,55 @@
               <td>skylos/analysis/architecture_support.py</td>
             </tr>
 
+            <tr class="searchable" data-search="mode_max_bytes def skylos/analysis/ast_cache.py run-scoped cache of parsed python module asts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">mode_max_bytes</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/analysis/ast_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="load_python_source def skylos/analysis/ast_cache.py run-scoped cache of parsed python module asts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">load_python_source</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/analysis/ast_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="load_python_module def skylos/analysis/ast_cache.py run-scoped cache of parsed python module asts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">load_python_module</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/analysis/ast_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="register_dependent_clear def skylos/analysis/ast_cache.py run-scoped cache of parsed python module asts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">register_dependent_clear</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/analysis/ast_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="python_ast_cache_session def skylos/analysis/ast_cache.py run-scoped cache of parsed python module asts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">python_ast_cache_session</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/analysis/ast_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="releases_python_ast_cache def skylos/analysis/ast_cache.py run-scoped cache of parsed python module asts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">releases_python_ast_cache</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/analysis/ast_cache.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="clear_python_ast_cache def skylos/analysis/ast_cache.py run-scoped cache of parsed python module asts.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_cache.py" rel="noopener noreferrer">clear_python_ast_cache</a></td>
+              <td>def</td>
+              <td><span class="ok">public</span></td>
+              <td>skylos/analysis/ast_cache.py</td>
+            </tr>
+
             <tr class="searchable" data-search="maskspec class skylos/analysis/ast_mask.py reusable static-analysis primitives: architecture, reachability, control-flow, penalties, and implicit references.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analysis/ast_mask.py" rel="noopener noreferrer">MaskSpec</a></td>
               <td>class</td>
@@ -6724,6 +6780,13 @@
               <td>skylos/analyzer.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_scoped_changed_paths def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_scoped_changed_paths</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_diff_result_has_text def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_diff_result_has_text</a></td>
               <td>def</td>
@@ -6740,6 +6803,13 @@
 
             <tr class="searchable" data-search="_scan_ai_defect_diff_signals def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_scan_ai_defect_diff_signals</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_dependency_bump_findings def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_dependency_bump_findings</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -6962,6 +7032,20 @@
               <td>skylos/analyzer.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_suppress_django_admin_stubs def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_suppress_django_admin_stubs</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_scan_has_top_level_python_module def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_scan_has_top_level_python_module</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_collect_grep_verify_candidates def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_collect_grep_verify_candidates</a></td>
               <td>def</td>
@@ -6997,6 +7081,20 @@
               <td>skylos/analyzer.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_source_file_key def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_source_file_key</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_definition_binding_name def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_definition_binding_name</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_has_evidence_marker def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_has_evidence_marker</a></td>
               <td>def</td>
@@ -7006,6 +7104,13 @@
 
             <tr class="searchable" data-search="_annotate_dead_code_evidence_sources def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_annotate_dead_code_evidence_sources</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
+            <tr class="searchable" data-search="_qualified_candidates def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_qualified_candidates</a></td>
               <td>def</td>
               <td><span class="muted">private</span></td>
               <td>skylos/analyzer.py</td>
@@ -8353,111 +8458,6 @@
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/risk_passport.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="format_risk_passport_markdown def skylos/cicd/risk_passport.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">format_risk_passport_markdown</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cicd/risk_passport.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="generate_workflow def skylos/cicd/workflow.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">generate_workflow</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cicd/workflow.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="write_workflow def skylos/cicd/workflow.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/workflow.py" rel="noopener noreferrer">write_workflow</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cicd/workflow.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_lazyinquirer class skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_LazyInquirer</a></td>
-              <td>class</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_inquirer_available def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_inquirer_available</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_get_inquirer def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_get_inquirer</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="_codemods_module def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">_codemods_module</a></td>
-              <td>def</td>
-              <td><span class="muted">private</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="remove_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_import_cst</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="remove_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">remove_unused_function_cst</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="comment_out_unused_import_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_import_cst</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="comment_out_unused_function_cst def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">comment_out_unused_function_cst</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="run_analyze def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_analyze</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="resolve_llm_runtime def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">resolve_llm_runtime</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="run_gate_interaction def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">run_gate_interaction</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="upload_report def skylos/cli.py root entrypoints and shared scan orchestration.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cli.py" rel="noopener noreferrer">upload_report</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cli.py</td>
             </tr></tbody>
       </table>
     </section>

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1073</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12218</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>1079</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12298</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1945,12 +1945,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/behavior.py skylos/verification/explanations.py skylos/verification/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/comparison.py skylos/verification/behavior.py skylos/verification/explanations.py skylos/verification/refactor.py skylos/verification/changes.py skylos/verification/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification" rel="noopener noreferrer">skylos/verification</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 3</span>
-          <span class="pill"><strong>symbols</strong> 19</span>
+          <span class="pill"><strong>files</strong> 6</span>
+          <span class="pill"><strong>symbols</strong> 41</span>
         </div>
       </div>
       <p>Generated facts are available; this folder still needs a curated summary.</p>
@@ -1964,13 +1964,21 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">skylos/verification/behavior.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">skylos/verification/comparison.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">skylos/verification/behavior.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">skylos/verification/explanations.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">skylos/verification/refactor.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/changes.py" rel="noopener noreferrer">skylos/verification/changes.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/__init__.py" rel="noopener noreferrer">skylos/verification/__init__.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">compare_python_behavior</a> <span>def</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">SourceSnapshot</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">ComparisonScope</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">is_environment_file</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">compare_source_changes</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">_new_result</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">compare_python_behavior</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Unknown</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Module</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Frame</a> <span>class</span></li>
@@ -1978,8 +1986,7 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">explain_difference</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_same</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_kind</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_short</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_value</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_short</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -2040,8 +2047,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 300</span>
-          <span class="pill"><strong>symbols</strong> 5156</span>
+          <span class="pill"><strong>files</strong> 303</span>
+          <span class="pill"><strong>symbols</strong> 5214</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -39,7 +39,7 @@
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
         <div class="metric"><strong>1081</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12327</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>12341</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1945,12 +1945,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/comparison.py skylos/verification/behavior.py skylos/verification/explanations.py skylos/verification/refactor.py skylos/verification/render.py skylos/verification/changes.py skylos/verification/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/comparison.py skylos/verification/behavior.py skylos/verification/refactor.py skylos/verification/explanations.py skylos/verification/render.py skylos/verification/changes.py skylos/verification/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification" rel="noopener noreferrer">skylos/verification</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 49</span>
+          <span class="pill"><strong>symbols</strong> 51</span>
         </div>
       </div>
       <p>Generated facts are available; this folder still needs a curated summary.</p>
@@ -1966,8 +1966,8 @@
         <div class="mini-label">Important files</div>
         <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">skylos/verification/comparison.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">skylos/verification/behavior.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">skylos/verification/explanations.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">skylos/verification/refactor.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">skylos/verification/explanations.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/render.py" rel="noopener noreferrer">skylos/verification/render.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/changes.py" rel="noopener noreferrer">skylos/verification/changes.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/__init__.py" rel="noopener noreferrer">skylos/verification/__init__.py</a></li></ul>
@@ -1984,10 +1984,10 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Module</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Frame</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_State</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">explain_difference</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_same</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_kind</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_short</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">verify_refactor</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">_snapshot_input</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">_git</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">_safe_relative</a> <span>def</span></li></ul>
       </div>
     </div>
       </details>
@@ -2049,7 +2049,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 304</span>
-          <span class="pill"><strong>symbols</strong> 5235</span>
+          <span class="pill"><strong>symbols</strong> 5247</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,9 +38,9 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1067</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12153</strong><span>top-level classes/functions</span></div>
-        <div class="metric"><strong>32</strong><span>ownership areas</span></div>
+        <div class="metric"><strong>1073</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12218</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
       <div class="note">Comprehension debt grows when the codebase changes faster than the team can maintain a shared mental model. This page keeps the first question simple: where should I start? Source framing: <a href="https://dev.to/javz/your-codebase-has-technical-debt-but-does-your-team-have-comprehension-debt-385f">DEV Community article</a>.</div>
@@ -1945,6 +1945,47 @@
     </article>
 
 
+    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/behavior.py skylos/verification/explanations.py skylos/verification/__init__.py">
+      <div class="card-head">
+        <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification" rel="noopener noreferrer">skylos/verification</a></h3>
+        <div class="stat-row">
+          <span class="pill"><strong>files</strong> 3</span>
+          <span class="pill"><strong>symbols</strong> 19</span>
+        </div>
+      </div>
+      <p>Generated facts are available; this folder still needs a curated summary.</p>
+      <p class="touch"><strong>Touch when:</strong> Use the module list and tests to decide whether this is the right ownership area.</p>
+      <details>
+        <summary>Entrypoints, tests, and key symbols</summary>
+        <div class="mini-label">Entrypoints</div>
+        <div class="link-row"><span class="muted">Generated only</span></div>
+        <div class="mini-label">Nearby tests</div>
+        <div class="link-row"><a href="https://github.com/duriantaco/skylos/blob/main/test/test_language_verification_integration.py" rel="noopener noreferrer">test/test_language_verification_integration.py</a> <a href="https://github.com/duriantaco/skylos/blob/main/test/test_verification_coverage.py" rel="noopener noreferrer">test/test_verification_coverage.py</a></div>
+        <div class="split-list">
+      <div>
+        <div class="mini-label">Important files</div>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">skylos/verification/behavior.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">skylos/verification/explanations.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/__init__.py" rel="noopener noreferrer">skylos/verification/__init__.py</a></li></ul>
+      </div>
+      <div>
+        <div class="mini-label">Key symbols</div>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">compare_python_behavior</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Unknown</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Module</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Frame</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_State</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">explain_difference</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_same</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_kind</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_short</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">_value</a> <span>def</span></li></ul>
+      </div>
+    </div>
+      </details>
+    </article>
+
+
     <article class="folder-card searchable" data-search="skylos/visitors ast/tree visitors that collect findings and semantic evidence. use this when a language-specific scan is missing or over-reporting code patterns. skylos/visitors/  skylos/visitors/languages/typescript/security_proofs.py skylos/visitors/languages/typescript/danger.py skylos/visitors/languages/typescript/quality_signals.py skylos/visitors/languages/typescript/analysis.py skylos/visitors/languages/java/danger.py skylos/visitors/languages/typescript/security_flow.py skylos/visitors/languages/typescript/type_safety.py skylos/visitors/languages/shell/danger.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/visitors" rel="noopener noreferrer">skylos/visitors</a></h3>
@@ -1999,8 +2040,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 297</span>
-          <span class="pill"><strong>symbols</strong> 5110</span>
+          <span class="pill"><strong>files</strong> 300</span>
+          <span class="pill"><strong>symbols</strong> 5156</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/commands/verify_cmd.py
+++ b/skylos/commands/verify_cmd.py
@@ -32,14 +32,14 @@ def run_verify_command(
     except ValueError as exc:
         parser.error(str(exc))
 
-    _write_payload(payload, args.output)
+    _write_payload(payload, args.output, machine_output=args.stdin)
     return _exit_code(payload, no_fail=args.no_fail)
 
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="skylos verify",
-        description="Verify changed code for AI-code defects.",
+        description="Verify code for AI-code defects and compare Python working changes with Git HEAD.",
     )
     _add_target_args(parser)
     _add_scope_args(parser)
@@ -66,7 +66,7 @@ def _add_scope_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--stdin",
         action="store_true",
-        help="Read a JSON manifest from stdin: {\"file\", \"code\", \"range\"?}.",
+        help='Read a JSON manifest from stdin: {"file", "code", "range"?}.',
     )
     parser.add_argument(
         "--range",
@@ -132,7 +132,7 @@ def _add_output_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--no-fail",
         action="store_true",
-        help="Exit 0 even when AI-code findings are returned.",
+        help="Exit 0 even when verification fails or is incomplete; preserve the JSON status.",
     )
     parser.add_argument(
         "--output",
@@ -216,15 +216,24 @@ def _exclude_folders(args: argparse.Namespace, parse_exclude_folders_func) -> li
     return exclude_folders
 
 
-def _write_payload(payload: dict[str, Any], output_path: str | None) -> None:
+def _write_payload(
+    payload: dict[str, Any], output_path: str | None, *, machine_output: bool = False
+) -> None:
     output = json.dumps(payload, indent=2)
     if output_path:
-        Path(output_path).write_text(  # skylos: ignore[SKY-D215] user-selected CLI output path
+        Path(
+            output_path
+        ).write_text(  # skylos: ignore[SKY-D215] user-selected CLI output path
             output + "\n",
             encoding="utf-8",
         )
         return
 
+    if not machine_output and sys.stdout.isatty():
+        from skylos.verification.render import render_verify_report
+
+        print(render_verify_report(payload))
+        return
     print(output)
 
 

--- a/skylos/commands/verify_cmd.py
+++ b/skylos/commands/verify_cmd.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from pathlib import Path
 from typing import Any, Sequence
 
 from skylos.constants import parse_exclude_folders
+from skylos.core.safe_cache_io import write_text_no_symlink
 from skylos.verify_change import verify_change_path, verify_change_stdin_payload
 
 
@@ -29,10 +29,10 @@ def run_verify_command(
             verify_change_path_func,
             verify_change_stdin_payload_func,
         )
+        _write_payload(payload, args.output, machine_output=args.stdin)
     except ValueError as exc:
         parser.error(str(exc))
 
-    _write_payload(payload, args.output, machine_output=args.stdin)
     return _exit_code(payload, no_fail=args.no_fail)
 
 
@@ -221,12 +221,12 @@ def _write_payload(
 ) -> None:
     output = json.dumps(payload, indent=2)
     if output_path:
-        Path(
-            output_path
-        ).write_text(  # skylos: ignore[SKY-D215] user-selected CLI output path
-            output + "\n",
-            encoding="utf-8",
-        )
+        if not write_text_no_symlink(output_path, output + "\n", encoding="utf-8"):
+            raise ValueError(
+                f"Cannot safely write output to {output_path!r}: "
+                "use a writable regular file with no symlinks or hard links "
+                "and an existing parent directory."
+            )
         return
 
     if not machine_output and sys.stdout.isatty():

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -24,7 +24,11 @@ COMMANDS = [
     },
     {
         "name": "skylos verify <path>",
-        "desc": "Verify changed code for AI-code defects",
+        "desc": "Verify AI-code defects and Python working changes",
+        "details": [
+            "Automatically compares affected Python functions with Git HEAD",
+            "Explains changes and their impact in the terminal; pipes and saved output use JSON",
+        ],
         "group": "AI Agent",
     },
     {

--- a/skylos/verification/__init__.py
+++ b/skylos/verification/__init__.py
@@ -1,0 +1,1 @@
+"""Shared source comparison and bounded static verification."""

--- a/skylos/verification/behavior.py
+++ b/skylos/verification/behavior.py
@@ -1,0 +1,786 @@
+"""Bounded, source-only comparison of a small Python effect language.
+
+This is deliberately not a Python equivalence prover.  Supported functions are
+interpreted over symbolic arguments, and local helpers are inlined.  Every
+opaque call is allowed an arbitrary return value or BaseException.  The result
+compares those model traces, including call outcomes and exception propagation.
+Unsupported syntax is an incomplete result even when the source is identical.
+"""
+
+from __future__ import annotations
+
+import ast
+import warnings
+from dataclasses import dataclass, field, replace
+from pathlib import PurePosixPath
+from typing import Mapping
+
+from skylos.verification.explanations import explain_difference
+
+
+_ASSUMPTIONS = [
+    "Comparison concerns the selected synchronous function after module initialization; module import and initialization effects are excluded.",
+    "Names resolve to their declared source/import bindings after successful module initialization and remain stable during invocation; import hooks, initialization-time rebinding, monkey-patching, and namespace mutation are excluded.",
+    "Opaque calls are modeled as arbitrary stateful operations that may return any value or raise any BaseException; modeled differences may be infeasible for a fixed external API.",
+    "The selected function's declared parameter names and parameter kinds are a preservation obligation, including positional-only names.",
+    "Observable behavior is ordered opaque calls (including argument and keyword order and active exception context), returned symbolic values, and propagated exceptions.",
+    "Stack frames, tracebacks, function identity, tracing/profiling, timing, memory use, reference counts, finalizers, and interpreter resource failures are outside the model.",
+]
+
+
+class _Unknown(Exception):
+    pass
+
+
+@dataclass
+class _Module:
+    path: str
+    name: str
+    tree: ast.Module
+    bindings: dict[str, list[tuple]] = field(default_factory=dict)
+
+
+@dataclass
+class _Frame:
+    module: _Module
+    function: ast.FunctionDef
+    local_names: set[str]
+    stack: tuple[tuple[str, str], ...]
+
+
+@dataclass
+class _State:
+    env: dict[str, tuple]
+    events: tuple = ()
+    control: str = "running"
+    value: tuple | None = None
+    active_exception: tuple | None = None
+
+
+def _constant(value):
+    if type(value) not in (type(None), bool, int, float, complex, str, bytes):
+        raise _Unknown("Unsupported literal value")
+    return ("constant", type(value).__name__, repr(value))
+
+
+_NONE = _constant(None)
+
+
+def _module_name(path):
+    parts = list(PurePosixPath(path).with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _range(node):
+    if node is None:
+        return None
+    return {"start_line": node.lineno, "end_line": node.end_lineno}
+
+
+class _Program:
+    def __init__(self, sources, known_modules, max_paths, max_depth):
+        self.sources = sources
+        self.known_modules = known_modules
+        self.max_paths = max_paths
+        self.max_depth = max_depth
+        self.modules = {}
+        self.by_name = {}
+        self.steps = 0
+        self.max_steps = max_paths * max_depth * 512
+        for path in sources:
+            self.by_name.setdefault(_module_name(path), []).append(path)
+
+    def _tick(self):
+        self.steps += 1
+        if self.steps > self.max_steps:
+            raise _Unknown("Symbolic evaluation work budget exhausted")
+
+    def _bounded(self, states):
+        if len(states) > self.max_paths:
+            raise _Unknown(
+                f"Symbolic path budget exhausted (max_paths={self.max_paths})"
+            )
+        return states
+
+    def module(self, path):
+        if path in self.modules:
+            return self.modules[path]
+        if path not in self.sources:
+            raise _Unknown(f"Source unavailable for repository module {path}")
+        try:
+            tree = ast.parse(self.sources[path], filename=path)
+            # Compilation performs syntax/scope validation only. Never execute
+            # or import this code object (e.g. duplicate arguments evade parse).
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", SyntaxWarning)
+                compile(tree, path, "exec", dont_inherit=True)
+        except (SyntaxError, ValueError, TypeError, RecursionError) as exc:
+            raise _Unknown(
+                f"Invalid Python source in {path}: {type(exc).__name__}"
+            ) from exc
+        module = _Module(path, _module_name(path), tree)
+        self.modules[path] = module
+
+        def bind(name, value):
+            module.bindings.setdefault(name, []).append(value)
+
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._validate_header(node)
+                bind(node.name, ("function", path, node.name))
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    bind(
+                        alias.asname or alias.name.split(".")[0],
+                        (
+                            "module",
+                            alias.name if alias.asname else alias.name.split(".")[0],
+                        ),
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                if any(alias.name == "*" for alias in node.names):
+                    raise _Unknown(
+                        f"Wildcard import makes bindings ambiguous in {path}"
+                    )
+                imported = self._import_module(module, node)
+                for alias in node.names:
+                    bind(alias.asname or alias.name, ("import", imported, alias.name))
+            elif (
+                isinstance(node, ast.Expr)
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+            ):
+                continue
+            elif isinstance(node, ast.Pass):
+                continue
+            else:
+                raise _Unknown(
+                    f"Unsupported module-level {type(node).__name__} in {path}; stable bindings cannot be established"
+                )
+        return module
+
+    def _import_module(self, module, node):
+        if not node.level:
+            return node.module or ""
+        if not module.name:
+            raise _Unknown(
+                f"Relative import has no established package identity in {module.path}"
+            )
+        package = module.name.split(".")
+        if PurePosixPath(module.path).name != "__init__.py":
+            package = package[:-1]
+        if node.level > len(package):
+            raise _Unknown(f"Unresolved relative import in {module.path}")
+        package = package[: len(package) - node.level + 1]
+        if node.module:
+            package.extend(node.module.split("."))
+        return ".".join(package)
+
+    def _module_path(self, name):
+        if not name or name.startswith("."):
+            raise _Unknown(
+                f"Import has no established absolute module identity: {name!r}"
+            )
+        for known in self.known_modules:
+            pieces = known.split(".")
+            if any(
+                ".".join(pieces[index:]).casefold() == name.casefold()
+                or ".".join(pieces[index:]).casefold().startswith(name.casefold() + ".")
+                for index in range(1, len(pieces))
+            ):
+                raise _Unknown(
+                    f"Repository import {name} may use an undeclared source root"
+                )
+        paths = self.by_name.get(name, [])
+        if len(paths) > 1:
+            raise _Unknown(f"Ambiguous repository module {name}")
+        if paths:
+            return paths[0]
+        if name in self.known_modules:
+            raise _Unknown(f"Repository module {name} is unavailable in this revision")
+        if any(known.casefold() == name.casefold() for known in self.known_modules):
+            raise _Unknown(f"Case-ambiguous repository import {name}")
+        return None
+
+    def _binding(self, module, name, seen=()):
+        key = (module.path, name)
+        if key in seen:
+            raise _Unknown(f"Cyclic import binding for {name} in {module.path}")
+        values = module.bindings.get(name, [])
+        if len(values) != 1:
+            raise _Unknown(f"Unresolved or ambiguous global {name} in {module.path}")
+        value = values[0]
+        if value[0] == "import":
+            return self._imported(value[1], value[2], seen + (key,))
+        return value
+
+    def _imported(self, name, member, seen=()):
+        pieces = name.split(".")
+        for index in range(1, len(pieces)):
+            parent = self._module_path(".".join(pieces[:index]))
+            if parent:
+                self.module(parent)
+        path = self._module_path(name)
+        if path:
+            module = self.module(path)
+            submodule = f"{name}.{member}"
+            if member in module.bindings:
+                if self._module_path(submodule):
+                    raise _Unknown(
+                        f"Package binding conflicts with a source child module: {submodule}"
+                    )
+                return self._binding(module, member, seen)
+            if self._module_path(submodule):
+                return ("module", submodule)
+            raise _Unknown(f"Unresolved repository import {name}.{member}")
+        # A namespace package can have source children without an __init__.py.
+        submodule = f"{name}.{member}"
+        if self._module_path(submodule):
+            return ("module", submodule)
+        if any(known.startswith(name + ".") for known in self.known_modules):
+            raise _Unknown(f"Unresolved member of repository namespace {name}.{member}")
+        return ("external", f"{name}.{member}")
+
+    @staticmethod
+    def _validate_header(node):
+        name = node.name
+        if node.decorator_list or node.returns or getattr(node, "type_params", []):
+            raise _Unknown(
+                f"Decorators, annotations, and type parameters are unsupported: {name}"
+            )
+        args = node.args
+        if (
+            args.defaults
+            or any(value is not None for value in args.kw_defaults)
+            or args.vararg
+            or args.kwarg
+        ):
+            raise _Unknown(
+                f"Default, variadic, and keyword-variadic parameters are unsupported: {name}"
+            )
+        if any(
+            arg.annotation for arg in args.posonlyargs + args.args + args.kwonlyargs
+        ):
+            raise _Unknown(f"Parameter annotations are unsupported: {name}")
+
+    def function(self, path, name):
+        module = self.module(path)
+        binding = self._binding(module, name)
+        if binding != ("function", path, name):
+            raise _Unknown(
+                f"Selected symbol {name} is not a local module-level function"
+            )
+        nodes = [
+            node
+            for node in module.tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ]
+        if len(nodes) != 1 or not isinstance(nodes[0], ast.FunctionDef):
+            raise _Unknown(
+                f"Only synchronous module-level functions are supported: {name}"
+            )
+        node = nodes[0]
+        allowed_statements = (
+            ast.Return,
+            ast.Assign,
+            ast.Expr,
+            ast.Pass,
+            ast.Try,
+            ast.Raise,
+        )
+        allowed_expressions = (ast.Name, ast.Constant, ast.Call, ast.Attribute)
+        for statement in node.body:
+            for child in ast.walk(statement):
+                if isinstance(child, ast.stmt) and not isinstance(
+                    child, allowed_statements
+                ):
+                    raise _Unknown(
+                        f"Unsupported {type(child).__name__} in {path}:{child.lineno}"
+                    )
+                if isinstance(child, ast.expr) and not isinstance(
+                    child, allowed_expressions
+                ):
+                    raise _Unknown(
+                        f"Unsupported {type(child).__name__} in {path}:{child.lineno}"
+                    )
+                if isinstance(child, ast.Assign) and (
+                    len(child.targets) != 1
+                    or not isinstance(child.targets[0], ast.Name)
+                ):
+                    raise _Unknown(
+                        f"Only single local-name assignment is supported in {name}"
+                    )
+                if isinstance(child, ast.Call) and any(
+                    keyword.arg is None for keyword in child.keywords
+                ):
+                    raise _Unknown(
+                        f"Expanded keyword arguments are unsupported in {name}"
+                    )
+                if isinstance(child, ast.Raise) and child.cause is not None:
+                    raise _Unknown(
+                        f"Explicit exception causes are unsupported in {name}"
+                    )
+        return module, node
+
+    @staticmethod
+    def signature(node):
+        return tuple(
+            (kind, arg.arg)
+            for kind, args in (
+                ("positional_only", node.args.posonlyargs),
+                ("positional_or_keyword", node.args.args),
+                ("keyword_only", node.args.kwonlyargs),
+            )
+            for arg in args
+        )
+
+    def _frame(self, module, function, stack):
+        key = (module.path, function.name)
+        if key in stack:
+            raise _Unknown(f"Recursive helper call: {module.path}:{function.name}")
+        if len(stack) >= self.max_depth:
+            raise _Unknown(
+                f"Helper depth budget exhausted (max_depth={self.max_depth})"
+            )
+        local = {name for _, name in self.signature(function)}
+        for statement in function.body:
+            for node in ast.walk(statement):
+                if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                    local.add(node.id)
+                elif isinstance(node, ast.ExceptHandler) and node.name:
+                    local.add(node.name)
+        return _Frame(module, function, local, stack + (key,))
+
+    def analyze(self, path, name):
+        module, function = self.function(path, name)
+        frame = self._frame(module, function, ())
+        env = {name: ("parameter", name) for _, name in self.signature(function)}
+        states = self._block(function.body, [_State(env)], frame)
+        traces = set()
+        for state in states:
+            value = _NONE if state.control == "running" else state.value
+            if value and value[0] in ("function", "module", "external"):
+                raise _Unknown(
+                    "A local or imported callable/module escapes as the selected function's return value"
+                )
+            traces.add(
+                (state.events, "raise" if state.control == "raise" else "return", value)
+            )
+        return traces
+
+    def _name(self, name, state, frame):
+        if name in state.env:
+            return state.env[name]
+        if name in frame.local_names:
+            raise _Unknown(
+                f"Local {name} may be read before assignment in {frame.function.name}"
+            )
+        return self._binding(frame.module, name)
+
+    def _eval(self, node, state, frame):
+        self._tick()
+        if state.control != "running":
+            return [(state, None)]
+        if isinstance(node, ast.Constant):
+            return [(state, _constant(node.value))]
+        if isinstance(node, ast.Name):
+            return [(state, self._name(node.id, state, frame))]
+        if isinstance(node, ast.Attribute):
+            results = []
+            for branch, owner in self._eval(node.value, state, frame):
+                if branch.control != "running":
+                    results.append((branch, None))
+                elif owner[0] != "module":
+                    raise _Unknown(
+                        f"Dynamic attribute access is unsupported at {frame.module.path}:{node.lineno}"
+                    )
+                else:
+                    results.append((branch, self._imported(owner[1], node.attr)))
+            return results
+        if isinstance(node, ast.Call):
+            outcomes = []
+            for initial, target in self._eval(node.func, state, frame):
+                branches = [(initial, (), ())]
+                for argument in node.args:
+                    expanded = []
+                    for branch, args, keywords in branches:
+                        for evaluated, value in self._eval(argument, branch, frame):
+                            expanded.append((evaluated, args + (value,), keywords))
+                    branches = self._bounded(expanded)
+                for keyword in node.keywords:
+                    expanded = []
+                    for branch, args, keywords in branches:
+                        for evaluated, value in self._eval(
+                            keyword.value, branch, frame
+                        ):
+                            expanded.append(
+                                (evaluated, args, keywords + ((keyword.arg, value),))
+                            )
+                    branches = self._bounded(expanded)
+                for branch, args, keywords in branches:
+                    if branch.control != "running":
+                        outcomes.append((branch, None))
+                    elif target[0] == "function":
+                        outcomes.extend(
+                            self._invoke(target, args, keywords, branch, frame)
+                        )
+                    elif target[0] in ("parameter", "external", "result"):
+                        if any(
+                            value[0] in ("function", "module", "external")
+                            for value in args + tuple(value for _, value in keywords)
+                        ):
+                            raise _Unknown(
+                                "A source-defined or imported callable/module escapes into an opaque call"
+                            )
+                        index = len(branch.events)
+                        event = ("call", target, args, keywords)
+                        outcomes.append(
+                            (
+                                replace(
+                                    branch,
+                                    events=branch.events
+                                    + (event + ("return", branch.active_exception),),
+                                ),
+                                ("result", index),
+                            )
+                        )
+                        outcomes.append(
+                            (
+                                replace(
+                                    branch,
+                                    events=branch.events
+                                    + (event + ("raise", branch.active_exception),),
+                                    control="raise",
+                                    value=("exception", index, branch.active_exception),
+                                ),
+                                None,
+                            )
+                        )
+                    else:
+                        raise _Unknown(
+                            f"Unsupported call target at {frame.module.path}:{node.lineno}"
+                        )
+                self._bounded(outcomes)
+            return outcomes
+        raise _Unknown(f"Unsupported expression {type(node).__name__}")
+
+    def _invoke(self, target, args, keywords, state, caller):
+        module, function = self.function(target[1], target[2])
+        frame = self._frame(module, function, caller.stack)
+        positional = function.args.posonlyargs + function.args.args
+        if len(args) > len(positional):
+            raise _Unknown(f"Invalid argument binding for helper {function.name}")
+        env = {argument.arg: value for argument, value in zip(positional, args)}
+        keyword_names = {
+            argument.arg for argument in function.args.args + function.args.kwonlyargs
+        }
+        for name, value in keywords:
+            if name not in keyword_names or name in env:
+                raise _Unknown(f"Invalid keyword binding for helper {function.name}")
+            env[name] = value
+        if set(env) != {name for _, name in self.signature(function)}:
+            raise _Unknown(f"Missing argument for helper {function.name}")
+        entered = replace(state, env=env)
+        outcomes = []
+        for result in self._block(function.body, [entered], frame):
+            if result.control == "raise":
+                outcomes.append(
+                    (
+                        replace(
+                            result,
+                            env=state.env,
+                            active_exception=state.active_exception,
+                        ),
+                        None,
+                    )
+                )
+            else:
+                value = result.value if result.control == "return" else _NONE
+                outcomes.append(
+                    (
+                        replace(
+                            result,
+                            env=state.env,
+                            control="running",
+                            value=None,
+                            active_exception=state.active_exception,
+                        ),
+                        value,
+                    )
+                )
+        return self._bounded(outcomes)
+
+    def _block(self, statements, states, frame):
+        for node in statements:
+            following = []
+            for state in states:
+                self._tick()
+                if state.control != "running":
+                    following.append(state)
+                else:
+                    following.extend(self._statement(node, state, frame))
+                self._bounded(following)
+            states = following
+        return states
+
+    def _statement(self, node, state, frame):
+        if isinstance(node, ast.Pass):
+            return [state]
+        if isinstance(node, ast.Expr):
+            return [branch for branch, _ in self._eval(node.value, state, frame)]
+        if isinstance(node, ast.Assign):
+            results = []
+            for branch, value in self._eval(node.value, state, frame):
+                if branch.control == "running":
+                    branch = replace(
+                        branch, env={**branch.env, node.targets[0].id: value}
+                    )
+                results.append(branch)
+            return results
+        if isinstance(node, ast.Return):
+            if node.value is None:
+                return [replace(state, control="return", value=_NONE)]
+            return [
+                replace(branch, control="return", value=value)
+                if branch.control == "running"
+                else branch
+                for branch, value in self._eval(node.value, state, frame)
+            ]
+        if isinstance(node, ast.Raise):
+            if node.exc is None:
+                if state.active_exception is None:
+                    raise _Unknown("Bare raise without a modeled active exception")
+                return [replace(state, control="raise", value=state.active_exception)]
+            results = []
+            for branch, value in self._eval(node.exc, state, frame):
+                if branch.control != "running":
+                    results.append(branch)
+                elif value[0] == "exception" and value == branch.active_exception:
+                    results.append(replace(branch, control="raise", value=value))
+                else:
+                    raise _Unknown(
+                        "Only re-raising the current modeled exception is supported"
+                    )
+            return results
+        if isinstance(node, ast.Try):
+            return self._try(node, state, frame)
+        raise _Unknown(f"Unsupported statement {type(node).__name__}")
+
+    def _try(self, node, state, frame):
+        if len(node.handlers) > 1:
+            raise _Unknown("Multiple or typed exception handlers are unsupported")
+        handler = node.handlers[0] if node.handlers else None
+        if handler is not None and handler.type is not None:
+            if (
+                not isinstance(handler.type, ast.Name)
+                or handler.type.id != "BaseException"
+            ):
+                raise _Unknown(
+                    "Typed exception matching is unsupported; only bare except or unshadowed BaseException is modeled"
+                )
+            if (
+                "BaseException" in frame.local_names
+                or "BaseException" in frame.module.bindings
+            ):
+                raise _Unknown(
+                    "BaseException is shadowed; catch-all behavior cannot be established"
+                )
+        outcomes = []
+        for body in self._block(node.body, [state], frame):
+            if body.control == "raise" and handler is not None:
+                env = dict(body.env)
+                if handler.name:
+                    env[handler.name] = body.value
+                entered = replace(
+                    body,
+                    env=env,
+                    control="running",
+                    active_exception=body.value,
+                    value=None,
+                )
+                handled = self._block(handler.body, [entered], frame)
+                for result in handled:
+                    env = dict(result.env)
+                    if handler.name:
+                        env.pop(handler.name, None)
+                    outcomes.append(
+                        replace(
+                            result, env=env, active_exception=state.active_exception
+                        )
+                    )
+            elif body.control == "running":
+                outcomes.extend(self._block(node.orelse, [body], frame))
+            else:
+                outcomes.append(body)
+            self._bounded(outcomes)
+        if not node.finalbody:
+            return outcomes
+        finalized = []
+        for pending in outcomes:
+            entered = replace(
+                pending,
+                control="running",
+                value=None,
+                active_exception=pending.value
+                if pending.control == "raise"
+                else pending.active_exception,
+            )
+            for result in self._block(node.finalbody, [entered], frame):
+                if result.control == "running":
+                    result = replace(
+                        result, control=pending.control, value=pending.value
+                    )
+                finalized.append(
+                    replace(result, active_exception=pending.active_exception)
+                )
+            self._bounded(finalized)
+        return finalized
+
+
+def _public_trace(trace):
+    events, outcome, value = trace
+    return {
+        "calls": [
+            {
+                "target": event[1],
+                "args": event[2],
+                "kwargs": event[3],
+                "outcome": event[4],
+                "active_exception": event[5],
+            }
+            for event in events
+        ],
+        "outcome": outcome,
+        "value": value,
+    }
+
+
+def compare_python_behavior(
+    before_sources: Mapping[str, str],
+    after_sources: Mapping[str, str],
+    *,
+    file: str,
+    symbol: str,
+    max_paths: int = 64,
+    max_depth: int = 8,
+) -> dict:
+    """Compare modeled invocation behavior; no target source is executed.
+
+    ``equivalent`` means equal complete traces in this restricted model.
+    ``different`` means a model mismatch, not an executed regression witness.
+    ``unknown`` means an unsupported construct, unresolved dependency, or bound
+    prevented comparison. Source keys are repository-relative POSIX .py paths.
+    """
+    result = {
+        "status": "unknown",
+        "file": file,
+        "symbol": symbol,
+        "before_range": None,
+        "after_range": None,
+        "differences": [],
+        "reasons": [],
+        "assumptions": list(_ASSUMPTIONS),
+        "model_version": 1,
+    }
+    try:
+        if (
+            type(max_paths) is not int
+            or max_paths < 1
+            or type(max_depth) is not int
+            or max_depth < 1
+        ):
+            raise _Unknown("max_paths and max_depth must be positive integers")
+        if (
+            not isinstance(file, str)
+            or not file.endswith(".py")
+            or PurePosixPath(file).is_absolute()
+            or ".." in PurePosixPath(file).parts
+        ):
+            raise _Unknown("file must be a repository-relative POSIX Python path")
+        if not isinstance(symbol, str) or not symbol.isidentifier():
+            raise _Unknown("symbol must name a module-level Python function")
+        for sources in (before_sources, after_sources):
+            if not isinstance(sources, Mapping) or any(
+                not isinstance(path, str)
+                or not path.endswith(".py")
+                or not isinstance(source, str)
+                for path, source in sources.items()
+            ):
+                raise _Unknown(
+                    "Sources must map repository-relative Python paths to source text"
+                )
+        known = {
+            _module_name(path) for path in set(before_sources) | set(after_sources)
+        }
+        programs = [
+            _Program(sources, known, max_paths, max_depth)
+            for sources in (before_sources, after_sources)
+        ]
+        functions = []
+        errors = []
+        for side, program in zip(("before", "after"), programs):
+            try:
+                _, function = program.function(file, symbol)
+                result[f"{side}_range"] = _range(function)
+                functions.append(function)
+            except _Unknown as exc:
+                errors.append(f"{side}: {exc}")
+        if errors:
+            result["reasons"] = errors
+            return result
+        signatures = [
+            program.signature(function)
+            for program, function in zip(programs, functions)
+        ]
+        if signatures[0] != signatures[1]:
+            result["status"] = "different"
+            result["differences"] = [
+                {
+                    "kind": "signature",
+                    "message": "The selected function's parameter names or parameter kinds changed",
+                    "before": signatures[0],
+                    "after": signatures[1],
+                    "evidence": "modeled_counterexample",
+                    "runtime_witness": False,
+                }
+            ]
+            for difference in result["differences"]:
+                difference["explanation"] = explain_difference(difference)
+            return result
+        traces = []
+        for side, program in zip(("before", "after"), programs):
+            try:
+                traces.append(program.analyze(file, symbol))
+            except _Unknown as exc:
+                errors.append(f"{side}: {exc}")
+        if errors:
+            result["reasons"] = errors
+            return result
+        if traces[0] == traces[1]:
+            result["status"] = "equivalent"
+            return result
+        result["status"] = "different"
+        removed = sorted(traces[0] - traces[1], key=repr)
+        added = sorted(traces[1] - traces[0], key=repr)
+        result["differences"] = [
+            {
+                "kind": "behavior_trace",
+                "message": "Ordered calls, forwarded values, return behavior, or exception propagation differ in the bounded model",
+                "before": _public_trace(removed[0]) if removed else None,
+                "after": _public_trace(added[0]) if added else None,
+                "before_only_paths": len(removed),
+                "after_only_paths": len(added),
+                "evidence": "modeled_counterexample",
+                "runtime_witness": False,
+            }
+        ]
+        for difference in result["differences"]:
+            difference["explanation"] = explain_difference(difference)
+    except _Unknown as exc:
+        result["reasons"] = [str(exc)]
+    except (RecursionError, MemoryError) as exc:
+        result["reasons"] = [f"Static analysis resource limit: {type(exc).__name__}"]
+    return result

--- a/skylos/verification/changes.py
+++ b/skylos/verification/changes.py
@@ -1,0 +1,130 @@
+"""Load Git snapshots for the shared source-comparison service."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from skylos.core.verify_change_schema import parse_line_range
+from skylos.verification.comparison import (
+    ComparisonScope,
+    SourceSnapshot,
+    _new_result,
+    compare_source_changes,
+)
+from skylos.verification.refactor import (
+    _base_sources,
+    _current_sources,
+    _git,
+    _selected_file,
+)
+
+_GIT_ASSUMPTIONS = [
+    "Tracked and unignored Python sources are compared; ignored dependencies and the external environment are assumed stable.",
+    "Unchanged Git submodules are treated as external dependencies; their source is not analyzed.",
+    "Snapshot hashes identify the bytes read; working-tree reads are not an atomic filesystem transaction.",
+]
+
+
+def _scope(path, file):
+    target = Path(path).expanduser().absolute()
+    if target.is_symlink():
+        raise ValueError("Verification path must not be a symlink")
+    directory = target.is_dir()
+    if file is not None and (Path(file).is_absolute() or ".." in Path(file).parts):
+        raise ValueError("--file must be a relative path within the selected directory")
+    if file is not None and not directory:
+        raise ValueError("--file cannot be combined with a file path target")
+    anchor = target if directory else target.parent
+    try:
+        root = Path(
+            os.fsdecode(_git(anchor, "rev-parse", "--show-toplevel")).removesuffix("\n")
+        ).resolve()
+        commit = _git(root, "rev-parse", "--verify", "HEAD^{commit}").decode().strip()
+    except ValueError:
+        return None
+    selected = target / file if file is not None else target
+    if not selected.resolve().is_relative_to(root):
+        raise ValueError("Verification scope must stay within the Git repository")
+    if not directory or file is not None:
+        if selected.suffix != ".py":
+            return root, commit, selected.resolve().relative_to(root).as_posix(), False
+        _, relative = _selected_file(target, file)
+        return root, commit, relative, False
+    return root, commit, target.resolve().relative_to(root).as_posix(), True
+
+
+def compare_working_changes(
+    path, *, file=None, line_range=None, exclude_folders=None
+) -> dict:
+    """Infer affected existing functions; differences require intent review.
+
+    This is an automatic companion to normal verification, not an implicit
+    assertion that every code change must preserve behavior.
+    """
+    result = _new_result("unavailable")
+    result["base"] = {"ref": "HEAD", "commit": None}
+    result["assumptions"].extend(_GIT_ASSUMPTIONS)
+    scope = _scope(path, file)
+    if scope is None:
+        result["reasons"] = ["No local Git HEAD is available for behavior comparison"]
+        return result
+    root, commit, selected, directory = scope
+    result["base"]["commit"] = commit
+    if not directory and not selected.endswith(".py"):
+        result["reasons"] = [
+            "Automatic behavior comparison currently applies to Python files"
+        ]
+        return result
+    excluded = set(exclude_folders or [])
+    bounds = (
+        line_range if isinstance(line_range, tuple) else parse_line_range(line_range)
+    )
+    if bounds is not None and (
+        len(bounds) != 2 or bounds[0] < 1 or bounds[1] < bounds[0]
+    ):
+        raise ValueError("Invalid line range")
+
+    comparison_scope = ComparisonScope(
+        selected=selected,
+        directory=directory,
+        line_range=bounds,
+        exclude_folders=excluded,
+    )
+
+    try:
+        before, before_hashes = _base_sources(root, commit, allow_submodules=True)
+        after, after_hashes = _current_sources(
+            root, None if directory else selected, allow_submodules=True
+        )
+        changes = _git(
+            root,
+            "diff",
+            "--raw",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--ignore-submodules=none",
+            commit,
+            "--",
+        )
+        if any(
+            b"160000" in row.split(b"\t", 1)[0].split() or row.startswith(b":160000 ")
+            for row in changes.splitlines()
+        ):
+            raise ValueError(
+                "Git submodule dependencies changed; behavior comparison is incomplete"
+            )
+    except ValueError as exc:
+        result.update(status="unknown", reasons=[str(exc)])
+        return result
+    result["base"]["source_hashes"] = before_hashes
+    result["current"] = {"source_hashes": after_hashes}
+    result.update(
+        compare_source_changes(
+            SourceSnapshot(before, before_hashes),
+            SourceSnapshot(after, after_hashes),
+            scope=comparison_scope,
+        )
+    )
+    result["assumptions"] = [*result["assumptions"], *_GIT_ASSUMPTIONS]
+    return result

--- a/skylos/verification/comparison.py
+++ b/skylos/verification/comparison.py
@@ -1,0 +1,451 @@
+"""Compare prepared source snapshots without Git, analyzer or command policy."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+import hashlib
+from pathlib import PurePosixPath
+from types import MappingProxyType
+from typing import Mapping
+
+from skylos.verification.behavior import compare_python_behavior
+
+_MAX_COMPARISONS = 128
+
+
+@dataclass(frozen=True)
+class SourceSnapshot:
+    """Decoded Python sources and hashes of original Python/environment bytes.
+
+    Paths are repository-relative POSIX names. Hashes remain evidence supplied
+    by the snapshot loader; Python change selection uses the source contents.
+    Copying the mappings prevents later caller edits from changing this input.
+    """
+
+    sources: Mapping[str, str]
+    hashes: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "sources", MappingProxyType(dict(self.sources)))
+        object.__setattr__(self, "hashes", MappingProxyType(dict(self.hashes)))
+
+
+@dataclass(frozen=True)
+class ComparisonScope:
+    """A selected repository-relative file or directory within the snapshots."""
+
+    selected: str = "."
+    directory: bool = True
+    line_range: tuple[int, int] | None = None
+    exclude_folders: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        path = PurePosixPath(self.selected)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("Comparison scope must be repository-relative")
+        object.__setattr__(self, "selected", path.as_posix())
+        object.__setattr__(self, "exclude_folders", frozenset(self.exclude_folders))
+        if self.line_range is not None:
+            bounds = tuple(self.line_range)
+            if (
+                len(bounds) != 2
+                or any(type(value) is not int for value in bounds)
+                or bounds[0] < 1
+                or bounds[1] < bounds[0]
+            ):
+                raise ValueError("Invalid line range")
+            object.__setattr__(self, "line_range", bounds)
+
+    def contains(self, name: str) -> bool:
+        matches = (
+            (self.selected == "." or name.startswith(self.selected + "/"))
+            if self.directory
+            else name == self.selected
+        )
+        return matches and not any(
+            part in self.exclude_folders for part in PurePosixPath(name).parts[:-1]
+        )
+
+
+def _new_result(status: str = "unchanged") -> dict:
+    return {
+        "schema_version": 1,
+        "status": status,
+        "comparisons": [],
+        "reasons": [],
+        "changed_files": [],
+        "selection": "affected_python_functions",
+        "runtime_witness": False,
+        "limits": {
+            "functions": _MAX_COMPARISONS,
+            "paths_per_function": 64,
+            "helper_depth": 8,
+        },
+        "assumptions": [
+            "Affected-function selection follows static imports and name references; dynamic loading and runtime rebinding are outside impact discovery.",
+        ],
+    }
+
+
+def is_environment_file(name: str) -> bool:
+    path = PurePosixPath(name)
+    filename = path.name
+    return filename in {
+        "pyproject.toml",
+        "poetry.lock",
+        "uv.lock",
+        "Pipfile",
+        "Pipfile.lock",
+        "setup.py",
+        "setup.cfg",
+        "pdm.lock",
+        "pixi.lock",
+        "pixi.toml",
+        ".python-version",
+        ".gitmodules",
+        "environment.yml",
+        "environment.yaml",
+    } or (
+        (filename.startswith("requirements") or "requirements" in path.parts[:-1])
+        and filename.endswith((".txt", ".in"))
+    )
+
+
+@dataclass
+class _Function:
+    digest: str
+    start: int
+    end: int
+    references: set[str]
+
+
+@dataclass
+class _Source:
+    functions: dict[str, _Function] = field(default_factory=dict)
+    imports: dict[str, str] = field(default_factory=dict)
+    dependencies: set[str] = field(default_factory=set)
+    structure: str = ""
+    digest: str = ""
+    error: str | None = None
+
+
+def _digest(node) -> str:
+    return hashlib.sha256(ast.dump(node, include_attributes=False).encode()).hexdigest()
+
+
+def _module(path: str) -> str:
+    parts = list(PurePosixPath(path).with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _dotted(node) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _dotted(node.value)
+        return f"{parent}.{node.attr}" if parent else ""
+    return ""
+
+
+def _index(path: str, source: str) -> _Source:
+    info = _Source(digest=hashlib.sha256(source.encode()).hexdigest())
+    try:
+        tree = ast.parse(source, filename=path)
+        info.digest = _digest(tree)
+        residual = []
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                arguments = (
+                    node.args.posonlyargs + node.args.args + node.args.kwonlyargs
+                )
+                if (
+                    node.decorator_list
+                    or node.returns
+                    or node.args.defaults
+                    or any(value is not None for value in node.args.kw_defaults)
+                    or any(argument.annotation for argument in arguments)
+                    or getattr(node, "type_params", [])
+                ):
+                    info.error = "Function definition headers are outside the supported behavior model"
+                if node.name in info.functions:
+                    info.error = (
+                        "Duplicate function definitions prevent automatic selection"
+                    )
+                info.functions[node.name] = _Function(
+                    _digest(node),
+                    min([node.lineno] + [d.lineno for d in node.decorator_list]),
+                    node.end_lineno or node.lineno,
+                    {name for child in ast.walk(node) if (name := _dotted(child))},
+                )
+            else:
+                residual.append(node)
+                if not isinstance(
+                    node, (ast.Import, ast.ImportFrom, ast.Pass)
+                ) and not (
+                    isinstance(node, ast.Expr)
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                ):
+                    info.error = "Module bindings or statements are outside the supported behavior model"
+        info.structure = _digest(ast.Module(body=residual, type_ignores=[]))
+        # Imports anywhere in a file conservatively contribute dependency edges.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    info.dependencies.add(alias.name)
+                    info.imports[alias.asname or alias.name.split(".")[0]] = (
+                        alias.name if alias.asname else alias.name.split(".")[0]
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if node.level:
+                    package = _module(path).split(".")
+                    if PurePosixPath(path).name != "__init__.py":
+                        package = package[:-1]
+                    module = ".".join(
+                        package[: max(0, len(package) - node.level + 1)]
+                        + ([module] if module else [])
+                    )
+                info.dependencies.add(module)
+                for alias in node.names:
+                    imported = f"{module}.{alias.name}".strip(".")
+                    info.imports[alias.asname or alias.name] = imported
+                    info.dependencies.add(imported)
+    except (SyntaxError, ValueError, RecursionError, MemoryError) as exc:
+        info.error = f"Cannot index Python source: {type(exc).__name__}"
+    return info
+
+
+def _matches_module(module: str, imported: str) -> bool:
+    # Unknown import roots must broaden impact, never hide a changed dependency.
+    module, imported = module.casefold(), imported.casefold()
+    return bool(imported) and (
+        module == imported
+        or module.endswith("." + imported)
+        or imported.startswith(module + ".")
+        or module.startswith(imported + ".")
+    )
+
+
+def compare_source_changes(
+    before: SourceSnapshot,
+    after: SourceSnapshot,
+    *,
+    scope: ComparisonScope | None = None,
+) -> dict:
+    """Return modeled changes and unsupported coverage for prepared sources.
+
+    Callers own snapshot acquisition, revision metadata, display and exit
+    policy. No filesystem access, Git invocation or static analyzer runs here.
+    """
+    scope = scope or ComparisonScope()
+    selected, directory = scope.selected, scope.directory
+    bounds = scope.line_range
+    in_scope = scope.contains
+    result = _new_result()
+    before_hashes, after_hashes = before.hashes, after.hashes
+    before, after = before.sources, after.sources
+    files = before.keys() | after.keys()
+    raw_changed = {name for name in files if before.get(name) != after.get(name)}
+    environment_changes = sorted(
+        name
+        for name in before_hashes.keys() | after_hashes.keys()
+        if is_environment_file(name)
+        and before_hashes.get(name) != after_hashes.get(name)
+    )
+    if not raw_changed and not environment_changes:
+        result["status"] = "unchanged"
+        return result
+    # A known unsupported edit in a file target needs no repository-wide graph.
+    # This also keeps selected-file comparison cheap for code outside the model.
+    if not directory and selected in raw_changed and in_scope(selected):
+        left = _index(selected, before.get(selected, ""))
+        right = _index(selected, after.get(selected, ""))
+        if (left.error or right.error) and left.digest != right.digest:
+            result.update(
+                status="unknown",
+                changed_files=[selected],
+                reasons=[f"{selected}: {left.error or right.error}"],
+            )
+            for symbol in sorted(left.functions.keys() | right.functions.keys())[
+                :_MAX_COMPARISONS
+            ]:
+                a, b = left.functions.get(symbol), right.functions.get(symbol)
+                if bounds and not any(
+                    node and node.start <= bounds[1] and node.end >= bounds[0]
+                    for node in (a, b)
+                ):
+                    continue
+                result["comparisons"].append(
+                    compare_python_behavior(before, after, file=selected, symbol=symbol)
+                )
+            return result
+    old = {name: _index(name, source) for name, source in before.items()}
+    new = {
+        name: old[name]
+        if name in old and before.get(name) == source
+        else _index(name, source)
+        for name, source in after.items()
+    }
+    empty = _index("empty.py", "")
+    # Line changes alone do not alter the behavior model.
+    changed = {
+        name
+        for name in raw_changed
+        if name not in before
+        or name not in after
+        or old.get(name, empty).digest != new.get(name, empty).digest
+    }
+    result["changed_files"] = sorted(changed)
+    affected_modules = set(changed)
+    if environment_changes:
+        affected_modules.update(name for name in files if in_scope(name))
+    modules = {name: _module(name) for name in files}
+    identities, descendants = {}, {}
+    for name, module in modules.items():
+        parts = module.casefold().split(".")
+        for start in range(len(parts)):
+            suffix = parts[start:]
+            identities.setdefault(".".join(suffix), set()).add(name)
+            for end in range(1, len(suffix) + 1):
+                descendants.setdefault(".".join(suffix[:end]), set()).add(name)
+    dependents = {}
+    for name in files:
+        dependencies = (
+            old.get(name, empty).dependencies | new.get(name, empty).dependencies
+        )
+        for dependency in dependencies:
+            parts = dependency.casefold().split(".")
+            targets = set(descendants.get(dependency.casefold(), ()))
+            for end in range(1, len(parts) + 1):
+                targets.update(identities.get(".".join(parts[:end]), ()))
+            for target in targets:
+                dependents.setdefault(target, set()).add(name)
+    pending = list(affected_modules)
+    while pending:
+        for caller in dependents.get(pending.pop(), ()):
+            if caller not in affected_modules:
+                affected_modules.add(caller)
+                pending.append(caller)
+    functions = {
+        (name, symbol)
+        for name in files
+        for symbol in old.get(name, empty).functions.keys()
+        | new.get(name, empty).functions.keys()
+    }
+    by_symbol = {}
+    for key in functions:
+        by_symbol.setdefault(key[1], []).append(key)
+    edges = {key: set() for key in functions}
+    for key in functions:
+        name, symbol = key
+        for index in (old, new):
+            info = index.get(name, empty)
+            function = info.functions.get(symbol)
+            if function is None:
+                continue
+            for reference in function.references:
+                if (name, reference) in functions:
+                    edges[key].add((name, reference))
+                head, _, tail = reference.partition(".")
+                if head in info.imports:
+                    qualified = info.imports[head] + ("." + tail if tail else "")
+                    module, _, member = qualified.rpartition(".")
+                    edges[key].update(
+                        candidate
+                        for candidate in by_symbol.get(member, ())
+                        if _matches_module(modules[candidate[0]], module)
+                    )
+    affected = set()
+    for name in affected_modules:
+        left, right = old.get(name, empty), new.get(name, empty)
+        broad = (
+            name not in changed
+            or left.structure != right.structure
+            or left.error
+            or right.error
+        )
+        for symbol in left.functions.keys() | right.functions.keys():
+            a, b = left.functions.get(symbol), right.functions.get(symbol)
+            if broad or a is None or b is None or a.digest != b.digest:
+                affected.add((name, symbol))
+    while True:
+        expanded = affected | {key for key, refs in edges.items() if refs & affected}
+        if expanded == affected:
+            break
+        affected = expanded
+
+    # New helpers are checked by inlining them into surviving affected callers.
+    def selected_function(key):
+        if not in_scope(key[0]):
+            return False
+        nodes = [index.get(key[0], empty).functions.get(key[1]) for index in (old, new)]
+        return not bounds or any(
+            node and node.start <= bounds[1] and node.end >= bounds[0] for node in nodes
+        )
+
+    existing = {
+        key
+        for key in affected
+        if key[1] in old.get(key[0], empty).functions
+        and key[1] in new.get(key[0], empty).functions
+        and selected_function(key)
+    }
+    reached = set(existing)
+    while True:
+        expanded = reached | set().union(*(edges[key] for key in reached))
+        if expanded == reached:
+            break
+        reached = expanded
+    candidates = []
+    for name, symbol in sorted(affected):
+        if not in_scope(name):
+            continue
+        a, b = (
+            old.get(name, empty).functions.get(symbol),
+            new.get(name, empty).functions.get(symbol),
+        )
+        if a is None and (name, symbol) in reached:
+            continue
+        if bounds and not any(
+            node and node.start <= bounds[1] and node.end >= bounds[0]
+            for node in (a, b)
+        ):
+            continue
+        candidates.append((name, symbol))
+    reasons = []
+    if environment_changes and any(in_scope(name) for name in files):
+        reasons.append(
+            "Dependency or Python environment files changed: "
+            + ", ".join(environment_changes)
+        )
+    for name in sorted(affected_modules):
+        if in_scope(name):
+            left, right = old.get(name, empty), new.get(name, empty)
+            if left.error or right.error:
+                reasons.append(f"{name}: {left.error or right.error}")
+            elif name in changed and not left.functions and not right.functions:
+                reasons.append(
+                    f"{name}: changes outside supported module-level functions"
+                )
+    if len(candidates) > _MAX_COMPARISONS:
+        reasons.append(f"Affected function budget exhausted (limit {_MAX_COMPARISONS})")
+    for name, symbol in candidates[:_MAX_COMPARISONS]:
+        result["comparisons"].append(
+            compare_python_behavior(before, after, file=name, symbol=symbol)
+        )
+    states = {comparison["status"] for comparison in result["comparisons"]}
+    result["reasons"] = reasons
+    result["status"] = (
+        "unknown"
+        if reasons or "unknown" in states
+        else "different"
+        if "different" in states
+        else "equivalent"
+        if states
+        else "unchanged"
+    )
+    return result

--- a/skylos/verification/explanations.py
+++ b/skylos/verification/explanations.py
@@ -1,0 +1,160 @@
+"""Explain recorded comparison evidence without inventing runtime witnesses."""
+
+from __future__ import annotations
+
+import json
+
+
+def _same(left, right):
+    try:
+        return json.dumps(left, sort_keys=True) == json.dumps(right, sort_keys=True)
+    except (TypeError, ValueError, RecursionError):
+        return False
+
+
+def _kind(value):
+    return value[0] if isinstance(value, (list, tuple)) and value else None
+
+
+def _short(value, limit=180):
+    text = str(value)
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def _value(value, calls, depth=0):
+    if depth > 6:
+        return "an earlier call result"
+    kind = _kind(value)
+    if kind in {"parameter", "external", "module"} and len(value) > 1:
+        return _short(value[1])
+    if kind == "constant" and len(value) > 2:
+        return _short(value[2])
+    if kind in {"result", "exception"} and len(value) > 1:
+        index = value[1]
+        if type(index) is int and 0 <= index < len(calls):
+            call = _call(calls[index], calls, depth + 1)
+            return call if kind == "result" else f"an exception from {call}"
+        return "an earlier call result" if kind == "result" else "an exception"
+    return "a modeled value"
+
+
+def _call(call, calls, depth=0):
+    if not isinstance(call, dict):
+        return "an outgoing call"
+    target = _value(call.get("target"), calls, depth)
+    arguments = [_value(arg, calls, depth) for arg in call.get("args", [])[:5]]
+    for keyword in call.get("kwargs", [])[:5]:
+        if isinstance(keyword, (list, tuple)) and len(keyword) == 2:
+            arguments.append(f"{keyword[0]}={_value(keyword[1], calls, depth)}")
+    if len(call.get("args", [])) > 5 or len(call.get("kwargs", [])) > 5:
+        arguments.append("...")
+    return _short(f"{target}({', '.join(arguments)})")
+
+
+def _terminal(trace, *, before=False):
+    if not isinstance(trace, dict):
+        return "No corresponding trace was selected for this side of the comparison."
+    value = trace.get("value")
+    calls = trace.get("calls", [])
+    if trace.get("outcome") == "raise":
+        verb = "Propagated" if before else "Propagates"
+        return f"{verb} {_value(value, calls)}."
+    verb = "Returned" if before else "Returns"
+    if _kind(value) == "result":
+        return f"{verb} the result of {_value(value, calls)}."
+    return f"{verb} {_value(value, calls)}."
+
+
+def _path(trace):
+    if not isinstance(trace, dict):
+        return "No corresponding trace was selected for this side of the comparison."
+    calls = trace.get("calls", [])
+    steps = [
+        f"{_call(call, calls)} ({'raises' if call.get('outcome') == 'raise' else 'returns'})"
+        for call in calls[:4]
+        if isinstance(call, dict)
+    ]
+    if len(calls) > 4:
+        steps.append(f"{len(calls) - 4} more calls")
+    description = " -> ".join(steps) if steps else "No outgoing calls"
+    return f"{description}. {_terminal(trace)}"
+
+
+def _signature(value):
+    if not isinstance(value, (list, tuple)):
+        return "Signature details unavailable."
+    parameters = [
+        f"{name} ({str(kind).replace('_', ' ')})"
+        for kind, name in value
+        if isinstance(name, str)
+    ]
+    return "Parameters: " + (", ".join(parameters) if parameters else "none") + "."
+
+
+def explain_difference(difference: dict) -> dict[str, str]:
+    """Specific transitions require matching call histories and outcomes.
+
+    The engine's first removed and first added traces are independently chosen.
+    Otherwise describe separate model paths, not a same-input runtime witness.
+    """
+    before, after = difference.get("before"), difference.get("after")
+    review = "Confirm whether this behavior change was intentional."
+    if difference.get("kind") == "signature":
+        return {
+            "title": "Function signature changed",
+            "before": _signature(before),
+            "after": _signature(after),
+            "impact": "Callers may need to change how they pass arguments.",
+            "review": review,
+        }
+
+    explanation = {
+        "title": "Behavior changed on compared paths",
+        "before": _path(before),
+        "after": _path(after),
+        "impact": "These are different modeled paths; they are not an executed same-input example.",
+        "review": review,
+    }
+    if not isinstance(before, dict) or not isinstance(after, dict):
+        return explanation
+    left_calls, right_calls = before.get("calls", []), after.get("calls", [])
+    if not _same(left_calls, right_calls):
+        explanation["title"] = "Call sequence changed"
+        return explanation
+
+    explanation["before"] = _terminal(before, before=True)
+    explanation["after"] = _terminal(after)
+    left, right = before.get("outcome"), after.get("outcome")
+    if left == "raise" and right == "return":
+        explanation.update(
+            title="Exception no longer propagated",
+            impact="Callers may continue without being told the operation failed.",
+        )
+    elif left == "return" and right == "raise":
+        explanation.update(
+            title="Exception now propagated",
+            impact="Callers may now need to handle an exception instead of receiving a result.",
+        )
+    elif left == right == "return" and not _same(
+        before.get("value"), after.get("value")
+    ):
+        explanation.update(
+            title="Return value changed",
+            impact="Callers that use the returned value may behave differently.",
+        )
+        if _kind(before.get("value")) == "result" and _same(
+            after.get("value"), ("constant", "NoneType", "None")
+        ):
+            index = before["value"][1]
+            callback = (
+                type(index) is int
+                and 0 <= index < len(left_calls)
+                and _kind(left_calls[index].get("target")) == "parameter"
+            )
+            explanation.update(
+                title="Callback result discarded"
+                if callback
+                else "Call result discarded",
+                impact="Callers that use the returned value now receive None and may break.",
+            )
+    return explanation

--- a/skylos/verification/refactor.py
+++ b/skylos/verification/refactor.py
@@ -70,7 +70,12 @@ def _git(
 
 def _safe_relative(name: str) -> bool:
     path = PurePosixPath(name)
-    return bool(name) and not path.is_absolute() and ".." not in path.parts
+    return (
+        bool(path.parts)
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and "\0" not in name
+    )
 
 
 def _selected_file(path: str | Path, file: str | Path | None) -> tuple[Path, str]:
@@ -187,6 +192,61 @@ def _base_sources(
     return sources, hashes
 
 
+def _source_directory_flags() -> int:
+    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+
+
+def _read_working_source(root_fd: int, name: str) -> bytes | None:
+    """Read a bounded regular file through directories pinned beneath root_fd."""
+    if not _safe_relative(name):
+        raise ValueError("Unsafe path in working source snapshot")
+    parts = PurePosixPath(name).parts
+    directory_fd = None
+    file_fd = None
+    try:
+        directory_fd = os.dup(root_fd)
+        try:
+            for part in parts[:-1]:
+                next_fd = os.open(part, _source_directory_flags(), dir_fd=directory_fd)
+                os.close(directory_fd)
+                directory_fd = next_fd
+            file_fd = os.open(  # skylos: ignore[SKY-D215] validated basename below no-follow repository directory descriptors
+                parts[-1],
+                os.O_RDONLY
+                | os.O_NOFOLLOW
+                | getattr(os, "O_NONBLOCK", 0)
+                | getattr(os, "O_CLOEXEC", 0),
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            return None  # Deleted files are absent from the current snapshot.
+        before = os.fstat(file_fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError(f"Working source is not a regular file: {name}")
+        if before.st_size > _MAX_FILE_BYTES:
+            raise ValueError(
+                f"Working source exceeds the verification size limit: {name}"
+            )
+        with os.fdopen(file_fd, "rb") as handle:
+            file_fd = None
+            raw = handle.read(_MAX_FILE_BYTES + 1)
+            after = os.fstat(handle.fileno())
+        if (before.st_size, before.st_mtime_ns, before.st_ctime_ns) != (
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        ):
+            raise ValueError(f"Working source changed while being read: {name}")
+        return raw
+    except OSError as exc:
+        raise ValueError(f"Cannot read working source: {name}") from exc
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        if directory_fd is not None:
+            os.close(directory_fd)
+
+
 def _current_sources(
     root: Path, selected: str | None = None, *, allow_submodules: bool = False
 ) -> tuple[dict[str, str], dict[str, str]]:
@@ -210,52 +270,35 @@ def _current_sources(
         names.add(selected)
     if len(names) > _MAX_FILES:
         raise ValueError("Working source snapshot exceeds the verification file limit")
+    if (
+        os.open not in os.supports_dir_fd
+        or not hasattr(os, "O_DIRECTORY")
+        or not hasattr(os, "O_NOFOLLOW")
+    ):
+        raise ValueError("Platform does not support safe working source snapshot reads")
+    try:
+        root_fd = os.open(  # skylos: ignore[SKY-D215] caller-selected Git root opened as a no-follow directory anchor
+            root, _source_directory_flags()
+        )
+    except OSError as exc:
+        raise ValueError("Cannot open working source snapshot root") from exc
     sources, hashes = {}, {}
     total = 0
-    for name in sorted(names):
-        if not _safe_relative(name):
-            raise ValueError("Unsafe path in working source snapshot")
-        source = root / name
-        for parent in (source, *source.parents):
-            if parent == root:
-                break
-            if parent.is_symlink():
-                raise ValueError(f"Symlink source is unsupported: {name}")
-        try:
-            descriptor = os.open(
-                source,
-                os.O_RDONLY
-                | getattr(os, "O_NONBLOCK", 0)
-                | getattr(os, "O_NOFOLLOW", 0),
-            )
-        except FileNotFoundError:
-            continue  # Deleted files must be absent from the current snapshot.
-        except OSError as exc:
-            raise ValueError(f"Cannot read working source: {name}") from exc
-        with os.fdopen(descriptor, "rb") as handle:
-            before = os.fstat(handle.fileno())
-            if not stat.S_ISREG(before.st_mode):
-                raise ValueError(f"Working source is not a regular file: {name}")
-            if before.st_size > _MAX_FILE_BYTES:
+    try:
+        for name in sorted(names):
+            raw = _read_working_source(root_fd, name)
+            if raw is None:
+                continue
+            total += len(raw)
+            if len(raw) > _MAX_FILE_BYTES or total > _MAX_SOURCE_BYTES:
                 raise ValueError(
-                    f"Working source exceeds the verification size limit: {name}"
+                    "Working source snapshot exceeds the verification size limit"
                 )
-            raw = handle.read(_MAX_FILE_BYTES + 1)
-            after = os.fstat(handle.fileno())
-        if (before.st_size, before.st_mtime_ns, before.st_ctime_ns) != (
-            after.st_size,
-            after.st_mtime_ns,
-            after.st_ctime_ns,
-        ):
-            raise ValueError(f"Working source changed while being read: {name}")
-        total += len(raw)
-        if len(raw) > _MAX_FILE_BYTES or total > _MAX_SOURCE_BYTES:
-            raise ValueError(
-                "Working source snapshot exceeds the verification size limit"
-            )
-        if name.endswith(".py"):
-            sources[name] = _decode_source(raw, name)
-        hashes[name] = hashlib.sha256(raw).hexdigest()
+            if name.endswith(".py"):
+                sources[name] = _decode_source(raw, name)
+            hashes[name] = hashlib.sha256(raw).hexdigest()
+    finally:
+        os.close(root_fd)
     return sources, hashes
 
 

--- a/skylos/verification/refactor.py
+++ b/skylos/verification/refactor.py
@@ -1,0 +1,400 @@
+"""Compare Git source snapshots without importing or executing target code."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from pathlib import Path, PurePosixPath
+import stat
+import subprocess
+import tempfile
+import tokenize
+from typing import Any
+
+from skylos.verification.behavior import compare_python_behavior
+from skylos.verification.comparison import is_environment_file as _environment_file
+
+_MAX_FILES = 4096
+_MAX_FILE_BYTES = 1024 * 1024
+_MAX_SOURCE_BYTES = 16 * 1024 * 1024
+_MAX_LIST_BYTES = 8 * 1024 * 1024
+
+
+def _snapshot_input(name: str) -> bool:
+    return name.endswith(".py") or _environment_file(name)
+
+
+def _git(
+    root: Path, *args: str, data: bytes | None = None, limit: int = _MAX_LIST_BYTES
+) -> bytes:
+    # Ambient Git variables must not redirect the caller's requested repository.
+    env = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    env["GIT_NO_LAZY_FETCH"] = "1"
+    command = [
+        "git",
+        "--no-pager",
+        "--no-replace-objects",
+        "-c",
+        "core.fsmonitor=false",
+        "-C",
+        str(root),
+        *args,
+    ]
+    try:
+        # A file bounds memory even when a repository produces excessive output.
+        with tempfile.TemporaryFile() as output, tempfile.TemporaryFile() as errors:
+            proc = subprocess.run(
+                command,
+                input=data,
+                stdout=output,
+                stderr=errors,
+                env=env,
+                timeout=30,
+                check=False,
+            )
+            if proc.returncode:
+                raise ValueError(
+                    f"Cannot read Git snapshot ({args[0]}). Check repository and base ref."
+                )
+            if output.tell() > limit:
+                raise ValueError("Git snapshot exceeds the verification size limit")
+            output.seek(0)
+            return output.read(limit + 1)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"Cannot read Git snapshot: {type(exc).__name__}") from exc
+
+
+def _safe_relative(name: str) -> bool:
+    path = PurePosixPath(name)
+    return bool(name) and not path.is_absolute() and ".." not in path.parts
+
+
+def _selected_file(path: str | Path, file: str | Path | None) -> tuple[Path, str]:
+    target = Path(path).expanduser().absolute()
+    if target.is_symlink():
+        raise ValueError("Verification path must not be a symlink")
+    if target.is_dir():
+        if file is None:
+            raise ValueError("--file is required when verifying a project directory")
+        requested = Path(file)
+        if requested.is_absolute() or ".." in requested.parts:
+            raise ValueError(
+                "--file must be a relative path within the selected directory"
+            )
+        selected = target / requested
+        anchor = target
+    else:
+        if file is not None:
+            raise ValueError("--file cannot be combined with a file path target")
+        selected = target
+        anchor = target.parent
+    if not anchor.is_dir():
+        raise ValueError("Verification path does not exist")
+    root = Path(
+        os.fsdecode(_git(anchor, "rev-parse", "--show-toplevel")).removesuffix("\n")
+    ).resolve()
+    # Resolve the anchor for platform aliases such as /tmp, but check every
+    # repository-relative component before allowing resolution of the target.
+    ancestor = selected
+    while ancestor != ancestor.parent:
+        if ancestor.is_symlink() and ancestor.resolve().is_relative_to(root):
+            raise ValueError("Verification file or directory must not be a symlink")
+        if ancestor.resolve() == root:
+            break
+        ancestor = ancestor.parent
+    if selected.is_symlink():
+        raise ValueError("Verification file must not be a symlink")
+    resolved = selected.resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError("Verification file must be within the Git repository")
+    if resolved.suffix != ".py":
+        raise ValueError(
+            "Behavior preservation currently supports Python .py files only"
+        )
+    if resolved.exists() and not resolved.is_file():
+        raise ValueError("Verification target must be a regular Python file")
+    return root, resolved.relative_to(root).as_posix()
+
+
+def _decode_source(raw: bytes, name: str) -> str:
+    try:
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(raw).readline)
+        return raw.decode(encoding)
+    except (SyntaxError, UnicodeError, LookupError) as exc:
+        raise ValueError(f"Cannot decode Python source: {name}") from exc
+
+
+def _base_sources(
+    root: Path, commit: str, *, allow_submodules: bool = False
+) -> tuple[dict[str, str], dict[str, str]]:
+    listing = _git(root, "ls-tree", "-r", "-l", "-z", commit)
+    entries = []
+    total = 0
+    for entry in listing.split(b"\0"):
+        if not entry:
+            continue
+        metadata, raw_name = entry.split(b"\t", 1)
+        name = os.fsdecode(raw_name)
+        if metadata.split()[1] == b"commit":
+            if allow_submodules:
+                continue
+            raise ValueError(f"Git submodule dependencies are unsupported: {name}")
+        if not _snapshot_input(name):
+            continue
+        mode, kind, oid, size = metadata.split()
+        if (
+            not _safe_relative(name)
+            or mode not in (b"100644", b"100755")
+            or kind != b"blob"
+        ):
+            raise ValueError(
+                f"Unsupported Python source entry in base snapshot: {name}"
+            )
+        count = int(size)
+        total += count
+        if (
+            count > _MAX_FILE_BYTES
+            or total > _MAX_SOURCE_BYTES
+            or len(entries) >= _MAX_FILES
+        ):
+            raise ValueError("Base source snapshot exceeds the verification size limit")
+        entries.append((name, oid, count))
+    if not entries:
+        return {}, {}
+    batch = _git(
+        root,
+        "cat-file",
+        "--batch",
+        data=b"\n".join(e[1] for e in entries) + b"\n",
+        limit=_MAX_SOURCE_BYTES + _MAX_FILES * 128,
+    )
+    stream = io.BytesIO(batch)
+    sources, hashes = {}, {}
+    for name, oid, count in entries:
+        header = stream.readline().split()
+        if header != [oid, b"blob", str(count).encode()]:
+            raise ValueError("Invalid Git blob response")
+        raw = stream.read(count)
+        if len(raw) != count or stream.read(1) != b"\n":
+            raise ValueError("Truncated Git blob response")
+        if name.endswith(".py"):
+            sources[name] = _decode_source(raw, name)
+        hashes[name] = hashlib.sha256(raw).hexdigest()
+    return sources, hashes
+
+
+def _current_sources(
+    root: Path, selected: str | None = None, *, allow_submodules: bool = False
+) -> tuple[dict[str, str], dict[str, str]]:
+    index = _git(root, "ls-files", "--stage", "-z")
+    if not allow_submodules and any(
+        entry.startswith(b"160000 ") for entry in index.split(b"\0")
+    ):
+        raise ValueError("Git submodule dependencies are unsupported")
+    listing = _git(
+        root, "ls-files", "--cached", "--others", "--exclude-standard", "-z"
+    ).split(b"\0")
+    if any(name.endswith(b"/") for name in listing):
+        raise ValueError("Untracked nested repository dependencies are unsupported")
+    names = {
+        os.fsdecode(name)
+        for name in listing
+        if name and _snapshot_input(os.fsdecode(name))
+    }
+    # An explicitly selected ignored file is still part of the obligation.
+    if selected is not None:
+        names.add(selected)
+    if len(names) > _MAX_FILES:
+        raise ValueError("Working source snapshot exceeds the verification file limit")
+    sources, hashes = {}, {}
+    total = 0
+    for name in sorted(names):
+        if not _safe_relative(name):
+            raise ValueError("Unsafe path in working source snapshot")
+        source = root / name
+        for parent in (source, *source.parents):
+            if parent == root:
+                break
+            if parent.is_symlink():
+                raise ValueError(f"Symlink source is unsupported: {name}")
+        try:
+            descriptor = os.open(
+                source,
+                os.O_RDONLY
+                | getattr(os, "O_NONBLOCK", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+        except FileNotFoundError:
+            continue  # Deleted files must be absent from the current snapshot.
+        except OSError as exc:
+            raise ValueError(f"Cannot read working source: {name}") from exc
+        with os.fdopen(descriptor, "rb") as handle:
+            before = os.fstat(handle.fileno())
+            if not stat.S_ISREG(before.st_mode):
+                raise ValueError(f"Working source is not a regular file: {name}")
+            if before.st_size > _MAX_FILE_BYTES:
+                raise ValueError(
+                    f"Working source exceeds the verification size limit: {name}"
+                )
+            raw = handle.read(_MAX_FILE_BYTES + 1)
+            after = os.fstat(handle.fileno())
+        if (before.st_size, before.st_mtime_ns, before.st_ctime_ns) != (
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        ):
+            raise ValueError(f"Working source changed while being read: {name}")
+        total += len(raw)
+        if len(raw) > _MAX_FILE_BYTES or total > _MAX_SOURCE_BYTES:
+            raise ValueError(
+                "Working source snapshot exceeds the verification size limit"
+            )
+        if name.endswith(".py"):
+            sources[name] = _decode_source(raw, name)
+        hashes[name] = hashlib.sha256(raw).hexdigest()
+    return sources, hashes
+
+
+def verify_refactor(
+    path: str | Path,
+    *,
+    base: str,
+    file: str | Path | None = None,
+    symbol: str,
+    max_paths: int = 64,
+    max_depth: int = 8,
+) -> dict[str, Any]:
+    """Verify a selected function's explicit preserve-behavior obligation.
+
+    A pass is conditional on the engine's stated model and snapshot assumptions.
+    It is not a claim of equivalence for arbitrary Python programs.
+    """
+    if (
+        not isinstance(base, str)
+        or not base.strip()
+        or len(base) > 1024
+        or base.startswith("-")
+        or "\0" in base
+    ):
+        raise ValueError("--base must be a valid Git commit reference")
+    if not isinstance(symbol, str) or not symbol.isidentifier():
+        raise ValueError("--symbol must name one module-level Python function")
+    if type(max_paths) is not int or not 1 <= max_paths <= 1024:
+        raise ValueError("max_paths must be between 1 and 1024")
+    if type(max_depth) is not int or not 1 <= max_depth <= 64:
+        raise ValueError("max_depth must be between 1 and 64")
+    root, relative = _selected_file(path, file)
+    commit = (
+        _git(root, "rev-parse", "--verify", "--end-of-options", f"{base}^{{commit}}")
+        .decode()
+        .strip()
+    )
+    before_hashes, after_hashes = {}, {}
+    try:
+        before, before_hashes = _base_sources(root, commit)
+        after, after_hashes = _current_sources(root, relative)
+        environment_changes = sorted(
+            name
+            for name in before_hashes.keys() | after_hashes.keys()
+            if _environment_file(name)
+            and before_hashes.get(name) != after_hashes.get(name)
+        )
+        if environment_changes:
+            raise ValueError(
+                "Dependency or Python environment files changed: "
+                + ", ".join(environment_changes)
+            )
+        comparison = compare_python_behavior(
+            before,
+            after,
+            file=relative,
+            symbol=symbol,
+            max_paths=max_paths,
+            max_depth=max_depth,
+        )
+    except ValueError as exc:
+        comparison = {
+            "status": "unknown",
+            "model_version": 1,
+            "file": relative,
+            "symbol": symbol,
+            "before_range": None,
+            "after_range": None,
+            "differences": [],
+            "reasons": [str(exc)],
+            "assumptions": [],
+        }
+    comparison["assumptions"] = list(comparison.get("assumptions", [])) + [
+        "Snapshots include tracked and unignored Python files; ignored dependencies and the external environment are assumed stable.",
+        "The current snapshot identifies the bytes read, not an atomic filesystem transaction.",
+    ]
+    status = {"equivalent": "pass", "different": "fail", "unknown": "incomplete"}[
+        comparison["status"]
+    ]
+    findings = (
+        [
+            {
+                "check_id": "python_behavior_preservation",
+                "file": relative,
+                "symbol": symbol,
+                **difference,
+                "evidence_kind": "modeled_difference",
+                "runtime_witness": False,
+            }
+            for difference in comparison.get("differences", [])
+        ]
+        if status == "fail"
+        else []
+    )
+    return {
+        "schema_version": 1,
+        "tool": "verify_behavior",
+        "status": status,
+        "obligation": "preserve_behavior",
+        "target": {"path": str(root), "file": relative, "symbol": symbol},
+        "base": {
+            "ref": base,
+            "commit": commit,
+            "source_hashes": {
+                name: digest
+                for name, digest in before_hashes.items()
+                if name.endswith(".py")
+            },
+            "environment_hashes": {
+                name: digest
+                for name, digest in before_hashes.items()
+                if _environment_file(name)
+            },
+        },
+        "current": {
+            "source_hashes": {
+                name: digest
+                for name, digest in after_hashes.items()
+                if name.endswith(".py")
+            },
+            "environment_hashes": {
+                name: digest
+                for name, digest in after_hashes.items()
+                if _environment_file(name)
+            },
+        },
+        "comparison": comparison,
+        "findings": findings,
+        "summary": {
+            "pass": "Selected function preserves observable behavior within the supported model and stated assumptions.",
+            "fail": "A modeled behavior difference violates the requested preservation obligation.",
+            "incomplete": "Behavior preservation could not be established; inspect comparison.reasons.",
+        }[status],
+        "coverage": {
+            "state": "incomplete" if status == "incomplete" else "complete",
+            "check": "python_behavior_preservation",
+            "scope": "selected_function_and_resolved_helpers",
+            "max_paths": max_paths,
+            "max_depth": max_depth,
+            "reasons": comparison.get("reasons", []),
+        },
+    }

--- a/skylos/verification/render.py
+++ b/skylos/verification/render.py
@@ -1,0 +1,208 @@
+"""Readable terminal reports for verification, without exposing symbolic internals."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_DISPLAY_LIMIT = 20
+_TEXT_LIMIT = 1000
+
+
+def _text(value: Any, default: str = "") -> str:
+    """Keep repository-controlled text on its own printable terminal line."""
+    if not isinstance(value, str):
+        return default
+    escaped = []
+    for character in value[:_TEXT_LIMIT]:
+        if character.isprintable():
+            escaped.append(character)
+        elif character == "\n":
+            escaped.append("\\n")
+        elif character == "\r":
+            escaped.append("\\r")
+        elif character == "\t":
+            escaped.append("\\t")
+        else:
+            number = ord(character)
+            prefix, width = ("x", 2) if number < 256 else ("u", 4)
+            if number > 65535:
+                prefix, width = "U", 8
+            escaped.append(f"\\{prefix}{number:0{width}x}")
+    if len(value) > _TEXT_LIMIT:
+        escaped.append("... (truncated)")
+    return "".join(escaped) or default
+
+
+def _rows(value: Any) -> list[dict]:
+    return (
+        [row for row in value if isinstance(row, dict)]
+        if isinstance(value, list)
+        else []
+    )
+
+
+def _location(row: dict, *, behavior: bool = False) -> str:
+    keys = ("after_range", "before_range") if behavior else ("range",)
+    bounds = next((row[key] for key in keys if isinstance(row.get(key), dict)), {})
+    filename = _text(row.get("file") or bounds.get("file"), "<unknown file>")
+    line = bounds.get("start_line", row.get("line"))
+    if isinstance(line, int) and not isinstance(line, bool) and line > 0:
+        filename += f":{line}"
+    if behavior:
+        filename += f" — {_text(row.get('symbol'), '<unknown function>')}"
+    return filename
+
+
+def _reasons(value: Any, *, indent: str = "  ") -> list[str]:
+    reasons = value if isinstance(value, list) else []
+    lines = [
+        f"{indent}{_text(reason)}"
+        for reason in reasons[:_DISPLAY_LIMIT]
+        if isinstance(reason, str) and reason
+    ]
+    if len(reasons) > _DISPLAY_LIMIT:
+        lines.append(f"{indent}{len(reasons) - _DISPLAY_LIMIT} more reasons omitted.")
+    return lines
+
+
+def _findings(payload: dict) -> list[str]:
+    findings = _rows(payload.get("findings"))
+    if not findings:
+        return []
+    lines = ["", f"Code issues ({len(findings)})"]
+    for finding in findings[:_DISPLAY_LIMIT]:
+        rule = _text(finding.get("rule_id"), "Finding")
+        severity = _text(finding.get("severity"))
+        label = f"{rule} [{severity}]" if severity else rule
+        lines.append(f"  {_location(finding)} — {label}")
+        lines.append(f"    {_text(finding.get('message'), 'Review this finding.')}")
+        fix = _text(finding.get("suggested_fix"))
+        if fix:
+            lines.append(f"    Suggested fix: {fix}")
+    if len(findings) > _DISPLAY_LIMIT:
+        lines.append(f"  {len(findings) - _DISPLAY_LIMIT} more code issues omitted.")
+    return lines
+
+
+def _difference(comparison: dict) -> list[str]:
+    lines = [f"  {_location(comparison, behavior=True)}"]
+    differences = _rows(comparison.get("differences"))
+    for difference in differences[:_DISPLAY_LIMIT]:
+        explanation = difference.get("explanation")
+        explanation = explanation if isinstance(explanation, dict) else {}
+        title = _text(explanation.get("title"), "Behavior changed")
+        lines.append(f"    {title}")
+        explained = False
+        for key, label in (
+            ("before", "Before"),
+            ("after", "After"),
+            ("impact", "Impact"),
+            ("review", "Review"),
+        ):
+            message = _text(explanation.get(key))
+            if message:
+                lines.append(f"    {label}: {message}")
+                explained = True
+        if not explained:
+            lines.append(
+                "    The supported static model found a change, but no readable detail is available."
+            )
+            lines.append(
+                "    Review the function's calls, return value, and error handling."
+            )
+    if not differences:
+        lines.append(
+            "    Behavior changed; details are unavailable. Review whether the edit was intentional."
+        )
+    if len(differences) > _DISPLAY_LIMIT:
+        lines.append(
+            f"    {len(differences) - _DISPLAY_LIMIT} more differences omitted."
+        )
+    return lines
+
+
+def _behavior(payload: dict) -> list[str]:
+    behavior = payload.get("behavior")
+    if not isinstance(behavior, dict) or not behavior:
+        return []
+    status = behavior.get("status")
+    comparisons = _rows(behavior.get("comparisons"))
+    changed = [row for row in comparisons if row.get("status") == "different"]
+    unknown = [
+        row
+        for row in comparisons
+        if row.get("status") not in ("different", "equivalent")
+    ]
+    equivalent = sum(row.get("status") == "equivalent" for row in comparisons)
+    lines = ["", "Behavior comparison with HEAD"]
+    displayed = (changed + unknown)[:_DISPLAY_LIMIT]
+    for comparison in displayed:
+        if comparison.get("status") == "different":
+            lines.extend(_difference(comparison))
+        else:
+            lines.append(f"  {_location(comparison, behavior=True)}")
+            lines.append("    Could not establish whether behavior is preserved.")
+            lines.extend(_reasons(comparison.get("reasons"), indent="    "))
+    omitted = len(changed) + len(unknown) - len(displayed)
+    if omitted:
+        lines.append(f"  {omitted} more function comparisons needing review omitted.")
+    if equivalent:
+        noun = "function" if equivalent == 1 else "functions"
+        lines.append(
+            f"  {equivalent} affected {noun} equivalent within the supported static model."
+        )
+    if changed or status == "different":
+        if not changed:
+            lines.append(
+                "  Modeled behavior changed; function details are unavailable."
+            )
+            lines.append("  Review whether the behavior change was intentional.")
+    if status == "unknown":
+        lines.append("  Behavior comparison is incomplete.")
+    elif status == "unavailable":
+        lines.append("  Behavior comparison is unavailable.")
+    elif status == "unchanged" and not comparisons:
+        lines.append("  No affected Python functions found in the selected scope.")
+    elif status == "equivalent" and not equivalent:
+        lines.append("  Equivalent within the supported static model.")
+    elif status not in (
+        "different",
+        "equivalent",
+        "unchanged",
+        "unknown",
+        "unavailable",
+    ):
+        lines.append("  Behavior comparison status is unavailable.")
+    lines.extend(_reasons(behavior.get("reasons")))
+    if changed or equivalent:
+        lines.append(
+            "  Static comparison only; target code was not executed and external behavior is assumed stable."
+        )
+    if omitted or any(
+        len(_rows(row.get("differences"))) > _DISPLAY_LIMIT for row in displayed
+    ):
+        lines.append("  The JSON report contains all recorded comparisons.")
+    return lines
+
+
+def render_verify_report(payload: dict[str, Any]) -> str:
+    """Return plain text for an interactive ``skylos verify`` terminal."""
+    headline = {
+        "pass": "Verification passed",
+        "fail": "Verification found issues",
+        "incomplete": "Verification needs review",
+    }.get(payload.get("status"), "Verification status unavailable")
+    lines = [headline]
+    summary = _text(payload.get("summary"))
+    behavior = payload.get("behavior")
+    behavior_needs_review = isinstance(behavior, dict) and behavior.get("status") in {
+        "different",
+        "unknown",
+    }
+    if summary and not (
+        behavior_needs_review and summary.startswith("No AI-code issues found")
+    ):
+        lines.append(summary)
+    lines.extend(_findings(payload))
+    lines.extend(_behavior(payload))
+    return "\n".join(lines)

--- a/skylos/verify_change.py
+++ b/skylos/verify_change.py
@@ -42,6 +42,7 @@ def verify_change_path(
 ) -> dict[str, Any]:
     target = Path(path).expanduser()
     target_file = _optional_path(file)
+    _validate_verify_target(target, target_file)
     scan_target = _scan_target(target, target_file, project_context=project_context)
     root = _root_for_verify_target(target)
     contract_file = _contract_path_for_verify_target(
@@ -317,6 +318,22 @@ def _write_new_file_no_follow(path: Path, code: str) -> None:
                 os.close(fd)
             except OSError:
                 pass
+
+
+def _validate_verify_target(path: Path, target_file: Path | None) -> None:
+    # Validate the selected file even when analysis will scan its whole project.
+    selected = _scan_target(path, target_file, project_context=False)
+    for candidate in (path, selected):
+        if not candidate.exists():
+            raise ValueError(
+                f"Verification target does not exist: {candidate.absolute()}"
+            )
+        if not (candidate.is_file() or candidate.is_dir()):
+            raise ValueError(
+                f"Verification target must be a file or directory: {candidate.absolute()}"
+            )
+    if target_file is not None and not selected.is_file():
+        raise ValueError(f"--file must select a file: {selected.absolute()}")
 
 
 def _scan_target(

--- a/skylos/verify_change.py
+++ b/skylos/verify_change.py
@@ -88,7 +88,7 @@ def verify_change_path(
         changed_files=changed_files,
     )
 
-    return build_verify_change_response(
+    response = build_verify_change_response(
         analysis_result,
         project_root=root,
         target_file=target_file,
@@ -98,6 +98,21 @@ def verify_change_path(
         include_security_findings=include_security_findings,
         analyzer_owned=analyzer_owned,
     )
+    from skylos.verification.changes import compare_working_changes
+
+    behavior = compare_working_changes(
+        path, file=file, line_range=line_range, exclude_folders=exclude_folders
+    )
+    response["behavior"] = behavior
+    if behavior["status"] in {"different", "unknown"}:
+        if response["status"] == "pass":
+            response["status"] = "incomplete"
+        response["summary"] += (
+            "; behavior comparison needs review: modeled changes detected"
+            if behavior["status"] == "different"
+            else "; behavior comparison incomplete"
+        )
+    return response
 
 
 def verify_change_stdin_payload(

--- a/test/test_behavior_changes.py
+++ b/test/test_behavior_changes.py
@@ -1,0 +1,450 @@
+"""Automatic behavior comparison observes Git sources, never fixture execution."""
+
+from __future__ import annotations
+
+import os
+import hashlib
+from pathlib import Path
+import shutil
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
+from skylos.verification.changes import compare_working_changes
+
+
+_IDENTITY = "def run(value):\n    return value\n"
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+    return subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.strip()
+
+
+def _write(repo: Path, name: str, source: str) -> None:
+    path = repo / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(
+        repo,
+        "-c",
+        "user.name=Skylos Test",
+        "-c",
+        "user.email=skylos-test@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-qm",
+        message,
+    )
+
+
+def _register_local_submodule(repo: Path) -> Path:
+    """Register an existing local nested repository without clone or transport."""
+    dependency = repo / "dependency"
+    dependency.mkdir()
+    _git(dependency, "init", "-q")
+    _write(dependency, "module.py", _IDENTITY)
+    _git(dependency, "add", "--", "module.py")
+    _commit(dependency, "dependency baseline")
+    _write(
+        repo,
+        ".gitmodules",
+        '[submodule "dependency"]\n\tpath = dependency\n\turl = ./dependency\n',
+    )
+    _git(repo, "add", "--", ".gitmodules", "dependency")
+    _commit(repo, "register local dependency")
+    return dependency
+
+
+@pytest.fixture
+def change_repo(tmp_path):
+    if shutil.which("git") is None:
+        pytest.skip("git is required")
+
+    def create(files: dict[str, str]) -> tuple[Path, str]:
+        repo = tmp_path / "automatic comparison project"
+        repo.mkdir()
+        _git(repo, "init", "-q")
+        for name, source in files.items():
+            _write(repo, name, source)
+        _git(repo, "add", "--", *files)
+        _commit(repo, "baseline")
+        return repo, _git(repo, "rev-parse", "HEAD")
+
+    return create
+
+
+def _comparisons(result):
+    return {(item["file"], item["symbol"]): item for item in result["comparisons"]}
+
+
+def test_git_adapter_reuses_shared_service_once_and_preserves_byte_evidence(
+    change_repo, monkeypatch
+):
+    import skylos.verification.changes as changes
+
+    original = "# coding: latin-1\ndef run(value):\n    return value\n"
+    repo, commit = change_repo({"app.py": original})
+    changed_bytes = (
+        "# coding: latin-1\ndef run(value):\n    return 'caf\u00e9'\n".encode("latin-1")
+    )
+    (repo / "app.py").write_bytes(changed_bytes)
+    base_loader = Mock(wraps=changes._base_sources)
+    current_loader = Mock(wraps=changes._current_sources)
+    compare = changes.compare_source_changes
+    recorded = []
+
+    def record_comparison(*args, **kwargs):
+        result = compare(*args, **kwargs)
+        recorded.append(result)
+        return result
+
+    service = Mock(side_effect=record_comparison)
+    monkeypatch.setattr(changes, "_base_sources", base_loader)
+    monkeypatch.setattr(changes, "_current_sources", current_loader)
+    monkeypatch.setattr(changes, "compare_source_changes", service)
+
+    result = compare_working_changes(repo / "app.py")
+
+    base_loader.assert_called_once()
+    current_loader.assert_called_once()
+    service.assert_called_once()
+    before, after = service.call_args.args
+    assert before.sources["app.py"] == original
+    assert "caf\u00e9" in after.sources["app.py"]
+    assert after.hashes["app.py"] == hashlib.sha256(changed_bytes).hexdigest()
+    assert result["base"] == {
+        "ref": "HEAD",
+        "commit": commit,
+        "source_hashes": {"app.py": hashlib.sha256(original.encode()).hexdigest()},
+    }
+    assert result["current"]["source_hashes"] == dict(after.hashes)
+    for key, value in recorded[0].items():
+        if key != "assumptions":
+            assert result[key] == value
+    assert result["status"] == "different"
+    assert len(result["assumptions"]) == 4
+    assert len(recorded[0]["assumptions"]) == 1
+    assert result["assumptions"][:1] == recorded[0]["assumptions"]
+
+
+@pytest.mark.parametrize("file_scope", [False, True], ids=["directory", "file"])
+def test_changed_function_is_discovered_without_symbol_or_base(change_repo, file_scope):
+    repo, commit = change_repo({"app.py": _IDENTITY})
+    _write(repo, "app.py", "def run(value):\n    return 'changed'\n")
+
+    result = compare_working_changes(repo / "app.py" if file_scope else repo)
+
+    assert result["status"] == "different"
+    assert result["base"]["commit"] == commit
+    assert _comparisons(result)[("app.py", "run")]["status"] == "different"
+
+
+@pytest.mark.parametrize("file_scope", [False, True], ids=["directory", "file"])
+def test_changed_imported_helper_includes_unchanged_caller(change_repo, file_scope):
+    app = (
+        "from helpers import identity\n\ndef run(value):\n    return identity(value)\n"
+    )
+    repo, _ = change_repo(
+        {"app.py": app, "helpers.py": "def identity(value):\n    return value\n"}
+    )
+    _write(repo, "helpers.py", "def identity(value):\n    return 'changed'\n")
+
+    result = compare_working_changes(repo / "app.py" if file_scope else repo)
+
+    assert result["status"] == "different"
+    assert _comparisons(result)[("app.py", "run")]["status"] == "different"
+
+
+@pytest.mark.parametrize(
+    "separate_file", [False, True], ids=["local", "untracked-module"]
+)
+def test_extracted_helper_is_covered_by_existing_function(change_repo, separate_file):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    helper = "def identity(value):\n    return value\n"
+    if separate_file:
+        _write(repo, "helpers.py", helper)
+        prefix = "from helpers import identity\n\n"
+    else:
+        prefix = helper + "\n"
+    _write(repo, "app.py", prefix + "def run(value):\n    return identity(value)\n")
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "equivalent"
+    assert _comparisons(result)[("app.py", "run")]["status"] == "equivalent"
+    assert all(item["status"] == "equivalent" for item in result["comparisons"])
+
+
+def test_new_helper_selected_alone_has_no_compared_caller_baseline(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    _write(
+        repo,
+        "app.py",
+        "from helpers import identity\n\ndef run(value):\n    return identity(value)\n",
+    )
+    _write(repo, "helpers.py", "def identity(value):\n    return value\n")
+
+    result = compare_working_changes(repo / "helpers.py")
+
+    assert result["status"] == "unknown"
+    assert ("app.py", "run") not in _comparisons(result)
+    assert _comparisons(result)[("helpers.py", "identity")]["status"] == "unknown"
+
+
+def test_deleted_public_function_is_not_silently_ignored(change_repo):
+    repo, _ = change_repo(
+        {"app.py": _IDENTITY + "\ndef previously_available(value):\n    return value\n"}
+    )
+    _write(repo, "app.py", _IDENTITY)
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+    assert result["reasons"] or any(
+        item["status"] == "unknown" for item in result["comparisons"]
+    )
+
+
+def test_new_independent_function_has_no_baseline(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    _write(repo, "app.py", _IDENTITY + "\ndef new_entry(value):\n    return value\n")
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+    assert result["reasons"] or any(
+        item["status"] == "unknown" for item in result["comparisons"]
+    )
+
+
+def test_clean_working_tree_needs_no_behavior_obligation(change_repo):
+    repo, commit = change_repo({"app.py": _IDENTITY})
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unchanged"
+    assert result["base"]["commit"] == commit
+    assert result["comparisons"] == []
+
+
+def test_non_git_project_reports_baseline_unavailable(tmp_path):
+    app = tmp_path / "app.py"
+    app.write_text(_IDENTITY, encoding="utf-8")
+
+    result = compare_working_changes(tmp_path)
+
+    assert result["status"] == "unavailable"
+    assert result["reasons"]
+
+
+def test_changed_module_state_cannot_report_unchanged(change_repo):
+    repo, _ = change_repo({"app.py": "MODE = 'before'\n\n" + _IDENTITY})
+    _write(repo, "app.py", "MODE = 'after'\n\n" + _IDENTITY)
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] in {"different", "unknown"}
+
+
+def test_import_binding_change_cannot_hide_behind_unchanged_function_ast(change_repo):
+    function = "\ndef run(value):\n    return emit(value)\n"
+    repo, _ = change_repo({"app.py": "from old_fixture_api import emit\n" + function})
+    _write(repo, "app.py", "from new_fixture_api import emit\n" + function)
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] in {"different", "unknown"}
+    assert ("app.py", "run") in _comparisons(result)
+
+
+def test_dependency_change_with_unchanged_python_requires_qualification(change_repo):
+    repo, _ = change_repo(
+        {"app.py": _IDENTITY, "requirements.txt": "fixture-dependency==1.0\n"}
+    )
+    _write(repo, "requirements.txt", "fixture-dependency==2.0\n")
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+    assert result["reasons"]
+
+
+def test_line_range_limits_obligations_to_selected_function(change_repo):
+    before = (
+        "def first(value):\n    return value\n\ndef second(value):\n    return value\n"
+    )
+    after = "def first(value):\n    return 'changed'\n\ndef second(value):\n    return value\n"
+    repo, _ = change_repo({"app.py": before})
+    _write(repo, "app.py", after)
+
+    result = compare_working_changes(repo / "app.py", line_range="4:5")
+
+    assert result["status"] in {"unchanged", "equivalent"}
+    assert ("app.py", "first") not in _comparisons(result)
+
+
+def test_directory_file_scope_rejects_parent_escape(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY, "pkg/app.py": _IDENTITY})
+
+    with pytest.raises(ValueError):
+        compare_working_changes(repo / "pkg", file="../app.py")
+
+
+def test_selected_subdirectory_uses_repository_relative_file_identity(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY, "pkg/app.py": _IDENTITY})
+    _write(repo, "pkg/app.py", "def run(value):\n    return 'changed'\n")
+
+    result = compare_working_changes(repo / "pkg", file="app.py")
+
+    assert result["status"] == "different"
+    assert ("pkg/app.py", "run") in _comparisons(result)
+    assert ("app.py", "run") not in _comparisons(result)
+
+
+def test_module_source_is_never_executed(change_repo, tmp_path):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    marker = tmp_path / "fixture must not run"
+    _write(repo, "app.py", f"open({str(marker)!r}, 'w').write('ran')\n\n" + _IDENTITY)
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "before,after",
+    [
+        (
+            "class Worker:\n    def run(self, value):\n        return value\n",
+            "class Worker:\n    def run(self, value):\n        return 'changed'\n",
+        ),
+        (
+            "async def run(value):\n    return value\n",
+            "async def run(value):\n    return 'changed'\n",
+        ),
+    ],
+    ids=["method", "async-function"],
+)
+def test_changed_unsupported_function_shape_is_not_ignored(change_repo, before, after):
+    repo, _ = change_repo({"app.py": before})
+    _write(repo, "app.py", after)
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+
+
+def test_deleted_python_module_is_not_ignored(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY, "removed.py": _IDENTITY})
+    (repo / "removed.py").unlink()
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+
+
+def test_comments_and_formatting_do_not_create_a_behavior_difference(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    _write(
+        repo,
+        "app.py",
+        "# Explanation\n\ndef run(value):\n    return (value)  # Same result\n",
+    )
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] in {"equivalent", "unchanged"}
+
+
+def test_reordered_effectful_function_headers_are_not_treated_as_formatting(
+    change_repo,
+):
+    first = "def first(value=record('first')):\n    return value\n"
+    second = "def second(value=record('second')):\n    return value\n"
+    repo, _ = change_repo({"app.py": first + "\n" + second})
+    _write(repo, "app.py", second + "\n" + first)
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+
+
+def test_line_scoped_caller_includes_changed_same_module_helper(change_repo):
+    before = (
+        "def helper(value):\n    return value\n\n"
+        "def run(value):\n    callback = helper\n    return callback(value)\n"
+    )
+    after = before.replace("return value", "return 'changed'", 1)
+    repo, _ = change_repo({"app.py": before})
+    _write(repo, "app.py", after)
+
+    result = compare_working_changes(repo / "app.py", line_range="4:6")
+
+    assert result["status"] == "different"
+    assert set(_comparisons(result)) == {("app.py", "run")}
+
+
+def test_unsupported_global_alias_cannot_hide_changed_helper_from_scoped_caller(
+    change_repo,
+):
+    before = (
+        "def helper(value):\n    return value\n\n"
+        "callback = helper\n\n"
+        "def run(value):\n    return callback(value)\n"
+    )
+    after = before.replace("return value", "return 'changed'", 1)
+    repo, _ = change_repo({"app.py": before})
+    _write(repo, "app.py", after)
+
+    result = compare_working_changes(repo / "app.py", line_range="6:7")
+
+    assert result["status"] == "unknown"
+
+
+def test_unchanged_registered_submodule_allows_application_comparison(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    _register_local_submodule(repo)
+    _write(repo, "app.py", "def run(value):\n    return 'changed'\n")
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "different"
+    assert _comparisons(result)[("app.py", "run")]["status"] == "different"
+    assert "dependency/module.py" not in result["base"]["source_hashes"]
+    assert any("submodule" in assumption for assumption in result["assumptions"])
+
+
+@pytest.mark.parametrize(
+    "commit_dependency", [False, True], ids=["dirty", "new-commit"]
+)
+def test_changed_registered_submodule_requires_qualification(
+    change_repo, commit_dependency
+):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    dependency = _register_local_submodule(repo)
+    _write(dependency, "module.py", "def run(value):\n    return 'changed'\n")
+    if commit_dependency:
+        _git(dependency, "add", "--", "module.py")
+        _commit(dependency, "dependency behavior changed")
+
+    result = compare_working_changes(repo)
+
+    assert result["status"] == "unknown"
+    assert any("submodule" in reason for reason in result["reasons"])

--- a/test/test_behavior_changes.py
+++ b/test/test_behavior_changes.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from skylos.core.safe_cache_io import write_text_no_symlink
 from skylos.verification.changes import compare_working_changes
 
 
@@ -35,7 +36,7 @@ def _git(repo: Path, *args: str) -> str:
 def _write(repo: Path, name: str, source: str) -> None:
     path = repo / name
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(source, encoding="utf-8")
+    assert write_text_no_symlink(path, source, encoding="utf-8")
 
 
 def _commit(repo: Path, message: str) -> None:

--- a/test/test_behavior_comparison.py
+++ b/test/test_behavior_comparison.py
@@ -1,0 +1,263 @@
+"""Shared behavior facts use supplied source snapshots without command or Git IO."""
+
+from dataclasses import FrozenInstanceError
+import hashlib
+import io
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from skylos.verification.comparison import (
+    ComparisonScope,
+    SourceSnapshot,
+    compare_source_changes,
+)
+
+
+_IDENTITY = "def run(value):\n    return value\n"
+_CHANGED = "def run(value):\n    return None\n"
+
+
+def _snapshot(sources, *, hashes=None):
+    if hashes is None:
+        hashes = {
+            name: hashlib.sha256(source.encode()).hexdigest()
+            for name, source in sources.items()
+        }
+    return SourceSnapshot(sources=sources, hashes=hashes)
+
+
+def _comparisons(result):
+    return {(item["file"], item["symbol"]): item for item in result["comparisons"]}
+
+
+def test_return_loss_preserves_explanation_as_behavior_facts():
+    before = _snapshot(
+        {"app.py": "def run(callback, value):\n    return callback(value)\n"}
+    )
+    after = _snapshot(
+        {"app.py": "def run(callback, value):\n    callback(value)\n    return None\n"}
+    )
+
+    result = compare_source_changes(before, after)
+
+    assert result["status"] == "different"
+    assert result["changed_files"] == ["app.py"]
+    comparison = _comparisons(result)[("app.py", "run")]
+    assert comparison["status"] == "different"
+    explanation = comparison["differences"][0]["explanation"]
+    assert explanation["title"] == "Callback result discarded"
+    assert "callback(value)" in explanation["before"]
+    assert "None" in explanation["after"]
+    assert result["runtime_witness"] is False
+    assert {"base", "current", "exit_code", "tool"}.isdisjoint(result)
+    assert not any("git" in text.lower() for text in result["assumptions"])
+
+
+def test_extracted_helper_is_compared_through_existing_caller():
+    before = _snapshot({"app.py": _IDENTITY})
+    after = _snapshot(
+        {
+            "app.py": (
+                "from helpers import identity\n\n"
+                "def run(value):\n    return identity(value)\n"
+            ),
+            "helpers.py": "def identity(value):\n    return value\n",
+        }
+    )
+
+    result = compare_source_changes(before, after)
+
+    assert result["status"] == "equivalent"
+    assert set(_comparisons(result)) == {("app.py", "run")}
+
+
+@pytest.mark.parametrize("hash_mode", ["missing", "stale"])
+def test_changed_helper_selects_unchanged_caller_even_without_reliable_hashes(
+    hash_mode,
+):
+    app = (
+        "from helpers import identity\n\ndef run(value):\n    return identity(value)\n"
+    )
+    before_sources = {
+        "app.py": app,
+        "helpers.py": "def identity(value):\n    return value\n",
+    }
+    after_sources = {
+        "app.py": app,
+        "helpers.py": "def identity(value):\n    return None\n",
+    }
+    hashes = (
+        {} if hash_mode == "missing" else {name: "stale" for name in before_sources}
+    )
+
+    result = compare_source_changes(
+        _snapshot(before_sources, hashes=hashes),
+        _snapshot(after_sources, hashes=hashes),
+        scope=ComparisonScope(selected="app.py", directory=False),
+    )
+
+    assert result["status"] == "different"
+    assert result["changed_files"] == ["helpers.py"]
+    assert set(_comparisons(result)) == {("app.py", "run")}
+    assert _comparisons(result)[("app.py", "run")]["status"] == "different"
+
+
+def test_python_hash_difference_alone_does_not_create_a_source_edit():
+    sources = {"app.py": _IDENTITY}
+
+    result = compare_source_changes(
+        _snapshot(sources, hashes={"app.py": "original-encoded-bytes"}),
+        _snapshot(sources, hashes={"app.py": "different-encoded-bytes"}),
+    )
+
+    assert result["status"] == "unchanged"
+    assert result["changed_files"] == []
+    assert result["comparisons"] == []
+
+
+def test_snapshot_copies_inputs_and_preserves_supplied_byte_hashes():
+    sources = {"app.py": _IDENTITY}
+    hashes = {"app.py": "hash-of-original-bytes"}
+    before = SourceSnapshot(sources=sources, hashes=hashes)
+    after = _snapshot({"app.py": _CHANGED})
+    sources["app.py"] = _CHANGED
+    hashes["app.py"] = "mutated-by-caller"
+
+    assert before.sources["app.py"] == _IDENTITY
+    assert before.hashes["app.py"] == "hash-of-original-bytes"
+    with pytest.raises(TypeError):
+        before.sources["app.py"] = _CHANGED
+    with pytest.raises(TypeError):
+        before.hashes["app.py"] = "mutated"
+    with pytest.raises(FrozenInstanceError):
+        before.sources = {}
+
+    result = compare_source_changes(before, after)
+    assert result["status"] == "different"
+    assert compare_source_changes(before, after) == result
+    assert before.hashes["app.py"] == "hash-of-original-bytes"
+
+
+def test_subdirectory_scope_excludes_generated_functions():
+    names = ("app.py", "pkg/app.py", "pkg/generated/app.py")
+    before = _snapshot({name: _IDENTITY for name in names})
+    after = _snapshot({name: _CHANGED for name in names})
+    excluded = {"generated"}
+    scope = ComparisonScope(selected="pkg", exclude_folders=excluded)
+    excluded.clear()
+
+    result = compare_source_changes(before, after, scope=scope)
+
+    assert result["status"] == "different"
+    assert set(_comparisons(result)) == {("pkg/app.py", "run")}
+    assert scope.exclude_folders == frozenset({"generated"})
+
+
+@pytest.mark.parametrize("parameter", ["value", "value: str"])
+def test_excluded_selected_file_has_no_comparisons_even_with_unsupported_syntax(
+    parameter,
+):
+    result = compare_source_changes(
+        _snapshot({"generated/app.py": f"def run({parameter}):\n    return value\n"}),
+        _snapshot({"generated/app.py": f"def run({parameter}):\n    return None\n"}),
+        scope=ComparisonScope(
+            selected="generated/app.py",
+            directory=False,
+            exclude_folders=frozenset({"generated"}),
+        ),
+    )
+
+    assert result["status"] == "unchanged"
+    assert result["comparisons"] == []
+    assert result["reasons"] == []
+
+
+def test_line_scope_selects_only_intersecting_changed_function():
+    before = _snapshot(
+        {
+            "app.py": "def first(value):\n    return value\n\ndef second(value):\n    return value\n"
+        }
+    )
+    after = _snapshot(
+        {
+            "app.py": "def first(value):\n    return None\n\ndef second(value):\n    return None\n"
+        }
+    )
+
+    result = compare_source_changes(
+        before,
+        after,
+        scope=ComparisonScope(selected="app.py", directory=False, line_range=(4, 5)),
+    )
+
+    assert result["status"] == "different"
+    assert set(_comparisons(result)) == {("app.py", "second")}
+
+
+def test_environment_hash_change_qualifies_unchanged_python():
+    sources = {"app.py": _IDENTITY}
+    before = _snapshot(sources, hashes={"pyproject.toml": "old-environment-bytes"})
+    after = _snapshot(sources, hashes={"pyproject.toml": "new-environment-bytes"})
+
+    result = compare_source_changes(before, after)
+
+    assert result["status"] == "unknown"
+    assert any("pyproject.toml" in reason for reason in result["reasons"])
+    assert result["changed_files"] == []
+    assert _comparisons(result)[("app.py", "run")]["status"] == "equivalent"
+
+
+def test_deleted_symbol_is_unknown_without_requiring_a_current_file():
+    result = compare_source_changes(
+        _snapshot({"removed.py": _IDENTITY}),
+        _snapshot({}),
+        scope=ComparisonScope(selected="removed.py", directory=False),
+    )
+
+    assert result["status"] == "unknown"
+    assert result["changed_files"] == ["removed.py"]
+    assert _comparisons(result)[("removed.py", "run")]["status"] == "unknown"
+
+
+def test_function_budget_reports_unassessed_work_instead_of_completeness():
+    before_source = "\n".join(
+        f"def function_{index}(value):\n    return value\n" for index in range(129)
+    )
+    after_source = "\n".join(
+        f"def function_{index}(value):\n    return None\n" for index in range(129)
+    )
+
+    result = compare_source_changes(
+        _snapshot({"app.py": before_source}),
+        _snapshot({"app.py": after_source}),
+    )
+
+    assert result["status"] == "unknown"
+    assert len(result["comparisons"]) == 128
+    assert all(item["status"] == "different" for item in result["comparisons"])
+    assert any("budget exhausted" in reason.lower() for reason in result["reasons"])
+
+
+def test_comparison_uses_no_filesystem_process_or_analyzer_io(monkeypatch):
+    import skylos
+    import skylos.analyzer
+
+    before = _snapshot({"app.py": _IDENTITY})
+    after = _snapshot({"app.py": _CHANGED})
+
+    def unexpected_io(*args, **kwargs):
+        raise AssertionError("Shared comparison must only inspect supplied source data")
+
+    with monkeypatch.context() as blocked:
+        blocked.setattr("builtins.open", unexpected_io)
+        blocked.setattr(io, "open", unexpected_io)
+        blocked.setattr(Path, "stat", unexpected_io)
+        blocked.setattr(subprocess, "run", unexpected_io)
+        blocked.setattr(subprocess, "Popen", unexpected_io)
+        blocked.setattr(skylos, "analyze", unexpected_io)
+        blocked.setattr(skylos.analyzer, "analyze", unexpected_io)
+        result = compare_source_changes(before, after)
+
+    assert result["status"] == "different"

--- a/test/test_behavior_engine.py
+++ b/test/test_behavior_engine.py
@@ -1,0 +1,198 @@
+"""Behavior-model unit tests; fixture sources are parsed, never executed."""
+
+import json
+from textwrap import dedent
+
+import pytest
+
+from skylos.verification.behavior import compare_python_behavior
+
+
+def compare(before, after, **options):
+    return compare_python_behavior(
+        {"app.py": dedent(before)},
+        {"app.py": dedent(after)},
+        file="app.py",
+        symbol="run",
+        **options,
+    )
+
+
+def test_relative_import_helper_extraction_and_keyword_binding():
+    before = {"pkg/app.py": "def run(callback, value):\n    return callback(value)\n"}
+    after = {
+        "pkg/app.py": (
+            "from .helpers import apply\n"
+            "def run(callback, value):\n"
+            "    return apply(item=value, transform=callback)\n"
+        ),
+        "pkg/helpers.py": (
+            "def apply(transform, *, item):\n    return transform(item)\n"
+        ),
+    }
+    result = compare_python_behavior(before, after, file="pkg/app.py", symbol="run")
+    assert result["status"] == "equivalent", result
+    assert result["after_range"] == {"start_line": 2, "end_line": 3}
+    assert result["model_version"] == 1
+    json.dumps(result)
+
+
+def test_assignment_alias_and_eager_argument_evaluation_preserve_effects():
+    result = compare(
+        """
+        def run(callback, prepare, value):
+            return callback(prepare(value))
+        """,
+        """
+        def run(callback, prepare, value):
+            invoke = callback
+            item = prepare(value)
+            return invoke(item)
+        """,
+    )
+    assert result["status"] == "equivalent", result
+
+
+def test_argument_evaluation_order_is_observable():
+    result = compare(
+        """
+        def run(callback, left, right):
+            return callback(left(), right())
+        """,
+        """
+        def run(callback, left, right):
+            second = right()
+            first = left()
+            return callback(first, second)
+        """,
+    )
+    assert result["status"] == "different", result
+    assert result["differences"][0]["runtime_witness"] is False
+
+
+def test_active_exception_context_is_part_of_cleanup_observation():
+    result = compare(
+        """
+        def run(callback, cleanup):
+            try:
+                callback()
+            except BaseException:
+                cleanup()
+            else:
+                cleanup()
+        """,
+        """
+        def run(callback, cleanup):
+            try:
+                callback()
+            except BaseException:
+                pass
+            cleanup()
+        """,
+    )
+    assert result["status"] == "different", result
+    evidence = result["differences"][0]
+    assert any(
+        call["active_exception"] is not None for call in evidence["before"]["calls"]
+    )
+
+
+def test_helper_keeps_caller_exception_context():
+    result = compare(
+        """
+        def run(callback, cleanup):
+            try:
+                callback()
+            except BaseException:
+                cleanup()
+                raise
+        """,
+        """
+        def finish(cleanup):
+            cleanup()
+            raise
+
+        def run(callback, cleanup):
+            try:
+                callback()
+            except BaseException:
+                finish(cleanup)
+        """,
+    )
+    assert result["status"] == "equivalent", result
+
+
+def test_except_alias_is_cleared_after_handler():
+    source = """
+    def run(callback):
+        try:
+            callback()
+        except BaseException as error:
+            pass
+        return error
+    """
+    result = compare(source, source)
+    assert result["status"] == "unknown", result
+    assert any("before assignment" in reason for reason in result["reasons"])
+
+
+def test_explicit_raise_of_saved_exception_under_new_context_is_unknown():
+    source = """
+    def run(callback, cleanup):
+        try:
+            callback()
+        except BaseException as error:
+            try:
+                cleanup()
+            except BaseException:
+                raise error
+    """
+    assert compare(source, source)["status"] == "unknown"
+
+
+def test_missing_previously_local_dependency_is_unknown():
+    source = "from helper import apply\ndef run(value):\n    return apply(value)\n"
+    result = compare_python_behavior(
+        {"app.py": source, "helper.py": "def apply(value):\n    return value\n"},
+        {"app.py": source},
+        file="app.py",
+        symbol="run",
+    )
+    assert result["status"] == "unknown", result
+    assert any("unavailable" in reason for reason in result["reasons"])
+
+
+@pytest.mark.parametrize(
+    "call", ["apply()", "apply(value, value)", "apply(other=value)"]
+)
+def test_invalid_local_helper_argument_binding_is_unknown(call):
+    source = (
+        f"def apply(value):\n    return value\ndef run(value):\n    return {call}\n"
+    )
+    assert compare(source, source)["status"] == "unknown"
+
+
+def test_helper_depth_budget_is_unknown():
+    source = """
+    def apply(value):
+        return value
+    def run(value):
+        return apply(value)
+    """
+    result = compare(source, source, max_depth=1)
+    assert result["status"] == "unknown", result
+    assert any("depth budget" in reason for reason in result["reasons"])
+
+
+@pytest.mark.parametrize("budget", [0, -1, True, 1.5])
+def test_invalid_budgets_fail_closed(budget):
+    source = "def run(value):\n    return value\n"
+    assert compare(source, source, max_paths=budget)["status"] == "unknown"
+
+
+def test_no_import_or_execution_of_fixture_code(tmp_path):
+    marker = tmp_path / "must-not-be-created"
+    source = f"open({str(marker)!r}, 'w')\ndef run(value):\n    return value\n"
+    result = compare(source, source)
+    assert result["status"] == "unknown", result
+    assert not marker.exists()

--- a/test/test_behavior_explanations.py
+++ b/test/test_behavior_explanations.py
@@ -1,0 +1,199 @@
+"""Plain-language evidence tests; fixture programs are parsed, never run."""
+
+from copy import deepcopy
+import json
+
+import pytest
+
+from skylos.verification.behavior import compare_python_behavior
+from skylos.verification.explanations import explain_difference
+
+
+def _difference(before, after):
+    comparison = compare_python_behavior(
+        {"app.py": before}, {"app.py": after}, file="app.py", symbol="run"
+    )
+    assert comparison["status"] == "different", comparison
+    assert len(comparison["differences"]) == 1
+    difference = comparison["differences"][0]
+    assert difference["runtime_witness"] is False
+    explanation = difference["explanation"]
+    for field in ("title", "before", "after", "impact", "review"):
+        assert isinstance(explanation[field], str) and explanation[field]
+    return difference
+
+
+def test_discarded_callback_result_explains_caller_visible_change():
+    difference = _difference(
+        "def run(callback, value):\n    return callback(value)\n",
+        "def run(callback, value):\n    callback(value)\n    return None\n",
+    )
+    explanation = difference["explanation"]
+    assert explanation["title"] == "Callback result discarded"
+    assert "callback(value)" in explanation["before"]
+    assert "None" in explanation["after"]
+    assert "caller" in explanation["impact"].lower()
+    assert any(
+        word in explanation["review"].lower()
+        for word in ("intentional", "intended")
+    )
+    assert difference["before"]["value"] == ("result", 0)
+    assert difference["after"]["value"] == ("constant", "NoneType", "None")
+
+
+def test_changed_constant_return_is_not_described_as_discarded_callback():
+    explanation = _difference(
+        "def run(callback):\n    callback()\n    return 1\n",
+        "def run(callback):\n    callback()\n    return 2\n",
+    )["explanation"]
+    assert explanation["title"] == "Return value changed"
+    assert "1" in explanation["before"]
+    assert "2" in explanation["after"]
+
+
+def test_swallowed_exception_explains_propagation_for_matching_call_history():
+    difference = _difference(
+        "def run(callback):\n    return callback()\n",
+        "def run(callback):\n"
+        "    try:\n"
+        "        return callback()\n"
+        "    except BaseException:\n"
+        "        return None\n",
+    )
+    assert difference["before"]["calls"] == difference["after"]["calls"]
+    explanation = difference["explanation"]
+    assert explanation["title"] == "Exception no longer propagated"
+    assert "callback()" in explanation["before"]
+    assert "None" in explanation["after"]
+    assert any(
+        word in explanation["impact"].lower()
+        for word in ("caller", "failure", "error", "exception")
+    )
+
+
+def test_parameter_kind_change_has_signature_explanation():
+    explanation = _difference(
+        "def run(value):\n    return value\n",
+        "def run(*, value):\n    return value\n",
+    )["explanation"]
+    assert explanation["title"] == "Function signature changed"
+    assert "value" in explanation["before"]
+    assert "value" in explanation["after"]
+    assert explanation["before"] != explanation["after"]
+
+
+def test_nested_call_result_is_readable_without_symbolic_tuple_jargon():
+    explanation = _difference(
+        "def run(callback, prepare, value):\n"
+        "    return callback(prepare(value))\n",
+        "def run(callback, prepare, value):\n"
+        "    callback(prepare(value))\n"
+        "    return None\n",
+    )["explanation"]
+    assert "callback(prepare(value))" in explanation["before"]
+    assert "('result'," not in explanation["before"]
+    assert "('parameter'," not in explanation["before"]
+
+
+def test_unmatched_call_histories_do_not_claim_a_same_call_return_change():
+    difference = _difference(
+        "def run(left, right):\n    return left()\n",
+        "def run(left, right):\n    return right()\n",
+    )
+    explanation = difference["explanation"]
+    assert explanation["title"] in {
+        "Call sequence changed",
+        "Behavior changed on compared paths",
+    }
+    assert "left()" in explanation["before"]
+    assert "right()" in explanation["after"]
+
+
+def test_different_call_histories_prevent_exception_swallowing_claim():
+    before_call = {
+        "target": ("parameter", "left"),
+        "args": (),
+        "kwargs": (),
+        "outcome": "raise",
+        "active_exception": None,
+    }
+    after_call = {
+        "target": ("parameter", "right"),
+        "args": (),
+        "kwargs": (),
+        "outcome": "return",
+        "active_exception": None,
+    }
+    explanation = explain_difference(
+        {
+            "kind": "behavior_trace",
+            "before": {
+                "calls": [before_call],
+                "outcome": "raise",
+                "value": ("exception", 0, None),
+            },
+            "after": {
+                "calls": [after_call],
+                "outcome": "return",
+                "value": ("constant", "NoneType", "None"),
+            },
+        }
+    )
+    assert explanation["title"] in {
+        "Call sequence changed",
+        "Behavior changed on compared paths",
+    }
+
+
+@pytest.mark.parametrize(
+    "difference",
+    [
+        {"kind": "behavior_trace", "before": None, "after": None},
+        {"kind": "behavior_trace"},
+        {
+            "kind": "behavior_trace",
+            "before": None,
+            "after": {
+                "calls": [],
+                "outcome": "return",
+                "value": ("constant", "NoneType", "None"),
+            },
+        },
+    ],
+)
+def test_missing_trace_evidence_is_handled_without_inventing_a_change(difference):
+    explanation = explain_difference(difference)
+    assert explanation["title"] == "Behavior changed on compared paths"
+    for field in ("title", "before", "after", "impact", "review"):
+        assert isinstance(explanation[field], str) and explanation[field]
+
+
+def test_serialized_json_trace_has_the_same_explanation_and_keeps_evidence():
+    difference = _difference(
+        "def run(callback, prepare, value):\n"
+        "    return callback(prepare(value), flag=True)\n",
+        "def run(callback, prepare, value):\n"
+        "    callback(prepare(value), flag=True)\n"
+        "    return None\n",
+    )
+    before = deepcopy(difference)
+    serialized = json.loads(json.dumps(difference))
+    assert explain_difference(serialized) == explain_difference(difference)
+    assert difference == before
+    assert "flag=True" in difference["explanation"]["before"]
+    assert difference["before"]["calls"][1]["kwargs"] == (
+        ("flag", ("constant", "bool", "True")),
+    )
+
+
+def test_explanation_does_not_claim_an_executed_or_proven_regression():
+    difference = _difference(
+        "def run(value):\n    return value\n",
+        "def run(value):\n    return None\n",
+    )
+    prose = " ".join(difference["explanation"].values()).lower()
+    assert "proven regression" not in prose
+    assert "verified by execution" not in prose
+    assert "execution proved" not in prose
+    assert "will break" not in prose
+    assert difference["runtime_witness"] is False

--- a/test/test_behavior_soundness.py
+++ b/test/test_behavior_soundness.py
@@ -1,0 +1,368 @@
+"""Independent source-as-data checks for bounded refactor verification.
+
+None of these snippets is imported or executed. The assertions exercise the
+verifier's handling of observable effects and its refusal to certify code
+outside the supported model.
+"""
+
+from textwrap import dedent
+
+import pytest
+
+from skylos.verification.behavior import compare_python_behavior
+
+
+def _compare(before, after, *, before_extra=None, after_extra=None, **options):
+    return compare_python_behavior(
+        {"app.py": dedent(before), **(before_extra or {})},
+        {"app.py": dedent(after), **(after_extra or {})},
+        file="app.py",
+        symbol="run",
+        **options,
+    )
+
+
+def test_helper_extraction_preserves_callback_results_and_exceptions():
+    result = _compare(
+        """
+        def run(callback, value):
+            return callback(value)
+        """,
+        """
+        def apply(transform, item):
+            return transform(item)
+
+        def run(callback, value):
+            return apply(callback, value)
+        """,
+    )
+    assert result["status"] == "equivalent", result
+
+
+def test_imported_helper_implementation_is_part_of_the_comparison():
+    source = "from helpers import prepare\ndef run(value):\n    return prepare(value)\n"
+    result = _compare(
+        source,
+        source,
+        before_extra={"helpers.py": "def prepare(value):\n    return 'original'\n"},
+        after_extra={"helpers.py": "def prepare(value):\n    return 'changed'\n"},
+    )
+    assert result["status"] == "different", result
+
+
+@pytest.mark.parametrize("body", ["return register(helper)", "return helper"])
+def test_escaping_helper_does_not_hide_changed_implementation(body):
+    result = _compare(
+        f"def helper(value):\n    return 'original'\ndef run(register):\n    {body}\n",
+        f"def helper(value):\n    return 'changed'\ndef run(register):\n    {body}\n",
+    )
+    assert result["status"] != "equivalent", result
+
+
+@pytest.mark.parametrize(
+    ("before_body", "after_body"),
+    [
+        ("return True", "return 1"),
+        ("return 1", "return 1.0"),
+        ("callback(value)\n    return None", "return None"),
+        (
+            "callback(value)\n    return callback(value)",
+            "return callback(value)",
+        ),
+        ("return callback(value, label='a')", "return callback(value, label='b')"),
+        (
+            "return callback(first=value, second=1)",
+            "return callback(second=1, first=value)",
+        ),
+    ],
+)
+def test_supported_observable_changes_are_not_certified(before_body, after_body):
+    result = _compare(
+        f"def run(callback, value):\n    {before_body}\n",
+        f"def run(callback, value):\n    {after_body}\n",
+    )
+    assert result["status"] == "different", result
+
+
+def test_finally_cleanup_survives_helper_extraction():
+    result = _compare(
+        """
+        def run(callback, cleanup, value):
+            try:
+                return callback(value)
+            finally:
+                cleanup()
+        """,
+        """
+        def apply(callback, cleanup, value):
+            try:
+                return callback(value)
+            finally:
+                cleanup()
+
+        def run(callback, cleanup, value):
+            return apply(callback, cleanup, value)
+        """,
+    )
+    assert result["status"] == "equivalent", result
+
+
+def test_finally_return_does_not_erase_prior_callback_effects():
+    result = _compare(
+        """
+        def run(callback, value):
+            try:
+                callback(value)
+            finally:
+                return 'done'
+        """,
+        """
+        def run(callback, value):
+            return 'done'
+        """,
+    )
+    assert result["status"] == "different", result
+
+
+def test_moving_finally_cleanup_changes_exception_behavior_and_order():
+    result = _compare(
+        """
+        def run(callback, cleanup, value):
+            try:
+                return callback(value)
+            finally:
+                cleanup()
+        """,
+        """
+        def run(callback, cleanup, value):
+            cleanup()
+            return callback(value)
+        """,
+    )
+    assert result["status"] == "different", result
+
+
+def test_swallowing_callback_exception_changes_behavior():
+    result = _compare(
+        """
+        def run(callback, value):
+            return callback(value)
+        """,
+        """
+        def run(callback, value):
+            try:
+                return callback(value)
+            except BaseException:
+                return None
+        """,
+    )
+    assert result["status"] == "different", result
+
+
+def test_catch_and_reraise_preserves_the_original_exception():
+    result = _compare(
+        """
+        def run(callback, value):
+            return callback(value)
+        """,
+        """
+        def run(callback, value):
+            try:
+                return callback(value)
+            except BaseException:
+                raise
+        """,
+    )
+    assert result["status"] == "equivalent", result
+
+
+def test_finally_reraise_uses_the_current_exception_after_nested_call():
+    result = _compare(
+        """
+        def run(callback, cleanup):
+            try:
+                callback()
+            except BaseException:
+                cleanup()
+                raise
+        """,
+        """
+        def run(callback, cleanup):
+            try:
+                callback()
+            except BaseException:
+                try:
+                    cleanup()
+                finally:
+                    raise
+        """,
+    )
+    assert result["status"] == "equivalent", result
+
+
+def test_keyword_parameter_rename_cannot_be_certified_by_positional_trace():
+    result = _compare(
+        "def run(value):\n    return value\n",
+        "def run(item):\n    return item\n",
+    )
+    assert result["status"] != "equivalent", result
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def run(value=1):\n    return value\n",
+        "@decorate\ndef run(value):\n    return value\n",
+        "def run(value: int):\n    return value\n",
+        "def run(value):\n    return value.name\n",
+        "def run(value):\n    return value[0]\n",
+        "def run(value):\n    return value + 0\n",
+        "def run(value):\n    yield value\n",
+        "async def run(value):\n    return value\n",
+        "def run(value):\n    with value:\n        return None\n",
+        "def run(callback):\n    try:\n        callback()\n    except Exception:\n        return None\n",
+        "def run(value):\n    return run(value)\n",
+        "def run(value, value):\n    return value\n",
+        "def run(value):\n    __debug__ = value\n    return value\n",
+    ],
+)
+def test_identical_unsupported_source_is_unknown(source):
+    result = _compare(source, source)
+    assert result["status"] == "unknown", result
+
+
+def test_shadowed_baseexception_is_not_treated_as_builtin_catch_all():
+    source = """
+    def run(BaseException, callback):
+        try:
+            callback()
+        except BaseException:
+            return None
+    """
+    result = _compare(source, source)
+    assert result["status"] == "unknown", result
+
+
+def test_module_rebinding_is_not_ignored_even_with_identical_selected_function():
+    result = _compare(
+        """
+        def helper(value):
+            return value
+
+        def run(value):
+            return helper(value)
+        """,
+        """
+        def helper(value):
+            return value
+
+        def run(value):
+            return helper(value)
+
+        helper = replacement
+        """,
+    )
+    assert result["status"] == "unknown", result
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "@decorate\ndef unrelated(value):",
+        "def unrelated(value=initialize()):",
+        "def unrelated(value: initialize()):",
+    ],
+)
+def test_unrelated_definition_headers_cannot_establish_stable_bindings(header):
+    source = (
+        "from opaque_library import decorate, initialize\n"
+        f"{header}\n    return value\n"
+        "def run(value):\n    return value\n"
+    )
+    result = _compare(source, source)
+    assert result["status"] == "unknown", result
+
+
+@pytest.mark.parametrize("source_root", ["src", "lib", "python"])
+def test_src_layout_helper_change_is_not_hidden_as_an_opaque_import(source_root):
+    app = (
+        "from pkg.helpers import prepare\ndef run(value):\n    return prepare(value)\n"
+    )
+    result = compare_python_behavior(
+        {
+            f"{source_root}/pkg/app.py": app,
+            f"{source_root}/pkg/helpers.py": "def prepare(value):\n    return 'original'\n",
+        },
+        {
+            f"{source_root}/pkg/app.py": app,
+            f"{source_root}/pkg/helpers.py": "def prepare(value):\n    return 'changed'\n",
+        },
+        file=f"{source_root}/pkg/app.py",
+        symbol="run",
+    )
+    assert result["status"] != "equivalent", result
+
+
+def test_root_package_relative_import_is_not_mistaken_for_external_dependency():
+    app = "from .helpers import prepare\ndef run(value):\n    return prepare(value)\n"
+    result = compare_python_behavior(
+        {
+            "__init__.py": app,
+            "helpers.py": "def prepare(value):\n    return 'original'\n",
+        },
+        {
+            "__init__.py": app,
+            "helpers.py": "def prepare(value):\n    return 'changed'\n",
+        },
+        file="__init__.py",
+        symbol="run",
+    )
+    assert result["status"] != "equivalent", result
+
+
+def test_explicit_child_import_does_not_follow_conflicting_package_alias():
+    app = "import pkg.child\ndef run(value):\n    return pkg.child.identity(value)\n"
+    common = {
+        "app.py": app,
+        "pkg/__init__.py": "import other as child\n",
+        "other.py": "def identity(value):\n    return None\n",
+    }
+    result = compare_python_behavior(
+        {**common, "pkg/child.py": "def identity(value):\n    return value\n"},
+        {**common, "pkg/child.py": "def identity(value):\n    return 'changed'\n"},
+        file="app.py",
+        symbol="run",
+    )
+    assert result["status"] != "equivalent", result
+
+
+def test_local_assignment_prevents_resolving_an_earlier_global_call():
+    result = _compare(
+        """
+        def helper(value):
+            return value
+
+        def run(value):
+            result = helper(value)
+            helper = value
+            return result
+        """,
+        """
+        def run(value):
+            return value
+        """,
+    )
+    assert result["status"] == "unknown", result
+
+
+def test_path_budget_exhaustion_is_unknown_for_identical_sources():
+    source = "def run(callback, value):\n    return callback(value)\n"
+    result = _compare(source, source, max_paths=1)
+    assert result["status"] == "unknown", result
+
+
+def test_missing_selected_symbol_is_not_empty_trace_equivalence():
+    result = _compare(
+        "def other():\n    return None\n", "def other():\n    return None\n"
+    )
+    assert result["status"] == "unknown", result

--- a/test/test_refactor_verify.py
+++ b/test/test_refactor_verify.py
@@ -1,0 +1,268 @@
+"""Compare Git snapshots without importing or executing fixture applications."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from skylos.verification.refactor import verify_refactor
+
+
+_GIT_ENV = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_INTERNAL_SUPER_PREFIX",
+)
+_IDENTITY = "def run(value):\n    return value\n"
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = dict(os.environ)
+    for key in _GIT_ENV:
+        env.pop(key, None)
+    return subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.strip()
+
+
+def _write(repo: Path, name: str, source: str) -> None:
+    path = repo / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+@pytest.fixture
+def make_repo(tmp_path, monkeypatch):
+    if shutil.which("git") is None:
+        pytest.skip("git is required")
+    for key in _GIT_ENV:
+        monkeypatch.delenv(key, raising=False)
+
+    def create(files: dict[str, str]) -> tuple[Path, str]:
+        repo = tmp_path / "refactor project"
+        repo.mkdir()
+        _git(repo, "init", "-q")
+        for name, source in files.items():
+            _write(repo, name, source)
+        _git(repo, "add", "--", *files)
+        _git(
+            repo,
+            "-c",
+            "user.name=Skylos Test",
+            "-c",
+            "user.email=skylos-test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-qm",
+            "baseline",
+        )
+        return repo, _git(repo, "rev-parse", "HEAD")
+
+    return create
+
+
+def test_unchanged_symbol_records_snapshot_identity(make_repo):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+
+    result = verify_refactor(repo, base="HEAD", file="app.py", symbol="run")
+
+    assert result["tool"] == "verify_behavior"
+    assert result["status"] == "pass"
+    assert result["comparison"]["status"] == "equivalent"
+    assert result["base"]["commit"] == commit
+    digest = hashlib.sha256(_IDENTITY.encode()).hexdigest()
+    assert result["base"]["source_hashes"]["app.py"] == digest
+    assert result["current"]["source_hashes"]["app.py"] == digest
+    assert result["findings"] == []
+    assert result["summary"]
+    assert result["coverage"]
+
+
+def test_extracting_local_helper_preserves_behavior(make_repo):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+    _write(
+        repo,
+        "app.py",
+        "def identity(value):\n    return value\n\n"
+        "def run(value):\n    return identity(value)\n",
+    )
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "pass"
+    assert result["comparison"]["status"] == "equivalent"
+    assert result["base"]["source_hashes"] != result["current"]["source_hashes"]
+
+
+@pytest.mark.parametrize(
+    "current_body",
+    ["    return emit('different')\n", "    emit(value)\n"],
+    ids=["changed-call-argument", "dropped-return-value"],
+)
+def test_changed_external_effect_or_return_fails(make_repo, current_body):
+    imports = "from unavailable_fixture_library import emit\n\n"
+    repo, commit = make_repo(
+        {"app.py": imports + "def run(value):\n    return emit(value)\n"}
+    )
+    _write(repo, "app.py", imports + "def run(value):\n" + current_body)
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "fail"
+    assert result["comparison"]["status"] == "different"
+    assert result["findings"]
+
+
+def test_imported_helper_change_is_detected_without_entry_file_change(make_repo):
+    app = (
+        "from helpers import identity\n\ndef run(value):\n    return identity(value)\n"
+    )
+    repo, commit = make_repo(
+        {"app.py": app, "helpers.py": "def identity(value):\n    return value\n"}
+    )
+    _write(repo, "helpers.py", "def identity(value):\n    return 'different'\n")
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "fail"
+    assert result["comparison"]["status"] == "different"
+    before = result["base"]["source_hashes"]
+    after = result["current"]["source_hashes"]
+    assert before["app.py"] == after["app.py"]
+    assert before["helpers.py"] != after["helpers.py"]
+
+
+@pytest.mark.parametrize(
+    "manifest,before,after",
+    [
+        ("requirements.txt", "example-library==1.0\n", "example-library==2.0\n"),
+        ("requirements/base.txt", "example-library==1.0\n", "example-library==2.0\n"),
+        (
+            "pyproject.toml",
+            '[project]\nname = "fixture"\ndependencies = ["example-library==1.0"]\n',
+            '[project]\nname = "fixture"\ndependencies = ["example-library==2.0"]\n',
+        ),
+    ],
+)
+def test_changed_dependency_environment_prevents_equivalence(
+    make_repo, manifest, before, after
+):
+    repo, commit = make_repo({"app.py": _IDENTITY, manifest: before})
+    _write(repo, manifest, after)
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert result["comparison"]["status"] == "unknown"
+    assert result["base"]["source_hashes"] == result["current"]["source_hashes"]
+    assert (
+        result["base"]["environment_hashes"] != result["current"]["environment_hashes"]
+    )
+
+
+def test_extraction_into_untracked_helper_is_included(make_repo):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+    _write(
+        repo,
+        "app.py",
+        "from helpers import identity\n\ndef run(value):\n    return identity(value)\n",
+    )
+    _write(repo, "helpers.py", "def identity(value):\n    return value\n")
+    assert _git(repo, "ls-files", "--", "helpers.py") == ""
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "pass"
+    assert result["comparison"]["status"] == "equivalent"
+    assert "helpers.py" not in result["base"]["source_hashes"]
+    assert "helpers.py" in result["current"]["source_hashes"]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"base": "missing-revision"}, {"base": "--help"}, {"file": "app.ts"}],
+    ids=["missing-base", "option-like-base", "unsupported-file-type"],
+)
+def test_invalid_snapshot_inputs_are_rejected(make_repo, overrides):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+    options = {"base": commit, "file": "app.py", "symbol": "run", **overrides}
+
+    with pytest.raises(ValueError):
+        verify_refactor(repo, **options)
+
+
+@pytest.mark.parametrize("file,symbol", [("app.py", "missing"), ("missing.py", "run")])
+def test_missing_obligation_target_is_incomplete(make_repo, file, symbol):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+
+    result = verify_refactor(repo, base=commit, file=file, symbol=symbol)
+
+    assert result["status"] == "incomplete"
+    assert result["comparison"]["status"] == "unknown"
+
+
+def test_symlinked_import_is_not_used_as_source(make_repo, tmp_path):
+    repo, commit = make_repo(
+        {
+            "app.py": "from helpers import identity\n\ndef run(value):\n    return identity(value)\n",
+            "helpers.py": "def identity(value):\n    return value\n",
+        }
+    )
+    outside = tmp_path / "external helper.py"
+    outside.write_text("def identity(value):\n    return value\n", encoding="utf-8")
+    (repo / "helpers.py").unlink()
+    (repo / "helpers.py").symlink_to(outside)
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert result["comparison"]["status"] == "unknown"
+    assert "helpers.py" not in result["current"]["source_hashes"]
+
+
+def test_subdirectory_scope_selects_its_file_and_rejects_parent_escape(make_repo):
+    repo, commit = make_repo({"app.py": _IDENTITY, "pkg/app.py": _IDENTITY})
+    _write(repo, "pkg/app.py", "def run(value):\n    return 'different'\n")
+
+    result = verify_refactor(repo / "pkg", base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "fail"
+    assert result["comparison"]["status"] == "different"
+    assert result["target"]["file"] == "pkg/app.py"
+    assert "pkg/app.py" in result["current"]["source_hashes"]
+    with pytest.raises(ValueError):
+        verify_refactor(repo / "pkg", base=commit, file="../app.py", symbol="run")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def run(value):\n    for item in value:\n        print(item)\n    return value\n",
+        "def run(value):\n    return (\n",
+    ],
+    ids=["unsupported-loop", "invalid-syntax"],
+)
+def test_unmodeled_or_invalid_source_is_incomplete(make_repo, source):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+    _write(repo, "app.py", source)
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert result["comparison"]["status"] == "unknown"

--- a/test/test_refactor_verify.py
+++ b/test/test_refactor_verify.py
@@ -9,10 +9,13 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from skylos.commands.verify_cmd import run_verify_command
+from skylos.core.safe_cache_io import write_text_no_symlink
+from skylos.verification import refactor
 from skylos.verification.refactor import verify_refactor
 from skylos.verify_change import verify_change_path
 
@@ -47,7 +50,7 @@ def _git(repo: Path, *args: str) -> str:
 def _write(repo: Path, name: str, source: str) -> None:
     path = repo / name
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(source, encoding="utf-8")
+    assert write_text_no_symlink(path, source, encoding="utf-8")
 
 
 @pytest.fixture
@@ -238,6 +241,161 @@ def test_symlinked_import_is_not_used_as_source(make_repo, tmp_path):
     assert result["status"] == "incomplete"
     assert result["comparison"]["status"] == "unknown"
     assert "helpers.py" not in result["current"]["source_hashes"]
+
+
+def test_working_snapshot_preserves_encoded_bytes_and_line_endings(make_repo):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+    source = "# coding: latin-1\r\ndef run(value):\r\n    return 'caf\xe9'\r\n"
+    assert write_text_no_symlink(repo / "app.py", source, encoding="latin-1")
+
+    sources, hashes = refactor._current_sources(repo)
+
+    assert sources["app.py"] == source
+    assert hashes["app.py"] == hashlib.sha256(source.encode("latin-1")).hexdigest()
+
+
+def test_deleted_working_source_is_absent_from_snapshot(make_repo):
+    repo, _ = make_repo({"app.py": _IDENTITY, "pkg/helper.py": _IDENTITY})
+    (repo / "pkg/helper.py").unlink()
+    (repo / "pkg").rmdir()
+
+    sources, hashes = refactor._current_sources(repo)
+
+    assert sources == {"app.py": _IDENTITY}
+    assert set(hashes) == {"app.py"}
+
+
+def test_symlinked_source_directory_is_rejected_even_within_repository(make_repo):
+    repo, commit = make_repo({"app.py": _IDENTITY, "pkg/helper.py": _IDENTITY})
+    (repo / "pkg").rename(repo / "saved")
+    (repo / "pkg").symlink_to(repo / "saved", target_is_directory=True)
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert (
+        "Cannot read working source: pkg/helper.py" in result["comparison"]["reasons"]
+    )
+    assert not result["current"]["source_hashes"]
+
+
+def test_working_snapshot_rejects_symlinked_root(make_repo, tmp_path):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+    alias = tmp_path / "repository alias"
+    alias.symlink_to(repo, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="Cannot open working source snapshot root"):
+        refactor._current_sources(alias)
+
+
+def test_unreadable_working_source_is_incomplete_instead_of_deleted(
+    make_repo, monkeypatch
+):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+    real_open = os.open
+
+    def unreadable_source(path, flags, *args, **kwargs):
+        if path == "app.py" and kwargs.get("dir_fd") is not None:
+            raise PermissionError("fixture denied")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", unreadable_source)
+    monkeypatch.setattr(os, "supports_dir_fd", {*os.supports_dir_fd, unreadable_source})
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert "Cannot read working source: app.py" in result["comparison"]["reasons"]
+
+
+def test_working_source_descriptor_allocation_failure_is_incomplete(
+    make_repo, monkeypatch
+):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+
+    def exhausted_descriptors(fd):
+        raise OSError("fixture descriptor allocation failed")
+
+    monkeypatch.setattr(os, "dup", exhausted_descriptors)
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert result["comparison"]["reasons"] == ["Cannot read working source: app.py"]
+    assert not result["current"]["source_hashes"]
+
+
+@pytest.mark.parametrize("kind", ["directory", "fifo"])
+def test_nonregular_working_source_is_rejected(make_repo, kind):
+    if kind == "fifo" and not hasattr(os, "mkfifo"):
+        pytest.skip("FIFOs are unavailable")
+    repo, commit = make_repo({"app.py": _IDENTITY, "helper.py": _IDENTITY})
+    helper = repo / "helper.py"
+    helper.unlink()
+    if kind == "directory":
+        helper.mkdir()
+    else:
+        os.mkfifo(helper)
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert (
+        "Working source is not a regular file: helper.py"
+        in result["comparison"]["reasons"]
+    )
+
+
+@pytest.mark.parametrize("limit", ["_MAX_FILE_BYTES", "_MAX_SOURCE_BYTES"])
+def test_working_snapshot_read_limits_are_preserved(make_repo, monkeypatch, limit):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+    monkeypatch.setattr(refactor, limit, len(_IDENTITY.encode()) - 1)
+
+    with pytest.raises(ValueError, match="verification size limit"):
+        refactor._current_sources(repo)
+
+
+def test_working_snapshot_detects_changed_metadata(make_repo, monkeypatch):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+    real_fstat = os.fstat
+    observed = 0
+
+    def changed_metadata(fd):
+        nonlocal observed
+        result = real_fstat(fd)
+        observed += 1
+        return SimpleNamespace(
+            st_mode=result.st_mode,
+            st_size=result.st_size,
+            st_mtime_ns=result.st_mtime_ns,
+            st_ctime_ns=result.st_ctime_ns + (observed > 1),
+        )
+
+    monkeypatch.setattr(os, "fstat", changed_metadata)
+
+    with pytest.raises(ValueError, match="Working source changed while being read"):
+        refactor._current_sources(repo)
+
+
+def test_working_snapshot_requires_descriptor_relative_no_follow_support(
+    make_repo, monkeypatch
+):
+    repo, commit = make_repo({"app.py": _IDENTITY})
+    monkeypatch.setattr(os, "supports_dir_fd", set())
+
+    result = verify_refactor(repo, base=commit, file="app.py", symbol="run")
+
+    assert result["status"] == "incomplete"
+    assert (
+        "Platform does not support safe working source snapshot reads"
+        in result["comparison"]["reasons"]
+    )
+
+
+@pytest.mark.parametrize("name", ["../app.py", "/app.py", ".", "\0"])
+def test_working_source_rejects_unsafe_relative_names_before_opening(name):
+    with pytest.raises(ValueError, match="Unsafe path"):
+        refactor._read_working_source(-1, name)
 
 
 def test_subdirectory_scope_selects_its_file_and_rejects_parent_escape(make_repo):

--- a/test/test_refactor_verify.py
+++ b/test/test_refactor_verify.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from skylos.commands.verify_cmd import run_verify_command
 from skylos.verification.refactor import verify_refactor
+from skylos.verify_change import verify_change_path
 
 
 _GIT_ENV = (
@@ -266,3 +270,100 @@ def test_unmodeled_or_invalid_source_is_incomplete(make_repo, source):
 
     assert result["status"] == "incomplete"
     assert result["comparison"]["status"] == "unknown"
+
+
+@pytest.mark.parametrize("has_ai_finding", [False, True])
+@pytest.mark.parametrize("target_mode", ["file", "directory"])
+def test_verify_change_adds_behavior_comparison_to_analyzer_result(
+    make_repo, has_ai_finding, target_mode
+):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+    _write(repo, "app.py", "def run(value):\n    return 'different'\n")
+    target = repo / "app.py" if target_mode == "file" else repo
+    calls = []
+
+    def analyzer(path, **kwargs):
+        calls.append(path)
+        if not has_ai_finding:
+            return {}
+        return {
+            "ai_defects": [
+                {
+                    "rule_id": "SKY-L012",
+                    "file": str(repo / "app.py"),
+                    "line": 2,
+                    "message": "Missing call target.",
+                    "severity": "HIGH",
+                }
+            ]
+        }
+
+    result = verify_change_path(
+        target,
+        analyze_func=analyzer,
+    )
+
+    assert calls == [str(target)]
+    assert result["schema_version"] == 2
+    assert result["tool"] == "verify_change"
+    assert result["status"] == ("fail" if has_ai_finding else "incomplete")
+    assert result["behavior"]["status"] == "different"
+    assert result["behavior"]["comparisons"]
+    assert bool(result["findings"]) is has_ai_finding
+
+
+@pytest.mark.parametrize(
+    "source,behavior_status,no_fail,expected_exit",
+    [
+        ("def run(value):\n    return 'different'\n", "different", False, 2),
+        ("def run(value):\n    return 'different'\n", "different", True, 0),
+        ("def run(value):\n    while value:\n        pass\n", "unknown", False, 2),
+        ("def run(value):\n    while value:\n        pass\n", "unknown", True, 0),
+    ],
+)
+def test_normal_verify_cli_compares_behavior_and_applies_exit_policy(
+    make_repo, capsys, source, behavior_status, no_fail, expected_exit
+):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+    _write(repo, "app.py", source)
+
+    exit_code = run_verify_command(
+        [
+            str(repo / "app.py"),
+            *(["--no-fail"] if no_fail else []),
+        ]
+    )
+    result = json.loads(capsys.readouterr().out)
+
+    assert exit_code == expected_exit
+    assert result["tool"] == "verify_change"
+    assert result["status"] == "incomplete"
+    assert result["behavior"]["status"] == behavior_status
+    assert result["behavior"]["comparisons"]
+
+
+def test_cli_entry_point_infers_behavior_comparison_without_flags(make_repo):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+    _write(repo, "app.py", "def run(value):\n    return 'different'\n")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from skylos.cli import main; main()",
+            "verify",
+            str(repo / "app.py"),
+        ],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 2, completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["tool"] == "verify_change"
+    assert result["status"] == "incomplete"
+    assert result["behavior"]["status"] == "different"
+    assert result["behavior"]["comparisons"]

--- a/test/test_verify_cmd.py
+++ b/test/test_verify_cmd.py
@@ -3,8 +3,88 @@ from __future__ import annotations
 import io
 import json
 import sys
+from functools import partial
+
+import pytest
 
 from skylos.commands.verify_cmd import run_verify_command
+from skylos.verify_change import verify_change_path
+
+
+def _unexpected_analysis(*_args, **_kwargs):
+    pytest.fail("Invalid verification targets must be rejected before analysis")
+
+
+@pytest.mark.parametrize("terminal", [False, True])
+@pytest.mark.parametrize("no_fail", [False, True])
+def test_missing_target_is_an_input_error(
+    monkeypatch, capsys, tmp_path, terminal, no_fail
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: terminal)
+    args = ["app.py"]
+    if no_fail:
+        args.append("--no-fail")
+
+    with pytest.raises(SystemExit) as exc:
+        run_verify_command(
+            args,
+            verify_change_path_func=partial(
+                verify_change_path, analyze_func=_unexpected_analysis
+            ),
+        )
+
+    output = capsys.readouterr()
+    assert exc.value.code == 2
+    assert output.out == ""
+    assert "does not exist" in output.err
+    assert str(tmp_path / "app.py") in output.err
+
+
+@pytest.mark.parametrize("project_context", [False, True])
+def test_missing_selected_file_is_an_input_error(capsys, tmp_path, project_context):
+    (tmp_path / "existing.py").write_text("def existing():\n    return None\n")
+    args = [str(tmp_path), "--file", "missing.py"]
+    if project_context:
+        args.append("--project-context")
+
+    with pytest.raises(SystemExit) as exc:
+        run_verify_command(
+            args,
+            verify_change_path_func=partial(
+                verify_change_path, analyze_func=_unexpected_analysis
+            ),
+        )
+
+    output = capsys.readouterr()
+    assert exc.value.code == 2
+    assert output.out == ""
+    assert "does not exist" in output.err
+    assert str(tmp_path / "missing.py") in output.err
+
+
+@pytest.mark.parametrize("project_context", [False, True])
+def test_selected_directory_is_an_input_error(capsys, tmp_path, project_context):
+    selected_directory = tmp_path / "sources"
+    selected_directory.mkdir()
+    (selected_directory / "app.py").write_text("def run():\n    return None\n")
+    args = [str(tmp_path), "--file", "sources"]
+    if project_context:
+        args.append("--project-context")
+
+    with pytest.raises(SystemExit) as exc:
+        run_verify_command(
+            args,
+            verify_change_path_func=partial(
+                verify_change_path, analyze_func=_unexpected_analysis
+            ),
+        )
+
+    output = capsys.readouterr()
+    assert exc.value.code == 2
+    assert output.out == ""
+    assert "--file must select a file" in output.err
+    assert str(selected_directory) in output.err
 
 
 def test_run_verify_command_prints_json_and_preserves_args(capsys):

--- a/test/test_verify_cmd.py
+++ b/test/test_verify_cmd.py
@@ -133,17 +133,58 @@ def test_stdin_keeps_json_even_in_a_terminal(monkeypatch, capsys):
     )
 
 
-def test_output_file_keeps_json_even_in_a_terminal(monkeypatch, capsys, tmp_path):
+@pytest.mark.parametrize("relative_path", [False, True])
+@pytest.mark.parametrize("existing_output", [False, True])
+def test_output_file_keeps_json_even_in_a_terminal(
+    monkeypatch, capsys, tmp_path, relative_path, existing_output
+):
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.chdir(tmp_path)
     output_path = tmp_path / "report.json"
+    if existing_output:
+        output_path.write_text("old report contents\n" * 1000, encoding="utf-8")
+    destination = output_path.name if relative_path else str(output_path)
     code = run_verify_command(
-        ["app.py", "--output", str(output_path)],
+        ["app.py", "--output", destination],
         verify_change_path_func=lambda *args, **kwargs: _behavior_payload(),
     )
     payload = json.loads(output_path.read_text())
     assert code == 2
     assert payload["behavior"]["status"] == "different"
     assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize("no_fail", [False, True])
+@pytest.mark.parametrize("destination_kind", ["directory", "missing_parent"])
+def test_output_write_failure_is_a_cli_error(
+    monkeypatch, capsys, tmp_path, no_fail, destination_kind
+):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    output_path = (
+        tmp_path
+        if destination_kind == "directory"
+        else tmp_path / "missing" / "report.json"
+    )
+    args = ["app.py", "--output", str(output_path)]
+    if no_fail:
+        args.append("--no-fail")
+
+    with pytest.raises(SystemExit) as exc:
+        run_verify_command(
+            args,
+            verify_change_path_func=lambda *args, **kwargs: {
+                "status": "pass",
+                "findings": [],
+            },
+        )
+
+    output = capsys.readouterr()
+    assert exc.value.code == 2
+    assert output.out == ""
+    assert "Cannot safely write output" in output.err
+    assert str(output_path) in output.err
+    assert "Traceback" not in output.err
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_run_verify_command_prints_json_and_preserves_args(capsys):

--- a/test/test_verify_cmd.py
+++ b/test/test_verify_cmd.py
@@ -87,6 +87,65 @@ def test_selected_directory_is_an_input_error(capsys, tmp_path, project_context)
     assert str(selected_directory) in output.err
 
 
+def _behavior_payload():
+    from skylos.verification.behavior import compare_python_behavior
+
+    comparison = compare_python_behavior(
+        {"app.py": "def run(callback, value):\n    return callback(value)\n"},
+        {"app.py": "def run(callback, value):\n    callback(value)\n    return None\n"},
+        file="app.py",
+        symbol="run",
+    )
+    return {
+        "tool": "verify_change",
+        "status": "incomplete",
+        "findings": [],
+        "behavior": {"status": "different", "comparisons": [comparison]},
+    }
+
+
+def test_terminal_explains_behavior_change_without_flags(monkeypatch, capsys):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    code = run_verify_command(
+        ["app.py"], verify_change_path_func=lambda *args, **kwargs: _behavior_payload()
+    )
+    output = capsys.readouterr().out
+    assert code == 2
+    assert output.startswith("Verification needs review")
+    assert "app.py:1" in output and "run" in output
+    assert "Callback result discarded" in output
+    assert "callback(value)" in output and "None" in output
+    assert '"schema_version"' not in output
+
+
+def test_stdin_keeps_json_even_in_a_terminal(monkeypatch, capsys):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"file":"app.py","code":"pass"}'))
+    code = run_verify_command(
+        ["--stdin"],
+        verify_change_stdin_payload_func=lambda *args, **kwargs: _behavior_payload(),
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert (
+        payload["behavior"]["comparisons"][0]["differences"][0]["explanation"]["title"]
+        == "Callback result discarded"
+    )
+
+
+def test_output_file_keeps_json_even_in_a_terminal(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    output_path = tmp_path / "report.json"
+    code = run_verify_command(
+        ["app.py", "--output", str(output_path)],
+        verify_change_path_func=lambda *args, **kwargs: _behavior_payload(),
+    )
+    payload = json.loads(output_path.read_text())
+    assert code == 2
+    assert payload["behavior"]["status"] == "different"
+    assert capsys.readouterr().out == ""
+
+
 def test_run_verify_command_prints_json_and_preserves_args(capsys):
     seen = {}
 

--- a/test/test_verify_render.py
+++ b/test/test_verify_render.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from skylos.verification.render import render_verify_report
+
+
+def _comparison(**overrides):
+    row = {
+        "status": "different",
+        "file": "app.py",
+        "symbol": "run",
+        "after_range": {"start_line": 1, "end_line": 3},
+        "differences": [
+            {
+                "before": {"value": ["result", 0]},
+                "after": {"value": ["constant", "NoneType", "None"]},
+                "explanation": {
+                    "title": "Callback result discarded",
+                    "before": "Returned callback(value).",
+                    "after": "Returns None after calling callback(value).",
+                    "impact": "Callers relying on the callback result may break.",
+                    "review": "Confirm that discarding the result was intentional.",
+                },
+            }
+        ],
+    }
+    row.update(overrides)
+    return row
+
+
+def _payload(comparisons, **behavior):
+    return {
+        "tool": "verify_change",
+        "status": "incomplete",
+        "summary": "No AI-code issues found; behavior comparison needs review.",
+        "findings": [],
+        "behavior": {
+            "status": "different",
+            "comparisons": comparisons,
+            "base": {"source_hashes": {"app.py": "hidden-source-hash"}},
+            **behavior,
+        },
+    }
+
+
+def test_lost_return_explains_before_after_and_effect_on_callers():
+    report = render_verify_report(_payload([_comparison()]))
+
+    assert report.startswith("Verification needs review\n")
+    assert "app.py:1 — run" in report
+    assert "Callback result discarded" in report
+    assert "Before: Returned callback(value)." in report
+    assert "After: Returns None after calling callback(value)." in report
+    assert "Impact: Callers relying on the callback result may break." in report
+    assert "Review: Confirm that discarding the result was intentional." in report
+    assert "Static comparison only; target code was not executed" in report
+    assert "target code was not executed" in report
+    assert "hidden-source-hash" not in report
+    assert "NoneType" not in report
+    assert "['result', 0]" not in report
+
+
+def test_ordinary_findings_are_reported_without_behavior_payload():
+    report = render_verify_report(
+        {
+            "status": "fail",
+            "summary": "1 AI-code issue found",
+            "findings": [
+                {
+                    "rule_id": "SKY-L012",
+                    "severity": "HIGH",
+                    "range": {"file": "service.py", "start_line": 8},
+                    "message": "Call to lookup() is never defined.",
+                    "suggested_fix": "Define or import lookup().",
+                }
+            ],
+        }
+    )
+
+    assert "Verification found issues" in report
+    assert "service.py:8 — SKY-L012 [HIGH]" in report
+    assert "Call to lookup() is never defined." in report
+    assert "Suggested fix: Define or import lookup()." in report
+    assert "Behavior comparison" not in report
+
+
+def test_unknown_comparison_explains_location_and_unsupported_reason():
+    comparison = _comparison(
+        status="unknown", differences=[], reasons=["Unsupported statement: While"]
+    )
+    report = render_verify_report(_payload([comparison], status="unknown"))
+
+    assert "app.py:1 — run" in report
+    assert "Could not establish whether behavior is preserved." in report
+    assert "Unsupported statement: While" in report
+    assert "Behavior comparison is incomplete." in report
+    assert "Verification passed" not in report
+
+
+def test_mixed_unknown_overall_status_retains_known_difference():
+    unknown = _comparison(
+        status="unknown", symbol="poll", differences=[], reasons=["Loop unsupported"]
+    )
+    report = render_verify_report(_payload([unknown, _comparison()], status="unknown"))
+
+    assert "Callback result discarded" in report
+    assert "app.py:1 — poll" in report
+    assert "Loop unsupported" in report
+    assert "Behavior comparison is incomplete." in report
+
+
+def test_unavailable_comparison_does_not_claim_equivalence():
+    report = render_verify_report(
+        _payload([], status="unavailable", reasons=["No local Git HEAD is available"])
+    )
+    assert "Behavior comparison is unavailable." in report
+    assert "No local Git HEAD is available" in report
+    assert "equivalent" not in report
+
+
+def test_unchanged_scope_is_distinguished_from_equivalence():
+    report = render_verify_report(_payload([], status="unchanged"))
+    assert "No affected Python functions found in the selected scope." in report
+    assert "equivalent" not in report
+
+
+def test_equivalence_is_scoped_to_the_static_model():
+    report = render_verify_report(
+        _payload(
+            [_comparison(status="equivalent", differences=[])], status="equivalent"
+        )
+    )
+    assert "1 affected function equivalent within the supported static model." in report
+    assert "external behavior is assumed stable" in report
+    assert "Callback result discarded" not in report
+
+
+def test_removed_function_uses_before_location():
+    report = render_verify_report(
+        _payload(
+            [
+                _comparison(
+                    status="unknown",
+                    after_range=None,
+                    before_range={"start_line": 9},
+                    differences=[],
+                    reasons=["Selected function missing after edit"],
+                )
+            ],
+            status="unknown",
+        )
+    )
+    assert "app.py:9 — run" in report
+    assert "Selected function missing after edit" in report
+
+
+def test_terminal_controls_in_paths_and_explanations_are_escaped():
+    comparison = _comparison(file="app\x1b[2J\r.py", symbol="run\u202e", reasons=[])
+    comparison["differences"][0]["explanation"]["impact"] = (
+        "Danger\nVerification passed\x07"
+    )
+    payload = _payload([comparison])
+    payload["summary"] = "Summary\tline"
+    report = render_verify_report(payload)
+
+    assert "app\\x1b[2J\\r.py:1 — run\\u202e" in report
+    assert "Danger\\nVerification passed\\x07" in report
+    assert "Summary\\tline" in report
+    assert all(character.isprintable() or character == "\n" for character in report)
+
+
+def test_missing_or_malformed_explanations_do_not_leak_symbolic_values():
+    report = render_verify_report(
+        _payload(
+            [
+                _comparison(
+                    differences=[
+                        {
+                            "before": {"value": ["result", 7]},
+                            "after": {"value": ["constant", "NoneType", "None"]},
+                            "explanation": "malformed",
+                        }
+                    ]
+                )
+            ]
+        )
+    )
+    assert "Behavior changed" in report
+    assert "no readable detail is available" in report
+    assert "result" not in report
+    assert "NoneType" not in report
+
+
+def test_output_cap_announces_omitted_comparisons():
+    report = render_verify_report(
+        _payload([_comparison(symbol=f"run{index}") for index in range(23)])
+    )
+    assert "3 more function comparisons needing review omitted." in report
+    assert "JSON report contains all recorded comparisons." in report
+    assert "run19" in report
+    assert "run20" not in report
+
+
+def test_long_untrusted_messages_are_bounded():
+    report = render_verify_report({"status": "incomplete", "summary": "x" * 5000})
+    assert "... (truncated)" in report
+    assert len(report) < 1100


### PR DESCRIPTION
## Summary

  - Automatically compare affected Python functions with HEAD during `skylos verify`,
  - Explain before/after behavior and potential caller impact in terminal output
  - Reject missing targets instead of reporting a false pass.

## Tests

- `pytest test/test_behavior*.py test/test_refactor_verify.py test/test_verify_cmd.py test/test_verify_render.py \
test/test_verify_change.py test/test_verify_change_dependency_bump.py test/test_cli_refactor_guardrails.py \ test/test_cli.py`