### PR TITLE
feat(verification): add explicit local and branch comparison baselines

### DIFF
--- a/docs/behavior-integration-plan.md
+++ b/docs/behavior-integration-plan.md
@@ -1,8 +1,8 @@
 # Behavior comparison integration plan
 
-Updated: 2026-09-09.
+Updated: 2026-09-10.
 
-Progress: step 1 complete; step 2 is next. Steps 2–5 have not been executed.
+Progress: steps 1 and 2 complete; step 3 is next. Steps 3–5 have not been executed.
 
 ## Objective
 
@@ -99,7 +99,7 @@ Completion evidence (2026-09-09):
 
 ## 2. Make the comparison baseline explicit
 
-Status: pending; depends on step 1.
+Status: complete.
 
 Implementation:
 
@@ -125,6 +125,37 @@ Acceptance checks:
 - Cover diverged branches, dirty files, file/directory/multiple-path scopes,
   targets outside the current directory, no Git, and missing base history.
 - Base/current commit identities agree with the source bytes in the report.
+
+Completion evidence (2026-09-10):
+
+- Added `ComparisonTarget`, immutable `ComparisonContext`, and the repository
+  resolver in `skylos/verification/context.py`. Local contexts pin HEAD and load
+  working sources; branch contexts pin both refs and load merge-base/HEAD blobs.
+- Added `compare_target_changes(...)` for repository-grouped comparisons. The
+  existing `compare_working_changes(...)` remains its local single-target
+  adapter. Reports retain prior fields and add current source kind, commit
+  identity and explicit context metadata.
+- The source service unions scopes without repeating graph construction or
+  function comparisons. Multiple explicitly selected ignored files share one
+  working snapshot; existing read limits and no-follow checks remain enforced.
+- Added 27 independent baseline acceptance cases, plus scope-union, snapshot
+  grouping, ignored-file, submodule and compatibility regressions. Coverage
+  includes refs moving during loading, dirty/index restoration, diverged and
+  shallow history, multiple repositories, deleted paths, file/directory changes,
+  non-Python selections and original encoded-byte hashes.
+- Independent review caught and fixed the non-Python fast-path regression and
+  dirty symlink scope redirection. Missing committed scopes report unavailable;
+  committed file/directory transitions retain both affected selections.
+- Full relevant behavior/verify/CLI and safe-output suite: **532 passed**.
+  Ruff, formatting, diff and generated repo-map checks pass. Published Skylos
+  **4.36.1** reports no security/secrets findings or analysis errors across all
+  eight changed Python files.
+- Real temporary-repository demo: uncommitted return loss is `different`; after
+  commit local comparison is `unchanged`, while branch comparison is
+  `different`. Restoring the return only locally leaves branch status and
+  committed byte evidence unchanged.
+- Regular scans, `suite`, finding baselines, grades and exit policies retain
+  their existing behavior. No CLI flags were added. Step 3 remains pending.
 
 ## 3. Separate behavior review from defect policy
 
@@ -207,11 +238,11 @@ and reuse parsed sources before considering automatic execution on every scan.
 
 ## Resume notes
 
-- Current authorized execution: step 1 only.
+- Current authorized execution: step 2.
 - Step 1 is complete. Regular scans and `suite` still retain their existing
   activation behavior; their comparison integration is step 4.
-- Next work after step 1: explicit comparison context and baseline tests in
-  step 2; do not enable regular-scan comparison before the integration checks.
-- The user authorized splitting this tested checkpoint into focused commits.
-  Preserve the completed behavior-comparison work; step 2 remains pending.
-  No push or PR is requested.
+- Step 1 and its I/O fixes are merged into main. Step 2 starts from updated main
+  on `feat/behavior-comparison-baselines`.
+- Step 2 is complete. Next is the behavior report/policy contract in step 3;
+  steps 3–5 remain separate work and have not been executed.
+- Preserve the user's preference for focused commits. Do not open a PR.

--- a/docs/behavior-preservation.md
+++ b/docs/behavior-preservation.md
@@ -19,8 +19,36 @@ tree, alongside the existing AI-code checks. The path selects a file or project;
 Skylos selects the functions and baseline. Changed local helpers can affect a
 function even when that function's own source is unchanged.
 
-The selected path must exist. A missing file or project directory is an input
-error (exit code 2), including when using `--file` with `--project-context`.
+The shared Git adapter also supports committed branch comparisons through
+`compare_target_changes` in `skylos.verification.changes`:
+
+```python
+from skylos.verification.changes import ComparisonTarget, compare_target_changes
+
+local_reports = compare_target_changes(["src", "tests"])
+branch_reports = compare_target_changes(
+    [ComparisonTarget(".", file="app.py")], base_ref="origin/main"
+)
+```
+
+Each result describes one repository. Local mode compares HEAD with working
+sources. Branch mode resolves the requested reference and HEAD to immutable
+commits, then compares their merge base with committed HEAD. Staged edits,
+working files and untracked files do not change branch evidence. Selected files
+and directories are identified from the committed trees, including deleted
+paths. Missing references, unavailable history or ambiguous merge bases produce
+an explicit unavailable comparison.
+
+Multiple targets in one repository share source snapshots and comparison work.
+Overlapping scopes compare each affected function once, with one function budget
+per repository. `ComparisonTarget` also accepts a line range, and the adapter
+accepts folder exclusions. This service is preparation for the existing diff
+workflow; regular scans and `suite` have not activated behavior comparison yet.
+Finding fingerprints from `--baseline` are unrelated to these source revisions.
+
+Targets passed to the `skylos verify` CLI must exist. A missing file or project
+directory is an input error (exit code 2), including when using `--file` with
+`--project-context`.
 
 In a terminal, the command explains each difference with its location, before
 and after behavior, possible impact on callers, and a review prompt. For example:
@@ -109,6 +137,10 @@ The behavior evidence records:
 - Individual function comparisons, including the model version, symbol ranges,
   differences, reasons for incompleteness, and assumptions.
 - The selected function/helper scope and comparison budgets.
+- A `context` object recording the repository, local/branch mode, resolved
+  reference commit, actual base commit, HEAD identity and selected scopes.
+- The current source `kind` (`working_tree` or `commit`). A working tree has no
+  current commit ID; a branch result records the exact current commit.
 
 These hashes identify the inputs to the comparison. They do not establish
 semantic correctness independently of the model. Working-tree reads are not an

--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1081</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12341</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>1083</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12408</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1945,12 +1945,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/comparison.py skylos/verification/behavior.py skylos/verification/refactor.py skylos/verification/explanations.py skylos/verification/render.py skylos/verification/changes.py skylos/verification/__init__.py">
+    <article class="folder-card searchable" data-search="skylos/verification generated facts are available; this folder still needs a curated summary. use the module list and tests to decide whether this is the right ownership area.  test/test_language_verification_integration.py test/test_verification_coverage.py skylos/verification/context.py skylos/verification/comparison.py skylos/verification/behavior.py skylos/verification/refactor.py skylos/verification/explanations.py skylos/verification/render.py skylos/verification/changes.py skylos/verification/__init__.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification" rel="noopener noreferrer">skylos/verification</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 51</span>
+          <span class="pill"><strong>files</strong> 8</span>
+          <span class="pill"><strong>symbols</strong> 69</span>
         </div>
       </div>
       <p>Generated facts are available; this folder still needs a curated summary.</p>
@@ -1964,7 +1964,8 @@
         <div class="split-list">
       <div>
         <div class="mini-label">Important files</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">skylos/verification/comparison.py</a></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/context.py" rel="noopener noreferrer">skylos/verification/context.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">skylos/verification/comparison.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">skylos/verification/behavior.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">skylos/verification/refactor.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/explanations.py" rel="noopener noreferrer">skylos/verification/explanations.py</a></li>
@@ -1974,7 +1975,12 @@
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
-        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">SourceSnapshot</a> <span>class</span></li>
+        <ul><li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/context.py" rel="noopener noreferrer">ComparisonTarget</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/context.py" rel="noopener noreferrer">ComparisonContext</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/context.py" rel="noopener noreferrer">resolve_comparison_contexts</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/context.py" rel="noopener noreferrer">_LocatedTarget</a> <span>class</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/context.py" rel="noopener noreferrer">_validate_base_ref</a> <span>def</span></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">SourceSnapshot</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">ComparisonScope</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">is_environment_file</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/comparison.py" rel="noopener noreferrer">compare_source_changes</a> <span>def</span></li>
@@ -1982,12 +1988,7 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">compare_python_behavior</a> <span>def</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Unknown</a> <span>class</span></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Module</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Frame</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_State</a> <span>class</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">verify_refactor</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">_snapshot_input</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">_git</a> <span>def</span></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/refactor.py" rel="noopener noreferrer">_safe_relative</a> <span>def</span></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/verification/behavior.py" rel="noopener noreferrer">_Frame</a> <span>class</span></li></ul>
       </div>
     </div>
       </details>
@@ -2048,8 +2049,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 304</span>
-          <span class="pill"><strong>symbols</strong> 5247</span>
+          <span class="pill"><strong>files</strong> 305</span>
+          <span class="pill"><strong>symbols</strong> 5296</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/verification/changes.py
+++ b/skylos/verification/changes.py
@@ -1,130 +1,92 @@
-"""Load Git snapshots for the shared source-comparison service."""
+"""Compare local or committed Git changes through the shared source service."""
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
+from typing import Sequence
 
-from skylos.core.verify_change_schema import parse_line_range
-from skylos.verification.comparison import (
-    ComparisonScope,
-    SourceSnapshot,
-    _new_result,
-    compare_source_changes,
-)
-from skylos.verification.refactor import (
-    _base_sources,
-    _current_sources,
-    _git,
-    _selected_file,
+from skylos.verification.comparison import _new_result, compare_source_changes
+from skylos.verification.context import (
+    ComparisonContext,
+    ComparisonTarget as ComparisonTarget,
+    resolve_comparison_contexts,
 )
 
-_GIT_ASSUMPTIONS = [
-    "Tracked and unignored Python sources are compared; ignored dependencies and the external environment are assumed stable.",
+_SHARED_ASSUMPTIONS = [
     "Unchanged Git submodules are treated as external dependencies; their source is not analyzed.",
+]
+_WORKING_ASSUMPTIONS = [
+    "Tracked and unignored Python sources are compared; ignored dependencies and the external environment are assumed stable.",
+    *_SHARED_ASSUMPTIONS,
     "Snapshot hashes identify the bytes read; working-tree reads are not an atomic filesystem transaction.",
+]
+_COMMITTED_ASSUMPTIONS = [
+    "Both source snapshots come from the recorded immutable commits; staged, working and untracked files do not participate.",
+    *_SHARED_ASSUMPTIONS,
+    "The external Python environment is assumed stable; it is not captured by Git source snapshots.",
 ]
 
 
-def _scope(path, file):
-    target = Path(path).expanduser().absolute()
-    if target.is_symlink():
-        raise ValueError("Verification path must not be a symlink")
-    directory = target.is_dir()
-    if file is not None and (Path(file).is_absolute() or ".." in Path(file).parts):
-        raise ValueError("--file must be a relative path within the selected directory")
-    if file is not None and not directory:
-        raise ValueError("--file cannot be combined with a file path target")
-    anchor = target if directory else target.parent
-    try:
-        root = Path(
-            os.fsdecode(_git(anchor, "rev-parse", "--show-toplevel")).removesuffix("\n")
-        ).resolve()
-        commit = _git(root, "rev-parse", "--verify", "HEAD^{commit}").decode().strip()
-    except ValueError:
-        return None
-    selected = target / file if file is not None else target
-    if not selected.resolve().is_relative_to(root):
-        raise ValueError("Verification scope must stay within the Git repository")
-    if not directory or file is not None:
-        if selected.suffix != ".py":
-            return root, commit, selected.resolve().relative_to(root).as_posix(), False
-        _, relative = _selected_file(target, file)
-        return root, commit, relative, False
-    return root, commit, target.resolve().relative_to(root).as_posix(), True
+def _compare_context(context: ComparisonContext) -> dict:
+    result = _new_result(context.status)
+    if context.status == "ready":
+        if len(context.scopes) == 1:
+            result.update(
+                compare_source_changes(
+                    context.before, context.after, scope=context.scopes[0]
+                )
+            )
+        else:
+            result.update(
+                compare_source_changes(
+                    context.before, context.after, scopes=context.scopes
+                )
+            )
+    else:
+        result["reasons"] = list(context.reasons)
+    result["base"] = {"ref": context.base_ref, "commit": context.base_commit}
+    result["current"] = {
+        "kind": context.current_kind,
+        "commit": context.current_commit,
+        "source_hashes": dict(context.after.hashes) if context.after else {},
+    }
+    if context.before is not None:
+        result["base"]["source_hashes"] = dict(context.before.hashes)
+    result["context"] = context.metadata()
+    assumptions = (
+        _COMMITTED_ASSUMPTIONS
+        if context.current_kind == "commit"
+        else _WORKING_ASSUMPTIONS
+    )
+    result["assumptions"] = [*result["assumptions"], *assumptions]
+    return result
+
+
+def compare_target_changes(
+    paths: Sequence[str | Path | ComparisonTarget],
+    *,
+    base_ref: str | None = None,
+    exclude_folders: Sequence[str] | None = None,
+) -> list[dict]:
+    """Return one behavior report per repository selected by the requested paths.
+
+    Without a base reference compare HEAD to working sources. With a reference,
+    compare its merge base with HEAD to committed HEAD. This API prepares branch
+    review for existing diff workflows; it does not activate ordinary CLI scans.
+    """
+    return [
+        _compare_context(context)
+        for context in resolve_comparison_contexts(
+            paths, base_ref=base_ref, exclude_folders=exclude_folders
+        )
+    ]
 
 
 def compare_working_changes(
     path, *, file=None, line_range=None, exclude_folders=None
 ) -> dict:
-    """Infer affected existing functions; differences require intent review.
-
-    This is an automatic companion to normal verification, not an implicit
-    assertion that every code change must preserve behavior.
-    """
-    result = _new_result("unavailable")
-    result["base"] = {"ref": "HEAD", "commit": None}
-    result["assumptions"].extend(_GIT_ASSUMPTIONS)
-    scope = _scope(path, file)
-    if scope is None:
-        result["reasons"] = ["No local Git HEAD is available for behavior comparison"]
-        return result
-    root, commit, selected, directory = scope
-    result["base"]["commit"] = commit
-    if not directory and not selected.endswith(".py"):
-        result["reasons"] = [
-            "Automatic behavior comparison currently applies to Python files"
-        ]
-        return result
-    excluded = set(exclude_folders or [])
-    bounds = (
-        line_range if isinstance(line_range, tuple) else parse_line_range(line_range)
-    )
-    if bounds is not None and (
-        len(bounds) != 2 or bounds[0] < 1 or bounds[1] < bounds[0]
-    ):
-        raise ValueError("Invalid line range")
-
-    comparison_scope = ComparisonScope(
-        selected=selected,
-        directory=directory,
-        line_range=bounds,
-        exclude_folders=excluded,
-    )
-
-    try:
-        before, before_hashes = _base_sources(root, commit, allow_submodules=True)
-        after, after_hashes = _current_sources(
-            root, None if directory else selected, allow_submodules=True
-        )
-        changes = _git(
-            root,
-            "diff",
-            "--raw",
-            "--no-ext-diff",
-            "--no-textconv",
-            "--ignore-submodules=none",
-            commit,
-            "--",
-        )
-        if any(
-            b"160000" in row.split(b"\t", 1)[0].split() or row.startswith(b":160000 ")
-            for row in changes.splitlines()
-        ):
-            raise ValueError(
-                "Git submodule dependencies changed; behavior comparison is incomplete"
-            )
-    except ValueError as exc:
-        result.update(status="unknown", reasons=[str(exc)])
-        return result
-    result["base"]["source_hashes"] = before_hashes
-    result["current"] = {"source_hashes": after_hashes}
-    result.update(
-        compare_source_changes(
-            SourceSnapshot(before, before_hashes),
-            SourceSnapshot(after, after_hashes),
-            scope=comparison_scope,
-        )
-    )
-    result["assumptions"] = [*result["assumptions"], *_GIT_ASSUMPTIONS]
-    return result
+    """Keep focused verification's HEAD-to-working-tree comparison compatible."""
+    return compare_target_changes(
+        [ComparisonTarget(path, file=file, line_range=line_range)],
+        exclude_folders=exclude_folders,
+    )[0]

--- a/skylos/verification/comparison.py
+++ b/skylos/verification/comparison.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 import hashlib
 from pathlib import PurePosixPath
 from types import MappingProxyType
-from typing import Mapping
+from typing import Mapping, Sequence
 
 from skylos.verification.behavior import compare_python_behavior
 
@@ -235,16 +235,28 @@ def compare_source_changes(
     after: SourceSnapshot,
     *,
     scope: ComparisonScope | None = None,
+    scopes: Sequence[ComparisonScope] | None = None,
 ) -> dict:
     """Return modeled changes and unsupported coverage for prepared sources.
 
     Callers own snapshot acquisition, revision metadata, display and exit
     policy. No filesystem access, Git invocation or static analyzer runs here.
+    Multiple scopes are a union, with line ranges and exclusions applied per
+    scope. Selected functions share one impact graph and comparison budget.
     """
-    scope = scope or ComparisonScope()
-    selected, directory = scope.selected, scope.directory
-    bounds = scope.line_range
-    in_scope = scope.contains
+    if scope is not None and scopes is not None:
+        raise ValueError("Specify either scope or scopes, not both")
+    selections = (
+        tuple(dict.fromkeys(scopes))
+        if scopes is not None
+        else (scope or ComparisonScope(),)
+    )
+    if not selections:
+        raise ValueError("At least one comparison scope is required")
+
+    def in_scope(name: str) -> bool:
+        return any(selection.contains(name) for selection in selections)
+
     result = _new_result()
     before_hashes, after_hashes = before.hashes, after.hashes
     before, after = before.sources, after.sources
@@ -261,7 +273,14 @@ def compare_source_changes(
         return result
     # A known unsupported edit in a file target needs no repository-wide graph.
     # This also keeps selected-file comparison cheap for code outside the model.
-    if not directory and selected in raw_changed and in_scope(selected):
+    single_scope = selections[0] if len(selections) == 1 else None
+    if (
+        single_scope is not None
+        and not single_scope.directory
+        and single_scope.selected in raw_changed
+        and in_scope(single_scope.selected)
+    ):
+        selected, bounds = single_scope.selected, single_scope.line_range
         left = _index(selected, before.get(selected, ""))
         right = _index(selected, after.get(selected, ""))
         if (left.error or right.error) and left.digest != right.digest:
@@ -380,11 +399,19 @@ def compare_source_changes(
 
     # New helpers are checked by inlining them into surviving affected callers.
     def selected_function(key):
-        if not in_scope(key[0]):
-            return False
         nodes = [index.get(key[0], empty).functions.get(key[1]) for index in (old, new)]
-        return not bounds or any(
-            node and node.start <= bounds[1] and node.end >= bounds[0] for node in nodes
+        return any(
+            selection.contains(key[0])
+            and (
+                selection.line_range is None
+                or any(
+                    node
+                    and node.start <= selection.line_range[1]
+                    and node.end >= selection.line_range[0]
+                    for node in nodes
+                )
+            )
+            for selection in selections
         )
 
     existing = {
@@ -402,18 +429,10 @@ def compare_source_changes(
         reached = expanded
     candidates = []
     for name, symbol in sorted(affected):
-        if not in_scope(name):
+        if not selected_function((name, symbol)):
             continue
-        a, b = (
-            old.get(name, empty).functions.get(symbol),
-            new.get(name, empty).functions.get(symbol),
-        )
+        a = old.get(name, empty).functions.get(symbol)
         if a is None and (name, symbol) in reached:
-            continue
-        if bounds and not any(
-            node and node.start <= bounds[1] and node.end >= bounds[0]
-            for node in (a, b)
-        ):
             continue
         candidates.append((name, symbol))
     reasons = []

--- a/skylos/verification/context.py
+++ b/skylos/verification/context.py
@@ -1,0 +1,440 @@
+"""Resolve selected repositories and immutable identities before comparison."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import os
+from pathlib import Path
+from typing import Sequence
+
+from skylos.core.verify_change_schema import parse_line_range
+from skylos.verification.comparison import ComparisonScope, SourceSnapshot
+from skylos.verification.refactor import _base_sources, _current_sources, _git
+
+
+@dataclass(frozen=True)
+class ComparisonTarget:
+    """A caller-selected path, optional relative file and function line scope."""
+
+    path: str | Path
+    file: str | Path | None = None
+    line_range: str | tuple[int, int] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", Path(self.path).expanduser())
+        if self.file is not None:
+            selected = Path(self.file)
+            if (
+                selected.is_absolute()
+                or ".." in selected.parts
+                or "\0" in str(selected)
+            ):
+                raise ValueError(
+                    "--file must be a relative path within the selected directory"
+                )
+            object.__setattr__(self, "file", selected)
+        bounds = self.line_range
+        if isinstance(bounds, str):
+            bounds = parse_line_range(bounds)
+        scope = ComparisonScope(line_range=bounds)
+        object.__setattr__(self, "line_range", scope.line_range)
+
+
+@dataclass(frozen=True)
+class ComparisonContext:
+    """A prepared source pair and the exact revisions/scopes that identify it."""
+
+    repository_root: Path | None
+    base_ref: str
+    current_kind: str
+    base_ref_commit: str | None = None
+    base_commit: str | None = None
+    head_commit: str | None = None
+    scopes: tuple[ComparisonScope, ...] = ()
+    before: SourceSnapshot | None = None
+    after: SourceSnapshot | None = None
+    status: str = "ready"
+    reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.repository_root is not None:
+            object.__setattr__(self, "repository_root", Path(self.repository_root))
+        object.__setattr__(self, "scopes", tuple(self.scopes))
+        object.__setattr__(self, "reasons", tuple(self.reasons))
+
+    @property
+    def current_commit(self) -> str | None:
+        return self.head_commit if self.current_kind == "commit" else None
+
+    def metadata(self) -> dict:
+        return {
+            "repository_root": str(self.repository_root)
+            if self.repository_root is not None
+            else None,
+            "mode": "branch" if self.current_kind == "commit" else "local",
+            "base_ref": self.base_ref,
+            "base_ref_commit": self.base_ref_commit,
+            "base_commit": self.base_commit,
+            "head_commit": self.head_commit,
+            "current_kind": self.current_kind,
+            "current_commit": self.current_commit,
+            "scopes": [
+                {
+                    "selected": scope.selected,
+                    "directory": scope.directory,
+                    "line_range": list(scope.line_range)
+                    if scope.line_range is not None
+                    else None,
+                    "exclude_folders": sorted(scope.exclude_folders),
+                }
+                for scope in self.scopes
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class _LocatedTarget:
+    target: ComparisonTarget
+    selected: str
+    path: str
+    directory_hint: bool
+
+
+def _validate_base_ref(base_ref: str | None) -> None:
+    if base_ref is not None and (
+        not isinstance(base_ref, str)
+        or not base_ref.strip()
+        or len(base_ref) > 1024
+        or base_ref.startswith("-")
+        or "\0" in base_ref
+    ):
+        raise ValueError("Comparison base must be a valid Git commit reference")
+
+
+def _existing_anchor(path: Path) -> Path:
+    anchor = path if path.is_dir() else path.parent
+    while not anchor.is_dir() and anchor != anchor.parent:
+        anchor = anchor.parent
+    return anchor
+
+
+def _reject_local_symlinks(path: Path, root: Path) -> None:
+    ancestor = path
+    while True:
+        if ancestor.is_symlink():
+            if ancestor == path or ancestor.resolve().is_relative_to(root):
+                raise ValueError("Verification file or directory must not be a symlink")
+        if ancestor.resolve() == root or ancestor == ancestor.parent:
+            return
+        ancestor = ancestor.parent
+
+
+def _locate_target(target: ComparisonTarget, *, branch: bool):
+    path = target.path.absolute()
+    if "\0" in str(path):
+        raise ValueError("Verification scope contains an invalid path")
+    if path.is_symlink():
+        raise ValueError("Verification path must not be a symlink")
+    selected = path / target.file if target.file is not None else path
+    anchor = _existing_anchor(path)
+    try:
+        root = Path(
+            os.fsdecode(_git(anchor, "rev-parse", "--show-toplevel")).removesuffix("\n")
+        ).resolve()
+    except ValueError:
+        return None, anchor.resolve(), None
+    _reject_local_symlinks(selected, root)
+    if not branch:
+        if target.file is not None and path.exists() and not path.is_dir():
+            raise ValueError("--file cannot be combined with a file path target")
+        resolved = selected.resolve()
+        resolved_path = path.resolve()
+    else:
+        # Preserve the selected spelling below the discovery anchor: dirty files
+        # and directories do not decide which committed path is compared.
+        resolved = anchor.resolve() / selected.relative_to(anchor)
+        resolved_path = anchor.resolve() / path.relative_to(anchor)
+    if not resolved.is_relative_to(root) or ".." in resolved.relative_to(root).parts:
+        raise ValueError("Verification scope must stay within the Git repository")
+    located = _LocatedTarget(
+        target,
+        resolved.relative_to(root).as_posix(),
+        resolved_path.relative_to(root).as_posix(),
+        target.file is None and path.is_dir(),
+    )
+    return root, root, located
+
+
+def _resolve_commit(root: Path, ref: str) -> str:
+    return (
+        _git(root, "rev-parse", "--verify", "--end-of-options", f"{ref}^{{commit}}")
+        .decode("ascii")
+        .strip()
+    )
+
+
+def _pin_revisions(context: ComparisonContext) -> ComparisonContext:
+    root = context.repository_root
+    try:
+        head = _resolve_commit(root, "HEAD")
+    except ValueError:
+        return replace(
+            context,
+            status="unavailable",
+            reasons=("No local Git HEAD is available for behavior comparison",),
+        )
+    context = replace(context, head_commit=head)
+    if context.current_kind == "working_tree":
+        return replace(context, base_ref_commit=head, base_commit=head)
+    try:
+        reference = (
+            head
+            if context.base_ref == "HEAD"
+            else _resolve_commit(root, context.base_ref)
+        )
+    except ValueError:
+        return replace(
+            context,
+            status="unavailable",
+            reasons=(
+                f"Cannot resolve comparison base {context.base_ref!r} in the target repository",
+            ),
+        )
+    context = replace(context, base_ref_commit=reference)
+    try:
+        bases = (
+            _git(root, "merge-base", "--all", reference, head)
+            .decode("ascii")
+            .splitlines()
+        )
+    except ValueError:
+        bases = []
+    if len(bases) != 1:
+        reason = (
+            "Comparison history has multiple merge bases; a unique baseline is required"
+            if bases
+            else "Comparison merge-base history is unavailable; history may be shallow or unrelated"
+        )
+        return replace(context, status="unavailable", reasons=(reason,))
+    return replace(context, base_commit=bases[0])
+
+
+def _snapshot_kind(name: str, names: set[str]) -> str | None:
+    if name == "." or any(path.startswith(name + "/") for path in names):
+        return "directory"
+    return "file" if name in names else None
+
+
+class _UnavailableScope(ValueError):
+    pass
+
+
+def _committed_kind(root: Path, commit: str, name: str) -> str | None:
+    if name == ".":
+        return "directory"
+    try:
+        # The object-path suffix is exact, not a glob or working-tree path.
+        kind = _git(root, "cat-file", "-t", f"{commit}:{name}").strip()
+    except ValueError:
+        return None
+    return {b"blob": "file", b"tree": "directory", b"commit": "submodule"}.get(kind)
+
+
+def _target_kinds(context: ComparisonContext, name: str) -> set[str]:
+    if context.current_kind == "commit":
+        return {
+            kind
+            for commit in {context.base_commit, context.head_commit}
+            if (kind := _committed_kind(context.repository_root, commit, name))
+            is not None
+        }
+    return {
+        kind
+        for snapshot in (context.before, context.after)
+        if (kind := _snapshot_kind(name, set(snapshot.hashes))) is not None
+    }
+
+
+def _scopes_for_targets(
+    targets: Sequence[_LocatedTarget],
+    context: ComparisonContext,
+    *,
+    excluded: frozenset[str],
+) -> tuple[ComparisonScope, ...]:
+    scopes = []
+    for item in targets:
+        kinds = _target_kinds(context, item.selected)
+        branch = context.current_kind == "commit"
+        if branch and not kinds:
+            raise _UnavailableScope(
+                f"Selected scope {item.selected!r} does not exist in either compared commit"
+            )
+        if "submodule" in kinds:
+            raise _UnavailableScope(
+                "Selected scope is a Git submodule, outside source comparison"
+            )
+        if item.target.file is not None:
+            if "file" in _target_kinds(context, item.path):
+                raise _UnavailableScope(
+                    "--file cannot be combined with a file path target"
+                )
+            if "directory" in kinds:
+                raise _UnavailableScope(
+                    "--file must select a file in the compared sources"
+                )
+            kinds = {"file"}
+        elif not branch:
+            if item.directory_hint:
+                kinds.add("directory")
+            if not kinds:
+                kinds.add("file")
+        # A committed file-to-directory change includes both the deleted file
+        # and new descendants; neither side may disappear during selection.
+        for kind in sorted(kinds):
+            scope = ComparisonScope(
+                item.selected, kind == "directory", item.target.line_range, excluded
+            )
+            if scope not in scopes:
+                scopes.append(scope)
+    return tuple(scopes)
+
+
+def _check_submodules(context: ComparisonContext) -> None:
+    revisions = [context.base_commit]
+    if context.current_kind == "commit":
+        revisions.append(context.head_commit)
+    changes = _git(
+        context.repository_root,
+        "diff",
+        "--raw",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--ignore-submodules=none",
+        *revisions,
+        "--",
+    )
+    if any(
+        b"160000" in row.split(b"\t", 1)[0].split() or row.startswith(b":160000 ")
+        for row in changes.splitlines()
+    ):
+        raise ValueError(
+            "Git submodule dependencies changed; behavior comparison is incomplete"
+        )
+
+
+def _load_context(
+    context: ComparisonContext,
+    targets: Sequence[_LocatedTarget],
+    excluded: frozenset[str],
+) -> ComparisonContext:
+    context = _pin_revisions(context)
+    if context.status != "ready":
+        return context
+    root = context.repository_root
+    branch = context.current_kind == "commit"
+    if not branch and all(
+        not item.directory_hint
+        and (
+            Path(item.selected).suffix
+            or (item.target.path / (item.target.file or "")).is_file()
+        )
+        and not item.selected.endswith(".py")
+        for item in targets
+    ):
+        return replace(
+            context,
+            status="unavailable",
+            reasons=(
+                "Automatic behavior comparison currently applies to Python files",
+            ),
+            scopes=tuple(
+                ComparisonScope(item.selected, False, item.target.line_range, excluded)
+                for item in targets
+            ),
+        )
+    try:
+        before = SourceSnapshot(
+            *_base_sources(root, context.base_commit, allow_submodules=True)
+        )
+        if branch:
+            after = (
+                before
+                if context.base_commit == context.head_commit
+                else SourceSnapshot(
+                    *_base_sources(root, context.head_commit, allow_submodules=True)
+                )
+            )
+        else:
+            selected = tuple(
+                sorted(
+                    {
+                        item.selected
+                        for item in targets
+                        if not item.directory_hint and item.selected.endswith(".py")
+                    }
+                )
+            )
+            after = SourceSnapshot(
+                *_current_sources(root, selected or None, allow_submodules=True)
+            )
+        context = replace(context, before=before, after=after)
+        _check_submodules(context)
+    except ValueError as exc:
+        return replace(context, status="unknown", reasons=(str(exc),))
+    try:
+        scopes = _scopes_for_targets(targets, context, excluded=excluded)
+    except _UnavailableScope as exc:
+        return replace(context, status="unavailable", reasons=(str(exc),))
+    if not any(scope.directory or scope.selected.endswith(".py") for scope in scopes):
+        return replace(
+            context,
+            scopes=scopes,
+            status="unavailable",
+            reasons=(
+                "Automatic behavior comparison currently applies to Python files",
+            ),
+        )
+    return replace(context, scopes=scopes)
+
+
+def resolve_comparison_contexts(
+    paths: Sequence[str | Path | ComparisonTarget],
+    *,
+    base_ref: str | None = None,
+    exclude_folders: Sequence[str] | None = None,
+) -> list[ComparisonContext]:
+    """Read each selected repository's source pair once with pinned revisions."""
+    _validate_base_ref(base_ref)
+    if isinstance(paths, (str, Path, ComparisonTarget)):
+        paths = [paths]
+    excluded = frozenset(exclude_folders or ())
+    groups = {}
+    for value in paths:
+        target = (
+            value if isinstance(value, ComparisonTarget) else ComparisonTarget(value)
+        )
+        root, group, located = _locate_target(target, branch=base_ref is not None)
+        if group not in groups:
+            groups[group] = (root, [])
+        if located is not None:
+            groups[group][1].append(located)
+    contexts = []
+    for root, targets in groups.values():
+        context = ComparisonContext(
+            root,
+            base_ref or "HEAD",
+            "commit" if base_ref is not None else "working_tree",
+        )
+        if root is None:
+            contexts.append(
+                replace(
+                    context,
+                    status="unavailable",
+                    reasons=(
+                        "No local Git repository is available for behavior comparison",
+                    ),
+                )
+            )
+        else:
+            contexts.append(_load_context(context, targets, excluded))
+    return contexts

--- a/skylos/verification/refactor.py
+++ b/skylos/verification/refactor.py
@@ -248,7 +248,10 @@ def _read_working_source(root_fd: int, name: str) -> bytes | None:
 
 
 def _current_sources(
-    root: Path, selected: str | None = None, *, allow_submodules: bool = False
+    root: Path,
+    selected: str | tuple[str, ...] | None = None,
+    *,
+    allow_submodules: bool = False,
 ) -> tuple[dict[str, str], dict[str, str]]:
     index = _git(root, "ls-files", "--stage", "-z")
     if not allow_submodules and any(
@@ -265,9 +268,9 @@ def _current_sources(
         for name in listing
         if name and _snapshot_input(os.fsdecode(name))
     }
-    # An explicitly selected ignored file is still part of the obligation.
+    # Explicitly selected ignored files are still part of the obligation.
     if selected is not None:
-        names.add(selected)
+        names.update((selected,) if isinstance(selected, str) else selected)
     if len(names) > _MAX_FILES:
         raise ValueError("Working source snapshot exceeds the verification file limit")
     if (

--- a/test/test_behavior_baselines.py
+++ b/test/test_behavior_baselines.py
@@ -1,0 +1,502 @@
+"""Acceptance tests compare local Git snapshots without running fixture code."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from skylos.core.safe_cache_io import write_text_no_symlink
+from skylos.verification.changes import ComparisonTarget, compare_target_changes
+
+
+_RETURN = "def run(callback, value):\n    return callback(value)\n"
+_LOST_RETURN = "def run(callback, value):\n    callback(value)\n    return None\n"
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+    return subprocess.run(
+        [
+            "git",
+            "--no-pager",
+            "--no-replace-objects",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.autocrlf=false",
+            *args,
+        ],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.strip()
+
+
+def _write(repo: Path, name: str, source: str, *, encoding: str = "utf-8") -> None:
+    path = repo / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    assert write_text_no_symlink(path, source, encoding=encoding)
+
+
+def _commit(repo: Path, *names: str) -> str:
+    _git(repo, "add", "--", *names)
+    _git(
+        repo,
+        "-c",
+        "user.name=Skylos Test",
+        "-c",
+        "user.email=skylos-test@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-qm",
+        "fixture snapshot",
+    )
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def baseline_repo(tmp_path):
+    if shutil.which("git") is None:
+        pytest.skip("git is required")
+    created = 0
+
+    def create(files: dict[str, str] | None = None) -> tuple[Path, str]:
+        nonlocal created
+        created += 1
+        repo = tmp_path / f"baseline repository {created}"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "feature")
+        files = files or {"app.py": _RETURN}
+        for name, source in files.items():
+            _write(repo, name, source)
+        commit = _commit(repo, *files)
+        _git(repo, "branch", "comparison-base")
+        return repo, commit
+
+    return create
+
+
+def _one(paths, **kwargs):
+    reports = compare_target_changes(paths, **kwargs)
+    assert len(reports) == 1
+    return reports[0]
+
+
+def _symbols(result):
+    return [(item["file"], item["symbol"]) for item in result["comparisons"]]
+
+
+def _assert_branch_identity(result, repo, baseline, head, *, ref_commit=None):
+    assert result["base"]["ref"] == "comparison-base"
+    assert result["base"]["commit"] == baseline
+    assert result["current"]["kind"] == "commit"
+    assert result["current"]["commit"] == head
+    context = result["context"]
+    assert Path(context["repository_root"]) == repo
+    assert context["mode"] == "branch"
+    assert context["base_ref"] == "comparison-base"
+    assert context["base_ref_commit"] == (ref_commit or baseline)
+    assert context["base_commit"] == baseline
+    assert context["head_commit"] == head
+    assert context["current_kind"] == "commit"
+    assert context["current_commit"] == head
+
+
+def test_local_return_loss_compares_head_with_working_sources(baseline_repo):
+    repo, head = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+
+    result = _one([repo / "app.py"])
+
+    assert result["status"] == "different"
+    assert _symbols(result) == [("app.py", "run")]
+    assert result["base"]["ref"] == "HEAD"
+    assert result["base"]["commit"] == head
+    assert result["current"]["kind"] == "working_tree"
+    assert result["current"]["commit"] is None
+    context = result["context"]
+    assert context["mode"] == "local"
+    assert context["base_commit"] == context["head_commit"] == head
+    assert context["current_kind"] == "working_tree"
+    assert context["current_commit"] is None
+    explanation = result["comparisons"][0]["differences"][0]["explanation"]
+    assert explanation["title"] == "Callback result discarded"
+
+
+def test_clean_committed_branch_retains_return_loss(baseline_repo):
+    repo, baseline = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    head = _commit(repo, "app.py")
+
+    result = _one([repo], base_ref="comparison-base")
+
+    assert result["status"] == "different"
+    assert _symbols(result) == [("app.py", "run")]
+    _assert_branch_identity(result, repo, baseline, head)
+    assert _one([repo])["status"] == "unchanged"
+
+
+@pytest.mark.parametrize("staged", [False, True], ids=["working-tree", "index"])
+def test_local_restoration_cannot_hide_committed_return_loss(baseline_repo, staged):
+    repo, baseline = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    head = _commit(repo, "app.py")
+    _write(repo, "app.py", _RETURN)
+    if staged:
+        _git(repo, "add", "--", "app.py")
+
+    result = _one([repo / "app.py"], base_ref="comparison-base")
+
+    assert result["status"] == "different"
+    _assert_branch_identity(result, repo, baseline, head)
+    assert (
+        result["current"]["source_hashes"]["app.py"]
+        == hashlib.sha256(_LOST_RETURN.encode()).hexdigest()
+    )
+
+
+def test_diverged_reference_uses_merge_base_not_reference_tip(baseline_repo):
+    repo, common = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    feature = _commit(repo, "app.py")
+    _git(repo, "switch", "-q", "comparison-base")
+    _write(repo, "app.py", "def run(callback, value):\n    return 'base branch'\n")
+    reference_tip = _commit(repo, "app.py")
+    _git(repo, "switch", "-q", "feature")
+
+    result = _one([repo], base_ref="comparison-base")
+
+    assert result["status"] == "different"
+    _assert_branch_identity(result, repo, common, feature, ref_commit=reference_tip)
+    assert (
+        result["base"]["source_hashes"]["app.py"]
+        == hashlib.sha256(_RETURN.encode()).hexdigest()
+    )
+
+
+def test_reference_is_resolved_in_target_repo_from_another_cwd(
+    baseline_repo, monkeypatch
+):
+    repo, baseline = baseline_repo()
+    other, _ = baseline_repo({"elsewhere.py": "def elsewhere():\n    return None\n"})
+    _write(repo, "app.py", _LOST_RETURN)
+    head = _commit(repo, "app.py")
+    monkeypatch.chdir(other)
+
+    result = _one([str(repo / "app.py")], base_ref="comparison-base")
+
+    assert result["status"] == "different"
+    _assert_branch_identity(result, repo, baseline, head)
+
+
+def test_committed_comparison_never_loads_working_sources(baseline_repo, monkeypatch):
+    from skylos.verification import context
+
+    repo, _ = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    _commit(repo, "app.py")
+
+    def forbidden_working_read(*args, **kwargs):
+        pytest.fail("Committed comparison must not read working source files")
+
+    monkeypatch.setattr(context, "_current_sources", forbidden_working_read)
+
+    assert _one([repo], base_ref="comparison-base")["status"] == "different"
+
+
+def test_refs_moving_during_snapshot_loading_cannot_change_pinned_comparison(
+    baseline_repo, monkeypatch
+):
+    from skylos.verification import context
+
+    repo, baseline = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    head = _commit(repo, "app.py")
+    _write(repo, "app.py", _RETURN)
+    later_commit = _commit(repo, "app.py")
+    _git(repo, "update-ref", "refs/heads/feature", head, later_commit)
+    original_loader = context._base_sources
+    moved = False
+
+    def move_refs_after_pinning(root, commit, **kwargs):
+        nonlocal moved
+        if not moved:
+            moved = True
+            _git(repo, "update-ref", "refs/heads/feature", later_commit, head)
+            _git(
+                repo, "update-ref", "refs/heads/comparison-base", later_commit, baseline
+            )
+        return original_loader(root, commit, **kwargs)
+
+    monkeypatch.setattr(context, "_base_sources", move_refs_after_pinning)
+
+    result = _one([repo / "app.py"], base_ref="comparison-base")
+
+    assert _git(repo, "rev-parse", "HEAD") == later_commit
+    assert _git(repo, "rev-parse", "comparison-base") == later_commit
+    assert result["status"] == "different"
+    _assert_branch_identity(result, repo, baseline, head)
+    assert (
+        result["current"]["source_hashes"]["app.py"]
+        == hashlib.sha256(_LOST_RETURN.encode()).hexdigest()
+    )
+
+
+def test_dirty_directory_cannot_reclassify_a_committed_file(baseline_repo):
+    repo, _ = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    _commit(repo, "app.py")
+    (repo / "app.py").unlink()
+    (repo / "app.py").mkdir()
+
+    result = _one([repo / "app.py"], base_ref="comparison-base")
+
+    assert result["status"] == "different"
+    assert _symbols(result) == [("app.py", "run")]
+    assert result["context"]["scopes"][0]["directory"] is False
+
+
+@pytest.mark.parametrize("selected", ["pkg", "pkg/app.py"])
+def test_committed_deletion_remains_visible_when_local_scope_is_absent(
+    baseline_repo, selected
+):
+    repo, _ = baseline_repo({"pkg/app.py": _RETURN, "other.py": _RETURN})
+    (repo / "pkg/app.py").unlink()
+    (repo / "pkg").rmdir()
+    _commit(repo, "pkg/app.py")
+
+    result = _one([repo / selected], base_ref="comparison-base")
+
+    assert result["status"] in {"different", "unknown"}
+    assert ("pkg/app.py", "run") in _symbols(result)
+    assert result["context"]["scopes"][0]["directory"] is (selected == "pkg")
+
+
+@pytest.mark.parametrize("mode", ["local", "branch"])
+def test_overlapping_targets_compare_each_function_once(baseline_repo, mode):
+    repo, _ = baseline_repo({"pkg/app.py": _RETURN, "pkg/other.py": _RETURN})
+    _write(repo, "pkg/app.py", _LOST_RETURN)
+    _write(repo, "pkg/other.py", _LOST_RETURN)
+    if mode == "branch":
+        _commit(repo, "pkg/app.py", "pkg/other.py")
+
+    result = _one(
+        [repo / "pkg", repo / "pkg/app.py", repo / "pkg"],
+        base_ref="comparison-base" if mode == "branch" else None,
+    )
+
+    assert result["status"] == "different"
+    assert sorted(_symbols(result)) == [("pkg/app.py", "run"), ("pkg/other.py", "run")]
+
+
+def test_multiple_file_targets_keep_their_scope_and_omit_unselected_files(
+    baseline_repo,
+):
+    repo, _ = baseline_repo({name: _RETURN for name in ("a.py", "b.py", "c.py")})
+    for name in ("a.py", "b.py", "c.py"):
+        _write(repo, name, _LOST_RETURN)
+    _commit(repo, "a.py", "b.py", "c.py")
+
+    result = _one([repo / "a.py", repo / "b.py"], base_ref="comparison-base")
+
+    assert sorted(_symbols(result)) == [("a.py", "run"), ("b.py", "run")]
+    assert {scope["selected"] for scope in result["context"]["scopes"]} == {
+        "a.py",
+        "b.py",
+    }
+
+
+def test_target_file_range_and_exclusions_survive_scope_resolution(baseline_repo):
+    before = _RETURN + "\ndef second(value):\n    return value\n"
+    after = _LOST_RETURN + "\ndef second(value):\n    return None\n"
+    repo, _ = baseline_repo({"pkg/app.py": before, "pkg/ignored/skip.py": _RETURN})
+    _write(repo, "pkg/app.py", after)
+    _write(repo, "pkg/ignored/skip.py", _LOST_RETURN)
+    _commit(repo, "pkg/app.py", "pkg/ignored/skip.py")
+
+    result = _one(
+        [ComparisonTarget(repo / "pkg", file="app.py", line_range="1:3")],
+        base_ref="comparison-base",
+        exclude_folders=["ignored"],
+    )
+
+    assert _symbols(result) == [("pkg/app.py", "run")]
+    scope = result["context"]["scopes"][0]
+    assert scope["selected"] == "pkg/app.py"
+    assert scope["directory"] is False
+    assert tuple(scope["line_range"]) == (1, 3)
+    assert set(scope["exclude_folders"]) == {"ignored"}
+
+
+def test_directory_exclusions_apply_to_committed_branch_changes(baseline_repo):
+    repo, _ = baseline_repo({"pkg/app.py": _RETURN, "pkg/ignored/skip.py": _RETURN})
+    _write(repo, "pkg/app.py", _LOST_RETURN)
+    _write(repo, "pkg/ignored/skip.py", _LOST_RETURN)
+    _commit(repo, "pkg/app.py", "pkg/ignored/skip.py")
+
+    result = _one(
+        [repo / "pkg"], base_ref="comparison-base", exclude_folders=["ignored"]
+    )
+
+    assert _symbols(result) == [("pkg/app.py", "run")]
+
+
+def test_multiple_repositories_have_independent_commit_identities(baseline_repo):
+    first, first_base = baseline_repo()
+    second, second_base = baseline_repo({"other.py": _RETURN})
+    _write(first, "app.py", _LOST_RETURN)
+    first_head = _commit(first, "app.py")
+    _write(second, "other.py", _LOST_RETURN)
+    second_head = _commit(second, "other.py")
+
+    reports = compare_target_changes(
+        [first, second / "other.py"], base_ref="comparison-base"
+    )
+
+    assert len(reports) == 2
+    by_root = {Path(report["context"]["repository_root"]): report for report in reports}
+    for repo, baseline, head in (
+        (first, first_base, first_head),
+        (second, second_base, second_head),
+    ):
+        result = by_root[repo]
+        assert result["status"] == "different"
+        _assert_branch_identity(result, repo, baseline, head)
+
+
+def test_unknown_reference_is_explicitly_unavailable(baseline_repo):
+    repo, _ = baseline_repo()
+
+    result = _one([repo], base_ref="refs/heads/not-present")
+
+    assert result["status"] == "unavailable"
+    assert result["reasons"]
+    assert result["comparisons"] == []
+    assert result["base"]["commit"] is None
+
+
+def test_unavailable_repository_does_not_discard_another_repository_result(
+    baseline_repo,
+):
+    available, _ = baseline_repo()
+    unavailable, _ = baseline_repo({"other.py": _RETURN})
+    _write(available, "app.py", _LOST_RETURN)
+    _commit(available, "app.py")
+    _git(unavailable, "branch", "-D", "comparison-base")
+
+    reports = compare_target_changes(
+        [unavailable, available], base_ref="comparison-base"
+    )
+
+    assert len(reports) == 2
+    by_root = {Path(report["context"]["repository_root"]): report for report in reports}
+    assert by_root[available]["status"] == "different"
+    assert by_root[unavailable]["status"] == "unavailable"
+    assert by_root[unavailable]["reasons"]
+
+
+def test_non_git_target_does_not_discard_a_git_repository_result(
+    baseline_repo, tmp_path
+):
+    repo, _ = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    _write(tmp_path, "plain/app.py", _RETURN)
+
+    reports = compare_target_changes([tmp_path / "plain", repo])
+
+    assert len(reports) == 2
+    assert sorted(report["status"] for report in reports) == [
+        "different",
+        "unavailable",
+    ]
+    successful = next(report for report in reports if report["status"] == "different")
+    assert Path(successful["context"]["repository_root"]) == repo
+
+
+@pytest.mark.parametrize("base_ref", [None, "comparison-base"])
+def test_non_git_target_is_explicitly_unavailable(tmp_path, base_ref):
+    _write(tmp_path, "app.py", _RETURN)
+
+    result = _one([tmp_path / "app.py"], base_ref=base_ref)
+
+    assert result["status"] == "unavailable"
+    assert result["reasons"]
+    assert result["comparisons"] == []
+
+
+@pytest.mark.parametrize("base_ref", [None, "HEAD"])
+def test_unborn_repository_is_explicitly_unavailable(tmp_path, base_ref):
+    _git(tmp_path, "init", "-q", "-b", "feature")
+    _write(tmp_path, "app.py", _RETURN)
+
+    result = _one([tmp_path], base_ref=base_ref)
+
+    assert result["status"] == "unavailable"
+    assert result["reasons"]
+    assert result["comparisons"] == []
+
+
+def test_shallow_missing_merge_history_is_explicitly_unavailable(baseline_repo):
+    repo, _ = baseline_repo()
+    _write(repo, "app.py", _LOST_RETURN)
+    head = _commit(repo, "app.py")
+    _write(repo, ".git/shallow", head + "\n")
+    assert _git(repo, "rev-parse", "--is-shallow-repository") == "true"
+
+    result = _one([repo], base_ref="comparison-base")
+
+    assert result["status"] == "unavailable"
+    assert result["reasons"]
+    assert result["comparisons"] == []
+    assert any(
+        "shallow" in reason.lower() or "history" in reason.lower()
+        for reason in result["reasons"]
+    )
+
+
+@pytest.mark.parametrize("mode", ["local", "branch"])
+def test_snapshot_identity_hashes_exact_encoded_bytes(baseline_repo, mode):
+    repo, _ = baseline_repo()
+    before = "# coding: latin-1\r\ndef run(value):\r\n    return 'caf\u00e9'\r\n"
+    after = "# coding: latin-1\r\ndef run(value):\r\n    return 'th\u00e9'\r\n"
+    manifest = "[project]\r\nname = 'fixture'\r\nversion = '1.0'\r\n"
+    _write(repo, "app.py", before, encoding="latin-1")
+    _write(repo, "pyproject.toml", manifest)
+    baseline = _commit(repo, "app.py", "pyproject.toml")
+    _git(repo, "branch", "-f", "comparison-base", baseline)
+    _write(repo, "app.py", after, encoding="latin-1")
+    if mode == "branch":
+        _commit(repo, "app.py")
+        _write(repo, "app.py", _RETURN)
+
+    result = _one(
+        [repo / "app.py"], base_ref="comparison-base" if mode == "branch" else None
+    )
+
+    assert result["status"] == "different"
+    assert (
+        result["base"]["source_hashes"]["app.py"]
+        == hashlib.sha256(before.encode("latin-1")).hexdigest()
+    )
+    assert (
+        result["current"]["source_hashes"]["app.py"]
+        == hashlib.sha256(after.encode("latin-1")).hexdigest()
+    )
+    expected_manifest_hash = hashlib.sha256(manifest.encode()).hexdigest()
+    assert result["base"]["source_hashes"]["pyproject.toml"] == expected_manifest_hash
+    assert (
+        result["current"]["source_hashes"]["pyproject.toml"] == expected_manifest_hash
+    )

--- a/test/test_behavior_changes.py
+++ b/test/test_behavior_changes.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock
 import pytest
 
 from skylos.core.safe_cache_io import write_text_no_symlink
-from skylos.verification.changes import compare_working_changes
+from skylos.verification.changes import compare_target_changes, compare_working_changes
 
 
 _IDENTITY = "def run(value):\n    return value\n"
@@ -98,6 +98,7 @@ def test_git_adapter_reuses_shared_service_once_and_preserves_byte_evidence(
     change_repo, monkeypatch
 ):
     import skylos.verification.changes as changes
+    import skylos.verification.context as context
 
     original = "# coding: latin-1\ndef run(value):\n    return value\n"
     repo, commit = change_repo({"app.py": original})
@@ -105,8 +106,8 @@ def test_git_adapter_reuses_shared_service_once_and_preserves_byte_evidence(
         "# coding: latin-1\ndef run(value):\n    return 'caf\u00e9'\n".encode("latin-1")
     )
     (repo / "app.py").write_bytes(changed_bytes)
-    base_loader = Mock(wraps=changes._base_sources)
-    current_loader = Mock(wraps=changes._current_sources)
+    base_loader = Mock(wraps=context._base_sources)
+    current_loader = Mock(wraps=context._current_sources)
     compare = changes.compare_source_changes
     recorded = []
 
@@ -116,8 +117,8 @@ def test_git_adapter_reuses_shared_service_once_and_preserves_byte_evidence(
         return result
 
     service = Mock(side_effect=record_comparison)
-    monkeypatch.setattr(changes, "_base_sources", base_loader)
-    monkeypatch.setattr(changes, "_current_sources", current_loader)
+    monkeypatch.setattr(context, "_base_sources", base_loader)
+    monkeypatch.setattr(context, "_current_sources", current_loader)
     monkeypatch.setattr(changes, "compare_source_changes", service)
 
     result = compare_working_changes(repo / "app.py")
@@ -449,3 +450,173 @@ def test_changed_registered_submodule_requires_qualification(
 
     assert result["status"] == "unknown"
     assert any("submodule" in reason for reason in result["reasons"])
+
+
+@pytest.mark.parametrize("branch", [False, True], ids=["local", "branch"])
+def test_grouped_targets_load_each_snapshot_and_compare_only_once(
+    change_repo, monkeypatch, branch
+):
+    import skylos.verification.changes as changes
+    import skylos.verification.context as context
+
+    repo, base = change_repo({"pkg/app.py": _IDENTITY, "pkg/other.py": _IDENTITY})
+    _write(repo, "pkg/app.py", "def run(value):\n    return None\n")
+    if branch:
+        _git(repo, "add", "--", "pkg/app.py")
+        _commit(repo, "committed change")
+    head = _git(repo, "rev-parse", "HEAD")
+    base_loader = Mock(wraps=context._base_sources)
+    current_loader = Mock(wraps=context._current_sources)
+    service = Mock(wraps=changes.compare_source_changes)
+    git_reads = Mock(wraps=context._git)
+    monkeypatch.setattr(context, "_base_sources", base_loader)
+    monkeypatch.setattr(context, "_current_sources", current_loader)
+    monkeypatch.setattr(changes, "compare_source_changes", service)
+    monkeypatch.setattr(context, "_git", git_reads)
+
+    reports = compare_target_changes(
+        [repo / "pkg", repo / "pkg/app.py", repo / "pkg"],
+        base_ref=base if branch else None,
+    )
+
+    assert len(reports) == 1
+    assert reports[0]["status"] == "different"
+    service.assert_called_once()
+    assert [call.args[1] for call in base_loader.call_args_list] == (
+        [base, head] if branch else [head]
+    )
+    assert current_loader.call_count == (0 if branch else 1)
+    head_resolutions = [
+        call
+        for call in git_reads.call_args_list
+        if call.args[1] == "rev-parse" and "HEAD^{commit}" in call.args
+    ]
+    assert len(head_resolutions) == 1
+    if branch:
+        merge_reads = [
+            call for call in git_reads.call_args_list if call.args[1] == "merge-base"
+        ]
+        assert len(merge_reads) == 1
+        assert base in merge_reads[0].args and head in merge_reads[0].args
+
+
+def test_grouped_explicit_ignored_files_share_one_working_snapshot(
+    change_repo, monkeypatch
+):
+    import skylos.verification.context as context
+
+    repo, _ = change_repo({"app.py": _IDENTITY, ".gitignore": "*.local.py\n"})
+    _write(repo, "first.local.py", _IDENTITY)
+    _write(repo, "second.local.py", _IDENTITY)
+    _write(repo, "unselected.local.py", _IDENTITY)
+    loader = Mock(wraps=context._current_sources)
+    monkeypatch.setattr(context, "_current_sources", loader)
+
+    reports = compare_target_changes(
+        [repo / "first.local.py", repo / "second.local.py"]
+    )
+
+    assert len(reports) == 1
+    loader.assert_called_once()
+    assert set(reports[0]["current"]["source_hashes"]) == {
+        "app.py",
+        "first.local.py",
+        "second.local.py",
+    }
+    assert set(_comparisons(reports[0])) == {
+        ("first.local.py", "run"),
+        ("second.local.py", "run"),
+    }
+
+
+def test_branch_submodule_evidence_ignores_dirty_working_dependency(change_repo):
+    repo, _ = change_repo({"app.py": _IDENTITY})
+    dependency = _register_local_submodule(repo)
+    base = _git(repo, "rev-parse", "HEAD")
+    _write(repo, "app.py", "def run(value):\n    return None\n")
+    _git(repo, "add", "--", "app.py")
+    _commit(repo, "application change")
+    _write(dependency, "module.py", "def run(value):\n    return 'dirty'\n")
+
+    report = compare_target_changes([repo], base_ref=base)[0]
+
+    assert report["status"] == "different"
+    assert compare_working_changes(repo)["status"] == "unknown"
+    assert "dependency/module.py" not in report["current"]["source_hashes"]
+
+
+@pytest.mark.parametrize("base_ref", ["", " ", "--all", "HEAD\0", "a" * 1025])
+def test_invalid_branch_reference_is_an_input_error_before_git(
+    tmp_path, monkeypatch, base_ref
+):
+    import skylos.verification.context as context
+
+    def unexpected_git(*args, **kwargs):
+        pytest.fail("Invalid refs must be rejected before Git access")
+
+    monkeypatch.setattr(context, "_git", unexpected_git)
+    with pytest.raises(ValueError, match="reference|ref|base"):
+        compare_target_changes([tmp_path], base_ref=base_ref)
+
+
+@pytest.mark.parametrize("selected", ["app.ts", "README"])
+@pytest.mark.parametrize("file_option", [False, True])
+def test_non_python_local_target_does_not_load_unrelated_python_sources(
+    change_repo, monkeypatch, selected, file_option
+):
+    import skylos.verification.context as context
+
+    repo, _ = change_repo({"app.py": _IDENTITY, selected: "Non-Python fixture\n"})
+
+    def unexpected_snapshot(*args, **kwargs):
+        pytest.fail("Non-Python local selections must not load Python snapshots")
+
+    monkeypatch.setattr(context, "_base_sources", unexpected_snapshot)
+    monkeypatch.setattr(context, "_current_sources", unexpected_snapshot)
+
+    report = (
+        compare_working_changes(repo, file=selected)
+        if file_option
+        else compare_working_changes(repo / selected)
+    )
+
+    assert report["status"] == "unavailable"
+    assert report["comparisons"] == []
+
+
+@pytest.mark.parametrize("selected", ["missing.py", "missing_directory"])
+def test_missing_branch_scope_is_unavailable_instead_of_unchanged(
+    change_repo, selected
+):
+    repo, base = change_repo({"app.py": _IDENTITY})
+
+    report = compare_target_changes([repo / selected], base_ref=base)[0]
+
+    assert report["status"] == "unavailable"
+    assert report["comparisons"] == []
+    assert report["reasons"]
+
+
+def test_committed_extensionless_file_is_not_classified_as_directory(change_repo):
+    repo, base = change_repo({"app.py": _IDENTITY, "README": "Project overview\n"})
+
+    report = compare_target_changes([repo / "README"], base_ref=base)[0]
+
+    assert report["status"] == "unavailable"
+    assert report["context"]["scopes"][0]["directory"] is False
+
+
+def test_committed_file_to_directory_change_does_not_hide_removed_function(change_repo):
+    repo, base = change_repo({"app.py": _IDENTITY})
+    (repo / "app.py").unlink()
+    _write(repo, "app.py/helper.py", _IDENTITY)
+    _git(repo, "add", "--", "app.py")
+    _commit(repo, "source path became a directory")
+
+    report = compare_target_changes([repo / "app.py"], base_ref=base)[0]
+
+    assert report["status"] == "unknown"
+    assert ("app.py", "run") in _comparisons(report) or any(
+        "type" in reason.lower() or "kind" in reason.lower()
+        for reason in report["reasons"]
+    )

--- a/test/test_behavior_comparison.py
+++ b/test/test_behavior_comparison.py
@@ -5,9 +5,11 @@ import hashlib
 import io
 from pathlib import Path
 import subprocess
+from unittest.mock import Mock
 
 import pytest
 
+from skylos.verification import comparison
 from skylos.verification.comparison import (
     ComparisonScope,
     SourceSnapshot,
@@ -196,6 +198,213 @@ def test_line_scope_selects_only_intersecting_changed_function():
     assert set(_comparisons(result)) == {("app.py", "second")}
 
 
+def test_overlapping_scopes_compare_each_function_once(monkeypatch):
+    names = ("pkg/app.py", "pkg/other.py")
+    compare = Mock(wraps=comparison.compare_python_behavior)
+    monkeypatch.setattr(comparison, "compare_python_behavior", compare)
+    monkeypatch.setattr(comparison, "_MAX_COMPARISONS", 2)
+    file_scope = ComparisonScope(selected="pkg/app.py", directory=False)
+
+    result = compare_source_changes(
+        _snapshot({name: _IDENTITY for name in names}),
+        _snapshot({name: _CHANGED for name in names}),
+        scopes=[ComparisonScope(selected="pkg"), file_scope, file_scope],
+    )
+
+    assert result["status"] == "different"
+    assert result["reasons"] == []
+    assert set(_comparisons(result)) == {(name, "run") for name in names}
+    assert len(result["comparisons"]) == compare.call_count == 2
+
+
+def test_disjoint_scopes_share_source_indexing(monkeypatch):
+    names = ("first/app.py", "second/app.py", "unselected.py")
+    index = Mock(wraps=comparison._index)
+    monkeypatch.setattr(comparison, "_index", index)
+
+    result = compare_source_changes(
+        _snapshot({name: _IDENTITY for name in names}),
+        _snapshot({name: _CHANGED for name in names}),
+        scopes=[ComparisonScope(selected="first"), ComparisonScope(selected="second")],
+    )
+
+    assert result["status"] == "different"
+    assert set(_comparisons(result)) == {
+        ("first/app.py", "run"),
+        ("second/app.py", "run"),
+    }
+    calls = [call.args for call in index.call_args_list]
+    for name in names:
+        assert calls.count((name, _IDENTITY)) == 1
+        assert calls.count((name, _CHANGED)) == 1
+
+
+def test_each_scope_keeps_its_own_line_range_and_exclusions():
+    before_source = (
+        "def first(value):\n    return value\n\n"
+        "def second(value):\n    return value\n\n"
+        "def third(value):\n    return value\n"
+    )
+    after_source = before_source.replace("return value", "return None")
+    names = ("pkg/app.py", "pkg/generated/app.py", "pkg/private/app.py")
+
+    result = compare_source_changes(
+        _snapshot({name: before_source for name in names}),
+        _snapshot({name: after_source for name in names}),
+        scopes=[
+            ComparisonScope(
+                selected="pkg",
+                line_range=(1, 2),
+                exclude_folders=frozenset({"generated"}),
+            ),
+            ComparisonScope(
+                selected="pkg/generated/app.py",
+                directory=False,
+                line_range=(4, 5),
+            ),
+            ComparisonScope(
+                selected="pkg",
+                line_range=(7, 8),
+                exclude_folders=frozenset({"generated", "private"}),
+            ),
+        ],
+    )
+
+    assert result["status"] == "different"
+    assert set(_comparisons(result)) == {
+        ("pkg/app.py", "first"),
+        ("pkg/app.py", "third"),
+        ("pkg/generated/app.py", "second"),
+        ("pkg/private/app.py", "first"),
+    }
+
+
+def test_multiple_scopes_include_unchanged_callers_of_changed_unselected_helper():
+    caller = (
+        "from helpers import identity\n\ndef run(value):\n    return identity(value)\n"
+    )
+    callers = {"first.py": caller, "second.py": caller, "unselected.py": caller}
+
+    result = compare_source_changes(
+        _snapshot(
+            {**callers, "helpers.py": "def identity(value):\n    return value\n"}
+        ),
+        _snapshot({**callers, "helpers.py": "def identity(value):\n    return None\n"}),
+        scopes=[
+            ComparisonScope(selected="first.py", directory=False),
+            ComparisonScope(selected="second.py", directory=False),
+        ],
+    )
+
+    assert result["status"] == "different"
+    assert result["changed_files"] == ["helpers.py"]
+    assert set(_comparisons(result)) == {("first.py", "run"), ("second.py", "run")}
+    assert all(item["status"] == "different" for item in result["comparisons"])
+
+
+def test_helper_selected_by_another_scope_is_covered_by_existing_caller():
+    result = compare_source_changes(
+        _snapshot({"app.py": _IDENTITY}),
+        _snapshot(
+            {
+                "app.py": (
+                    "from helpers import identity\n\n"
+                    "def run(value):\n    return identity(value)\n"
+                ),
+                "helpers.py": "def identity(value):\n    return value\n",
+            }
+        ),
+        scopes=[
+            ComparisonScope(selected="app.py", directory=False),
+            ComparisonScope(selected="helpers.py", directory=False),
+        ],
+    )
+
+    assert result["status"] == "equivalent"
+    assert set(_comparisons(result)) == {("app.py", "run")}
+
+
+def test_multiple_scopes_share_one_function_budget(monkeypatch):
+    before_source = "\n".join(
+        f"def function_{index}(value):\n    return value\n" for index in range(3)
+    )
+    after_source = before_source.replace("return value", "return None")
+    names = ("first.py", "second.py")
+    monkeypatch.setattr(comparison, "_MAX_COMPARISONS", 4)
+
+    result = compare_source_changes(
+        _snapshot({name: before_source for name in names}),
+        _snapshot({name: after_source for name in names}),
+        scopes=[ComparisonScope(selected=name, directory=False) for name in names],
+    )
+
+    assert result["status"] == "unknown"
+    assert len(result["comparisons"]) == len(_comparisons(result)) == 4
+    assert result["limits"]["functions"] == 4
+    assert result["reasons"] == ["Affected function budget exhausted (limit 4)"]
+
+
+def test_environment_change_qualifies_every_selected_scope_once():
+    sources = {name: _IDENTITY for name in ("first.py", "second.py", "unselected.py")}
+
+    result = compare_source_changes(
+        _snapshot(sources, hashes={"pyproject.toml": "before"}),
+        _snapshot(sources, hashes={"pyproject.toml": "after"}),
+        scopes=[
+            ComparisonScope(selected="first.py", directory=False),
+            ComparisonScope(selected="second.py", directory=False),
+        ],
+    )
+
+    assert result["status"] == "unknown"
+    assert set(_comparisons(result)) == {("first.py", "run"), ("second.py", "run")}
+    assert result["reasons"] == [
+        "Dependency or Python environment files changed: pyproject.toml"
+    ]
+
+
+@pytest.mark.parametrize("use_scopes", [False, True])
+def test_single_scope_preserves_unsupported_file_fastpath(monkeypatch, use_scopes):
+    index = Mock(wraps=comparison._index)
+    monkeypatch.setattr(comparison, "_index", index)
+    selected = ComparisonScope(selected="app.py", directory=False)
+
+    result = compare_source_changes(
+        _snapshot(
+            {
+                "app.py": "def run(value: str):\n    return value\n",
+                "other.py": _IDENTITY,
+            }
+        ),
+        _snapshot(
+            {"app.py": "def run(value: str):\n    return None\n", "other.py": _CHANGED}
+        ),
+        **({"scopes": [selected]} if use_scopes else {"scope": selected}),
+    )
+
+    assert result["status"] == "unknown"
+    assert set(_comparisons(result)) == {("app.py", "run")}
+    assert [call.args[0] for call in index.call_args_list] == ["app.py", "app.py"]
+
+
+def test_scope_and_scopes_cannot_be_supplied_together():
+    snapshot = _snapshot({"app.py": _IDENTITY})
+
+    with pytest.raises(ValueError, match="either scope or scopes"):
+        compare_source_changes(
+            snapshot, snapshot, scope=ComparisonScope(), scopes=[ComparisonScope()]
+        )
+
+
+def test_empty_scopes_do_not_default_to_whole_repository():
+    with pytest.raises(ValueError, match="At least one comparison scope"):
+        compare_source_changes(
+            _snapshot({"app.py": _IDENTITY}),
+            _snapshot({"app.py": _CHANGED}),
+            scopes=[],
+        )
+
+
 def test_environment_hash_change_qualifies_unchanged_python():
     sources = {"app.py": _IDENTITY}
     before = _snapshot(sources, hashes={"pyproject.toml": "old-environment-bytes"})
@@ -240,12 +449,23 @@ def test_function_budget_reports_unassessed_work_instead_of_completeness():
     assert any("budget exhausted" in reason.lower() for reason in result["reasons"])
 
 
-def test_comparison_uses_no_filesystem_process_or_analyzer_io(monkeypatch):
+@pytest.mark.parametrize("multiple_scopes", [False, True])
+def test_comparison_uses_no_filesystem_process_or_analyzer_io(
+    monkeypatch, multiple_scopes
+):
     import skylos
     import skylos.analyzer
 
-    before = _snapshot({"app.py": _IDENTITY})
-    after = _snapshot({"app.py": _CHANGED})
+    before = _snapshot({"app.py": _IDENTITY, "pkg/app.py": _IDENTITY})
+    after = _snapshot({"app.py": _CHANGED, "pkg/app.py": _CHANGED})
+    scopes = (
+        [
+            ComparisonScope(selected="app.py", directory=False),
+            ComparisonScope(selected="pkg"),
+        ]
+        if multiple_scopes
+        else None
+    )
 
     def unexpected_io(*args, **kwargs):
         raise AssertionError("Shared comparison must only inspect supplied source data")
@@ -258,6 +478,7 @@ def test_comparison_uses_no_filesystem_process_or_analyzer_io(monkeypatch):
         blocked.setattr(subprocess, "Popen", unexpected_io)
         blocked.setattr(skylos, "analyze", unexpected_io)
         blocked.setattr(skylos.analyzer, "analyze", unexpected_io)
-        result = compare_source_changes(before, after)
+        result = compare_source_changes(before, after, scopes=scopes)
 
     assert result["status"] == "different"
+    assert set(_comparisons(result)) == {("app.py", "run"), ("pkg/app.py", "run")}

--- a/test/test_refactor_verify.py
+++ b/test/test_refactor_verify.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -252,6 +253,59 @@ def test_working_snapshot_preserves_encoded_bytes_and_line_endings(make_repo):
 
     assert sources["app.py"] == source
     assert hashes["app.py"] == hashlib.sha256(source.encode("latin-1")).hexdigest()
+
+
+@pytest.mark.parametrize("multiple_files", [False, True])
+def test_explicit_ignored_files_share_one_working_snapshot(
+    make_repo, monkeypatch, multiple_files
+):
+    repo, _ = make_repo({"app.py": _IDENTITY, ".gitignore": "generated/\n"})
+    ignored = {
+        "generated/first.py": _IDENTITY,
+        "generated/second.py": "def run(value):\n    return None\n",
+        "generated/unselected.py": _IDENTITY,
+    }
+    for name, source in ignored.items():
+        _write(repo, name, source)
+    assert set(_git(repo, "check-ignore", "--", *ignored).splitlines()) == set(ignored)
+    selected = (
+        ("generated/first.py", "generated/second.py", "generated/first.py")
+        if multiple_files
+        else "generated/first.py"
+    )
+    reader = Mock(wraps=refactor._read_working_source)
+    monkeypatch.setattr(refactor, "_read_working_source", reader)
+
+    sources, hashes = refactor._current_sources(repo, selected)
+
+    expected = {"app.py": _IDENTITY, "generated/first.py": _IDENTITY}
+    if multiple_files:
+        expected["generated/second.py"] = ignored["generated/second.py"]
+    assert sources == expected
+    assert hashes == {
+        name: hashlib.sha256(source.encode()).hexdigest()
+        for name, source in expected.items()
+    }
+    assert sorted(call.args[1] for call in reader.call_args_list) == sorted(expected)
+
+
+@pytest.mark.parametrize("name", ["../app.py", "/app.py", ".", "\0"])
+def test_explicit_file_tuple_rejects_unsafe_member(make_repo, name):
+    repo, _ = make_repo({"app.py": _IDENTITY})
+
+    with pytest.raises(ValueError, match="Unsafe path"):
+        refactor._current_sources(repo, ("app.py", name))
+
+
+def test_explicit_ignored_files_count_toward_snapshot_limit(make_repo, monkeypatch):
+    repo, _ = make_repo({"app.py": _IDENTITY, ".gitignore": "generated/\n"})
+    selected = ("generated/first.py", "generated/second.py")
+    for name in selected:
+        _write(repo, name, _IDENTITY)
+    monkeypatch.setattr(refactor, "_MAX_FILES", 2)
+
+    with pytest.raises(ValueError, match="verification file limit"):
+        refactor._current_sources(repo, selected)
 
 
 def test_deleted_working_source_is_absent_from_snapshot(make_repo):


### PR DESCRIPTION
# Summary

  - Add committed branch comparison using merge-base -> HEAD, alongside existing HEAD -> working-tree comparison.
  - Pin commit identities so dirty files, staged edits, or moving refs cannot alter committed comparison evidence.
  - Share snapshots and comparison work across targets in the same repo
  - Report missing history and unavailable scopes

# Tests

- `pytest test/test_behavior_comparison.py test/test_behavior_changes.py test/test_behavior_baselines.py \
    test/test_refactor_verify.py test/test_behavior_engine.py test/test_behavior_soundness.py \
    test/test_behavior_explanations.py test/test_verify_render.py test/test_verify_cmd.py \
    test/test_verify_change.py test/test_verify_change_dependency_bump.py test/test_cli_refactor_guardrails.py \
    test/test_cli.py test/test_safe_output.py`